### PR TITLE
Fix Docgen in static builds for Info

### DIFF
--- a/app/react/src/server/config/babel.prod.js
+++ b/app/react/src/server/config/babel.prod.js
@@ -16,6 +16,12 @@ module.exports = {
     require.resolve('babel-preset-minify'),
   ],
   plugins: [
+    [
+      require.resolve('babel-plugin-react-docgen'),
+      {
+        DOC_GEN_COLLECTION_NAME: 'STORYBOOK_REACT_CLASSES',
+      },
+    ],
     require.resolve('babel-plugin-transform-regenerator'),
     [
       require.resolve('babel-plugin-transform-runtime'),

--- a/app/react/src/server/config/webpack.config.prod.js
+++ b/app/react/src/server/config/webpack.config.prod.js
@@ -23,7 +23,7 @@ export default function() {
       publicPath: '',
     },
     plugins: [
-      new webpack.DefinePlugin(loadEnv()), // load development env so PropTypes are left alone for the Info Addon
+      new webpack.DefinePlugin(loadEnv({ production: true })),
       new webpack.optimize.UglifyJsPlugin({
         compress: {
           screw_ie8: true,

--- a/app/react/src/server/config/webpack.config.prod.js
+++ b/app/react/src/server/config/webpack.config.prod.js
@@ -23,7 +23,7 @@ export default function() {
       publicPath: '',
     },
     plugins: [
-      new webpack.DefinePlugin(loadEnv({ production: true })),
+      new webpack.DefinePlugin(loadEnv()), // load development env so PropTypes are left alone for the Info Addon
       new webpack.optimize.UglifyJsPlugin({
         compress: {
           screw_ie8: true,

--- a/examples/cra-kitchen-sink/src/components/ImportedPropsButton.js
+++ b/examples/cra-kitchen-sink/src/components/ImportedPropsButton.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import DocgenButton from './DocgenButton';
+
+/** Button component description */
+const ImportedPropsButton = ({ disabled, label, onClick }) =>
+  <button disabled={disabled} onClick={onClick}>
+    {label}
+  </button>;
+
+ImportedPropsButton.defaultProps = DocgenButton.defaultProps;
+
+ImportedPropsButton.propTypes = DocgenButton.propTypes;
+
+export default ImportedPropsButton;

--- a/examples/cra-kitchen-sink/src/stories/__snapshots__/index.storyshot
+++ b/examples/cra-kitchen-sink/src/stories/__snapshots__/index.storyshot
@@ -838,6 +838,474 @@ exports[`Storyshots AddonInfo.FlowTypeButton FlowTypeButton 1`] = `
 </div>
 `;
 
+exports[`Storyshots AddonInfo.ImportedPropsButton ImportedPropsButton 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      disabled={false}
+      onClick={[Function]}
+    >
+      Docgen Button
+    </button>
+  </div>
+  <a
+    onClick={[Function]}
+    role="button"
+    style={
+      Object {
+        "background": "#28c",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "textDecoration": "none",
+        "top": 0,
+      }
+    }
+    tabIndex="0"
+  >
+    Show Info
+  </a>
+  <div
+    style={
+      Object {
+        "background": "white",
+        "bottom": 0,
+        "display": "none",
+        "left": 0,
+        "overflow": "auto",
+        "padding": "0 40px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+        "zIndex": 99999,
+      }
+    }
+  >
+    <a
+      onClick={[Function]}
+      role="button"
+      style={
+        Object {
+          "background": "#28c",
+          "borderRadius": "0 0 0 5px",
+          "color": "#fff",
+          "cursor": "pointer",
+          "display": "block",
+          "fontFamily": "sans-serif",
+          "fontSize": "12px",
+          "padding": "5px 15px",
+          "position": "fixed",
+          "right": 0,
+          "textDecoration": "none",
+          "top": 0,
+        }
+      }
+      tabIndex="0"
+    >
+      ×
+    </a>
+    <div
+      style={undefined}
+    >
+      <div
+        style={
+          Object {
+            "WebkitFontSmoothing": "antialiased",
+            "backgroundColor": "#fff",
+            "border": "1px solid #eee",
+            "borderRadius": "2px",
+            "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+            "color": "#444",
+            "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+            "fontSize": "15px",
+            "fontWeight": 300,
+            "lineHeight": 1.45,
+            "marginTop": "50px",
+            "padding": "20px 40px 40px",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "borderBottom": "1px solid #eee",
+              "marginBottom": 10,
+              "paddingTop": 10,
+            }
+          }
+        >
+          <h1
+            style={
+              Object {
+                "fontSize": "35px",
+                "margin": 0,
+                "padding": 0,
+              }
+            }
+          >
+            AddonInfo.ImportedPropsButton
+          </h1>
+          <h2
+            style={
+              Object {
+                "fontSize": "22px",
+                "fontWeight": 400,
+                "margin": "0 0 10px 0",
+                "padding": 0,
+              }
+            }
+          >
+            ImportedPropsButton
+          </h2>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": 0,
+            }
+          }
+        >
+          <p
+            style={
+              Object {
+                "WebkitFontSmoothing": "antialiased",
+                "color": "#444",
+                "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+                "fontSize": "15px",
+              }
+            }
+          >
+            Button with PropTypes imported from another file. Should fallback to using PropTypes for data.
+          </p>
+        </div>
+        <div>
+          <h1
+            style={
+              Object {
+                "borderBottom": "1px solid #EEE",
+                "fontSize": "25px",
+                "margin": "20px 0 0 0",
+                "padding": "0 0 5px 0",
+              }
+            }
+          >
+            Story Source
+          </h1>
+          <pre
+            style={
+              Object {
+                "backgroundColor": "#fafafa",
+                "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+                "fontSize": ".88em",
+                "lineHeight": 1.5,
+                "overflowX": "scroll",
+                "padding": ".5rem",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "paddingLeft": 18,
+                  "paddingRight": 3,
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "color": "#777",
+                  }
+                }
+              >
+                &lt;
+                ImportedPropsButton
+              </span>
+              <span>
+                <span>
+                   
+                  <span
+                    style={Object {}}
+                  >
+                    onClick
+                  </span>
+                  <span>
+                    =
+                    <span
+                      style={Object {}}
+                    >
+                      <span>
+                        <span
+                          style={
+                            Object {
+                              "color": "#170",
+                            }
+                          }
+                        >
+                          clicked()
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                </span>
+                <span>
+                   
+                  <span
+                    style={Object {}}
+                  >
+                    label
+                  </span>
+                  <span>
+                    =
+                    <span
+                      style={Object {}}
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        "
+                        Docgen Button
+                        "
+                      </span>
+                    </span>
+                  </span>
+                   
+                </span>
+              </span>
+              <span
+                style={
+                  Object {
+                    "color": "#777",
+                  }
+                }
+              >
+                /&gt;
+              </span>
+            </div>
+          </pre>
+        </div>
+        <div>
+          <h1
+            style={
+              Object {
+                "borderBottom": "1px solid #EEE",
+                "fontSize": "25px",
+                "margin": "20px 0 0 0",
+                "padding": "0 0 5px 0",
+              }
+            }
+          >
+            Prop Types
+          </h1>
+          <div>
+            <h2
+              style={
+                Object {
+                  "margin": "20px 0 0 0",
+                }
+              }
+            >
+              "
+              ImportedPropsButton
+              " Component
+            </h2>
+            <table
+              style={
+                Object {
+                  "borderCollapse": "separate",
+                  "borderSpacing": "10px 5px",
+                  "marginLeft": -10,
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th>
+                    property
+                  </th>
+                  <th>
+                    propType
+                  </th>
+                  <th>
+                    required
+                  </th>
+                  <th>
+                    default
+                  </th>
+                  <th>
+                    description
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    disabled
+                  </td>
+                  <td>
+                    bool
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#a11",
+                          }
+                        }
+                      >
+                        false
+                      </span>
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>
+                    label
+                  </td>
+                  <td>
+                    string
+                  </td>
+                  <td>
+                    yes
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>
+                    onClick
+                  </td>
+                  <td>
+                    func
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    <span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#170",
+                          }
+                        }
+                      >
+                        onClick()
+                      </span>
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>
+                    one
+                  </td>
+                  <td>
+                    other
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>
+                    two
+                  </td>
+                  <td>
+                    other
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>
+                    msg
+                  </td>
+                  <td>
+                    other
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>
+                    enm
+                  </td>
+                  <td>
+                    other
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>
+                    union
+                  </td>
+                  <td>
+                    other
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots App full app 1`] = `
 <div
   className="App"

--- a/examples/cra-kitchen-sink/src/stories/__snapshots__/index.storyshot
+++ b/examples/cra-kitchen-sink/src/stories/__snapshots__/index.storyshot
@@ -150,7 +150,7 @@ exports[`Storyshots AddonInfo.DocgenButton DocgenButton 1`] = `
               }
             }
           >
-            Some Description
+            Button with PropTypes and doc comments
           </p>
         </div>
         <div>
@@ -618,7 +618,7 @@ exports[`Storyshots AddonInfo.FlowTypeButton FlowTypeButton 1`] = `
               }
             }
           >
-            Some Description
+            Button with Flow type documentation comments
           </p>
         </div>
         <div>
@@ -1316,7 +1316,7 @@ exports[`Storyshots App full app 1`] = `
     <img
       alt="logo"
       className="App-logo"
-      src="file-stub"
+      src="logo.svg"
     />
     <h2>
       Welcome to React

--- a/examples/cra-kitchen-sink/src/stories/__snapshots__/index.storyshot
+++ b/examples/cra-kitchen-sink/src/stories/__snapshots__/index.storyshot
@@ -1316,7 +1316,7 @@ exports[`Storyshots App full app 1`] = `
     <img
       alt="logo"
       className="App-logo"
-      src="logo.svg"
+      src="file-stub"
     />
     <h2>
       Welcome to React

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -28,6 +28,7 @@ import Logger from './Logger';
 import Container from './Container';
 import DocgenButton from '../components/DocgenButton';
 import FlowTypeButton from '../components/FlowTypeButton';
+import ImportedPropsButton from '../components/ImportedPropsButton';
 
 const EVENTS = {
   TEST_EVENT_1: 'test-event-1',
@@ -164,14 +165,26 @@ storiesOf('Button', module)
     )
   );
 
-storiesOf('AddonInfo.DocgenButton', module).addWithInfo('DocgenButton', 'Some Description', () =>
+storiesOf(
+  'AddonInfo.DocgenButton',
+  module
+).addWithInfo('DocgenButton', 'Button with PropTypes and doc comments', () =>
   <DocgenButton onClick={action('clicked')} label="Docgen Button" />
+);
+
+storiesOf(
+  'AddonInfo.ImportedPropsButton',
+  module
+).addWithInfo(
+  'ImportedPropsButton',
+  'Button with PropTypes imported from another file. Should fallback to using PropTypes for data.',
+  () => <ImportedPropsButton onClick={action('clicked')} label="Docgen Button" />
 );
 
 storiesOf(
   'AddonInfo.FlowTypeButton',
   module
-).addWithInfo('FlowTypeButton', 'Some Description', () =>
+).addWithInfo('FlowTypeButton', 'Button with Flow type documentation comments', () =>
   <FlowTypeButton onClick={action('clicked')} label="Flow Typed Button" />
 );
 


### PR DESCRIPTION
Issue:
Fixes: #1661 #1141

PropTypes get removed during our build and Docgen never runs so the Prop Table in Info shows up empty and undefined.


## What I did

* set webpack static build environment to dev to prevent PropTypes from being stripped out
* added docgen plugin to static build babelrc
* created new story component in example to show PropType table from fallback method
* updated storyshots

## How to test

run cra-kitchen-sink and check the 3 AddonInfo buttons.

Is this testable with jest or storyshots?
yes
Does this need a new example in the kitchen sink apps?
yes
Does this need an update to the documentation?
no
If your answer is yes to any of these, please make sure to include it in your PR.
