### PR TITLE
Install `@storybook/react-native` in RN getstorybook

### DIFF
--- a/lib/cli/generators/REACT_NATIVE/index.js
+++ b/lib/cli/generators/REACT_NATIVE/index.js
@@ -6,7 +6,7 @@ const chalk = require('chalk');
 const helpers = require('../../lib/helpers');
 
 module.exports = Promise.all([
-  latestVersion('@storybook/react'),
+  latestVersion('@storybook/react-native'),
   latestVersion('@storybook/addon-actions'),
   latestVersion('@storybook/addon-links'),
   latestVersion('prop-types'),
@@ -33,7 +33,7 @@ module.exports = Promise.all([
   packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
 
-  packageJson.devDependencies['@storybook/react'] = `^${storybookVersion}`;
+  packageJson.devDependencies['@storybook/react-native'] = `^${storybookVersion}`;
   packageJson.devDependencies['@storybook/addon-actions'] = `^${actionsVersion}`;
   packageJson.devDependencies['@storybook/addon-links'] = `^${linksVersion}`;
 

--- a/lib/cli/generators/REACT_NATIVE_SCRIPTS/index.js
+++ b/lib/cli/generators/REACT_NATIVE_SCRIPTS/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 const latestVersion = require('latest-version');
 
 module.exports = Promise.all([
-  latestVersion('@storybook/react'),
+  latestVersion('@storybook/react-native'),
   latestVersion('@storybook/addon-actions'),
   latestVersion('@storybook/addon-links'),
   latestVersion('prop-types'),
@@ -17,7 +17,7 @@ module.exports = Promise.all([
   packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
 
-  packageJson.devDependencies['@storybook/react'] = `^${storybookVersion}`;
+  packageJson.devDependencies['@storybook/react-native'] = `^${storybookVersion}`;
   packageJson.devDependencies['@storybook/addon-actions'] = `^${actionsVersion}`;
   packageJson.devDependencies['@storybook/addon-links'] = `^${linksVersion}`;
 


### PR DESCRIPTION
Issue: #1738 

## What I did

Fixes a bug introduced in https://github.com/storybooks/storybook/pull/1652 where `@storybook/react-native` is no longer being installed by `getstorybook` for RN projects.

## How to test

```
yarn bootstrap -- --core
cd ..
yarn create react-native-app crna
cd crna
../storybook/node_modules/\@storybook/cli/bin/generate.js
yarn storybook
```

Is this testable with jest or storyshots? No

Does this need a new example in the kitchen sink apps? No

Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
