### PR TITLE
Replaced deprecated `markdown-to-react-components` with `marksy`

### DIFF
--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@storybook/addons": "^3.0.0",
     "babel-runtime": "^6.23.0",
-    "markdown-to-react-components": "^0.2.1",
+    "marksy": "^1.0.1",
     "prop-types": "^15.5.8",
     "react-addons-create-fragment": "^15.5.3"
   },

--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import MTRC from 'markdown-to-react-components';
+import marksy from 'marksy';
 import PropTable from './PropTable';
 import Node from './Node';
 import { baseFonts } from './theme';
@@ -90,7 +90,7 @@ export default class Story extends React.Component {
       open: false,
       stylesheet: this.props.styles(JSON.parse(JSON.stringify(stylesheet))),
     };
-    MTRC.configure(this.props.mtrcConf);
+    this.marksy = marksy(this.props.mtrcConf);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -211,7 +211,7 @@ export default class Story extends React.Component {
     const source = lines.map(s => s.slice(padding)).join('\n');
     return (
       <div style={this.state.stylesheet.infoContent}>
-        {MTRC(source).tree}
+        {this.marksy(source).tree}
       </div>
     );
   }
@@ -340,12 +340,12 @@ Story.propTypes = {
   showSource: PropTypes.bool,
   styles: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-  mtrcConf: PropTypes.object,
+  marksyConf: PropTypes.object,
 };
 
 Story.defaultProps = {
   showInline: false,
   showHeader: true,
   showSource: true,
-  mtrcConf: {},
+  marksyConf: {},
 };

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -10,7 +10,7 @@ const defaultOptions = {
   propTables: [],
 };
 
-const defaultMtrcConf = {
+const defaultMarksyConf = {
   h1: H1,
   h2: H2,
   h3: H3,
@@ -48,9 +48,9 @@ export default {
       options.propTables = null;
     }
 
-    const mtrcConf = { ...defaultMtrcConf };
-    if (options && options.mtrcConf) {
-      Object.assign(mtrcConf, options.mtrcConf);
+    const marksyConf = { ...defaultMarksyConf };
+    if (options && options.marksyConf) {
+      Object.assign(marksyConf, options.marksyConf);
     }
 
     return this.add(storyName, context => {
@@ -63,7 +63,7 @@ export default {
         propTables: options.propTables,
         propTablesExclude: options.propTablesExclude,
         styles: typeof options.styles === 'function' ? options.styles : s => s,
-        mtrcConf,
+        marksyConf,
       };
 
       return (


### PR DESCRIPTION
Issue: #1114 

## What I did

Looking at issue 1114 (https://github.com/storybooks/storybook/issues/1114)...
The error came from a package called `markdown-to-react-components`. Looking at this package's github (https://github.com/christianalfoni/markdown-to-react-components) it's clear that the package is deprecated. They recommend using `marksy` (https://github.com/cerebral/marksy).

Marksy appears to be a fork of `markdown-to-react-components` because the APIs are almost identical (namely, the configuration is exactly the same). This made swapping out the old version for the new one very easy, which is what I did. I also updated the name of the config (which can be passed as an argument to this addon) to reflect the new underlying mechanism.

## How to test

1. Create a simple Storybook project with info (use the readme of @storybook/addon-info for helP)
2. Make a story for a component WITH PROPTYPES DEFINED.
2. Confirm that when you run your storybook, clicking on "Show Info" at the top shows the correct PropType info.