### PR TITLE
Remove dataId argument on postmsg channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@kadira/storybook-addon-actions": "^1.0.2",
     "@kadira/storybook-addon-links": "^1.0.0",
     "@kadira/storybook-addons": "^1.5.0",
-    "@kadira/storybook-channel-postmsg": "^1.0.3",
+    "@kadira/storybook-channel-postmsg": "^1.1.0",
     "@kadira/storybook-ui": "^3.6.0",
     "airbnb-js-shims": "^1.0.1",
     "autoprefixer": "^6.3.7",

--- a/src/client/manager/provider.js
+++ b/src/client/manager/provider.js
@@ -1,7 +1,6 @@
 /* global location */
 /* eslint class-methods-use-this: 0 */
 
-import UUID from 'uuid';
 import qs from 'qs';
 import React from 'react';
 import { Provider } from '@kadira/storybook-ui';
@@ -12,8 +11,7 @@ import Preview from './preview';
 export default class ReactProvider extends Provider {
   constructor() {
     super();
-    this.dataId = UUID.v4();
-    this.channel = createChannel({ key: this.dataId });
+    this.channel = createChannel();
     addons.setChannel(this.channel);
   }
 
@@ -23,7 +21,6 @@ export default class ReactProvider extends Provider {
 
   renderPreview(selectedKind, selectedStory) {
     const queryParams = {
-      dataId: this.dataId,
       selectedKind,
       selectedStory,
     };

--- a/src/client/preview/index.js
+++ b/src/client/preview/index.js
@@ -22,10 +22,7 @@ const context = { storyStore, reduxStore };
 
 if (isBrowser) {
   const queryParams = qs.parse(window.location.search.substring(1));
-  if (!queryParams.dataId) {
-    throw new Error('dataId is not supplied via queryString');
-  }
-  const channel = createChannel({ key: queryParams.dataId });
+  const channel = createChannel();
   channel.on('setCurrentStory', (data) => {
     reduxStore.dispatch(selectStory(data.kind, data.story));
   });


### PR DESCRIPTION
Use the new version of postmsg channel which does
not require a dataId (because it uses a constant dataId).
This will make rendering preview area more flexible.
