### PR TITLE
Fix issue when extending webpack config

### DIFF
--- a/app/react/src/server/config.js
+++ b/app/react/src/server/config.js
@@ -73,7 +73,10 @@ export default function(configType, baseConfig, configDir) {
       ...config.module,
       // We need to use our and custom rules.
       ...customConfig.module,
-      rules: [...config.module.rules, ...(customConfig.module.rules || [])],
+      rules: [
+        ...config.module.rules,
+        ...((customConfig.module && customConfig.module.rules) || []),
+      ],
     },
     resolve: {
       ...config.resolve,


### PR DESCRIPTION
Issue: #1467

## What I did
Fix bug leading to property access on undefined value


## How to test
Run storybook after extending the webpack config with the following:

webpack.config.js
```javascript
const webpack = require('webpack');

module.exports = {
  plugins: [
    new webpack.ProvidePlugin({
      $: 'jquery',
    }),
  ],
};
```
(Assumes `jquery` is installed)