### PR TITLE
Restore deep link for addon docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Storybook is a development environment for React UI components. It allows you to
 
 Storybook runs outside of your app. This allows you to develop UI components in isolation, which can improve component reuse, testability, and development speed. You can build quickly without having to worry about application-specific dependencies.
 
-Storybook comes with a lot of [addons](https://storybooks.js.org) for component design, documentation, testing, interactivity, and so on. Storybook's easy-to-use API makes it easy to configure and extend in various ways. It has even been extended to support React Native development for mobile.
+Storybook comes with a lot of [addons](https://storybooks.js.org/docs/react-storybook/addons/introduction) for component design, documentation, testing, interactivity, and so on. Storybook's easy-to-use API makes it easy to configure and extend in various ways. It has even been extended to support React Native development for mobile.
 
 ## Getting Started
 


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybooks.github.io/issues/5

## What I did

Update docs link now that deep-linking works for the docs site.

## How to test

Navigate directly to https://storybooks.js.org/docs/react-storybook/addons/introduction and it should show content.