### PR TITLE
Disable npm publish on all non-master branches

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,8 @@
       "ignore": [
         "cra-kitchen-sink",
         "vue-example"
-      ]
+      ],
+      "allowBranch": "master"
     }
   },
   "concurrency": 1,


### PR DESCRIPTION
Issue: N/A

## What I did

Use Lerna's new `allowBranch` feature to disable publishing on non-master banches  to prevent mistakes

https://github.com/lerna/lerna/pull/1026/

## How to test

Run the following on a non-master branch:

```
yarn lerna publish --skip-git --skip-npm --npm-tag=block
```
