### PR TITLE
Fix typo with Vue README referring to react

### DIFF
--- a/app/vue/README.md
+++ b/app/vue/README.md
@@ -10,10 +10,10 @@
 
 * * *
 
-Storybook for Vue is a UI development environment for your React components.
+Storybook for Vue is a UI development environment for your Vue components.
 With it, you can visualize different states of your UI components and develop them interactively.
 
-![Storybook Screenshot](https://github.com/storybooks/storybook/blob/master/app/react/docs/demo.gif)
+![Storybook Screenshot](https://github.com/storybooks/storybook/blob/master/app/vue/docs/demo.gif)
 
 Storybook runs outside of your app.
 So you can develop UI components in isolation without worrying about app specific dependencies and requirements.


### PR DESCRIPTION
Note: It wouldn't hurt for someone to make a new gif w/ vue instead of react. I'm at work so I don't have the time to do so currently. 

## What I did

Correct a typo referring back to React. Also updated a link to the demo gif to point to the vue docs directory as opposed to the react docs directory. 

## How to test

None needed, just a docs update
