### PR TITLE
Last publication (1.37.0) included `npm-shrinkwrap.json` and `node_modules2`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 .idea
+npm-shrinkwrap.json


### PR DESCRIPTION
I'm sure it was done by mistake, since this files should not be published.

I've added the shrinkwrap file to `.npmignore` just in case.

Is it possible to republish anytime soon?

thanks!
