### PR TITLE
Proposed update to add()

### DIFF
--- a/dist/client/client_api.js
+++ b/dist/client/client_api.js
@@ -39,8 +39,8 @@ var ClientApi = function () {
         });
       }
 
-      var add = function add(storyName, fn) {
-        _this._storyStore.addStory(kind, storyName, fn);
+      var add = function add(storyName, fn, props) {
+        _this._storyStore.addStory(kind, storyName, fn, props);
         return { add: add };
       };
 

--- a/dist/client/story_store.js
+++ b/dist/client/story_store.js
@@ -29,7 +29,7 @@ var StoreStore = function () {
 
   (0, _createClass3.default)(StoreStore, [{
     key: "addStory",
-    value: function addStory(kind, name, fn) {
+    value: function addStory(kind, name, fn, props) {
       if (!this._data[kind]) {
         this._data[kind] = {
           kind: kind,
@@ -41,7 +41,8 @@ var StoreStore = function () {
       this._data[kind].stories[name] = {
         name: name,
         index: cnt++,
-        fn: fn
+        fn: fn,
+        props: props
       };
     }
   }, {
@@ -87,7 +88,7 @@ var StoreStore = function () {
         return null;
       }
 
-      return storyInfo.fn;
+      return storyInfo;
     }
   }, {
     key: "removeStoryKind",

--- a/dist/client/ui/preview.js
+++ b/dist/client/ui/preview.js
@@ -58,7 +58,7 @@ function renderMain(data) {
   //    https://github.com/kadirahq/react-storybook/issues/81
   _reactDom2.default.unmountComponentAtNode(rootEl);
 
-  return _reactDom2.default.render(story(), rootEl);
+  return _reactDom2.default.render(_react2.default.createElement(story.fn, story.props), rootEl);
 }
 
 function renderPreview(data) {

--- a/src/client/client_api.js
+++ b/src/client/client_api.js
@@ -11,8 +11,8 @@ export default class ClientApi {
       });
     }
 
-    const add = (storyName, fn) => {
-      this._storyStore.addStory(kind, storyName, fn);
+    const add = (storyName, fn, props) => {
+      this._storyStore.addStory(kind, storyName, fn, props);
       return { add };
     };
 

--- a/src/client/story_store.js
+++ b/src/client/story_store.js
@@ -5,7 +5,7 @@ export default class StoreStore {
     this._data = {};
   }
 
-  addStory(kind, name, fn) {
+  addStory(kind, name, fn, props) {
     if (!this._data[kind]) {
       this._data[kind] = {
         kind,
@@ -18,6 +18,7 @@ export default class StoreStore {
       name,
       index: cnt++,
       fn,
+      props
     };
   }
 
@@ -50,7 +51,7 @@ export default class StoreStore {
       return null;
     }
 
-    return storyInfo.fn;
+    return storyInfo;
   }
 
   removeStoryKind(kind) {

--- a/src/client/ui/preview.js
+++ b/src/client/ui/preview.js
@@ -32,7 +32,7 @@ export function renderMain(data) {
   //    https://github.com/kadirahq/react-storybook/issues/81
   ReactDOM.unmountComponentAtNode(rootEl);
 
-  return ReactDOM.render(story(), rootEl);
+  return ReactDOM.render(React.createElement(story.fn, story.props), rootEl);
 }
 
 export default function renderPreview(data) {


### PR DESCRIPTION
This PR is more for discussion than immediate merge as it proposes a change to the main API. This was born out of discussion on #112. 

Instead of rendering the component by just [executing the render function](https://github.com/kadirahq/react-storybook/blob/master/src/client/ui/preview.js#L35) of the story, we can wrap it in a `React.createElement` and everything should still work as it currently does:

``` javascript
// Before
return ReactDOM.render(story(), rootEl);

// After
return ReactDOM.render(React.createElement(story), rootEl);
```

This allows you to pass just a component to the `add()` function:

``` javascript
// Before:
stories.add('default view', () => <MyComponent />);

// After:
stories.add('default view', MyComponent);
```

Of course, now we are without `props`. The API change in this PR adds a third optional argument to the `add` method, `props`. These get passed to the `createElement` allowing you to:

``` javascript
stories.add('default view', MyComponent, { label: 'Component label' });
```

This paves the way for a matching `addAll`` style API:

``` javascript
stories.addAll(MyComponent, {
  'default view': { label: 'Component label' },
  'another view': { label: 'Another label' }
});
```

---

_Anyway, as I mentioned, this is more for discussion than immediate merge._
