### PR TITLE
Implement filtering on story-level

### DIFF
--- a/lib/ui/src/modules/ui/containers/left_panel.js
+++ b/lib/ui/src/modules/ui/containers/left_panel.js
@@ -8,9 +8,14 @@ export const mapper = (state, props, { actions }) => {
   const actionMap = actions();
   const { stories, selectedKind, selectedStory, uiOptions, storyFilter } = state;
   const { name, url, sortStoriesByKind, hierarchySeparator } = uiOptions;
-  const filteredStores = filters.storyFilter(stories, storyFilter, selectedKind, sortStoriesByKind);
+  const filteredStories = filters.storyFilter(
+    stories,
+    storyFilter,
+    selectedKind,
+    sortStoriesByKind
+  );
 
-  const storiesHierarchy = createHierarchy(filteredStores, hierarchySeparator);
+  const storiesHierarchy = createHierarchy(filteredStories, hierarchySeparator);
   const selectedHierarchy = resolveStoryHierarchy(selectedKind, hierarchySeparator);
 
   const data = {

--- a/lib/ui/src/modules/ui/libs/filters.js
+++ b/lib/ui/src/modules/ui/libs/filters.js
@@ -11,7 +11,6 @@ export function storyFilter(stories, filter, selectedKind, sortStoriesByKind) {
   if (!stories) return null;
   const sorted = sort(stories, sortStoriesByKind);
   if (!filter) return sorted;
-
   return sorted.reduce((acc, kindInfo) => {
     // Don't filter out currently selected filter
     if (kindInfo.kind === selectedKind) return acc.concat(kindInfo);
@@ -22,7 +21,10 @@ export function storyFilter(stories, filter, selectedKind, sortStoriesByKind) {
     if (fuzzysearch(needle, hstack)) return acc.concat(kindInfo);
 
     // Now search at individual story level and filter results
-    const matchedStories = kindInfo.stories.filter(story => fuzzysearch(needle, story));
+    const matchedStories = kindInfo.stories.filter(story => {
+      const storyHstack = story.toLocaleLowerCase();
+      return fuzzysearch(needle, storyHstack);
+    });
 
     if (matchedStories.length)
       return acc.concat({

--- a/lib/ui/src/modules/ui/libs/filters.js
+++ b/lib/ui/src/modules/ui/libs/filters.js
@@ -12,10 +12,24 @@ export function storyFilter(stories, filter, selectedKind, sortStoriesByKind) {
   const sorted = sort(stories, sortStoriesByKind);
   if (!filter) return sorted;
 
-  return sorted.filter(kindInfo => {
-    if (kindInfo.kind === selectedKind) return true;
+  return sorted.reduce((acc, kindInfo) => {
+    // Don't filter out currently selected filter
+    if (kindInfo.kind === selectedKind) return acc.concat(kindInfo);
     const needle = filter.toLocaleLowerCase();
     const hstack = kindInfo.kind.toLocaleLowerCase();
-    return fuzzysearch(needle, hstack);
-  });
+
+    // If a match is found in the story hierachy structure return kindInfo
+    if (fuzzysearch(needle, hstack)) return acc.concat(kindInfo);
+
+    // Now search at individual story level and filter results
+    const matchedStories = kindInfo.stories.filter(story => fuzzysearch(needle, story));
+
+    if (matchedStories.length)
+      return acc.concat({
+        kind: kindInfo.kind,
+        stories: matchedStories,
+      });
+
+    return acc;
+  }, []);
 }

--- a/lib/ui/src/modules/ui/libs/filters.test.js
+++ b/lib/ui/src/modules/ui/libs/filters.test.js
@@ -78,5 +78,21 @@ describe('manager.ui.libs.filters', () => {
 
       expect(res).toEqual([stories[0], { kind: 'ee', stories: ['ff'] }]);
     });
+
+    test('should be case insensitive at tree level', () => {
+      const stories = [{ kind: 'aA', stories: ['bb'] }, { kind: 'cc', stories: ['dd'] }];
+      const selectedKind = 'aA';
+      const res = storyFilter(stories, 'aa', selectedKind);
+
+      expect(res).toEqual([stories[0]]);
+    });
+
+    test('should be case insensitive at story level', () => {
+      const stories = [{ kind: 'aa', stories: ['bb'] }, { kind: 'cc', stories: ['dd', 'eE'] }];
+      const selectedKind = 'aa';
+      const res = storyFilter(stories, 'ee', selectedKind);
+
+      expect(res).toEqual([stories[0], { kind: 'cc', stories: ['eE'] }]);
+    });
   });
 });

--- a/lib/ui/src/modules/ui/libs/filters.test.js
+++ b/lib/ui/src/modules/ui/libs/filters.test.js
@@ -54,5 +54,29 @@ describe('manager.ui.libs.filters', () => {
 
       expect(res).toEqual([stories[1], stories[2], stories[0]]);
     });
+
+    test('should filter on story level', () => {
+      const stories = [
+        { kind: 'aa', stories: ['bb'] },
+        { kind: 'cc', stories: ['dd'] },
+        { kind: 'ee', stories: ['ff'] },
+      ];
+      const selectedKind = 'aa';
+      const res = storyFilter(stories, 'ff', selectedKind);
+
+      expect(res).toEqual([stories[0], stories[2]]);
+    });
+
+    test('should filter out unmatched stories at lowest level', () => {
+      const stories = [
+        { kind: 'aa', stories: ['bb'] },
+        { kind: 'cc', stories: ['dd'] },
+        { kind: 'ee', stories: ['ff', 'gg'] },
+      ];
+      const selectedKind = 'aa';
+      const res = storyFilter(stories, 'ff', selectedKind);
+
+      expect(res).toEqual([stories[0], { kind: 'ee', stories: ['ff'] }]);
+    });
   });
 });


### PR DESCRIPTION
Issue:
https://github.com/storybooks/storybook/issues/109

## What I did
I edited the `storyFilter()` function to enable filtering on the story-level.
If the "fuzzysearch" matches a storiesOf() level story it will return all stories that are matched.

If the fuzzysearch matches an individual story, it will just return that story.

It will leave the currently active story unfiltered


## How to test

See the additions to `filters.test.js` for examples of it in action.
