### PR TITLE
Modify bug that show header when not use header

### DIFF
--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -125,11 +125,13 @@ export default class Story extends React.Component {
   _renderInline() {
     return (
       <div>
-        <div style={this.state.stylesheet.infoPage}>
-          <div style={this.state.stylesheet.infoBody}>
-            {this._getInfoHeader()}
-          </div>
-        </div>
+        {this.props.context &&
+          this.props.showHeader &&
+          <div style={this.state.stylesheet.infoPage}>
+            <div style={this.state.stylesheet.infoBody}>
+              {this._getInfoHeader()}
+            </div>
+          </div>}
         <div>
           {this._renderStory()}
         </div>


### PR DESCRIPTION
Issue:

## What I did

I have modified bug that show header when not use header.

## How to test

When I pass `header: false` of options, header is displayed

<img width="776" alt="2017-06-16 6 15 56" src="https://user-images.githubusercontent.com/1321707/27221150-8f4f2832-52c2-11e7-94e0-c147e77e2fc7.png">

So I have modified code like below image.

<img width="787" alt="2017-06-16 6 37 46" src="https://user-images.githubusercontent.com/1321707/27221274-fcfb784a-52c2-11e7-8deb-53d18c093a1c.png">

