### PR TITLE
bot for closing old issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 55
+daysUntilStale: 85
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 5
 # Issues with these labels will never be considered stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,15 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 45
+daysUntilStale: 55
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 45
+daysUntilClose: 5
 # Issues with these labels will never be considered stale
 exemptLabels:
   - bug
   - 'help wanted'
+  - 'in progress'
+  - 'do not merge'
+  - 'needs review'
+
 # Label to use when marking an issue as stale
 staleLabel: inactive
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 45
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 45
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - bug
+  - 'help wanted'
+# Label to use when marking an issue as stale
+staleLabel: inactive
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  Hi everyone! Seems like there hasn't been much going on in this issue lately.
+  If there are still questions, comments, or bugs, please feel free to continue
+  the discussion. We do try to do some housekeeping every once in a while so
+  inactive issues will get closed after 90 days. Thanks!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Hey there, it's me again! I am going to help our maintainers close this issue
+  so they can focus on development efforts instead. If the issue mentioned is
+  still a concern, please open a new ticket and mention this old one. Cheers
+  and thanks for using Storybook!


### PR DESCRIPTION
Issue:

#1138
As discussed in our roadmap meetings, the number of issues we get is getting out of hand and manually closing stale issues is very time consuming. I hope this bot will help us out.

## What I did

This is a bot from https://probot.github.io/apps/stale/ 

The config I have here is a bit more conservative in my opinion. 45 days for a stale message and another 45 days until issue close. We can also add labels that are excluded from automatically getting closed.

Any opinions?

## How to test

Is this testable with jest or storyshots?
no
Does this need a new example in the kitchen sink apps?
no
Does this need an update to the documentation?
maybe? should the 90 days be documented?
If your answer is yes to any of these, please make sure to include it in your PR.
