### PR TITLE
Update story shots docs and fix a typo in the API

### DIFF
--- a/addons/storyshots/README.md
+++ b/addons/storyshots/README.md
@@ -68,15 +68,15 @@ initStoryshots({
 });
 ```
 
-### `suit`
+### `suite`
 
-By default, Storyshots groups stories inside a Jest test suit called "Storyshots". You could change it like this:
+By default, Storyshots groups stories inside a Jest test suite called "Storyshots". You could change it like this:
 
 ```js
 import initStoryshots from '@storybook/addon-storyshots';
 
 initStoryshots({
-  suit: 'MyStoryshots'
+  suite: 'MyStoryshots'
 });
 ```
 

--- a/addons/storyshots/src/index.js
+++ b/addons/storyshots/src/index.js
@@ -56,6 +56,7 @@ export default function testStorySnapshots(options = {}) {
     throw new Error('testStorySnapshots is intended only to be used inside jest');
   }
 
+  // NOTE: keep `suit` typo for backwards compatibility
   const suite = options.suite || options.suit || 'Storyshots';
   const stories = storybook.getStorybook();
 

--- a/addons/storyshots/src/index.js
+++ b/addons/storyshots/src/index.js
@@ -56,7 +56,7 @@ export default function testStorySnapshots(options = {}) {
     throw new Error('testStorySnapshots is intended only to be used inside jest');
   }
 
-  const suit = options.suit || 'Storyshots';
+  const suite = options.suite || options.suit || 'Storyshots';
   const stories = storybook.getStorybook();
 
   // Added not to break existing storyshots configs (can be removed in a future major release)
@@ -72,7 +72,7 @@ export default function testStorySnapshots(options = {}) {
       continue;
     }
 
-    describe(suit, () => {
+    describe(suite, () => {
       describe(group.kind, () => {
         // eslint-disable-next-line
         for (const story of group.stories) {

--- a/docs/pages/testing/structural-testing/index.md
+++ b/docs/pages/testing/structural-testing/index.md
@@ -34,31 +34,28 @@ Then, install StoryShots into your app with:
 npm i -D @storybook/addon-storyshots
 ```
 
-Then, add the following NPM script into your package.json:
+Then, assuming you are using Jest for testing, you can create a test file `storyshots.test.js` that contains the following:
 
-```json
-{
-  "scripts": {
-    "test-storybook": "storyshots"
-  }
-}
+```js
+import initStoryshots from '@storybook/addon-storyshots';
+
+initStoryshots({ /* configuration options */ });
 ```
 
-Now you can run the above command with:
+Now you can snapshot test all of your stories with:
 
 ```sh
-npm run test-storybook
+npm test
 ```
 
 This will save the initial set of snapshots inside your Storybook config directory.
 
 ![StoryShots First](../static/storyshots-first-run.png)
 
-After you complete any changes, you can run the above NPM script again and find our structural changes.
+After you complete any changes, you can run the test again and find all structural changes.
 
 ![StoryShots Diff View](../static/storyshots-diff-view.png)
 
 * * *
 
-StoryShots also comes with a few important [productive features](https://github.com/storybooks/storybook/tree/master/addons/storyshots#key-features) that can be customized.
-Have a look at the StoryShots [repo](https://github.com/storybooks/storybook/tree/master/addons/storyshots) for more information.
+StoryShots also comes with a variety of customization options. Have a look at the StoryShots [repo](https://github.com/storybooks/storybook/tree/master/addons/storyshots) for more information.


### PR DESCRIPTION
Issue: #1396 

## What I did

Fixed the documentation  -- there is no storyshots binary

Also `suit` option should be `suite`

## How to test

```
npm run bootstrap:test-cra
npm test
```