### PR TITLE
add description field from __docgenInfo for prop table for info plugin

### DIFF
--- a/packages/addon-info/src/components/PropTable.js
+++ b/packages/addon-info/src/components/PropTable.js
@@ -38,7 +38,8 @@ export default class PropTable extends React.Component {
         const typeInfo = type.propTypes[property];
         const propType = PropTypesMap.get(typeInfo) || 'other';
         const required = typeInfo.isRequired === undefined ? 'yes' : 'no';
-        props[property] = { property, propType, required };
+        const description = type.__docgenInfo && type.__docgenInfo.props && type.__docgenInfo.props[property] ? type.__docgenInfo.props[property].description : null;
+        props[property] = { property, propType, required, description };
       }
     }
 
@@ -72,6 +73,7 @@ export default class PropTable extends React.Component {
             <th>propType</th>
             <th>required</th>
             <th>default</th>
+            <th>description></th>
           </tr>
         </thead>
         <tbody>
@@ -81,6 +83,7 @@ export default class PropTable extends React.Component {
               <td>{row.propType}</td>
               <td>{row.required}</td>
               <td>{row.defaultValue === undefined ? '-' : <PropVal val={row.defaultValue} />}</td>
+              <td>{row.description}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
Issue:

I'd like to see `description` from `__docgenInfo` in the props documentation in info plugin

## What I did

Added code to `PropTable`


## How to test

Make a story with a component that has documented (via docgen-style text) props, and the description will show up.

Like this:

```js
/** cool button-type thing */
const Button = ({children, onClick}) => (
  <button onClick={onClick}>{children}</button>
)
Button.propTypes = {
  /** Things and stuffs */
  onClick: PropTypes.func
}

storiesOf('Button', module)
  .addWithInfo('demo - David', 'Button with children set to "David"', () => (
    <Button onClick={action('clicked')}>David</Button>
  ))
```

You will see a `description` field in the table that says `Things and stuffs`.
