### PR TITLE
Fix/suppress current eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,10 +31,9 @@ module.exports = {
     'class-methods-use-this': ignore,
     'arrow-parens': [warn, 'as-needed'],
     'space-before-function-paren': ignore,
-    'import/no-unresolved': warn,
+    'import/no-unresolved': error,
     'import/extensions': [
-      // because of highlight.js and fuse.js
-      warn,
+      error,
       {
         js: 'never',
         json: 'always',

--- a/addons/actions/src/preview.test.js
+++ b/addons/actions/src/preview.test.js
@@ -9,7 +9,7 @@ describe('preview', () => {
   describe('action()', () => {
     it('should use a uuid for action ids', () => {
       const channel = { emit: jest.fn() };
-      const uuidGenerator = (function*() {
+      const uuidGenerator = (function* uuidGenerator() {
         yield '42';
         yield '24';
       })();

--- a/addons/graphql/demo/.eslintrc.js
+++ b/addons/graphql/demo/.eslintrc.js
@@ -1,0 +1,7 @@
+const ignore = 0;
+
+module.exports = {
+  rules: {
+    'import/no-unresolved': ignore,
+  },
+};

--- a/addons/graphql/demo/index.js
+++ b/addons/graphql/demo/index.js
@@ -49,4 +49,5 @@ express()
   .use('/graphql', graphqlHTTP({ schema, pretty: true }))
   .listen(3000);
 
+// eslint-disable-next-line no-console
 console.log('GraphQL server running on http://localhost:3000/graphql');

--- a/addons/notes/src/register.js
+++ b/addons/notes/src/register.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React from 'react';
 import PropTypes from 'prop-types';
 import addons from '@storybook/addons';

--- a/app/react-native/src/bin/storybook-start.js
+++ b/app/react-native/src/bin/storybook-start.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 
 import path from 'path';
 import program from 'commander';
@@ -41,7 +42,7 @@ server.listen(...listenAddr, err => {
     throw err;
   }
   const address = `http://${program.host || 'localhost'}:${program.port}/`;
-  console.info(`\nReact Native Storybook started on => ${address}\n`); // eslint-disable-line no-console
+  console.info(`\nReact Native Storybook started on => ${address}\n`);
   if (program.smokeTest) {
     process.exit(0);
   }

--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -1,5 +1,18 @@
+const warn = 1;
+
 module.exports = {
   settings: {
     'import/core-modules': ['config'],
+  },
+  rules: {
+    'import/no-unresolved': warn,
+    'import/extensions': [
+      // because of highlight.js
+      warn,
+      {
+        js: 'never',
+        json: 'always',
+      },
+    ],
   },
 };

--- a/docs/components/Highlight.js
+++ b/docs/components/Highlight.js
@@ -23,6 +23,7 @@ class Highlight extends React.Component {
 
   render() {
     const { children } = this.props;
+    // eslint-disable-next-line react/no-danger
     return <div dangerouslySetInnerHTML={{ __html: children }} />;
   }
 }

--- a/docs/html.js
+++ b/docs/html.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React from 'react';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';

--- a/docs/wrappers/md.jsx
+++ b/docs/wrappers/md.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React from 'react';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';

--- a/examples/crna-kitchen-sink/.eslintrc.js
+++ b/examples/crna-kitchen-sink/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['plugin:import/react-native'],
+};

--- a/examples/react-native-vanilla/.eslintrc.js
+++ b/examples/react-native-vanilla/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['plugin:import/react-native'],
+};

--- a/lib/ui/example/server.js
+++ b/lib/ui/example/server.js
@@ -9,5 +9,6 @@ new WebpackDevServer(webpack(config), {
 }).listen(
   9999,
   'localhost',
+  // eslint-disable-next-line no-console
   err => (err ? console.log(err) : console.log('Listening at http://localhost:9999/'))
 );

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -28,4 +28,5 @@ if (code !== 0) {
 const licence = path.join(__dirname, '..', 'LICENSE');
 shell.cp(licence, './');
 
+// eslint-disable-next-line no-console
 console.log(chalk.gray(`Built: ${chalk.bold(`${packageJson.name}@${packageJson.version}`)}`));


### PR DESCRIPTION
This also raises `import/no-unresolved` and `import/extensions` to error level
everywhere except `docs`.

I didn't touch the warning about lacking tests for `addons/notes` so that it keeps reminding that they still have to be written.

It would be nice if we could find a way to know if some new warnings are introduced with a PR (like it's done with code coverage). Does anyone know how to get this metric from CircleCI?
