### PR TITLE
Show webpack 2 config example in docs: rules not loaders

### DIFF
--- a/docs/pages/configurations/custom-webpack-config/index.md
+++ b/docs/pages/configurations/custom-webpack-config/index.md
@@ -23,10 +23,10 @@ const path = require('path');
 
 module.exports = {
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.scss$/,
-        loaders: ["style", "css", "sass"],
+        loaders: ["style-loader", "css-loader", "sass-loader"],
         include: path.resolve(__dirname, '../')
       }
     ]
@@ -67,9 +67,9 @@ module.exports = function(storybookBaseConfig, configType) {
   // 'PRODUCTION' is used when building the static version of storybook.
 
   // Make whatever fine-grained changes you need
-  storybookBaseConfig.module.loaders.push({
+  storybookBaseConfig.module.rules.push({
     test: /\.scss$/,
-    loaders: ["style", "css", "sass"],
+    loaders: ["style-loader", "css-loader", "sass-loader"],
     include: path.resolve(__dirname, '../')
   });
 


### PR DESCRIPTION
Issue:
It took me 2 hours to figure it out how to config webpack in the new version.
All I wanted is something like this. But I'm not familiar with webpack breaking changes.
```
const path = require('path');

module.exports = {
  module: {
    rules: [
      {
        test: /\.md$/,
        loaders: ['raw-loader'],
        include: path.resolve(__dirname, '../'),
      },
    ],
  },
};
```

## What I did

changed `module.loaders` into `module.rules` in docs/**/custome-webpack-config.md

## How to test
