### PR TITLE
FIX hoist-internals: remove existing folder/link before linking

### DIFF
--- a/scripts/hoist-internals.js
+++ b/scripts/hoist-internals.js
@@ -69,7 +69,9 @@ const task = getLernaPackages()
               return path.join(targetPath, packageName);
             })
             .then(localTargetPath =>
-              symlink(sourcePath, localTargetPath)
+              fse
+                .remove(localTargetPath)
+                .then(() => symlink(sourcePath, localTargetPath))
                 .then(
                   passingLog(() => {
                     log.silly(prefix, 'symlinked ', [sourcePath, localTargetPath]);
@@ -77,7 +79,7 @@ const task = getLernaPackages()
                 )
                 .then(() => localTargetPath)
                 .catch(error => {
-                  log.error(prefix, 'symlink', error);
+                  log.error(prefix, 'symlink', error, [sourcePath, localTargetPath]);
                   throw new Error('failed symlink');
                 })
             )


### PR DESCRIPTION
Issue: -sometimes known packages are not linked by lerna, because it feels like the semver doesn't match -

This can happen when the version is something like `3.2.0-alpha.8` which is strictly speaking not valid semver.

We always want our packages linked, no matter the semver.

## What I did
This fixes it, by always linking.
This resolves the problem where `hoist-internals` would fail to symlink a folder, because it the target was a folder instead of a symlink.

The way I fixed it was by removing the target before creating the symlink.

## How to test
- Do a clean install & bootstrap
- check if all folders in @storybook/ are symlinks 