### PR TITLE
Tweak display of function props in story source to better reflect actual markup

### DIFF
--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -93,7 +93,7 @@ export default function PropVal(props) {
   } else if (Array.isArray(val)) {
     content = previewArray(val, maxPropArrayLength);
   } else if (typeof val === 'function') {
-    content = <span style={valueStyles.func}>{val.name ? `${val.name}()` : 'anonymous()'}</span>;
+    content = <span style={valueStyles.func}>{val.name ? val.name : 'anonymousFunction'}</span>;
   } else if (!val) {
     content = <span style={valueStyles.empty}>{`${val}`}</span>;
   } else if (typeof val !== 'object') {


### PR DESCRIPTION
Issue: displayed story source did not reflect actual usage for function props. Current version shows `someProp={myCallback()}` or `someProp={anonymous()}`, which, while it indicates that it is a function, implies that the function is called and the result used as the prop to anyone reading it as JSX.

## What I did

Tweaked output to now display `someProp={myCallback}` or `someProp={anonymousFunction}`. This is still very distinct from any other type:

- bool: `someProp`
- string: `someProp="foo"`
- number: `someProp={3}`
- object: `someProp={{foo: "foo"}}`
- component/element: `someProp={<Foo />}`
- array: `someProp={["foo", "bar"]}`

## How to test

Is this testable with jest or storyshots? **Yes**, but neither appear to be used within the `addon/info` directory. The result of running `npm test` within `examples/cra-kitchen-sink` indicated two unrelated storyshot changes, and not the one I would expect, so I suspect it has not been maintained correctly for use with the info addon. I'm not much of a storyshotter, so happy to follow any guidance on this.

Does this need a new example in the kitchen sink apps? **No**

Does this need an update to the documentation? **Yes**, specifically `addons/info/docs/home-screenshot.png`. I do not have access to a Macbook to generate an accurate screenshot, however.

If your answer is yes to any of these, please make sure to include it in your PR.
