### PR TITLE
Circular json can possibly hang 

### DIFF
--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@storybook/addons": "^3.2.6",
     "deep-equal": "^1.0.1",
-    "json-stringify-safe": "^5.0.1",
     "prop-types": "^15.5.10",
     "react-inspector": "^2.1.1",
     "uuid": "^3.1.0"

--- a/addons/actions/src/preview.js
+++ b/addons/actions/src/preview.js
@@ -1,21 +1,14 @@
 /* eslint-disable no-underscore-dangle */
 
 import addons from '@storybook/addons';
-import stringify from 'json-stringify-safe';
+import { format } from 'util';
 import uuid from 'uuid/v1';
 import { EVENT_ID } from './';
-
-function _format(arg) {
-  if (arg && typeof arg.preventDefault !== 'undefined') {
-    return stringify('[SyntheticEvent]');
-  }
-  return stringify(arg);
-}
 
 export function action(name) {
   // eslint-disable-next-line no-unused-vars, func-names
   const handler = function(..._args) {
-    const args = Array.from(_args).map(_format);
+    const args = Array.from(_args).map(format);
     const channel = addons.getChannel();
     const id = uuid();
     channel.emit(EVENT_ID, {

--- a/addons/actions/src/preview.test.js
+++ b/addons/actions/src/preview.test.js
@@ -23,5 +23,10 @@ describe('preview', () => {
       expect(channel.emit.mock.calls[0][1].id).toBe('42');
       expect(channel.emit.mock.calls[1][1].id).toBe('24');
     });
+    it('should be able to stringify recursive object without hanging', () => {
+      const fn = action('foo');
+
+      fn(process);
+    });
   });
 });


### PR DESCRIPTION
Replaced `json-stringify-safe` with `util.format` from node.js in order not to hang action storybooks when objects with circular references are being serialized..

I've added a simple test which causes a timeout in the current situation.