### PR TITLE
Use a pack -> install technique to recreate local packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ packages/examples/automated-*
 yarn.lock
 /**/LICENSE
 docs/public
-packs
+packs/*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ packages/examples/automated-*
 yarn.lock
 /**/LICENSE
 docs/public
+packs

--- a/addons/storyshots/package.json
+++ b/addons/storyshots/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@storybook/addons": "^3.0.0",
     "@storybook/channels": "^3.0.0",
+    "@storybook/react": "^3.0.0",
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",

--- a/examples/test-cra/package-lock.json
+++ b/examples/test-cra/package-lock.json
@@ -4,7910 +4,50 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@storybook/addon-actions": {
-      "version": "file:../../addons/actions",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "asap": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true
-        },
-        "create-react-class": {
-          "version": "15.6.0",
-          "bundled": true
-        },
-        "deep-equal": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.12",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true
-        },
-        "iconv-lite": {
-          "version": "0.4.18",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "interpret": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "is-dom": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "node-fetch": {
-          "version": "1.7.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.5.10",
-          "bundled": true
-        },
-        "react": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "react-dom": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "react-inspector": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-test-renderer": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "bundled": true
-        },
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.3.3",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "shelljs": {
-          "version": "0.7.8",
-          "bundled": true
-        },
-        "ua-parser-js": {
-          "version": "0.7.12",
-          "bundled": true
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
+      "version": "file:../../packs/storybook-addon-actions.tgz",
+      "integrity": "sha1-IBagi2CvshMZxoNhNn3h2M/cCT8=",
+      "dev": true
     },
     "@storybook/addon-links": {
-      "version": "file:../../addons/links",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "asap": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true
-        },
-        "create-react-class": {
-          "version": "15.6.0",
-          "bundled": true
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.12",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true
-        },
-        "iconv-lite": {
-          "version": "0.4.18",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "interpret": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "node-fetch": {
-          "version": "1.7.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.5.10",
-          "bundled": true
-        },
-        "react": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "react-dom": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "bundled": true
-        },
-        "resolve": {
-          "version": "1.3.3",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "shelljs": {
-          "version": "0.7.8",
-          "bundled": true
-        },
-        "ua-parser-js": {
-          "version": "0.7.12",
-          "bundled": true
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
+      "version": "file:../../packs/storybook-addon-links.tgz",
+      "integrity": "sha1-OvTGc2ii0K8+LdJbS/cIcyheUMU=",
+      "dev": true
     },
     "@storybook/addon-storyshots": {
-      "version": "file:../../addons/storyshots",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dependencies": {
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "interpret": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "bundled": true
-            },
-            "resolve": {
-              "version": "1.3.3",
-              "bundled": true
-            },
-            "shelljs": {
-              "version": "0.7.8",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "@storybook/channels": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dependencies": {
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "interpret": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "bundled": true
-            },
-            "resolve": {
-              "version": "1.3.3",
-              "bundled": true
-            },
-            "shelljs": {
-              "version": "0.7.8",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "anymatch": {
-          "version": "1.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "arr-flatten": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "bundled": true,
-          "optional": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "asap": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "async-each": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "babel-cli": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-code-frame": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-core": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-generator": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-helper-builder-react-jsx": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-call-delegate": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-define-map": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-function-name": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-get-function-arity": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-hoist-variables": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-optimise-call-expression": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-regex": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-replace-supers": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helpers": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-plugin-check-es2015-constants": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-flow": {
-          "version": "6.18.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-jsx": {
-          "version": "6.18.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-classes": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-for-of": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-function-name": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-literals": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-object-super": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-parameters": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-spread": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-flow-strip-types": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-react-display-name": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-react-jsx": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-react-jsx-self": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-react-jsx-source": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-regenerator": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-plugin-transform-runtime": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-strict-mode": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-polyfill": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-preset-es2015": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-preset-flow": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-preset-react": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-register": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-template": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-traverse": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-types": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babylon": {
-          "version": "6.17.4",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "binary-extensions": {
-          "version": "1.8.0",
-          "bundled": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "bundled": true,
-          "optional": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "chokidar": {
-          "version": "1.7.0",
-          "bundled": true,
-          "optional": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "convert-source-map": {
-          "version": "1.5.0",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "2.4.1",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "create-react-class": {
-          "version": "15.6.0",
-          "bundled": true
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "dom-walk": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "optional": true
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "bundled": true,
-          "optional": true
-        },
-        "fbjs": {
-          "version": "0.8.12",
-          "bundled": true,
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            }
-          }
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true
-        },
-        "fs-readdir-recursive": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fsevents": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "optional": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "aproba": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "optional": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.7",
-              "bundled": true
-            },
-            "buffer-shims": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true,
-              "optional": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "optional": true
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true,
-              "optional": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "extsprintf": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true,
-              "optional": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "optional": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "optional": true
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "optional": true
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "optional": true
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "jodid25519": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "jsprim": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.27.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.36",
-              "bundled": true,
-              "optional": true
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "npmlog": {
-              "version": "4.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "optional": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true,
-              "optional": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.2.9",
-              "bundled": true
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.0",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "bundled": true,
-              "optional": true
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "optional": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "verror": {
-              "version": "1.3.6",
-              "bundled": true,
-              "optional": true
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "global": {
-          "version": "4.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "globals": {
-          "version": "9.18.0",
-          "bundled": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "home-or-tmp": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "hosted-git-info": {
-          "version": "2.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.18",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "is-buffer": {
-          "version": "1.1.5",
-          "bundled": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "optional": true
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "bundled": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "bundled": true,
-          "optional": true
-        },
-        "min-document": {
-          "version": "2.19.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "nan": {
-          "version": "2.6.2",
-          "bundled": true,
-          "optional": true
-        },
-        "node-fetch": {
-          "version": "1.7.1",
-          "bundled": true
-        },
-        "normalize-package-data": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "output-file-sync": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "p-limit": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "optional": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "private": {
-          "version": "0.1.7",
-          "bundled": true
-        },
-        "process": {
-          "version": "0.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "optional": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.5.10",
-          "bundled": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "optional": true,
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "react": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "react-dom": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "readdirp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "regenerate": {
-          "version": "1.3.2",
-          "bundled": true
-        },
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "bundled": true
-        },
-        "regenerator-transform": {
-          "version": "0.9.11",
-          "bundled": true
-        },
-        "regex-cache": {
-          "version": "0.4.3",
-          "bundled": true,
-          "optional": true
-        },
-        "regexpu-core": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "regjsgen": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "regjsparser": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dependencies": {
-            "jsesc": {
-              "version": "0.5.0",
-              "bundled": true
-            }
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "safe-buffer": {
-          "version": "5.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-immediate-shim": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "bundled": true
-        },
-        "source-map-support": {
-          "version": "0.4.15",
-          "bundled": true
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "ua-parser-js": {
-          "version": "0.7.12",
-          "bundled": true
-        },
-        "user-home": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "v8flags": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
+      "version": "file:../../packs/storybook-addon-storyshots.tgz",
+      "integrity": "sha1-EeDV4Qo8i/BmuJ2f+tn15QxHG5k=",
+      "dev": true
     },
     "@storybook/addons": {
-      "version": "file:../../lib/addons",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "interpret": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "bundled": true
-        },
-        "resolve": {
-          "version": "1.3.3",
-          "bundled": true
-        },
-        "shelljs": {
-          "version": "0.7.8",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
+      "version": "file:../../packs/storybook-addons.tgz",
+      "integrity": "sha1-0oP0whomN4qq0FMZECDu/EGtVw0=",
+      "dev": true
     },
     "@storybook/channel-postmessage": {
-      "version": "file:../../lib/channel-postmessage",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "dom-walk": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true
-        },
-        "global": {
-          "version": "4.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "interpret": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "min-document": {
-          "version": "2.19.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "process": {
-          "version": "0.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "bundled": true
-        },
-        "resolve": {
-          "version": "1.3.3",
-          "bundled": true
-        },
-        "shelljs": {
-          "version": "0.7.8",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
+      "version": "file:../../packs/storybook-channel-postmessage.tgz",
+      "integrity": "sha1-HOIEFMTwoWDxRiYTwKdqa0Ln8+I=",
+      "dev": true
     },
     "@storybook/channels": {
-      "version": "file:../../lib/channels",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "interpret": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "bundled": true
-        },
-        "resolve": {
-          "version": "1.3.3",
-          "bundled": true
-        },
-        "shelljs": {
-          "version": "0.7.8",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
+      "version": "file:../../packs/storybook-channels.tgz",
+      "integrity": "sha1-wElbG767mhnF2J3Ah5E0JPd5M0M=",
+      "dev": true
     },
     "@storybook/react": {
-      "version": "file:../../app/react",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addon-actions": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "@storybook/addons": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "asap": {
-              "version": "2.0.5",
-              "bundled": true
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "bundled": true,
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "create-react-class": {
-              "version": "15.6.0",
-              "bundled": true
-            },
-            "deep-equal": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.12",
-              "bundled": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true
-            },
-            "iconv-lite": {
-              "version": "0.4.18",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "interpret": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "is-dom": {
-              "version": "1.0.9",
-              "bundled": true,
-              "dev": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "node-fetch": {
-              "version": "1.7.1",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.5.10",
-              "bundled": true
-            },
-            "react": {
-              "version": "15.6.1",
-              "bundled": true
-            },
-            "react-dom": {
-              "version": "15.6.1",
-              "bundled": true
-            },
-            "react-inspector": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "react-test-renderer": {
-              "version": "15.6.1",
-              "bundled": true
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "bundled": true
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "bundled": true,
-              "dev": true
-            },
-            "resolve": {
-              "version": "1.3.3",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "shelljs": {
-              "version": "0.7.8",
-              "bundled": true
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "@storybook/addon-links": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "@storybook/addons": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "asap": {
-              "version": "2.0.5",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "create-react-class": {
-              "version": "15.6.0",
-              "bundled": true
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.12",
-              "bundled": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true
-            },
-            "iconv-lite": {
-              "version": "0.4.18",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "interpret": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "node-fetch": {
-              "version": "1.7.1",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.5.10",
-              "bundled": true
-            },
-            "react": {
-              "version": "15.6.1",
-              "bundled": true
-            },
-            "react-dom": {
-              "version": "15.6.1",
-              "bundled": true
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "bundled": true
-            },
-            "resolve": {
-              "version": "1.3.3",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "shelljs": {
-              "version": "0.7.8",
-              "bundled": true
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "@storybook/addons": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "interpret": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "bundled": true
-            },
-            "resolve": {
-              "version": "1.3.3",
-              "bundled": true
-            },
-            "shelljs": {
-              "version": "0.7.8",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "@storybook/channel-postmessage": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "@storybook/channels": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "dom-walk": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true
-            },
-            "global": {
-              "version": "4.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "interpret": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "min-document": {
-              "version": "2.19.0",
-              "bundled": true,
-              "dev": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "process": {
-              "version": "0.5.2",
-              "bundled": true,
-              "dev": true
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "bundled": true
-            },
-            "resolve": {
-              "version": "1.3.3",
-              "bundled": true
-            },
-            "shelljs": {
-              "version": "0.7.8",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "@storybook/ui": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "@storybook/react-fuzzy": {
-              "version": "0.4.0",
-              "bundled": true,
-              "dev": true
-            },
-            "asap": {
-              "version": "2.0.5",
-              "bundled": true
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "bundled": true,
-              "dev": true
-            },
-            "boolbase": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "bowser": {
-              "version": "1.7.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cheerio": {
-              "version": "0.22.0",
-              "bundled": true
-            },
-            "classnames": {
-              "version": "2.2.5",
-              "bundled": true,
-              "dev": true
-            },
-            "core-js": {
-              "version": "2.4.1",
-              "bundled": true,
-              "dev": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "create-react-class": {
-              "version": "15.6.0",
-              "bundled": true,
-              "dev": true
-            },
-            "css-in-js-utils": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "css-select": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "css-what": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "deep-equal": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "define-properties": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "dom-serializer": {
-              "version": "0.1.0",
-              "bundled": true
-            },
-            "dom-walk": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "domelementtype": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "domhandler": {
-              "version": "2.4.1",
-              "bundled": true
-            },
-            "domutils": {
-              "version": "1.5.1",
-              "bundled": true
-            },
-            "element-class": {
-              "version": "0.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true
-            },
-            "entities": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "enzyme": {
-              "version": "2.8.2",
-              "bundled": true
-            },
-            "es-abstract": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "es-to-primitive": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "events": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "exenv": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fbjs": {
-              "version": "0.8.12",
-              "bundled": true
-            },
-            "foreach": {
-              "version": "2.0.5",
-              "bundled": true
-            },
-            "function-bind": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "function.prototype.name": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fuse.js": {
-              "version": "3.0.5",
-              "bundled": true,
-              "dev": true
-            },
-            "fuzzysearch": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "global": {
-              "version": "4.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "has": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "htmlparser2": {
-              "version": "3.9.2",
-              "bundled": true
-            },
-            "hyphenate-style-name": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "iconv-lite": {
-              "version": "0.4.18",
-              "bundled": true
-            },
-            "immutable": {
-              "version": "3.8.1",
-              "bundled": true,
-              "dev": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "inline-style-prefixer": {
-              "version": "3.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true
-            },
-            "is-callable": {
-              "version": "1.1.3",
-              "bundled": true
-            },
-            "is-date-object": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "is-dom": {
-              "version": "1.0.9",
-              "bundled": true,
-              "dev": true
-            },
-            "is-regex": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-subset": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-symbol": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "keycode": {
-              "version": "2.1.9",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._getnative": {
-              "version": "3.9.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.assign": {
-              "version": "4.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.assignin": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "lodash.bind": {
-              "version": "4.2.1",
-              "bundled": true
-            },
-            "lodash.defaults": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "lodash.filter": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "lodash.flatten": {
-              "version": "4.4.0",
-              "bundled": true
-            },
-            "lodash.foreach": {
-              "version": "4.5.0",
-              "bundled": true
-            },
-            "lodash.isarguments": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.isarray": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.map": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "lodash.merge": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "lodash.pick": {
-              "version": "4.4.0",
-              "bundled": true
-            },
-            "lodash.reduce": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "lodash.reject": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "lodash.some": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true,
-              "dev": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "mantra-core": {
-              "version": "1.7.0",
-              "bundled": true,
-              "dev": true
-            },
-            "min-document": {
-              "version": "2.19.0",
-              "bundled": true,
-              "dev": true
-            },
-            "mobx": {
-              "version": "2.7.0",
-              "bundled": true
-            },
-            "node-fetch": {
-              "version": "1.7.1",
-              "bundled": true
-            },
-            "nth-check": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "object-is": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "object-keys": {
-              "version": "1.0.11",
-              "bundled": true
-            },
-            "object.assign": {
-              "version": "4.0.4",
-              "bundled": true
-            },
-            "object.entries": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "object.values": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "podda": {
-              "version": "1.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "process": {
-              "version": "0.5.2",
-              "bundled": true,
-              "dev": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true
-            },
-            "prop-types": {
-              "version": "15.5.10",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true,
-              "dev": true
-            },
-            "react-dom-factories": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "react-inspector": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "react-komposer": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "react-modal": {
-              "version": "1.9.7",
-              "bundled": true,
-              "dev": true
-            },
-            "react-simple-di": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "react-split-pane": {
-              "version": "0.1.63",
-              "bundled": true,
-              "dev": true
-            },
-            "react-stubber": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "react-style-proptype": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.0",
-              "bundled": true
-            },
-            "redux": {
-              "version": "3.7.0",
-              "bundled": true,
-              "dev": true
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "bundled": true,
-              "dev": true
-            },
-            "safe-buffer": {
-              "version": "5.1.0",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "shallowequal": {
-              "version": "0.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "string_decoder": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "accepts": {
-          "version": "1.3.3",
-          "bundled": true,
-          "dev": true
-        },
-        "acorn": {
-          "version": "5.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "acorn-dynamic-import": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "acorn": {
-              "version": "4.0.13",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "airbnb-js-shims": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ajv": {
-          "version": "5.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "alphanum-sort": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-html": {
-          "version": "0.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "anymatch": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "argparse": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "arr-flatten": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "array-flatten": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "array-includes": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "asn1.js": {
-          "version": "4.9.1",
-          "bundled": true,
-          "dev": true
-        },
-        "assert": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ast-types": {
-          "version": "0.9.6",
-          "bundled": true,
-          "dev": true
-        },
-        "async": {
-          "version": "2.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "async-each": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "autoprefixer": {
-          "version": "7.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-cli": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-code-frame": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-core": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-generator": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-helper-bindify-decorators": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-builder-binary-assignment-operator-visitor": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-builder-react-jsx": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-call-delegate": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-define-map": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-explode-assignable-expression": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-explode-class": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-function-name": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-get-function-arity": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-hoist-variables": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-optimise-call-expression": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-regex": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-remap-async-to-generator": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helper-replace-supers": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-helpers": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-loader": {
-          "version": "7.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-plugin-check-es2015-constants": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-dynamic-import-node": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-react-docgen": {
-          "version": "1.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-async-functions": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-async-generators": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-class-constructor-call": {
-          "version": "6.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-class-properties": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-decorators": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-do-expressions": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-dynamic-import": {
-          "version": "6.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-exponentiation-operator": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-export-extensions": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-flow": {
-          "version": "6.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-function-bind": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-jsx": {
-          "version": "6.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-object-rest-spread": {
-          "version": "6.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-syntax-trailing-function-commas": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-async-generator-functions": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-async-to-generator": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-class-constructor-call": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-class-properties": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-decorators": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-do-expressions": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-classes": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-for-of": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-function-name": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-literals": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-object-super": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-parameters": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-spread": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-exponentiation-operator": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-export-extensions": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-flow-strip-types": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-function-bind": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-object-rest-spread": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-react-constant-elements": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-react-display-name": {
-          "version": "6.25.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-react-jsx": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-react-jsx-self": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-react-jsx-source": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-regenerator": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-runtime": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-plugin-transform-strict-mode": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-polyfill": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-preset-env": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "browserslist": {
-              "version": "1.7.7",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "babel-preset-es2015": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-preset-es2016": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-preset-flow": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-preset-react": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-preset-react-app": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-preset-stage-0": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-preset-stage-1": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-preset-stage-2": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-preset-stage-3": {
-          "version": "6.24.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-register": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "bundled": true
-        },
-        "babel-template": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-traverse": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-types": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babylon": {
-          "version": "6.17.4",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "base64-js": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "big.js": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "binary-extensions": {
-          "version": "1.8.0",
-          "bundled": true
-        },
-        "bn.js": {
-          "version": "4.11.7",
-          "bundled": true,
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "bundled": true
-        },
-        "brcast": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brorand": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "browserify-aes": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "browserify-cipher": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "browserify-des": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "browserify-rsa": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "browserify-sign": {
-          "version": "4.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "browserify-zlib": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "browserslist": {
-          "version": "2.1.5",
-          "bundled": true,
-          "dev": true
-        },
-        "buffer": {
-          "version": "4.9.1",
-          "bundled": true,
-          "dev": true
-        },
-        "buffer-xor": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "builtin-status-codes": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "caniuse-api": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "browserslist": {
-              "version": "1.7.7",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "caniuse-db": {
-          "version": "1.0.30000692",
-          "bundled": true,
-          "dev": true
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000692",
-          "bundled": true,
-          "dev": true
-        },
-        "case-sensitive-paths-webpack-plugin": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "chokidar": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "cipher-base": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "clap": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "clone": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "coa": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "color": {
-          "version": "0.11.4",
-          "bundled": true,
-          "dev": true
-        },
-        "color-convert": {
-          "version": "1.9.0",
-          "bundled": true,
-          "dev": true
-        },
-        "color-name": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "color-string": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "colormin": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "colors": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "bundled": true
-        },
-        "common-tags": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "configstore": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "console-browserify": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "constants-browserify": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "content-disposition": {
-          "version": "0.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "content-type": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.5.0",
-          "bundled": true
-        },
-        "cookie": {
-          "version": "0.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "cookie-signature": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.4.1",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cosmiconfig": {
-          "version": "2.1.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "create-ecdh": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "create-hash": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "create-hmac": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "create-react-class": {
-          "version": "15.6.0",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "crypto-browserify": {
-          "version": "3.11.0",
-          "bundled": true,
-          "dev": true
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "css-color-names": {
-          "version": "0.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "css-loader": {
-          "version": "0.28.4",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "css-selector-tokenizer": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "regexpu-core": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "cssesc": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "cssnano": {
-          "version": "3.10.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "autoprefixer": {
-              "version": "6.7.7",
-              "bundled": true,
-              "dev": true
-            },
-            "browserslist": {
-              "version": "1.7.7",
-              "bundled": true,
-              "dev": true
-            },
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "csso": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "date-now": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "define-properties": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "defined": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "depd": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "des.js": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "destroy": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "diffie-hellman": {
-          "version": "5.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "doctrine": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "dom-walk": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "domain-browser": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true
-        },
-        "dot-prop": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "duplexer": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "duplexify": {
-          "version": "3.5.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ee-first": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.14",
-          "bundled": true,
-          "dev": true
-        },
-        "element-class": {
-          "version": "0.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "elliptic": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "encodeurl": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true
-        },
-        "end-of-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dependencies": {
-            "once": {
-              "version": "1.3.3",
-              "bundled": true
-            }
-          }
-        },
-        "enhanced-resolve": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "errno": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "es-abstract": {
-          "version": "1.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "es-to-primitive": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "es5-shim": {
-          "version": "4.5.9",
-          "bundled": true,
-          "dev": true
-        },
-        "es6-promise": {
-          "version": "3.3.1",
-          "bundled": true
-        },
-        "es6-shim": {
-          "version": "0.35.3",
-          "bundled": true,
-          "dev": true
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "etag": {
-          "version": "1.8.0",
-          "bundled": true,
-          "dev": true
-        },
-        "event-stream": {
-          "version": "3.3.4",
-          "bundled": true
-        },
-        "events": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "evp_bytestokey": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "exenv": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "bundled": true
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true
-        },
-        "express": {
-          "version": "4.15.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "debug": {
-              "version": "2.6.7",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-memoize": {
-          "version": "2.2.7",
-          "bundled": true,
-          "dev": true
-        },
-        "fastparse": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "fbjs": {
-          "version": "0.8.12",
-          "bundled": true,
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            }
-          }
-        },
-        "file-loader": {
-          "version": "0.11.2",
-          "bundled": true,
-          "dev": true
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "bundled": true
-        },
-        "finalhandler": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "debug": {
-              "version": "2.6.7",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "find-cache-dir": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "flatten": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true
-        },
-        "foreach": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "forwarded": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fresh": {
-          "version": "0.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "from": {
-          "version": "0.1.7",
-          "bundled": true
-        },
-        "fs-readdir-recursive": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fsevents": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "optional": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "aproba": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "optional": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.7",
-              "bundled": true
-            },
-            "buffer-shims": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true,
-              "optional": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "optional": true
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true,
-              "optional": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "extsprintf": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true,
-              "optional": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "optional": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "optional": true
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "optional": true
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "optional": true
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "jodid25519": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "jsprim": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.27.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.36",
-              "bundled": true,
-              "optional": true
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "npmlog": {
-              "version": "4.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "optional": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true,
-              "optional": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.2.9",
-              "bundled": true
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.0",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "bundled": true,
-              "optional": true
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "optional": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "verror": {
-              "version": "1.3.6",
-              "bundled": true,
-              "optional": true
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "function-bind": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "glamor": {
-          "version": "2.20.25",
-          "bundled": true,
-          "dev": true
-        },
-        "glamorous": {
-          "version": "3.23.3",
-          "bundled": true,
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "global": {
-          "version": "4.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "globals": {
-          "version": "9.18.0",
-          "bundled": true
-        },
-        "got": {
-          "version": "3.3.1",
-          "bundled": true,
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "has": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "hash-base": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "hash.js": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "hmac-drbg": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "hosted-git-info": {
-          "version": "2.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "html-comment-regex": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "html-element-attributes": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "html-entities": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "html-tag-names": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "https-browserify": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.18",
-          "bundled": true
-        },
-        "icss-replace-symbols": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "icss-utils": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ieee754": {
-          "version": "1.1.8",
-          "bundled": true,
-          "dev": true
-        },
-        "ignore-by-default": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "indexes-of": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "indexof": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "infinity-agent": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true
-        },
-        "interpret": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ipaddr.js": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-absolute-url": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-buffer": {
-          "version": "1.1.5",
-          "bundled": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-directory": {
-          "version": "0.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "is-npm": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-svg": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "js-base64": {
-          "version": "2.1.9",
-          "bundled": true,
-          "dev": true
-        },
-        "js-tokens": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "js-yaml": {
-          "version": "3.7.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.3",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "json-loader": {
-          "version": "0.5.4",
-          "bundled": true,
-          "dev": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "latest-version": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loader-runner": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._baseassign": {
-          "version": "3.2.0",
-          "bundled": true
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._createassigner": {
-          "version": "3.1.1",
-          "bundled": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "bundled": true
-        },
-        "lodash.assign": {
-          "version": "3.2.0",
-          "bundled": true
-        },
-        "lodash.camelcase": {
-          "version": "4.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.defaults": {
-          "version": "3.1.2",
-          "bundled": true
-        },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "bundled": true
-        },
-        "lodash.memoize": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.pick": {
-          "version": "4.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "bundled": true
-        },
-        "lodash.uniq": {
-          "version": "4.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "lowercase-keys": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "macaddress": {
-          "version": "0.2.8",
-          "bundled": true,
-          "dev": true
-        },
-        "make-dir": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "map-stream": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "math-expression-evaluator": {
-          "version": "1.2.17",
-          "bundled": true,
-          "dev": true
-        },
-        "media-typer": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "memory-fs": {
-          "version": "0.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "merge-descriptors": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "methods": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "bundled": true
-        },
-        "miller-rabin": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true
-        },
-        "min-document": {
-          "version": "2.19.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimalistic-assert": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimalistic-crypto-utils": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true
-        },
-        "mock-fs": {
-          "version": "4.4.1",
-          "bundled": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "nan": {
-          "version": "2.6.2",
-          "bundled": true,
-          "optional": true
-        },
-        "negotiator": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "nested-error-stacks": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "node-dir": {
-          "version": "0.1.17",
-          "bundled": true,
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.7.1",
-          "bundled": true
-        },
-        "node-libs-browser": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "process": {
-              "version": "0.11.10",
-              "bundled": true,
-              "dev": true
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "nodemon": {
-          "version": "1.11.0",
-          "bundled": true
-        },
-        "nopt": {
-          "version": "1.0.10",
-          "bundled": true
-        },
-        "normalize-package-data": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "normalize-range": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "normalize-url": {
-          "version": "1.9.1",
-          "bundled": true,
-          "dev": true
-        },
-        "num2fraction": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "object-keys": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true
-        },
-        "object.entries": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "object.getownpropertydescriptors": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "object.values": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "on-finished": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "os-browserify": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "output-file-sync": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "p-limit": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "package-json": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "pako": {
-          "version": "0.2.9",
-          "bundled": true,
-          "dev": true
-        },
-        "parse-asn1": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "parseurl": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-browserify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pause-stream": {
-          "version": "0.0.11",
-          "bundled": true
-        },
-        "pbkdf2": {
-          "version": "3.0.12",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "pkg-dir": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss": {
-          "version": "6.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-calc": {
-          "version": "5.3.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-colormin": {
-          "version": "2.2.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-convert-values": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-discard-comments": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-discard-duplicates": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-discard-empty": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-discard-overridden": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-discard-unused": {
-          "version": "2.2.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-filter-plugins": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-flexbugs-fixes": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-load-config": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-load-options": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-load-plugins": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-loader": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-merge-idents": {
-          "version": "2.1.7",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-merge-longhand": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-merge-rules": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "browserslist": {
-              "version": "1.7.7",
-              "bundled": true,
-              "dev": true
-            },
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-message-helpers": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-minify-font-values": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-minify-gradients": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-minify-params": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-minify-selectors": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-modules-extract-imports": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-modules-local-by-default": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-modules-scope": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-modules-values": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-normalize-charset": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-normalize-url": {
-          "version": "3.0.8",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-ordered-values": {
-          "version": "2.2.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-reduce-idents": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-reduce-initial": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-reduce-transforms": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-selector-parser": {
-          "version": "2.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-svgo": {
-          "version": "2.1.6",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-unique-selectors": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "postcss-zindex": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "postcss": {
-              "version": "5.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "private": {
-          "version": "0.1.7",
-          "bundled": true
-        },
-        "process": {
-          "version": "0.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.5.10",
-          "bundled": true
-        },
-        "proxy-addr": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "prr": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ps-tree": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "public-encrypt": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "q": {
-          "version": "1.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "query-string": {
-          "version": "4.3.4",
-          "bundled": true,
-          "dev": true
-        },
-        "querystring": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "querystring-es3": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "randombytes": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "range-parser": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "react": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "react-docgen": {
-          "version": "2.16.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "babylon": {
-              "version": "5.8.38",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "react-dom": {
-          "version": "15.6.1",
-          "bundled": true
-        },
-        "react-dom-factories": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-html-attributes": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-modal": {
-          "version": "1.9.7",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "lodash.assign": {
-              "version": "4.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "read-all-stream": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.0",
-          "bundled": true
-        },
-        "readdirp": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "recast": {
-          "version": "0.11.23",
-          "bundled": true,
-          "dev": true
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "bundled": true,
-          "dev": true
-        },
-        "reduce-css-calc": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "reduce-function-call": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "redux": {
-          "version": "3.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "regenerate": {
-          "version": "1.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "bundled": true
-        },
-        "regenerator-transform": {
-          "version": "0.9.11",
-          "bundled": true,
-          "dev": true
-        },
-        "regex-cache": {
-          "version": "0.4.3",
-          "bundled": true
-        },
-        "regexpu-core": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "regjsgen": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "regjsparser": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "jsesc": {
-              "version": "0.5.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-from-string": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.3.3",
-          "bundled": true,
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ripemd160": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.1.0",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true
-        },
-        "semver-diff": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "send": {
-          "version": "0.15.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "debug": {
-              "version": "2.6.7",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "serve-favicon": {
-          "version": "2.4.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "serve-static": {
-          "version": "1.12.3",
-          "bundled": true,
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-immediate-shim": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "sha.js": {
-          "version": "2.4.8",
-          "bundled": true,
-          "dev": true
-        },
-        "shelljs": {
-          "version": "0.7.8",
-          "bundled": true,
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true
-        },
-        "sort-keys": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "source-list-map": {
-          "version": "0.1.8",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "bundled": true
-        },
-        "source-map-support": {
-          "version": "0.4.15",
-          "bundled": true
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "split": {
-          "version": "0.3.3",
-          "bundled": true
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "stream-browserify": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "stream-combiner": {
-          "version": "0.0.4",
-          "bundled": true
-        },
-        "stream-http": {
-          "version": "2.7.2",
-          "bundled": true,
-          "dev": true
-        },
-        "stream-shift": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "strict-uri-encode": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "string-length": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "string.prototype.padend": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "string.prototype.padstart": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "style-loader": {
-          "version": "0.17.0",
-          "bundled": true,
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "svg-tag-names": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "svgo": {
-          "version": "0.7.2",
-          "bundled": true,
-          "dev": true
-        },
-        "symbol-observable": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "tapable": {
-          "version": "0.2.6",
-          "bundled": true,
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "bundled": true
-        },
-        "timed-out": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "timers-browserify": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "to-arraybuffer": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "touch": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "tty-browserify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "type-is": {
-          "version": "1.6.15",
-          "bundled": true,
-          "dev": true
-        },
-        "ua-parser-js": {
-          "version": "0.7.12",
-          "bundled": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "undefsafe": {
-          "version": "0.0.3",
-          "bundled": true
-        },
-        "uniq": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "uniqid": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "uniqs": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "unique-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "0.5.0",
-          "bundled": true,
-          "dependencies": {
-            "configstore": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "write-file-atomic": {
-              "version": "1.3.4",
-              "bundled": true
-            },
-            "xdg-basedir": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "url": {
-          "version": "0.11.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "url-loader": {
-          "version": "0.5.9",
-          "bundled": true,
-          "dev": true
-        },
-        "user-home": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "util": {
-          "version": "0.10.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "utils-merge": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "v8flags": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "vary": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "vendors": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true
-        },
-        "vm-browserify": {
-          "version": "0.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "watchpack": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "webpack": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "dev": true
-            },
-            "loader-utils": {
-              "version": "0.2.17",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "webpack-dev-middleware": {
-          "version": "1.10.2",
-          "bundled": true,
-          "dev": true
-        },
-        "webpack-hot-middleware": {
-          "version": "2.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "webpack-sources": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "source-list-map": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "whet.extend": {
-          "version": "0.9.9",
-          "bundled": true,
-          "dev": true
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "write-file-atomic": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "yargs": {
-          "version": "6.6.0",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cliui": {
-              "version": "3.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        }
-      }
+      "version": "file:../../packs/storybook-react.tgz",
+      "integrity": "sha1-HNNIAsFQw4pygn4U37Nj8zk53D0=",
+      "dev": true
+    },
+    "@storybook/react-fuzzy": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react-fuzzy/-/react-fuzzy-0.4.0.tgz",
+      "integrity": "sha1-KWHoofbBr8zpfp6aFNHf6dkGEIc=",
+      "dev": true
     },
     "@storybook/ui": {
-      "version": "file:../../lib/ui",
-      "dev": true,
-      "dependencies": {
-        "@storybook/react-fuzzy": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "asap": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
-        },
-        "boolbase": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "bowser": {
-          "version": "1.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "cheerio": {
-          "version": "0.22.0",
-          "bundled": true
-        },
-        "classnames": {
-          "version": "2.2.5",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "create-react-class": {
-          "version": "15.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "css-in-js-utils": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "css-select": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "css-what": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "deep-equal": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "define-properties": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "dom-serializer": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "dom-walk": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "domelementtype": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "domhandler": {
-          "version": "2.4.1",
-          "bundled": true
-        },
-        "domutils": {
-          "version": "1.5.1",
-          "bundled": true
-        },
-        "element-class": {
-          "version": "0.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true
-        },
-        "entities": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "enzyme": {
-          "version": "2.8.2",
-          "bundled": true
-        },
-        "es-abstract": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "es-to-primitive": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "events": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "exenv": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fbjs": {
-          "version": "0.8.12",
-          "bundled": true
-        },
-        "foreach": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "function-bind": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "function.prototype.name": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fuse.js": {
-          "version": "3.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "fuzzysearch": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "global": {
-          "version": "4.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "has": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "3.9.2",
-          "bundled": true
-        },
-        "hyphenate-style-name": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.18",
-          "bundled": true
-        },
-        "immutable": {
-          "version": "3.8.1",
-          "bundled": true,
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "inline-style-prefixer": {
-          "version": "3.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true
-        },
-        "is-callable": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-dom": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-subset": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "is-symbol": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "keycode": {
-          "version": "2.1.9",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.assign": {
-          "version": "4.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.assignin": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "lodash.bind": {
-          "version": "4.2.1",
-          "bundled": true
-        },
-        "lodash.defaults": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "lodash.filter": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.flatten": {
-          "version": "4.4.0",
-          "bundled": true
-        },
-        "lodash.foreach": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.map": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.merge": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.pick": {
-          "version": "4.4.0",
-          "bundled": true
-        },
-        "lodash.reduce": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.reject": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.some": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "mantra-core": {
-          "version": "1.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "min-document": {
-          "version": "2.19.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mobx": {
-          "version": "2.7.0",
-          "bundled": true
-        },
-        "node-fetch": {
-          "version": "1.7.1",
-          "bundled": true
-        },
-        "nth-check": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "object-is": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-keys": {
-          "version": "1.0.11",
-          "bundled": true
-        },
-        "object.assign": {
-          "version": "4.0.4",
-          "bundled": true
-        },
-        "object.entries": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "object.values": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "podda": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "process": {
-          "version": "0.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.5.10",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-dom-factories": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-inspector": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-komposer": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-modal": {
-          "version": "1.9.7",
-          "bundled": true,
-          "dev": true
-        },
-        "react-simple-di": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-split-pane": {
-          "version": "0.1.63",
-          "bundled": true,
-          "dev": true
-        },
-        "react-stubber": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "react-style-proptype": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.0",
-          "bundled": true
-        },
-        "redux": {
-          "version": "3.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "bundled": true,
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.1.0",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "shallowequal": {
-          "version": "0.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "symbol-observable": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "ua-parser-js": {
-          "version": "0.7.12",
-          "bundled": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        }
-      }
+      "version": "file:../../packs/storybook-ui.tgz",
+      "integrity": "sha1-Q19SfHt1qOthTbPWzY/tsb7o5OA=",
+      "dev": true
     },
     "@timer/detect-port": {
       "version": "1.1.3",
@@ -7981,10 +121,16 @@
       "integrity": "sha1-Nj9dPyvibQZV2K/VqVYuT8IZRTc=",
       "dev": true
     },
+    "airbnb-js-shims": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.1.1.tgz",
+      "integrity": "sha1-JyJPADDyROZXBELtECB3LBQ0rsI=",
+      "dev": true
+    },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
+      "integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
       "dev": true
     },
     "ajv-keywords": {
@@ -8178,6 +324,12 @@
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
+    "ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+      "dev": true
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -8203,9 +355,9 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.0.tgz",
-      "integrity": "sha1-rkkTrcIh+mylrTpvgDn2pcBrOHc=",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.1.tgz",
+      "integrity": "sha1-l7yFTH0Ll5+NZIneVHoNF/swf20=",
       "dev": true
     },
     "aws-sign2": {
@@ -8233,9 +385,9 @@
       "dev": true
     },
     "babel-core": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
       "dev": true
     },
     "babel-eslint": {
@@ -8248,6 +400,12 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+      "dev": true
+    },
+    "babel-helper-bindify-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -8278,6 +436,12 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true
+    },
+    "babel-helper-explode-class": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true
     },
     "babel-helper-function-name": {
@@ -8335,9 +499,9 @@
       "dev": true
     },
     "babel-loader": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.0.0.tgz",
-      "integrity": "sha1-LkOma+4f/0RwUz0EAsikUy+vuvc=",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.0.tgz",
+      "integrity": "sha1-P78lgfCFd0vZZC3KmZDm1sFJEUQ=",
       "dev": true
     },
     "babel-messages": {
@@ -8370,16 +534,46 @@
       "integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
       "dev": true
     },
+    "babel-plugin-react-docgen": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.5.0.tgz",
+      "integrity": "sha1-AzlxetUfSlzkNJMwuCZupaVvU7Q=",
+      "dev": true
+    },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-constructor-call": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+      "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+      "dev": true
+    },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+      "dev": true
+    },
+    "babel-plugin-syntax-do-expressions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+      "integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
       "dev": true
     },
     "babel-plugin-syntax-dynamic-import": {
@@ -8394,10 +588,22 @@
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
+    "babel-plugin-syntax-export-extensions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+      "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+      "dev": true
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-function-bind": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+      "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
       "dev": true
     },
     "babel-plugin-syntax-jsx": {
@@ -8418,16 +624,40 @@
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "dev": true
     },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+      "dev": true
+    },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true
     },
+    "babel-plugin-transform-class-constructor-call": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
+      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+      "dev": true
+    },
     "babel-plugin-transform-class-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+      "dev": true
+    },
+    "babel-plugin-transform-do-expressions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
+      "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
       "dev": true
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -8568,10 +798,22 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true
     },
+    "babel-plugin-transform-export-extensions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
+      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+      "dev": true
+    },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "dev": true
+    },
+    "babel-plugin-transform-function-bind": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
+      "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
       "dev": true
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -8642,6 +884,18 @@
         }
       }
     },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true
+    },
+    "babel-preset-es2016": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz",
+      "integrity": "sha1-+QC/k+LrwNJ235uKtZck6/2Vn4s=",
+      "dev": true
+    },
     "babel-preset-flow": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
@@ -8664,6 +918,30 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-3.0.0.tgz",
       "integrity": "sha1-9FBQkvi7oPAUfHZNxyBV/kasFBY=",
+      "dev": true
+    },
+    "babel-preset-stage-0": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
+      "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
+      "dev": true
+    },
+    "babel-preset-stage-1": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
+      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+      "dev": true
+    },
+    "babel-preset-stage-2": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+      "dev": true
+    },
+    "babel-preset-stage-3": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true
     },
     "babel-register": {
@@ -8779,6 +1057,12 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true
     },
+    "bowser": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.7.0.tgz",
+      "integrity": "sha1-Fp3kAYcR+ZQkK/+agAnneh814AM=",
+      "dev": true
+    },
     "boxen": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
@@ -8803,6 +1087,12 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true
+    },
+    "brcast": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.0.tgz",
+      "integrity": "sha1-nmJ6uCIJiVZkwdbB9FzYxDQi4/Y=",
       "dev": true
     },
     "brorand": {
@@ -8974,9 +1264,9 @@
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.0.0.tgz",
-      "integrity": "sha1-YBQtfQvqvbNWdu8K6s4wJ9oFeLo=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz",
+      "integrity": "sha1-PSnO2MHxJL9vU4Rvs/WJRzH9yQk=",
       "dev": true
     },
     "caseless": {
@@ -9035,6 +1325,12 @@
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
       "dev": true
     },
+    "classnames": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=",
+      "dev": true
+    },
     "clean-css": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.4.tgz",
@@ -9063,15 +1359,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "clone": {
       "version": "1.0.2",
@@ -9145,6 +1433,12 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true
     },
+    "common-tags": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
+      "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -9190,18 +1484,10 @@
       "dev": true
     },
     "configstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-      "dev": true,
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
-        }
-      }
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
+      "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
+      "dev": true
     },
     "connect-history-api-fallback": {
       "version": "1.3.0",
@@ -9335,16 +1621,28 @@
       "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
       "dev": true
     },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
+    "css-in-js-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz",
+      "integrity": "sha1-msfgL3Y8+F2UAXZmVl7WiltfMhU=",
+      "dev": true
+    },
     "css-loader": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.1.tgz",
-      "integrity": "sha1-IgMlWZ+PAEUtnOtMPKbIpmeYZC0=",
+      "version": "0.28.4",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.4.tgz",
+      "integrity": "sha1-bPNXkZLONV6LONX0Ldeh8uyJjQ8=",
       "dev": true,
       "dependencies": {
         "postcss": {
@@ -9481,6 +1779,12 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
@@ -9497,7 +1801,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
+        }
+      }
     },
     "define-properties": {
       "version": "1.1.2",
@@ -9635,9 +1947,9 @@
       "dev": true
     },
     "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
       "dev": true
     },
     "dotenv": {
@@ -9675,6 +1987,12 @@
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
       "integrity": "sha1-ZK8Pnv08PGrNV9cfg7Scp+6cS0M=",
+      "dev": true
+    },
+    "element-class": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/element-class/-/element-class-0.2.2.tgz",
+      "integrity": "sha1-nTu9B2f5AT744cjr5yLBQCpgBQ4=",
       "dev": true
     },
     "elliptic": {
@@ -9748,6 +2066,12 @@
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
       "dev": true
     },
+    "es5-shim": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
+      "integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA=",
+      "dev": true
+    },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
@@ -9770,6 +2094,12 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true
+    },
+    "es6-shim": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
+      "integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY=",
       "dev": true
     },
     "es6-symbol": {
@@ -9802,6 +2132,12 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
         "estraverse": {
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -9827,15 +2163,7 @@
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true,
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "eslint-config-react-app": {
       "version": "1.0.4",
@@ -9853,7 +2181,33 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.7.1.tgz",
       "integrity": "sha1-ULFY3WJy3O+5fphCVIN/gaWALOA=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "dev": true
+        }
+      }
     },
     "eslint-module-utils": {
       "version": "2.0.0",
@@ -9867,10 +2221,28 @@
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true
         },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
         "ms": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true
         }
       }
@@ -9914,9 +2286,9 @@
       "dev": true
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
       "dev": true
     },
     "esquery": {
@@ -9985,6 +2357,12 @@
       "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
       "dev": true
     },
+    "exenv": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz",
+      "integrity": "sha1-ODXxJ6vwdb/ggtCu1EhAV8eOPIk=",
+      "dev": true
+    },
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -10014,12 +2392,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
           "dev": true
-        },
-        "path-to-regexp": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-          "dev": true
         }
       }
     },
@@ -10045,7 +2417,21 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz",
       "integrity": "sha1-aTFbiF+Hbb+W04Gfap8cynrr8Vk=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true
+        },
+        "webpack-sources": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
+          "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
+          "dev": true
+        }
+      }
     },
     "extsprintf": {
       "version": "1.0.2",
@@ -10063,6 +2449,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha1-8UXFwiA5zt8KHU/2ylkq0CaEcMo=",
       "dev": true
     },
     "fastparse": {
@@ -10101,9 +2493,9 @@
       "dev": true
     },
     "file-loader": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.1.tgz",
-      "integrity": "sha1-azKO4SNKcp5OR9Njdd1tNcDh24Q=",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
+      "integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
       "dev": true
     },
     "filename-regex": {
@@ -10151,9 +2543,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-      "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true
     },
     "find-up": {
@@ -10229,705 +2621,772 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
-      "integrity": "sha1-hTfz8SJyZ4dltP1lKMDx9m+PRVg=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "bundled": true,
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "aproba": {
-          "version": "1.0.4",
-          "bundled": true,
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.2",
-          "bundled": true,
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true,
           "optional": true
         },
         "aws4": {
-          "version": "1.5.0",
-          "bundled": true,
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "bcrypt-pbkdf": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true
         },
         "boom": {
           "version": "2.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.6",
-          "bundled": true,
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
         },
         "caseless": {
-          "version": "0.11.0",
-          "bundled": true,
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true,
           "optional": true
         },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true,
-          "optional": true,
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "optional": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
           }
         },
         "debug": {
-          "version": "2.2.0",
-          "bundled": true,
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "optional": true
         },
         "deep-extend": {
-          "version": "0.4.1",
-          "bundled": true,
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true
         },
         "extend": {
-          "version": "3.0.0",
-          "bundled": true,
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true,
           "optional": true
         },
         "form-data": {
-          "version": "2.1.2",
-          "bundled": true,
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
-          "version": "1.0.10",
-          "bundled": true,
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "optional": true
         },
         "gauge": {
-          "version": "2.7.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "bundled": true,
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true
         },
         "getpass": {
-          "version": "0.1.6",
-          "bundled": true,
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
           }
         },
         "glob": {
-          "version": "7.1.1",
-          "bundled": true,
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true,
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "dev": true,
           "optional": true
         },
         "har-validator": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "optional": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "optional": true
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "optional": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true
-        },
-        "is-my-json-valid": {
-          "version": "2.15.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
           "optional": true
         },
         "jsbn": {
-          "version": "0.1.0",
-          "bundled": true,
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "optional": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true,
           "optional": true
         },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "bundled": true,
+        "jsonify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "dev": true,
           "optional": true
         },
         "jsprim": {
-          "version": "1.3.1",
-          "bundled": true,
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
         },
         "mime-db": {
-          "version": "1.25.0",
-          "bundled": true,
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.13",
-          "bundled": true,
+          "version": "2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.3",
-          "bundled": true,
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true
         },
         "ms": {
-          "version": "0.7.1",
-          "bundled": true,
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.32",
-          "bundled": true,
+          "version": "0.6.36",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
           "dev": true,
           "optional": true
         },
         "nopt": {
-          "version": "3.0.6",
-          "bundled": true,
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true
         },
         "npmlog": {
-          "version": "4.0.2",
-          "bundled": true,
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
           "optional": true
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
-          "version": "4.1.0",
-          "bundled": true,
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true
         },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "dev": true,
+          "optional": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "qs": {
-          "version": "6.3.0",
-          "bundled": true,
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true,
           "optional": true
         },
         "rc": {
-          "version": "1.1.6",
-          "bundled": true,
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
-          "version": "2.2.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "2.2.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "dev": true
         },
         "request": {
-          "version": "2.79.0",
-          "bundled": true,
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "optional": true
         },
         "rimraf": {
-          "version": "2.5.4",
-          "bundled": true,
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "optional": true
         },
         "sshpk": {
-          "version": "1.10.1",
-          "bundled": true,
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "bundled": true,
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true
         },
         "strip-json-comments": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "bundled": true,
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true
         },
         "tar-pack": {
-          "version": "3.3.0",
-          "bundled": true,
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
-          "optional": true,
-          "dependencies": {
-            "once": {
-              "version": "1.3.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "readable-stream": {
-              "version": "2.1.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "optional": true
         },
         "tunnel-agent": {
-          "version": "0.4.3",
-          "bundled": true,
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "optional": true
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -10935,6 +3394,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "fuse.js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.0.5.tgz",
+      "integrity": "sha1-tY2Fh4gCMh3pRGFlSUe5OvEIZyc=",
+      "dev": true
+    },
+    "fuzzysearch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fuzzysearch/-/fuzzysearch-1.0.3.tgz",
+      "integrity": "sha1-3/yA9tawQiPyImqnndGUIxCW0Ag=",
       "dev": true
     },
     "generate-function": {
@@ -10974,6 +3445,18 @@
           "dev": true
         }
       }
+    },
+    "glamor": {
+      "version": "2.20.25",
+      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.25.tgz",
+      "integrity": "sha1-cbhLgrZ6kyd3GsWd5T7pFdFIpKM=",
+      "dev": true
+    },
+    "glamorous": {
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-3.23.3.tgz",
+      "integrity": "sha1-T2S44/qwG/nlHVBWSVWguP3ssP4=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -11063,29 +3546,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.6",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -11099,7 +3559,15 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true
+        }
+      }
     },
     "has": {
       "version": "1.0.1",
@@ -11155,6 +3623,12 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
+    "hoist-non-react-statics": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
+      "dev": true
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -11179,6 +3653,12 @@
       "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
       "dev": true
     },
+    "html-element-attributes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-1.2.0.tgz",
+      "integrity": "sha1-ixx6r5Q1P9m0VcJ+x+uvFYPin9A=",
+      "dev": true
+    },
     "html-encoding-sniffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
@@ -11195,6 +3675,20 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
       "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
+      "dev": true,
+      "dependencies": {
+        "uglify-js": {
+          "version": "3.0.19",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.19.tgz",
+          "integrity": "sha512-/MRnHKKJemMVs4iKmiUZY8S0knDRFOJI9Ein/rdn0w9hrK8ELdj+6bjWmHeBjSDPGUWxi/4960A+GAWZbzHvDA==",
+          "dev": true
+        }
+      }
+    },
+    "html-tag-names": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.1.tgz",
+      "integrity": "sha1-+KB2ET8W45NRiTf2s7XSIpZ1XUo=",
       "dev": true
     },
     "html-webpack-plugin": {
@@ -11293,6 +3787,12 @@
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
@@ -11302,6 +3802,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+      "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true
     },
     "ieee754": {
@@ -11314,6 +3820,12 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
       "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "dev": true
+    },
+    "immutable": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+      "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI=",
       "dev": true
     },
     "imurmurhash": {
@@ -11356,6 +3868,12 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "dev": true
+    },
+    "inline-style-prefixer": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.6.tgz",
+      "integrity": "sha1-sn/jCbQWijHq84yOjGCrnnwRcx8=",
       "dev": true
     },
     "inquirer": {
@@ -11440,6 +3958,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-dom": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.0.9.tgz",
+      "integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0=",
       "dev": true
     },
     "is-dotfile": {
@@ -11698,10 +4222,76 @@
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
         "jest-cli": {
           "version": "20.0.4",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
           "integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true
         }
       }
@@ -11802,10 +4392,72 @@
       "integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
       "dev": true,
       "dependencies": {
-        "strip-bom": {
+        "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "dependencies": {
+            "strip-bom": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "dev": true
+            }
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true
         }
       }
@@ -11843,7 +4495,15 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        }
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -11958,6 +4618,12 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "keycode": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
+      "integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo=",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -12007,16 +4673,42 @@
       "dev": true
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true
     },
     "loader-fs-cache": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
       "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "dev": true
+        }
+      }
     },
     "loader-runner": {
       "version": "2.3.0",
@@ -12042,10 +4734,28 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.camelcase": {
@@ -12066,10 +4776,40 @@
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "dev": true
     },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.template": {
@@ -12131,11 +4871,31 @@
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
     },
+    "make-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true
+    },
+    "mantra-core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mantra-core/-/mantra-core-1.7.0.tgz",
+      "integrity": "sha1-qMg+jO6D72pzgxMVGf6AMa1UY4Y=",
+      "dev": true,
+      "dependencies": {
+        "react-komposer": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-1.13.1.tgz",
+          "integrity": "sha1-S4rEvMcTI710E9yrlcgxGX9Q7tA=",
+          "dev": true
+        }
+      }
     },
     "map-obj": {
       "version": "1.0.1",
@@ -12167,10 +4927,52 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true
         }
       }
@@ -12206,9 +5008,9 @@
       "dev": true
     },
     "mime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
       "dev": true
     },
     "mime-db": {
@@ -12264,6 +5066,12 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true
     },
+    "mobx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-2.7.0.tgz",
+      "integrity": "sha1-zz2C0YwMp/RY2PKiQIF7PcflSgE=",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -12305,6 +5113,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
       "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
+      "dev": true
+    },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "dev": true
     },
     "node-fetch": {
@@ -12421,10 +5235,28 @@
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "dev": true
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true
+    },
+    "object.values": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true
     },
     "obuf": {
@@ -12467,21 +5299,21 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
     },
     "original": {
       "version": "1.0.0",
@@ -12624,23 +5456,15 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true
     },
     "pbkdf2": {
@@ -12674,24 +5498,10 @@
       "dev": true
     },
     "pkg-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true,
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true
-        }
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true
     },
     "pkg-up": {
       "version": "1.0.0",
@@ -12717,6 +5527,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "podda": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/podda/-/podda-1.2.2.tgz",
+      "integrity": "sha1-FbDtvTNK3hRYEzQ/Xs+cEKcc9QA=",
       "dev": true
     },
     "portfinder": {
@@ -12890,9 +5706,9 @@
       "dev": true
     },
     "postcss-loader": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.5.tgz",
-      "integrity": "sha1-wZ0+i4PrGsMW9WIe9MDvWz0bizo=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.6.tgz",
+      "integrity": "sha512-HIq7yy1hh9KI472Y38iSRV4WupZUNy6zObkxQM/ZuInoaE2+PyX4NcO6jjP5HG5mXL7j5kcNEl0fAG4Kva7O9w==",
       "dev": true
     },
     "postcss-merge-idents": {
@@ -13431,10 +6247,30 @@
         }
       }
     },
+    "react-docgen": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.16.0.tgz",
+      "integrity": "sha1-A8nrqTXegDHXkatiZXt7ZgbsXaY=",
+      "dev": true,
+      "dependencies": {
+        "babylon": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        }
+      }
+    },
     "react-dom": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
       "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA="
+    },
+    "react-dom-factories": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.0.tgz",
+      "integrity": "sha1-9DwF5QUbME8zJRYY1byFmynka20=",
+      "dev": true
     },
     "react-error-overlay": {
       "version": "1.0.7",
@@ -13518,19 +6354,870 @@
         }
       }
     },
+    "react-html-attributes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.3.0.tgz",
+      "integrity": "sha1-yXiW6crEetnE5mGLg1ApqCb10ow=",
+      "dev": true
+    },
+    "react-inspector": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.0.0.tgz",
+      "integrity": "sha1-yUWTLywr8vq3hzxuB9g4gUBLkxM=",
+      "dev": true
+    },
+    "react-komposer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-2.0.0.tgz",
+      "integrity": "sha1-uWRzgBSptK7klKg8C1uDPWYHKpA=",
+      "dev": true
+    },
+    "react-modal": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.7.tgz",
+      "integrity": "sha512-oZNqI0ZnPD7NnfObrCMz2hxHTAw5oEuhZJ+gnyFNIQB2rR8h1YbLQTfhms1mtSJigb0J23OOWElHjXYYaKO+wg==",
+      "dev": true
+    },
     "react-scripts": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.0.2.tgz",
       "integrity": "sha1-IK/pqE1fBdkzi+uxQ2SPbOh3vGc=",
       "dev": true,
       "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true
+        },
+        "autoprefixer": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.0.tgz",
+          "integrity": "sha1-rkkTrcIh+mylrTpvgDn2pcBrOHc=",
+          "dev": true
+        },
+        "babel-core": {
+          "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+          "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
+          "dev": true
+        },
+        "babel-loader": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.0.0.tgz",
+          "integrity": "sha1-LkOma+4f/0RwUz0EAsikUy+vuvc=",
+          "dev": true
+        },
+        "case-sensitive-paths-webpack-plugin": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.0.0.tgz",
+          "integrity": "sha1-YBQtfQvqvbNWdu8K6s4wJ9oFeLo=",
+          "dev": true
+        },
+        "css-loader": {
+          "version": "0.28.1",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.1.tgz",
+          "integrity": "sha1-IgMlWZ+PAEUtnOtMPKbIpmeYZC0=",
+          "dev": true,
+          "dependencies": {
+            "postcss": {
+              "version": "5.2.17",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+              "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+              "dev": true
+            }
+          }
+        },
+        "file-loader": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.1.tgz",
+          "integrity": "sha1-azKO4SNKcp5OR9Njdd1tNcDh24Q=",
+          "dev": true
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
+        "fsevents": {
+          "version": "1.0.17",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
+          "integrity": "sha1-hTfz8SJyZ4dltP1lKMDx9m+PRVg=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "abbrev": {
+              "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+              "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+              "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+              "dev": true,
+              "optional": true
+            },
+            "asn1": {
+              "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+              "dev": true,
+              "optional": true
+            },
+            "assert-plus": {
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+              "dev": true,
+              "optional": true
+            },
+            "asynckit": {
+              "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+              "dev": true,
+              "optional": true
+            },
+            "aws-sign2": {
+              "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "dev": true,
+              "optional": true
+            },
+            "aws4": {
+              "version": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+              "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
+              "dev": true,
+              "optional": true
+            },
+            "balanced-match": {
+              "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+              "dev": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+              "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+              "dev": true,
+              "optional": true
+            },
+            "block-stream": {
+              "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+              "dev": true
+            },
+            "boom": {
+              "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+              "dev": true
+            },
+            "brace-expansion": {
+              "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+              "dev": true
+            },
+            "buffer-shims": {
+              "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+              "dev": true
+            },
+            "caseless": {
+              "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "dev": true,
+              "optional": true
+            },
+            "chalk": {
+              "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "optional": true,
+              "dependencies": {
+                "supports-color": {
+                  "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "code-point-at": {
+              "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "dev": true
+            },
+            "combined-stream": {
+              "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "dev": true
+            },
+            "commander": {
+              "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "dev": true
+            },
+            "console-control-strings": {
+              "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "dev": true
+            },
+            "cryptiles": {
+              "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+              "dev": true,
+              "optional": true
+            },
+            "dashdash": {
+              "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+              "dev": true,
+              "optional": true,
+              "dependencies": {
+                "assert-plus": {
+                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "debug": {
+              "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "dev": true,
+              "optional": true
+            },
+            "deep-extend": {
+              "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+              "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+              "dev": true,
+              "optional": true
+            },
+            "delayed-stream": {
+              "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+              "dev": true
+            },
+            "delegates": {
+              "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+              "dev": true,
+              "optional": true
+            },
+            "ecc-jsbn": {
+              "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+              "dev": true,
+              "optional": true
+            },
+            "escape-string-regexp": {
+              "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true,
+              "optional": true
+            },
+            "extend": {
+              "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true,
+              "optional": true
+            },
+            "extsprintf": {
+              "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+              "dev": true
+            },
+            "forever-agent": {
+              "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "dev": true,
+              "optional": true
+            },
+            "form-data": {
+              "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+              "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
+              "dev": true,
+              "optional": true
+            },
+            "fs.realpath": {
+              "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "dev": true
+            },
+            "fstream": {
+              "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+              "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+              "dev": true
+            },
+            "fstream-ignore": {
+              "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
+              "integrity": "sha1-Fc7MMbAtBTRaXWsOFxzbOtIwd3Q=",
+              "dev": true,
+              "optional": true
+            },
+            "generate-function": {
+              "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+              "dev": true,
+              "optional": true
+            },
+            "generate-object-property": {
+              "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+              "dev": true,
+              "optional": true
+            },
+            "getpass": {
+              "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+              "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+              "dev": true,
+              "optional": true,
+              "dependencies": {
+                "assert-plus": {
+                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "glob": {
+              "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+              "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+              "dev": true
+            },
+            "graceful-fs": {
+              "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+              "dev": true
+            },
+            "graceful-readlink": {
+              "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+              "dev": true,
+              "optional": true
+            },
+            "har-validator": {
+              "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "dev": true,
+              "optional": true
+            },
+            "has-ansi": {
+              "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "dev": true,
+              "optional": true
+            },
+            "has-unicode": {
+              "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+              "dev": true,
+              "optional": true
+            },
+            "hawk": {
+              "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "dev": true,
+              "optional": true
+            },
+            "hoek": {
+              "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+              "dev": true
+            },
+            "http-signature": {
+              "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "dev": true,
+              "optional": true
+            },
+            "inflight": {
+              "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "ini": {
+              "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true
+            },
+            "is-my-json-valid": {
+              "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+              "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+              "dev": true,
+              "optional": true
+            },
+            "is-property": {
+              "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+              "dev": true,
+              "optional": true
+            },
+            "is-typedarray": {
+              "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "dev": true,
+              "optional": true
+            },
+            "isarray": {
+              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "isstream": {
+              "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "dev": true,
+              "optional": true
+            },
+            "jodid25519": {
+              "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+              "dev": true,
+              "optional": true
+            },
+            "jsbn": {
+              "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+              "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+              "dev": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+              "dev": true,
+              "optional": true
+            },
+            "json-stringify-safe": {
+              "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "dev": true,
+              "optional": true
+            },
+            "jsonpointer": {
+              "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+              "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+              "dev": true,
+              "optional": true
+            },
+            "jsprim": {
+              "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+              "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+              "dev": true,
+              "optional": true
+            },
+            "mime-db": {
+              "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+              "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
+              "dev": true
+            },
+            "mime-types": {
+              "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+              "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+              "dev": true
+            },
+            "minimist": {
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true
+            },
+            "ms": {
+              "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+              "dev": true,
+              "optional": true
+            },
+            "node-pre-gyp": {
+              "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
+              "integrity": "sha1-/EUrN25zGbPSVfXzSFPvb9j+H9U=",
+              "dev": true,
+              "optional": true
+            },
+            "nopt": {
+              "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "dev": true,
+              "optional": true
+            },
+            "npmlog": {
+              "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+              "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
+              "dev": true,
+              "optional": true
+            },
+            "number-is-nan": {
+              "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "dev": true
+            },
+            "oauth-sign": {
+              "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+              "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true
+            },
+            "path-is-absolute": {
+              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true
+            },
+            "pinkie": {
+              "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+              "dev": true,
+              "optional": true
+            },
+            "pinkie-promise": {
+              "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+              "dev": true
+            },
+            "punycode": {
+              "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+              "dev": true,
+              "optional": true
+            },
+            "qs": {
+              "version": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+              "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+              "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+              "dev": true,
+              "optional": true,
+              "dependencies": {
+                "minimist": {
+                  "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+              "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
+              "dev": true,
+              "optional": true
+            },
+            "request": {
+              "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+              "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+              "dev": true,
+              "optional": true
+            },
+            "rimraf": {
+              "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+              "dev": true
+            },
+            "semver": {
+              "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+              "dev": true,
+              "optional": true
+            },
+            "sntp": {
+              "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+              "dev": true,
+              "optional": true
+            },
+            "sshpk": {
+              "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+              "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
+              "dev": true,
+              "optional": true,
+              "dependencies": {
+                "assert-plus": {
+                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true
+            },
+            "stringstream": {
+              "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "dev": true,
+              "optional": true
+            },
+            "strip-ansi": {
+              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true
+            },
+            "strip-json-comments": {
+              "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+              "dev": true,
+              "optional": true
+            },
+            "supports-color": {
+              "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "dev": true
+            },
+            "tar-pack": {
+              "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+              "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+              "dev": true,
+              "optional": true,
+              "dependencies": {
+                "once": {
+                  "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "dev": true,
+                  "optional": true
+                },
+                "readable-stream": {
+                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                  "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+              "dev": true,
+              "optional": true
+            },
+            "tunnel-agent": {
+              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+              "dev": true,
+              "optional": true
+            },
+            "tweetnacl": {
+              "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+              "dev": true,
+              "optional": true
+            },
+            "uid-number": {
+              "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+              "dev": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "dev": true
+            },
+            "uuid": {
+              "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+              "dev": true,
+              "optional": true
+            },
+            "verror": {
+              "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+              "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+              "dev": true,
+              "optional": true
+            },
+            "wrappy": {
+              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "dev": true
+            },
+            "xtend": {
+              "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "dev": true
+        },
+        "postcss-loader": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.5.tgz",
+          "integrity": "sha1-wZ0+i4PrGsMW9WIe9MDvWz0bizo=",
+          "dev": true
+        },
         "promise": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
           "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
           "dev": true
+        },
+        "url-loader": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.8.tgz",
+          "integrity": "sha1-uRg7GAHg+EdxhnNnMEC8ncHHFcU=",
+          "dev": true
+        },
+        "webpack": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.5.1.tgz",
+          "integrity": "sha1-YXQvDPivVVuHRgqc2Lui8ePuL84=",
+          "dev": true,
+          "dependencies": {
+            "loader-utils": {
+              "version": "0.2.17",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+              "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+              "dev": true
+            }
+          }
         }
       }
+    },
+    "react-simple-di": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-simple-di/-/react-simple-di-1.2.0.tgz",
+      "integrity": "sha1-3eDlv2ifOR7yqwLJBDshP+I5xtA=",
+      "dev": true
+    },
+    "react-split-pane": {
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.63.tgz",
+      "integrity": "sha1-+ts5YMxlmRHdBf+8iKzuS+n1NYM=",
+      "dev": true
+    },
+    "react-stubber": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-stubber/-/react-stubber-1.0.0.tgz",
+      "integrity": "sha1-Qe4srHLU1P1wpjiW2pjhNzm4Rig=",
+      "dev": true
+    },
+    "react-style-proptype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.0.0.tgz",
+      "integrity": "sha1-ieC2RvJmxlarsPDdggLb1QNsMeY=",
+      "dev": true
     },
     "react-test-renderer": {
       "version": "15.6.1",
@@ -13545,35 +7232,21 @@
       "dev": true
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true
-        }
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true
     },
     "readable-stream": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
-      "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+      "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
       "dev": true
     },
     "readdirp": {
@@ -13586,6 +7259,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true
+    },
+    "recast": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
       "dev": true
     },
     "rechoir": {
@@ -13641,6 +7320,12 @@
           "dev": true
         }
       }
+    },
+    "redux": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.0.tgz",
+      "integrity": "sha512-GHjaOkEQtQnnuLoYPFkRKHIqs1i1tdTlisu/xUHfk2juzCobSy4STxs4Lz5bPkc07Owb6BeGKx/r76c9IVTkOw==",
+      "dev": true
     },
     "regenerate": {
       "version": "1.3.2",
@@ -13839,9 +7524,9 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "sane": {
@@ -13880,15 +7565,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-      "dev": true,
-      "dependencies": {
-        "ajv": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
-          "integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -13919,11 +7596,19 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
           "dev": true
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+        }
+      }
+    },
+    "serve-favicon": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.3.tgz",
+      "integrity": "sha1-WYaxewUCZCtkHCH4GLGszjICXSM=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         }
       }
@@ -13979,6 +7664,12 @@
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+      "dev": true
+    },
+    "shallowequal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
+      "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
       "dev": true
     },
     "shell-quote": {
@@ -14179,6 +7870,18 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true
     },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true
+    },
+    "string.prototype.padstart": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
+      "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
+      "dev": true
+    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -14192,9 +7895,9 @@
       "dev": true
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-indent": {
@@ -14221,6 +7924,12 @@
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "dev": true
     },
+    "svg-tag-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.0.tgz",
+      "integrity": "sha1-JMBNs38u4u4ovGGfTool7iH8AgM=",
+      "dev": true
+    },
     "svgo": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
@@ -14237,26 +7946,32 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/sw-precache-webpack-plugin/-/sw-precache-webpack-plugin-0.9.1.tgz",
       "integrity": "sha1-I4H/cG+7bKvbIKIDN96OWPtJoqc=",
-      "dev": true,
-      "dependencies": {
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "sw-toolbox": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true
+        }
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
       "dev": true
     },
     "symbol-tree": {
@@ -14271,6 +7986,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -14295,7 +8016,51 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
+        }
+      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -14430,10 +8195,18 @@
       "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs="
     },
     "uglify-js": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.18.tgz",
-      "integrity": "sha512-0M/KeXO8bPYtlqnwIYpO4R6om1mrScMzPuWn2UPfUYOaowIhQmmFpL9Q5tlD18ulKLRKD12GQ0IiYDKJS/si1w==",
-      "dev": true
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "dependencies": {
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true
+        }
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -14460,6 +8233,12 @@
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true
+    },
     "universalify": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.0.tgz",
@@ -14482,7 +8261,39 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
       "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "configstore": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+          "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+          "dev": true
+        },
+        "dot-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "dev": true
+        },
+        "xdg-basedir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+          "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+          "dev": true
+        }
+      }
     },
     "upper-case": {
       "version": "1.1.3",
@@ -14511,9 +8322,9 @@
       }
     },
     "url-loader": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.8.tgz",
-      "integrity": "sha1-uRg7GAHg+EdxhnNnMEC8ncHHFcU=",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
+      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
       "dev": true
     },
     "url-parse": {
@@ -14641,76 +8452,22 @@
       "dev": true
     },
     "webpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.5.1.tgz",
-      "integrity": "sha1-YXQvDPivVVuHRgqc2Lui8ePuL84=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
+      "integrity": "sha1-LgRX8KuxrF3zqxBsacZy8jZ4Xwc=",
       "dev": true,
       "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true
+        },
         "loader-utils": {
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true
-        },
-        "source-list-map": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
-          "integrity": "sha1-mIkBnRAkzOVc3AaUmDN+9hhqEaE=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true
-            }
-          }
-        },
-        "webpack-sources": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
-          "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true,
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-              "dev": true
-            },
-            "cliui": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "dev": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true,
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -14726,18 +8483,6 @@
       "integrity": "sha1-MThM6BE2vhCAtLTN4OubkOVO5s8=",
       "dev": true,
       "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true
-        },
         "opn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
@@ -14749,20 +8494,14 @@
           "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz",
           "integrity": "sha1-8CEqhVDkyUaMjM6u79LjSTwDOtU=",
           "dev": true
-        },
-        "yargs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true
         }
       }
+    },
+    "webpack-hot-middleware": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.18.0.tgz",
+      "integrity": "sha1-oWu1Nbg6aslKeKxevOTzBZ6CdNM=",
+      "dev": true
     },
     "webpack-manifest-plugin": {
       "version": "1.1.0",
@@ -14785,10 +8524,18 @@
       }
     },
     "webpack-sources": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
-      "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-      "dev": true
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
+      "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
+      "dev": true,
+      "dependencies": {
+        "source-list-map": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
+          "integrity": "sha1-mIkBnRAkzOVc3AaUmDN+9hhqEaE=",
+          "dev": true
+        }
+      }
     },
     "websocket-driver": {
       "version": "0.6.5",
@@ -14866,9 +8613,9 @@
       "dev": true
     },
     "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
       "dev": true
     },
     "worker-farm": {
@@ -14896,15 +8643,15 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
       "dev": true
     },
     "xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
     "xml-char-classes": {
@@ -14938,9 +8685,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "dev": true,
       "dependencies": {
         "camelcase": {
@@ -14954,13 +8701,55 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "dependencies": {
         "camelcase": {

--- a/examples/test-cra/package.json
+++ b/examples/test-cra/package.json
@@ -17,14 +17,14 @@
     "react-dom": "^15.5.4"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "file:../../addons/actions",
-    "@storybook/addon-links": "file:../../addons/links",
-    "@storybook/addon-storyshots": "file:../../addons/storyshots",
-    "@storybook/addons": "file:../../lib/addons",
-    "@storybook/channel-postmessage": "file:../../lib/channel-postmessage",
-    "@storybook/channels": "file:../../lib/channels",
-    "@storybook/react": "file:../../app/react",
-    "@storybook/ui": "file:../../lib/ui",
+    "@storybook/addon-actions": "file:../../packs/storybook-addon-actions.tgz",
+    "@storybook/addon-links": "file:../../packs/storybook-addon-links.tgz",
+    "@storybook/addon-storyshots": "file:../../packs/storybook-addon-storyshots.tgz",
+    "@storybook/addons": "file:../../packs/storybook-addons.tgz",
+    "@storybook/channel-postmessage": "file:../../packs/storybook-channel-postmessage.tgz",
+    "@storybook/channels": "file:../../packs/storybook-channels.tgz",
+    "@storybook/react": "file:../../packs/storybook-react.tgz",
+    "@storybook/ui": "file:../../packs/storybook-ui.tgz",
     "react-scripts": "1.0.2",
     "react-test-renderer": "^15.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "bootstrap:docs": "cd docs && npmc install",
-    "bootstrap:test-cra": "lerna exec --scope test-cra -- npmc install",
+    "bootstrap:test-cra": "npm run build-packs && lerna exec --scope test-cra -- npmc install",
     "bootstrap:react-native-vanilla": "lerna exec --scope react-native-vanilla -- npmc install",
+    "build-packs": "lerna exec --scope '@storybook/*' --parallel -- ../../scripts/build-pack.sh ../../packs",
     "changelog": "pr-log --sloppy",
     "precommit": "lint-staged",
     "coverage": "codecov",

--- a/packs/README.md
+++ b/packs/README.md
@@ -1,0 +1,5 @@
+# Git packs
+
+This directory is filled with git packs of our packages when you run the `build-packs` command.
+
+The purpose of this is to enable the `test-cra` app to use the packs as "local" installs without linking, and thus behave like a normal app would, yet still use our latest code. It's awkward for development but good to double check things, especially in CI.

--- a/scripts/build-pack.sh
+++ b/scripts/build-pack.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -
+
+# run in package directory
+
+PACK_DIR=$1
+FILE=$(npm pack | tail -n 1)
+
+mv "$FILE" "$PACK_DIR/${FILE%-[0-9]*\.[0-9]*\.[0-9]*\.tgz}.tgz"


### PR DESCRIPTION
As suggested by https://github.com/npm/npm/pull/15900. This is a workaround until we get a better resolution of https://github.com/storybooks/storybook/issues/1286

Issue: https://github.com/storybooks/storybook/issues/1331

## What I did

Added a `build-packs` command that builds a pack (this is what npm does right before publishing) for each of our packages, and moves them to `packs/$name.tgz` (note, no version number).

`test-cra` depends on those packs directly, which recreates the old npm<5 local package install.

## How to test

```bash
npm install
npm run bootstrap
# you may need to clear out node_modules first
npm run bootstrap:test-cra
npm run bootstrap:react-native-vanilla

# this should pass! (+ in CI)
npm test

# also, test that the app works
cd examples/test-cra
npm start
npm run storybook
```
