### PR TITLE
Fix for types `number` for addon knobs

### DIFF
--- a/packages/addon-knobs/example/typescript/index.tsx
+++ b/packages/addon-knobs/example/typescript/index.tsx
@@ -25,7 +25,9 @@ stories.add('with all knobs', () => {
   const dob = date('DOB', new Date('January 20 1887'));
 
   const bold = boolean('Bold', false);
-  const color = color('Color', 'black');
+  const selectedColor = color('Color', 'black');
+  const favoriteNumber = number('Favorite Number', 42);
+  const comfortTemp = number('Comfort Temp', 72, { range: true, min: 60, max: 90, step: 1 });
   const textDecoration = select('Decoration', {
     none: 'None',
     underline: 'Underline',
@@ -39,13 +41,15 @@ stories.add('with all knobs', () => {
 
   const style = Object.assign({}, customStyle, {
     fontWeight: bold ? 800: 400,
-    color,
+    color: selectedColor,
     textDecoration
   });
 
   return (
     <div style={style}>
       I'm {name} and I was born on "{moment(dob).format("DD MMM YYYY")}"
+      <p>My favorite number is {favoriteNumber}.</p>
+      <p>My most comfortable room temperature is {comfortTemp} degrees Fahrenheit.</p>
     </div>
   );
 });

--- a/packages/addon-knobs/storybook-addon-knobs.d.ts
+++ b/packages/addon-knobs/storybook-addon-knobs.d.ts
@@ -10,13 +10,20 @@ interface StoryContext {
 	story: string,
 }
 
+interface NumberOptions {
+	range: boolean,
+	min: number,
+	max: number,
+	step: number,
+}
+
 export function knob<T>(name: string, options: KnobOption<T>): T;
 
 export function text(name: string, value: string | null): string;
 
 export function boolean(name: string, value: boolean): boolean;
 
-export function number(name: string, value: number): number;
+export function number(name: string, value: number, options?: NumberOptions): number;
 
 export function color(name: string, value: string): string;
 


### PR DESCRIPTION
Issue: `number` did not have the correct types to allow for passing options in typescript. 

## What I did

I added the types, and updated the typescript example (which wasn't using `number`).

## How to test

Typescript does not complain about `packages/addon-knobs/example/typescript/index.tsx`. If you only use the first commit you'll see it breakhttps://github.com/marcfallows/storybook/commit/07ddee747e839f0e93ffc010a479d94bc9b6c9c5 and then it is fixed on https://github.com/marcfallows/storybook/commit/378acbc8fc377141c5a177052e00c86ca768607d.
