### PR TITLE
Reminders in PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,13 @@ Issue:
 
 
 ## How to test
+
+
+
+Is this testable with jest or storyshots?
+
+Does this need a new example in the kitchen sink apps?
+
+Does this need an update to the documentation?
+
+If your answer is yes to any of these, please make sure to include it in your PR.


### PR DESCRIPTION
Issue: 

Contributors, new and old, sometimes forget to add tests, update storyshots, include examples in the kitchen-sink apps, etc. I'm definitely guilty. If we have a list of reminders at the bottom, it might help cut down on our time wasted asking for test and examples to be written.

Definitely open to suggestions here!