### PR TITLE
Completely avoid re-rendering the preview iframe

### DIFF
--- a/src/client/manager/preview.js
+++ b/src/client/manager/preview.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 const iframeStyle = {
   width: '100%',
@@ -8,13 +8,28 @@ const iframeStyle = {
   padding: 0,
 };
 
-const Preview = ({ url }) => (
-  <iframe
-    id="storybook-preview-iframe"
-    style={iframeStyle}
-    src={url}
-  />
-);
+class Preview extends Component {
+  /* eslint-disable class-methods-use-this */
+  shouldComponentUpdate() {
+    // When the manager is re-rendered, due to changes in the layout (going full screen / changing
+    // addon panel to right) Preview section will update. If its re-rendered the whole html page
+    // inside the html is re-rendered making the story to re-mount.
+    // We dont have to re-render this component for any reason since changes are communicated to
+    // story using the channel and necessary changes are done by it.
+    return false;
+  }
+  /* eslint-enable class-methods-use-this */
+
+  render() {
+    return (
+      <iframe
+        id="storybook-preview-iframe"
+        style={iframeStyle}
+        src={this.props.url}
+      />
+    );
+  }
+}
 
 Preview.propTypes = {
   url: React.PropTypes.string,


### PR DESCRIPTION
When manager re-rendered there is a chance that this component is rerendered. That makes the iframe to load again. So the complete story is re-mounted. 

This is not preferred except when changing stories. 

The case of changing stories is anyway handled by communicating through the channel. So we don't need to rerender the Preview component at all.