### PR TITLE
[moved to #597] Use webpack chunkhash to enable long-term caching

### DIFF
--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -28,7 +28,7 @@ export default function () {
     },
     output: {
       path: path.join(__dirname, 'dist'),
-      filename: 'static/[name].bundle.js',
+      filename: 'static/[name].bundle.[chunkhash].js',
       publicPath: '/',
     },
     plugins: [

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -26,7 +26,7 @@ export default function () {
     devtool: '#cheap-module-source-map',
     entry: entries,
     output: {
-      filename: 'static/[name].bundle.js',
+      filename: 'static/[name].bundle.[chunkhash].js',
       // Here we set the publicPath to ''.
       // This allows us to deploy storybook into subpaths like GitHub pages.
       // This works with css and image loaders too.


### PR DESCRIPTION
Fixes #372

Use chunkhash in the output filenames to enable long-term caching.

FYI: I realized this isn't going to work as-is, so this is still WIP. Need to use the updated value inside the `iframe.html`.