### PR TITLE
Ship json-loader by default.

### DIFF
--- a/dist/server/config.js
+++ b/dist/server/config.js
@@ -12,6 +12,8 @@ var _extends2 = require('babel-runtime/helpers/extends');
 
 var _extends3 = _interopRequireDefault(_extends2);
 
+exports.addJsonLoaderIfNotAvailable = addJsonLoaderIfNotAvailable;
+
 exports.default = function (configType, baseConfig, configDir) {
   var config = baseConfig;
 
@@ -57,7 +59,7 @@ exports.default = function (configType, baseConfig, configDir) {
 
   customConfig.module = customConfig.module || {};
 
-  return (0, _extends3.default)({}, customConfig, config, {
+  var newConfig = (0, _extends3.default)({}, customConfig, config, {
     // We need to use our and custom plugins.
     plugins: [].concat((0, _toConsumableArray3.default)(config.plugins), (0, _toConsumableArray3.default)(customConfig.plugins || [])),
     module: (0, _extends3.default)({}, config.module, customConfig.module, {
@@ -67,6 +69,10 @@ exports.default = function (configType, baseConfig, configDir) {
       alias: (0, _extends3.default)({}, config.alias, customConfig.resolve && customConfig.resolve.alias)
     })
   });
+
+  addJsonLoaderIfNotAvailable(newConfig);
+
+  return newConfig;
 };
 
 var _fs = require('fs');
@@ -81,12 +87,29 @@ var _babel_config = require('./babel_config');
 
 var _babel_config2 = _interopRequireDefault(_babel_config);
 
+var _utils = require('./config/utils');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // avoid ESLint errors
+/* eslint global-require: 0 */
+
 var logger = console;
+
+function addJsonLoaderIfNotAvailable(config) {
+  var jsonLoaderExists = config.module.loaders.reduce(function (value, loader) {
+    return value || loader.test.test('my_package.json');
+  }, false);
+
+  if (!jsonLoaderExists) {
+    config.module.loaders.push({
+      test: /\.json$/,
+      include: _utils.includePaths,
+      loader: require.resolve('json-loader')
+    });
+  }
+}
 
 // `baseConfig` is a webpack configuration bundled with storybook.
 // React Storybook will look in the `configDir` directory
 // (inside working directory) if a config path is not provided.
-/* eslint global-require: 0 */

--- a/dist/server/config.js
+++ b/dist/server/config.js
@@ -63,7 +63,7 @@ exports.default = function (configType, baseConfig, configDir) {
     module: (0, _extends3.default)({}, config.module, customConfig.module, {
       loaders: [].concat((0, _toConsumableArray3.default)(config.module.loaders), (0, _toConsumableArray3.default)(customConfig.module.loaders || []))
     }),
-    resolve: (0, _extends3.default)({}, customConfig.resolve, {
+    resolve: (0, _extends3.default)({}, config.resolve, customConfig.resolve, {
       alias: (0, _extends3.default)({}, config.alias, customConfig.resolve && customConfig.resolve.alias)
     })
   });

--- a/dist/server/config/defaults/webpack.config.js
+++ b/dist/server/config/defaults/webpack.config.js
@@ -50,7 +50,6 @@ module.exports = function (storybookBaseConfig) {
     })];
   };
 
-  newConfig.resolve.extensions = ['.js', '.json', '.jsx', ''];
   newConfig.resolve.alias = (0, _extends3.default)({}, storybookBaseConfig.resolve.alias, {
     // This is to support NPM2
     'babel-runtime/regenerator': require.resolve('babel-runtime/regenerator')

--- a/dist/server/config/utils.js
+++ b/dist/server/config/utils.js
@@ -47,12 +47,12 @@ function loadEnv() {
 
   var defaultNodeEnv = options.production ? 'production' : 'development';
   var env = {
-    'NODE_ENV': process.env.NODE_ENV || defaultNodeEnv,
+    NODE_ENV: process.env.NODE_ENV || defaultNodeEnv,
     // This is to support CRA's public folder feature.
     // In production we set this to dot(.) to allow the browser to access these assests
     // even when deployed inside a subpath. (like in GitHub pages)
     // In development this is just empty as we always serves from the root.
-    'PUBLIC_URL': options.production ? '.' : ''
+    PUBLIC_URL: options.production ? '.' : ''
   };
 
   (0, _keys2.default)(process.env).filter(function (name) {

--- a/dist/server/config/webpack.config.js
+++ b/dist/server/config/webpack.config.js
@@ -24,10 +24,6 @@ exports.default = function () {
         query: _babel2.default,
         include: _utils.includePaths,
         exclude: _utils.excludePaths
-      }, {
-        test: /\.json$/,
-        include: _utils.includePaths,
-        loader: require.resolve('json-loader')
       }]
     },
     resolve: {

--- a/dist/server/config/webpack.config.js
+++ b/dist/server/config/webpack.config.js
@@ -24,9 +24,16 @@ exports.default = function () {
         query: _babel2.default,
         include: _utils.includePaths,
         exclude: _utils.excludePaths
+      }, {
+        test: /\.json$/,
+        include: _utils.includePaths,
+        loader: require.resolve('json-loader')
       }]
     },
     resolve: {
+      // Since we ship with json-loader always, it's better to move extensions to here
+      // from the default config.
+      extensions: ['.js', '.json', '.jsx', ''],
       // Add support to NODE_PATH. With this we could avoid relative path imports.
       // Based on this CRA feature: https://github.com/facebookincubator/create-react-app/issues/253
       fallback: _utils.nodePaths,

--- a/dist/server/config/webpack.config.prod.js
+++ b/dist/server/config/webpack.config.prod.js
@@ -41,6 +41,10 @@ exports.default = function () {
         query: _babelProd2.default,
         include: _utils.includePaths,
         exclude: _utils.excludePaths
+      }, {
+        test: /\.json$/,
+        include: _utils.includePaths,
+        loader: require.resolve('json-loader')
       }]
     },
     resolve: {

--- a/dist/server/config/webpack.config.prod.js
+++ b/dist/server/config/webpack.config.prod.js
@@ -41,10 +41,6 @@ exports.default = function () {
         query: _babelProd2.default,
         include: _utils.includePaths,
         exclude: _utils.excludePaths
-      }, {
-        test: /\.json$/,
-        include: _utils.includePaths,
-        loader: require.resolve('json-loader')
       }]
     },
     resolve: {

--- a/dist/server/config/webpack.config.prod.js
+++ b/dist/server/config/webpack.config.prod.js
@@ -48,6 +48,9 @@ exports.default = function () {
       }]
     },
     resolve: {
+      // Since we ship with json-loader always, it's better to move extensions to here
+      // from the default config.
+      extensions: ['.js', '.json', '.jsx', ''],
       // Add support to NODE_PATH. With this we could avoid relative path imports.
       // Based on this CRA feature: https://github.com/facebookincubator/create-react-app/issues/253
       fallback: _utils.nodePaths,

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -13,7 +13,7 @@ export function addJsonLoaderIfNotAvailable(config) {
     (value, loader) => {
       return value || loader.test.test('my_package.json');
     },
-    false,
+    false
   );
 
   if (!jsonLoaderExists) {

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -3,9 +3,27 @@
 import fs from 'fs';
 import path from 'path';
 import loadBabelConfig from './babel_config';
+import { includePaths } from './config/utils';
 
 // avoid ESLint errors
 const logger = console;
+
+export function addJsonLoaderIfNotAvailable(config) {
+  const jsonLoaderExists = config.module.loaders.reduce(
+    (value, loader) => {
+      return value || loader.test.test('my_package.json');
+    },
+    false,
+  );
+
+  if (!jsonLoaderExists) {
+    config.module.loaders.push({
+      test: /\.json$/,
+      include: includePaths,
+      loader: require.resolve('json-loader'),
+    });
+  }
+}
 
 // `baseConfig` is a webpack configuration bundled with storybook.
 // React Storybook will look in the `configDir` directory
@@ -55,7 +73,7 @@ export default function (configType, baseConfig, configDir) {
 
   customConfig.module = customConfig.module || {};
 
-  return {
+  const newConfig = {
     ...customConfig,
     // We'll always load our configurations after the custom config.
     // So, we'll always load the stuff we need.
@@ -83,4 +101,8 @@ export default function (configType, baseConfig, configDir) {
       },
     },
   };
+
+  addJsonLoaderIfNotAvailable(newConfig);
+
+  return newConfig;
 }

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -75,6 +75,7 @@ export default function (configType, baseConfig, configDir) {
       ],
     },
     resolve: {
+      ...config.resolve,
       ...customConfig.resolve,
       alias: {
         ...config.alias,

--- a/src/server/config/defaults/webpack.config.js
+++ b/src/server/config/defaults/webpack.config.js
@@ -52,7 +52,6 @@ module.exports = (storybookBaseConfig) => {
     ];
   };
 
-  newConfig.resolve.extensions = ['.js', '.json', '.jsx', ''];
   newConfig.resolve.alias = {
     ...storybookBaseConfig.resolve.alias,
     // This is to support NPM2

--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -48,9 +48,17 @@ export default function () {
           include: includePaths,
           exclude: excludePaths,
         },
+        {
+          test: /\.json$/,
+          include: includePaths,
+          loader: require.resolve('json-loader'),
+        },
       ],
     },
     resolve: {
+      // Since we ship with json-loader always, it's better to move extensions to here
+      // from the default config.
+      extensions: ['.js', '.json', '.jsx', ''],
       // Add support to NODE_PATH. With this we could avoid relative path imports.
       // Based on this CRA feature: https://github.com/facebookincubator/create-react-app/issues/253
       fallback: nodePaths,

--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -48,11 +48,6 @@ export default function () {
           include: includePaths,
           exclude: excludePaths,
         },
-        {
-          test: /\.json$/,
-          include: includePaths,
-          loader: require.resolve('json-loader'),
-        },
       ],
     },
     resolve: {

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -58,6 +58,11 @@ export default function () {
           include: includePaths,
           exclude: excludePaths,
         },
+        {
+          test: /\.json$/,
+          include: includePaths,
+          loader: require.resolve('json-loader'),
+        },
       ],
     },
     resolve: {

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -58,11 +58,6 @@ export default function () {
           include: includePaths,
           exclude: excludePaths,
         },
-        {
-          test: /\.json$/,
-          include: includePaths,
-          loader: require.resolve('json-loader'),
-        },
       ],
     },
     resolve: {

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -66,6 +66,9 @@ export default function () {
       ],
     },
     resolve: {
+      // Since we ship with json-loader always, it's better to move extensions to here
+      // from the default config.
+      extensions: ['.js', '.json', '.jsx', ''],
       // Add support to NODE_PATH. With this we could avoid relative path imports.
       // Based on this CRA feature: https://github.com/facebookincubator/create-react-app/issues/253
       fallback: nodePaths,


### PR DESCRIPTION
Fixes #574

It's pretty import to use the json-loader by default (Not just with the default CRA config)
Our comments addon and some other uses modules which needs json-loader so, we must do this.

This also move the resolve.extensions to the base webpack config and fixed an issue with merging webpack resolve with the custom config.
