### PR TITLE
remove extract-text-webpack-plugin dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "css-loader": "0.23.1",
     "es6-shim": "^0.35.1",
     "express": "^4.13.3",
-    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "json-loader": "^0.5.4",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
resolves https://github.com/kadirahq/react-storybook/issues/367

allows storybook v2 usage with webpack v2 projects. 

@arunoda reports `extract-text-webpack-plugin` is unused
