### PR TITLE
Fix the prepublish script

### DIFF
--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -1,5 +1,6 @@
 echo "> Start transpiling ES2015"
 echo ""
+rm -rf ./dist
 ./node_modules/.bin/babel --ignore __tests__ --plugins "transform-runtime" ./src --out-dir ./dist
 echo ""
 echo "> Complete transpiling ES2015"


### PR DESCRIPTION
Remove the dist directory before babel compile to ensure
that it will only have up-to-date content
