### PR TITLE
Fixed withKnobs definition.

### DIFF
--- a/addons/knobs/storybook-addon-knobs.d.ts
+++ b/addons/knobs/storybook-addon-knobs.d.ts
@@ -17,10 +17,6 @@ interface NumberOptions {
 	step: number,
 }
 
-interface withKnobs {
-	(storyFn: Function, context: StoryContext): React.ReactElement<IWrapStoryProps>;
-}
-
 export function knob<T>(name: string, options: KnobOption<T>): T;
 
 export function text(name: string, value: string | null): string;
@@ -46,4 +42,5 @@ interface IWrapStoryProps {
   initialContent?: Object;
 }
 
-export function withKnobsOptions(options: Object): (storyFn: Function, context: StoryContext) => withKnobs;
+export function withKnobs(storyFn: Function, context: StoryContext): React.ReactElement<IWrapStoryProps>;
+export function withKnobsOptions(options: Object): (storyFn: Function, context: StoryContext) => React.ReactElement<IWrapStoryProps>;


### PR DESCRIPTION
Issue: #1160 

## What I did
Previously I released an update for addon-knobs (added method withKnobsOptions). By doing that I screwed up previously existing method withKnobs. Now both methods should work.