### PR TITLE
Ensure we add the correct version of `react-dom`

### DIFF
--- a/lib/cli/generators/REACT_NATIVE/index.js
+++ b/lib/cli/generators/REACT_NATIVE/index.js
@@ -31,7 +31,8 @@ module.exports = latestVersion('@storybook/react-native').then(version => {
   packageJson.devDependencies['@storybook/react-native'] = `^${version}`;
 
   if (!packageJson.dependencies['react-dom'] && !packageJson.devDependencies['react-dom']) {
-    packageJson.devDependencies['react-dom'] = '^15.5.4';
+    const reactVersion = packageJson.dependencies.react;
+    packageJson.devDependencies['react-dom'] = reactVersion;
   }
 
   packageJson.scripts = packageJson.scripts || {};

--- a/lib/cli/generators/REACT_NATIVE_SCRIPTS/index.js
+++ b/lib/cli/generators/REACT_NATIVE_SCRIPTS/index.js
@@ -15,7 +15,8 @@ module.exports = latestVersion('@storybook/react-native').then(version => {
   packageJson.devDependencies['@storybook/react-native'] = `^${version}`;
 
   if (!packageJson.dependencies['react-dom'] && !packageJson.devDependencies['react-dom']) {
-    packageJson.devDependencies['react-dom'] = '^15.5.4';
+    const reactVersion = packageJson.dependencies.react;
+    packageJson.devDependencies['react-dom'] = reactVersion;
   }
 
   packageJson.scripts = packageJson.scripts || {};


### PR DESCRIPTION
Issue: #1284

We need to use an equal version to the `react` version the app is using.


## What I did

Looked in `package.json#dependencies`. 

We could also look elsewhere (e.g. `devDependencies`), but that's where RN will put it.

## How to test

```
cd /tmp
react-native init App
cd App
# ensure this is npm-linked
getstorybook
npm run storybook
```

@shilman maybe can test CRNA too?