### PR TITLE
Add react-dom to the devDependency list for React Native projects

### DIFF
--- a/lib/cli/generators/REACT_NATIVE/index.js
+++ b/lib/cli/generators/REACT_NATIVE/index.js
@@ -19,8 +19,14 @@ module.exports = latestVersion('@storybook/react-native').then(version => {
 
   const packageJson = helpers.getPackageJson();
 
+  packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
+
   packageJson.devDependencies['@storybook/react-native'] = `^${version}`;
+
+  if (!packageJson.dependencies['react-dom'] && !packageJson.devDependencies['react-dom']) {
+    packageJson.devDependencies['react-dom'] = '^15.5.4';
+  }
 
   packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts['storybook'] = 'storybook start -p 7007';


### PR DESCRIPTION
Issue: Closes #1099

## What I did
I have added a check to see if `react-dom` isn't already in either the `dependencies` or `devDependencies` of the React Native project when `getstorybook` is run. If it isn't, it will add it to the `devDependencies` of the `package.json`.

## How to test
**Testing adding**
1. Create a React Native project _without_ `react-dom` as a dependency.
2. Run `getstorybook`.
3. `yarn run storybook` should run without further steps.

**Testing ignoring**
1. Create a React Native project _with_ `react-dom` as a dependency.
2. Run `getstorybook`.
3. `yarn run storybook` should run without further steps and the `react-dom` dependency should not have been touched.