### PR TITLE
assets.manager can be undefined even when assets is not undefined

### DIFF
--- a/src/server/index.html.js
+++ b/src/server/index.html.js
@@ -9,7 +9,7 @@ import { version } from '../../package.json';
 // [ 'static/manager.c6e6350b6eb01fff8bad.bundle.js',
 //   'static/manager.c6e6350b6eb01fff8bad.bundle.js.map' ]
 const managerUrlsFromAssets = (assets) => {
-  if (!assets) {
+  if (!assets || !assets.manager) {
     return {
       js: 'static/manager.bundle.js',
     };


### PR DESCRIPTION
I think the code was missing a check when `assets` is not `undefined` but `assets.manager` is `undefined`. The code right above says so in the comment:

```js
// assets.manager will be:
// - undefined
// ...
```

I found out about this b/c I was getting this error. I have reverted to `"@kadira/storybook": "2.29.1"` to get this to work.

```
> build-storybook -o dist/storybook

@kadira/storybook v2.29.7

=> Loading custom .babelrc
=> Loading custom webpack config.
Building storybook ...
/Users/shu/code/es-frontend/node_modules/@kadira/storybook/dist/server/index.html.js:44
    js: assets.manager.find(function (filename) {
                      ^

TypeError: Cannot read property 'find' of undefined
    at managerUrlsFromAssets (/Users/shu/code/es-frontend/node_modules/@kadira/storybook/dist/server/index.html.js:44:23)
    at exports.default (/Users/shu/code/es-frontend/node_modules/@kadira/storybook/dist/server/index.html.js:12:21)
    at /Users/shu/code/es-frontend/node_modules/@kadira/storybook/dist/server/build.js:120:99
    at Compiler.<anonymous> (/Users/shu/code/es-frontend/node_modules/webpack/lib/Compiler.js:194:14)
    at Compiler.emitRecords (/Users/shu/code/es-frontend/node_modules/webpack/lib/Compiler.js:282:37)
    at Compiler.<anonymous> (/Users/shu/code/es-frontend/node_modules/webpack/lib/Compiler.js:187:11)
    at /Users/shu/code/es-frontend/node_modules/webpack/lib/Compiler.js:275:11
    at Compiler.applyPluginsAsync (/Users/shu/code/es-frontend/node_modules/tapable/lib/Tapable.js:60:69)
    at Compiler.afterEmit (/Users/shu/code/es-frontend/node_modules/webpack/lib/Compiler.js:272:8)
    at Compiler.<anonymous> (/Users/shu/code/es-frontend/node_modules/webpack/lib/Compiler.js:267:14)
    at /Users/shu/code/es-frontend/node_modules/async/lib/async.js:52:16
    at Object.async.forEachOf.async.eachOf (/Users/shu/code/es-frontend/node_modules/async/lib/async.js:236:30)
    at Object.async.forEach.async.each (/Users/shu/code/es-frontend/node_modules/async/lib/async.js:209:22)
    at Compiler.emitFiles (/Users/shu/code/es-frontend/node_modules/webpack/lib/Compiler.js:235:20)
    at /Users/shu/code/es-frontend/node_modules/mkdirp/index.js:48:26
    at FSReqWrap.oncomplete (fs.js:123:15)
```