### PR TITLE
chore(pkg): rename name to getstorybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kadira/storybook",
+  "name": "getstorybook",
   "version": "2.35.3",
   "description": "React Storybook: Isolate React Component Development with Hot Reloading.",
   "repository": {


### PR DESCRIPTION
I'm a bit confused to what is the most recent version. The README tells me it's `getstorybook`, but the package.json here still mentions `@kadira/storybook`. 

I replaced the one in the package.json to bring more clarity.
