### PR TITLE
Addon note without decorator

### DIFF
--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -37,5 +37,8 @@ import { withNotes } from '@storybook/addon-notes';
 import Component from './Component';
 
 storiesOf('Component', module)
-  .add('with some emoji', withNotes({ notes: 'A very simple component'})(() => <Component></Component>));
+  .add('with some emoji', () => {
+    withNotes('some notes')
+    return <Component></Component>
+  });
 ```

--- a/addons/notes/src/index.js
+++ b/addons/notes/src/index.js
@@ -2,14 +2,10 @@ import deprecate from 'util-deprecate';
 import addons from '@storybook/addons';
 import { WithNotes as ReactWithNotes } from './react';
 
-export const withNotes = ({ notes }) => {
+export const withNotes = notes => {
   const channel = addons.getChannel();
-
-  return getStory => () => {
-    // send the notes to the channel before the story is rendered
-    channel.emit('storybook/notes/add_notes', notes);
-    return getStory();
-  };
+  // send the notes to the channel before the story is rendered
+  channel.emit('storybook/notes/add_notes', notes);
 };
 
 Object.defineProperty(exports, 'WithNotes', {

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -113,14 +113,31 @@ storiesOf('WithEvents', module)
   .add('Logger', () => <Logger emiter={emiter} />);
 
 storiesOf('withNotes', module)
-  .add('with some text', withNotes({ notes: 'Hello guys' })(() => <div>Hello copain</div>))
-  .add('with some emoji', withNotes({ notes: 'My notes on emojies' })(() => <p>🤔😳😯😮</p>))
-  .add(
-    'with a button and some emoji',
-    withNotes({ notes: 'My notes on a button with emojies' })(() =>
-      <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>
-    )
-  )
+  .add('with some text', () => {
+    withNotes('Hello guys');
+    return <div>Hello guys</div>;
+  })
+  .add('with some emoji', () => {
+    withNotes('My notes on emojies');
+    return <p>🤔😳😯😮</p>;
+  })
+  .add('with a button and some emoji', () => {
+    withNotes('My notes on a button with emojies');
+    return <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>;
+  })
+  .add('with notes on button and new notes onClick', () => {
+    withNotes('My notes on a button with new notes on click');
+    return (
+      <Button
+        onClick={event => {
+          withNotes('new notes on click');
+          action('clicked')(event);
+        }}
+      >
+        😀 😎 👍 💯
+      </Button>
+    );
+  })
   .add('with old API', () =>
     <WithNotes notes="Hello">
       <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>

--- a/examples/vue/src/stories/index.js
+++ b/examples/vue/src/stories/index.js
@@ -76,23 +76,53 @@ storiesOf('Other', module)
 
 
 storiesOf('Addon Notes', module)
-  .add('with some emoji', withNotes({notes: 'My notes on emojies'})(() => '<p>🤔😳😯😮</p>'))
-  .add('with some button', withNotes({ notes: 'My notes on some button' })(() => ({
-    components: { MyButton },
-    template: '<my-button :rounded="true">rounded</my-button>'
-  })))
-  .add('with some color', withNotes({ notes: 'Some notes on some colored component' })(() => ({
-    render(h) {
-      return h(MyButton, { props: { color: 'pink' } }, ['colorful']);
+  .add('with some emoji', () => {
+    withNotes('My notes on emojies');
+    return '<p>🤔😳😯😮</p>'
+  })
+  .add('with some button', () => {
+    withNotes('My notes on some button');
+
+    return {
+      components: { MyButton },
+      template: '<my-button :rounded="true">rounded</my-button>'
     }
-  })))
-  .add('with some text', withNotes({ notes: 'My notes on some text' })(() => ({
+  })
+  .add('with some color', () => {
+    withNotes('Some notes on some colored component')
+
+    return {
+      render(h) {
+        return h(MyButton, { props: { color: 'pink' } }, ['colorful']);
+      }
+    }
+  })
+  .add('with some text', () => {
+    withNotes('My notes on some text')
+    return {
       template: '<div>Text</div>'
-    })
-  ))
-  .add('with some long text', withNotes({ notes: 'My notes on some long text' })(
-    () => '<div>A looooooooonnnnnnnggggggggggggg text</div>'
-  ))
-  .add('with some bold text', withNotes({ notes: 'My notes on some bold text' })(() => ({
-    render: h => h('div', [h('strong', ['A very long text to display'])])
-  })));
+    };
+  })
+  .add('with some long text', () => {
+    withNotes('My notes on some long text')
+    return {
+      template: '<div>A looooooooonnnnnnnggggggggggggg text</div>'
+    };
+  })
+  .add('with a button and clickable update', () => {
+    withNotes('My notes on a button and clickable update')
+    return {
+      methods: {
+        onClick() {
+          withNotes('My new notes');
+        }
+      },
+      template: '<button @click="onClick">Text</button>'
+    };
+  })
+  .add('with some bold text', () => {
+    withNotes('My notes on some bold text');
+    return {
+      render: h => h('div', [h('strong', ['A very long text to display'])])
+    }
+  });


### PR DESCRIPTION
## What I did

I changed the notes addon to be usable as a simple function. 

This brings some cool benefits:

- The user can call the function anytime during the story life cycle (e.g update notes on an event in the story)
- No need to wrap the story (cleaner for the user)

@shilman @ndelangen 

If you like it we can I'll merge into vue to bring it for the Vue release

Somewhat related, I'd like your thoughts on this [idea (gist)](https://gist.github.com/alexandrebodin/f470bb293e728be359bf739c9750ca15)
=> Make addon API available in props 

Cheers! 