### PR TITLE
Fix addon notes

### DIFF
--- a/addons/notes/src/index.js
+++ b/addons/notes/src/index.js
@@ -5,10 +5,10 @@ import { WithNotes as ReactWithNotes } from './react';
 export const addonNotes = ({ notes }) => {
   const channel = addons.getChannel();
 
-  return getStory => () => {
+  return getStory => (context) => {
     // send the notes to the channel before the story is rendered
     channel.emit('storybook/notes/add_notes', notes);
-    return getStory();
+    return getStory(context);
   };
 };
 


### PR DESCRIPTION
Issue:
currently storiesOf has such API:
```js
storiesOf(...).add(name, (context) => { /* return <Component /> */ })
```
so `addonNotes` should pass `context` as well, but it doesn't

## What I did

added `context` prop to a function returning by `addonNotes`

## How to test

this should work:

```js
.add('with some text', 
  addonNotes({ notes: 'Hello guys' })((context) => <div>Hello {context.story}</div>)
)
```

