### PR TITLE
Fixing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For full documentation on using Storybook visit: https://storybooks.js.org
 - [react-native-storybook](packages/react-native-storybook) - Storybook for React components
 - [storyshots](packages/storyshots) - Easy snapshot testing for storybook
 - [getstorybook](packages/getstorybook) - Streamlined installation for a variety of app types
-- [examples](packages/examples) - Code examples to illustrate different Storybook use cases
+- [examples](examples) - Code examples to illustrate different Storybook use cases
 
 ## Addons
 - [addon-actions](packages/addon-actions/) - Log actions as users interact with components in storybook


### PR DESCRIPTION
Issue:  Examples link was returning 404 

## What I did
Change link to examples, as it's on storybook/examples, not  storybook/**packages**/examples


## How to test
Click on **examples** link on readme