### PR TITLE
CLI: handle promise rejections

### DIFF
--- a/lib/cli/bin/generate.js
+++ b/lib/cli/bin/generate.js
@@ -57,6 +57,11 @@ const end = () => {
   logger.log();
 };
 
+const handleError = ex => {
+  logger.error(chalk.red(ex.stack));
+  process.exit(1);
+};
+
 const CRNA_DISCUSSION =
   'https://github.com/storybooks/storybook/blob/master/app/react-native/docs/manual-setup.md';
 
@@ -76,21 +81,24 @@ switch (projectType) {
     require('../generators/UPDATE_PACKAGE_ORGANIZATIONS').default(program.parser)
       .then(() => null) // commmandLog doesn't like to see output
       .then(commandLog('Upgrading your project to the new storybook packages.'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   case types.REACT_SCRIPTS:
     // eslint-disable-next-line
     require('../generators/REACT_SCRIPTS').default
       .then(commandLog('Adding storybook support to your "Create React App" based project'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   case types.REACT:
     // eslint-disable-next-line
     require('../generators/REACT').default
       .then(commandLog('Adding storybook support to your "React" app'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   case types.REACT_NATIVE_SCRIPTS: {
@@ -106,7 +114,8 @@ switch (projectType) {
         logger.log('\nFor a more complete discussion of options, see:\n');
         logger.log(chalk.cyan(CRNA_DISCUSSION));
         logger.log();
-      });
+      })
+      .catch(handleError);
     break;
   }
 
@@ -114,42 +123,48 @@ switch (projectType) {
     // eslint-disable-next-line
     require('../generators/REACT_NATIVE').default
       .then(commandLog('Adding storybook support to your "React Native" app'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   case types.METEOR:
     // eslint-disable-next-line
     require('../generators/METEOR').default
       .then(commandLog('Adding storybook support to your "Meteor" app'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   case types.WEBPACK_REACT:
     // eslint-disable-next-line
     require('../generators/WEBPACK_REACT').default
       .then(commandLog('Adding storybook support to your "Webpack React" app'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   case types.REACT_PROJECT:
     // eslint-disable-next-line
     require('../generators/REACT').default
       .then(commandLog('Adding storybook support to your "React" library'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   case types.SFC_VUE:
     // eslint-disable-next-line
     require('../generators/SFC_VUE').default
       .then(commandLog('Adding storybook support to your "Single File Components Vue" app'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   case types.VUE:
     // eslint-disable-next-line
     require('../generators/VUE').default
       .then(commandLog('Adding storybook support to your "Vue" app'))
-      .then(end);
+      .then(end)
+      .catch(handleError);
     break;
 
   default:


### PR DESCRIPTION
Issue: promise rejections are left unhandled, which leads to node warning and false-negative tests

## What I did

## How to test
* add this line to `const end` handler in `generate.js`:
   ```
   throw new Error("OOPS");
   ```
* run CLI test: `yarn test --cli`

Before:
```
 • Adding storybook support to your "Meteor" app. ✓
(node:48487) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: OOPS
(node:48487) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

 getstorybook - the simplest way to add a storybook to your project. 

 • Detecting project type. ✓
 • Adding storybook support to your "React" app
```
Note that tests keep running without error

After:
```
 • Adding storybook support to your "Meteor" app. ✓
Error: OOPS
    at end (/Users/jetbrains/IdeaProjects/storybook/lib/cli/bin/generate.js:50:9)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
npm ERR! Test failed.  See above for more details.
error Command failed with exit code 1.
```
