### PR TITLE
remove webpack-hot-middleware's config > noInfo=true

### DIFF
--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -13,7 +13,7 @@ const config = {
     preview: [
       require.resolve('./polyfills'),
       require.resolve('./error_enhancements'),
-      `${require.resolve('webpack-hot-middleware/client')}?noInfo=true`,
+      require.resolve('webpack-hot-middleware/client'),
     ],
   },
   output: {


### PR DESCRIPTION
we really need HMR's info for debug.

![image](https://cloud.githubusercontent.com/assets/5069410/18046810/3c1a8396-6e0c-11e6-938b-97f8ef24fa50.png)
