### PR TITLE
Make cursor a pointer for down_panel tab links.

### DIFF
--- a/lib/ui/src/modules/ui/components/down_panel/style.js
+++ b/lib/ui/src/modules/ui/components/down_panel/style.js
@@ -49,6 +49,7 @@ export default {
     opacity: 0.5,
     maxHeight: 60,
     overflow: 'hidden',
+    cursor: 'pointer',
   },
 
   activetab: {


### PR DESCRIPTION
Add `cursor: pointer` style to `tablist` style settings in `down_panel/style.js`.
