### PR TITLE
Fix preview scrolling

### DIFF
--- a/app/react-native/src/server/index.html.js
+++ b/app/react-native/src/server/index.html.js
@@ -9,15 +9,6 @@ export default function(publicPath, options) {
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Storybook for React</title>
         <style>
-          /*
-            When resizing panels, the drag event breaks if the cursor
-            moves over the iframe. Add the 'dragging' class to the body
-            at drag start and remove it when the drag ends.
-           */
-          .dragging iframe {
-            pointer-events: none;
-          }
-
           /* Styling the fuzzy search box placeholders */
           .searchBox::-webkit-input-placeholder { /* Chrome/Opera/Safari */
             color: #ddd;

--- a/app/react/src/server/index.html.js
+++ b/app/react/src/server/index.html.js
@@ -40,15 +40,6 @@ export default function({ assets, publicPath, headHtml }) {
         <meta content="IE=edge" http-equiv="X-UA-Compatible" />
         <title>Storybook</title>
         <style>
-          /*
-            When resizing panels, the drag event breaks if the cursor
-            moves over the iframe. Add the 'dragging' class to the body
-            at drag start and remove it when the drag ends.
-           */
-          .dragging iframe {
-            pointer-events: none;
-          }
-
           /* Styling the fuzzy search box placeholders */
           .searchBox::-webkit-input-placeholder { /* Chrome/Opera/Safari */
             color: #ddd;

--- a/app/vue/src/server/index.html.js
+++ b/app/vue/src/server/index.html.js
@@ -40,15 +40,6 @@ export default function({ assets, publicPath, headHtml }) {
         <meta content="IE=edge" http-equiv="X-UA-Compatible" />
         <title>Storybook</title>
         <style>
-          /*
-            When resizing panels, the drag event breaks if the cursor
-            moves over the iframe. Add the 'dragging' class to the body
-            at drag start and remove it when the drag ends.
-           */
-          .dragging iframe {
-            pointer-events: none;
-          }
-
           /* Styling the fuzzy search box placeholders */
           .searchBox::-webkit-input-placeholder { /* Chrome/Opera/Safari */
             color: #ddd;

--- a/lib/ui/src/modules/ui/components/layout/index.js
+++ b/lib/ui/src/modules/ui/components/layout/index.js
@@ -1,4 +1,4 @@
-import { document, localStorage, window } from 'global';
+import { localStorage, window } from 'global';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SplitPane from 'react-split-pane';
@@ -78,6 +78,15 @@ const fullScreenPreviewStyle = {
   overflow: 'hidden',
 };
 
+const overlayStyle = isDragging => ({
+  display: isDragging ? 'block' : 'none',
+  position: 'absolute',
+  top: '0px',
+  right: '0px',
+  bottom: '0px',
+  left: '0px',
+});
+
 const defaultSizes = {
   addonPanel: {
     down: 200,
@@ -88,10 +97,6 @@ const defaultSizes = {
     top: 400,
   },
 };
-
-const onDragStart = () => document.body.classList.add('dragging');
-
-const onDragEnd = () => document.body.classList.remove('dragging');
 
 const saveSizes = sizes => {
   try {
@@ -129,9 +134,12 @@ class Layout extends React.Component {
         height: 0,
         width: 0,
       },
+      isDragging: false,
     };
 
     this.onResize = this.onResize.bind(this);
+    this.onDragStart = this.onDragStart.bind(this);
+    this.onDragEnd = this.onDragEnd.bind(this);
   }
 
   componentDidMount() {
@@ -140,6 +148,14 @@ class Layout extends React.Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.onResize);
+  }
+
+  onDragStart() {
+    this.setState({ isDragging: true });
+  }
+
+  onDragEnd() {
+    this.setState({ isDragging: false });
   }
 
   onResize(pane, mode) {
@@ -200,8 +216,8 @@ class Layout extends React.Component {
           size={showStoriesPanel ? storiesPanelDefaultSize : 1}
           defaultSize={storiesPanelDefaultSize}
           resizerStyle={storiesResizerStyle(showStoriesPanel, storiesPanelOnTop)}
-          onDragStarted={onDragStart}
-          onDragFinished={onDragEnd}
+          onDragStarted={this.onDragStart}
+          onDragFinished={this.onDragEnd}
           onChange={this.onResize('storiesPanel', storiesPanelOnTop ? 'top' : 'left')}
         >
           {conditionalRender(
@@ -225,11 +241,17 @@ class Layout extends React.Component {
             size={showAddonPanel ? addonPanelDefaultSize : 1}
             defaultSize={addonPanelDefaultSize}
             resizerStyle={addonResizerStyle(showAddonPanel, addonPanelInRight)}
-            onDragStarted={onDragStart}
-            onDragFinished={onDragEnd}
+            onDragStarted={this.onDragStart}
+            onDragFinished={this.onDragEnd}
             onChange={this.onResize('addonPanel', addonPanelInRight ? 'right' : 'down')}
           >
             <div style={contentPanelStyle(addonPanelInRight, storiesPanelOnTop)}>
+              {/*
+                When resizing panels, the drag event breaks if the cursor
+                moves over the iframe. Show an overlay div over iframe
+                at drag start and hide it when the drag ends.
+              */}
+              <div style={overlayStyle(this.state.isDragging)} />
               <div
                 style={previewStyle}
                 ref={ref => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4949,6 +4949,13 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
 glob@^4.0.2:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
@@ -6589,9 +6596,9 @@ left-pad@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.1.3.tgz#612f61c033f3a9e08e939f1caebeea41b6f3199a"
 
-lerna@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.1.0.tgz#22da4c9cb09f7733a7e87ba8f34779a509c172ea"
+lerna@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.1.2.tgz#b07eb7a4d7dd7d44a105262fef49b2229301c577"
   dependencies:
     async "^1.5.0"
     chalk "^2.1.0"
@@ -6606,6 +6613,7 @@ lerna@2.1.0:
     fs-extra "^4.0.1"
     get-port "^3.2.0"
     glob "^7.1.2"
+    glob-parent "^3.1.0"
     globby "^6.1.0"
     graceful-fs "^4.1.11"
     inquirer "^3.2.2"
@@ -8104,6 +8112,10 @@ parseurl@~1.3.0, parseurl@~1.3.1:
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
 
 path-exists@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Issue: #1779

## What I did
Used an overlay div instead of `pointer-events: none` when dragging.
See https://github.com/tomkp/react-split-pane/issues/30, [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=750765&q=iframe%20pointer%20events&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified)

## How to test
1. Open `cra-kitchen-sink` in Chrome
2. Resize browser window so that it's lower than the preview content
3. Resize some of the panes (stories / addon)
4. Try to scroll the preview
