### PR TITLE
Log correct url when using --https

### DIFF
--- a/app/react/src/server/index.js
+++ b/app/react/src/server/index.js
@@ -152,7 +152,8 @@ server.listen(...listenAddr, error => {
 
 Promise.all([webpackValid, serverListening])
   .then(() => {
-    const address = `http://${program.host || 'localhost'}:${program.port}/`;
+    const proto = program.https ? 'https' : 'http';
+    const address = `${proto}://${program.host || 'localhost'}:${program.port}/`;
     logger.info(`Storybook started on => ${chalk.cyan(address)}\n`);
     if (program.smokeTest) {
       process.exit(0);

--- a/app/vue/src/server/index.js
+++ b/app/vue/src/server/index.js
@@ -152,7 +152,8 @@ server.listen(...listenAddr, error => {
 
 Promise.all([webpackValid, serverListening])
   .then(() => {
-    const address = `http://${program.host || 'localhost'}:${program.port}/`;
+    const proto = program.https ? 'https' : 'http';
+    const address = `${proto}://${program.host || 'localhost'}:${program.port}/`;
     logger.info(`Storybook started on => ${chalk.cyan(address)}\n`);
     if (program.smokeTest) {
       process.exit(0);


### PR DESCRIPTION
Issue: Storybook always logs http addresses. This is incorrect when the `--https` flag is passed.

## What I did
Update the log statement to check for the https flag.

## How to test
Start storybook in both http and https modes and verify the correct urls are logged