### PR TITLE
Webpack config file.

### DIFF
--- a/dist/server/config/webpack.config.prod.js
+++ b/dist/server/config/webpack.config.prod.js
@@ -12,7 +12,7 @@ exports.default = function () {
 
   var config = {
     bail: true,
-    devtool: 'inline-source-map',
+    devtool: '#cheap-module-source-map',
     entry: entries,
     output: {
       filename: 'static/[name].bundle.js',

--- a/dist/server/config/webpack.config.prod.js
+++ b/dist/server/config/webpack.config.prod.js
@@ -12,7 +12,7 @@ exports.default = function () {
 
   var config = {
     bail: true,
-    devtool: '#cheap-module-source-map',
+    devtool: 'inline-source-map',
     entry: entries,
     output: {
       filename: 'static/[name].bundle.js',

--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -14,7 +14,7 @@ import babelLoaderConfig from './babel.js';
 
 export default function () {
   const config = {
-    devtool: '#cheap-module-eval-source-map',
+    devtool: 'inline-source-map',
     entry: {
       manager: [
         require.resolve('./polyfills'),


### PR DESCRIPTION
Making dist webpack file sourcemap debuggable for end users who build on
top of react-storybook.

This code review addresses issues of #457
Since the react-storybook is used as a toolkit for developers to build custom react components on top of it, changing this option allows a relatively light weight debug friendly version for other developers to build and debug their separate components built/demoed on react-storybook.
