### PR TITLE
Use JSON5 instead of CJSON to parse .babelrc.

### DIFF
--- a/dist/server/config.js
+++ b/dist/server/config.js
@@ -92,9 +92,9 @@ var _path = require('path');
 
 var _path2 = _interopRequireDefault(_path);
 
-var _cjson = require('cjson');
+var _json = require('json5');
 
-var _cjson2 = _interopRequireDefault(_cjson);
+var _json2 = _interopRequireDefault(_json);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -114,7 +114,7 @@ function loadBabelConfig(babelConfigPath) {
   if (_fs2.default.existsSync(babelConfigPath)) {
     var content = _fs2.default.readFileSync(babelConfigPath, 'utf-8');
     try {
-      config = _cjson2.default.parse(content);
+      config = _json2.default.parse(content);
       config.babelrc = false;
       logger.info('=> Loading custom .babelrc');
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "file-loader": "^0.9.0",
     "json-loader": "^0.5.4",
     "json-stringify-safe": "^5.0.1",
+    "json5": "^0.5.0",
     "lodash.pick": "^4.2.0",
     "postcss-loader": "0.9.1",
     "qs": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "babel-preset-react": "^6.11.1",
     "babel-runtime": "^6.9.2",
     "case-sensitive-paths-webpack-plugin": "^1.1.2",
-    "cjson": "^0.4.0",
     "commander": "^2.9.0",
     "configstore": "^2.0.0",
     "css-loader": "0.23.1",

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import cjson from 'cjson';
+import JSON5 from 'json5';
 
 // avoid ESLint errors
 const logger = console;
@@ -18,7 +18,7 @@ function loadBabelConfig(babelConfigPath) {
   if (fs.existsSync(babelConfigPath)) {
     const content = fs.readFileSync(babelConfigPath, 'utf-8');
     try {
-      config = cjson.parse(content);
+      config = JSON5.parse(content);
       config.babelrc = false;
       logger.info('=> Loading custom .babelrc');
     } catch (e) {


### PR DESCRIPTION
Fixes #362 
