### PR TITLE
[Info Addon] Enable many components of same type in prop tables

### DIFF
--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -349,7 +349,7 @@ export default class Story extends React.Component {
 
     const { maxPropObjectKeys, maxPropArrayLength, maxPropStringLength } = this.props;
     const propTables = array.map(type =>
-      <div key={type.name}>
+      <div key={type.displayName || type.name}>
         <h2 style={this.state.stylesheet.propTableHead}>
           "{type.displayName || type.name}" Component
         </h2>


### PR DESCRIPTION
Issue: Could not show components in Prop Tables if they had the same `type.name` prop.

## What I did

Use the `displayName` as a key for the Prop Tables instead.

## More

Case: Higher Order Components

Previously the keying of Tables was done with the `name` prop of the component type. This inadvertently filtered out all other components that had the same `name` value. eg Higher Order Components.

Making sure we first check `displayName` for key usage means that components with the same type can all appear in the Prop Tables, if their individual `displayName`'s are different.