### PR TITLE
storiesOf().add() reads fn.name if only 1 arg provided

### DIFF
--- a/src/client/__tests__/client_api.js
+++ b/src/client/__tests__/client_api.js
@@ -63,6 +63,20 @@ describe('client.ClientApi', () => {
       expect(args[2]).to.be.equal(handle);
     });
 
+    it('should add a given story reading name from fn.name', () => {
+      const api = getClientApi();
+      const story = () => {};
+
+      api._storyStore.addStory = sinon.stub();
+      api.storiesOf('kind')
+        .add(story);
+
+      const args = api._storyStore.addStory.args[0];
+      expect(args[0]).to.be.equal('kind');
+      expect(args[1]).to.be.equal('story');
+      expect(args[2]).to.be.equal(story);
+    });
+
     it('should support method chaining', () => {
       const api = getClientApi();
       const handle = () => {};

--- a/src/client/client_api.js
+++ b/src/client/client_api.js
@@ -12,7 +12,11 @@ export default class ClientApi {
     }
 
     const add = (storyName, fn) => {
-      this._storyStore.addStory(kind, storyName, fn);
+      if (typeof storyName === 'function') {
+        this._storyStore.addStory(kind, storyName.name, storyName);
+      } else {
+        this._storyStore.addStory(kind, storyName, fn);
+      }
       return { add };
     };
 


### PR DESCRIPTION
This change helps when the function provided to .add() is reused in the same file for eg. tests, so it is defined outside of the call to .add() and assigned to a variable. The story takes the name of the function/variable.
