### PR TITLE
Ensure asset directory exists

### DIFF
--- a/src/server/build.js
+++ b/src/server/build.js
@@ -66,7 +66,7 @@ webpack(config).compile(function (err, stats) {
 
     const source = asset._value;
     const dstPath = path.resolve(outputDir, `static/${filename}`);
-    
+
     // Ensure the asset directory exists
     shelljs.mkdir('-p', path.parse(dstPath).dir);
     fs.writeFileSync(dstPath, source);

--- a/src/server/build.js
+++ b/src/server/build.js
@@ -66,6 +66,9 @@ webpack(config).compile(function (err, stats) {
 
     const source = asset._value;
     const dstPath = path.resolve(outputDir, `static/${filename}`);
+    
+    // Ensure the asset directory exists
+    shelljs.mkdir('-p', path.parse(dstPath).dir);
     fs.writeFileSync(dstPath, source);
 
     // We need to copy the manager bundle distributed via the React Storybook


### PR DESCRIPTION
Creating a static build would fail (Error: ENOENT: no such file or directory) if it encountered an asset in a subdirectory.
Use mkdir to ensure the path exists, before writing the file.

For example, referencing fonts would fail:

```
@font-face {
  font-family: 'vaud';
  src: url('../fonts/vauddisplaybold-webfont.eot');
  src:
    url('../fonts/vauddisplaybold-webfont.eot?#iefix') format('embedded-opentype'),
    url('../fonts/vauddisplaybold-webfont.woff') format('woff'),
    url('../fonts/vauddisplaybold-webfont.ttf') format('truetype'),
    url('../fonts/vauddisplaybold-webfont.svg#vaud_displayregular') format('svg');
  font-weight: 700;
  font-style: normal;
}
```
