### PR TITLE
Don't always override NODE_ENV in build-storybook

### DIFF
--- a/src/server/build.js
+++ b/src/server/build.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-process.env.NODE_ENV = 'production';
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
 import webpack from 'webpack';
 import program from 'commander';


### PR DESCRIPTION
My webpack configuration uses the `DefinePlugin` to make `process.env.NODE_ENV` available to my react components, which in turn optionally do different things depending on the NODE_ENV (related to debugging and such).

Unfortunately, these development-only features don't show up when I use `build-storybook` because `build-storybook` overrides `process.env.NODE_ENV`.

While I think it is quite reasonable for `build-storybook` to default to a "production ready" build, it should not unconditionally override the `NODE_ENV` environment variable to do so.

This change makes `"production"` the default, but also allows people to set a different `NODE_ENV` value and have it get used.
