### PR TITLE
Added error message for `addon-options` when used in RN incorrectly

### DIFF
--- a/addons/options/src/preview/index.js
+++ b/addons/options/src/preview/index.js
@@ -11,5 +11,10 @@ export function init() {
 // ready. If called before, options will be cached until it can be sent.
 export function setOptions(options) {
   const channel = addons.getChannel();
+  if (!channel) {
+    throw new Error(
+      'Failed to find addon channel. This may be due to https://github.com/storybooks/storybook/issues/1192.'
+    );
+  }
   channel.emit(EVENT_ID, { options });
 }


### PR DESCRIPTION


Issue: You can't really use `addon-options` with RN, unless you put in a `setTimeout`.

See https://github.com/storybooks/storybook/issues/1192 and https://github.com/storybooks/storybook/issues/815


## What I did

Made the error message a little bit more useful:
![screenshot 2017-06-05 15 49 03](https://cloud.githubusercontent.com/assets/132554/26772105/d1ca6fa6-4a06-11e7-88e3-68894c66606b.png)

## How to test

Not easy right now unfortunately. We need to fix https://github.com/storybooks/storybook/issues/1012 :/

You can try using the options addon with a RN project, and `file://` linking this version in to see the better error. See https://github.com/storybooks/storybook/issues/815 for a repro of the original problem.