### PR TITLE
Fix `storybook-build` manager-head.html bug

### DIFF
--- a/app/react/src/server/build.js
+++ b/app/react/src/server/build.js
@@ -11,7 +11,7 @@ import getBaseConfig from './config/webpack.config.prod';
 import loadConfig from './config';
 import getIndexHtml from './index.html';
 import getIframeHtml from './iframe.html';
-import { getHeadHtml, parseList, getEnvConfig } from './utils';
+import { getPreviewHeadHtml, getManagerHeadHtml, parseList, getEnvConfig } from './utils';
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
@@ -87,9 +87,14 @@ webpack(config).run((err, stats) => {
     publicPath: config.output.publicPath,
     assets: stats.toJson().assetsByChunkName,
   };
-  const headHtml = getHeadHtml(configDir);
 
   // Write both the storybook UI and IFRAME HTML files to destination path.
-  fs.writeFileSync(path.resolve(outputDir, 'index.html'), getIndexHtml(data));
-  fs.writeFileSync(path.resolve(outputDir, 'iframe.html'), getIframeHtml({ ...data, headHtml }));
+  fs.writeFileSync(
+    path.resolve(outputDir, 'index.html'),
+    getIndexHtml({ ...data, headHtml: getManagerHeadHtml(configDir) })
+  );
+  fs.writeFileSync(
+    path.resolve(outputDir, 'iframe.html'),
+    getIframeHtml({ ...data, headHtml: getPreviewHeadHtml(configDir) })
+  );
 });

--- a/app/react/src/server/iframe.html.js
+++ b/app/react/src/server/iframe.html.js
@@ -38,9 +38,7 @@ const urlsFromAssets = assets => {
   return urls;
 };
 
-export default function(data) {
-  const { assets, headHtml, publicPath } = data;
-
+export default function({ assets, publicPath, headHtml }) {
   const urls = urlsFromAssets(assets);
 
   const cssTags = urls.css

--- a/app/react/src/server/index.html.js
+++ b/app/react/src/server/index.html.js
@@ -27,9 +27,7 @@ const managerUrlsFromAssets = assets => {
   };
 };
 
-export default function(data) {
-  const { assets, publicPath, headHtml } = data;
-
+export default function({ assets, publicPath, headHtml }) {
   const managerUrls = managerUrlsFromAssets(assets);
 
   return `

--- a/app/react/src/server/middleware.js
+++ b/app/react/src/server/middleware.js
@@ -6,7 +6,7 @@ import getBaseConfig from './config/webpack.config';
 import loadConfig from './config';
 import getIndexHtml from './index.html';
 import getIframeHtml from './iframe.html';
-import { getHeadHtml, getManagerHeadHtml, getMiddleware } from './utils';
+import { getPreviewHeadHtml, getManagerHeadHtml, getMiddleware } from './utils';
 
 let webpackResolve = () => {};
 let webpackReject = () => {};
@@ -55,7 +55,7 @@ export default function(configDir) {
     });
 
     router.get('/iframe.html', (req, res) => {
-      const headHtml = getHeadHtml(configDir);
+      const headHtml = getPreviewHeadHtml(configDir);
       res.send(getIframeHtml({ ...data, headHtml, publicPath }));
     });
 

--- a/app/react/src/server/utils.js
+++ b/app/react/src/server/utils.js
@@ -11,7 +11,7 @@ export function parseList(str) {
   return str.split(',');
 }
 
-export function getHeadHtml(configDirPath) {
+export function getPreviewHeadHtml(configDirPath) {
   const headHtmlPath = path.resolve(configDirPath, 'preview-head.html');
   const fallbackHtmlPath = path.resolve(configDirPath, 'head.html');
   let headHtml = '';

--- a/app/react/src/server/utils.test.js
+++ b/app/react/src/server/utils.test.js
@@ -1,9 +1,9 @@
 import mock from 'mock-fs';
-import { getHeadHtml } from './utils';
+import { getPreviewHeadHtml } from './utils';
 
 const HEAD_HTML_CONTENTS = '<script>console.log("custom script!");</script>';
 
-describe('server.getHeadHtml', () => {
+describe('server.getPreviewHeadHtml', () => {
   describe('when .storybook/head.html does not exist', () => {
     beforeEach(() => {
       mock({
@@ -16,7 +16,7 @@ describe('server.getHeadHtml', () => {
     });
 
     it('return an empty string', () => {
-      const result = getHeadHtml('./config');
+      const result = getPreviewHeadHtml('./config');
       expect(result).toEqual('');
     });
   });
@@ -35,7 +35,7 @@ describe('server.getHeadHtml', () => {
     });
 
     it('return the contents of the file', () => {
-      const result = getHeadHtml('./config');
+      const result = getPreviewHeadHtml('./config');
       expect(result).toEqual(HEAD_HTML_CONTENTS);
     });
   });


### PR DESCRIPTION
Issue: #1239 

## What I did

- rename `getHeadHtml` to `getPreviewHeadHtml` to make it more explicit
- make sure that we are calling `getManagerHeadHtml` in both dev and build modes
- `chmod +x build.js`

## How to test

#### No preview/manager head case:
```
yarn bootstrap
cd examples/cra-storybook
yarn storybook
yarn build-storybook
cd storybook-public
serve
open http://localhost:5000
```

Verify that there is no `undefined` across the top of the screen

#### Preview/manager head case:
```
echo "manager" > examples/cra-storybook/.storybook/manager-head.html
echo "preview" > examples/cra-storybook/.storybook/preview-head.html
```

Run the same tests as above, verify that there is `manager` across the top of the screen and `preview` across the top of the preview iframe.



