### PR TITLE
Handle multiple -p port arguments

### DIFF
--- a/app/react/src/server/index.js
+++ b/app/react/src/server/index.js
@@ -18,7 +18,7 @@ const logger = console;
 
 program
   .version(packageJson.version)
-  .option('-p, --port [number]', 'Port to run Storybook (Required)', parseInt)
+  .option('-p, --port [number]', 'Port to run Storybook (Required)', str => parseInt(str, 10))
   .option('-h, --host [string]', 'Host to run Storybook')
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from')
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')

--- a/app/vue/src/server/index.js
+++ b/app/vue/src/server/index.js
@@ -18,7 +18,7 @@ const logger = console;
 
 program
   .version(packageJson.version)
-  .option('-p, --port [number]', 'Port to run Storybook (Required)', parseInt)
+  .option('-p, --port [number]', 'Port to run Storybook (Required)', str => parseInt(str, 10))
   .option('-h, --host [string]', 'Host to run Storybook')
   .option('-s, --static-dir <dir-names>', 'Directory where to load static files from')
   .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')


### PR DESCRIPTION
Issue: Currently, if you run `start-storybook` and specify the port with `-p` multiple times, it errors out with `Error: port to run Storybook is required!` This is due to a quirk of how commander passes multiple args to the option formatter parameter, leading to `parseInt` getting called with a weird 2nd parameter and ultimately `program.port` being set to NaN. See, for example, https://github.com/tj/commander.js/issues/523

This bug probably came up because the example on [commander's README](https://github.com/tj/commander.js/#coercion) erroneously uses parseInt in this same way.

This is annoying when I have multiple checkouts of a project using storybook with the automatically added npm script: `"storybook": "start-storybook -p 6006"`. If I want to run multiple storybook instances, I would expect to be able to do `npm run storybook` in one checkout, and then `npm run storybook -- -p 6007` in the other to override the port number (It would expand to `start-storybook -p 6006 -p 6007`)

Most CLI programs interpret extra instances of an argument to override previous instances. For example: `ls -l --block-size=1 --block-size=16` uses 16 as the block size.

## What I did
Changed the commander option parsing function to pass only the first parameter to `parseInt` and call it with a specified radix.

## How to test
Get this branch's `start-storybook` linked into some project with storybook setup, then `start-storybook -p 6006 -p 6007` should start storybook running on port 6007.