### PR TITLE
Move the babel config loading logic into a seperate file

### DIFF
--- a/src/server/babel_config.js
+++ b/src/server/babel_config.js
@@ -1,0 +1,70 @@
+/* eslint global-require: 0 */
+
+import fs from 'fs';
+import path from 'path';
+import JSON5 from 'json5';
+import defaultConfig from './config/babel.js';
+// avoid ESLint errors
+const logger = console;
+
+function removeReactHmre(presets) {
+  const index = presets.indexOf('react-hmre');
+  if (index > -1) {
+    presets.splice(index, 1);
+  }
+}
+
+// Tries to load a .babelrc and returns the parsed object if successful
+function loadFromPath(babelConfigPath) {
+  let config;
+  if (fs.existsSync(babelConfigPath)) {
+    const content = fs.readFileSync(babelConfigPath, 'utf-8');
+    try {
+      config = JSON5.parse(content);
+      config.babelrc = false;
+      logger.info('=> Loading custom .babelrc');
+    } catch (e) {
+      logger.error(`=> Error parsing .babelrc file: ${e.message}`);
+      throw e;
+    }
+  }
+
+  if (!config) return null;
+
+  // Remove react-hmre preset.
+  // It causes issues with react-storybook.
+  // We don't really need it.
+  // Earlier, we fix this by runnign storybook in the production mode.
+  // But, that hide some useful debug messages.
+  if (config.presets) {
+    removeReactHmre(config.presets);
+  }
+
+  if (config.env && config.env.development && config.env.development.presets) {
+    removeReactHmre(config.env.development.presets);
+  }
+
+  return config;
+}
+
+export default function (configDir) {
+  let babelConfig = loadFromPath(path.resolve(configDir, '.babelrc'));
+  let inConfigDir = true;
+
+  if (!babelConfig) {
+    babelConfig = loadFromPath('.babelrc');
+    inConfigDir = false;
+  }
+
+  if (babelConfig) {
+    // If the custom config uses babel's `extends` clause, then replace it with
+    // an absolute path. `extends` will not work unless we do this.
+    if (babelConfig.extends) {
+      babelConfig.extends = inConfigDir ?
+        path.resolve(configDir, babelConfig.extends) :
+        path.resolve(babelConfig.extends);
+    }
+  }
+
+  return babelConfig || defaultConfig;
+}


### PR DESCRIPTION
Now everything regarding loading babel configuration is handled in a single file. So by requiring this file you can get the complete babel config. This should help supporting tools like storybook snapshot tests to get users babel config.
