### PR TITLE
Check if hierarchySeparator presents in the options object

### DIFF
--- a/addons/options/src/preview/index.js
+++ b/addons/options/src/preview/index.js
@@ -22,10 +22,17 @@ export function setOptions(newOptions) {
       'Failed to find addon channel. This may be due to https://github.com/storybooks/storybook/issues/1192.'
     );
   }
-  const options = {
-    ...newOptions,
-    hierarchySeparator: regExpStringify(newOptions.hierarchySeparator),
-  };
+
+  let options = newOptions;
+
+  // since 'undefined' and 'null' are the valid values we don't want to
+  // override the hierarchySeparator if the prop is missing
+  if (Object.prototype.hasOwnProperty.call(newOptions, 'hierarchySeparator')) {
+    options = {
+      ...newOptions,
+      hierarchySeparator: regExpStringify(newOptions.hierarchySeparator),
+    };
+  }
 
   channel.emit(EVENT_ID, { options });
 }


### PR DESCRIPTION
Issue: When using options plugin and not providing the `hierarchySeparator` it's overridden by a `NULL` . In this case hierarchy will not created. 

## What I did
I've added a check for the `hierarchySeparator` prop is owned by an object.

## How to test
TBD