### PR TITLE
Create empty db file for static build

### DIFF
--- a/dist/server/build.js
+++ b/dist/server/build.js
@@ -90,6 +90,10 @@ if (_commander2.default.staticDir) {
 // It should be enabled with the --enable-db for dev server
 if (_commander2.default.enableDb) {
   var dbPath = _commander2.default.dbPath || _path2.default.resolve(configDir, 'addon-db.json');
+  // create addon-db.json file if it's missing to avoid the 404 error
+  if (!_fs2.default.existsSync(dbPath)) {
+    _fs2.default.writeFileSync(dbPath, '{}');
+  }
   _shelljs2.default.cp(dbPath, outputDir);
 }
 

--- a/src/server/build.js
+++ b/src/server/build.js
@@ -64,6 +64,10 @@ if (program.staticDir) {
 // It should be enabled with the --enable-db for dev server
 if (program.enableDb) {
   const dbPath = program.dbPath || path.resolve(configDir, 'addon-db.json');
+  // create addon-db.json file if it's missing to avoid the 404 error
+  if (!fs.existsSync(dbPath)) {
+    fs.writeFileSync(dbPath, '{}');
+  }
   shelljs.cp(dbPath, outputDir);
 }
 


### PR DESCRIPTION
This will prevent the 404 error. If we handle this on the
client side we can't be sure whether the error is caused
by an empty database or some other issue.
