### PR TITLE
Update `marksy` dependecy due broken 1.1.0 version

### DIFF
--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@storybook/addons": "^3.0.0",
     "babel-runtime": "^6.23.0",
-    "marksy": "^1.0.1",
+    "marksy": "^2.0.0",
     "prop-types": "^15.5.8",
     "react-addons-create-fragment": "^15.5.3"
   },


### PR DESCRIPTION
Important issue:
Current `addon-info` dependecy `marksy: ^1.0.1` resolves as `1.1.0` which brings to Storybook an error
```js
Prism is not defined
ReferenceError: Prism is not defined
    at CodeComponent (http://localhost:9001/static/preview.bundle.js:89694:119)
```

This error leads to #163 issue with confusing answer, because `marksy` already switched from `Prism` to `HiglightJS` in version `2.0.0`
(See cerebral/marksy#11)

There is no breaking changes betwen `1.1.0` and `2.0.0` versions of `marksy`

## What I did
Updated `marksy` dependecy version for `@storybook/addon-info`

## How to test
Write any story description that can lead to markdown parsing.
My case is:
```js
storiesOf('SomeComponent', module).addWithInfo(
    'Defalut',
    `
      \tvalue: {
        \tcounter: number,
        \tisMin: bool,
        \tisMax: bool,
      \t}
    `,
    () => {
        // Story here
    }
)