### PR TITLE
Use strict equality in action logger

### DIFF
--- a/addons/actions/src/containers/ActionLogger/index.js
+++ b/addons/actions/src/containers/ActionLogger/index.js
@@ -14,7 +14,7 @@ export default class ActionLogger extends React.Component {
     action.data.args = action.data.args.map(arg => JSON.parse(arg));
     const actions = [...this.state.actions];
     const previous = actions.length && actions[0];
-    if (previous && deepEqual(previous.data, action.data)) {
+    if (previous && deepEqual(previous.data, action.data, { strict: true })) {
       previous.count++;
     } else {
       action.count = 1;


### PR DESCRIPTION
When comparing `0` and empty string (`''`), action logger doesn't see the difference. See https://github.com/storybooks/storybook-addon-actions/pull/33.

Steps to reproduce the issue:
- Log action with data: `0`
- `[0]` is logged in
- Log action with data: `''`
- `[0]` is logged in

## What I did

Added [strict equality](https://www.npmjs.com/package/deep-equal#deepequala-b-opts) to distinguish `0` from an empty string (`''`).

## How to test

Use action logger with `0` and then with an empty string (`''`) and check if both were logged in correctly.
