### PR TITLE
Add typings for links add-on

### DIFF
--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -31,5 +31,6 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"
-  }
+  },
+  "typings": "./storybook-addon-links.d.ts"
 }

--- a/addons/links/storybook-addon-links.d.ts
+++ b/addons/links/storybook-addon-links.d.ts
@@ -1,0 +1,3 @@
+import * as React from 'react';
+
+export function linkTo<E>(book: string, kind?: string): React.MouseEventHandler<E>;


### PR DESCRIPTION
Issue: `storybook-addon-links` can't be used from Typescript.

## What I did
Added Typescript typings for `storybook-addon-links`.

## How to test
n/a