### PR TITLE
Update 'Substories/Hierarchy' section in docs

### DIFF
--- a/docs/pages/basics/writing-stories/index.md
+++ b/docs/pages/basics/writing-stories/index.md
@@ -105,34 +105,29 @@ configure(function () {
 }, module);
 ```
 
-## Managing stories
+## Nesting stories
 
-Storybook has a very simple API to write stories.
-With that, you can’t display nested stories.
-
-But you might ask, how do I manage stories If I have many of them?
-We're currently very much interested in changing our api to support this!
-
-Until that's implemented, here's how different developers address this issue, right now:
-
-### Prefix with dots
-
-For example, you can prefix story names with a dot (`.`):
+You can organize your stories in a nesting structures using "/" as a separator:
 
 ```js
-import { storiesOf } from '@storybook/react';
+// file: src/stories/index.js
 
-storiesOf('core.Button', module);
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Button from '../components/Button';
+
+storiesOf('My App/Buttons/Simple', module)
+  .add('with text', () => (
+    <Button onClick={action('clicked')}>Hello Button</Button>
+  ));
+
+storiesOf('My App/Buttons/Emoji', module)
+  .add('with some emoji', () => (
+    <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>
+  ));
 ```
 
-Then you can filter stories to display only the stories you want to see.
-
-### [Chapters](https://github.com/yangshun/react-storybook-addon-chapters)
-
-With this addon, you can showcase multiple components (or varying component states) within 1 story.
-Break your stories down into smaller categories (chapters) and subcategories (sections) for more organizational goodness.
-
-### Run multiple storybooks
+## Run multiple storybooks
 
 You can run multiple storybooks for different kinds of stories (or components). To do that, you can create different NPM scripts to start different stories. See:
 


### PR DESCRIPTION
Issue: https://storybook.js.org/basics/writing-stories/#chapters

## What I did

- remove https://github.com/yangshun/react-storybook-addon-chapters from docs

- provide information about using Substories/Hierarchy feature of Storybook 3.2

## How to test

n/a