### PR TITLE
Update README: mention that addon-links needs to be registered manually

### DIFF
--- a/addons/links/README.md
+++ b/addons/links/README.md
@@ -20,7 +20,7 @@ You can use this addon without installing it.
 First configure it as an addon by adding it to your addons.js file (located in the Storybook config directory).
 
 ```js
-import '@storybook/addon-knobs/register'
+import '@storybook/addon-links/register';
 ```
 
 Then you can import `linkTo` in your stories and use like this:

--- a/addons/links/README.md
+++ b/addons/links/README.md
@@ -15,7 +15,10 @@ This addon works with Storybook for:
 
 ## Getting Started
 
-You can use this addon without installing it.
+Install this addon by adding the `@storybook/addon-links` dependency:
+```sh
+yarn add @storybook/addon-links
+```
 
 First configure it as an addon by adding it to your addons.js file (located in the Storybook config directory).
 

--- a/addons/links/README.md
+++ b/addons/links/README.md
@@ -17,6 +17,14 @@ This addon works with Storybook for:
 
 You can use this addon without installing it.
 
+First configure it as an addon by adding it to your addons.js file (located in the Storybook config directory).
+
+```js
+import '@storybook/addon-knobs/register'
+```
+
+Then you can import `linkTo` in your stories and use like this:
+
 ```js
 import { storiesOf } from '@storybook/react'
 import { linkTo } from '@storybook/addon-links'


### PR DESCRIPTION
Issue:

## What I did

Update README.md by mentioning that `addon-links` needs to be manually registered. I just ran into this and since the README didn't mention anything it cost me some time to figure out why I couldn't make it work.

## How to test

N.A.

Is this testable with jest or storyshots?
N.A.
Does this need a new example in the kitchen sink apps?
N.A.
Does this need an update to the documentation?
N.A.
If your answer is yes to any of these, please make sure to include it in your PR.
