### PR TITLE
CLI test: always remove `run` directory before exiting

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -22,9 +22,7 @@
   },
   "scripts": {
     "test-latest-cra": "cd test && ./test_latest_cra.sh",
-    "posttest-latest-cra": "yarn posttest",
-    "test": "cd test && ./run_tests.sh",
-    "posttest": "rm -rfd test/run"
+    "test": "cd test && ./run_tests.sh"
   },
   "dependencies": {
     "@storybook/codemod": "^3.3.0-alpha.2",

--- a/lib/cli/test/run_tests.sh
+++ b/lib/cli/test/run_tests.sh
@@ -3,6 +3,14 @@
 # exit on error
 set -e
 
+declare test_root=$PWD
+
+# remove run directory before exit to prevent yarn.lock spoiling
+function cleanup {
+  rm -rfd ${test_root}/run
+}
+trap cleanup EXIT
+
 update=0
 skip=0
 fixtures_dir='fixtures'
@@ -65,9 +73,9 @@ if [ $update -eq 1 ]
   fi
 
 # install all the dependencies in a single run
-cd ..
+cd ../../..
 yarn --pure-lockfile
-cd test/run
+cd ${test_root}/run
 
 for dir in *
 do


### PR DESCRIPTION
Issue: `posttest` script runs only when `test` is successful, so there is `run` directory left after a CLI test failure. It's a part of workspaces (because we want to use linked packages in smoke tests), so if you run `yarn` at some point later, this leads to an unintended change in lockfile.

Here I use `trap` command to intercept `EXIT` signal and run cleanup command while preserving the exit code
