### PR TITLE
fix addon broken links in documentation

### DIFF
--- a/docs/pages/addons/introduction/index.md
+++ b/docs/pages/addons/introduction/index.md
@@ -89,7 +89,7 @@ storiesOf('Button', module)
 
 Native addons use Storybook as a platform and interact with it. Native addons can add extra features beyond wrapping stories.
 
-For example, [storybook-actions](https://github.com/storybooks/storybook/tree/master/addon/actions) is such an addon.
+For example, [storybook-actions](https://github.com/storybooks/storybook/tree/master/addons/actions) is such an addon.
 
 ![Demo of Storybook Addon Actions](../static/addon-actions-demo.gif)
 

--- a/docs/pages/addons/using-addons/index.md
+++ b/docs/pages/addons/using-addons/index.md
@@ -3,11 +3,11 @@ id: 'using-addons'
 title: 'Using Addons'
 ---
 
-Storybook comes with a variety of "core" addons developed and maintained alongside Storybook. Most examples in this site use [actions](https://github.com/storybooks/storybook/tree/master/addon/actions) and [links](https://github.com/storybooks/storybook/tree/master/addon/links). But it's easy to use any third party addons distributed via NPM.
+Storybook comes with a variety of "core" addons developed and maintained alongside Storybook. Most examples in this site use [actions](https://github.com/storybooks/storybook/tree/master/addons/actions) and [links](https://github.com/storybooks/storybook/tree/master/addons/links). But it's easy to use any third party addons distributed via NPM.
 
 Here's how to do it.
 
-We are going to use an addon called [Notes](https://github.com/storybooks/storybook/tree/master/addon/notes). Basically, it allows you to write notes for your stories.
+We are going to use an addon called [Notes](https://github.com/storybooks/storybook/tree/master/addons/notes). Basically, it allows you to write notes for your stories.
 
 First, we need to install the addons:
 


### PR DESCRIPTION
Issue:

## What I did
- Fixed a few broken links in the documentation for the add on pages (introduction and using add ons)

## How to test
- Click on the links :)