### PR TITLE
Add warning when module is missing in storiesOf

### DIFF
--- a/app/react/src/client/preview/client_api.js
+++ b/app/react/src/client/preview/client_api.js
@@ -34,6 +34,13 @@ export default class ClientApi {
       throw new Error('Invalid or missing kind provided for stories, should be a string');
     }
 
+    if (!m) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Missing 'module' parameter for story with a kind of '${kind}'. It will break your HMR`
+      );
+    }
+
     if (m && m.hot) {
       m.hot.dispose(() => {
         this._storyStore.removeStoryKind(kind);

--- a/app/vue/src/client/preview/client_api.js
+++ b/app/vue/src/client/preview/client_api.js
@@ -30,6 +30,10 @@ export default class ClientApi {
       throw new Error('Invalid or missing kind provided for stories, should be a string');
     }
 
+    if(!m) {
+      console.warn(`Missing 'module' parameter for story with a kind of '${kind}'. It will break your HMR`);
+    }
+
     if (m && m.hot) {
       m.hot.dispose(() => {
         this._storyStore.removeStoryKind(kind);

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -33,7 +33,6 @@
     "react-komposer": "^2.0.0",
     "react-modal": "^1.7.7",
     "react-split-pane": "^0.1.63",
-    "react-split-pane": "^0.1.65",
     "redux": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue: Based on conversation in #1506 

## What I did
I've added a warning when module parameter is not provided

![image](https://user-images.githubusercontent.com/7867954/28608757-7acaa6ba-71ea-11e7-999b-d3a4659c3ffb.png)

## How to test
1. Run `cra-kitchen-sync`
2. Find some story and remove module parameter
3. Should be a warning in devtools console