### PR TITLE
Support webpack 3.0.0

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -67,7 +67,7 @@
     "url-loader": "^0.5.8",
     "util-deprecate": "^1.0.2",
     "uuid": "^3.0.1",
-    "webpack": "^2.5.1",
+    "webpack": "^2.5.1 || ^3.0.0",
     "webpack-dev-middleware": "^1.10.2",
     "webpack-hot-middleware": "^2.18.0"
   },


### PR DESCRIPTION
Without this, the main webpack dependency will break for users using 3.0.0. See #1371

Issue:
#1371 
## What I did
I allowed for webpack 3.0.0.

## How to test
Se #1371
