### PR TITLE
Use webpack chunkhash to enable long-term caching

### DIFF
--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -28,7 +28,7 @@ export default function () {
     },
     output: {
       path: path.join(__dirname, 'dist'),
-      filename: 'static/[name].bundle.js',
+      filename: 'static/[name].bundle.[chunkhash].js',
       publicPath: '/',
     },
     plugins: [

--- a/src/server/config/webpack.config.js
+++ b/src/server/config/webpack.config.js
@@ -28,7 +28,7 @@ export default function () {
     },
     output: {
       path: path.join(__dirname, 'dist'),
-      filename: 'static/[name].bundle.[chunkhash].js',
+      filename: 'static/[name].bundle.js',
       publicPath: '/',
     },
     plugins: [

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -26,7 +26,7 @@ export default function () {
     devtool: '#cheap-module-source-map',
     entry: entries,
     output: {
-      filename: 'static/[name].bundle.js',
+      filename: 'static/[name].bundle.[chunkhash].js',
       // Here we set the publicPath to ''.
       // This allows us to deploy storybook into subpaths like GitHub pages.
       // This works with css and image loaders too.

--- a/src/server/config/webpack.config.prod.js
+++ b/src/server/config/webpack.config.prod.js
@@ -26,7 +26,7 @@ export default function () {
     devtool: '#cheap-module-source-map',
     entry: entries,
     output: {
-      filename: 'static/[name].bundle.[chunkhash].js',
+      filename: 'static/[name].[chunkhash].bundle.js',
       // Here we set the publicPath to ''.
       // This allows us to deploy storybook into subpaths like GitHub pages.
       // This works with css and image loaders too.

--- a/src/server/iframe.html.js
+++ b/src/server/iframe.html.js
@@ -1,7 +1,42 @@
 import url from 'url';
 
-export default function (headHtml, publicPath, cacheKey) {
-  const previewUrl = cacheKey ? `static/preview.bundle.js?${cacheKey}` : 'static/preview.bundle.js';
+// assets.preview will be:
+// - undefined
+// - string e.g. 'static/preview.9adbb5ef965106be1cc3.bundle.js'
+// - array of strings e.g.
+// [ 'static/preview.9adbb5ef965106be1cc3.bundle.js',
+//   'preview.0d2d3d845f78399fd6d5e859daa152a9.css',
+//   'static/preview.9adbb5ef965106be1cc3.bundle.js.map',
+//   'preview.0d2d3d845f78399fd6d5e859daa152a9.css.map' ]
+const previewUrlsFromAssets = (assets) => {
+  if (!assets) {
+    return {
+      js: 'static/preview.bundle.js',
+    };
+  }
+
+  if (typeof assets.preview === 'string') {
+    return {
+      js: assets.preview,
+    };
+  }
+
+  return {
+    js: assets.preview.find(filename => filename.match(/\.js$/)),
+    css: assets.preview.find(filename => filename.match(/\.css$/)),
+  };
+};
+
+export default function (data) {
+  const { assets, headHtml, publicPath } = data;
+
+  const previewUrls = previewUrlsFromAssets(assets);
+
+  let previewCssTag;
+  if (previewUrls.css) {
+    previewCssTag = `<link rel='stylesheet' type='text/css' href='${url.resolve(publicPath, previewUrls.css)}'>`;
+  }
+
   return `
     <!DOCTYPE html>
     <html>
@@ -15,11 +50,12 @@ export default function (headHtml, publicPath, cacheKey) {
         </script>
         <title>React Storybook</title>
         ${headHtml}
+        ${previewCssTag}
       </head>
       <body>
         <div id="root"></div>
         <div id="error-display"></div>
-        <script src="${url.resolve(publicPath, previewUrl)}"></script>
+        <script src="${url.resolve(publicPath, previewUrls.js)}"></script>
       </body>
     </html>
   `;

--- a/src/server/index.html.js
+++ b/src/server/index.html.js
@@ -1,7 +1,36 @@
 import url from 'url';
 
-export default function (publicPath, cacheKey) {
-  const managerUrl = cacheKey ? `static/manager.bundle.js?${cacheKey}` : 'static/manager.bundle.js';
+// assets.manager will be:
+// - undefined
+// - string e.g. 'static/manager.9adbb5ef965106be1cc3.bundle.js'
+// - array of strings e.g.
+// assets.manager will be something like:
+// [ 'static/manager.c6e6350b6eb01fff8bad.bundle.js',
+//   'static/manager.c6e6350b6eb01fff8bad.bundle.js.map' ]
+const managerUrlsFromAssets = (assets) => {
+  if (!assets) {
+    return {
+      js: 'static/manager.bundle.js',
+    };
+  }
+
+  if (typeof assets.manager === 'string') {
+    return {
+      js: assets.manager,
+    };
+  }
+
+  return {
+    js: assets.manager.find(filename => filename.match(/\.js$/)),
+    css: assets.manager.find(filename => filename.match(/\.css$/)),
+  };
+};
+
+export default function (data) {
+  const { assets, publicPath } = data;
+
+  const managerUrls = managerUrlsFromAssets(assets);
+
   return `
     <!DOCTYPE html>
     <html>
@@ -41,7 +70,7 @@ export default function (publicPath, cacheKey) {
       </head>
       <body style="margin: 0;">
         <div id="root"></div>
-        <script src="${url.resolve(publicPath, managerUrl)}"></script>
+        <script src="${url.resolve(publicPath, managerUrls.js)}"></script>
       </body>
     </html>
   `;


### PR DESCRIPTION
Fixes #372

Use chunkhash in the output filenames to enable long-term caching.

Note: This was originally #594 but was closed. I updated it and am re-opening. @arunoda you mentioned that caching already exists via https://github.com/kadirahq/react-storybook/pull/578, however given that this project is already using webpack I'd think it's better to use the built-in webpack caching feature vs the "old way" of appending a random cachebuster.

This PR also fixes a bug with some assets were not being included in the `iframe.html`. My compiled CSS was never being output, I think it may have something to do with the fact that I'm using the [ExtractTextPlugin](https://github.com/webpack/extract-text-webpack-plugin) which automatically hashes my CSS file using `chunkhash`. After this PR, my `preview.css` is output into the `iframe.html`.

NOTE: This bugfix wouldn't be possible with the cachekey method since you need to parse webpack's output to get the hashed filename.