### PR TITLE
Decorator less addons (experiment on KNOBS)

### DIFF
--- a/addons/knobs/src/components/Panel.js
+++ b/addons/knobs/src/components/Panel.js
@@ -106,6 +106,7 @@ export default class Panel extends React.Component {
 
   emitChange(changedKnob) {
     this.props.channel.emit('addon:knobs:knobChange', changedKnob);
+    this.props.channel.emit('refresh');
   }
 
   handleChange(changedKnob) {

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -1,7 +1,7 @@
 import addons from '@storybook/addons';
 import KnobManager from './KnobManager';
 
-const manager = new KnobManager();
+const manager = new KnobManager(addons.getChannel());
 
 export function knob(name, options) {
   return manager.knob(name, options);
@@ -55,16 +55,16 @@ export function date(name, value = new Date()) {
   return manager.knob(name, { type: 'date', value: proxyValue });
 }
 
-export function withKnobs(storyFn, context) {
-  const channel = addons.getChannel();
-  return manager.wrapStory(channel, storyFn, context);
-}
+// export function withKnobs(storyFn, context) {
+//   const channel = addons.getChannel();
+//   return manager.wrapStory(channel, storyFn, context);
+// }
 
-export function withKnobsOptions(options = {}) {
-  return (...args) => {
-    const channel = addons.getChannel();
-    channel.emit('addon:knobs:setOptions', options);
+// export function withKnobsOptions(options = {}) {
+//   return (...args) => {
+//     const channel = addons.getChannel();
+//     channel.emit('addon:knobs:setOptions', options);
 
-    return withKnobs(...args);
-  };
-}
+//     return withKnobs(...args);
+//   };
+// }

--- a/app/react/src/client/preview/index.js
+++ b/app/react/src/client/preview/index.js
@@ -29,6 +29,7 @@ if (isBrowser) {
   channel.on('setCurrentStory', data => {
     reduxStore.dispatch(selectStory(data.kind, data.story));
   });
+  channel.on('refresh', () => render(context));
   Object.assign(context, { channel, window, queryParams });
   addons.setChannel(channel);
   init(context);

--- a/app/react/src/client/preview/render.js
+++ b/app/react/src/client/preview/render.js
@@ -57,7 +57,7 @@ export function renderMain(data, storyStore) {
   //    https://github.com/storybooks/react-storybook/issues/116
   if (selectedKind !== previousKind || previousStory !== selectedStory) {
     // We need to unmount the existing set of components in the DOM node.
-    // Otherwise, React may not recrease instances for every story run.
+    // Otherwise, React may not recreate instances for every story run.
     // This could leads to issues like below:
     //    https://github.com/storybooks/react-storybook/issues/81
     previousKind = selectedKind;

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -6,17 +6,7 @@ import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 import WithEvents from '@storybook/addon-events';
 import { WithNotes } from '@storybook/addon-notes';
-import {
-  withKnobs,
-  text,
-  number,
-  boolean,
-  color,
-  select,
-  array,
-  date,
-  object,
-} from '@storybook/addon-knobs';
+import { text, number, boolean, color, select, array, date, object } from '@storybook/addon-knobs';
 import centered from '@storybook/addon-centered';
 
 import Button from '@storybook/components/dist/demo/Button';
@@ -38,7 +28,7 @@ const emit = emiter.emit.bind(emiter);
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
 
 storiesOf('Button', module)
-  .addDecorator(withKnobs)
+  // .addDecorator(withKnobs)
   .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)
   .add('with some emoji', () => <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>)
   .add('with notes', () =>


### PR DESCRIPTION
## What I did

I started experimenting with decoratorless addons after a discussion with @ndelangen.

I tried it out and could knobs "work" (only updating values no reset etc) with a decorator. 

I think that's pretty cool, and we should maybe add it to the api somehow as a good practice pattern.

My opinion is that with such an approach. We can lift the refreshing need etc in the api and let user use our addons without too much thinking. 

If they really need a decorator that should be for a specific use case (theme etc) that maybe we should let the user handle on it's own. 


This is just an experiment but might be worse thinking about for the addon api v2 😄 
