### PR TITLE
Remove text transform uppercase for knob labels

### DIFF
--- a/packages/addon-knobs/src/components/PropField.js
+++ b/packages/addon-knobs/src/components/PropField.js
@@ -19,7 +19,6 @@ const stylesheet = {
     width: 80,
     fontSize: 10,
     color: 'rgb(68, 68, 68)',
-    textTransform: 'uppercase',
     fontWeight: 600,
   },
 };


### PR DESCRIPTION
Issue:

## What I did

Removed `text-transform: uppercase` from knob labels.

## How to test

Create a knob that's camel case (e.g. `boolean("isCollapsed", false)`). It should render `isCollapsed` instead of `ISCOLLAPSED`.

## FYI

I found this PR that does the same thing:

"Remove UPPERCASE text-transform from labels #53"
https://github.com/storybooks/storybook-addon-knobs/issues/53
but it looks like the `storybooks/storybook-addon-knobs` repository is now deprecated.

I saw this related issue on this repository:

"Remove UPPERCASE text-transform from labels #793"
https://github.com/storybooks/storybook/issues/793

with a comment saying:

> A PR fixing this was merged couple days ago.

but I still see `text-transform: 'uppercase'` on master:
https://github.com/storybooks/storybook/blob/master/packages/addon-knobs/src/components/PropField.js#L22

Sorry if this is a duplicate of something else I didn't find.