### PR TITLE
Fix: build-storybook no longer supports relative paths

### DIFF
--- a/app/react/src/server/build.js
+++ b/app/react/src/server/build.js
@@ -60,7 +60,7 @@ shelljs.cp(path.resolve(__dirname, 'public/favicon.ico'), outputDir);
 // custom `.babelrc` file and `webpack.config.js` files
 // NOTE changes to env should be done before calling `getBaseConfig`
 const config = loadConfig('PRODUCTION', getBaseConfig(), configDir);
-config.output.path = outputDir;
+config.output.path = path.resolve(outputDir);
 
 // copy all static files
 if (program.staticDir) {


### PR DESCRIPTION
Issue:
Fixes #1052

I've tested this locally and it resolves the issue I described above.

## What I did

Resolve the output path passed in CLI config to an absolute path before handing it to Webpack.

## How to test

When using `@storybook/react@3.0.0-alpha.0` in a project, run:

```bash
build-storybook -o ./relative/path
```