### PR TITLE
Fix a 'funny' hmr issue in cra-kitchen-sink

### DIFF
--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -251,7 +251,7 @@ storiesOf('Addon Knobs', module).add(
   })
 );
 
-storiesOf('component.base.Link')
+storiesOf('component.base.Link', module)
   .addDecorator(withKnobs)
   .add('first', () =>
     <a>
@@ -264,15 +264,15 @@ storiesOf('component.base.Link')
     </a>
   );
 
-storiesOf('component.base.Span')
+storiesOf('component.base.Span', module)
   .add('first', () => <span>first span</span>)
   .add('second', () => <span>second span</span>);
 
-storiesOf('component.common.Div')
+storiesOf('component.common.Div', module)
   .add('first', () => <div>first div</div>)
   .add('second', () => <div>second div</div>);
 
-storiesOf('component.common.Table')
+storiesOf('component.common.Table', module)
   .add('first', () =>
     <table>
       <tr>
@@ -288,7 +288,7 @@ storiesOf('component.common.Table')
     </table>
   );
 
-storiesOf('component.Button')
+storiesOf('component.Button', module)
   .add('first', () => <button>first button</button>)
   .add('second', () => <button>first second</button>);
 


### PR DESCRIPTION
Issue: #1506 

## What was the problem

`module` parameter was missing in a few stories that I've added as an example of hierarchy.

## How to test
Check #1506 

### TBD
- Throw error when `module` is missing in `storiesOf()`