### PR TITLE
Fix sidebar header wrapping

### DIFF
--- a/lib/ui/src/modules/ui/components/left_panel/header.js
+++ b/lib/ui/src/modules/ui/components/left_panel/header.js
@@ -6,7 +6,6 @@ const wrapperStyle = {
   background: '#F7F7F7',
   marginBottom: 10,
   display: 'flex',
-  height: 27,
 };
 
 const headingStyle = {
@@ -16,8 +15,9 @@ const headingStyle = {
   fontSize: '12px',
   fontWeight: 'bolder',
   color: '#828282',
+  textAlign: 'center',
   cursor: 'pointer',
-  padding: 0,
+  padding: '5px',
   margin: 0,
   overflow: 'hidden',
 };
@@ -37,6 +37,7 @@ const shortcutIconStyle = {
   backgroundColor: 'inherit',
   outline: 0,
   width: 30,
+  flexShrink: 0,
 };
 
 const linkStyle = {


### PR DESCRIPTION
Issue: #1961

## What I did
This partially reverts changes from #1769 while keeping the height alignment itself

## How to test
Open `cra-kitchen-sink` and resize stories panel

![image](https://user-images.githubusercontent.com/6651625/31193259-4643c4b4-a94c-11e7-9330-c11c3237ad4e.png)
