### PR TITLE
fix(warning): Fix the React Warning about CSS property

### DIFF
--- a/src/client/ui/action_logger.js
+++ b/src/client/ui/action_logger.js
@@ -8,7 +8,7 @@ const preStyle = {
   border: '1px solid #ECECEC',
   borderRadius: 4,
   backgroundColor: '#FFF',
-  margin: '0',
+  margin: 0,
   position: 'absolute',
   top: '30px',
   right: 0,


### PR DESCRIPTION
Ultra simple Pull Request to avoid the warning since React@15.0.0

<img width="416" alt="capture d ecran 2016-04-08 a 11 58 11" src="https://cloud.githubusercontent.com/assets/3336873/14380696/3508dab8-fd81-11e5-851e-7f2486039ca1.png">
