### PR TITLE
Exit storybook build non-zero on stats errors (e.g. errors in the transpilation pipeline)

### DIFF
--- a/app/react/src/server/build.js
+++ b/app/react/src/server/build.js
@@ -80,8 +80,17 @@ webpack(config).run((err, stats) => {
   if (err) {
     logger.error('Failed to build the storybook');
     logger.error(err.message);
+  }
+  if (stats.hasErrors()) {
+    logger.error('Failed to build the storybook');
+    stats.toJson().errors.forEach(function (e) {
+      return logger.error(e);
+    });
+  }
+  if (err || stats.hasErrors()) {
     process.exit(1);
   }
+  
 
   const data = {
     publicPath: config.output.publicPath,

--- a/app/react/src/server/build.js
+++ b/app/react/src/server/build.js
@@ -90,7 +90,6 @@ webpack(config).run((err, stats) => {
   if (err || stats.hasErrors()) {
     process.exit(1);
   }
-  
 
   const data = {
     publicPath: config.output.publicPath,

--- a/app/react/src/server/build.js
+++ b/app/react/src/server/build.js
@@ -79,7 +79,9 @@ logger.log('Building storybook ...');
 webpack(config).run((err, stats) => {
   if (err || stats.hasErrors()) {
     logger.error('Failed to build the storybook');
+    // eslint-disable-next-line no-unused-expressions
     err && logger.error(err.message);
+    // eslint-disable-next-line no-unused-expressions
     stats.hasErrors() && stats.toJson().errors.forEach(e => logger.error(e));
     process.exit(1);
   }

--- a/app/react/src/server/build.js
+++ b/app/react/src/server/build.js
@@ -77,17 +77,10 @@ if (program.staticDir) {
 // compile all resources with webpack and write them to the disk.
 logger.log('Building storybook ...');
 webpack(config).run((err, stats) => {
-  if (err) {
-    logger.error('Failed to build the storybook');
-    logger.error(err.message);
-  }
-  if (stats.hasErrors()) {
-    logger.error('Failed to build the storybook');
-    stats.toJson().errors.forEach(function (e) {
-      return logger.error(e);
-    });
-  }
   if (err || stats.hasErrors()) {
+    logger.error('Failed to build the storybook');
+    err && logger.error(err.message);
+    stats.hasErrors() && stats.toJson().errors.forEach(e => logger.error(e));
     process.exit(1);
   }
 


### PR DESCRIPTION
Currently, storybook does not exit non-zero when there are errors in the pipeline, e.g. we are using TypeScript with `ts-loader` and a type error that fails tsc does not make storybook exit non-zero even though the transpilation failed.

Issue:

## What I did

Run `build-storybook` with a "broken" typescript source.

## How to test

Any transpiler (for example typescript) producing an error will still not make storybook exit non-zero.
