### PR TITLE
Fixed border-radius typo in MyButton.vue

### DIFF
--- a/lib/cli/generators/SFC_VUE/template/src/stories/MyButton.vue
+++ b/lib/cli/generators/SFC_VUE/template/src/stories/MyButton.vue
@@ -18,7 +18,7 @@
 <style>
   .button-styles {
     border: 1px solid #eee;
-    border-radiuas: 3px;
+    border-radius: 3px;
     background-color: #FFFFFF;
     cursor: pointer;
     font-size: 15pt;


### PR DESCRIPTION
Issue:
There was a small typo in MyButton.vue, `border-radius` was misspelled.

## What I did
Renamed to border-radius.


## How to test
Create a new vue project (e.g. using vue-cli). Run `getstorybook`and run `yarn run storybook`.