### PR TITLE
Add state addon to the addons page

### DIFF
--- a/docs/pages/addons/addon-gallery/index.md
+++ b/docs/pages/addons/addon-gallery/index.md
@@ -113,3 +113,7 @@ Save the screenshot image of your stories. via [Puppeteer](https://github.com/Go
 ### [Figma](https://github.com/hharnisc/storybook-addon-figma)
 
 Embed [Figma](https://figma.com) designs in a storybook panel.
+
+### [State](https://github.com/Sambego/storybook-state)
+
+Manage state inside a story. Update components when this state changes.


### PR DESCRIPTION
### Added
- An [addon](https://github.com/Sambego/storybook-state) to manage state inside a story and update components when this state changes.