### PR TITLE
Add two additional CLI commands to storybook CLI

### DIFF
--- a/app/react-native/src/bin/storybook-start.js
+++ b/app/react-native/src/bin/storybook-start.js
@@ -17,6 +17,8 @@ program
   .option('-i, --manual-id', 'allow multiple users to work with same storybook')
   .option('--smoke-test', 'Exit after successful start')
   .option('--packager-port <packagerPort>', 'Custom packager port')
+  .option('--root [root]', 'Add additional root(s) to be used by the packager in this project')
+  .option('--projectRoots [projectRoots]', 'Override the root(s) to be used by the packager')
   .parse(process.argv);
 
 const projectDir = path.resolve();
@@ -48,6 +50,12 @@ server.listen(...listenAddr, err => {
 if (!program.skipPackager) {
   let symlinks = [];
 
+  let roots = [projectDir];
+
+  if (program.root) {
+    roots = roots.concat(program.root.split(',').map(root => path.resolve(root)));
+  }
+
   try {
     const findSymlinksPaths = require('react-native/local-cli/util/findSymlinksPaths'); // eslint-disable-line global-require
     symlinks = findSymlinksPaths(path.join(projectDir, 'node_modules'), [projectDir]);
@@ -55,9 +63,15 @@ if (!program.skipPackager) {
     console.warn(`Unable to load findSymlinksPaths: ${e.message}`);
   }
 
-  const projectRoots = (configDir === projectDir ? [configDir] : [configDir, projectDir]).concat(
+  let projectRoots = (configDir === projectDir ? [configDir] : [configDir, projectDir]).concat(
     symlinks
   );
+
+  if (program.projectRoots) {
+    projectRoots = projectRoots.concat(
+      program.projectRoots.split(',').map(root => path.resolve(root))
+    );
+  }
 
   let cliCommand = 'node node_modules/react-native/local-cli/cli.js start';
   if (program.haul) {
@@ -68,7 +82,7 @@ if (!program.skipPackager) {
     [
       cliCommand,
       `--projectRoots ${projectRoots.join(',')}`,
-      `--root ${projectDir}`,
+      `--root ${roots.join(',')}`,
       program.resetCache && '--reset-cache',
       program.packagerPort && `--port=${program.packagerPort}`,
     ]


### PR DESCRIPTION
Issue: #1804 

## What I did

Added a passthrough for two pretty essential arguments to the react-native packager

## How to test

Add a `--root <ABSOLUTE OR RELATIVE PATH>` and a `--projectRoots <ABSOLUTE OR RELATIVE PATH>` to the storybook start command in a react-native project and ensure the paths show up in the packager window.

### Is this testable with jest or storyshots?

I didn't see any tests around this CLI tool

### Does this need a new example in the kitchen sink apps?

I do not believe so. Probably just some documentation.

### Does this need an update to the documentation?

I couldn't find a good spot in the docs for this to go on first pass. I will be sure to update documentation once I know the best place to put this information

NOTE: A very similar PR was opened #1861. I believe both of these could live happily together as #1861 allows you to specify an entire config and this one specifically lets you append to `--root` and `--projectRoots`
