### PR TITLE
Show first story on OnDeviceUI startup

### DIFF
--- a/app/react-native/src/manager/components/PreviewHelp.js
+++ b/app/react-native/src/manager/components/PreviewHelp.js
@@ -52,7 +52,7 @@ const PreviewHelp = () =>
       For <span style={styles.code}>react-native init</span> apps:
     </p>
     <div style={styles.codeBlock}>
-      <pre style={styles.instructionsCode}>npm run &lt;platform&gt;</pre>
+      <pre style={styles.instructionsCode}>react-native run-&lt;platform&gt;</pre>
     </div>
   </div>;
 

--- a/app/react-native/src/preview/components/StoryListView/index.js
+++ b/app/react-native/src/preview/components/StoryListView/index.js
@@ -46,6 +46,11 @@ export default class StoryListView extends Component {
 
   componentDidMount() {
     this.handleStoryAdded();
+    const dump = this.props.stories.dumpStoryBook();
+    const nonEmptyKind = dump.find(kind => kind.stories.length > 0);
+    if (nonEmptyKind) {
+      this.changeStory(nonEmptyKind.kind, nonEmptyKind.stories[0]);
+    }
   }
 
   componentWillUnmount() {

--- a/examples/react-native-vanilla/storybook/storybook.js
+++ b/examples/react-native-vanilla/storybook/storybook.js
@@ -8,7 +8,12 @@ configure(() => {
   require('./stories');
 }, module);
 
-const StorybookUI = getStorybookUI({ port: 7007, host: 'localhost', onDeviceUI: true });
+const StorybookUI = getStorybookUI({
+  port: 7007,
+  host: 'localhost',
+  onDeviceUI: true,
+  resetStorybook: true,
+});
 
 setTimeout(
   () =>


### PR DESCRIPTION
Issue: #1492 

## What I did

- Fix startup message
- Fix required URL prop-type error (I think this is not really a fix @matt-oakes @ajwhite ?)
- Automatically jump to first story when OnDeviceUI starts

## How to test

```
yarn && yarn bootstrap && yarn bootstrap:react-native-vanilla
cd examples/react-native-vanilla
yarn storybook
open http://localhost:7007
./node_modules/.bin/react-native run-ios
```

You should see the first story `Welcome > to Storybook` selected in the on-device UI.
