### PR TITLE
Fix react native example and bootstrapping

### DIFF
--- a/docs/components/Homepage/index.js
+++ b/docs/components/Homepage/index.js
@@ -43,13 +43,13 @@ import Footer from '../Footer';
 const Homepage = ({ users }) =>
   <div className="container">
     <Helmet title="Storybook - UI dev environment you'll love to use" />
-    {/* <Header currentSection="home" />*/}
+    {/* <Header currentSection="home" /> */}
     <Heading />
     <Demo />
-    {/* <Platforms />*/}
+    {/* <Platforms /> */}
     <MainLinks />
     <UsedBy users={users} />
-    {/* <Featured featuredStorybooks={featuredStorybooks} />*/}
+    {/* <Featured featuredStorybooks={featuredStorybooks} /> */}
     <Footer />
   </div>;
 

--- a/examples/test-cra/src/stories/ComponentWithRef.js
+++ b/examples/test-cra/src/stories/ComponentWithRef.js
@@ -7,7 +7,13 @@ class ComponentWithRef extends Component {
   }
   scrollWidth = 0;
   render() {
-    return <div ref={r => (this.ref = r)} />;
+    return (
+      <div
+        ref={r => {
+          this.ref = r;
+        }}
+      />
+    );
   }
 }
 

--- a/lib/addons/src/index.js
+++ b/lib/addons/src/index.js
@@ -3,7 +3,8 @@ export class AddonStore {
     this.loaders = {};
     this.panels = {};
     // this.channel should get overwritten by setChannel if package versions are
-    // correct and AddonStore is a proper singleton. If not, throw an error.
+    // correct and AddonStore is a proper singleton. If not, this will be null
+    // (currently required by @storybook/react-native getStorybookUI)
     this.channel = null;
     this.preview = null;
     this.database = null;

--- a/lib/addons/src/index.js
+++ b/lib/addons/src/index.js
@@ -1,16 +1,10 @@
-function channelError() {
-  throw new Error(
-    'Accessing nonexistent addons channel, see https://storybook.js.org/basics/faq/#why-is-there-no-addons-channel'
-  );
-}
-
 export class AddonStore {
   constructor() {
     this.loaders = {};
     this.panels = {};
     // this.channel should get overwritten by setChannel if package versions are
     // correct and AddonStore is a proper singleton. If not, throw an error.
-    this.channel = { on: channelError, emit: channelError };
+    this.channel = null;
     this.preview = null;
     this.database = null;
   }


### PR DESCRIPTION
Issue: #1509 

## What I did

Addresses issues raised in #1509:
- bootstrapping react native doesn't work
- error-logging channel breaks RN, so reverting this (cc @tmeasday)

## How to test
```
yarn bootstrap && yarn bootstrap:react-native-vanillla
cd examples/react-native-vanilla
yarn storybook
./node_modules/.bin/react-native run-ios
```
