### PR TITLE
Proposal for withX api change

### DIFF
--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -7,19 +7,13 @@ import { reactHandler } from './react';
 const channel = addons.getChannel();
 const manager = new KnobManager(channel);
 
-export function knob(name, options) {
-  return manager.knob(name, options);
-}
+const knob = (name, options) => manager.knob(name, options);
 
-export function text(name, value) {
-  return manager.knob(name, { type: 'text', value });
-}
+const text = (name, value) => manager.knob(name, { type: 'text', value });
 
-export function boolean(name, value) {
-  return manager.knob(name, { type: 'boolean', value });
-}
+const boolean = (name, value) => manager.knob(name, { type: 'boolean', value });
 
-export function number(name, value, options = {}) {
+const number = (name, value, options = {}) => {
   const defaults = {
     range: false,
     min: 0,
@@ -36,42 +30,32 @@ export function number(name, value, options = {}) {
   };
 
   return manager.knob(name, finalOptions);
-}
+};
 
-export function color(name, value) {
-  return manager.knob(name, { type: 'color', value });
-}
+const color = (name, value) => manager.knob(name, { type: 'color', value });
 
-export function object(name, value) {
-  return manager.knob(name, { type: 'object', value });
-}
+const object = (name, value) => manager.knob(name, { type: 'object', value });
 
-export function select(name, options, value) {
-  return manager.knob(name, { type: 'select', options, value });
-}
+const select = (name, options, value) => manager.knob(name, { type: 'select', options, value });
 
-export function array(name, value, separator = ',') {
-  return manager.knob(name, { type: 'array', value, separator });
-}
+const array = (name, value, separator = ',') =>
+  manager.knob(name, { type: 'array', value, separator });
 
-export function date(name, value = new Date()) {
+const date = (name, value = new Date()) => {
   const proxyValue = value ? value.getTime() : null;
   return manager.knob(name, { type: 'date', value: proxyValue });
-}
+};
 
-export function withKnobs(storyFn, context) {
-  return reactHandler(channel, manager.knobStore)(storyFn)(context);
-}
+const ReactDecorator = (storyFn, context) =>
+  reactHandler(channel, manager.knobStore)(storyFn)(context);
 
-export function withKnobsOptions(options = {}) {
-  return (...args) => {
-    channel.emit('addon:knobs:setOptions', options);
+const ReactDecoratorWithOptions = (options = {}) => (...args) => {
+  channel.emit('addon:knobs:setOptions', options);
 
-    return withKnobs(...args);
-  };
-}
+  return ReactDecorator(...args);
+};
 
-export function withKnobsV2(options) {
+const wrapper = options => {
   if (options) channel.emit('addon:knobs:setOptions', options);
 
   switch (window.STORYBOOK_ENV) {
@@ -85,4 +69,10 @@ export function withKnobsV2(options) {
       return reactHandler(channel, manager.knobStore);
     }
   }
-}
+};
+
+export { wrapper as with };
+export { array, boolean, color, date, knob, object, number, select, text };
+
+// legacy
+export { ReactDecorator as withKnobs, ReactDecoratorWithOptions as withKnobsOptions };

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -1,5 +1,4 @@
 import { window } from 'global';
-import deprecate from 'util-deprecate';
 import addons from '@storybook/addons';
 import KnobManager from './KnobManager';
 import { vueHandler } from './vue';
@@ -60,37 +59,19 @@ export function date(name, value = new Date()) {
   return manager.knob(name, { type: 'date', value: proxyValue });
 }
 
-function oldKnobs(storyFn, context) {
+export function withKnobs(storyFn, context) {
   return reactHandler(channel, manager.knobStore)(storyFn)(context);
 }
 
-function oldKnobsWithOptions(options = {}) {
+export function withKnobsOptions(options = {}) {
   return (...args) => {
     channel.emit('addon:knobs:setOptions', options);
 
-    return oldKnobs(...args);
+    return withKnobs(...args);
   };
 }
 
-Object.defineProperty(exports, 'withKnobs', {
-  configurable: true,
-  enumerable: true,
-  get: deprecate(
-    () => oldKnobs,
-    '@storybook/addon-knobs withKnobs decorator is deprecated, use addonKnobs() instead. See https://github.com/storybooks/storybook/tree/master/addons/knobs'
-  ),
-});
-
-Object.defineProperty(exports, 'withKnobsOptions', {
-  configurable: true,
-  enumerable: true,
-  get: deprecate(
-    () => oldKnobsWithOptions,
-    '@storybook/addon-knobs withKnobsOptions decorator is deprecated, use addonKnobs() instead. See https://github.com/storybooks/storybook/tree/master/addons/knobs'
-  ),
-});
-
-export function addonKnobs(options) {
+export function withKnobsV2(options) {
   if (options) channel.emit('addon:knobs:setOptions', options);
 
   switch (window.STORYBOOK_ENV) {

--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -32,10 +32,10 @@ Then write your stories like this:
 
 ```js
 import { storiesOf } from '@storybook/react';
-import { addonNotes } from '@storybook/addon-notes';
+import { withNotes } from '@storybook/addon-notes';
 
 import Component from './Component';
 
 storiesOf('Component', module)
-  .add('with some emoji', addonNotes({ notes: 'A very simple component'})(() => <Component></Component>));
+  .add('with some emoji', withNotes({ notes: 'A very simple component'})(() => <Component></Component>));
 ```

--- a/addons/notes/src/index.js
+++ b/addons/notes/src/index.js
@@ -1,8 +1,8 @@
-import deprecate from 'util-deprecate';
 import addons from '@storybook/addons';
-import { WithNotes as ReactWithNotes } from './react';
 
-export const addonNotes = ({ notes }) => {
+export { WithNotes } from './react';
+
+export const withNotes = ({ notes }) => {
   const channel = addons.getChannel();
 
   return getStory => context => {
@@ -11,12 +11,3 @@ export const addonNotes = ({ notes }) => {
     return getStory(context);
   };
 };
-
-Object.defineProperty(exports, 'WithNotes', {
-  configurable: true,
-  enumerable: true,
-  get: deprecate(
-    () => ReactWithNotes,
-    '@storybook/addon-notes WithNotes Component is deprecated, use withNotes() instead. See https://github.com/storybooks/storybook/tree/master/addons/notes'
-  ),
-});

--- a/addons/notes/src/index.js
+++ b/addons/notes/src/index.js
@@ -1,6 +1,6 @@
 import addons from '@storybook/addons';
 
-import { ReactDecorator } from './react';
+import ReactDecorator from './react';
 
 const wrapper = ({ notes }) => {
   const channel = addons.getChannel();

--- a/addons/notes/src/index.js
+++ b/addons/notes/src/index.js
@@ -1,8 +1,8 @@
 import addons from '@storybook/addons';
 
-export { WithNotes } from './react';
+import { ReactDecorator } from './react';
 
-export const withNotes = ({ notes }) => {
+const wrapper = ({ notes }) => {
   const channel = addons.getChannel();
 
   return getStory => context => {
@@ -11,3 +11,8 @@ export const withNotes = ({ notes }) => {
     return getStory(context);
   };
 };
+
+export { wrapper as with };
+
+/* legacy */
+export { ReactDecorator as WithNotes };

--- a/addons/notes/src/react.js
+++ b/addons/notes/src/react.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import addons from '@storybook/addons';
 
-export class WithNotes extends React.Component {
+export default class WithNotes extends React.Component {
   render() {
     const { children, notes } = this.props;
     const channel = addons.getChannel();

--- a/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
+++ b/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
@@ -447,7 +447,7 @@ exports[`Storyshots Button with knobs 1`] = `
   </p>
   <p>
     My birthday is: 
-    2017-1-20
+    2017-01-19T23:00:00.000Z
   </p>
   <p>
     My wallet contains: $

--- a/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
+++ b/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
@@ -1805,36 +1805,6 @@ exports[`Storyshots WithEvents Logger 1`] = `
 </div>
 `;
 
-exports[`Storyshots addonNotes with a button and some emoji 1`] = `
-<button
-  className="css-1yjiefr"
-  onClick={[Function]}
->
-  😀 😎 👍 💯
-</button>
-`;
-
-exports[`Storyshots addonNotes with old API 1`] = `
-<button
-  className="css-1yjiefr"
-  onClick={[Function]}
->
-  😀 😎 👍 💯
-</button>
-`;
-
-exports[`Storyshots addonNotes with some emoji 1`] = `
-<p>
-  🤔😳😯😮
-</p>
-`;
-
-exports[`Storyshots addonNotes with some text 1`] = `
-<div>
-  Hello guys
-</div>
-`;
-
 exports[`Storyshots component.Button first 1`] = `
 <button>
   first button
@@ -1901,4 +1871,34 @@ exports[`Storyshots component.common.Table second 1`] = `
     </td>
   </tr>
 </table>
+`;
+
+exports[`Storyshots withNotes with a button and some emoji 1`] = `
+<button
+  className="css-1yjiefr"
+  onClick={[Function]}
+>
+  😀 😎 👍 💯
+</button>
+`;
+
+exports[`Storyshots withNotes with old API 1`] = `
+<button
+  className="css-1yjiefr"
+  onClick={[Function]}
+>
+  😀 😎 👍 💯
+</button>
+`;
+
+exports[`Storyshots withNotes with some emoji 1`] = `
+<p>
+  🤔😳😯😮
+</p>
+`;
+
+exports[`Storyshots withNotes with some text 1`] = `
+<div>
+  Hello guys
+</div>
 `;

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -8,7 +8,7 @@ import { linkTo } from '@storybook/addon-links';
 import WithEvents from '@storybook/addon-events';
 import {
   withKnobs,
-  addonKnobs,
+  withKnobsV2,
   text,
   number,
   boolean,
@@ -239,7 +239,7 @@ storiesOf('Addon Knobs deprecated Decorator', module)
 
 storiesOf('Addon Knobs', module).add(
   'with dynamic variables new method',
-  addonKnobs()(() => {
+  withKnobsV2()(() => {
     const name = text('Name', 'Arunoda Susiripala');
     const age = number('Age', 89);
 

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -97,7 +97,7 @@ storiesOf('Button', module)
           {intro}
         </p>
         <p>
-          My birthday is: {new Date(birthday).toLocaleDateString()}
+          My birthday is: {new Date(birthday).toISOString()}
         </p>
         <p>
           My wallet contains: ${dollars.toFixed(2)}

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -3,7 +3,7 @@ import EventEmiter from 'eventemitter3';
 
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { addonNotes, WithNotes } from '@storybook/addon-notes';
+import { withNotes, WithNotes } from '@storybook/addon-notes';
 import { linkTo } from '@storybook/addon-links';
 import WithEvents from '@storybook/addon-events';
 import {
@@ -137,7 +137,7 @@ storiesOf('Button', module)
   .add(
     'addons composition',
     withInfo('see Notes panel for composition info')(
-      addonNotes({ notes: 'Composition: Info(Notes())' })(context =>
+      withNotes({ notes: 'Composition: Info(Notes())' })(context =>
         <div>
           click the <InfoButton /> label in top right for info about "{context.story}"
         </div>
@@ -208,12 +208,12 @@ storiesOf('WithEvents', module)
   )
   .add('Logger', () => <Logger emiter={emiter} />);
 
-storiesOf('addonNotes', module)
-  .add('with some text', addonNotes({ notes: 'Hello guys' })(() => <div>Hello guys</div>))
-  .add('with some emoji', addonNotes({ notes: 'My notes on emojies' })(() => <p>🤔😳😯😮</p>))
+storiesOf('withNotes', module)
+  .add('with some text', withNotes({ notes: 'Hello guys' })(() => <div>Hello guys</div>))
+  .add('with some emoji', withNotes({ notes: 'My notes on emojies' })(() => <p>🤔😳😯😮</p>))
   .add(
     'with a button and some emoji',
-    addonNotes({ notes: 'My notes on a button with emojies' })(() =>
+    withNotes({ notes: 'My notes on a button with emojies' })(() =>
       <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>
     )
   )

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -3,12 +3,12 @@ import EventEmiter from 'eventemitter3';
 
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withNotes, WithNotes } from '@storybook/addon-notes';
+import { with as withNotes, WithNotes } from '@storybook/addon-notes';
 import { linkTo } from '@storybook/addon-links';
 import WithEvents from '@storybook/addon-events';
 import {
-  withKnobs,
-  withKnobsV2,
+  withKnobs as WithKnobs,
+  with as withKnobs,
   text,
   number,
   boolean,
@@ -56,7 +56,7 @@ const InfoButton = () =>
   </span>;
 
 storiesOf('Button', module)
-  .addDecorator(withKnobs)
+  .addDecorator(WithKnobs)
   .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)
   .add('with some emoji', () => <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>)
   .add('with notes', () =>
@@ -224,7 +224,7 @@ storiesOf('withNotes', module)
   );
 
 storiesOf('Addon Knobs deprecated Decorator', module)
-  .addDecorator(withKnobs) // test deprecated
+  .addDecorator(WithKnobs) // test deprecated
   .add('with dynamic variables deprecated', () => {
     const name = text('Name', 'Story Teller');
     const age = number('Age', 120);
@@ -239,7 +239,7 @@ storiesOf('Addon Knobs deprecated Decorator', module)
 
 storiesOf('Addon Knobs', module).add(
   'with dynamic variables new method',
-  withKnobsV2()(() => {
+  withKnobs()(() => {
     const name = text('Name', 'Arunoda Susiripala');
     const age = number('Age', 89);
 
@@ -253,7 +253,7 @@ storiesOf('Addon Knobs', module).add(
 );
 
 storiesOf('component.base.Link', module)
-  .addDecorator(withKnobs)
+  .addDecorator(WithKnobs)
   .add('first', () =>
     <a>
       {text('firstLink', 'first link')}
@@ -296,7 +296,7 @@ storiesOf('component.Button', module)
 // Atomic
 
 storiesOf('Cells¯\\_(ツ)_/¯Molecules.Atoms/simple', module)
-  .addDecorator(withKnobs)
+  .addDecorator(WithKnobs)
   .add('with text', () =>
     <Button>
       {text('buttonText', 'Hello Button')}

--- a/examples/vue-kitchen-sink/src/stories/index.js
+++ b/examples/vue-kitchen-sink/src/stories/index.js
@@ -197,7 +197,7 @@ storiesOf('Addon Knobs', module)
         template: `
           <div style="border:2px dotted ${colour}; padding: 8px 22px; border-radius: 8px">
             <h1>My name is ${name},</h1>
-            <h3>today is ${new Date(today).toLocaleDateString()}</h3>
+            <h3>today is ${new Date(today).toISOString()}</h3>
             <p>${stockMessage}</p>
             <p>Also, I have:</p>
             <ul>

--- a/examples/vue-kitchen-sink/src/stories/index.js
+++ b/examples/vue-kitchen-sink/src/stories/index.js
@@ -4,10 +4,10 @@ import { storiesOf } from '@storybook/vue';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 
-import { addonNotes } from '@storybook/addon-notes';
+import { withNotes } from '@storybook/addon-notes';
 
 import {
-  addonKnobs,
+  withKnobsV2,
   text,
   number,
   boolean,
@@ -137,14 +137,14 @@ storiesOf('Addon Actions', module)
 storiesOf('Addon Notes', module)
   .add(
     'Simple note',
-    addonNotes({ notes: 'My notes on some bold text' })(() => ({
+    withNotes({ notes: 'My notes on some bold text' })(() => ({
       template:
         '<p><strong>Etiam vulputate elit eu venenatis eleifend. Duis nec lectus augue. Morbi egestas diam sed vulputate mollis. Fusce egestas pretium vehicula. Integer sed neque diam. Donec consectetur velit vitae enim varius, ut placerat arcu imperdiet. Praesent sed faucibus arcu. Nullam sit amet nibh a enim eleifend rhoncus. Donec pretium elementum leo at fermentum. Nulla sollicitudin, mauris quis semper tempus, sem metus tristique diam, efficitur pulvinar mi urna id urna.</strong></p>',
     }))
   )
   .add(
     'Note with HTML',
-    addonNotes({
+    withNotes({
       notes: `
       <h2>My notes on emojies</h2>
 
@@ -160,7 +160,7 @@ storiesOf('Addon Notes', module)
 storiesOf('Addon Knobs', module)
   .add(
     'Simple',
-    addonKnobs()(() => {
+    withKnobsV2()(() => {
       const name = text('Name', 'John Doe');
       const age = number('Age', 44);
       const content = `I am ${name} and I'm ${age} years old.`;
@@ -172,7 +172,7 @@ storiesOf('Addon Knobs', module)
   )
   .add(
     'All knobs',
-    addonKnobs()(() => {
+    withKnobsV2()(() => {
       const name = text('Name', 'Jane');
       const stock = number('Stock', 20, { range: true, min: 0, max: 30, step: 5 });
       const fruits = {

--- a/examples/vue-kitchen-sink/src/stories/index.js
+++ b/examples/vue-kitchen-sink/src/stories/index.js
@@ -4,10 +4,10 @@ import { storiesOf } from '@storybook/vue';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 
-import { withNotes } from '@storybook/addon-notes';
+import { with as withNotes } from '@storybook/addon-notes';
 
 import {
-  withKnobsV2,
+  with as withKnobs,
   text,
   number,
   boolean,
@@ -160,7 +160,7 @@ storiesOf('Addon Notes', module)
 storiesOf('Addon Knobs', module)
   .add(
     'Simple',
-    withKnobsV2()(() => {
+    withKnobs()(() => {
       const name = text('Name', 'John Doe');
       const age = number('Age', 44);
       const content = `I am ${name} and I'm ${age} years old.`;
@@ -172,7 +172,7 @@ storiesOf('Addon Knobs', module)
   )
   .add(
     'All knobs',
-    withKnobsV2()(() => {
+    withKnobs()(() => {
       const name = text('Name', 'Jane');
       const stock = number('Stock', 20, { range: true, min: 0, max: 30, step: 5 });
       const fruits = {

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -33,7 +33,6 @@
     "react-komposer": "^2.0.0",
     "react-modal": "^1.7.7",
     "react-split-pane": "^0.1.63",
-    "react-split-pane": "^0.1.65",
     "redux": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue: #1383 

One of the blockers for 3.2 release is the issue of `addonKnobs` and `addonNotes`.
We want to change the fundamental nature of how the addons work, but in a non-disruptive gradual way. We need to, to support more addons for more libraries/frameworks.

Previously `addonX` was introduced, but after some discussion we agreed this was not the right way forward. We'd like to continue with the phrasing of `withX`. However cannot simply detect which api the user is expecting.

## What I did
I introduced a `with` export for 2 addons.
If you like this idea, we can work towards making all addons have this.

## How to test
run install, bootstrap, test
run vue example and view knobs and notes
run react example and view knobs and notes