### PR TITLE
Change file name to add links

### DIFF
--- a/docs/pages/configurations/add-custom-head-tags/index.md
+++ b/docs/pages/configurations/add-custom-head-tags/index.md
@@ -5,11 +5,12 @@ title: 'Add Custom Head Tags'
 
 Sometimes, you may need to add different tags to the HTML head. This is useful for adding web fonts or some external scripts.
 
-You can do this very easily. Simply create a file called `preview-head.html` inside the Storybook config directory and add tags like this:
+You can do this very easily. Simply create a file called `head.html` inside the Storybook config directory and add tags like this:
 
 ```html
 <script src="https://use.typekit.net/xxxyyy.js"></script>
 <script>try{ Typekit.load(); } catch(e){ }</script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 ```
 
 That's it. Storybook will inject these tags.


### PR DESCRIPTION
I tried adding a <link> tag to my storybook and it didn't work according to old instructions. So I referenced a few projects and it seems that it has changed, i.e. https://github.com/bufferapp/buffer-components/blob/master/.storybook/head.html

Issue:

## What I did



## How to test
