### PR TITLE
Disable eslint rules for click-events-have-key-events

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,6 +75,7 @@ module.exports = {
     'jsx-a11y/href-no-hash': ignore,
     'jsx-a11y/label-has-for': ignore,
     'jsx-a11y/anchor-is-valid': [warn, { aspects: ['invalidHref'] }],
+    'jsx-a11y/click-events-have-key-events': ignore,
     'react/no-unescaped-entities': ignore,
   },
 };


### PR DESCRIPTION
Issue: https://www.codefactor.io/repository/github/storybooks/storybook/file/master/addons/info/src/components/Story.js

## What I did
configure eslint to allow onClick handles without a keyboard handler.