### PR TITLE
Don’t render leftpanel stories tree if stories are empty

### DIFF
--- a/lib/ui/src/modules/ui/components/left_panel/index.js
+++ b/lib/ui/src/modules/ui/components/left_panel/index.js
@@ -25,6 +25,10 @@ const storyProps = [
   'sidebarAnimations',
 ];
 
+function hierarchyContainsStories(storiesHierarchy) {
+  return storiesHierarchy && storiesHierarchy.map.size
+}
+
 // eslint-disable-next-line react/prefer-stateless-function
 class LeftPanel extends Component {
   render() {
@@ -46,7 +50,7 @@ class LeftPanel extends Component {
           onChange={text => onStoryFilter(text)}
         />
         <div style={scrollStyle}>
-          {storiesHierarchy && storiesHierarchy.map.size
+          {hierarchyContainsStories(storiesHierarchy) 
             ? <Stories {...pick(this.props, storyProps)} /> 
             : null}
         </div>

--- a/lib/ui/src/modules/ui/components/left_panel/index.js
+++ b/lib/ui/src/modules/ui/components/left_panel/index.js
@@ -46,7 +46,9 @@ class LeftPanel extends Component {
           onChange={text => onStoryFilter(text)}
         />
         <div style={scrollStyle}>
-          {storiesHierarchy ? <Stories {...pick(this.props, storyProps)} /> : null}
+          {storiesHierarchy && storiesHierarchy.map.size
+            ? <Stories {...pick(this.props, storyProps)} /> 
+            : null}
         </div>
       </div>
     );

--- a/lib/ui/src/modules/ui/components/left_panel/index.test.js
+++ b/lib/ui/src/modules/ui/components/left_panel/index.test.js
@@ -44,6 +44,13 @@ describe('manager.ui.components.left_panel.index', () => {
     });
   });
 
+  test('should not render stories if storiesHierarchy exists but is empty', () => {
+    const storiesHierarchy = createHierarchy([]);
+    const wrap = shallow(<LeftPanel storiesHierarchy={storiesHierarchy} />);
+
+    expect(wrap.find(Stories).exists()).toBe(false);
+  });
+
   describe('onStoryFilter prop', () => {
     test('should set filter as an empty text on TextFilter.onClear', () => {
       const onStoryFilter = jest.fn();


### PR DESCRIPTION
Issue: Fixes https://github.com/storybooks/storybook/issues/1588, Warnings about missing `selectedKind` and `selectedStory` on initial page render.

## What I did
Stopped the LeftPanel from trying to render a Stories hierarchy tree when there are no stories to render.

Code in client init script of `@storybook/react` gets executed after LeftPanel gets mounted, so tweaking the code in [the react client init script](https://github.com/storybooks/storybook/blob/a9944e1533de79ce4a1a2fd8d2b25aa450998147/app/react/src/client/preview/init.js#L7) as suggested by @edoroshenko did not have any effect. Instead of making the propTypes in the Stories tree optional it seems more logical to not render it at all when there's no content to render.

## How to test
- Go through installation guide (https://storybook.js.org/basics/slow-start-guide/)
- Open http://localhost:9001/ (without query string!)
- Open console
