### PR TITLE
Simplify the option to stop tracking.

### DIFF
--- a/dist/server/index.js
+++ b/dist/server/index.js
@@ -33,18 +33,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var logger = console;
 
-_commander2.default.version(_package2.default.version).option('-p, --port [number]', 'Port to run Storybook (Required)', parseInt).option('-h, --host [string]', 'Host to run Storybook').option('-s, --static-dir <dir-names>', 'Directory where to load static files from', _utils.parseList).option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from').option('--dont-track', 'Do not send anonymous usage stats').option('--do-track', 'Send anonymous usage stats').parse(process.argv);
+_commander2.default.version(_package2.default.version).option('-p, --port [number]', 'Port to run Storybook (Required)', parseInt).option('-h, --host [string]', 'Host to run Storybook').option('-s, --static-dir <dir-names>', 'Directory where to load static files from', _utils.parseList).option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from').option('--dont-track', 'Do not send anonymous usage stats.').parse(process.argv);
 
 if (_commander2.default.dontTrack) {
   (0, _track_usage.dontTrack)();
-  logger.info('Storybook would not send anonymous usage stats anymore.');
-  process.exit(0);
-}
-
-if (_commander2.default.doTrack) {
-  (0, _track_usage.dontTrack)(false);
-  logger.info('Storybook would send anonymous usage to getstorybooks.io.');
-  process.exit(0);
 }
 
 if (!_commander2.default.port) {

--- a/dist/server/track_usage.js
+++ b/dist/server/track_usage.js
@@ -42,8 +42,9 @@ var logger = console; // ### WHAT?
 // ### CAN I STOP THIS?
 //
 // You(or your company) may have certain policies.
-// If so, you can stop sending these metrics. Simply run:
-//    start-storybook --dont-track
+// If so, you can stop sending these metrics.
+// To do that, use --dont-track flag when running React Storybook.
+//    start-storybook --dont-track -p 9001
 
 // ### HELP US?
 //
@@ -54,6 +55,8 @@ var logger = console; // ### WHAT?
 // service around it. With that, we could continue to maintain and
 // improve Storybook.
 
+var DONT_TRACK = false;
+
 function getStore() {
   var key = 'react-storybook-usage';
   var store = new _configstore2.default(key);
@@ -61,6 +64,8 @@ function getStore() {
 }
 
 function track() {
+  if (DONT_TRACK) return;
+
   var store = getStore();
 
   // Just a hash to aggregate metrics. Don't use any personal info.
@@ -69,22 +74,6 @@ function track() {
     userId = _uuid2.default.v4();
     store.set('userId', userId);
   }
-
-  if (store.get('dontTrack')) {
-    // Here we'll try to send a one last ping saying you are asked to don't track.
-    // We used this to identify the ratio of dontTrack.
-    if (!store.get('notifiedDontTrack')) {
-      // We don't wanna worry about the success or failure of this.
-      _request2.default.post('https://ping.getstorybook.io/react-storybook-dont-track', {
-        json: { userId: userId }
-      }, function () {});
-      store.set('notifiedDontTrack', true);
-    }
-    return;
-  }
-
-  // We need to clear this in case user decided to track again.
-  store.set('notifiedDontTrack', null);
 
   var pkg = require('../../package.json');
 
@@ -111,8 +100,5 @@ function track() {
 }
 
 function dontTrack() {
-  var state = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
-
-  var store = getStore();
-  store.set('dontTrack', Boolean(state));
+  DONT_TRACK = true;
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -17,21 +17,12 @@ program
   .option('-h, --host [string]', 'Host to run Storybook')
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
-  .option('--dont-track', 'Do not send anonymous usage stats')
-  .option('--do-track', 'Send anonymous usage stats')
+  .option('--dont-track', 'Do not send anonymous usage stats.')
   .parse(process.argv);
 
 
 if (program.dontTrack) {
   dontTrack();
-  logger.info('Storybook would not send anonymous usage stats anymore.');
-  process.exit(0);
-}
-
-if (program.doTrack) {
-  dontTrack(false);
-  logger.info('Storybook would send anonymous usage to getstorybooks.io.');
-  process.exit(0);
 }
 
 if (!program.port) {

--- a/src/server/track_usage.js
+++ b/src/server/track_usage.js
@@ -19,8 +19,9 @@
 // ### CAN I STOP THIS?
 //
 // You(or your company) may have certain policies.
-// If so, you can stop sending these metrics. Simply run:
-//    start-storybook --dont-track
+// If so, you can stop sending these metrics.
+// To do that, use --dont-track flag when running React Storybook.
+//    start-storybook --dont-track -p 9001
 
 // ### HELP US?
 //
@@ -37,6 +38,8 @@ import request from 'request';
 
 const logger = console;
 
+let DONT_TRACK = false;
+
 export function getStore() {
   const key = 'react-storybook-usage';
   const store = new ConfigStore(key);
@@ -44,6 +47,8 @@ export function getStore() {
 }
 
 export function track() {
+  if (DONT_TRACK) return;
+
   const store = getStore();
 
   // Just a hash to aggregate metrics. Don't use any personal info.
@@ -52,22 +57,6 @@ export function track() {
     userId = UUID.v4();
     store.set('userId', userId);
   }
-
-  if (store.get('dontTrack')) {
-    // Here we'll try to send a one last ping saying you are asked to don't track.
-    // We used this to identify the ratio of dontTrack.
-    if (!store.get('notifiedDontTrack')) {
-      // We don't wanna worry about the success or failure of this.
-      request.post('https://ping.getstorybook.io/react-storybook-dont-track', {
-        json: { userId },
-      }, () => {});
-      store.set('notifiedDontTrack', true);
-    }
-    return;
-  }
-
-  // We need to clear this in case user decided to track again.
-  store.set('notifiedDontTrack', null);
 
   const pkg = require('../../package.json');
 
@@ -93,7 +82,6 @@ export function track() {
   }
 }
 
-export function dontTrack(state = true) {
-  const store = getStore();
-  store.set('dontTrack', Boolean(state));
+export function dontTrack() {
+  DONT_TRACK = true;
 }


### PR DESCRIPTION
Fixes #395

Now you can pass `--dont-track` option to start-storybook.
Then it won't send any tracking pings.

If there's no `--dont-track` option, it'll will send the ping.

This is pretty useful when you are working in a team and you want to stop tracking. So, you can --dont-track option to your NPM script and it'll apply to anyone who uses this project.
