### PR TITLE
Fix image imported as data uri

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -12,6 +12,9 @@ import style from './style';
 import StoryListView from '../StoryListView';
 import StoryView from '../StoryView';
 
+const openMenuImage = require('./menu_open.png');
+const closeMenuImage = require('./menu_close.png');
+
 export default class OnDeviceUI extends Component {
   constructor(...args) {
     super(...args);
@@ -100,10 +103,18 @@ export default class OnDeviceUI extends Component {
       },
     ];
 
-    /* eslint-disable global-require */
-    const openMenuImage = require('./menu_open.png');
-    const closeMenuImage = require('./menu_close.png');
-    /* eslint-enable global-require */
+    /*
+      Checks if import is a base64 encoded string uri.
+      If using haul as bundler, some projects are set up to include small files as base64 strings.
+     */
+    let openIcon = openMenuImage;
+    if (typeof openIcon === 'string') {
+      openIcon = { uri: openMenuImage };
+    }
+    let closeIcon = closeMenuImage;
+    if (typeof closeIcon === 'string') {
+      closeIcon = { uri: closeMenuImage };
+    }
 
     return (
       <View style={style.main}>
@@ -113,7 +124,7 @@ export default class OnDeviceUI extends Component {
           <Animated.View style={headerStyles}>
             <TouchableWithoutFeedback onPress={this.menuToggledHandler}>
               <View>
-                <Image source={openMenuImage} style={style.icon} />
+                <Image source={openIcon} style={style.icon} />
               </View>
             </TouchableWithoutFeedback>
             <Text style={style.headerText} numberOfLines={1}>
@@ -129,7 +140,7 @@ export default class OnDeviceUI extends Component {
         <Animated.View style={menuStyles} onLayout={this.menuLayoutHandler}>
           <TouchableWithoutFeedback onPress={this.menuToggledHandler}>
             <View style={style.closeButton}>
-              <Image source={closeMenuImage} style={style.icon} />
+              <Image source={closeIcon} style={style.icon} />
             </View>
           </TouchableWithoutFeedback>
           <StoryListView


### PR DESCRIPTION
Issue: If using a custom bundler or haul, some configurations may choose to import small icons as data uri. The menu icon doesn't support data uri.

## What I did

Added a check for string and put it in the appropriate react-native Image prop format.

## How to test

Launch react native with haul as the bundler and use `url-loader` for files