### PR TITLE
Show outline when navigating with tab

### DIFF
--- a/app/react-native/src/server/index.html.js
+++ b/app/react-native/src/server/index.html.js
@@ -36,11 +36,6 @@ export default function(publicPath, options) {
           .btn:hover{
             background-color: #eee
           }
-
-          /* Remove blue outline defined by the user argent*/
-          :focus {
-            outline: none !important;
-          }
         </style>
       </head>
       <body style="margin: 0;">

--- a/app/react/src/server/index.html.js
+++ b/app/react/src/server/index.html.js
@@ -67,11 +67,6 @@ export default function({ assets, publicPath, headHtml }) {
           .btn:hover{
             background-color: #eee
           }
-
-          /* Remove blue outline defined by the user argent*/
-          :focus {
-            outline: none !important;
-          }
         </style>
         ${headHtml}
       </head>

--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_decorators.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_decorators.js
@@ -53,6 +53,11 @@ function createHeaderDecoratorScope(parent) {
       onKeyDown(event, node);
     }
 
+    // Prevent focusing on mousedown
+    onMouseDown(event) {
+      event.preventDefault();
+    }
+
     render() {
       const { style, node } = this.props;
 
@@ -65,7 +70,13 @@ function createHeaderDecoratorScope(parent) {
       }
 
       return (
-        <div style={style.base} role="menuitem" tabIndex="0" onKeyDown={this.onKeyDown}>
+        <div
+          style={style.base}
+          role="menuitem"
+          tabIndex="0"
+          onKeyDown={this.onKeyDown}
+          onMouseDown={this.onMouseDown}
+        >
           <a style={newStyleTitle}>
             {node.name}
           </a>


### PR DESCRIPTION
But prevent focusing when clicking on menu items

#1497 has removed focus outline from all the DOM nodes. I don't think the intention was to break tab navigation, it was rather to stop seeing the annoying outlines when working with mouse. This PR fixes that by preventing default effect of mousedown events on menu items.
