### PR TITLE
[SHOW STOPPER] Fix new eslint error

### DIFF
--- a/addons/knobs/src/components/PropField.js
+++ b/addons/knobs/src/components/PropField.js
@@ -65,6 +65,6 @@ PropField.propTypes = {
   knob: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.any,
-  }),
+  }).isRequired,
   onChange: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
`eslint-plugin-react` has [fixed its `require-default-props` rule](https://github.com/yannickcr/eslint-plugin-react/pull/1380). Because of this, and because we don't commit `yarn.lock` while having caret version dependencies, we have failing builds for all the PRs