### PR TITLE
Verify that name is a string in addons/actions

### DIFF
--- a/addons/actions/src/preview.js
+++ b/addons/actions/src/preview.js
@@ -30,7 +30,7 @@ export function action(name) {
   // the same.
   //
   // Ref: https://bocoup.com/weblog/whats-in-a-function-name
-  const fnName = name ? name.replace(/\W+/g, '_') : 'action';
+  const fnName = name && typeof name === 'string' ? name.replace(/\W+/g, '_') : 'action';
   // eslint-disable-next-line no-eval
   const named = eval(`(function ${fnName}() { return handler.apply(this, arguments) })`);
   return named;


### PR DESCRIPTION
Issue: Within addon/actions, it appears that it’s possible that `name` can be passed in as an object when a string is expected. This causes the error seen below in Chrome (version 59.0.3071.115):

![image](https://user-images.githubusercontent.com/1479563/27876157-a893ea72-617b-11e7-9903-27659f4c54d5.png)

I’ve noticed that this error doesn’t always happen. If Storybook loads with a component that uses the action addon, there is no error. However, if you navigate to a component that uses the action addon, then the error appears.

## What I did
This pull request adds a condition to the `fnName` constant that verifies the value of `name` is a string.

## How to test
- Create a component that uses the action addon
- Launch Storybook and navigate to the component with the action from the left-hand menu
- JavaScript error message should appear

As I mentioned above, the error only seems to happen when you navigate to a component by clicking on its name from the menu.

I wanted to write a test for this, but wasn’t quite sure if the `fnName` constant needs to be extracted from the `action` function in order to make it testable.