### PR TITLE
Vue: add support for using Nuxt.js in dependencies section 

### DIFF
--- a/lib/cli/lib/detect.js
+++ b/lib/cli/lib/detect.js
@@ -40,6 +40,7 @@ module.exports = function detect(options) {
   if (
     (packageJson.dependencies && packageJson.dependencies.vue) ||
     (packageJson.devDependencies && packageJson.devDependencies.vue) ||
+    (packageJson.dependencies && packageJson.dependencies.nuxt) ||
     (packageJson.devDependencies && packageJson.devDependencies.nuxt)
   ) {
     return types.VUE;


### PR DESCRIPTION
Issue: none
Related Pull-Requests: https://github.com/storybooks/storybook/pull/1794

## What I did
In my case, `getstorybook` command is failed when nuxt.js  saved to "dependencies" in package.json.

So, I added  "dependencies" checking in delect.js.

## How to test

Is this testable with jest or storyshots?
No

Does this need a new example in the kitchen sink apps?
No

Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.

