### PR TITLE
Fix invalid prop 'node.type' supplied to 'Props'

### DIFF
--- a/addons/info/src/components/Props.js
+++ b/addons/info/src/components/Props.js
@@ -61,10 +61,7 @@ Props.defaultProps = {
 };
 
 Props.propTypes = {
-  node: PropTypes.shape({
-    props: PropTypes.object,
-    type: PropTypes.node.isRequired,
-  }).isRequired,
+  node: PropTypes.node.isRequired,
   singleLine: PropTypes.bool,
   maxPropsIntoLine: PropTypes.number.isRequired,
   maxPropObjectKeys: PropTypes.number.isRequired,


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/1307

## What I did
- Use the `PropTypes.node` directly instead of specifying specific `node` & `type` key. 

# How to test
- Switch to current `master` branch
- Launch storybook of `examples/cra-kitchen-sink`, go to _Button_  >> _with some infos_.
- Check the console, it displays the message:  `Warning: Failed prop type: Invalid prop `node.type` supplied to `Props`, expected a ReactNode`

Now switch to this branch, launch storybook & display the same story.
- No warning should be visible in the console.

Let me know if you need anything else ! 