### PR TITLE
Fix info upgrade codemod failing when optional description string is not supplied

### DIFF
--- a/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.input.js
+++ b/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.input.js
@@ -195,5 +195,4 @@ storiesOf('shared/ProgressBar', module)
     <ProgressBar progress={number('progress', 25)}
       delay={number('delay', 500)}
     />
-
   ));

--- a/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.input.js
+++ b/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.input.js
@@ -188,3 +188,12 @@ storiesOf('Button').addWithInfo(
     }
   }
 )
+
+storiesOf('shared/ProgressBar', module)
+  .addDecorator(withKnobs)
+  .addWithInfo('default style', () => (
+    <ProgressBar progress={number('progress', 25)}
+      delay={number('delay', 500)}
+    />
+
+  ));

--- a/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.output.js
+++ b/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.output.js
@@ -184,3 +184,11 @@ storiesOf('Button').add('with custom styles', withInfo({
     return stylesheet
   }
 })(() => <Button label="The Button" onClick={action('onClick')} />))
+
+storiesOf('shared/ProgressBar', module)
+  .addDecorator(withKnobs)
+  .add('default style', withInfo('default style')(() => (
+    <ProgressBar progress={number('progress', 25)}
+      delay={number('delay', 500)}
+    />
+  )));

--- a/lib/codemod/src/transforms/update-addon-info.js
+++ b/lib/codemod/src/transforms/update-addon-info.js
@@ -66,10 +66,9 @@ export default function transformer(file, api) {
     node.callee.property.name = 'add';
     node.arguments = [
       args[0],
-      j.callExpression(
-        j.callExpression(j.identifier('withInfo'), getOptions(args)),
-        storyComponent
-      ),
+      j.callExpression(j.callExpression(j.identifier('withInfo'), getOptions(args)), [
+        storyComponent,
+      ]),
     ];
 
     return node;

--- a/lib/codemod/src/transforms/update-addon-info.js
+++ b/lib/codemod/src/transforms/update-addon-info.js
@@ -36,6 +36,10 @@ export default function transformer(file, api) {
    */
   const getOptions = args => {
     if (args[3] === undefined) {
+      if (args[2] === undefined) {
+        // when the optional description string is not supplied for addWithInfo, just use story name
+        return [args[0]];
+      }
       return [args[1]];
     }
     return [
@@ -56,10 +60,16 @@ export default function transformer(file, api) {
     const node = addWithInfoExpression.node;
     const args = node.arguments;
 
+    // if optional description string is not supplied, the story component becomes second arg
+    const storyComponent = args[2] ? args[2] : args[1];
+
     node.callee.property.name = 'add';
     node.arguments = [
       args[0],
-      j.callExpression(j.callExpression(j.identifier('withInfo'), getOptions(args)), [args[2]]),
+      j.callExpression(
+        j.callExpression(j.identifier('withInfo'), getOptions(args)),
+        storyComponent
+      ),
     ];
 
     return node;


### PR DESCRIPTION
Issue:

#2132

## What I did

Added a check

## How to test

Is this testable with jest or storyshots?
yes

Does this need a new example in the kitchen sink apps?
no

Does this need an update to the documentation?
no

If your answer is yes to any of these, please make sure to include it in your PR.
