### PR TITLE
Replace React PropTypes with prop-types in RN CLI/examples

### DIFF
--- a/examples/crna-kitchen-sink/storybook/stories/Button/index.android.js
+++ b/examples/crna-kitchen-sink/storybook/stories/Button/index.android.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { TouchableNativeFeedback } from 'react-native';
 
 export default function Button(props) {

--- a/examples/crna-kitchen-sink/storybook/stories/Button/index.ios.js
+++ b/examples/crna-kitchen-sink/storybook/stories/Button/index.ios.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { TouchableHighlight } from 'react-native';
 
 export default function Button(props) {

--- a/examples/crna-kitchen-sink/storybook/stories/CenterView/index.js
+++ b/examples/crna-kitchen-sink/storybook/stories/CenterView/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import style from './style';
 

--- a/examples/crna-kitchen-sink/storybook/stories/Welcome/index.js
+++ b/examples/crna-kitchen-sink/storybook/stories/Welcome/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 
 export default class Welcome extends React.Component {

--- a/examples/react-native-vanilla/storybook/stories/Button/index.android.js
+++ b/examples/react-native-vanilla/storybook/stories/Button/index.android.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { TouchableNativeFeedback } from 'react-native';
 
 export default function Button(props) {

--- a/examples/react-native-vanilla/storybook/stories/Button/index.ios.js
+++ b/examples/react-native-vanilla/storybook/stories/Button/index.ios.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { TouchableHighlight } from 'react-native';
 
 export default function Button(props) {

--- a/examples/react-native-vanilla/storybook/stories/CenterView/index.js
+++ b/examples/react-native-vanilla/storybook/stories/CenterView/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import style from './style';
 

--- a/examples/react-native-vanilla/storybook/stories/Welcome/index.js
+++ b/examples/react-native-vanilla/storybook/stories/Welcome/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 
 export default class Welcome extends React.Component {

--- a/lib/cli/generators/REACT_NATIVE/template/storybook/stories/Button/index.android.js
+++ b/lib/cli/generators/REACT_NATIVE/template/storybook/stories/Button/index.android.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { TouchableNativeFeedback } from 'react-native';
 
 export default function Button(props) {

--- a/lib/cli/generators/REACT_NATIVE/template/storybook/stories/Button/index.ios.js
+++ b/lib/cli/generators/REACT_NATIVE/template/storybook/stories/Button/index.ios.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { TouchableHighlight } from 'react-native';
 
 export default function Button(props) {

--- a/lib/cli/generators/REACT_NATIVE/template/storybook/stories/CenterView/index.js
+++ b/lib/cli/generators/REACT_NATIVE/template/storybook/stories/CenterView/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import style from './style';
 

--- a/lib/cli/generators/REACT_NATIVE/template/storybook/stories/Welcome/index.js
+++ b/lib/cli/generators/REACT_NATIVE/template/storybook/stories/Welcome/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/extensions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 
 export default class Welcome extends React.Component {


### PR DESCRIPTION
Issue: CLI was still using react PropTypes which are deprecated

## What I did

Upgraded RN to use `prop-types` package

## How to test

```
yarn bootstrap && yarn build-packs && yarn bootstrap:react-native-vanilla
cd examples/react-native-vanilla
yarn storybook
./node_modules/.bin/react-native run-ios
```
