### PR TITLE
Update typings

### DIFF
--- a/config/storybook.d.ts
+++ b/config/storybook.d.ts
@@ -9,5 +9,6 @@ interface Story {
     addDecorator (decorator: StoryDecorator): Story;
 }
 
+export function linkTo(name: string, ...params: any[]): void;
 export function storiesOf(name: string, module: any): Story;
-export function action(name: string, ...params: any[]): Function;
+export function action(name: string, ...params: any[]): any;


### PR DESCRIPTION
- add typings for `linkTo` addon
- action must return `any` since it brakes typings chain

So, having such example leads to the typescript error 
`error TS2322: Type 'Function' is not assignable to type '(newVal: string) => void'.`

``` js
interface Props {
    onChange?(newVal: string): void,
}

class ExampleComponent extends Component<Props, void> {
    render() {
        return (
                <input onChange={this.props.onChange}>Hi!</div>
        )
    }
}

storiesOf('Example', module)
        .add('Regular use case', () => (
                <ExampleComponent onChange={action('changed')}/>
        ))
```
