### PR TITLE
Replace String.includes with String.indexOf: cross-browsing support

### DIFF
--- a/src/client/preview/index.js
+++ b/src/client/preview/index.js
@@ -14,7 +14,7 @@ import reducer from './reducer';
 
 // check whether we're running on node/browser
 const { navigator } = global;
-const isBrowser = navigator && navigator.userAgent !== 'storyshots' && !navigator.userAgent.indexOf('Node.js') > -1;
+const isBrowser = navigator && navigator.userAgent !== 'storyshots' && !(navigator.userAgent.indexOf('Node.js') > -1);
 
 const storyStore = new StoryStore();
 const reduxStore = createStore(reducer);

--- a/src/client/preview/index.js
+++ b/src/client/preview/index.js
@@ -14,7 +14,7 @@ import reducer from './reducer';
 
 // check whether we're running on node/browser
 const { navigator } = global;
-const isBrowser = navigator && navigator.userAgent !== 'storyshots' && !navigator.userAgent.includes('Node.js');
+const isBrowser = navigator && navigator.userAgent !== 'storyshots' && !navigator.userAgent.indexOf('Node.js') > -1;
 
 const storyStore = new StoryStore();
 const reduxStore = createStore(reducer);


### PR DESCRIPTION
Usage of `Array.includes` force include polyfills to browser compatibility. Can be easily replaced by indexOf. (I know includes is better, but a full polyfill is too much for only 1 line).

Image below is a project that I are working. Caused fatal error in IE11.
![image](https://cloud.githubusercontent.com/assets/3277185/23632655/70b66f0a-02a1-11e7-8e13-ca5060b19ef2.png)
