### PR TITLE
Fixing typo on VueJS withNotes Example

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -37,7 +37,7 @@ Here's an example of using Notes and Info in 3.2 with the new API.
 storiesOf('composition', module)
   .add('new addons api',
     withInfo('see Notes panel for composition info')(
-      withNotes({ notes: 'Composition: Info(Notes())' })(context =>
+      withNotes({ text: 'Composition: Info(Notes())' })(context =>
         <MyComponent name={context.story} />
       )
     )

--- a/examples/vue-kitchen-sink/src/stories/index.js
+++ b/examples/vue-kitchen-sink/src/stories/index.js
@@ -174,7 +174,7 @@ storiesOf('Addon Notes', module)
   .add(
     'Note with HTML',
     withNotes({
-      notes: `
+      text: `
       <h2>My notes on emojies</h2>
 
       <em>It's not all that important to be honest, but..</em>


### PR DESCRIPTION
Fixing wrong param passed to `withNotes` method.

## Issue:

#1766

## What I did

rename param `notes` => `text`

## How to test
simple run `yarn storybook` and now the example, and the example `Addon Notes => Note with HTML` should be working
