### PR TITLE
Add node_modules as a excludePath for js.

### DIFF
--- a/dist/server/config/defaults/webpack.config.js
+++ b/dist/server/config/defaults/webpack.config.js
@@ -13,7 +13,7 @@ var _paths = require('../paths');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // Add a default custom config which is similar to what React Create App does.
-module.exports = function (storybookBaseConfig, configType) {
+module.exports = function (storybookBaseConfig) {
   var newConfig = storybookBaseConfig;
   newConfig.module.loaders = [].concat((0, _toConsumableArray3.default)(newConfig.module.loaders), [{
     test: /\.css?$/,

--- a/dist/server/config/paths.js
+++ b/dist/server/config/paths.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.includePaths = undefined;
+exports.excludePaths = exports.includePaths = undefined;
 
 var _path = require('path');
 
@@ -11,4 +11,6 @@ var _path2 = _interopRequireDefault(_path);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var includePaths = exports.includePaths = [_path2.default.resolve('./'), __dirname, _path2.default.resolve(__dirname, '../../../src')];
+var includePaths = exports.includePaths = [_path2.default.resolve('./')];
+
+var excludePaths = exports.excludePaths = [_path2.default.resolve('./node_modules')];

--- a/dist/server/config/webpack.config.js
+++ b/dist/server/config/webpack.config.js
@@ -37,7 +37,8 @@ var config = {
       test: /\.jsx?$/,
       loader: 'babel',
       query: require('./babel.js'),
-      include: _paths.includePaths
+      include: _paths.includePaths,
+      exclude: _paths.excludePaths
     }]
   }
 };

--- a/dist/server/config/webpack.config.prod.js
+++ b/dist/server/config/webpack.config.prod.js
@@ -47,7 +47,8 @@ var config = {
       test: /\.jsx?$/,
       loader: 'babel',
       query: require('./babel.prod.js'),
-      include: _paths.includePaths
+      include: _paths.includePaths,
+      exclude: _paths.excludePaths
     }]
   }
 };

--- a/src/server/config/paths.js
+++ b/src/server/config/paths.js
@@ -2,5 +2,8 @@ import path from 'path';
 
 export const includePaths = [
   path.resolve('./'),
-  __dirname, path.resolve(__dirname, '../../../src'),
+];
+
+export const excludePaths = [
+  path.resolve('./node_modules'),
 ];

--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import webpack from 'webpack';
-import { includePaths } from './paths';
+import { includePaths, excludePaths } from './paths';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 
 const config = {
@@ -31,6 +31,7 @@ const config = {
         loader: 'babel',
         query: require('./babel.js'),
         include: includePaths,
+        exclude: excludePaths,
       },
     ],
   },

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import webpack from 'webpack';
-import { includePaths } from './paths';
+import { includePaths, excludePaths } from './paths';
 
 const entries = {
   preview: [],
@@ -42,6 +42,7 @@ const config = {
         loader: 'babel',
         query: require('./babel.prod.js'),
         include: includePaths,
+        exclude: excludePaths,
       },
     ],
   },


### PR DESCRIPTION
Introduce excludePath for babel-loader so it'll stop transpiling the `node_modules` directory.
