### PR TITLE
Fix CLI generators export

### DIFF
--- a/lib/cli/generators/VUE/index.js
+++ b/lib/cli/generators/VUE/index.js
@@ -3,7 +3,7 @@ const helpers = require('../../lib/helpers');
 const path = require('path');
 const latestVersion = require('latest-version');
 
-Promise.all([
+module.exports = Promise.all([
   latestVersion('@storybook/vue'),
   latestVersion('@storybook/addon-actions'),
   latestVersion('@storybook/addon-links'),

--- a/lib/cli/generators/WEBPACK_REACT/index.js
+++ b/lib/cli/generators/WEBPACK_REACT/index.js
@@ -3,7 +3,7 @@ const helpers = require('../../lib/helpers');
 const path = require('path');
 const latestVersion = require('latest-version');
 
-Promise.all([
+module.exports = Promise.all([
   latestVersion('@storybook/react'),
   latestVersion('@storybook/addon-actions'),
   latestVersion('@storybook/addon-links'),


### PR DESCRIPTION
## What I did

Fix [this PR #1652](https://github.com/storybooks/storybook/pull/1652)
Correctly export `VUE` and `WEBPACK_REACT` generators

## How to test

Use `cli` on vue / webpack_react projects