### PR TITLE
Don't run danger if DANGER_GITHUB_API_TOKEN is not set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
 - npm run lint
 - npm run test -- --coverage
 - npm run coverage
-- npm run danger
+- ([ -z "$DANGER_GITHUB_API_TOKEN" ] && echo "DANGER_GITHUB_API_TOKEN not set") || npm run danger
 git:
   depth: 1
 env:


### PR DESCRIPTION
Issue: #1275

## What I did

Don't run danger if DANGER_GITHUB_API_TOKEN is not set

## How to test

- [ ] Danger should not break the build on this PR
- [ ] Danger should not be run on https://github.com/storybooks/storybook/pull/1273 after we marge

