### PR TITLE
Add story kind regex

### DIFF
--- a/packages/storyshots/README.md
+++ b/packages/storyshots/README.md
@@ -51,7 +51,7 @@ Now run your Jest test command. (Usually, `npm test`.) Then you can see all of y
 
 ### `configPath`
 
-By default Storyshots assume the default config directory path for your project as below:
+By default, Storyshots assumes the config directory path for your project as below:
 
 * For React Storybook: `.storybook`
 * For React Native Storybook: `storybook`
@@ -66,21 +66,33 @@ initStoryshots({
 
 ### `suit`
 
-By default, we group stories inside Jest test suit called "StoryShots". You could change it like this:
+By default, Storyshots groups stories inside a Jest test suit called "Storyshots". You could change it like this:
 
 ```js
 initStoryshots({
-  suit: 'MyStoryShots'
+  suit: 'MyStoryshots'
 });
 ```
 
-### `storyRegex`
+### `storyKindRegex`
 
-If you'd like to only run a subset of the stories for your snapshot tests:
+If you'd like to only run a subset of the stories for your snapshot tests based on the story's kind:
 
 ```js
 initStoryshots({
-  storyRegex: /buttons/
+  storyKindRegex: /^MyComponent$/
+});
+```
+
+This can be useful if you want to separate the snapshots in directories next to each component. See an example [here](https://github.com/storybooks/storybook/issues/892).
+
+### `storyNameRegex`
+
+If you'd like to only run a subset of the stories for your snapshot tests based on the story's name:
+
+```js
+initStoryshots({
+  storyNameRegex: /buttons/
 });
 ```
 

--- a/packages/storyshots/src/index.js
+++ b/packages/storyshots/src/index.js
@@ -53,11 +53,18 @@ export default function testStorySnapshots(options = {}) {
   const suit = options.suit || 'Storyshots';
   const stories = storybook.getStorybook();
 
+  // Added not to break existing storyshots configs (can be removed in a future major release)
+  options.storyNameRegex = options.storyNameRegex || options.storyRegex;
+
   for (const group of stories) {
+    if (options.storyKindRegex && !group.kind.match(options.storyKindRegex)) {
+      continue;
+    }
+
     describe(suit, () => {
       describe(group.kind, () => {
         for (const story of group.stories) {
-          if (options.storyRegex && !story.name.match(options.storyRegex)) {
+          if (options.storyNameRegex && !story.name.match(options.storyNameRegex)) {
             continue;
           }
 


### PR DESCRIPTION
Issue: #892

## What I did

* Added `storyKindRegex` to filter stories based on the story's kind.
* Renamed `storyRegex` to `storyNameRegex`, but preserved backward compatibility (let me know if this is no longer required).
* Updated documentation to reflect changes.

## How to test

* Create a basic storybook and:
  * Check `storyRegex` still works.
  * Check `storyNameRegex` behaves the same as `storyRegex`.
  * Check `storyKindRegex` only runs stories which kind matches the regex.
