### PR TITLE
Fix error when component has object as props

### DIFF
--- a/packages/addon-info/src/components/PropVal.js
+++ b/packages/addon-info/src/components/PropVal.js
@@ -107,7 +107,7 @@ function previewProp(val) {
   }
 
   if (!braceWrap) return content;
-  return <span>{{ content }}</span>;
+  return <span>{`{${content}}`}</span>;
 }
 
 export default class PropVal extends React.Component {


### PR DESCRIPTION
When attempting to render a component's props in the story source pane – when a component has an object for a prop like `style`, `previewProp()` was attempting to render a literal object with the key `content`, which causes a React error. Seems the intention of the original code was to render the literal characters `"{"` and `"}"` around `content`.

Issue:

## What I did
Changed the final case in previewProp where `content` was being set as a `<span>`. Replaced intended functionality to render literal brace characters. 


## How to test
Cloned the latest branch and attempted to link `addons-info` in another project. 

```js
.addWithInfo('div', () => (
  <div style={{ color: 'red' }}>Oops</div>
)
```
Seems passing in any object as ay prop triggers a React error. 
