### PR TITLE
bump `react-split-pane` version

### DIFF
--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -31,7 +31,7 @@
     "react-inspector": "^2.1.1",
     "react-komposer": "^2.0.0",
     "react-modal": "^1.7.7",
-    "react-split-pane": "^0.1.63",
+    "react-split-pane": "^0.1.65",
     "redux": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
this should fix issue #1352

Issue: #1352

## What I did
Bump a version number

## How to test
Run the storybook in IE11 and check that the side panel renders correctly