### PR TITLE
CLI (React Native): ensure having an explicit dependency on `prop-types`

### DIFF
--- a/lib/cli/generators/REACT_NATIVE/index.js
+++ b/lib/cli/generators/REACT_NATIVE/index.js
@@ -9,7 +9,8 @@ module.exports = Promise.all([
   latestVersion('@storybook/react'),
   latestVersion('@storybook/addon-actions'),
   latestVersion('@storybook/addon-links'),
-]).then(([storybookVersion, actionsVersion, linksVersion]) => {
+  latestVersion('prop-types'),
+]).then(([storybookVersion, actionsVersion, linksVersion, propTypesVersion]) => {
   // copy all files from the template directory to project directory
   mergeDirs(path.resolve(__dirname, 'template/'), '.', 'overwrite');
 
@@ -39,6 +40,10 @@ module.exports = Promise.all([
   if (!packageJson.dependencies['react-dom'] && !packageJson.devDependencies['react-dom']) {
     const reactVersion = packageJson.dependencies.react;
     packageJson.devDependencies['react-dom'] = reactVersion;
+  }
+
+  if (!packageJson.dependencies['prop-types'] && !packageJson.devDependencies['prop-types']) {
+    packageJson.devDependencies['prop-types'] = `^${propTypesVersion}`;
   }
 
   packageJson.scripts = packageJson.scripts || {};

--- a/lib/cli/generators/REACT_NATIVE_SCRIPTS/index.js
+++ b/lib/cli/generators/REACT_NATIVE_SCRIPTS/index.js
@@ -7,7 +7,8 @@ module.exports = Promise.all([
   latestVersion('@storybook/react'),
   latestVersion('@storybook/addon-actions'),
   latestVersion('@storybook/addon-links'),
-]).then(([storybookVersion, actionsVersion, linksVersion]) => {
+  latestVersion('prop-types'),
+]).then(([storybookVersion, actionsVersion, linksVersion, propTypesVersion]) => {
   // copy all files from the template directory to project directory
   mergeDirs(path.resolve(__dirname, 'template/'), '.', 'overwrite');
 
@@ -23,6 +24,10 @@ module.exports = Promise.all([
   if (!packageJson.dependencies['react-dom'] && !packageJson.devDependencies['react-dom']) {
     const reactVersion = packageJson.dependencies.react;
     packageJson.devDependencies['react-dom'] = reactVersion;
+  }
+
+  if (!packageJson.dependencies['prop-types'] && !packageJson.devDependencies['prop-types']) {
+    packageJson.devDependencies['prop-types'] = `^${propTypesVersion}`;
   }
 
   packageJson.scripts = packageJson.scripts || {};


### PR DESCRIPTION
This is a follow-up to #1710 
It's safer to have a direct dependency to anything you import from your code