### PR TITLE
Fix terminal colors by reset console colors explicitly

### DIFF
--- a/app/react/src/server/index.js
+++ b/app/react/src/server/index.js
@@ -37,7 +37,7 @@ program
   .option('--enable-db', 'DEPRECATED!')
   .parse(process.argv);
 
-logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}\n`));
+logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}`) + chalk.reset('\n'));
 
 if (program.enableDb || program.dbPath) {
   logger.error(


### PR DESCRIPTION
Due to a bug in how Windows handles escape codes, the console output disappears after the version number (chalk/chalk#145 and Microsoft/BashOnWindows#2174). Resetting the output explicitly fixes storybook output on Windows.

![image](https://cloud.githubusercontent.com/assets/96213/26746649/1f40472a-47ae-11e7-9c5c-b2f092f747ce.png)

If I highlight my console output, you can see the text is still being output, but the colors are broken:

![image](https://cloud.githubusercontent.com/assets/96213/26746696/69a4cfca-47ae-11e7-8f17-6bcf2f0c74ee.png)

