### PR TITLE
Add polyfills to fix addon-actions in IE11

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -45,6 +45,7 @@
     "commander": "^2.11.0",
     "common-tags": "^1.4.0",
     "configstore": "^3.1.0",
+    "core-js": "^2.5.1",
     "css-loader": "^0.28.1",
     "express": "^4.15.3",
     "file-loader": "^0.11.1",

--- a/app/react/src/server/config/polyfills.js
+++ b/app/react/src/server/config/polyfills.js
@@ -1,1 +1,3 @@
-require('airbnb-js-shims');
+import 'core-js/es6/symbol';
+import 'core-js/fn/array/iterator';
+import 'airbnb-js-shims';

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -45,6 +45,7 @@
     "commander": "^2.11.0",
     "common-tags": "^1.4.0",
     "configstore": "^3.1.0",
+    "core-js": "^2.5.1",
     "css-loader": "^0.28.1",
     "express": "^4.15.3",
     "file-loader": "^0.11.1",

--- a/app/vue/src/server/config/polyfills.js
+++ b/app/vue/src/server/config/polyfills.js
@@ -1,1 +1,3 @@
-require('airbnb-js-shims');
+import 'core-js/es6/symbol';
+import 'core-js/fn/array/iterator';
+import 'airbnb-js-shims';


### PR DESCRIPTION
This is needed because `react-inspector` uses `Symbol` and `Array#@@iterator`

## How to test

Open `cra-kitchen-sink` in IE11, navigate to `Button/with text`, press the button.