### PR TITLE
Removed `>` typo in Info prop table header

### DIFF
--- a/addons/info/src/components/PropTable.js
+++ b/addons/info/src/components/PropTable.js
@@ -77,7 +77,7 @@ export default class PropTable extends React.Component {
             <th>propType</th>
             <th>required</th>
             <th>default</th>
-            <th>description&gt;</th>
+            <th>description</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Issue: Not sure why the table column is labeled `description>`.

## What I did

Changed it to just `description`

## How to test

Use the info addon with a react component that has props.