### PR TITLE
feat: add storybook version to output

### DIFF
--- a/src/server/index.html.js
+++ b/src/server/index.html.js
@@ -1,4 +1,5 @@
 import url from 'url';
+import { version } from '../../package.json';
 
 // assets.manager will be:
 // - undefined
@@ -37,6 +38,7 @@ export default function (data) {
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="storybook-version" content="${version}">
         <title>React Storybook</title>
         <style>
           /*


### PR DESCRIPTION
This adds the storybook version to the generated storybook.

We auto-generate storybooks in CI and publish them. Sometimes when we encounter errors, we are actually not sure with which storybook version they were built.