### PR TITLE
Fix usage of custom favicon

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -67,6 +67,8 @@ if (program.host) {
 
 const app = express();
 
+let hasCustomFavicon = false;
+
 if (program.staticDir) {
   program.staticDir = parseList(program.staticDir);
   program.staticDir.forEach((dir) => {
@@ -78,18 +80,17 @@ if (program.staticDir) {
     logger.log(`=> Loading static files from: ${staticPath} .`);
     app.use(express.static(staticPath, { index: false }));
 
-    // If there's a favicon on the specified path, use it.
     const faviconPath = path.resolve(staticPath, 'favicon.ico');
     if (fs.existsSync(faviconPath)) {
+      hasCustomFavicon = true;
       app.use(favicon(faviconPath));
     }
   });
 }
 
-// The first call to app.use(favicon) wins so we first check if there's a
-// favicon on any of the static paths (above). If none were found, this line
-// will ensure we serve the default storybook favicon.
-app.use(favicon(path.resolve(__dirname, 'public/favicon.ico')));
+if (!hasCustomFavicon) {
+  app.use(favicon(path.resolve(__dirname, 'public/favicon.ico')));
+}
 
 // Build the webpack configuration using the `baseConfig`
 // custom `.babelrc` file and `webpack.config.js` files

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -66,7 +66,6 @@ if (program.host) {
 }
 
 const app = express();
-app.use(favicon(path.resolve(__dirname, 'public/favicon.ico')));
 
 if (program.staticDir) {
   program.staticDir = parseList(program.staticDir);
@@ -78,8 +77,19 @@ if (program.staticDir) {
     }
     logger.log(`=> Loading static files from: ${staticPath} .`);
     app.use(express.static(staticPath, { index: false }));
+
+    // If there's a favicon on the specified path, use it.
+    const faviconPath = path.resolve(staticPath, 'favicon.ico');
+    if (fs.existsSync(faviconPath)) {
+      app.use(favicon(faviconPath));
+    }
   });
 }
+
+// The first call to app.use(favicon) wins so we first check if there's a
+// favicon on any of the static paths (above). If none were found, this line
+// will ensure we serve the default storybook favicon.
+app.use(favicon(path.resolve(__dirname, 'public/favicon.ico')));
 
 // Build the webpack configuration using the `baseConfig`
 // custom `.babelrc` file and `webpack.config.js` files


### PR DESCRIPTION
Fixes #581

This line (https://github.com/kadirahq/react-storybook/blob/master/src/server/index.js#L69) hard-codes the favicon to be pulled from `/node_modules/@kadira/storybook/dist/server/public/favicon.ico`.

This update first checks the specified static files for a `favicon.ico` and uses that if one is found. Otherwise, it falls back to using the default storybook favicon. The tricky part here is that it seems that the first call to `app.use(favicon)` wins, so we need to do the default last.