### PR TITLE
Fixed build-storybook for vue

### DIFF
--- a/app/vue/src/server/config/webpack.config.prod.js
+++ b/app/vue/src/server/config/webpack.config.prod.js
@@ -45,6 +45,11 @@ export default function() {
           include: includePaths,
           exclude: excludePaths,
         },
+        {
+          test: /\.vue$/,
+          loader: require.resolve('vue-loader'),
+          options: {},
+        },
       ],
     },
     resolve: {


### PR DESCRIPTION
Issue: N/A `build-storybook` was failing on vue projects (thanks @timhaines)

## What I did

Add the vue loader to the webpack config used by build-storybook

## How to test

```
yarn bootstrap
cd examples/vue-kitchen-sink
yarn build-storybook
```