### PR TITLE
Added typescript definition to addon notes

### DIFF
--- a/packages/addon-notes/package.json
+++ b/packages/addon-notes/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@kadira/storybook": "*",
+    "@types/react": "^15.0.23",
     "git-url-parse": "^6.0.1",
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.5.1",
@@ -31,5 +32,6 @@
     "react",
     "storybook",
     "addon"
-  ]
+  ],
+  "typings": "./storybook-addon-notes.d.ts"
 }

--- a/packages/addon-notes/storybook-addon-notes.d.ts
+++ b/packages/addon-notes/storybook-addon-notes.d.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export interface WithNotesProps extends React.HTMLProps<HTMLDivElement> {
+  notes?: string;
+}
+
+export const WithNotes: React.StatelessComponent<WithNotesProps>;


### PR DESCRIPTION
Issue: #953

## What I did

Add typescript definition to add-notes addons

## How to test

I test locally on my current project, you can have a look [here](https://github.com/fabien0102/gatsby-starter/blob/storybook/src/components/Tags.stories.tsx)

## Note

The package.json seams to be with CRLF before, it explain the wtf diff (I've only added `types` and `devDepencencies/@types/react`)