### PR TITLE
Remove broken react-button example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ React Storybook also comes with a lot of [addons](https://getstorybook.io/docs/a
 
 Here are some featured storybooks that you can reference to see how Storybook works:
 
-  * [React Button](http://kadira-samples.github.io/react-button) - [source](https://github.com/kadira-samples/react-button)
   * [Demo of React Dates](http://airbnb.io/react-dates/) - [source](https://github.com/airbnb/react-dates)
   * [Demo of React Native Web](http://necolas.github.io/react-native-web/storybook/) - [source](https://github.com/necolas/react-native-web)
 


### PR DESCRIPTION
The [react-button](http://kadira-samples.github.io/react-button/) storybook is linked to as an example here and on the homepage, but it [appears very broken now](https://github.com/kadira-samples/react-button/issues/15). As the first example I opened, this totally confused me as I wasn't sure if what I was seeing was intended. I think this should be removed until fixed so people don't get a bad first impression like I did, and the other examples are already pretty good.