### PR TITLE
extend devMiddlewareOptions with config.devServer

### DIFF
--- a/dist/server/middleware.js
+++ b/dist/server/middleware.js
@@ -4,6 +4,10 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
 exports.default = function (configDir) {
   // Build the webpack configuration using the `getBaseConfig`
   // custom `.babelrc` file and `webpack.config.js` files
@@ -17,11 +21,11 @@ exports.default = function (configDir) {
   }
 
   var compiler = (0, _webpack2.default)(config);
-  var devMiddlewareOptions = {
+  var devMiddlewareOptions = (0, _extends3.default)({
     noInfo: true,
     publicPath: config.output.publicPath,
     watchOptions: config.watchOptions || {}
-  };
+  }, config.devServer);
 
   var router = new _express.Router();
   router.use((0, _webpackDevMiddleware2.default)(compiler, devMiddlewareOptions));

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -25,6 +25,7 @@ export default function (configDir) {
     noInfo: true,
     publicPath: config.output.publicPath,
     watchOptions: config.watchOptions || {},
+    ...config.devServer,
   };
 
   const router = new Router();


### PR DESCRIPTION
# notes

since `devMiddlewareOptions` is pretty much the same as `devServer`, this simply allows a webpack config to naturally use `devServer` to override the default `devMiddlewareOptions`

fixes #650 