### PR TITLE
Exit with code 1 if `start-storybook --smoke-test` fails

### DIFF
--- a/app/react/src/server/index.js
+++ b/app/react/src/server/index.js
@@ -156,4 +156,9 @@ Promise.all([webpackValid, serverListening])
       process.exit(0);
     }
   })
-  .catch(error => logger.error(error));
+  .catch(error => {
+    logger.error(error);
+    if (program.smokeTest) {
+      process.exit(1);
+    }
+  });

--- a/app/vue/src/server/index.js
+++ b/app/vue/src/server/index.js
@@ -156,4 +156,9 @@ Promise.all([webpackValid, serverListening])
       process.exit(0);
     }
   })
-  .catch(error => logger.error(error));
+  .catch(error => {
+    logger.error(error);
+    if (program.smokeTest) {
+      process.exit(1);
+    }
+  });


### PR DESCRIPTION
Issue: If a compile error happens when running `start-storybook`, it doen't exit so that user is able to fix the error without relaunching the command. This makes smoke tests hang on errors, e.g. https://circleci.com/gh/storybooks/storybook/11910

## How to test
* Make an error in `examples/cra-kitchen-sink/.storybook/config.js`
* run `yarn start --smoke-test`
