### PR TITLE
Support specifying the react-native cli config

### DIFF
--- a/app/react-native/CHANGELOG.md
+++ b/app/react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add support for `--react-native-config` flag that can be used to specify the react-native cli config to use. When specified certain other flags are ignored.
+
 ## v2.3.0
 
 -   Add support for multiple users [#PR132](https://github.com/storybooks/react-native-storybook/pull/132)

--- a/app/react-native/src/bin/storybook-start.js
+++ b/app/react-native/src/bin/storybook-start.js
@@ -17,6 +17,7 @@ program
   .option('-i, --manual-id', 'allow multiple users to work with same storybook')
   .option('--smoke-test', 'Exit after successful start')
   .option('--packager-port <packagerPort>', 'Custom packager port')
+  .option('--react-native-config <reactNativeConfig>', 'React Native config path')
   .parse(process.argv);
 
 const projectDir = path.resolve();
@@ -63,14 +64,20 @@ if (!program.skipPackager) {
   if (program.haul) {
     cliCommand = `node node_modules/.bin/haul start --config ${program.haul} --platform all`;
   }
+
+  // If a react-native config has been supplied we don't pass certain
+  // flags to the RN cli as they would override parts of the config.
+  const configFileSupplied = Boolean(program.reactNativeConfig);
+
   // RN packager
   shelljs.exec(
     [
       cliCommand,
-      `--projectRoots ${projectRoots.join(',')}`,
-      `--root ${projectDir}`,
+      !configFileSupplied && `--projectRoots ${projectRoots.join(',')}`,
+      !configFileSupplied && `--root ${projectDir}`,
       program.resetCache && '--reset-cache',
-      program.packagerPort && `--port=${program.packagerPort}`,
+      program.packagerPort && !configFileSupplied && `--port=${program.packagerPort}`,
+      program.reactNativeConfig && `--config=${program.reactNativeConfig}`,
     ]
       .filter(x => x)
       .join(' '),


### PR DESCRIPTION
## Issue
Previously it was not possible to get sufficient control over the roots
that the react-native CLI would use. Specifically in the case when the
projectDir and configDir are the same, but it's desirable for the
packager to resolve symlinks one level up in the directory hierarchy.

Our specfic case is this. We have a Lerna monorepo where we end up with a symlink that traverse the directory structure one level up for native packages. The method added in #1530 is not sufficient as it only considers the node_modules at `native/node_modules`, but not any of `native/packages/*/node_modules` where the actual symlinks are located. The code is available [here](https://github.com/Skyscanner/backpack)

```
├── native
│   ├── rn-cli.config.js
│   └── storybook
│       ├── addons.js
│       ├── index.android.js
│       ├── index.ios.js
│       └── storybook.js <--- Native config
│   ├── packages
│   │   ├── react-native-bpk-component-button
│   │   │   ├── index.js
│   │   │   ├── package.json
│   │   │   ├── readme.md
│   │   │   ├── rightarrow_360.png
│   │   │   ├── src
│   │   │   ├── node_modules <-- Contains the symlink to `bpk-tokens`
│   │   │   └── stories.js
├── packages
│   ├── bpk-tokens <-- Package that we symlink via lerna in native packages
```

## What I did

I've added a new flag to `storybook-start.js`, `--react-native-config` which is the path to a react native CLI config. When specified it will be passed to the react native cli start invocation. It also disables certain other flags passed such as `--projectRoots` and `--root` as these will otherwise override what's specified in the config.

For our codebase this means we've gone frome 

```
Looking for JS files in
   /path/to/project/native/storybook
   /path/to/project/native
   /path/to/project/native
```
to

```
Looking for JS files in
   /path/to/project/native
   /path/to/project
```

using the following `rn-cli.config.js`

```
const path = require('path');

const config = {
  getProjectRoots() {
    return [path.resolve(__dirname), path.resolve(__dirname, '..')];
  },
};

module.exports = config;
```

## How to test

Is this testable with jest or storyshots?

The rest of `storybook-start.js` is not covered by test so I have not added any, but I'm happy to do so.

Does this need a new example in the kitchen sink apps?
No idea

Does this need an update to the documentation?
Yes most likely the behaviour around the `--react-native-config` flag needds to be documented.

If your answer is yes to any of these, please make sure to include it in your PR.
I'll do this given you are okay with this approach


Thanks for an awesome project 🎉 