### PR TITLE
ADD integration artefacts store step to circle.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,9 @@ jobs:
       - run:
           name: Integration Test - Kichen sinks
           command: yarn test --integration
+      - store_artifacts:
+          path: integration/__image_snapshots__
+          destination: integration_image_snapshots
   example-react-native:
     <<: *defaults
     steps:


### PR DESCRIPTION
Issue: -if the integration step failed on CI, locally passes, it's hard to debug-

## What I did
Added a step to the integration task to store screenshots as artefacts 

## How to test
Run the CI
Check if CI stored images