### PR TITLE
env babel config for storyshot

### DIFF
--- a/addons/storyshots/.babelrc
+++ b/addons/storyshots/.babelrc
@@ -1,7 +1,5 @@
 {
-  "presets": [
-    "es2015", "react"
-  ],
+  "presets": ["env", "react"],
   "plugins": [
     "transform-runtime"
   ]


### PR DESCRIPTION
Issue:

We missed one babel preset in addon/storyshots. It broke `prepublish` during `lerna bootstrap`

## What I did

updated it

## How to test
