### PR TITLE
Fix bad merge that removed react-treebeard dep from lib/ui

### DIFF
--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -32,7 +32,8 @@
     "react-inspector": "^2.1.1",
     "react-komposer": "^2.0.0",
     "react-modal": "^1.7.7",
-    "react-split-pane": "^0.1.63",
+    "react-split-pane": "^0.1.65",
+    "react-treebeard": "^2.0.3",
     "redux": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue: N/A

## What I did

Fix a bad merge, but submitting it as a PR because there are still some version issues and also I'm not comfortable with the current state on my machine. Somehow the treebeard stuff is still working on my machine in `cra-kitchen-sink` even when I do a clean install and I don't understand why.

## What I need

@ndelangen can you review and also fix these version issues?

```
lerna WARN EHOIST_ROOT_VERSION The repository root depends on babel-core@^6.25.0, which differs from the more common babel-core@^6.24.1.
lerna WARN EHOIST_PKG_VERSION "@storybook/vue" package depends on babel-core@^6.24.1, which differs from the hoisted babel-core@^6.25.0.
lerna WARN EHOIST_PKG_VERSION "vue-example" package depends on babel-core@^6.24.1, which differs from the hoisted babel-core@^6.25.0.
lerna WARN EHOIST_ROOT_VERSION The repository root depends on babel-preset-env@^1.6.0, which differs from the more common babel-preset-env@^1.5.2.
lerna WARN EHOIST_PKG_VERSION "@storybook/vue" package depends on babel-preset-env@^1.5.2, which differs from the hoisted babel-preset-env@^1.6.0.
lerna WARN EHOIST_PKG_VERSION "vue-example" package depends on babel-preset-env@^1.5.2, which differs from the hoisted babel-preset-env@^1.6.0.
lerna WARN EHOIST_ROOT_VERSION The repository root depends on enzyme@^2.9.1, which differs from the more common enzyme@^2.8.2.
lerna WARN EHOIST_PKG_VERSION "@storybook/ui" package depends on enzyme@^2.8.2, which differs from the hoisted enzyme@^2.9.1.
lerna WARN EHOIST_PKG_VERSION "@storybook/vue" package depends on react@^15.5.4, which differs from the hoisted react@^15.6.1.
lerna WARN EHOIST_PKG_VERSION "@storybook/vue" package depends on react-dom@^15.5.4, which differs from the hoisted react-dom@^15.6.1.
lerna WARN EHOIST_PKG_VERSION "@storybook/vue" package depends on shelljs@^0.7.7, which differs from the hoisted shelljs@^0.7.8.
lerna WARN EHOIST_PKG_VERSION "@storybook/react" package depends on babel-plugin-react-docgen@^1.6.0, which differs from the hoisted babel-plugin-react-docgen@^1.5.0.
```

I propose we fix up the versions, do one last alpha release, and test it out before we pull the trigger on the 3.2 release.
