### PR TITLE
Update postmsg channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@kadira/storybook-addon-actions": "^1.0.2",
     "@kadira/storybook-addon-links": "^1.0.0",
     "@kadira/storybook-addons": "^1.5.0",
-    "@kadira/storybook-channel-postmsg": "^1.0.1",
+    "@kadira/storybook-channel-postmsg": "^1.0.3",
     "@kadira/storybook-database-local": "^1.2.1",
     "@kadira/storybook-ui": "^3.6.0",
     "airbnb-js-shims": "^1.0.1",


### PR DESCRIPTION
It appears that postMessage throws an error when used with objects with methods.
Release `v1.0.3` encodes data before sending over postMessage.
