### PR TITLE
Addon Info: Remove broken prop type sort (keep defined order)

### DIFF
--- a/addons/info/src/components/PropTable.js
+++ b/addons/info/src/components/PropTable.js
@@ -130,8 +130,6 @@ export default function PropTable(props) {
     return <small>No propTypes defined!</small>;
   }
 
-  array.sort((a, b) => a.property > b.property);
-
   const propValProps = {
     maxPropObjectKeys,
     maxPropArrayLength,


### PR DESCRIPTION
Issue: Prop Types sort is fundamentally broken. Following conversation in Discord, resolution was to remove sort (rather than add fixed name-based sort).

## What I did

* Removed the broken sort for prop types in the PropTable component within the Info addon.
* Prop Types will now display in the order they are defined.

## How to test

Put prop types for a component in a given order. They will display in that order.

Is this testable with jest or storyshots?
Yes (not currently tested for; tests for the Info addon are minimal and need fleshing out)

Does this need a new example in the kitchen sink apps?
No

Does this need an update to the documentation?
No