### PR TITLE
Fix issue on error message hanging after even it solved.

### DIFF
--- a/dist/client/preview/config_api.js
+++ b/dist/client/preview/config_api.js
@@ -18,6 +18,8 @@ var _ = require('./');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+/* globals location */
+
 var ConfigApi = function () {
   function ConfigApi(_ref) {
     var channel = _ref.channel;
@@ -63,7 +65,16 @@ var ConfigApi = function () {
         try {
           _this._renderMain(loaders);
         } catch (error) {
-          _this._renderError(error);
+          if (module.hot.status() === 'apply') {
+            // We got this issue, after webpack fixed it and applying it.
+            // Therefore error message is displayed forever even it's being fixed.
+            // So, we'll detect it reload the page.
+            location.reload();
+          } else {
+            // If we are accessing the site, but the error is not fixed yet.
+            // There we can render the error.
+            _this._renderError(error);
+          }
         }
       };
 

--- a/src/client/preview/config_api.js
+++ b/src/client/preview/config_api.js
@@ -1,3 +1,5 @@
+/* globals location */
+
 import {
   setInitialStory,
   setError,
@@ -38,7 +40,16 @@ export default class ConfigApi {
       try {
         this._renderMain(loaders);
       } catch (error) {
-        this._renderError(error);
+        if (module.hot.status() === 'apply') {
+          // We got this issue, after webpack fixed it and applying it.
+          // Therefore error message is displayed forever even it's being fixed.
+          // So, we'll detect it reload the page.
+          location.reload();
+        } else {
+          // If we are accessing the site, but the error is not fixed yet.
+          // There we can render the error.
+          this._renderError(error);
+        }
       }
     };
 


### PR DESCRIPTION
Webpack detects a error in the code, it'll display a message on the terminal and the browser.
But when we fixed that error, storybook shows it's own error message which is not valid.

So in that case, we need to reload after we fixed an error.
That's what we are doing here.
