### PR TITLE
Refactoring of `addon-info`

### DIFF
--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -19,7 +19,8 @@
     "global": "^4.3.2",
     "marksy": "^2.0.0",
     "prop-types": "^15.5.8",
-    "react-addons-create-fragment": "^15.5.3"
+    "react-addons-create-fragment": "^15.5.3",
+    "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "git-url-parse": "^6.2.2",

--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -116,11 +116,11 @@ export default function PropVal(props) {
 }
 
 PropVal.defaultProps = {
-  val: null, // eslint-disable-line
-  maxPropObjectKeys: 0,
-  maxPropArrayLength: 0,
-  maxPropStringLength: 0,
-}
+  val: null,
+  maxPropObjectKeys: 3,
+  maxPropArrayLength: 3,
+  maxPropStringLength: 50,
+};
 
 PropVal.propTypes = {
   val: PropTypes.any, // eslint-disable-line

--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -115,9 +115,16 @@ export default function PropVal(props) {
   return <span>{content}</span>;
 }
 
+PropVal.defaultProps = {
+  val: null, // eslint-disable-line
+  maxPropObjectKeys: 0,
+  maxPropArrayLength: 0,
+  maxPropStringLength: 0,
+}
+
 PropVal.propTypes = {
-  val: PropTypes.any.isRequired, // eslint-disable-line
-  maxPropObjectKeys: PropTypes.number.isRequired,
-  maxPropArrayLength: PropTypes.number.isRequired,
-  maxPropStringLength: PropTypes.number.isRequired,
+  val: PropTypes.any, // eslint-disable-line
+  maxPropObjectKeys: PropTypes.number,
+  maxPropArrayLength: PropTypes.number,
+  maxPropStringLength: PropTypes.number,
 };

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -1,31 +1,11 @@
 import React from 'react';
+import deprecate from 'util-deprecate';
 import _Story from './components/Story';
 import { H1, H2, H3, H4, H5, H6, Code, P, UL, A, LI } from './components/markdown';
 
 function addonCompose(addonFn) {
   return storyFn => context => addonFn(storyFn, context);
 }
-
-function deprecate() {
-  const logger = console;
-  let warned = false;
-  const deprecated = msg => {
-    if (!warned) {
-      logger.warn(msg);
-      warned = true;
-    }
-  };
-  return deprecated;
-}
-
-const showWarning = deprecate();
-
-const warning = addonCompose((storyFn, context) => {
-  showWarning(
-    `Warning: Applying addWithInfo is deprecated and will be removed in the next major release. Use withInfo from the same package instead. \nPlease check the "${context.kind}/${context.story}" story. \nSee https://github.com/storybooks/storybook/tree/master/addons/info`
-  );
-  return storyFn(context);
-});
 
 export const Story = _Story;
 
@@ -54,7 +34,7 @@ const defaultMarksyConf = {
   ul: UL,
 };
 
-export function addInfo(storyFn, context, { info, _options }) {
+export function addInfo(storyFn, context, info, _options) {
   if (typeof storyFn !== 'function') {
     if (typeof info === 'function') {
         _options = storyFn; // eslint-disable-line
@@ -104,12 +84,12 @@ export function addInfo(storyFn, context, { info, _options }) {
 }
 
 export const withInfo = (info, _options) =>
-  addonCompose((storyFn, context) => addInfo(storyFn, context, { info, _options }));
+  addonCompose((storyFn, context) => addInfo(storyFn, context, info, _options));
 
 export default {
-  addWithInfo(storyName, info, storyFn, _options) {
-    return this.add(storyName, warning(withInfo(info, _options)(storyFn)));
-  },
+  addWithInfo: deprecate(function addWithInfo(storyName, info, storyFn, _options) {
+    return this.add(storyName, withInfo(info, _options)(storyFn));
+  }, '@storybook/addon-info .addWithInfo() addon is deprecated, use withInfo() from the same package instead. \nSee https://github.com/storybooks/storybook/tree/master/addons/info'),
 };
 
 export function setDefaults(newDefaults) {

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -29,57 +29,61 @@ const defaultMarksyConf = {
   ul: UL,
 };
 
+export function withInfo(info, storyFn, _options, context) {
+  if (typeof storyFn !== 'function') {
+    if (typeof info === 'function') {
+      _options = storyFn; // eslint-disable-line
+      storyFn = info; // eslint-disable-line
+      info = ''; // eslint-disable-line
+    } else {
+      throw new Error('No story defining function has been specified');
+    }
+  }
+
+  const options = {
+    ...defaultOptions,
+    ..._options,
+  };
+
+  // props.propTables can only be either an array of components or null
+  // propTables option is allowed to be set to 'false' (a boolean)
+  // if the option is false, replace it with null to avoid react warnings
+  if (!options.propTables) {
+    options.propTables = null;
+  }
+
+  const marksyConf = { ...defaultMarksyConf };
+  if (options && options.marksyConf) {
+    Object.assign(marksyConf, options.marksyConf);
+  }
+
+  const props = {
+    info,
+    context,
+    showInline: Boolean(options.inline),
+    showHeader: Boolean(options.header),
+    showSource: Boolean(options.source),
+    propTables: options.propTables,
+    propTablesExclude: options.propTablesExclude,
+    styles: typeof options.styles === 'function' ? options.styles : s => s,
+    marksyConf,
+    maxPropObjectKeys: options.maxPropObjectKeys,
+    maxPropArrayLength: options.maxPropArrayLength,
+    maxPropsIntoLine: options.maxPropsIntoLine,
+    maxPropStringLength: options.maxPropStringLength,
+  };
+
+  return (
+    <Story {...props}>
+      {storyFn(context)}
+    </Story>
+  );
+}
+
 export default {
   addWithInfo(storyName, info, storyFn, _options) {
-    if (typeof storyFn !== 'function') {
-      if (typeof info === 'function') {
-        _options = storyFn; // eslint-disable-line
-        storyFn = info; // eslint-disable-line
-        info = ''; // eslint-disable-line
-      } else {
-        throw new Error('No story defining function has been specified');
-      }
-    }
-
-    const options = {
-      ...defaultOptions,
-      ..._options,
-    };
-
-    // props.propTables can only be either an array of components or null
-    // propTables option is allowed to be set to 'false' (a boolean)
-    // if the option is false, replace it with null to avoid react warnings
-    if (!options.propTables) {
-      options.propTables = null;
-    }
-
-    const marksyConf = { ...defaultMarksyConf };
-    if (options && options.marksyConf) {
-      Object.assign(marksyConf, options.marksyConf);
-    }
-
     return this.add(storyName, context => {
-      const props = {
-        info,
-        context,
-        showInline: Boolean(options.inline),
-        showHeader: Boolean(options.header),
-        showSource: Boolean(options.source),
-        propTables: options.propTables,
-        propTablesExclude: options.propTablesExclude,
-        styles: typeof options.styles === 'function' ? options.styles : s => s,
-        marksyConf,
-        maxPropObjectKeys: options.maxPropObjectKeys,
-        maxPropArrayLength: options.maxPropArrayLength,
-        maxPropsIntoLine: options.maxPropsIntoLine,
-        maxPropStringLength: options.maxPropStringLength,
-      };
-
-      return (
-        <Story {...props}>
-          {storyFn(context)}
-        </Story>
-      );
+      return withInfo(info, storyFn, _options, context);
     });
   },
 };

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -18,10 +18,10 @@ function deprecate() {
   return deprecated;
 }
 
-const showWaring = deprecate();
+const showWarning = deprecate();
 
 const warning = addonCompose((storyFn, context) => {
-  showWaring(
+  showWarning(
     `Warning: Applying addWithInfo is deprecated and will be removed in the next major release. Use withInfo from the same package instead. \nPlease check the "${context.kind}/${context.story}" story. \nSee https://github.com/storybooks/storybook/tree/master/addons/info`
   );
   return storyFn(context);

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -29,61 +29,62 @@ const defaultMarksyConf = {
   ul: UL,
 };
 
-export function withInfo(info, storyFn, _options) {
-  if (typeof storyFn !== 'function') {
-    if (typeof info === 'function') {
-      _options = storyFn; // eslint-disable-line
-      storyFn = info; // eslint-disable-line
-      info = ''; // eslint-disable-line
-    } else {
-      throw new Error('No story defining function has been specified');
+export function withInfo(info, _options) {
+  return (storyFn) => {
+    if (typeof storyFn !== 'function') {
+      if (typeof info === 'function') {
+        _options = storyFn; // eslint-disable-line
+        storyFn = info; // eslint-disable-line
+        info = ''; // eslint-disable-line
+      } else {
+        throw new Error('No story defining function has been specified');
+      }
     }
-  }
 
-  const options = {
-    ...defaultOptions,
-    ..._options,
-  };
-
-  // props.propTables can only be either an array of components or null
-  // propTables option is allowed to be set to 'false' (a boolean)
-  // if the option is false, replace it with null to avoid react warnings
-  if (!options.propTables) {
-    options.propTables = null;
-  }
-
-  const marksyConf = { ...defaultMarksyConf };
-  if (options && options.marksyConf) {
-    Object.assign(marksyConf, options.marksyConf);
-  }
-
-  return context => {
-    const props = {
-      info,
-      context,
-      showInline: Boolean(options.inline),
-      showHeader: Boolean(options.header),
-      showSource: Boolean(options.source),
-      propTables: options.propTables,
-      propTablesExclude: options.propTablesExclude,
-      styles: typeof options.styles === 'function' ? options.styles : s => s,
-      marksyConf,
-      maxPropObjectKeys: options.maxPropObjectKeys,
-      maxPropArrayLength: options.maxPropArrayLength,
-      maxPropsIntoLine: options.maxPropsIntoLine,
-      maxPropStringLength: options.maxPropStringLength,
+    const options = {
+      ...defaultOptions,
+      ..._options,
     };
-    return (
-      <Story {...props}>
-        {storyFn(context)}
-      </Story>
-    );
-  };
+
+    // props.propTables can only be either an array of components or null
+    // propTables option is allowed to be set to 'false' (a boolean)
+    // if the option is false, replace it with null to avoid react warnings
+    if (!options.propTables) {
+      options.propTables = null;
+    }
+
+    const marksyConf = { ...defaultMarksyConf };
+    if (options && options.marksyConf) {
+      Object.assign(marksyConf, options.marksyConf);
+    }
+
+    return context => {
+      const props = {
+        info,
+        context,
+        showInline: Boolean(options.inline),
+        showHeader: Boolean(options.header),
+        showSource: Boolean(options.source),
+        propTables: options.propTables,
+        propTablesExclude: options.propTablesExclude,
+        styles: typeof options.styles === 'function' ? options.styles : s => s,
+        marksyConf,
+        maxPropObjectKeys: options.maxPropObjectKeys,
+        maxPropArrayLength: options.maxPropArrayLength,
+        maxPropsIntoLine: options.maxPropsIntoLine,
+        maxPropStringLength: options.maxPropStringLength,
+      };
+      return (
+        <Story {...props}>
+          {storyFn(context)}
+        </Story>
+      );
+    };}
 }
 
 export default {
   addWithInfo(storyName, info, storyFn, _options) {
-    return this.add(storyName, withInfo(info, storyFn, _options));
+    return this.add(storyName, withInfo(info, _options)(storyFn));
   },
 };
 

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -29,7 +29,7 @@ const defaultMarksyConf = {
   ul: UL,
 };
 
-export function withInfo(info, storyFn, _options, context) {
+export function withInfo(info, storyFn, _options) {
   if (typeof storyFn !== 'function') {
     if (typeof info === 'function') {
       _options = storyFn; // eslint-disable-line
@@ -57,34 +57,33 @@ export function withInfo(info, storyFn, _options, context) {
     Object.assign(marksyConf, options.marksyConf);
   }
 
-  const props = {
-    info,
-    context,
-    showInline: Boolean(options.inline),
-    showHeader: Boolean(options.header),
-    showSource: Boolean(options.source),
-    propTables: options.propTables,
-    propTablesExclude: options.propTablesExclude,
-    styles: typeof options.styles === 'function' ? options.styles : s => s,
-    marksyConf,
-    maxPropObjectKeys: options.maxPropObjectKeys,
-    maxPropArrayLength: options.maxPropArrayLength,
-    maxPropsIntoLine: options.maxPropsIntoLine,
-    maxPropStringLength: options.maxPropStringLength,
+  return context => {
+    const props = {
+      info,
+      context,
+      showInline: Boolean(options.inline),
+      showHeader: Boolean(options.header),
+      showSource: Boolean(options.source),
+      propTables: options.propTables,
+      propTablesExclude: options.propTablesExclude,
+      styles: typeof options.styles === 'function' ? options.styles : s => s,
+      marksyConf,
+      maxPropObjectKeys: options.maxPropObjectKeys,
+      maxPropArrayLength: options.maxPropArrayLength,
+      maxPropsIntoLine: options.maxPropsIntoLine,
+      maxPropStringLength: options.maxPropStringLength,
+    };
+    return (
+      <Story {...props}>
+        {storyFn(context)}
+      </Story>
+    );
   };
-
-  return (
-    <Story {...props}>
-      {storyFn(context)}
-    </Story>
-  );
 }
 
 export default {
   addWithInfo(storyName, info, storyFn, _options) {
-    return this.add(storyName, context => {
-      return withInfo(info, storyFn, _options, context);
-    });
+    return this.add(storyName, withInfo(info, storyFn, _options));
   },
 };
 

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -30,7 +30,7 @@ const defaultMarksyConf = {
 };
 
 export function withInfo(info, _options) {
-  return (storyFn) => {
+  return storyFn => {
     if (typeof storyFn !== 'function') {
       if (typeof info === 'function') {
         _options = storyFn; // eslint-disable-line
@@ -79,12 +79,34 @@ export function withInfo(info, _options) {
           {storyFn(context)}
         </Story>
       );
-    };}
+    };
+  };
 }
+
+function deprecate() {
+  const logger = console;
+  let warned = false;
+  const deprecated = msg => {
+    if (!warned) {
+      logger.warn(msg);
+      warned = true;
+    }
+  };
+  return deprecated;
+}
+
+const showWaring = deprecate();
+
+const warning = storyFn => context => {
+  showWaring(
+    `Warning: Applying addWithInfo is deprecated and will be removed in the next major release. Use withInfo from the same package instead. Please check the "${context.kind}/${context.story}" story. See https://github.com/storybooks/storybook/tree/master/addons/info`
+  );
+  return storyFn(context);
+};
 
 export default {
   addWithInfo(storyName, info, storyFn, _options) {
-    return this.add(storyName, withInfo(info, _options)(storyFn));
+    return this.add(storyName, warning(withInfo(info, _options)(storyFn)));
   },
 };
 

--- a/addons/info/src/index.test.js
+++ b/addons/info/src/index.test.js
@@ -50,7 +50,7 @@ describe('addon Info', () => {
   });
   it('should render with missed info', () => {
     setDefaults(testOptions);
-    addInfo(null, testContext, { info: story, options: testOptions });
+    addInfo(null, testContext, story, testOptions);
   });
   it('should show deprecation warning', () => {
     const addWithInfo = AddonInfo.addWithInfo.bind(api);

--- a/addons/info/src/index.test.js
+++ b/addons/info/src/index.test.js
@@ -1,0 +1,23 @@
+/* global document */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import AddonInfo, { withInfo } from './';
+
+describe('addon Info', () => {
+  const story = context =>
+    <div>
+      It's a {context.story} story
+    </div>;
+  const api = {
+    add: (name, fn) => fn({ kind: 'addon_info', story: 'jest_test' }),
+  };
+  it('should render <Info />', () => {
+    const Info = withInfo('Test Info')(story);
+    ReactDOM.render(<Info />, document.createElement('div'));
+  });
+  it('should show deprecation warning', () => {
+    const addWithInfo = AddonInfo.addWithInfo.bind(api);
+    addWithInfo('jest', 'test info', story);
+  });
+});

--- a/addons/info/src/index.test.js
+++ b/addons/info/src/index.test.js
@@ -2,22 +2,56 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import AddonInfo, { withInfo } from './';
+import AddonInfo, { withInfo, setDefaults, addInfo } from './';
+
+/* eslint-disable */
+const TestComponent = ({ func, obj, array, number, string, bool, empty }) =>
+  <div>
+    <h1>{func}</h1>
+    <h2>{obj.toString()}</h2>
+    <h3>{array}</h3>
+    <h4>{number}</h4>
+    <h5>{string}</h5>
+    <h6>{bool}</h6>
+    <p>{empty}</p>
+    <a href="#">test</a>
+    <code>storiesOf</code>
+    <ui>
+      <li>1</li>
+      <li>2</li>
+    </ui>
+  </div>;
+/* eslint-enable */
+
+const testContext = { kind: 'addon_info', story: 'jest_test' };
+const testOptions = { propTables: false };
 
 describe('addon Info', () => {
   const story = context =>
     <div>
-      It's a {context.story} story
+      It's a {context.story} story:
+      <TestComponent
+        func={x => x + 1}
+        obj={{ a: 'a', b: 'b' }}
+        array={[1, 2, 3]}
+        number={7}
+        string={'seven'}
+        bool
+      />
     </div>;
   const api = {
-    add: (name, fn) => fn({ kind: 'addon_info', story: 'jest_test' }),
+    add: (name, fn) => fn(testContext),
   };
   it('should render <Info />', () => {
     const Info = withInfo('Test Info')(story);
     ReactDOM.render(<Info />, document.createElement('div'));
   });
+  it('should should render with missed info', () => {
+    setDefaults(testOptions);
+    addInfo(null, testContext, { info: story, options: testOptions });
+  });
   it('should show deprecation warning', () => {
     const addWithInfo = AddonInfo.addWithInfo.bind(api);
-    addWithInfo('jest', 'test info', story);
+    addWithInfo('jest', story);
   });
 });

--- a/addons/info/src/index.test.js
+++ b/addons/info/src/index.test.js
@@ -42,11 +42,13 @@ describe('addon Info', () => {
   const api = {
     add: (name, fn) => fn(testContext),
   };
-  it('should render <Info />', () => {
-    const Info = withInfo('Test Info')(story);
+  it('should render <Info /> and markdown', () => {
+    const Info = withInfo(
+      '# Test story \n## with markdown info \ncontaing **bold**, *cursive* text and `code`'
+    )(story);
     ReactDOM.render(<Info />, document.createElement('div'));
   });
-  it('should should render with missed info', () => {
+  it('should render with missed info', () => {
     setDefaults(testOptions);
     addInfo(null, testContext, { info: story, options: testOptions });
   });

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -47,19 +47,12 @@ const InfoButton = () =>
       background: 'rgb(34, 136, 204)',
       color: 'rgb(255, 255, 255)',
       padding: '5px 15px',
-      margin: 4,
-      marginTop: 16,
-      cursor: 'pointer',
+      margin: 10,
       borderRadius: '0px 0px 0px 5px',
     }}
   >
     {' '}Show Info{' '}
   </span>;
-
-const withNotes = (note, storyFn) => context =>
-  <WithNotes notes={note}>
-    {storyFn(context)}
-  </WithNotes>;
 
 storiesOf('Button', module)
   .addDecorator(withKnobs)

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -19,6 +19,7 @@ import {
   object,
 } from '@storybook/addon-knobs';
 import centered from '@storybook/addon-centered';
+import { withInfo } from '@storybook/addon-info';
 
 import { Button, Welcome } from '@storybook/react/demo';
 
@@ -36,6 +37,24 @@ const emiter = new EventEmiter();
 const emit = emiter.emit.bind(emiter);
 
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
+
+const InfoButton = () =>
+  <span
+    style={{
+      fontFamily: 'sans-serif',
+      fontSize: 12,
+      //      display: 'block',
+      textDecoration: 'none',
+      background: 'rgb(34, 136, 204)',
+      color: 'rgb(255, 255, 255)',
+      padding: '5px 15px',
+      margin: 4,
+      cursor: 'pointer',
+      borderRadius: '0px 0px 0px 5px',
+    }}
+  >
+    {' '}Show Info{' '}
+  </span>;
 
 storiesOf('Button', module)
   .addDecorator(withKnobs)
@@ -75,21 +94,46 @@ storiesOf('Button', module)
 
     return (
       <div style={style}>
-        <p>{intro}</p>
-        <p>My birthday is: {new Date(birthday).toLocaleDateString()}</p>
-        <p>My wallet contains: ${dollars.toFixed(2)}</p>
+        <p>
+          {intro}
+        </p>
+        <p>
+          My birthday is: {new Date(birthday).toLocaleDateString()}
+        </p>
+        <p>
+          My wallet contains: ${dollars.toFixed(2)}
+        </p>
         <p>In my backpack, I have:</p>
         <ul>
-          {items.map(item => <li key={item}>{item}</li>)}
+          {items.map(item =>
+            <li key={item}>
+              {item}
+            </li>
+          )}
         </ul>
-        <p>{salutation}</p>
+        <p>
+          {salutation}
+        </p>
       </div>
     );
   })
   .addWithInfo(
     'with some info',
     'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its painful API.',
-    () => <Button>click the "?" in top right for info</Button>
+    () =>
+      <div>
+        click the <InfoButton /> label in top right for info
+      </div>
+  )
+  .add('with new info', (context) =>
+    withInfo(
+      'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its painful API.', () => (
+      <div>
+        click the <InfoButton /> label in top right for info
+      </div>),
+      {},
+      context
+    )
   );
 
 storiesOf('App', module).add('full app', () => <App />);
@@ -177,7 +221,11 @@ storiesOf('Addon Knobs deprecated Decorator', module)
     const age = number('Age', 120);
 
     const content = `I am ${name} and I'm ${age} years old.`;
-    return <div>{content}</div>;
+    return (
+      <div>
+        {content}
+      </div>
+    );
   });
 
 storiesOf('Addon Knobs', module).add(
@@ -187,14 +235,26 @@ storiesOf('Addon Knobs', module).add(
     const age = number('Age', 89);
 
     const content = `I am ${name} and I'm ${age} years old.`;
-    return <div>{content}</div>;
+    return (
+      <div>
+        {content}
+      </div>
+    );
   })
 );
 
 storiesOf('component.base.Link')
   .addDecorator(withKnobs)
-  .add('first', () => <a>{text('firstLink', 'first link')}</a>)
-  .add('second', () => <a>{text('secondLink', 'second link')}</a>);
+  .add('first', () =>
+    <a>
+      {text('firstLink', 'first link')}
+    </a>
+  )
+  .add('second', () =>
+    <a>
+      {text('secondLink', 'second link')}
+    </a>
+  );
 
 storiesOf('component.base.Span')
   .add('first', () => <span>first span</span>)
@@ -205,8 +265,20 @@ storiesOf('component.common.Div')
   .add('second', () => <div>second div</div>);
 
 storiesOf('component.common.Table')
-  .add('first', () => <table><tr><td>first table</td></tr></table>)
-  .add('second', () => <table><tr><td>first table</td></tr></table>);
+  .add('first', () =>
+    <table>
+      <tr>
+        <td>first table</td>
+      </tr>
+    </table>
+  )
+  .add('second', () =>
+    <table>
+      <tr>
+        <td>first table</td>
+      </tr>
+    </table>
+  );
 
 storiesOf('component.Button')
   .add('first', () => <button>first button</button>)
@@ -216,7 +288,11 @@ storiesOf('component.Button')
 
 storiesOf('Cells¯\\_(ツ)_/¯Molecules.Atoms/simple', module)
   .addDecorator(withKnobs)
-  .add('with text', () => <Button>{text('buttonText', 'Hello Button')}</Button>)
+  .add('with text', () =>
+    <Button>
+      {text('buttonText', 'Hello Button')}
+    </Button>
+  )
   .add('with some emoji', () => <Button>😀 😎 👍 💯</Button>);
 
 storiesOf('Cells/Molecules/Atoms.more', module)
@@ -230,4 +306,3 @@ storiesOf('Cells/Molecules', module)
 storiesOf('Cells.Molecules.Atoms', module)
   .add('with text2', () => <Button>Hello Button</Button>)
   .add('with some emoji2', () => <Button>😀 😎 👍 💯</Button>);
-

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -56,6 +56,11 @@ const InfoButton = () =>
     {' '}Show Info{' '}
   </span>;
 
+const withNotes = (note, storyFn) => context =>
+  <WithNotes notes={note}>
+    {storyFn(context)}
+  </WithNotes>;
+
 storiesOf('Button', module)
   .addDecorator(withKnobs)
   .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)
@@ -120,19 +125,31 @@ storiesOf('Button', module)
   .addWithInfo(
     'with some info',
     'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its painful API.',
-    () =>
+    context =>
       <div>
-        click the <InfoButton /> label in top right for info
+        click the <InfoButton /> label in top right for info about "{context.story}"
       </div>
   )
-  .add('with new info', (context) =>
+  .add(
+    'with new info',
     withInfo(
-      'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its painful API.', () => (
-      <div>
-        click the <InfoButton /> label in top right for info
-      </div>),
-      {},
-      context
+      'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its new painless API.',
+      context =>
+        <div>
+          click the <InfoButton /> label in top right for info about "{context.story}"
+        </div>
+    )
+  )
+  .add(
+    'addons composition',
+    withInfo(
+      'Addon info',
+      withNotes('Addons composition: Info(Notes(storyFn))', context =>
+        <div>
+          click the <InfoButton /> label in top right and select "Notes" on Addons Panel to know
+          more about "{context.story}"
+        </div>
+      )
     )
   );
 

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -43,12 +43,12 @@ const InfoButton = () =>
     style={{
       fontFamily: 'sans-serif',
       fontSize: 12,
-      //      display: 'block',
       textDecoration: 'none',
       background: 'rgb(34, 136, 204)',
       color: 'rgb(255, 255, 255)',
       padding: '5px 15px',
       margin: 4,
+      marginTop: 16,
       cursor: 'pointer',
       borderRadius: '0px 0px 0px 5px',
     }}
@@ -133,21 +133,19 @@ storiesOf('Button', module)
   .add(
     'with new info',
     withInfo(
-      'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its new painless API.',
-      context =>
-        <div>
-          click the <InfoButton /> label in top right for info about "{context.story}"
-        </div>
+      'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its new painless API.'
+    )(context =>
+      <div>
+        click the <InfoButton /> label in top right for info about "{context.story}"
+      </div>
     )
   )
   .add(
     'addons composition',
-    withInfo(
-      'Addon info',
-      withNotes('Addons composition: Info(Notes(storyFn))', context =>
+    withInfo('see Notes panel for composition info')(
+      addonNotes({ notes: 'Composition: Info(Notes())' })(context =>
         <div>
-          click the <InfoButton /> label in top right and select "Notes" on Addons Panel to know
-          more about "{context.story}"
+          click the <InfoButton /> label in top right for info about "{context.story}"
         </div>
       )
     )


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/1147#issuecomment-306409320 and a discussion below

since we're slowly moving from .addWithX addons to more wise solutions, we need an appropriate version of the addon

## What I did

1. Added `withInfo()` function.

accessible via:
```js
import { withInfo } from '@storybook/addon-info';
```

API:

```js
infoFn(context => { /* return <Story /> */ }) = withInfo(storyInfo, options)
```

Example:

```js
.add('with new info', withInfo('info addon')(context =>
      <div>
        click the <InfoButton /> label in top right for info about "{context.story}"
      </div>
))
```

2 Added deprecation warning to `.addWithInfo`

3 Added examples to cra-kitchen-sink:

- new `withInfo()` API

- `withInfo()` and `addonNotes()` composition

## How to test

- run cra-kitchen-sink 

- run tests
