### PR TITLE
Add airbnb-js-shims to client-side JS

### DIFF
--- a/dist/client/ui/admin.js
+++ b/dist/client/ui/admin.js
@@ -14,6 +14,8 @@ exports.getActionLogger = getActionLogger;
 exports.renderMain = renderMain;
 exports.default = renderAdmin;
 
+require('airbnb-js-shims');
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);

--- a/dist/client/ui/preview.js
+++ b/dist/client/ui/preview.js
@@ -7,6 +7,8 @@ exports.renderError = renderError;
 exports.renderMain = renderMain;
 exports.default = renderPreview;
 
+require('airbnb-js-shims');
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@kadira/react-split-pane": "^1.3.0",
+    "airbnb-js-shims": "^1.0.0",
     "babel-core": "^6.3.15",
     "babel-loader": "^6.2.0",
     "babel-polyfill": "^6.3.15",
@@ -60,7 +61,7 @@
     "babel-eslint": "^6.0.2",
     "babel-plugin-transform-runtime": "^6.3.14",
     "chai": "^3.5.0",
-    "eslint": "^2.4.0",
+    "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^4.2.3",

--- a/src/client/ui/admin.js
+++ b/src/client/ui/admin.js
@@ -1,3 +1,4 @@
+import 'airbnb-js-shims';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import StorybookControls from './controls';

--- a/src/client/ui/preview.js
+++ b/src/client/ui/preview.js
@@ -1,3 +1,4 @@
+import 'airbnb-js-shims';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReadBox from 'redbox-react';


### PR DESCRIPTION
This adds [airbnb-js-shims](https://github.com/airbnb/js-shims) to the admin js and the iframe js, which gets IE11 working for me, where it used to break on an `Array.from`
