### PR TITLE
Update webpack.config.js

### DIFF
--- a/src/server/webpack.config.js
+++ b/src/server/webpack.config.js
@@ -77,6 +77,24 @@ if (fs.existsSync(customConfigPath)) {
     logger.info(' => Loading custom webpack plugins.');
     config.plugins = config.plugins.concat(customConfig.plugins);
   }
+  
+  // load resolve.extensions
+  if (customConfig.resolve && customConfig.resolve.extensions) {
+    config.resolve = config.resolve || {};
+    config.resolve.extensions = customConfig.resolve.extensions.slice();
+    if (config.resolve.extensions.indexOf('.js') === -1) {
+      config.resolve.extensions.push('.js');
+    }
+  }
+  
+  // load resolve.modulesDirectories
+  if (customConfig.resolve && customConfig.resolve.modulesDirectories) {
+    config.resolve = config.resolve || {};
+    config.resolve.modulesDirectories = customConfig.resolve.modulesDirectories.slice();
+    if (config.resolve.modulesDirectories.indexOf('node_modules') === -1) {
+      config.resolve.modulesDirectories.push('node_modules');
+    }
+  }
 }
 
 export default config;

--- a/src/server/webpack.config.js
+++ b/src/server/webpack.config.js
@@ -26,6 +26,7 @@ const config = {
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
   ],
+  resolve: {},
   module: {
     loaders: [
       {
@@ -80,7 +81,6 @@ if (fs.existsSync(customConfigPath)) {
   
   // load resolve.extensions
   if (customConfig.resolve && customConfig.resolve.extensions) {
-    config.resolve = config.resolve || {};
     config.resolve.extensions = customConfig.resolve.extensions.slice();
     if (config.resolve.extensions.indexOf('.js') === -1) {
       config.resolve.extensions.push('.js');
@@ -89,7 +89,6 @@ if (fs.existsSync(customConfigPath)) {
   
   // load resolve.modulesDirectories
   if (customConfig.resolve && customConfig.resolve.modulesDirectories) {
-    config.resolve = config.resolve || {};
     config.resolve.modulesDirectories = customConfig.resolve.modulesDirectories.slice();
     if (config.resolve.modulesDirectories.indexOf('node_modules') === -1) {
       config.resolve.modulesDirectories.push('node_modules');


### PR DESCRIPTION
Load `resolve` option from custom webpack config file.

I don't always like adding the ".jsx" extension to my "require" calls.
