### PR TITLE
Removed unsafe Storyshots import

### DIFF
--- a/addons/storyshots/src/test-bodies.js
+++ b/addons/storyshots/src/test-bodies.js
@@ -1,5 +1,4 @@
 import renderer from 'react-test-renderer';
-import shallow from 'react-test-renderer/shallow';
 
 export const snapshotWithOptions = options => ({ story, context }) => {
   const storyElement = story.render(context);


### PR DESCRIPTION
See https://github.com/storybooks/storybook/issues/995#issuecomment-303733775

Issue: Accidentally included an unused import that isn't safe.

## What I did

Removed it

## How to test

CI should pick up if SS still runs.