### PR TITLE
Trying to consolidate hierarchy UI (+ some other fixes)

### DIFF
--- a/lib/ui/example/client/provider.js
+++ b/lib/ui/example/client/provider.js
@@ -79,7 +79,6 @@ export default class ReactProvider extends Provider {
     this.api.setOptions({
       name: 'REACT-STORYBOOK',
       sortStoriesByKind: true,
-      hierarchySeparator: '/'
     });
 
     // set stories

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -33,8 +33,8 @@
     "react-komposer": "^2.0.0",
     "react-modal": "^1.7.6",
     "react-split-pane": "^0.1.63",
-    "redux": "^3.6.0",
-    "storybook-react-treebeard": "^1.1.6"
+    "react-treebeard": "^2.0.3",
+    "redux": "^3.6.0"
   },
   "devDependencies": {
     "enzyme": "^2.8.2"

--- a/lib/ui/src/modules/api/index.js
+++ b/lib/ui/src/modules/api/index.js
@@ -8,7 +8,7 @@ export default {
       name: 'STORYBOOK',
       url: 'https://github.com/storybooks/storybook',
       sortStoriesByKind: false,
-      hierarchySeparator: '',
+      hierarchySeparator: '/',
     },
   },
   load({ clientStore, provider }, _actions) {

--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/index.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/index.js
@@ -1,4 +1,4 @@
-import { Treebeard } from 'storybook-react-treebeard';
+import { Treebeard } from 'react-treebeard';
 import PropTypes from 'prop-types';
 import React from 'react';
 import deepEqual from 'deep-equal';

--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_decorators.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_decorators.js
@@ -1,15 +1,26 @@
 import { decorators } from 'react-treebeard';
-import { IoFolder, IoDocumentText, IoCode } from 'react-icons/lib/io';
+import { IoChevronRight } from 'react-icons/lib/io';
 import React from 'react';
 import PropTypes from 'prop-types';
-import treeNodeTypes from './tree_node_type';
 
-const iconsColor = '#7d8890';
+function ToggleDecorator({ style }) {
+  const { height, width, arrow } = style;
 
-const iconsMap = {
-  [treeNodeTypes.NAMESPACE]: IoFolder,
-  [treeNodeTypes.COMPONENT]: IoDocumentText,
-  [treeNodeTypes.STORY]: IoCode,
+  return (
+    <div style={style.base}>
+      <div style={style.wrapper}>
+        <IoChevronRight height={height} width={width} style={arrow} />
+      </div>
+    </div>
+  );
+}
+
+ToggleDecorator.propTypes = {
+  style: PropTypes.shape({
+    width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+    arrow: PropTypes.object.isRequired,
+  }).isRequired,
 };
 
 function ContainerDecorator(props) {
@@ -55,15 +66,12 @@ function createHeaderDecoratorScope(parent) {
         ...style.title,
       };
 
-      const Icon = iconsMap[node.type];
-
       if (!node.children || !node.children.length) {
         newStyleTitle.fontSize = '13px';
       }
 
       return (
         <div style={style.base} role="menuitem" tabIndex="0" onKeyDown={this.onKeyDown}>
-          {Icon && <Icon color={iconsColor} />}
           <a style={newStyleTitle}>
             {node.name}
           </a>
@@ -90,5 +98,6 @@ export default function(parent) {
     ...decorators,
     Header: createHeaderDecoratorScope(parent),
     Container: ContainerDecorator,
+    Toggle: ToggleDecorator,
   };
 }

--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_decorators.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_decorators.js
@@ -1,4 +1,4 @@
-import { decorators } from 'storybook-react-treebeard';
+import { decorators } from 'react-treebeard';
 import { IoFolder, IoDocumentText, IoCode } from 'react-icons/lib/io';
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_style.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_style.js
@@ -39,13 +39,12 @@ export default {
           position: 'absolute',
           top: '50%',
           left: '50%',
-          margin: '-10px 0 0 -4px',
+          margin: '-12px 0 0 -4px',
         },
         height: 10,
         width: 10,
         arrow: {
           fill: '#9DA5AB',
-          strokeWidth: 0,
         },
       },
       header: {


### PR DESCRIPTION
Issue: #151 

## What I did

Here is the current state of the UI

1. Toggle icon changed to chevron 
2. Other icons are removed ( :cry: ). According to @shilman it looks cleaner.

![image](https://user-images.githubusercontent.com/7867954/28364092-be64c432-6c8b-11e7-9b3b-80894a5165eb.png)

Other changes in the same branch:

1. '/' is set as default to the `hierarchySeparator`
2. storybook-react-treebeard changed back to react-treebeard

## How to test

TBD