### PR TITLE
Drop "Install latest yarn version" step on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ jobs:
             - dependencies-{{ checksum "yarn.lock" }}
             - dependencies-
       - run:
-          name: "Install latest yarn version"
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s
-      - run:
           name: "Install dependencies"
           command: |
             yarn install
@@ -46,10 +42,6 @@ jobs:
           keys:
             - dependencies-{{ checksum "yarn.lock" }}
             - dependencies-
-      - run:
-          name: "Install latest yarn version"
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s
       - run:
           name: "Install dependencies"
           command: |
@@ -79,10 +71,6 @@ jobs:
             - dependencies-{{ checksum "yarn.lock" }}
             - dependencies-
       - run:
-          name: "Install latest yarn version"
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s
-      - run:
           name: "Install dependencies"
           command: |
             yarn install
@@ -109,10 +97,6 @@ jobs:
             - dependencies-{{ checksum "yarn.lock" }}
             - dependencies-
       - run:
-          name: "Install latest yarn version"
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s
-      - run:
           name: "Install dependencies"
           command: |
             yarn install
@@ -133,10 +117,6 @@ jobs:
             - dependencies-{{ checksum "yarn.lock" }}
             - dependencies-
       - run:
-          name: "Install latest yarn version"
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s
-      - run:
           name: "Install dependencies"
           command: |
             yarn install
@@ -152,10 +132,6 @@ jobs:
           keys:
             - dependencies-{{ checksum "yarn.lock" }}
             - dependencies-
-      - run:
-          name: "Install latest yarn version"
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s
       - run:
           name: "Install dependencies"
           command: |
@@ -182,10 +158,6 @@ jobs:
             - dependencies-{{ checksum "yarn.lock" }}
             - dependencies-
       - run:
-          name: "Install latest yarn version"
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s
-      - run:
           name: "Install dependencies"
           command: |
             yarn install
@@ -209,10 +181,6 @@ jobs:
           keys:
             - dependencies-{{ checksum "yarn.lock" }}
             - dependencies-
-      - run:
-          name: "Install latest yarn version"
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s
       - run:
           name: "Install dependencies"
           command: |


### PR DESCRIPTION
It's now part of official node docker image
