### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ It allows you to browse a component library, view the different states of each c
 
 Storybook runs outside of your app. This allows you to develop UI components in isolation, which can improve component reuse, testability, and development speed. You can build quickly without having to worry about application-specific dependencies.
 
+Here are some featured examples that you can reference to see how Storybook works: https://storybook.js.org/examples/
+
 Storybook comes with a lot of [addons](https://storybook.js.org/addons/introduction/) for component design, documentation, testing, interactivity, and so on. Storybook's easy-to-use API makes it easy to configure and extend in various ways. It has even been extended to support React Native development for mobile.
 
 ## Table of contents
@@ -45,6 +47,14 @@ getstorybook
 
 Once it's installed, you can `npm run storybook` and it will run the development server on your local machine, and give you a URL to browse some sample stories.
 
+**Storybook v2.x migration note**: If you're using Storybook v2.x and want to shift to 3.x version the easiest way is:
+```sh
+npm i -g @storybook/cli
+cd my-storybook-v2-app
+getstorybook
+```
+It runs a codemod to update all package names. Read all migration details in our [Migration Guide](MIGRATION.md)
+
 For full documentation on using Storybook visit: [storybook.js.org](https://storybook.js.org)
 
 ## Projects
@@ -63,6 +73,7 @@ For full documentation on using Storybook visit: [storybook.js.org](https://stor
 
 -   [storyshots](addons/storyshots) - Easy snapshot testing for storybook
 -   [actions](addons/actions/) - Log actions as users interact with components in storybook
+-   [links](addons/links/) - Create links between stories
 -   [comments](addons/comments/) - Comment on storybook stories
 -   [graphql](addons/graphql/) - Query a GraphQL server within Storybook stories
 -   [info](addons/info/) - Annotate stories with extra component usage information


### PR DESCRIPTION
Issues:

- #1268 (partially)

- https://github.com/storybooks/storybook/issues/1357#issuecomment-311766537 We don't have any link in the readme.md to clarify that `migration.md` exist

- We don't have any "live demo" links on the first page. We had, but it was shifted to a deeper level of docs then.

## What I did

- add a link to a links addon :)

- add a note about v2 -> v3 mirgation

- add a link to storybook "live" examples


## How to test

1. Read

2. Check links