### PR TITLE
Prefix config environment variables

### DIFF
--- a/src/server/build.js
+++ b/src/server/build.js
@@ -29,9 +29,9 @@ program
 // The key is the field created in `program` variable for
 // each command line argument. Value is the env variable.
 getEnvConfig(program, {
-  staticDir: 'STATIC_DIR',
-  outputDir: 'OUTPUT_DIR',
-  configDir: 'CONFIG_DIR',
+  staticDir: 'SBCONFIG_STATIC_DIR',
+  outputDir: 'SBCONFIG_OUTPUT_DIR',
+  configDir: 'SBCONFIG_CONFIG_DIR',
 });
 
 const configDir = program.configDir || './.storybook';

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -27,11 +27,11 @@ program
 // The key is the field created in `program` variable for
 // each command line argument. Value is the env variable.
 getEnvConfig(program, {
-  port: 'PORT',
-  host: 'HOSTNAME',
-  staticDir: 'STATIC_DIR',
-  configDir: 'CONFIG_DIR',
-  dontTrack: 'DO_NOT_TRACK',
+  port: 'SBCONFIG_PORT',
+  host: 'SBCONFIG_HOSTNAME',
+  staticDir: 'SBCONFIG_STATIC_DIR',
+  configDir: 'SBCONFIG_CONFIG_DIR',
+  dontTrack: 'SBCONFIG_DO_NOT_TRACK',
 });
 
 if (program.dontTrack) {


### PR DESCRIPTION
Vairables like HOSTNAME have other values
which can cause unexpected errors. Fixes #502
