### PR TITLE
Fix bug in storybook common components refactor

### DIFF
--- a/lib/cli/generators/METEOR/index.js
+++ b/lib/cli/generators/METEOR/index.js
@@ -7,6 +7,7 @@ const latestVersion = require('latest-version');
 
 module.exports = Promise.all([
   latestVersion('@storybook/react'),
+  latestVersion('@storybook/components'),
   latestVersion('react'),
   latestVersion('react-dom'),
   latestVersion('babel-preset-es2015'),
@@ -18,6 +19,7 @@ module.exports = Promise.all([
   (
     [
       storybookVersion,
+      componentsVersion,
       reactVersion,
       reactDomVersion,
       presetEs2015Version,
@@ -62,6 +64,7 @@ module.exports = Promise.all([
 
     // write the new package.json.
     packageJson.devDependencies['@storybook/react'] = `^${storybookVersion}`;
+    packageJson.devDependencies['@storybook/components'] = `^${componentsVersion}`;
     packageJson.scripts.storybook = 'start-storybook -p 6006';
     packageJson.scripts['build-storybook'] = 'build-storybook';
 

--- a/lib/cli/generators/REACT/index.js
+++ b/lib/cli/generators/REACT/index.js
@@ -3,13 +3,17 @@ const helpers = require('../../lib/helpers');
 const path = require('path');
 const latestVersion = require('latest-version');
 
-module.exports = latestVersion('@storybook/react').then(version => {
+module.exports = Promise.all([
+  latestVersion('@storybook/react'),
+  latestVersion('@storybook/components'),
+]).then(([storybookVersion, componentsVersion]) => {
   mergeDirs(path.resolve(__dirname, 'template/'), '.', 'overwrite');
 
   const packageJson = helpers.getPackageJson();
 
   packageJson.devDependencies = packageJson.devDependencies || {};
-  packageJson.devDependencies['@storybook/react'] = `^${version}`;
+  packageJson.devDependencies['@storybook/react'] = `^${storybookVersion}`;
+  packageJson.devDependencies['@storybook/components'] = `^${componentsVersion}`;
 
   packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts.storybook = 'start-storybook -p 6006';

--- a/lib/cli/generators/REACT_SCRIPTS/index.js
+++ b/lib/cli/generators/REACT_SCRIPTS/index.js
@@ -4,12 +4,19 @@ const path = require('path');
 const fs = require('fs');
 const latestVersion = require('latest-version');
 
-module.exports = latestVersion('@storybook/react').then(version => {
+module.exports = Promise.all([
+  latestVersion('@storybook/react'),
+  latestVersion('@storybook/components'),
+]).then(([storybookVersion, componentsVersion]) => {
   mergeDirs(path.resolve(__dirname, 'template/'), '.', 'overwrite');
 
   const packageJson = helpers.getPackageJson();
 
-  packageJson.devDependencies['@storybook/react'] = `^${version}`;
+  packageJson.devDependencies = packageJson.devDependencies || {};
+  packageJson.devDependencies['@storybook/react'] = `^${storybookVersion}`;
+  packageJson.devDependencies['@storybook/components'] = `^${componentsVersion}`;
+
+  packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts.storybook = 'start-storybook -p 9009';
   packageJson.scripts['build-storybook'] = 'build-storybook';
 

--- a/lib/cli/generators/WEBPACK_REACT/index.js
+++ b/lib/cli/generators/WEBPACK_REACT/index.js
@@ -3,13 +3,17 @@ const helpers = require('../../lib/helpers');
 const path = require('path');
 const latestVersion = require('latest-version');
 
-module.exports = latestVersion('@storybook/react').then(version => {
+module.exports = Promise.all([
+  latestVersion('@storybook/react'),
+  latestVersion('@storybook/components'),
+]).then(([storybookVersion, componentsVersion]) => {
   mergeDirs(path.resolve(__dirname, 'template/'), '.', 'overwrite');
 
   const packageJson = helpers.getPackageJson();
 
   packageJson.devDependencies = packageJson.devDependencies || {};
-  packageJson.devDependencies['@storybook/react'] = `^${version}`;
+  packageJson.devDependencies['@storybook/react'] = `^${storybookVersion}`;
+  packageJson.devDependencies['@storybook/components'] = `^${componentsVersion}`;
 
   packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts.storybook = 'start-storybook -p 6006';


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/pull/1266

## What I did

Fixed bug in components refactor. Now `getstorybook` needs to add a `@storybook/components` dependency when it runs, otherwise the components are not found.

## How to test

```
yarn install && yarn bootstrap
cd ..
yarn create react-app testapp
cd testapp
../storybook/lib/cli/bin/generate.js
yarn storybook
open http://localhost:9009
```