### PR TITLE
Update github link

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -2,7 +2,7 @@
   "name": "@storybook/react",
   "version": "3.2.10",
   "description": "Storybook for React: Develop React Component in isolation with Hot Reloading.",
-  "homepage": "https://github.com/storybooks/storybook/tree/master/apps/react",
+  "homepage": "https://github.com/storybooks/storybook/tree/master/app/react",
   "bugs": {
     "url": "https://github.com/storybooks/storybook/issues"
   },


### PR DESCRIPTION
This is broken in `yarn outdated`

Issue:

## What I did
Update link to github

## How to test
run `yarn outdated` and click link of outdated package
