### PR TITLE
Copy missing manager.js.map file

### DIFF
--- a/dist/server/build.js
+++ b/dist/server/build.js
@@ -111,4 +111,5 @@ logger.log('Building storybook ...');
   // We need to copy the manager bundle distributed via the React Storybook
   // directly into the production build overring webpack.
   _shelljs2.default.cp(_path2.default.resolve(__dirname, '../manager.js'), _path2.default.resolve(outputDir, publicPath, 'manager.bundle.js'));
+  _shelljs2.default.cp(_path2.default.resolve(__dirname, '../manager.js.map'), _path2.default.resolve(outputDir, publicPath, 'manager.js.map'));
 });

--- a/src/server/build.js
+++ b/src/server/build.js
@@ -86,4 +86,8 @@ webpack(config).compile(function (err, stats) {
     path.resolve(__dirname, '../manager.js'),
     path.resolve(outputDir, publicPath, 'manager.bundle.js')
   );
+  shelljs.cp(
+    path.resolve(__dirname, '../manager.js.map'),
+    path.resolve(outputDir, publicPath, 'manager.js.map')
+  );
 });


### PR DESCRIPTION
The sourcemap file for manager.js was not copied when
building the static storybook bundle. Which seems to cause
issues with Safari browser.

The static build seems to work fine on Safari 9. But better
fix the issue anyways.

Fixes #234
