### PR TITLE
fix: module.hot is not available in a static build

### DIFF
--- a/src/client/preview/config_api.js
+++ b/src/client/preview/config_api.js
@@ -40,7 +40,7 @@ export default class ConfigApi {
       try {
         this._renderMain(loaders);
       } catch (error) {
-        if (module.hot.status() === 'apply') {
+        if (module.hot && module.hot.status() === 'apply') {
           // We got this issue, after webpack fixed it and applying it.
           // Therefore error message is displayed forever even it's being fixed.
           // So, we'll detect it reload the page.


### PR DESCRIPTION
In a static storybook build if there is an error loading a module it is trying to call `.status()` on `module.hot`, however `module.hot` is undefined at that point in time, because we are not in dev any longer.

This results in a `config_api.js:68 Uncaught TypeError: Cannot read property 'status' of undefined(…)` in a s static build, such as here for example: https://aui-cdn.atlassian.com/atlaskit/pr/stories/a87b34d72786fc22fe3328c20fed2fa6366bafe8/