### PR TITLE
Improve `addon-info` README options documentation

### DIFF
--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -41,7 +41,7 @@ storiesOf('Component', module)
 
 ## Usage with options
 
-`withInfo` can also take an options object in case you want to configure how
+`withInfo` can also take an [options object](#global-options) in case you want to configure how
 the info panel looks on a per-story basis:
 
 ```js
@@ -50,10 +50,8 @@ import { withInfo } from '@storybook/addon-info';
 storiesOf('Component', module)
   .add('simple info',
     withInfo({
-      text: 'doc string about my component',
-      maxPropsIntoLine: 1,
-      maxPropObjectKeys: 10,
-      maxPropArrayLength: 10,
+      text: 'String or React Element with docs about my component', // Warning! This option's name will be likely renamed to "summary" in 3.3 release. Follow this PR #1501 for details
+      // other possible options see in Global options section below
     )(() =>
       <Component>Click the "?" mark at top-right to view the info.</Component>
     )
@@ -80,6 +78,11 @@ import { setDefaults } from '@storybook/addon-info';
 setDefaults({
   header: false, // Toggles display of header with component name and description
   inline: true, // Displays info inline vs click button to view
+  source: true, // Displays the source of story Component
+  propTables: [/* Components used in story */], // displays Prop Tables with this components
+  propTablesExclude: [], // Exclude Components from being shoun in Prop Tables section
+  styles: {}, // Overrides styles of addon
+  marksyConf: {}, // Overrides components used to display markdown. Warning! This option's name will be likely deprecated in favor to "components" with the same API in 3.3 release. Follow this PR #1501 for details
   maxPropsIntoLine: 1, // Max props to display per line in source code
   maxPropObjectKeys: 10,
   maxPropArrayLength: 10,

--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -78,8 +78,9 @@ import { setDefaults } from '@storybook/addon-info';
 
 // addon-info
 setDefaults({
-  inline: true,
-  maxPropsIntoLine: 1,
+  header: false, // Toggles display of header with component name and description
+  inline: true, // Displays info inline vs click button to view
+  maxPropsIntoLine: 1, // Max props to display per line in source code
   maxPropObjectKeys: 10,
   maxPropArrayLength: 10,
   maxPropStringLength: 100,


### PR DESCRIPTION
Added more info about options available since it was confusing 


