### PR TITLE
📝 Updated link to point to the correct place

### DIFF
--- a/docs/components/Homepage/MainLinks/index.js
+++ b/docs/components/Homepage/MainLinks/index.js
@@ -55,7 +55,7 @@ const MainLinks = () =>
           <ul>
             <li><Link to="/basics/quick-start-guide/">Quick setup</Link></li>
             <li><Link to="/basics/slow-start-guide/">Adding to existing project</Link></li>
-            <li><Link to="/basics/slow-start-guide/">Writing stories</Link></li>
+            <li><Link to="/basics/writing-stories/">Writing stories</Link></li>
           </ul>
         </div>
 


### PR DESCRIPTION
I updated `Writing stories` link which was pointing to https://storybook.js.org/basics/slow-start-guide/ instead of https://storybook.js.org/basics/writing-stories/