### PR TITLE
Stop uglifyjs from mangling names.

### DIFF
--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -35,9 +35,7 @@ export default function () {
           screw_ie8: true,
           warnings: false,
         },
-        mangle: {
-          screw_ie8: true,
-        },
+        mangle: false,
         output: {
           comments: false,
           screw_ie8: true,


### PR DESCRIPTION
Mangling affects info addon’s source inspection. Now the correct component name will be displayed in it.
