### PR TITLE
Fix addon panel layout styling

### DIFF
--- a/lib/ui/src/modules/ui/components/layout/index.js
+++ b/lib/ui/src/modules/ui/components/layout/index.js
@@ -22,6 +22,7 @@ const downPanelStyle = downPanelInRight => ({
   display: 'flex',
   flexDirection: downPanelInRight ? 'row' : 'column',
   alignItems: 'stretch',
+  position: 'absolute',
   width: '100%',
   height: '100%',
   padding: downPanelInRight ? '5px 10px 10px 0' : '0px 10px 10px 0',


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/1169

Steps to reproduce:

1. run the storybook dev server
2. point to ui `localhost:9001` using safari
3. press cmd + shift + j on mac to change the add on panel from bottom to right side
4. the right panel will look like the screenshot in https://github.com/storybooks/storybook/issues/1169

## What I did

Add an additional css rule `position: absolute` to make sure the panel fill the entire space.

## How to test

Tested manually in safari, firefox and chrome.