### PR TITLE
Fix capitalisation in Algolia example

### DIFF
--- a/docs/components/Grid/Examples/index.js
+++ b/docs/components/Grid/Examples/index.js
@@ -8,7 +8,7 @@ export default ({ items }) => (
       <h1>Storybook Examples</h1>
       <a
         className="edit-link"
-        href="https://github.com/storybooks/storybooks.github.io/tree/source/pages/examples/_examples.yml"
+        href="https://github.com/storybooks/storybook/edit/master/docs/pages/examples/_examples.yml"
         target="_blank"
       >
         Edit this list

--- a/docs/pages/examples/_examples.yml
+++ b/docs/pages/examples/_examples.yml
@@ -21,7 +21,7 @@ lonelyplanet:
   site: https://www.lonelyplanet.com/
 algolia:
   thumbnail: ./thumbnails/algolia.jpg
-  title: Algolia Instantsearch
+  title: Algolia InstantSearch
   description: Lightning-fast, hyper-configurable search.
   source: https://github.com/algolia/react-instantsearch/
   demo: https://community.algolia.com/react-instantsearch/storybook/


### PR DESCRIPTION
>Hey, thanks for the mention! according to our brand guidelines, InstantSearch is with two capital letters though, so this pr fixed that

see https://github.com/storybooks/storybooks.github.io/pull/69
