### PR TITLE
Fixed typo in `getstorybook` project type detection

### DIFF
--- a/lib/cli/lib/detect.js
+++ b/lib/cli/lib/detect.js
@@ -50,7 +50,7 @@ module.exports = function detect(options) {
     return types.REACT_PROJECT;
   }
 
-  if (packageJson.dependencies && packageJson.devDependencies['react-native-scripts']) {
+  if (packageJson.devDependencies && packageJson.devDependencies['react-native-scripts']) {
     return types.REACT_NATIVE_SCRIPTS;
   }
 


### PR DESCRIPTION
Issue: #1193

## What I did

Fix typo

## How to test

Did not test. Run `getstorybook` in a project with no `devDependencies` and it will break, as in the issue.