### PR TITLE
Remove local db from react-storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@kadira/storybook-addon-links": "^1.0.0",
     "@kadira/storybook-addons": "^1.5.0",
     "@kadira/storybook-channel-postmsg": "^1.0.3",
-    "@kadira/storybook-database-local": "^1.2.1",
     "@kadira/storybook-ui": "^3.6.0",
     "airbnb-js-shims": "^1.0.1",
     "autoprefixer": "^6.3.7",

--- a/src/client/manager/provider.js
+++ b/src/client/manager/provider.js
@@ -7,7 +7,6 @@ import React from 'react';
 import { Provider } from '@kadira/storybook-ui';
 import addons from '@kadira/storybook-addons';
 import createChannel from '@kadira/storybook-channel-postmsg';
-import createDatabase from '@kadira/storybook-database-local';
 import Preview from './preview';
 
 export default class ReactProvider extends Provider {
@@ -16,16 +15,6 @@ export default class ReactProvider extends Provider {
     this.dataId = UUID.v4();
     this.channel = createChannel({ key: this.dataId });
     addons.setChannel(this.channel);
-    this.database = addons.getDatabase();
-    if (!this.database && process.env.STORYBOOK_ENABLE_DB) {
-      const bundled = process.env.NODE_ENV === 'production';
-      if (bundled) {
-        this.database = createDatabase({ url: 'addon-db.json', bundled });
-      } else {
-        this.database = createDatabase({ url: `${location.origin}/db` });
-      }
-      addons.setDatabase(this.database);
-    }
   }
 
   getPanels() {

--- a/src/server/build.js
+++ b/src/server/build.js
@@ -22,8 +22,6 @@ program
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
   .option('-o, --output-dir [dir-name]', 'Directory where to store built files')
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
-  .option('-d, --db-path [db-file]', 'Path to the addon database JSON file')
-  .option('--enable-db', 'Enable the (experimental) addon database service on dev-server')
   .parse(process.argv);
 
 // The key is the field created in `program` variable for
@@ -41,19 +39,6 @@ const outputDir = program.outputDir || './storybook-static';
 shelljs.rm('-rf', outputDir);
 shelljs.mkdir('-p', path.resolve(outputDir));
 shelljs.cp(path.resolve(__dirname, 'public/favicon.ico'), outputDir);
-
-// The addon database service is disabled by default for now
-// It should be enabled with the --enable-db for dev server
-if (program.enableDb) {
-  // NOTE enables database on client
-  process.env.STORYBOOK_ENABLE_DB = 1;
-  const dbPath = program.dbPath || path.resolve(configDir, 'addon-db.json');
-  // create addon-db.json file if it's missing to avoid the 404 error
-  if (!fs.existsSync(dbPath)) {
-    fs.writeFileSync(dbPath, '{}');
-  }
-  shelljs.cp(dbPath, outputDir);
-}
 
 // Build the webpack configuration using the `baseConfig`
 // custom `.babelrc` file and `webpack.config.js` files

--- a/src/server/build.js
+++ b/src/server/build.js
@@ -22,7 +22,18 @@ program
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
   .option('-o, --output-dir [dir-name]', 'Directory where to store built files')
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
+  .option('-d, --db-path [db-file]', 'DEPRECATED!')
+  .option('--enable-db', 'DEPRECATED!')
   .parse(process.argv);
+
+if (program.enableDb || program.dbPath) {
+  logger.error([
+    'Error: the experimental local database addon is no longer bundled with',
+    'react-storybook. Please remove these flags (-d,--db-path,--enable-db)',
+    'from the command or npm script and try again.',
+  ].join(' '));
+  process.exit(1);
+}
 
 // The key is the field created in `program` variable for
 // each command line argument. Value is the env variable.

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import datastore from '@kadira/storybook-database-local/dist/server/middleware';
 import express from 'express';
 import favicon from 'serve-favicon';
 import program from 'commander';
@@ -21,8 +20,6 @@ program
   .option('-h, --host [string]', 'Host to run Storybook')
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from')
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
-  .option('-d, --db-path [db-file]', 'File where to store addon database JSON file')
-  .option('--enable-db', 'Enable the (experimental) addon database service on dev-server')
   .option('--dont-track', 'Do not send anonymous usage stats.')
   .parse(process.argv);
 
@@ -72,15 +69,6 @@ if (program.staticDir) {
 // Build the webpack configuration using the `baseConfig`
 // custom `.babelrc` file and `webpack.config.js` files
 const configDir = program.configDir || './.storybook';
-
-// The addon database service is disabled by default for now
-// It should be enabled with the --enable-db for dev server
-if (program.enableDb) {
-  // NOTE enables database on client
-  process.env.STORYBOOK_ENABLE_DB = 1;
-  const dbPath = program.dbPath || path.resolve(configDir, 'addon-db.json');
-  app.use('/db', datastore(dbPath));
-}
 
 // NOTE changes to env should be done before calling `getBaseConfig`
 // `getBaseConfig` function which is called inside the middleware

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -21,7 +21,18 @@ program
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from')
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
   .option('--dont-track', 'Do not send anonymous usage stats.')
+  .option('-d, --db-path [db-file]', 'DEPRECATED!')
+  .option('--enable-db', 'DEPRECATED!')
   .parse(process.argv);
+
+if (program.enableDb || program.dbPath) {
+  logger.error([
+    'Error: the experimental local database addon is no longer bundled with',
+    'react-storybook. Please remove these flags (-d,--db-path,--enable-db)',
+    'from the command or npm script and try again.',
+  ].join(' '));
+  process.exit(1);
+}
 
 // The key is the field created in `program` variable for
 // each command line argument. Value is the env variable.


### PR DESCRIPTION
Databases can be included using addons so there's no need to
bundle them with react-storybook
