### PR TITLE
Limit react versions to >=15

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -80,7 +80,7 @@
     "react-dom": "^15.6.1"
   },
   "peerDependencies": {
-    "react": ">=15.0.0",
-    "react-dom": ">=15.0.0"
+    "react": ">=15.0.0 || ^16.0.0-alpha",
+    "react-dom": ">=15.0.0 || ^16.0.0-alpha"
   }
 }

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -80,7 +80,7 @@
     "react-dom": "^15.6.1"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-dom": "*"
+    "react": ">=15.0.0",
+    "react-dom": ">=15.0.0"
   }
 }


### PR DESCRIPTION
Issue:
I don't think our code base supports React ~0.14 anymore. It's been a while since 15 was released and lots has changed in React land. I think it's probably better for us maintenance wise to drop 14 as well.

Either that, or we should have some tests in place to make sure our code base doesn't regress on 14.

This might break support for alpha builds like `16.0.0-alpha.2`. We could also document it somewhere in a README about deprecating support instead of in a peer dependency warning that everyone ignores.

Suggestions?

## What I did

Seems like we don't support React 0.14 anymore out of the box. Issue came up in support slack and our CRA example app won't take 0.14 either.

## How to test

Run CRA example app.