### PR TITLE
Add webpack2 support by changing the use of OccurenceOrderPlugin.

### DIFF
--- a/dist/server/config/defaults/webpack.config.js
+++ b/dist/server/config/defaults/webpack.config.js
@@ -8,7 +8,7 @@ var _autoprefixer = require('autoprefixer');
 
 var _autoprefixer2 = _interopRequireDefault(_autoprefixer);
 
-var _paths = require('../paths');
+var _utils = require('../utils');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -17,22 +17,22 @@ module.exports = function (storybookBaseConfig) {
   var newConfig = storybookBaseConfig;
   newConfig.module.loaders = [].concat((0, _toConsumableArray3.default)(newConfig.module.loaders), [{
     test: /\.css?$/,
-    include: _paths.includePaths,
+    include: _utils.includePaths,
     loaders: [require.resolve('style-loader'), require.resolve('css-loader'), require.resolve('postcss-loader')]
   }, {
     test: /\.json$/,
-    include: _paths.includePaths,
+    include: _utils.includePaths,
     loader: require.resolve('json-loader')
   }, {
     test: /\.(jpg|png|gif|eot|svg|ttf|woff|woff2)(\?.*)?$/,
-    include: _paths.includePaths,
+    include: _utils.includePaths,
     loader: require.resolve('file-loader'),
     query: {
       name: 'static/media/[name].[hash:8].[ext]'
     }
   }, {
     test: /\.(mp4|webm)(\?.*)?$/,
-    include: _paths.includePaths,
+    include: _utils.includePaths,
     loader: require.resolve('url-loader'),
     query: {
       limit: 10000,

--- a/dist/server/config/utils.js
+++ b/dist/server/config/utils.js
@@ -3,13 +3,23 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.excludePaths = exports.includePaths = undefined;
+exports.excludePaths = exports.includePaths = exports.OccurenceOrderPlugin = undefined;
+
+var _webpack = require('webpack');
+
+var _webpack2 = _interopRequireDefault(_webpack);
 
 var _path = require('path');
 
 var _path2 = _interopRequireDefault(_path);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var OccurenceOrderPlugin =
+// for webpack 2
+exports.OccurenceOrderPlugin = _webpack2.default.optimize.OccurrenceOrderPlugin ||
+// for webpack 1
+_webpack2.default.optimize.OccurenceOrderPlugin;
 
 var includePaths = exports.includePaths = [_path2.default.resolve('./')];
 

--- a/dist/server/config/webpack.config.js
+++ b/dist/server/config/webpack.config.js
@@ -12,11 +12,11 @@ var _webpack = require('webpack');
 
 var _webpack2 = _interopRequireDefault(_webpack);
 
-var _paths = require('./paths');
-
 var _caseSensitivePathsWebpackPlugin = require('case-sensitive-paths-webpack-plugin');
 
 var _caseSensitivePathsWebpackPlugin2 = _interopRequireDefault(_caseSensitivePathsWebpackPlugin);
+
+var _utils = require('./utils');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -31,14 +31,14 @@ var config = {
     filename: 'static/[name].bundle.js',
     publicPath: '/'
   },
-  plugins: [new _webpack2.default.optimize.OccurenceOrderPlugin(), new _webpack2.default.HotModuleReplacementPlugin(), new _caseSensitivePathsWebpackPlugin2.default()],
+  plugins: [new _utils.OccurenceOrderPlugin(), new _webpack2.default.HotModuleReplacementPlugin(), new _caseSensitivePathsWebpackPlugin2.default()],
   module: {
     loaders: [{
       test: /\.jsx?$/,
       loader: require.resolve('babel-loader'),
       query: require('./babel.js'),
-      include: _paths.includePaths,
-      exclude: _paths.excludePaths
+      include: _utils.includePaths,
+      exclude: _utils.excludePaths
     }]
   }
 };

--- a/dist/server/config/webpack.config.prod.js
+++ b/dist/server/config/webpack.config.prod.js
@@ -12,7 +12,7 @@ var _webpack = require('webpack');
 
 var _webpack2 = _interopRequireDefault(_webpack);
 
-var _paths = require('./paths');
+var _utils = require('./utils');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -29,7 +29,7 @@ var config = {
     filename: 'static/[name].bundle.js',
     publicPath: '/'
   },
-  plugins: [new _webpack2.default.DefinePlugin({ 'process.env.NODE_ENV': '"production"' }), new _webpack2.default.optimize.OccurrenceOrderPlugin(), new _webpack2.default.optimize.DedupePlugin(), new _webpack2.default.optimize.UglifyJsPlugin({
+  plugins: [new _webpack2.default.DefinePlugin({ 'process.env.NODE_ENV': '"production"' }), new _webpack2.default.optimize.DedupePlugin(), new _webpack2.default.optimize.UglifyJsPlugin({
     compress: {
       screw_ie8: true,
       warnings: false
@@ -47,10 +47,16 @@ var config = {
       test: /\.jsx?$/,
       loader: require.resolve('babel-loader'),
       query: require('./babel.prod.js'),
-      include: _paths.includePaths,
-      exclude: _paths.excludePaths
+      include: _utils.includePaths,
+      exclude: _utils.excludePaths
     }]
   }
 };
+
+// Webpack 2 doesn't have a OccurenceOrderPlugin plugin in the production mode.
+// But webpack 1 has it. That's why we do this.
+if (_utils.OccurenceOrderPlugin) {
+  config.plugins.unshift(new _utils.OccurenceOrderPlugin());
+}
 
 exports.default = config;

--- a/src/server/config/defaults/webpack.config.js
+++ b/src/server/config/defaults/webpack.config.js
@@ -1,5 +1,5 @@
 import autoprefixer from 'autoprefixer';
-import { includePaths } from '../paths';
+import { includePaths } from '../utils';
 
 // Add a default custom config which is similar to what React Create App does.
 module.exports = (storybookBaseConfig) => {

--- a/src/server/config/paths.js
+++ b/src/server/config/paths.js
@@ -1,9 +1,0 @@
-import path from 'path';
-
-export const includePaths = [
-  path.resolve('./'),
-];
-
-export const excludePaths = [
-  path.resolve('./node_modules'),
-];

--- a/src/server/config/utils.js
+++ b/src/server/config/utils.js
@@ -1,0 +1,16 @@
+import webpack from 'webpack';
+import path from 'path';
+
+export const OccurenceOrderPlugin =
+  // for webpack 2
+  webpack.optimize.OccurrenceOrderPlugin ||
+  // for webpack 1
+  webpack.optimize.OccurenceOrderPlugin;
+
+export const includePaths = [
+  path.resolve('./'),
+];
+
+export const excludePaths = [
+  path.resolve('./node_modules'),
+];

--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import webpack from 'webpack';
-import { includePaths, excludePaths } from './paths';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
+import { OccurenceOrderPlugin, includePaths, excludePaths } from './utils';
 
 const config = {
   devtool: '#cheap-module-eval-source-map',
@@ -22,7 +22,7 @@ const config = {
     publicPath: '/',
   },
   plugins: [
-    new webpack.optimize.OccurenceOrderPlugin(),
+    new OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new CaseSensitivePathsPlugin(),
   ],

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import webpack from 'webpack';
-import { includePaths, excludePaths } from './paths';
+import { OccurenceOrderPlugin, includePaths, excludePaths } from './utils';
 
 const entries = {
   preview: [
@@ -22,7 +22,6 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"production"' }),
-    new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
@@ -50,5 +49,11 @@ const config = {
     ],
   },
 };
+
+// Webpack 2 doesn't have a OccurenceOrderPlugin plugin in the production mode.
+// But webpack 1 has it. That's why we do this.
+if (OccurenceOrderPlugin) {
+  config.plugins.unshift(new OccurenceOrderPlugin());
+}
 
 export default config;


### PR DESCRIPTION
Fixes: #396, #248 

Stil storybook comes with Webpack 1. But it's possible to use webpack2 if your project use Webpack2.

Here we simply try to use the OccurenceOrderPlugin in both Webpack2 and Webpack1 in the way they exists. 
