### PR TITLE
Allow Webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "style-loader": "0.13.1",
     "url-loader": "^0.5.7",
     "uuid": "^2.0.3",
-    "webpack": "^1.13.1",
+    "webpack": "^1.13.1 || ^2.1.0-beta",
     "webpack-dev-middleware": "^1.6.0",
     "webpack-hot-middleware": "^2.13.2"
   },


### PR DESCRIPTION
Increase allowable webpack range, for folks using webpack 2, now webpack can be deduped in most cases so the users chosen version is used. This may require that webpack be specified in devDeps as well if you want to test against v1 only

related:  #556