### PR TITLE
Do not ignore story.js in prepublish

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -6,7 +6,7 @@ const babel = path.join(__dirname, '..', 'node_modules', '.bin', 'babel');
 require('./ver');
 
 const args = [
-  '--ignore tests,__tests__,test.js,stories/,story.jsx,story.js',
+  '--ignore tests,__tests__,test.js,stories/,story.jsx',
   '--plugins "transform-runtime"',
   './src --out-dir ./dist',
   '--copy-files',


### PR DESCRIPTION
This is causing an issue with addons-info as it ends up ignoring `Story.js` during compilation. Seems there are case-similar files in other addon packages called `story.js` that were supposed to be ignored from output... However, this seems like the quickest fix that doesn't really have an impact on other packages.

Issue:

## What I did
Removed `story.js` from the ignored babel output


## How to test
Run `npm run prepublish` from `addons-info` package. `Story.js` is not included in `dist/` as expected. 