### PR TITLE
Contributing guide: fix invalid storybook start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ yarn bootstrap --core
 cd examples/cra-kitchen-sink
 
 # make changes to try and reproduce the problem, such as adding components + stories
-yarn start storybook
+yarn storybook
 
 # see if you can see the problem, if so, commit it:
 git checkout "branch-describing-issue"


### PR DESCRIPTION
`yarn start storybook` does not exist, it is `yarn storybook` *or* `yarn start`