### PR TITLE
Dirty-check repo state on CI to ensure lockfiles being up-to-date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,10 @@ jobs:
           name: "Bootstrapping"
           command: |
             yarn bootstrap --core --docs --reactnative --reactnativeapp
+      - run:
+          name: "Dirty checking"
+          command: |
+            yarn repo-dirty-check
       - save_cache:
           key: dependencies-{{ checksum "yarn.lock" }}
           paths:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint:js": "eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.json",
     "lint:md": "remark",
     "publish": "lerna publish",
-    "test": "jest --projects ./ ./examples/react-native-vanilla"
+    "test": "jest --projects ./ ./examples/react-native-vanilla",
+    "repo-dirty-check": "node ./scripts/repo-dirty-check"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/scripts/repo-dirty-check.js
+++ b/scripts/repo-dirty-check.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-console */
+const shell = require('shelljs');
+
+// exit with code 1 if there are some changed files
+if (shell.exec('git status --porcelain').stdout.trim() !== '') {
+  console.error(
+    'Git repo is dirty, please consider updating lockfiles by running `yarn bootstrap --core --docs`'
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
This is, among other things, crucial for correct work of dependencies.io