### PR TITLE
Add support to get custom env variables.

### DIFF
--- a/dist/server/config/utils.js
+++ b/dist/server/config/utils.js
@@ -5,6 +5,16 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.excludePaths = exports.includePaths = exports.OccurenceOrderPlugin = undefined;
 
+var _keys = require('babel-runtime/core-js/object/keys');
+
+var _keys2 = _interopRequireDefault(_keys);
+
+var _stringify = require('babel-runtime/core-js/json/stringify');
+
+var _stringify2 = _interopRequireDefault(_stringify);
+
+exports.loadEnv = loadEnv;
+
 var _webpack = require('webpack');
 
 var _webpack2 = _interopRequireDefault(_webpack);
@@ -24,3 +34,22 @@ _webpack2.default.optimize.OccurenceOrderPlugin;
 var includePaths = exports.includePaths = [_path2.default.resolve('./')];
 
 var excludePaths = exports.excludePaths = [_path2.default.resolve('./node_modules')];
+
+// Load environment variables starts with STORYBOOK_ to the client side.
+function loadEnv() {
+  var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+  var defaultNodeEnv = options.production ? 'production' : 'development';
+  var env = {
+    'process.env.NODE_ENV': (0, _stringify2.default)(process.env.NODE_ENV || defaultNodeEnv)
+  };
+
+  (0, _keys2.default)(process.env).filter(function (name) {
+    return (/^STORYBOOK_/.test(name)
+    );
+  }).forEach(function (name) {
+    env['process.env.' + name] = (0, _stringify2.default)(process.env[name]);
+  });
+
+  return env;
+}

--- a/dist/server/config/webpack.config.js
+++ b/dist/server/config/webpack.config.js
@@ -35,7 +35,7 @@ var config = {
     filename: 'static/[name].bundle.js',
     publicPath: '/'
   },
-  plugins: [new _utils.OccurenceOrderPlugin(), new _webpack2.default.HotModuleReplacementPlugin(), new _caseSensitivePathsWebpackPlugin2.default()],
+  plugins: [new _webpack2.default.DefinePlugin((0, _utils.loadEnv)()), new _utils.OccurenceOrderPlugin(), new _webpack2.default.HotModuleReplacementPlugin(), new _caseSensitivePathsWebpackPlugin2.default()],
   module: {
     loaders: [{
       test: /\.jsx?$/,

--- a/dist/server/config/webpack.config.prod.js
+++ b/dist/server/config/webpack.config.prod.js
@@ -38,7 +38,7 @@ var config = {
     // relative URLs works always.
     publicPath: ''
   },
-  plugins: [new _webpack2.default.DefinePlugin({ 'process.env.NODE_ENV': '"production"' }), new _webpack2.default.optimize.DedupePlugin(), new _webpack2.default.optimize.UglifyJsPlugin({
+  plugins: [new _webpack2.default.DefinePlugin((0, _utils.loadEnv)({ production: true })), new _webpack2.default.optimize.DedupePlugin(), new _webpack2.default.optimize.UglifyJsPlugin({
     compress: {
       screw_ie8: true,
       warnings: false

--- a/src/server/config/utils.js
+++ b/src/server/config/utils.js
@@ -14,3 +14,19 @@ export const includePaths = [
 export const excludePaths = [
   path.resolve('./node_modules'),
 ];
+
+// Load environment variables starts with STORYBOOK_ to the client side.
+export function loadEnv(options = {}) {
+  const defaultNodeEnv = options.production ? 'production' : 'development';
+  const env = {
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || defaultNodeEnv),
+  };
+
+  Object.keys(process.env)
+    .filter((name) => /^STORYBOOK_/.test(name))
+    .forEach((name) => {
+      env[`process.env.${name}`] = JSON.stringify(process.env[name]);
+    });
+
+  return env;
+}

--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import webpack from 'webpack';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
-import { OccurenceOrderPlugin, includePaths, excludePaths } from './utils';
+import { OccurenceOrderPlugin, includePaths, excludePaths, loadEnv } from './utils';
 import babalLoaderConfig from './babel.js';
 
 const config = {
@@ -23,6 +23,7 @@ const config = {
     publicPath: '/',
   },
   plugins: [
+    new webpack.DefinePlugin(loadEnv()),
     new OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new CaseSensitivePathsPlugin(),

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import webpack from 'webpack';
-import { OccurenceOrderPlugin, includePaths, excludePaths } from './utils';
+import { OccurenceOrderPlugin, includePaths, excludePaths, loadEnv } from './utils';
 import babalLoaderConfig from './babel.prod.js';
 
 const entries = {
@@ -27,7 +27,7 @@ const config = {
     publicPath: '',
   },
   plugins: [
-    new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"production"' }),
+    new webpack.DefinePlugin(loadEnv({ production: true })),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({
       compress: {


### PR DESCRIPTION
User can pass env. variables prefixed with STORYBOOK_
and it'll be passed to the client.

If our env variable is `STORYBOOK_SCORE=100`, then you can get it via `process.env.STORYBOOK_SCORE` from the client.
### Todo
- [ ] Update docs on getstorybook.io
