### PR TITLE
Check all arguments sent to action() for event objects

### DIFF
--- a/dist/client/client_api.js
+++ b/dist/client/client_api.js
@@ -89,9 +89,12 @@ var ClientApi = function () {
 
         // Remove events from the args. Otherwise, it creates a huge JSON string.
 
-        if (args[0] && typeof args[0].preventDefault === 'function') {
-          args[0] = '[SyntheticEvent]';
-        }
+        args = args.map(function (arg) {
+          if (typeof arg.preventDefault === 'function') {
+            return '[SyntheticEvent]';
+          }
+          return arg;
+        });
 
         var id = ++idGenerator;
         var data = { name: name, args: args };

--- a/src/client/__tests__/client_api.js
+++ b/src/client/__tests__/client_api.js
@@ -162,6 +162,38 @@ describe('client.ClientApi', () => {
         count: 1,
       }]);
     });
+
+    it('should replace any Synthetic Event with it\'s name when not the first argument', () => {
+      const api = getClientApi();
+      api._syncedStore.getData = () => ({ actions: [] });
+      api._syncedStore.setData = sinon.stub();
+
+      const event = {
+        preventDefault() {},
+      };
+      const data = {
+        type: 'delete',
+      };
+
+      const cb = api.action('hello');
+      cb(data, event);
+
+      const args = api._syncedStore.setData.args[0];
+      const actions = clearActionId(args[0].actions);
+
+      expect(actions).to.be.deep.equal([{
+        data: {
+          name: 'hello',
+          args: [
+            {
+              type: 'delete',
+            },
+            '[SyntheticEvent]',
+          ],
+        },
+        count: 1,
+      }]);
+    });
   });
 
   describe('linkTo', () => {

--- a/src/client/client_api.js
+++ b/src/client/client_api.js
@@ -42,16 +42,16 @@ export default class ClientApi {
     const syncedStore = this._syncedStore;
 
     return function (..._args) {
-      const args = Array.from(_args);
+      let args = Array.from(_args);
       let { actions = [] } = syncedStore.getData();
 
       // Remove events from the args. Otherwise, it creates a huge JSON string.
-      if (
-        args[0] &&
-        typeof args[0].preventDefault === 'function'
-      ) {
-        args[0] = '[SyntheticEvent]';
-      }
+      args = args.map(arg => {
+        if (typeof arg.preventDefault === 'function') {
+          return '[SyntheticEvent]';
+        }
+        return arg;
+      });
 
       const id = ++idGenerator;
       const data = { name, args };


### PR DESCRIPTION
Currently, only the first argument sent to an action() is checked to see if it is an event (which cannot be serialized without creating an error). If an event is passed to the callback in any other position, i.e. if the component does some processing on the event first, it will still attempt serialization and fail.

This is a quick fix to map over all arguments and replace any event objects found.
