### PR TITLE
Pass selected kind and story as args

### DIFF
--- a/dist/client/preview/render.js
+++ b/dist/client/preview/render.js
@@ -70,7 +70,12 @@ function renderMain(data, storyStore) {
     _reactDom2.default.unmountComponentAtNode(rootEl);
   }
 
-  return _reactDom2.default.render(story(), rootEl);
+  var context = {
+    kind: selectedKind,
+    story: selectedStory
+  };
+
+  return _reactDom2.default.render(story(context), rootEl);
 }
 
 function renderPreview(_ref) {

--- a/src/client/preview/render.js
+++ b/src/client/preview/render.js
@@ -42,7 +42,12 @@ export function renderMain(data, storyStore) {
     ReactDOM.unmountComponentAtNode(rootEl);
   }
 
-  return ReactDOM.render(story(), rootEl);
+  const context = {
+    kind: selectedKind,
+    story: selectedStory,
+  };
+
+  return ReactDOM.render(story(context), rootEl);
 }
 
 export default function renderPreview({ reduxStore, storyStore }) {


### PR DESCRIPTION
When creating plugins for stories, it'll be useful to have
the kind name and the story name accessible to plugins.

The react-storybook-story plugin can be improved with this PR.
