### PR TITLE
Improve documentation for react-native : clarify where left pane is

### DIFF
--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -60,7 +60,7 @@ Now, you can open <http://localhost:7007> to view your storybook menus in the br
 
 ## Start App
 
-To see your Storybook stories on the device, you should start your mobile app for the `<platform>` of your choice (typically `ios` or `android`). (Note that due to an implementation detail, your stories will only show up in the left-pane after your device has connected to this storybook server.)
+To see your Storybook stories on the device, you should start your mobile app for the `<platform>` of your choice (typically `ios` or `android`). (Note that due to an implementation detail, your stories will only show up in the left pane of your browser window after your device has connected to this storybook server.)
 
 For CRNA apps:
 


### PR DESCRIPTION
I thought at first the left pane would be somewhere in my app, but this is referring to a left pane in the web browser.

Issue:

## What I did

## How to test

Is this testable with jest or storyshots?

Does this need a new example in the kitchen sink apps?

Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
