### PR TITLE
Ability for custom storyshots testFunctions to utilise "snapshot per story file"

### DIFF
--- a/addons/storyshots/README.md
+++ b/addons/storyshots/README.md
@@ -156,3 +156,25 @@ Take a snapshot of a shallow-rendered version of the component.
 ### `getSnapshotFileName`
 
 Utility function used in `multiSnapshotWithOptions`. This is made available for users who implement custom test functions that also want to take advantage of multi-file storyshots.
+
+###### Example:
+
+Let's say we wanted to create a test function for shallow && multi-file snapshots:
+
+```js
+import initStoryshots, { getSnapshotFileName } from '@storybook/addon-storyshots';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+initStoryshots({
+  test: ({ story, context }) => {
+    const snapshotFileName = getSnapshotFileName(context);
+    const storyElement = story.render(context);
+    const shallowTree = shallow(storyElement);
+
+    if (snapshotFileName) {
+      expect(toJson(shallowTree)).toMatchSpecificSnapshot(snapshotFileName);
+    }
+  }
+});
+```

--- a/addons/storyshots/README.md
+++ b/addons/storyshots/README.md
@@ -152,3 +152,7 @@ Like `snapshotWithOptions`, but generate a separate snapshot file for each stori
 ### `shallowSnapshot`
 
 Take a snapshot of a shallow-rendered version of the component.
+
+### `getSnapshotFileName`
+
+Utility function used in `multiSnapshotWithOptions`. This is made available for users who implement custom test functions that also want to take advantage of multi-file storyshots.

--- a/addons/storyshots/src/index.js
+++ b/addons/storyshots/src/index.js
@@ -8,7 +8,7 @@ import addons from '@storybook/addons';
 import runWithRequireContext from './require_context';
 import createChannel from './storybook-channel-mock';
 import { snapshot } from './test-bodies';
-import { getPossibleStoriesFiles } from './utils';
+import { getPossibleStoriesFiles, getSnapshotFileName } from './utils';
 
 export {
   snapshot,
@@ -17,6 +17,8 @@ export {
   shallowSnapshot,
   renderOnly,
 } from './test-bodies';
+
+export { getSnapshotFileName };
 
 let storybook;
 let configPath;

--- a/addons/storyshots/src/test-bodies.js
+++ b/addons/storyshots/src/test-bodies.js
@@ -1,21 +1,11 @@
 import renderer from 'react-test-renderer';
 import shallow from 'react-test-renderer/shallow';
 import 'jest-specific-snapshot';
-import { getStoryshotFile } from './utils';
+import { getSnapshotFileName } from './utils';
 
 function getRenderedTree(story, context, options) {
   const storyElement = story.render(context);
   return renderer.create(storyElement, options).toJSON();
-}
-
-function getSnapshotFileName(context) {
-  const fileName = context.fileName;
-
-  if (!fileName) {
-    return null;
-  }
-
-  return getStoryshotFile(fileName);
 }
 
 export const snapshotWithOptions = options => ({ story, context }) => {

--- a/addons/storyshots/src/utils.js
+++ b/addons/storyshots/src/utils.js
@@ -1,6 +1,6 @@
 import path from 'path';
 
-export function getStoryshotFile(fileName) {
+function getStoryshotFile(fileName) {
   const { dir, name } = path.parse(fileName);
   return path.format({ dir: path.join(dir, '__snapshots__'), name, ext: '.storyshot' });
 }
@@ -12,4 +12,14 @@ export function getPossibleStoriesFiles(storyshotFile) {
     path.format({ dir: path.dirname(dir), name, ext: '.js' }),
     path.format({ dir: path.dirname(dir), name, ext: '.jsx' }),
   ];
+}
+
+export function getSnapshotFileName(context) {
+  const fileName = context.fileName;
+
+  if (!fileName) {
+    return null;
+  }
+
+  return getStoryshotFile(fileName);
 }


### PR DESCRIPTION
## Issue:
Can't use `multiSnapshotWithOptions` with custom test function because `getSnapshotFileName` is not exported.

## What I did
This is a small tweak to the new `multiSnapshotWithOptions` test function. It basically just exports the `getSnapshotFileName` function so it can be used by those of use who have implemented our own custom test function. I also did a minor refactor and moved the `getSnapshotFileName` function to the `utils.js` file. Do let me know if this doesn't make any sense.

## How to test
Go to `storybook\addons\storyshots`
and run `yarn example`

Is this testable with jest or storyshots?
Storyshots

Does this need a new example in the kitchen sink apps?
It should not.

Does this need an update to the documentation?
[Updated Docs] Yes.. We could mention this export in the docs so other users could become aware of it.

If your answer is yes to any of these, please make sure to include it in your PR.
