### PR TITLE
Correctly detect and handle undefined/null in action calls

### DIFF
--- a/dist/client/client_api.js
+++ b/dist/client/client_api.js
@@ -90,7 +90,7 @@ var ClientApi = function () {
         // Remove events from the args. Otherwise, it creates a huge JSON string.
 
         args = args.map(function (arg) {
-          if (typeof arg.preventDefault === 'function') {
+          if (arg && typeof arg.preventDefault === 'function') {
             return '[SyntheticEvent]';
           }
           return arg;

--- a/src/client/__tests__/client_api.js
+++ b/src/client/__tests__/client_api.js
@@ -125,6 +125,25 @@ describe('client.ClientApi', () => {
       }]);
     });
 
+    it('should accept null and undefined values', () => {
+      const api = getClientApi();
+      api._syncedStore.getData = () => ({ actions: [] });
+      api._syncedStore.setData = sinon.stub();
+
+      const cb = api.action('hello');
+      cb(null, void 0);
+
+      const args = api._syncedStore.setData.args[0];
+      const actions = clearActionId(args[0].actions);
+      expect(actions).to.be.deep.equal([{
+        data: {
+          name: 'hello',
+          args: [null, void 0],
+        },
+        count: 1,
+      }]);
+    });
+
     it('should only keep the latest 10 actions in the syncedStore', () => {
       const api = getClientApi();
       api._syncedStore.getData = () => ({

--- a/src/client/client_api.js
+++ b/src/client/client_api.js
@@ -47,7 +47,7 @@ export default class ClientApi {
 
       // Remove events from the args. Otherwise, it creates a huge JSON string.
       args = args.map(arg => {
-        if (typeof arg.preventDefault === 'function') {
+        if (arg && typeof arg.preventDefault === 'function') {
           return '[SyntheticEvent]';
         }
         return arg;


### PR DESCRIPTION
Fixes a regression introduced in pull request #132 where passing null/undefined as an argument causes an exception to be thrown.

Additional test case has been added.
