### PR TITLE
Knobs: fix label alignment

### DIFF
--- a/addons/knobs/src/components/PropField.js
+++ b/addons/knobs/src/components/PropField.js
@@ -16,7 +16,7 @@ const stylesheet = {
     boxSizing: 'border-box',
     verticalAlign: 'top',
     paddingRight: 5,
-    paddingTop: 7,
+    paddingTop: 5,
     textAlign: 'right',
     width: 80,
     fontSize: 12,

--- a/addons/knobs/src/components/types/Number.js
+++ b/addons/knobs/src/components/types/Number.js
@@ -5,7 +5,7 @@ const styles = {
   display: 'table-cell',
   boxSizing: 'border-box',
   verticalAlign: 'middle',
-  height: '26px',
+  height: '25px',
   width: '100%',
   outline: 'none',
   border: '1px solid #f7f4f4',


### PR DESCRIPTION
Issue:
#1086 introduced increased font size for labels. Unfortunately, that broke alignment

## What I did
Lowered the `padding-top`

## How to test
Run any story with knobs addon

Before:
<img width="96" alt="screen shot 2017-07-14 at 20 36 52" src="https://user-images.githubusercontent.com/6651625/28223625-d1da20ee-68d4-11e7-9d68-9f217d9f234e.png">
After:
<img width="89" alt="screen shot 2017-07-14 at 20 37 09" src="https://user-images.githubusercontent.com/6651625/28223629-d889309c-68d4-11e7-9c10-a28c376b2604.png">
 
