### PR TITLE
Fixed typo in react-native browser instructions

### DIFF
--- a/app/react-native/src/manager/components/PreviewHelp.js
+++ b/app/react-native/src/manager/components/PreviewHelp.js
@@ -35,7 +35,7 @@ class PreviewHelp extends Component {
           For <span style={styles.code}>react-native init</span> apps:
         </p>
         <div style={styles.codeBlock}>
-          <pre style={styles.instructionsCode}>npm run &lt;platform&gt;</pre>
+          <pre style={styles.instructionsCode}>react-native run-&lt;platform&gt;</pre>
         </div>
       </div>
     );


### PR DESCRIPTION
Issue: N/A

## What I did

Minor typo

## How to test

Did not test. Followed instructions from `README.md` and also from https://facebook.github.io/react-native/docs/getting-started.html