### PR TITLE
Upgrade react-modal to v2.2.4

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -59,7 +59,7 @@
     "postcss-loader": "^2.0.5",
     "prop-types": "^15.5.10",
     "qs": "^6.4.0",
-    "react-modal": "^1.7.7",
+    "react-modal": "^2.2.4",
     "redux": "^3.6.0",
     "request": "^2.81.0",
     "serve-favicon": "^2.4.3",

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -57,7 +57,7 @@
     "qs": "^6.4.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "react-modal": "^1.7.7",
+    "react-modal": "^2.2.4",
     "redux": "^3.6.0",
     "request": "^2.81.0",
     "serve-favicon": "^2.4.3",

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -32,7 +32,7 @@
     "react-icons": "^2.2.5",
     "react-inspector": "^2.1.1",
     "react-komposer": "^2.0.0",
-    "react-modal": "^1.7.7",
+    "react-modal": "^2.2.4",
     "react-split-pane": "^0.1.65",
     "react-treebeard": "^2.0.3",
     "redux": "^3.6.0"


### PR DESCRIPTION
Issue:

Storybook was hard crashing if used alongside React 16 beta release.

## What I did

I followed error stack traces and found out that the isue was caused by `react-modal` package that used long gone `React.DOM.*` helpers.

I swapped it out with the latest version, and it worked! Turns out `react-modal` had a major release since the dependent-upon `1.7.7`, but according to [changelog](https://github.com/reactjs/react-modal/blob/master/CHANGELOG.md#v200---thu-15-jun-2017-181621-utc), it went without breaking changes.

I never used seach UI (which uses `react-modal`) before, but it seems to be working fine.

## How to test

- Set up a react project with storybook
- `npm install --save react@next react-dom@next`
- Run storybook, open http://localhost:9009/
- Expect it not to fail right away
- Try searching for something