### PR TITLE
Fix faq page title

### DIFF
--- a/docs/pages/basics/faq/index.md
+++ b/docs/pages/basics/faq/index.md
@@ -1,8 +1,7 @@
-* * *
-
+---
 id: 'faq'
-
-## title: 'Frequently Asked Questions'
+title: 'Frequently Asked Questions'
+---
 
 Here are some answers to frequently asked questions. If you have a question, you can ask it by opening an issue on the [Storybook Repository](https://github.com/storybooks/storybook/).
 


### PR DESCRIPTION
The markdown meta information for the [FAQ page](https://storybook.js.org/basics/faq/) wasn't formatted properly. I updated to match the other pages.

Currently, the html title of the page is `undefined` and the page looks like this.
![screen shot 2017-09-22 at 2 04 42 pm](https://user-images.githubusercontent.com/329222/30764338-44f8a34c-9f9f-11e7-89c5-49e5a046ed76.png)
