### PR TITLE
Fix spelling mistake - "element form the story" to  "element from the story"

### DIFF
--- a/src/client/preview/render.js
+++ b/src/client/preview/render.js
@@ -89,7 +89,7 @@ export function renderMain(data, storyStore) {
     const error = {
       title: `Expecting a valid React element from the story: "${selectedStory}" of "${selectedKind}".`,
       description: stripIndents`
-        Seems like you are not returning a correct React element form the story.
+        Seems like you are not returning a correct React element from the story.
         Could you double check that?
       `,
     };


### PR DESCRIPTION
Just noticed a minor spelling mistake when I got an error message.

render.js ->  "element form the story" to  "element from the story" in render.js.