### PR TITLE
Support watchOptions configuration.

### DIFF
--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -23,6 +23,7 @@ export default function (configDir) {
   const devMiddlewareOptions = {
     noInfo: true,
     publicPath: config.output.publicPath,
+    watchOptions: config.watchOptions || {},
   };
 
   const router = new Router();


### PR DESCRIPTION
This commit causes the watchOptions in the configuration provided to `react-storybook` to be passed on to `webpack-dev-middleware`.

This allows those who need these options for hot reloading to be able to use them again.
