### PR TITLE
centered addon missing global in package.json

### DIFF
--- a/addons/centered/package.json
+++ b/addons/centered/package.json
@@ -10,5 +10,8 @@
   },
   "peerDependencies": {
     "react": "*"
+  },
+  "dependencies": {
+    "global": "^4.3.2"
   }
 }


### PR DESCRIPTION
Issue:

Missing `global` npm package in `package.json`

## What I did

added those

## How to test
