### PR TITLE
add step for import addon-action to addons.js file before start using it

### DIFF
--- a/addons/actions/README.md
+++ b/addons/actions/README.md
@@ -23,6 +23,12 @@ Install:
 npm i -D @storybook/addon-actions
 ```
 
+Then, add following content to `.storybook/addons.js`
+
+```
+import '@storybook/addon-actions/register';
+```
+
 Import the `action` function and use it to create actions handlers. When creating action handlers, provide a **name** to make it easier to identify.
 
 > _Note: Make sure NOT to use reserved words as function names. [issues#29](https://github.com/storybooks/storybook-addon-actions/issues/29#issuecomment-288274794)_


### PR DESCRIPTION
Issue: When I try using Storybook I was following the step in this repository but it has no step that told me to import addon-action to addons.js file. So, I've spend a lot of time to find out why I have no action logger

## What I did
Add the step that told user to import @storybook/addon-actions/register to addons.js before start using action on components

## How to test
Nothing to test, MD file will break nothing. 