### PR TITLE
Removed empty array, since webpack 2 doesn't support them anymore.

### DIFF
--- a/app/react-native/src/server/config/webpack.config.prod.js
+++ b/app/react-native/src/server/config/webpack.config.prod.js
@@ -2,15 +2,12 @@ import path from 'path';
 import webpack from 'webpack';
 import { OccurenceOrderPlugin, includePaths, excludePaths } from './utils';
 
-const entries = {
-  preview: [],
-  manager: [path.resolve(__dirname, '../../manager')],
-};
-
 const config = {
   bail: true,
   devtool: '#cheap-module-source-map',
-  entry: entries,
+  entry: {
+    manager: [path.resolve(__dirname, '../../manager')],
+  },
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'static/[name].bundle.js',


### PR DESCRIPTION
Issue: Couldn't start RN storybook with Production environment.

## What I did

Removed empty array, since that was breaking webpack.

## How to test

https://github.com/wix/storybook-server - Try to run `npm run start`.