### PR TITLE
Height aligned 2 buttons in manager's header

### DIFF
--- a/lib/ui/src/modules/ui/components/left_panel/header.js
+++ b/lib/ui/src/modules/ui/components/left_panel/header.js
@@ -5,6 +5,8 @@ import { baseFonts } from '@storybook/components';
 const wrapperStyle = {
   background: '#F7F7F7',
   marginBottom: 10,
+  display: 'flex',
+  height: 27,
 };
 
 const headingStyle = {
@@ -14,51 +16,49 @@ const headingStyle = {
   fontSize: '12px',
   fontWeight: 'bolder',
   color: '#828282',
-  border: '1px solid #C1C1C1',
-  textAlign: 'center',
-  borderRadius: '2px',
-  padding: '5px',
   cursor: 'pointer',
+  padding: 0,
   margin: 0,
-  float: 'none',
   overflow: 'hidden',
 };
 
 const shortcutIconStyle = {
   textTransform: 'uppercase',
-  letterSpacing: '3.5px',
   fontSize: 12,
   fontWeight: 'bolder',
   color: 'rgb(130, 130, 130)',
   border: '1px solid rgb(193, 193, 193)',
   textAlign: 'center',
   borderRadius: 2,
-  padding: 5,
   cursor: 'pointer',
-  margin: 0,
   display: 'inlineBlock',
-  paddingLeft: 8,
-  float: 'right',
-  marginLeft: 5,
+  padding: 0,
+  margin: '0 0 0 5px',
   backgroundColor: 'inherit',
   outline: 0,
+  width: 30,
 };
 
 const linkStyle = {
   textDecoration: 'none',
+  flexGrow: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: '1px solid rgb(193, 193, 193)',
+  borderRadius: 2,
 };
 
-const Header = ({ openShortcutsHelp, name, url }) =>
+const Header = ({ openShortcutsHelp, name, url }) => (
   <div style={wrapperStyle}>
+    <a style={linkStyle} href={url} target="_blank" rel="noopener noreferrer">
+      <h3 style={headingStyle}>{name}</h3>
+    </a>
     <button style={shortcutIconStyle} onClick={openShortcutsHelp}>
       ⌘
     </button>
-    <a style={linkStyle} href={url} target="_blank" rel="noopener noreferrer">
-      <h3 style={headingStyle}>
-        {name}
-      </h3>
-    </a>
-  </div>;
+  </div>
+);
 
 Header.defaultProps = {
   openShortcutsHelp: null,


### PR DESCRIPTION
This PR is nitspick.

The height of the 2 buttons are not aligned **in Chrome**.
I am a designer, this feel sick to me...

#### ScreenShot in Chrome
![image](https://user-images.githubusercontent.com/9045135/29860740-f49a013e-8da1-11e7-9f75-9948d6ad3c3d.png)

#### ScreenShot in Safari
![image](https://user-images.githubusercontent.com/9045135/29860831-4ebadb20-8da2-11e7-9608-7640cca2caa3.png)


## What I did

Using flexbox

### After

#### ScreenShot in Chrome
![image](https://user-images.githubusercontent.com/9045135/29860915-89c59c50-8da2-11e7-8336-b22493d07a05.png)

#### ScreenShot in Safari
![image](https://user-images.githubusercontent.com/9045135/29860997-c1dcc2f8-8da2-11e7-9b60-7e20717d271b.png)


## How to test

>Is this testable with jest or storyshots?

Yes, maybe by storyshots.

>Does this need a new example in the kitchen sink apps?

No.

>Does this need an update to the documentation?

No.

---

I'm contributing to this repository for the first time.

Sorry, I did not fully understand if there are other files that need to be changed.
