### PR TITLE
Cleaner error handling for storiesOf

### DIFF
--- a/src/client/preview/client_api.js
+++ b/src/client/preview/client_api.js
@@ -24,6 +24,10 @@ export default class ClientApi {
   }
 
   storiesOf(kind, m) {
+    if (!kind) {
+      throw "Invalid kind provided for stories";
+    }
+    
     if (m && m.hot) {
       m.hot.dispose(() => {
         this._storyStore.removeStoryKind(kind);

--- a/src/client/preview/client_api.js
+++ b/src/client/preview/client_api.js
@@ -24,10 +24,10 @@ export default class ClientApi {
   }
 
   storiesOf(kind, m) {
-    if (!kind) {
-      throw "Invalid kind provided for stories";
+    if (!kind && typeof kind !== 'string') {
+      throw new Error('Invalid kind provided for stories, should be a string');
     }
-    
+
     if (m && m.hot) {
       m.hot.dispose(() => {
         this._storyStore.removeStoryKind(kind);


### PR DESCRIPTION
Our entire storybook was broken because of a simple error, we provided `undefined` as the first parameter of `storiesOf`.
This was pretty hard to track down as it only results in issues later on during the runtime where storybook tries to manipulate the names that were given to the stories.

If you want I can write extra tests for this usecase, but I would like to know if this is something you want to work on first.