### PR TITLE
fix sidebar - content float issue

### DIFF
--- a/load.js
+++ b/load.js
@@ -17,7 +17,7 @@ const Area = ({main, error}) => (
         onPaper={loadPaper}
         onBlock={loadBlock}/>
     </div>
-    <div style={{float: 'left'}}>
+    <div style={{marginLeft: '250px'}}>
       {error? <ReadBox error={error}/> : main}
     </div>
   </div>


### PR DESCRIPTION
content panel doesnt appear properly when added large contents for `papers` .
(check the screenshot)
 ![alt text](https://www.evernote.com/l/AK-fo5wyfKpJspzkykiMtulGoRVMO7s2CFcB/image.png)
