### PR TITLE
Updated repository URL to address broken npm images

### DIFF
--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "keywords": [
     "storybook"

--- a/addons/comments/package.json
+++ b/addons/comments/package.json
@@ -13,7 +13,7 @@
   "main": "preview.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "scripts": {
     "prepublish": "node ../../scripts/prepublish.js",

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "keywords": [
     "storybook"

--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -4,7 +4,7 @@
   "description": "A Storybook addon to show additional information for your stories.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "license": "MIT",
   "scripts": {

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -4,7 +4,7 @@
   "description": "Storybook Addon Prop Editor Component",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "license": "MIT",
   "scripts": {

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "keywords": [
     "storybook"

--- a/addons/notes/package.json
+++ b/addons/notes/package.json
@@ -4,7 +4,7 @@
   "description": "Write notes for your Storybook stories.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "license": "MIT",
   "scripts": {

--- a/addons/options/package.json
+++ b/addons/options/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "keywords": [
     "storybook"

--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "keywords": [
     "react",

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "keywords": [
     "storybook"

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "keywords": [
     "storybook",

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "main": "dist/index.js",
   "dependencies": {

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -4,7 +4,7 @@
   "description": "Core Storybook UI",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "storybook",
   "repository": {
     "type": "git",
-    "url": "git@github.com:storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Issue: #1196 

## What I did

Updated repository URL to address broken npm images.

## How to test

1. I'm not sure how to test this other than just merging and releasing
2. I'm not sure whether any other tools depend on the old repository structure
3. The new structure looks valid per NPM docs: https://docs.npmjs.com/files/package.json#repository
4. The old structure does not look valid?