### PR TITLE
Added meta IE=edge

### DIFF
--- a/src/server/index.html.js
+++ b/src/server/index.html.js
@@ -39,6 +39,7 @@ export default function (data) {
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="storybook-version" content="${version}">
+        <meta content="IE=edge" http-equiv="X-UA-Compatible" />
         <title>React Storybook</title>
         <style>
           /*


### PR DESCRIPTION
IE is sometimes configured to fall back to IE7-emulation on internal sites. 

This forces IE to use its latest version on this site.
