### PR TITLE
Revert knobs API to previous API.

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -37,7 +37,7 @@ Now, write your stories with knobs.
 
 ```js
 import { storiesOf } from '@storybook/react';
-import { addonKnobs, text, boolean, number } from '@storybook/addon-knobs';
+import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
 
 const stories = storiesOf('Storybook Knobs', module);
 
@@ -52,15 +52,14 @@ stories.add('with a button', () => (
   </button>
 ))
 
-const options = {};
 // Knobs as dynamic variables.
-stories.add('as dynamic variables', addonKnobs(options)(() => {
+stories.add('as dynamic variables', () => {
   const name = text('Name', 'Arunoda Susiripala');
   const age = number('Age', 89);
 
   const content = `I am ${name} and I'm ${age} years old.`;
   return (<div>{content}</div>);
-}));
+});
 ```
 
 You can see your Knobs in a Storybook panel as shown below.

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -1,5 +1,4 @@
 import { window } from 'global';
-import deprecate from 'util-deprecate';
 import addons from '@storybook/addons';
 import KnobManager from './KnobManager';
 import { vueHandler } from './vue';
@@ -60,37 +59,8 @@ export function date(name, value = new Date()) {
   return manager.knob(name, { type: 'date', value: proxyValue });
 }
 
-function oldKnobs(storyFn, context) {
-  return reactHandler(channel, manager.knobStore)(storyFn)(context);
-}
-
-function oldKnobsWithOptions(options = {}) {
-  return (...args) => {
-    channel.emit('addon:knobs:setOptions', options);
-
-    return oldKnobs(...args);
-  };
-}
-
-Object.defineProperty(exports, 'withKnobs', {
-  configurable: true,
-  enumerable: true,
-  get: deprecate(
-    () => oldKnobs,
-    '@storybook/addon-knobs withKnobs decorator is deprecated, use addonKnobs() instead. See https://github.com/storybooks/storybook/tree/master/addons/knobs'
-  ),
-});
-
-Object.defineProperty(exports, 'withKnobsOptions', {
-  configurable: true,
-  enumerable: true,
-  get: deprecate(
-    () => oldKnobsWithOptions,
-    '@storybook/addon-knobs withKnobsOptions decorator is deprecated, use addonKnobs() instead. See https://github.com/storybooks/storybook/tree/master/addons/knobs'
-  ),
-});
-
-export function addonKnobs(options) {
+// "Higher order component" / wrapper style API
+export function wrapperKnobs(options) {
   if (options) channel.emit('addon:knobs:setOptions', options);
 
   switch (window.STORYBOOK_ENV) {
@@ -104,4 +74,12 @@ export function addonKnobs(options) {
       return reactHandler(channel, manager.knobStore);
     }
   }
+}
+
+export function withKnobs(storyFn, context) {
+  return wrapperKnobs()(storyFn)(context);
+}
+
+export function withKnobsOptions(options = {}) {
+  return (storyFn, context) => wrapperKnobs(options)(storyFn)(context);
 }

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -60,7 +60,9 @@ export function date(name, value = new Date()) {
 }
 
 // "Higher order component" / wrapper style API
-export function wrapperKnobs(options) {
+// In 3.3, this will become `withKnobs`, once our decorator API supports it.
+//   See https://github.com/storybooks/storybook/pull/1527
+function wrapperKnobs(options) {
   if (options) channel.emit('addon:knobs:setOptions', options);
 
   switch (window.STORYBOOK_ENV) {

--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -32,10 +32,10 @@ Then write your stories like this:
 
 ```js
 import { storiesOf } from '@storybook/react';
-import { addonNotes } from '@storybook/addon-notes';
+import { withNotes } from '@storybook/addon-notes';
 
 import Component from './Component';
 
 storiesOf('Component', module)
-  .add('with some emoji', addonNotes({ notes: 'A very simple component'})(() => <Component></Component>));
+  .add('with some emoji', withNotes({ notes: 'A very simple component'})(() => <Component></Component>));
 ```

--- a/addons/notes/src/index.js
+++ b/addons/notes/src/index.js
@@ -2,7 +2,7 @@ import deprecate from 'util-deprecate';
 import addons from '@storybook/addons';
 import { WithNotes as ReactWithNotes } from './react';
 
-export const addonNotes = ({ notes }) => {
+export const withNotes = ({ notes }) => {
   const channel = addons.getChannel();
 
   return getStory => context => {

--- a/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
+++ b/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Addon Knobs deprecated Decorator with dynamic variables deprecated 1`] = `
-<div>
-  I am Story Teller and I'm 120 years old.
-</div>
-`;
-
-exports[`Storyshots Addon Knobs with dynamic variables new method 1`] = `
-<div>
-  I am Arunoda Susiripala and I'm 89 years old.
-</div>
-`;
-
 exports[`Storyshots App full app 1`] = `
 <div
   className="App"
@@ -1805,36 +1793,6 @@ exports[`Storyshots WithEvents Logger 1`] = `
 </div>
 `;
 
-exports[`Storyshots addonNotes with a button and some emoji 1`] = `
-<button
-  className="css-1yjiefr"
-  onClick={[Function]}
->
-  😀 😎 👍 💯
-</button>
-`;
-
-exports[`Storyshots addonNotes with old API 1`] = `
-<button
-  className="css-1yjiefr"
-  onClick={[Function]}
->
-  😀 😎 👍 💯
-</button>
-`;
-
-exports[`Storyshots addonNotes with some emoji 1`] = `
-<p>
-  🤔😳😯😮
-</p>
-`;
-
-exports[`Storyshots addonNotes with some text 1`] = `
-<div>
-  Hello guys
-</div>
-`;
-
 exports[`Storyshots component.Button first 1`] = `
 <button>
   first button
@@ -1901,4 +1859,34 @@ exports[`Storyshots component.common.Table second 1`] = `
     </td>
   </tr>
 </table>
+`;
+
+exports[`Storyshots withNotes with a button and some emoji 1`] = `
+<button
+  className="css-1yjiefr"
+  onClick={[Function]}
+>
+  😀 😎 👍 💯
+</button>
+`;
+
+exports[`Storyshots withNotes with old API 1`] = `
+<button
+  className="css-1yjiefr"
+  onClick={[Function]}
+>
+  😀 😎 👍 💯
+</button>
+`;
+
+exports[`Storyshots withNotes with some emoji 1`] = `
+<p>
+  🤔😳😯😮
+</p>
+`;
+
+exports[`Storyshots withNotes with some text 1`] = `
+<div>
+  Hello guys
+</div>
 `;

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -8,7 +8,6 @@ import { linkTo } from '@storybook/addon-links';
 import WithEvents from '@storybook/addon-events';
 import {
   withKnobs,
-  addonKnobs,
   text,
   number,
   boolean,
@@ -222,35 +221,6 @@ storiesOf('addonNotes', module)
       <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>
     </WithNotes>
   );
-
-storiesOf('Addon Knobs deprecated Decorator', module)
-  .addDecorator(withKnobs) // test deprecated
-  .add('with dynamic variables deprecated', () => {
-    const name = text('Name', 'Story Teller');
-    const age = number('Age', 120);
-
-    const content = `I am ${name} and I'm ${age} years old.`;
-    return (
-      <div>
-        {content}
-      </div>
-    );
-  });
-
-storiesOf('Addon Knobs', module).add(
-  'with dynamic variables new method',
-  addonKnobs()(() => {
-    const name = text('Name', 'Arunoda Susiripala');
-    const age = number('Age', 89);
-
-    const content = `I am ${name} and I'm ${age} years old.`;
-    return (
-      <div>
-        {content}
-      </div>
-    );
-  })
-);
 
 storiesOf('component.base.Link', module)
   .addDecorator(withKnobs)

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -3,7 +3,7 @@ import EventEmiter from 'eventemitter3';
 
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { addonNotes, WithNotes } from '@storybook/addon-notes';
+import { withNotes, WithNotes } from '@storybook/addon-notes';
 import { linkTo } from '@storybook/addon-links';
 import WithEvents from '@storybook/addon-events';
 import {
@@ -136,7 +136,7 @@ storiesOf('Button', module)
   .add(
     'addons composition',
     withInfo('see Notes panel for composition info')(
-      addonNotes({ notes: 'Composition: Info(Notes())' })(context =>
+      withNotes({ notes: 'Composition: Info(Notes())' })(context =>
         <div>
           click the <InfoButton /> label in top right for info about "{context.story}"
         </div>
@@ -207,12 +207,12 @@ storiesOf('WithEvents', module)
   )
   .add('Logger', () => <Logger emiter={emiter} />);
 
-storiesOf('addonNotes', module)
-  .add('with some text', addonNotes({ notes: 'Hello guys' })(() => <div>Hello guys</div>))
-  .add('with some emoji', addonNotes({ notes: 'My notes on emojies' })(() => <p>🤔😳😯😮</p>))
+storiesOf('withNotes', module)
+  .add('with some text', withNotes({ notes: 'Hello guys' })(() => <div>Hello guys</div>))
+  .add('with some emoji', withNotes({ notes: 'My notes on emojies' })(() => <p>🤔😳😯😮</p>))
   .add(
     'with a button and some emoji',
-    addonNotes({ notes: 'My notes on a button with emojies' })(() =>
+    withNotes({ notes: 'My notes on a button with emojies' })(() =>
       <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>
     )
   )

--- a/examples/vue-kitchen-sink/src/stories/index.js
+++ b/examples/vue-kitchen-sink/src/stories/index.js
@@ -7,7 +7,7 @@ import { linkTo } from '@storybook/addon-links';
 import { addonNotes } from '@storybook/addon-notes';
 
 import {
-  addonKnobs,
+  withKnobs,
   text,
   number,
   boolean,
@@ -51,7 +51,7 @@ storiesOf('Method for rendering Vue', module)
     template: `
       <div>
         <h1>A template</h1>
-        <p>rendered in vue in storybook</p> 
+        <p>rendered in vue in storybook</p>
       </div>`,
   }))
   .add('template + component', () => ({
@@ -158,43 +158,44 @@ storiesOf('Addon Notes', module)
   );
 
 storiesOf('Addon Knobs', module)
-  .add(
-    'Simple',
-    addonKnobs()(() => {
-      const name = text('Name', 'John Doe');
-      const age = number('Age', 44);
-      const content = `I am ${name} and I'm ${age} years old.`;
+  .addDecorator(withKnobs)
+  .add('Simple', () => {
+    const name = text('Name', 'John Doe');
+    const age = number('Age', 44);
+    const content = `I am ${name} and I'm ${age} years old.`;
 
-      return {
-        template: `<div>${content}</div>`,
-      };
-    })
-  )
-  .add(
-    'All knobs',
-    addonKnobs()(() => {
-      const name = text('Name', 'Jane');
-      const stock = number('Stock', 20, { range: true, min: 0, max: 30, step: 5 });
-      const fruits = {
-        apples: 'Apple',
-        bananas: 'Banana',
-        cherries: 'Cherry',
-      };
-      const fruit = select('Fruit', fruits, 'apple');
-      const price = number('Price', 2.25);
+    return {
+      template: `<div>${content}</div>`,
+    };
+  })
+  .add('All knobs', () => {
+    const name = text('Name', 'Jane');
+    const stock = number('Stock', 20, {
+      range: true,
+      min: 0,
+      max: 30,
+      step: 5,
+    });
+    const fruits = {
+      apples: 'Apple',
+      bananas: 'Banana',
+      cherries: 'Cherry',
+    };
+    const fruit = select('Fruit', fruits, 'apple');
+    const price = number('Price', 2.25);
 
-      const colour = color('Border', 'deeppink');
-      const today = date('Today', new Date('Jan 20 2017'));
-      const items = array('Items', ['Laptop', 'Book', 'Whiskey']);
-      const nice = boolean('Nice', true);
+    const colour = color('Border', 'deeppink');
+    const today = date('Today', new Date('Jan 20 2017'));
+    const items = array('Items', ['Laptop', 'Book', 'Whiskey']);
+    const nice = boolean('Nice', true);
 
-      const stockMessage = stock
-        ? `I have a stock of ${stock} ${fruit}, costing &dollar;${price} each.`
-        : `I'm out of ${fruit}${nice ? ', Sorry!' : '.'}`;
-      const salutation = nice ? 'Nice to meet you!' : 'Leave me alone!';
+    const stockMessage = stock
+      ? `I have a stock of ${stock} ${fruit}, costing &dollar;${price} each.`
+      : `I'm out of ${fruit}${nice ? ', Sorry!' : '.'}`;
+    const salutation = nice ? 'Nice to meet you!' : 'Leave me alone!';
 
-      return {
-        template: `
+    return {
+      template: `
           <div style="border:2px dotted ${colour}; padding: 8px 22px; border-radius: 8px">
             <h1>My name is ${name},</h1>
             <h3>today is ${new Date(today).toLocaleDateString()}</h3>
@@ -206,6 +207,5 @@ storiesOf('Addon Knobs', module)
             <p>${salutation}</p>
           </div>
         `,
-      };
-    })
-  );
+    };
+  });

--- a/examples/vue-kitchen-sink/src/stories/index.js
+++ b/examples/vue-kitchen-sink/src/stories/index.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/vue';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 
-import { addonNotes } from '@storybook/addon-notes';
+import { withNotes } from '@storybook/addon-notes';
 
 import {
   withKnobs,
@@ -137,14 +137,14 @@ storiesOf('Addon Actions', module)
 storiesOf('Addon Notes', module)
   .add(
     'Simple note',
-    addonNotes({ notes: 'My notes on some bold text' })(() => ({
+    withNotes({ notes: 'My notes on some bold text' })(() => ({
       template:
         '<p><strong>Etiam vulputate elit eu venenatis eleifend. Duis nec lectus augue. Morbi egestas diam sed vulputate mollis. Fusce egestas pretium vehicula. Integer sed neque diam. Donec consectetur velit vitae enim varius, ut placerat arcu imperdiet. Praesent sed faucibus arcu. Nullam sit amet nibh a enim eleifend rhoncus. Donec pretium elementum leo at fermentum. Nulla sollicitudin, mauris quis semper tempus, sem metus tristique diam, efficitur pulvinar mi urna id urna.</strong></p>',
     }))
   )
   .add(
     'Note with HTML',
-    addonNotes({
+    withNotes({
       notes: `
       <h2>My notes on emojies</h2>
 


### PR DESCRIPTION
`withKnobs` the decorator is still the base API. (This now works for
Vue).

The new API is called `wrapperKnobs` and will eventually be merged into
`withKnobs` (c.f. medium term addons plan, to be posted)

Counter proposal to https://github.com/storybooks/storybook/pull/1524

The basic idea is to leave the knobs API unchanged for now. `withKnobs` is still a decorator.

We now export `wrapperKnobs` (I'm open to changing this name, I'm not sure `addonKnobs` really says what it is though), which is a higher-order-component (HOC) wrapper API.

Medium term plan is as follows:

1. Allow "wrapper" HOC functions to be used as decorators (this require core changes, maybe in 3.3) (see https://github.com/storybooks/storybook/issues/1528)

2. Transition `withKnobs` to be a wrapper (ie `withKnobs = wrapperKnobs`).