### PR TITLE
Do not include addon register file on preview

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -89,10 +89,8 @@ export default function (configType, baseConfig, configDir) {
   const storybookCustomAddonsPath = path.resolve(configDir, 'addons.js');
   if (fs.existsSync(storybookCustomAddonsPath)) {
     logger.info('=> Loading custom addons config.');
-    config.entry.preview.unshift(storybookCustomAddonsPath);
     config.entry.manager.unshift(storybookCustomAddonsPath);
   } else {
-    config.entry.preview.unshift(storybookDefaultAddonsPath);
     config.entry.manager.unshift(storybookDefaultAddonsPath);
   }
 


### PR DESCRIPTION
The register function should be only used on Storybook Manager.
