### PR TITLE
Don't serve index.html as a site index

### DIFF
--- a/dist/server/index.js
+++ b/dist/server/index.js
@@ -73,7 +73,7 @@ if (_commander2.default.staticDir) {
   var staticPath = _path2.default.resolve(_commander2.default.staticDir);
   if (_fs2.default.existsSync(staticPath)) {
     logger.log('=> Loading static files from: ' + staticPath + ' .');
-    app.use(_express2.default.static(staticPath));
+    app.use(_express2.default.static(staticPath, { index: false }));
   } else {
     logger.error('Error: no such directory to load static files: ' + staticPath);
     process.exit(-1);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -37,7 +37,7 @@ if (program.staticDir) {
   const staticPath = path.resolve(program.staticDir);
   if (fs.existsSync(staticPath)) {
     logger.log(`=> Loading static files from: ${staticPath} .`);
-    app.use(express.static(staticPath));
+    app.use(express.static(staticPath, { index: false }));
   } else {
     logger.error(`Error: no such directory to load static files: ${staticPath}`);
     process.exit(-1);


### PR DESCRIPTION
This switch prevents the static files from serving `index.html` as an index. This means you can still have a `index.html` file in your static path and it won't get served up as the application index. Fixes #99.

From the ExpressJS documentation: http://expressjs.com/en/api.html#express.static

> Sends the specified directory index file. Set to false to disable directory indexing.

However, if the browser is navigated to (for example) `http://localhost:9001/index.html` then it will serve the `index.html` from the static path. This does not conflict with the application though as there is no application `index.html` file to serve anyway.

---

Another fix was to move the:

``` javascript
app.get('/', function (req, res) {
  res.send(getIndexHtml());
});
```

above the `if (program.staticDir) { ... }` call, but I believe this PR solves the problem more correctly.
