### PR TITLE
links should navigate in the parent window

### DIFF
--- a/app/react/src/server/iframe.html.js
+++ b/app/react/src/server/iframe.html.js
@@ -54,6 +54,7 @@ export default function({ assets, publicPath, headHtml }) {
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <base target="_parent">
         <script>
           if (window.parent !== window) {
             window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;

--- a/app/vue/src/server/iframe.html.js
+++ b/app/vue/src/server/iframe.html.js
@@ -54,6 +54,7 @@ export default function({ assets, publicPath, headHtml }) {
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <base target="_parent">
         <script>
           if (window.parent !== window) {
             window.__VUE_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__VUE_DEVTOOLS_GLOBAL_HOOK__;


### PR DESCRIPTION
## Issue:
fixes #1122

## What I did
I found that creating normal `<a target="_blank" href="https://www.google.com">foo</a>` links inside of a story would update the iframe and not actually take the user out to the external link

`<base>`tag is supported by all browsers https://stackoverflow.com/a/2656798/1536309 


## How to test

before: 
add a link to a component and click on it. 
`<a href="https://www.google.com">google</a>`
will only update the iframe

after: 
link moves on the parent window.