### PR TITLE
Remove typescript typings for @storybook/addon-links

### DIFF
--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -11,7 +11,6 @@
   },
   "license": "MIT",
   "main": "dist/index.js",
-  "typings": "./storybook-addon-links.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/storybooks/storybook.git"

--- a/addons/links/storybook-addon-links.d.ts
+++ b/addons/links/storybook-addon-links.d.ts
@@ -1,3 +1,0 @@
-import * as React from 'react';
-
-export function linkTo<E>(book: string, kind?: string): React.MouseEventHandler<E>;


### PR DESCRIPTION
references #1166, #1339
blocked by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17406

Merge when https://www.npmjs.com/search?q=@types/storybook__addon-links shows up