### PR TITLE
Add missing regenerator and runtime babel transform pkgs to package.json

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -32,6 +32,8 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.0.0",
     "babel-plugin-react-docgen": "^1.6.0",
+    "babel-plugin-transform-regenerator": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-minify": "^0.2.0",
     "babel-preset-react": "^6.24.1",

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -32,6 +32,8 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.0.0",
     "babel-plugin-react-docgen": "^1.6.0",
+    "babel-plugin-transform-regenerator": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-minify": "^0.2.0",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
app/react/src/server/config/babel.js uses require.resolve on both of
these packages, yet as they are not in the dependencies, they won't be
found unless they are installed alongside storybook itself

Issue: fix #1729

## What I did

I added the missing packages to `package.json`

## How to test

See https://github.com/valscion/storybook-repro-1729/tree/master for the broken case. Run `npm install` with `npm@2.x` version to force an error from these missing dependencies.

Note that this is not a specific issue for npm@2.x — it could happen also should newer npm versions  not install these packages at root level for one reason or another.

A fixed case with this change is here: https://github.com/valscion/storybook-repro-1729/tree/fix-repro