### PR TITLE
Upgrade React Native to webpack 2 config

### DIFF
--- a/app/react-native/src/server/config/defaults/webpack.config.js
+++ b/app/react-native/src/server/config/defaults/webpack.config.js
@@ -3,16 +3,26 @@ import { includePaths } from '../utils';
 
 // Add a default custom config which is similar to what React Create App does.
 module.exports = storybookBaseConfig => {
-  const newConfig = storybookBaseConfig;
+  const newConfig = { ...storybookBaseConfig };
+
   newConfig.module.loaders = [
     ...newConfig.module.loaders,
     {
       test: /\.css?$/,
       include: includePaths,
-      loaders: [
+      use: [
         require.resolve('style-loader'),
         require.resolve('css-loader'),
-        require.resolve('postcss-loader'),
+        {
+          loader: require.resolve('postcss-loader'),
+          options: {
+            plugins: () => [
+              autoprefixer({
+                browsers: ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 9'],
+              }),
+            ],
+          },
+        },
       ],
     },
     {
@@ -39,16 +49,10 @@ module.exports = storybookBaseConfig => {
     },
   ];
 
-  newConfig.postcss = () => [
-    autoprefixer({
-      browsers: ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 9'],
-    }),
-  ];
-
   newConfig.resolve = {
-    // These are the reasonable defaults supported by the Node ecosystem.
-    extensions: ['.js', '.json', ''],
+    ...newConfig.resolve,
     alias: {
+      ...((newConfig.resolve && newConfig.resolve.alias) || {}),
       // This is to support NPM2
       'babel-runtime/regenerator': require.resolve('babel-runtime/regenerator'),
     },


### PR DESCRIPTION
Issue: #1061 React Native is using the old webpack config format

## What I did
I have upgraded the default webpack config, following the changes made in #1062 by @danielduan ([see the diff here](https://github.com/storybooks/storybook/pull/1062/files#diff-b21d503215fbc42f1ce8fb9974a66486).

This is the first time I have used webpack directly, so my changes could be _very_ wrong. Feel free to close this and do it a better way if it's more useful. This is, however, allowing Storybook to work correctly with my React Native project.

## How to test
1. Create a React Native project (`react-native init StorybookTest`).
2. Run `getstorybook`.
3. Run `yarn run storybook`.
4. Run the app (`react-native run-ios`) and open http://localhost:7007/ to see the preview working.