### PR TITLE
Add addon-console to addons gallery

### DIFF
--- a/docs/pages/addons/addon-gallery/index.md
+++ b/docs/pages/addons/addon-gallery/index.md
@@ -38,6 +38,10 @@ The Storybook webapp UI can be customised with this addon. It can be used to cha
 
 Storyshots is a way to automatically jest-snapshot all your stories. [More info here](/testing/structural-testing/).
 
+### [Console](https://github.com/storybooks/storybook-addon-console)
+
+Redirects console output (logs, errors, warnings) into Action Logger Panel. `withConsole` decorator notifies from what stories logs are coming.
+
 ## Community Addons
 
 You need to install these addons directly from NPM in order to use them.


### PR DESCRIPTION
https://github.com/storybooks/storybook-addon-console

## How to test

`git clone https://github.com/storybooks/storybook-addon-console.git`

`yarn && yarn start`

Is this testable with jest or storyshots?

`yarn test`

Does this need a new example in the kitchen sink apps?

- yes

Does this need an update to the documentation?

- [x] add to addon gallery
