### PR TITLE
Gracefully handle fatal webpack errors.

### DIFF
--- a/app/react/src/server/build.js
+++ b/app/react/src/server/build.js
@@ -83,7 +83,7 @@ webpack(config).run((err, stats) => {
     // eslint-disable-next-line no-unused-expressions
     err && logger.error(err.message);
     // eslint-disable-next-line no-unused-expressions
-    stats.hasErrors() && stats.toJson().errors.forEach(e => logger.error(e));
+    stats && stats.hasErrors() && stats.toJson().errors.forEach(e => logger.error(e));
     process.exit(1);
   }
 


### PR DESCRIPTION
Issue:

When a fatal webpack error occurs (e.g. wrong configuration) storybook's error handler incorrectly assumes that the `stats` object is provided by webpack. See https://webpack.js.org/api/node/#error-handling for details on error handling.

The effect is the callback throwing an exception at https://github.com/storybooks/storybook/blob/master/app/react/src/server/build.js#L86, with a message to the effect of 'undefined has no property `hasErrors`'.

This is a problem because some webpack loaders will run timers or open sockets that prevent the node process from exiting, and when the callback throws an error before reaching the `process.exit(1);` code which would kill it.

There have been cases where in continuous integration environments the build will run indefinitely (which is a problem when you pay per-second).

## What I did

Added a simple check to ensure `stats` is passed, before using it.

## How to test

Create a webpack configuration that causes a fatal error, and run storybook.