### PR TITLE
Add support for 'jsx' extensions

### DIFF
--- a/src/server/webpack.config.js
+++ b/src/server/webpack.config.js
@@ -29,7 +29,7 @@ const config = {
   module: {
     loaders: [
       {
-        test: /\.js$/,
+        test: /\.jsx?$/,
         loader: 'babel',
         query: { presets: ['react', 'es2015', 'stage-2'] },
         exclude: [path.resolve('./node_modules'), path.resolve(__dirname, 'node_modules')],


### PR DESCRIPTION
It's fairly common for people having '.jsx' extensions for their react components.
