### PR TITLE
Fixed regression: CSS entries were not picked up for storybook pages (e.g. when using exract-text-webpack-plugin)

### DIFF
--- a/app/react/src/server/iframe.html.js
+++ b/app/react/src/server/iframe.html.js
@@ -8,7 +8,7 @@ import url from 'url';
 //   'preview.0d2d3d845f78399fd6d5e859daa152a9.css',
 //   'static/preview.9adbb5ef965106be1cc3.bundle.js.map',
 //   'preview.0d2d3d845f78399fd6d5e859daa152a9.css.map' ]
-const urlsFromAssets = assets => {
+export const urlsFromAssets = assets => {
   if (!assets) {
     return {
       js: ['static/preview.bundle.js'],
@@ -26,13 +26,13 @@ const urlsFromAssets = assets => {
     // Don't load the manager script in the iframe
     .filter(key => key !== 'manager')
     .forEach(key => {
-      const asset = assets[key];
-      if (typeof asset === 'string') {
-        urls[re.exec(asset)[1]].push(asset);
-      } else {
-        const assetUrl = asset.find(u => re.exec(u)[1] !== 'map');
-        urls[re.exec(assetUrl)[1]].push(assetUrl);
+      let assetList = assets[key];
+      if (!Array.isArray(assetList)) {
+        assetList = [assetList];
       }
+      assetList.filter(u => re.exec(u)[1] !== 'map').forEach(u => {
+        urls[re.exec(u)[1]].push(u);
+      });
     });
 
   return urls;

--- a/app/react/src/server/iframe.html.js
+++ b/app/react/src/server/iframe.html.js
@@ -30,8 +30,8 @@ export const urlsFromAssets = assets => {
       if (!Array.isArray(assetList)) {
         assetList = [assetList];
       }
-      assetList.filter(url => re.exec(url)[1] !== 'map').forEach(url => {
-        urls[re.exec(url)[1]].push(url);
+      assetList.filter(assetUrl => re.exec(assetUrl)[1] !== 'map').forEach(assetUrl => {
+        urls[re.exec(assetUrl)[1]].push(assetUrl);
       });
     });
 

--- a/app/react/src/server/iframe.html.js
+++ b/app/react/src/server/iframe.html.js
@@ -30,8 +30,8 @@ export const urlsFromAssets = assets => {
       if (!Array.isArray(assetList)) {
         assetList = [assetList];
       }
-      assetList.filter(u => re.exec(u)[1] !== 'map').forEach(u => {
-        urls[re.exec(u)[1]].push(u);
+      assetList.filter(url => re.exec(url)[1] !== 'map').forEach(url => {
+        urls[re.exec(url)[1]].push(url);
       });
     });
 

--- a/app/react/src/server/iframe.html.test.js
+++ b/app/react/src/server/iframe.html.test.js
@@ -1,0 +1,21 @@
+import { urlsFromAssets } from './iframe.html';
+
+describe('server.urlsFromAssets', () => {
+  it('should return the default when there are no assets', () => {
+    expect(urlsFromAssets()).toEqual({
+      js: ['static/preview.bundle.js'],
+      css: [],
+    });
+  });
+
+  it('should return multiple assets', () => {
+    const fixture = {
+      manager: 'static/manager.a.bundle.js',
+      preview: ['static/preview.x.bundle.js', 'static/preview.y.css', 'static/preview.y.css.map'],
+    };
+    expect(urlsFromAssets(fixture)).toEqual({
+      js: ['static/preview.x.bundle.js'],
+      css: ['static/preview.y.css'],
+    });
+  });
+});


### PR DESCRIPTION
Issue: CSS not displaying when using the `exract-text-webpack-plugin`, regression introduced in 38b9dfabfb1b8691c1f7b378f9dfff05b99603f5

## What I did

Upgraded from `@kadira/storybook@1.x` and had the [`extract-text-webpack-plugin`](https://github.com/webpack-contrib/extract-text-webpack-plugin/) enabled.

Unfortunately my CSS didn't load, encountering the same issue as described in #1104 and most likely #388 and #708.

Using the `extract-text-webpack-plugin` creates a new entry point however, making the asset list look something like this:
```js
{ manager: 'static/manager.02f732c9002a59214667.bundle.js',
  preview:
   [ 'static/preview.352040d027a7c22331ae.bundle.js',
     'static/preview.1f62768c19a65e75e4259a4c418d292d.css',
     'static/preview.1f62768c19a65e75e4259a4c418d292d.css.map' ] }
```
and due to https://github.com/storybooks/storybook/blob/34b96aae764a386c35d4db2a057e85236bd8ddfe/app/react/src/server/iframe.html.js#L33 only ever taking the very first asset, the CSS never makes it into `iframe.html`.

## How to test

I added new tests :)

fixes #388 
fixes #708
fixes #1104