### PR TITLE
Fix (?) PropType for node.type.

### DIFF
--- a/addons/info/src/components/Props.js
+++ b/addons/info/src/components/Props.js
@@ -63,7 +63,7 @@ Props.defaultProps = {
 Props.propTypes = {
   node: PropTypes.shape({
     props: PropTypes.object,
-    type: PropTypes.object.isRequired,
+    type: PropTypes.node.isRequired,
   }).isRequired,
   singleLine: PropTypes.bool,
   maxPropsIntoLine: PropTypes.number.isRequired,

--- a/lib/ui/src/modules/ui/components/down_panel/style.js
+++ b/lib/ui/src/modules/ui/components/down_panel/style.js
@@ -49,7 +49,6 @@ export default {
     opacity: 0.5,
     maxHeight: 60,
     overflow: 'hidden',
-    cursor: pointer
   },
 
   activetab: {

--- a/lib/ui/src/modules/ui/components/down_panel/style.js
+++ b/lib/ui/src/modules/ui/components/down_panel/style.js
@@ -49,6 +49,7 @@ export default {
     opacity: 0.5,
     maxHeight: 60,
     overflow: 'hidden',
+    cursor: pointer
   },
 
   activetab: {


### PR DESCRIPTION
Issue: Console errors about node.type expecting an object and receiving a function.

## What I did

Updated the propTypes for Props to expect node.type as a `node`, not an `object`.

_Unsure whether this handles all cases; a maintainer should verify._