### PR TITLE
Fix import of the IoChevronRight  from react-icons package

### DIFF
--- a/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_decorators.js
+++ b/lib/ui/src/modules/ui/components/left_panel/stories_tree/tree_decorators.js
@@ -1,5 +1,5 @@
 import { decorators } from 'react-treebeard';
-import { IoChevronRight } from 'react-icons/lib/io';
+import IoChevronRight from 'react-icons/lib/io/chevron-right';
 import React from 'react';
 import PropTypes from 'prop-types';
 import RoutedLink from '../../../containers/routed_link';


### PR DESCRIPTION
Issue: An aggregated bundle is polluted by the react-icons package. 

## What I did
Import only a relevant icon