### PR TITLE
Make return type of StoryDecorator nullable

### DIFF
--- a/config/storybook.d.ts
+++ b/config/storybook.d.ts
@@ -1,7 +1,7 @@
 declare var module: any; // dangerous
 
 interface StoryDecorator {
-  (story: Function, context: { kind: string, story: string }): Object;
+  (story: Function, context: { kind: string, story: string }): Object | null;
 }
 
 interface Story {


### PR DESCRIPTION
Since `render()` method returns `JSX.Element | null`, the signature of `StoryDecorator` breaks repos with [latest React definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/d79f340d574873ca4deabd545ee4b9fdab1164ec#diff-c863522a04b0cd3bf435811ce2a89677) and `--strictNullChecks`.