### PR TITLE
Avoid deprecated warning in Chrome Canary

### DIFF
--- a/src/server/webpack.config.js
+++ b/src/server/webpack.config.js
@@ -2,7 +2,7 @@ import path from 'path';
 import webpack from 'webpack';
 
 const config = {
-  devtool: 'cheap-module-eval-source-map',
+  devtool: '#cheap-module-eval-source-map',
   entry: {
     admin: [
       'stack-source-map/register',


### PR DESCRIPTION
Avoid this error: '//@ sourceURL' and '//@ sourceMappingURL' are deprecated, please use '//# sourceURL=' and '//# sourceMappingURL=' instead.
