### PR TITLE
Support read-only db with build-storybook

### DIFF
--- a/dist/client/manager/provider.js
+++ b/dist/client/manager/provider.js
@@ -69,7 +69,12 @@ var ReactProvider = function (_Provider) {
     _storybookAddons2.default.setChannel(_this.channel);
     _this.database = _storybookAddons2.default.getDatabase();
     if (!_this.database) {
-      _this.database = (0, _storybookDatabaseLocal2.default)({ url: location.origin + '/db' });
+      var bundled = process.env.NODE_ENV === 'production';
+      if (bundled) {
+        _this.database = (0, _storybookDatabaseLocal2.default)({ url: 'addon-db.json', bundled: bundled });
+      } else {
+        _this.database = (0, _storybookDatabaseLocal2.default)({ url: location.origin + '/db' });
+      }
       _storybookAddons2.default.setDatabase(_this.database);
     }
     return _this;

--- a/dist/server/build.js
+++ b/dist/server/build.js
@@ -50,7 +50,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 // avoid ESLint errors
 var logger = console;
 
-_commander2.default.version(_package2.default.version).option('-s, --static-dir <dir-names>', 'Directory where to load static files from', _utils.parseList).option('-o, --output-dir [dir-name]', 'Directory where to store built files').option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from').option('-d, --db-path [db-file]', 'File where to store addon database JSON file').option('--enable-db', 'Enable the (experimental) addon database service on dev-server').parse(process.argv);
+_commander2.default.version(_package2.default.version).option('-s, --static-dir <dir-names>', 'Directory where to load static files from', _utils.parseList).option('-o, --output-dir [dir-name]', 'Directory where to store built files').option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from').option('-d, --db-path [db-file]', 'Path to the addon database JSON file').option('--enable-db', 'Enable the (experimental) addon database service on dev-server').parse(process.argv);
 
 // The key is the field created in `program` variable for
 // each command line argument. Value is the env variable.

--- a/dist/server/build.js
+++ b/dist/server/build.js
@@ -50,7 +50,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 // avoid ESLint errors
 var logger = console;
 
-_commander2.default.version(_package2.default.version).option('-s, --static-dir <dir-names>', 'Directory where to load static files from', _utils.parseList).option('-o, --output-dir [dir-name]', 'Directory where to store built files').option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from').parse(process.argv);
+_commander2.default.version(_package2.default.version).option('-s, --static-dir <dir-names>', 'Directory where to load static files from', _utils.parseList).option('-o, --output-dir [dir-name]', 'Directory where to store built files').option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from').option('-d, --db-path [db-file]', 'File where to store addon database JSON file').option('--enable-db', 'Enable the (experimental) addon database service on dev-server').parse(process.argv);
 
 // The key is the field created in `program` variable for
 // each command line argument. Value is the env variable.
@@ -84,6 +84,13 @@ if (_commander2.default.staticDir) {
     logger.log('=> Copying static files from: ' + dir);
     _shelljs2.default.cp('-r', dir + '/', outputDir);
   });
+}
+
+// The addon database service is disabled by default for now
+// It should be enabled with the --enable-db for dev server
+if (_commander2.default.enableDb) {
+  var dbPath = _commander2.default.dbPath || './.storybook/addon-db.json';
+  _shelljs2.default.cp(dbPath, outputDir);
 }
 
 // Write both the storybook UI and IFRAME HTML files to destination path.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@kadira/storybook-addon-links": "^1.0.0",
     "@kadira/storybook-addons": "^1.5.0",
     "@kadira/storybook-channel-pagebus": "^2.0.2",
-    "@kadira/storybook-database-local": "^1.1.0",
+    "@kadira/storybook-database-local": "^1.2.0",
     "@kadira/storybook-ui": "^3.4.0",
     "autoprefixer": "^6.3.7",
     "babel-core": "^6.11.4",

--- a/src/client/manager/provider.js
+++ b/src/client/manager/provider.js
@@ -15,7 +15,12 @@ export default class ReactProvider extends Provider {
     addons.setChannel(this.channel);
     this.database = addons.getDatabase();
     if (!this.database) {
-      this.database = createDatabase({ url: `${location.origin}/db` });
+      const bundled = process.env.NODE_ENV === 'production';
+      if (bundled) {
+        this.database = createDatabase({ url: 'addon-db.json', bundled });
+      } else {
+        this.database = createDatabase({ url: `${location.origin}/db` });
+      }
       addons.setDatabase(this.database);
     }
   }

--- a/src/server/build.js
+++ b/src/server/build.js
@@ -22,6 +22,8 @@ program
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
   .option('-o, --output-dir [dir-name]', 'Directory where to store built files')
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
+  .option('-d, --db-path [db-file]', 'File where to store addon database JSON file')
+  .option('--enable-db', 'Enable the (experimental) addon database service on dev-server')
   .parse(process.argv);
 
 // The key is the field created in `program` variable for
@@ -56,6 +58,13 @@ if (program.staticDir) {
     logger.log(`=> Copying static files from: ${dir}`);
     shelljs.cp('-r', `${dir}/`, outputDir);
   });
+}
+
+// The addon database service is disabled by default for now
+// It should be enabled with the --enable-db for dev server
+if (program.enableDb) {
+  const dbPath = program.dbPath || './.storybook/addon-db.json';
+  shelljs.cp(dbPath, outputDir);
 }
 
 // Write both the storybook UI and IFRAME HTML files to destination path.

--- a/src/server/build.js
+++ b/src/server/build.js
@@ -22,7 +22,7 @@ program
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
   .option('-o, --output-dir [dir-name]', 'Directory where to store built files')
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
-  .option('-d, --db-path [db-file]', 'File where to store addon database JSON file')
+  .option('-d, --db-path [db-file]', 'Path to the addon database JSON file')
   .option('--enable-db', 'Enable the (experimental) addon database service on dev-server')
   .parse(process.argv);
 


### PR DESCRIPTION
The `@kadira/storybook-database-local` package now supports static JSON files as read-only DBs. This is useful when creating static storybooks with the `build-storybook` script and hosting them on Github pages. This PR updates the static build script to copy the database file when building static storybooks.
