### PR TITLE
Upgrade babel-preset-react-app to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-core": "^6.11.4",
     "babel-loader": "^6.2.4",
     "babel-plugin-react-docgen": "^1.4.2",
-    "babel-preset-react-app": "^1.0.0",
+    "babel-preset-react-app": "^2.0.0",
     "babel-runtime": "^6.9.2",
     "case-sensitive-paths-webpack-plugin": "^1.1.2",
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "babel-core": "^6.11.4",
     "babel-loader": "^6.2.4",
     "babel-plugin-react-docgen": "^1.4.2",
+    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-es2016": "^6.22.0",
     "babel-preset-react-app": "^2.0.0",
     "babel-runtime": "^6.9.2",
     "case-sensitive-paths-webpack-plugin": "^1.1.2",


### PR DESCRIPTION
Upgrade `babel-preset-react-app` to version 2.x.x, which uses `babel-preset-env` instead of the deprecated `babel-preset-latest`.

This enables depending modules to get rid of the following warning on `npm install` (when using the `@kadira/storybook` module).

```
npm WARN deprecated babel-preset-latest@6.16.0: 💥  preset-latest accomplishes the same task as babel-preset-env. 🙏  Please install it with 'npm install babel-preset-env --save-dev'. '{ "presets": ["latest"] }' to '{ "presets": ["env"] }'. For more info, please check the docs: http://babeljs.io/docs/plugins/preset-env 👌. And let us know how you're liking Babel at @babeljs on 🐦
```