### PR TITLE
adding react-dom to addon peer dependencies

### DIFF
--- a/addons/comments/package.json
+++ b/addons/comments/package.json
@@ -45,6 +45,7 @@
     "shelljs": "^0.7.7"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -32,6 +32,7 @@
     "shelljs": "^0.7.7"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -29,6 +29,7 @@
     "react-test-renderer": "^15.5.4"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/addons/notes/package.json
+++ b/addons/notes/package.json
@@ -30,7 +30,8 @@
     "react-dom": "^15.5.4"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   },
   "optionalDependencies": {
     "@types/react": "^15.0.24"

--- a/addons/storyshots/package.json
+++ b/addons/storyshots/package.json
@@ -32,6 +32,6 @@
     "@storybook/channels": "^3.0.0",
     "babel-core": "^6.24.1",
     "react": "*",
-    "react-test-renderer": "*"
+    "react-dom": "*"
   }
 }


### PR DESCRIPTION
Issue: There could be different versions of running in Storybook because some addons don't rely on peer dependencies to get the correct version number.

It could be related to this:
https://github.com/storybooks/storybook/issues/986

## What I did

Updated some `package.json`

## How to test

Please pull the branch and help me test this in your own storybook to see if there are any issues.