### PR TITLE
remove typings for @storybook/addon-notes

### DIFF
--- a/addons/notes/storybook-addon-notes.d.ts
+++ b/addons/notes/storybook-addon-notes.d.ts
@@ -1,7 +1,0 @@
-import * as React from 'react';
-
-export interface WithNotesProps extends React.HTMLProps<HTMLDivElement> {
-  notes?: string;
-}
-
-export const WithNotes: React.StatelessComponent<WithNotesProps>;


### PR DESCRIPTION
references https://github.com/storybooks/storybook/issues/1166
blocked by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17409

Merge when https://www.npmjs.com/search?q=@types/storybook__addon-notes shows up