### PR TITLE
Increase font size label on knobs

### DIFF
--- a/addons/knobs/src/components/PropField.js
+++ b/addons/knobs/src/components/PropField.js
@@ -17,7 +17,7 @@ const stylesheet = {
     paddingTop: 7,
     textAlign: 'right',
     width: 80,
-    fontSize: 10,
+    fontSize: 12,
     color: 'rgb(68, 68, 68)',
     fontWeight: 600,
   },


### PR DESCRIPTION
I found the font size of the knobs label a bit small especially after changing from having everything uppercase to a normal display. It's not perfect but increasing a bit the font size add some readability.

See before: 

![image](https://cloud.githubusercontent.com/assets/6885378/26285675/b6f784b0-3e54-11e7-8b7c-c402b1d2e532.png)

Now: 

![image](https://cloud.githubusercontent.com/assets/6885378/26285680/c0e532f6-3e54-11e7-850d-b29dfbb2191a.png)

What do you think? 