### PR TITLE
Also resolve JSX files

### DIFF
--- a/src/server/webpack.config.js
+++ b/src/server/webpack.config.js
@@ -34,6 +34,9 @@ const config = {
       },
     ],
   },
+  resolve: {
+    extensions: ['', '.js', '.jsx'],
+  },
 };
 
 export default config;


### PR DESCRIPTION
Allow to import react components from files with `.jsx` extensions. For instance, import components defined in `index.jsx`. 

```
$ ls components
compA/index.jsx
compB.jsx
```

``` javascript
import React from 'react';
import { storiesOf, action } from '@kadira/storybook';
import { CompA } from '../components/compA';

storiesOf('CompA', module)
  .add('default', () => (
      <CompA />
  ));

```

Also, it's useful for transitive dependency:

``` JSX
// compA.jsx
import CompB from "../compB"

class CompA extends React.Component {
  render() {
    return (
      <CompB />
    )
  }
}
```
