### PR TITLE
Update postcss-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "json-stringify-safe": "^5.0.1",
     "json5": "^0.5.0",
     "lodash.pick": "^4.2.0",
-    "postcss-loader": "0.13.0",
+    "postcss-loader": "1.1.0",
     "qs": "^6.1.0",
     "react-modal": "^1.2.0",
     "redux": "^3.5.2",


### PR DESCRIPTION
`postcss-loader@1.0.0` [introduces](https://github.com/postcss/postcss-loader/blob/master/CHANGELOG.md#10) support for "[common PostCSS configs](https://github.com/michael-ciniawsky/postcss-load-config)". I use the [`.postcssrc`](https://github.com/michael-ciniawsky/postcss-load-config#postcssrc) format to share a postcss config across my webpack-based projects. It would be great if `react-storybook` updated to this version of `postcss-loader`, so that my `react-storybook` webpack config can more easily make use of this shared postcss config.

I was digging around and saw that you've used greenkeeper to keep dependencies up to date in the past. I'm not sure why it didn't automatically create a pull request for this update. Anyhow, here's a tiny PR to do just that.