### PR TITLE
Add z-index to shortcuts popup overlay

### DIFF
--- a/lib/ui/src/modules/ui/components/shortcuts_help.js
+++ b/lib/ui/src/modules/ui/components/shortcuts_help.js
@@ -29,6 +29,7 @@ const modalStyles = {
   },
   overlay: {
     backgroundColor: 'rgba(0, 0, 0, 0.74902)',
+    zIndex: 1,
   },
 };
 


### PR DESCRIPTION
#1523 introduced z-index for menu items. This was needed to prevent situations like this:
<img width="310" alt="screen shot 2017-08-08 at 12 57 00" src="https://user-images.githubusercontent.com/6651625/29066824-1b1aa964-7c39-11e7-9b4c-8b091d9b11ea.png">

As a side effect, it led to chevrons popping out above the shortcuts popup overlay:
<img width="1031" alt="screen shot 2017-08-08 at 12 48 21" src="https://user-images.githubusercontent.com/6651625/29066864-3ea0457e-7c39-11e7-826e-e9e5278a4892.png">


This PR adds a z-index to overlay to fix that. Later, as a part of theming task, we can introduce some z-index constants