### PR TITLE
Fix(react-native) add missing `ws` dependency

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -71,6 +71,7 @@
     "uuid": "^3.0.1",
     "webpack": "^2.4.1",
     "webpack-dev-middleware": "^1.10.1",
-    "webpack-hot-middleware": "^2.18.0"
+    "webpack-hot-middleware": "^2.18.0",
+    "ws": "^3.0.0"
   }
 }

--- a/app/react-native/src/server/index.js
+++ b/app/react-native/src/server/index.js
@@ -11,7 +11,7 @@ export default class Server {
     this.expressApp = express();
     this.expressApp.use(storybook(options));
     this.httpServer.on('request', this.expressApp);
-    this.wsServer = ws.Server({ server: this.httpServer });
+    this.wsServer = new ws.Server({ server: this.httpServer });
     this.wsServer.on('connection', s => this.handleWS(s));
   }
 


### PR DESCRIPTION
## Issue
`ws` was a dependency, but wasn't specified in `package.json`. We got away with this b/c `ws` is a dependency of `react-native`, but that causes a problem because the version of `ws` used by `storybook` is non-deterministic. This can cause the following error on startup:

```
this.wsServer = _ws2.default.Server({ server: this.httpServer });
                                 ^

TypeError: Class constructor WebSocketServer cannot be invoked without 'new'
    at new Server (.../node_modules/@storybook/react-native/dist/server/index.js:48:34)
```
## What I did
Added `new`, and added `ws` to `package.json`

## How to test
Just run `storybook start`. It now works. Before, it would crash.