### PR TITLE
[Addon-Knobs] Fixed addon for RN

### DIFF
--- a/addons/knobs/src/KnobManager.js
+++ b/addons/knobs/src/KnobManager.js
@@ -6,9 +6,12 @@ import KnobStore from './KnobStore';
 const PANEL_UPDATE_INTERVAL = 400;
 
 export default class KnobManager {
-  constructor(channel) {
-    this.channel = channel;
+  constructor() {
     this.knobStore = new KnobStore();
+  }
+
+  setChannel(channel) {
+    this.channel = channel;
   }
 
   knob(name, options) {

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -4,8 +4,7 @@ import KnobManager from './KnobManager';
 import { vueHandler } from './vue';
 import { reactHandler } from './react';
 
-const channel = addons.getChannel();
-const manager = new KnobManager(channel);
+const manager = new KnobManager();
 
 export function knob(name, options) {
   return manager.knob(name, options);
@@ -63,6 +62,9 @@ export function date(name, value = new Date()) {
 // In 3.3, this will become `withKnobs`, once our decorator API supports it.
 //   See https://github.com/storybooks/storybook/pull/1527
 function wrapperKnobs(options) {
+  const channel = addons.getChannel();
+  manager.setChannel(channel);
+
   if (options) channel.emit('addon:knobs:setOptions', options);
 
   switch (window.STORYBOOK_ENV) {


### PR DESCRIPTION
## Issue:  #1586 Addon-knobs wasn't working on React Native

After cleanup done in https://github.com/storybooks/storybook/commit/4c1daabf50f0c9fb9d789ba3d40ca37d154445e7 addon wasn't breaking RN (since channel is not set while user is not connected to between app and browser).

## What I did

Pretty much reverted the change back.

## How to test

Adding knob examples to crna and react-vanilla-apps in a separate pr.