### PR TITLE
Adds support for preLoaders in custom webpack config

### DIFF
--- a/dist/server/config.js
+++ b/dist/server/config.js
@@ -52,6 +52,7 @@ exports.default = function (baseConfig, configDir) {
     plugins: [].concat((0, _toConsumableArray3.default)(config.plugins), (0, _toConsumableArray3.default)(customConfig.plugins || [])),
     module: (0, _extends3.default)({}, config.module, {
       // We need to use our and custom loaders.
+      preLoaders: [].concat((0, _toConsumableArray3.default)(customConfig.module.preLoaders || [])),
       loaders: [].concat((0, _toConsumableArray3.default)(config.module.loaders), (0, _toConsumableArray3.default)(customConfig.module.loaders || []))
     })
   });

--- a/dist/server/config.js
+++ b/dist/server/config.js
@@ -50,9 +50,7 @@ exports.default = function (baseConfig, configDir) {
   return (0, _extends3.default)({}, customConfig, config, {
     // We need to use our and custom plugins.
     plugins: [].concat((0, _toConsumableArray3.default)(config.plugins), (0, _toConsumableArray3.default)(customConfig.plugins || [])),
-    module: (0, _extends3.default)({}, config.module, {
-      // We need to use our and custom loaders.
-      preLoaders: [].concat((0, _toConsumableArray3.default)(customConfig.module.preLoaders || [])),
+    module: (0, _extends3.default)({}, config.module, customConfig.module || {}, {
       loaders: [].concat((0, _toConsumableArray3.default)(config.module.loaders), (0, _toConsumableArray3.default)(customConfig.module.loaders || []))
     })
   });

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -56,9 +56,7 @@ export default function (baseConfig, configDir) {
     module: {
       ...config.module,
       // We need to use our and custom loaders.
-      preLoaders: [
-        ...customConfig.module.preLoaders || [],
-      ],
+      ...customConfig.module || {},
       loaders: [
         ...config.module.loaders,
         ...customConfig.module.loaders || [],

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -56,6 +56,9 @@ export default function (baseConfig, configDir) {
     module: {
       ...config.module,
       // We need to use our and custom loaders.
+      preLoaders: [
+        ...customConfig.module.preLoaders || [],
+      ],
       loaders: [
         ...config.module.loaders,
         ...customConfig.module.loaders || [],


### PR DESCRIPTION
Fixes #90 

Adds support for preLoaders to be added to custom webpack config. This allows you to use preLoaders that need to be run before loaders, like code linting, hinting etc.

Was considering adding support for postLoaders too, but I don't have any experience with them so will leave it for now. 
