### PR TITLE
generate valid jsx when previewing arrays and objects in info addon

### DIFF
--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -44,11 +44,11 @@ function previewArray(val, maxPropArrayLength) {
     items[`c${i}`] = ', ';
   });
   if (val.length > maxPropArrayLength) {
-    items.last = '…';
+    items.last = "\'…\'";
   } else {
     delete items[`c${val.length - 1}`];
   }
-  return <span style={valueStyles.array}>[{createFragment(items)}]</span>;
+  return <span style={valueStyles.array}>{'{'}[{createFragment(items)}]{'}'}</span>;
 }
 
 function previewObject(val, maxPropObjectKeys) {
@@ -67,9 +67,9 @@ function previewObject(val, maxPropObjectKeys) {
   }
   return (
     <span style={valueStyles.object}>
-      {'{'}
+      {'{{'}
       {createFragment(items)}
-      {'}'}
+      {'}}'}
     </span>
   );
 }


### PR DESCRIPTION
Issue:
In the Story Source section of Info addon JSX is not generated correctly:

example:

```jsx
<UIRadio
  options=["Mr.", "Mrs.", "Ms."]
/>
```

or

```jsx
<UILabel
  title="Foo"
  style={ color: '#eee' }
/>
```

You cannot just copy and paste that code, because options array (or style object) needs curly braces around it.

## What I did

I fixed that issue, valid JSX is generated.

## How to test

Is this testable with jest or storyshots?
Don't know

Does this need a new example in the kitchen sink apps?
Don't think so

Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.
