### PR TITLE
add shortcut for running `yarn storybook` in `cra-kitchen-sink`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bootstrap:crna-kitchen-sink": "lerna exec --scope crna-kitchen-sink -- yarn install",
     "bootstrap:test-cra": "npm run build-packs && lerna exec --scope test-cra -- yarn install",
     "build-packs": "lerna exec --scope '@storybook/*' --parallel -- ../../scripts/build-pack.sh ../../packs",
+    "cra-kitchen-sink": "lerna run --stream --scope cra-kitchen-sink storybook",
     "changelog": "pr-log --sloppy",
     "precommit": "lint-staged",
     "coverage": "codecov",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bootstrap:crna-kitchen-sink": "lerna exec --scope crna-kitchen-sink -- yarn install",
     "bootstrap:test-cra": "npm run build-packs && lerna exec --scope test-cra -- yarn install",
     "build-packs": "lerna exec --scope '@storybook/*' --parallel -- ../../scripts/build-pack.sh ../../packs",
-    "cra-kitchen-sink": "lerna run --stream --scope cra-kitchen-sink storybook",
+    "start": "lerna run --stream --scope cra-kitchen-sink storybook",
     "changelog": "pr-log --sloppy",
     "precommit": "lint-staged",
     "coverage": "codecov",


### PR DESCRIPTION
Before
```
cd examples/cra-kitchen-sink && yarn storybook
```

After
```
yarn start
```
