### PR TITLE
Always collapse an expanded kind without changing selected story

### DIFF
--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/index.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/index.js
@@ -68,7 +68,7 @@ class Stories extends React.Component {
   onToggle(node, toggled) {
     if (node.story) {
       this.fireOnKindAndStory(node.kind, node.story);
-    } else if (node.kind) {
+    } else if (node.kind && toggled) {
       this.fireOnKind(node.kind);
     }
 

--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/index.test.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/index.test.js
@@ -4,12 +4,27 @@ import Stories from './index';
 import { createHierarchy } from '../../../libs/hierarchy';
 
 describe('manager.ui.components.left_panel.stories', () => {
+  const data = createHierarchy([
+    { kind: 'a', stories: ['a1', 'a2'] },
+    { kind: 'b', stories: ['b1', 'b2'] },
+  ]);
+  const dataWithoutSeparator = createHierarchy([
+    { kind: 'some.name.item1', stories: ['a1', 'a2'] },
+    { kind: 'another.space.20', stories: ['b1', 'b2'] },
+  ]);
+  const dataWithSeparator = createHierarchy(
+    [
+      { kind: 'some.name.item1', stories: ['a1', 'a2'] },
+      { kind: 'another.space.20', stories: ['b1', 'b2'] },
+    ],
+    '\\.'
+  );
+
   describe('render', () => {
     test('should render stories - empty', () => {
-      const data = createHierarchy([]);
       const wrap = shallow(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={createHierarchy([])}
           selectedKind={''}
           selectedStory={''}
           selectedHierarchy={[]}
@@ -22,36 +37,25 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should render stories', () => {
-      const data = createHierarchy([
-        { kind: 'a', stories: ['a1', 'a2'] },
-        { kind: '20', stories: ['b1', 'b2'] },
-      ]);
       const wrap = shallow(
         <Stories
           storiesHierarchy={data}
-          selectedKind="20"
+          selectedKind="b"
           selectedStory="b2"
-          selectedHierarchy={['20']}
+          selectedHierarchy={['b']}
         />
       );
 
       const output = wrap.html();
 
-      expect(output).toMatch(/20/);
+      expect(output).toMatch(/b/);
       expect(output).toMatch(/b2/);
     });
 
     test('should render stories with hierarchy - hierarchySeparator is defined', () => {
-      const data = createHierarchy(
-        [
-          { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-          { kind: 'another.space.20', stories: ['b1', 'b2'] },
-        ],
-        '\\.'
-      );
       const wrap = shallow(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithSeparator}
           selectedKind="another.space.20"
           selectedStory="b2"
           selectedHierarchy={['another', 'space', '20']}
@@ -73,13 +77,9 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should render stories without hierarchy - hierarchySeparator is not defined', () => {
-      const data = createHierarchy([
-        { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-        { kind: 'another.space.20', stories: ['b1', 'b2'] },
-      ]);
       const wrap = shallow(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithoutSeparator}
           selectedKind="another.space.20"
           selectedStory="b2"
           selectedHierarchy={['another.space.20']}
@@ -97,16 +97,9 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should render stories with initially selected nodes according to the selectedHierarchy', () => {
-      const data = createHierarchy(
-        [
-          { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-          { kind: 'another.space.20', stories: ['b1', 'b2'] },
-        ],
-        '\\.'
-      );
       const wrap = shallow(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithSeparator}
           selectedKind="another.space.20"
           selectedStory="b2"
           selectedHierarchy={['another', 'space', '20']}
@@ -123,16 +116,9 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should contain state with all selected nodes after clicking on the nodes', () => {
-      const data = createHierarchy(
-        [
-          { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-          { kind: 'another.space.20', stories: ['b1', 'b2'] },
-        ],
-        '\\.'
-      );
       const wrap = mount(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithSeparator}
           selectedKind="another.space.20"
           selectedStory="b2"
           selectedHierarchy={['another', 'space', '20']}
@@ -153,16 +139,9 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should recalculate selected nodes after selectedHierarchy changes', () => {
-      const data = createHierarchy(
-        [
-          { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-          { kind: 'another.space.20', stories: ['b1', 'b2'] },
-        ],
-        '\\.'
-      );
       const wrap = mount(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithSeparator}
           selectedKind="another.space.20"
           selectedStory="b2"
           selectedHierarchy={[]}
@@ -181,16 +160,9 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should add selected nodes to the state after selectedHierarchy changes with a new value', () => {
-      const data = createHierarchy(
-        [
-          { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-          { kind: 'another.space.20', stories: ['b1', 'b2'] },
-        ],
-        '\\.'
-      );
       const wrap = mount(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithSeparator}
           selectedKind="another.space.20"
           selectedStory="b2"
           selectedHierarchy={['another', 'space', '20']}
@@ -213,16 +185,9 @@ describe('manager.ui.components.left_panel.stories', () => {
 
     test('should not call setState when selectedHierarchy prop changes with the same value', () => {
       const selectedHierarchy = ['another', 'space', '20'];
-      const data = createHierarchy(
-        [
-          { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-          { kind: 'another.space.20', stories: ['b1', 'b2'] },
-        ],
-        '\\.'
-      );
       const wrap = mount(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithSeparator}
           selectedKind="another.space.20"
           selectedStory="b2"
           selectedHierarchy={selectedHierarchy}
@@ -240,10 +205,6 @@ describe('manager.ui.components.left_panel.stories', () => {
 
   describe('events', () => {
     test('should call the onSelectStory prop when a collapsed kind is clicked', () => {
-      const data = createHierarchy([
-        { kind: 'a', stories: ['a1', 'a2'] },
-        { kind: 'b', stories: ['b1', 'b2'] },
-      ]);
       const onSelectStory = jest.fn();
       const wrap = mount(
         <Stories
@@ -261,11 +222,7 @@ describe('manager.ui.components.left_panel.stories', () => {
       expect(onSelectStory).toHaveBeenCalledWith('a', null);
     });
 
-    test('should call the onSelectStory prop when an expanded kind is clicked', () => {
-      const data = createHierarchy([
-        { kind: 'a', stories: ['a1', 'a2'] },
-        { kind: 'b', stories: ['b1', 'b2'] },
-      ]);
+    test("shouldn't call the onSelectStory prop when an expanded kind is clicked", () => {
       const onSelectStory = jest.fn();
       const wrap = mount(
         <Stories
@@ -287,10 +244,6 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should call the onSelectStory prop when a story is clicked', () => {
-      const data = createHierarchy([
-        { kind: 'a', stories: ['a1', 'a2'] },
-        { kind: 'b', stories: ['b1', 'b2'] },
-      ]);
       const onSelectStory = jest.fn();
       const wrap = mount(
         <Stories
@@ -309,18 +262,10 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should call the onSelectStory prop when a story is clicked - hierarchySeparator is defined', () => {
-      const data = createHierarchy(
-        [
-          { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-          { kind: 'another.space.20', stories: ['b1', 'b2'] },
-        ],
-        '\\.'
-      );
-
       const onSelectStory = jest.fn();
       const wrap = mount(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithSeparator}
           selectedKind="some.name.item1"
           selectedStory="a2"
           selectedHierarchy={['some', 'name', 'item1']}
@@ -340,18 +285,10 @@ describe('manager.ui.components.left_panel.stories', () => {
     });
 
     test('should call the onSelectStory prop when a story is selected with enter key', () => {
-      const data = createHierarchy(
-        [
-          { kind: 'some.name.item1', stories: ['a1', 'a2'] },
-          { kind: 'another.space.20', stories: ['b1', 'b2'] },
-        ],
-        '\\.'
-      );
-
       const onSelectStory = jest.fn();
       const wrap = mount(
         <Stories
-          storiesHierarchy={data}
+          storiesHierarchy={dataWithSeparator}
           selectedKind="some.name.item1"
           selectedStory="a2"
           selectedHierarchy={['some', 'name', 'item1']}

--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/index.test.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/index.test.js
@@ -239,7 +239,7 @@ describe('manager.ui.components.left_panel.stories', () => {
   });
 
   describe('events', () => {
-    test('should call the onSelectStory prop when a kind is clicked', () => {
+    test('should call the onSelectStory prop when a collapsed kind is clicked', () => {
       const data = createHierarchy([
         { kind: 'a', stories: ['a1', 'a2'] },
         { kind: 'b', stories: ['b1', 'b2'] },
@@ -259,6 +259,31 @@ describe('manager.ui.components.left_panel.stories', () => {
       kind.simulate('click');
 
       expect(onSelectStory).toHaveBeenCalledWith('a', null);
+    });
+
+    test('should call the onSelectStory prop when an expanded kind is clicked', () => {
+      const data = createHierarchy([
+        { kind: 'a', stories: ['a1', 'a2'] },
+        { kind: 'b', stories: ['b1', 'b2'] },
+      ]);
+      const onSelectStory = jest.fn();
+      const wrap = mount(
+        <Stories
+          storiesHierarchy={data}
+          selectedKind="b"
+          selectedStory="b2"
+          selectedHierarchy={['b']}
+          onSelectStory={onSelectStory}
+        />
+      );
+
+      const kind = wrap.find('a').filterWhere(el => el.text() === 'a').last();
+      kind.simulate('click');
+
+      onSelectStory.mockClear();
+      kind.simulate('click');
+
+      expect(onSelectStory).not.toHaveBeenCalled();
     });
 
     test('should call the onSelectStory prop when a story is clicked', () => {


### PR DESCRIPTION
Currently, the stories hierarchy has a confusing behaviour when you click on an expanded kind. If the kind was selected at the moment of clicking, it collapses, but the selected story changes to the first of kind. Otherwise, the first story is selected without collapsing the kind.

I've changed this behaviour to always collapsing without selected story. I preferred though to keep the behaviour when a collapsed kind is expanded along with selecting the first story: this looks quite useful and usually saves a click.

<details>
  <summary>before (note the change in iframe on first click)</summary>
  <img src ="https://user-images.githubusercontent.com/6651625/28943418-7422f11e-78a7-11e7-83cd-5010b4aeace7.gif"/>
</details>
<details>
  <summary>after</summary>
  <img src ="https://user-images.githubusercontent.com/6651625/28943420-75311612-78a7-11e7-9134-13e3b5930e06.gif"/>
</details>

