### PR TITLE
Implement linkTo functionality

### DIFF
--- a/dist/client/client_api.js
+++ b/dist/client/client_api.js
@@ -73,6 +73,34 @@ var ClientApi = function () {
         syncedStore.setData({ actions: actions });
       };
     }
+  }, {
+    key: "linkTo",
+    value: function linkTo(kind, story) {
+      var syncedStore = this._syncedStore;
+
+      return function () {
+        var resolvedKind = typeof kind === "function" ? kind.apply(undefined, arguments) : kind;
+
+        var resolvedStory = void 0;
+        if (story) {
+          resolvedStory = typeof story === "function" ? story.apply(undefined, arguments) : story;
+        } else {
+          var _syncedStore$getData2 = syncedStore.getData();
+
+          var storyStore = _syncedStore$getData2.storyStore;
+
+
+          resolvedStory = storyStore.find(function (item) {
+            return item.kind === kind;
+          }).stories[0];
+        }
+
+        syncedStore.setData({
+          selectedKind: resolvedKind,
+          selectedStory: resolvedStory
+        });
+      };
+    }
   }]);
   return ClientApi;
 }();

--- a/dist/client/index.js
+++ b/dist/client/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.configure = exports.action = exports.storiesOf = undefined;
+exports.configure = exports.linkTo = exports.action = exports.storiesOf = undefined;
 exports.getStoryStore = getStoryStore;
 exports.getSyncedStore = getSyncedStore;
 
@@ -41,4 +41,5 @@ function getSyncedStore() {
 
 var storiesOf = exports.storiesOf = clientApi.storiesOf.bind(clientApi);
 var action = exports.action = clientApi.action.bind(clientApi);
+var linkTo = exports.linkTo = clientApi.linkTo.bind(clientApi);
 var configure = exports.configure = configApi.configure.bind(configApi);

--- a/src/client/__tests__/client_api.js
+++ b/src/client/__tests__/client_api.js
@@ -136,4 +136,57 @@ describe('client.ClientApi', () => {
       ]);
     });
   });
+
+  describe('linkTo', () => {
+    it('should send kind to the syncedStore', () => {
+      const api = getClientApi();
+      api._syncedStore.getData = () => ({
+        storyStore: [{ kind: 'Another Kind', stories: [] }],
+        selectedKind: 'Some Kind',
+      });
+      api._syncedStore.setData = sinon.stub();
+
+      const cb = api.linkTo('Another Kind');
+      cb();
+
+      const args = api._syncedStore.setData.args[0];
+      expect(args[0].selectedKind).to.equal('Another Kind');
+    });
+
+    it('should send story to the syncedStore', () => {
+      const api = getClientApi();
+      api._syncedStore.getData = () => ({
+        storyStore: [{ kind: 'Another Kind', stories: [] }],
+        selectedKind: 'Some Kind',
+        selectedStory: 'Some Story',
+      });
+      api._syncedStore.setData = sinon.stub();
+
+      const cb = api.linkTo('Another Kind', 'Another Story');
+      cb();
+
+      const args = api._syncedStore.setData.args[0];
+      expect(args[0].selectedKind).to.equal('Another Kind');
+      expect(args[0].selectedStory).to.equal('Another Story');
+    });
+
+    it('should allow functions for story and kind', () => {
+      const api = getClientApi();
+      api._syncedStore.getData = () => ({
+        storyStore: [{ kind: 'Another Kind', stories: [] }],
+        selectedKind: 'Some Kind',
+        selectedStory: 'Some Story',
+      });
+      api._syncedStore.setData = sinon.stub();
+
+      const cb = api.linkTo(
+        () => 'Another Kind',
+        () => 'Another Story');
+      cb();
+
+      const args = api._syncedStore.setData.args[0];
+      expect(args[0].selectedKind).to.equal('Another Kind');
+      expect(args[0].selectedStory).to.equal('Another Story');
+    });
+  });
 });

--- a/src/client/client_api.js
+++ b/src/client/client_api.js
@@ -39,4 +39,28 @@ export default class ClientApi {
       syncedStore.setData({ actions });
     };
   }
+
+  linkTo(kind, story) {
+    const syncedStore = this._syncedStore;
+
+    return function (...args) {
+      const resolvedKind = typeof kind === 'function' ? kind(...args) : kind;
+
+      let resolvedStory;
+      if (story) {
+        resolvedStory = typeof story === 'function' ? story(...args) : story;
+      } else {
+        const { storyStore } = syncedStore.getData();
+
+        resolvedStory = storyStore
+          .find(item => item.kind === kind)
+          .stories[0];
+      }
+
+      syncedStore.setData({
+        selectedKind: resolvedKind,
+        selectedStory: resolvedStory,
+      });
+    };
+  }
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -19,4 +19,5 @@ export function getSyncedStore() {
 
 export const storiesOf = clientApi.storiesOf.bind(clientApi);
 export const action = clientApi.action.bind(clientApi);
+export const linkTo = clientApi.linkTo.bind(clientApi);
 export const configure = configApi.configure.bind(configApi);


### PR DESCRIPTION
As mentioned in #50 this implements `linkTo`.

It uses the API suggested in the issue, with a couple of additions. The API is:

`linkTo(kind: string|func, [story: string|func])`

---

The initial suggestion was:

``` javascript
import { linkTo } from @kadira/storybook

storiesOf('Toggle', module)
  .add('on', () => {
    return <Toggle value={true} onChange={linkTo('Toggle', 'off')} />
  })
  .add('off', () => {
    return <Toggle value={false} onChange={linkTo('Toggle', 'on')} />
  });
```

In addition to this, made the _kind_ optional, so you can `linkTo('Toggle')` and it will link to the first _story_ in that _kind_.

Also, while building this functionality I found that there was a use case where the function being passed to the component should accept one or more arguments. That function should then decide where to go based on those arguments. For example, in the Todo Example:

``` javascript
  .add('show completed', () => (
    <div className="todoapp">
      <Footer
        completedCount={10}
        activeCount={4}
        filter={SHOW_COMPLETED}
        onClearCompleted={action('onClearCompleted')}
        onShow={action('onShow')} />
    </div>
  ))
```

In `onShow={action('onShow')}`, the `action()` is passed a constant describing the filter. There is no way to know what the filter will be, so we can't use a string. This is where you can use a function.

``` javascript
onShow={linkTo('Footer', (filter) => {
  switch (filter) {
  case SHOW_ALL: return 'default view';
  case SHOW_COMPLETED: return 'show completed';
  case SHOW_ACTIVE: return 'show active';
  }
})}
```
