### PR TITLE
Update template config for webpack react project

### DIFF
--- a/lib/cli/generators/WEBPACK_REACT/template/.storybook/webpack.config.js
+++ b/lib/cli/generators/WEBPACK_REACT/template/.storybook/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
   ],
   module: {
     rules: [
-      // add your custom loaders.
+      // add your custom rules.
     ],
   },
 };

--- a/lib/cli/generators/WEBPACK_REACT/template/.storybook/webpack.config.js
+++ b/lib/cli/generators/WEBPACK_REACT/template/.storybook/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
     // your custom plugins
   ],
   module: {
-    loaders: [
+    rules: [
       // add your custom loaders.
     ],
   },


### PR DESCRIPTION
Issue: webpack 2+ use `rules` instead of `loaders`

## What I did

Update template config for webpack react project

## How to test
