### PR TITLE
Use uuid for action IDs instead of Math.random (fixes #1109)

### DIFF
--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -25,7 +25,8 @@
     "deep-equal": "^1.0.1",
     "json-stringify-safe": "^5.0.1",
     "prop-types": "^15.5.8",
-    "react-inspector": "^2.0.0"
+    "react-inspector": "^2.0.0",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "react": "^15.5.4",

--- a/addons/actions/src/preview.js
+++ b/addons/actions/src/preview.js
@@ -2,6 +2,7 @@
 
 import addons from '@storybook/addons';
 import stringify from 'json-stringify-safe';
+import uuid from 'uuid/v1';
 import { EVENT_ID } from './';
 
 function _format(arg) {
@@ -16,9 +17,9 @@ export function action(name) {
   const handler = function(..._args) {
     const args = Array.from(_args).map(_format);
     const channel = addons.getChannel();
-    const randomId = Math.random().toString(16).slice(2);
+    const id = uuid();
     channel.emit(EVENT_ID, {
-      id: randomId,
+      id,
       data: { name, args },
     });
   };

--- a/addons/actions/src/preview.test.js
+++ b/addons/actions/src/preview.test.js
@@ -1,0 +1,27 @@
+import addons from '@storybook/addons';
+import uuid from 'uuid/v1';
+import { action } from './preview';
+
+jest.mock('uuid/v1');
+jest.mock('@storybook/addons');
+
+describe('preview', () => {
+  describe('action()', () => {
+    it('should use a uuid for action ids', () => {
+      const channel = { emit: jest.fn() };
+      const uuidGenerator = (function*() {
+        yield '42';
+        yield '24';
+      })();
+      uuid.mockImplementation(() => uuidGenerator.next().value);
+      addons.getChannel.mockReturnValue(channel);
+      const fn = action('foo');
+
+      fn();
+      fn();
+      expect(channel.emit).toHaveBeenCalledTimes(2);
+      expect(channel.emit.mock.calls[0][1].id).toBe('42');
+      expect(channel.emit.mock.calls[1][1].id).toBe('24');
+    });
+  });
+});


### PR DESCRIPTION
Issue: You can see the issue here: https://github.com/storybooks/storybook/issues/1109

## What I did

I replaced the randomly generated ID with a uuid.

## How to test

I included a test, so view/run the unit test included. Or, run storybook for the actions package and you'll see that IDs are now uuids.