### PR TITLE
fix(addons/info): Cannot read property 'props' of undefined

### DIFF
--- a/addons/info/src/components/markdown/text.js
+++ b/addons/info/src/components/markdown/text.js
@@ -46,4 +46,4 @@ export function A(props) {
 }
 
 A.defaultProps = defaultProps;
-A.propTypes = { children: PropTypes.node, href: PropTypes.string };
+A.propTypes = { children: PropTypes.node, href: PropTypes.string.isRequired };

--- a/addons/info/src/components/markdown/text.js
+++ b/addons/info/src/components/markdown/text.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { baseFonts } from '../theme';
 
 const defaultProps = { children: null };
-const propTypes = { children: PropTypes.node };
+const propTypes = { children: PropTypes.node, href: PropTypes.string };
 
 export function P(props) {
   const style = {

--- a/addons/info/src/components/markdown/text.js
+++ b/addons/info/src/components/markdown/text.js
@@ -42,7 +42,11 @@ export function A(props) {
   const style = {
     color: '#3498db',
   };
-  return <a href={props.href} style={style}>{props.children}</a>;
+  return (
+    <a href={props.href} target="_blank" rel="noopener noreferrer" style={style}>
+      {props.children}
+    </a>
+  );
 }
 
 A.defaultProps = defaultProps;

--- a/addons/info/src/components/markdown/text.js
+++ b/addons/info/src/components/markdown/text.js
@@ -42,7 +42,7 @@ export function A(props) {
   const style = {
     color: '#3498db',
   };
-  return <a href={this.props.href} style={style}>{props.children}</a>;
+  return <a href={props.href} style={style}>{props.children}</a>;
 }
 
 A.defaultProps = defaultProps;

--- a/addons/info/src/components/markdown/text.js
+++ b/addons/info/src/components/markdown/text.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { baseFonts } from '../theme';
 
 const defaultProps = { children: null };
-const propTypes = { children: PropTypes.node, href: PropTypes.string };
+const propTypes = { children: PropTypes.node };
 
 export function P(props) {
   const style = {
@@ -46,4 +46,4 @@ export function A(props) {
 }
 
 A.defaultProps = defaultProps;
-A.propTypes = propTypes;
+A.propTypes = { children: PropTypes.node, href: PropTypes.string };


### PR DESCRIPTION
Issue:

This error occurred when I want to update storybook. (I use yarn to lock versions.)

```diff
-    "@storybook/addon-info": "^3.0.1",
-    "@storybook/addon-options": "^3.0.1",
-    "@storybook/addon-storyshots": "^3.0.0",
-    "@storybook/react": "^3.0.1",
+    "@storybook/addon-info": "^3.1.3",
+    "@storybook/addon-options": "^3.1.2",
+    "@storybook/addon-storyshots": "^3.1.2",
+    "@storybook/react": "^3.1.3",
```

![2017-06-12 11 02 52](https://user-images.githubusercontent.com/1527371/27017902-b56061ba-4f5e-11e7-9bea-7612d71751dc.png)


## What I did

Remove the `this` for functional component.

## How to test

Add some **links** for your story description in the second paramter of `addWithInfo`:

```diff
storiesOf('DomAlign', module).addWithInfo(
  'API',
  `
      With config: ${JSON.stringify(alignConfig)}.
+     Reference: React.js [dom-align](https://github.com/yiminghe/dom-align) integration component.
    `,
  () => <Container />,
  { inline: true, propTables: [DomAlign] },
);
```

There will be an `a` tag rendered on the page, and this PR fixed the `A` component error.

[Source code](https://github.com/MCS-Lite/mcs-lite/blob/master/packages/mcs-lite-ui/src/DomAlign/DomAlign.example.js#L34) 
[Demo link](https://deploy-preview-357--mcs-lite-ui.netlify.com/?selectedKind=DomAlign&selectedStory=API&full=0&down=0&left=1&panelRight=0&downPanel=storybook%2Factions%2Factions-panel)
[Related issue mcs-lite PR#357](https://github.com/MCS-Lite/mcs-lite/pull/357)