### PR TITLE
Add RegExp option for hierarchySeparator

### DIFF
--- a/addons/options/src/preview/index.js
+++ b/addons/options/src/preview/index.js
@@ -8,10 +8,9 @@ export function init() {
 }
 
 function regExpStringify(exp) {
-  if (!exp) return null;
-  if (Object.prototype.toString.call(exp) === '[object String]') return exp;
-  if (Object.prototype.toString.call(exp) !== '[object RegExp]') return null;
-  return exp.source;
+  if (typeof exp === 'string') return exp;
+  if (Object.prototype.toString.call(exp) === '[object RegExp]') return exp.source;
+  return null;
 }
 
 // setOptions function will send Storybook UI options when the channel is

--- a/addons/options/src/preview/index.js
+++ b/addons/options/src/preview/index.js
@@ -7,14 +7,26 @@ export function init() {
   // NOTE nothing to do here
 }
 
+function regExpStringify(exp) {
+  if (!exp) return null;
+  if (Object.prototype.toString.call(exp) === '[object String]') return exp;
+  if (Object.prototype.toString.call(exp) !== '[object RegExp]') return null;
+  return exp.source;
+}
+
 // setOptions function will send Storybook UI options when the channel is
 // ready. If called before, options will be cached until it can be sent.
-export function setOptions(options) {
+export function setOptions(newOptions) {
   const channel = addons.getChannel();
   if (!channel) {
     throw new Error(
       'Failed to find addon channel. This may be due to https://github.com/storybooks/storybook/issues/1192.'
     );
   }
+  const options = {
+    ...newOptions,
+    hierarchySeparator: regExpStringify(newOptions.hierarchySeparator),
+  };
+
   channel.emit(EVENT_ID, { options });
 }

--- a/examples/cra-kitchen-sink/.storybook/config.js
+++ b/examples/cra-kitchen-sink/.storybook/config.js
@@ -11,7 +11,7 @@ setOptions({
   showSearchBox: false,
   downPanelInRight: true,
   sortStoriesByKind: false,
-  hierarchySeparator: '\\/|\\.|¯\\\\_\\(ツ\\)_\\/¯'
+  hierarchySeparator: /\/|\./,
 });
 
 setAddon(infoAddon);

--- a/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
+++ b/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
@@ -1605,6 +1605,22 @@ exports[`Storyshots Cells/Molecules with text 1`] = `
 </button>
 `;
 
+exports[`Storyshots Cells/Molecules.Atoms/simple with some emoji 1`] = `
+<button
+  className="css-1yjiefr"
+>
+  😀 😎 👍 💯
+</button>
+`;
+
+exports[`Storyshots Cells/Molecules.Atoms/simple with text 1`] = `
+<button
+  className="css-1yjiefr"
+>
+  Hello Button
+</button>
+`;
+
 exports[`Storyshots Cells/Molecules/Atoms.more with some emoji2 1`] = `
 <button
   className="css-1yjiefr"
@@ -1614,22 +1630,6 @@ exports[`Storyshots Cells/Molecules/Atoms.more with some emoji2 1`] = `
 `;
 
 exports[`Storyshots Cells/Molecules/Atoms.more with text2 1`] = `
-<button
-  className="css-1yjiefr"
->
-  Hello Button
-</button>
-`;
-
-exports[`Storyshots Cells¯\\_(ツ)_/¯Molecules.Atoms/simple with some emoji 1`] = `
-<button
-  className="css-1yjiefr"
->
-  😀 😎 👍 💯
-</button>
-`;
-
-exports[`Storyshots Cells¯\\_(ツ)_/¯Molecules.Atoms/simple with text 1`] = `
 <button
   className="css-1yjiefr"
 >

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -266,7 +266,7 @@ storiesOf('component.Button', module)
 
 // Atomic
 
-storiesOf('Cells¯\\_(ツ)_/¯Molecules.Atoms/simple', module)
+storiesOf('Cells/Molecules.Atoms/simple', module)
   .addDecorator(withKnobs)
   .add('with text', () =>
     <Button>


### PR DESCRIPTION
Issue: #151

`hierarchySeparator` option allows only a string with RegExp

## What I did

`hierarchySeparator` could take a `Regular Expression` directly (as well as strings)

## How to test

run `cra-kitchen-sink`
