### PR TITLE
#2209 knobs refactor accidentally removed select

### DIFF
--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -5,9 +5,21 @@ import addons from '@storybook/addons';
 import { vueHandler } from './vue';
 import { reactHandler } from './react';
 
-import { knob, text, boolean, number, color, object, array, date, button, manager } from './base';
+import {
+  array,
+  boolean,
+  button,
+  color,
+  date,
+  knob,
+  manager,
+  number,
+  object,
+  select,
+  text,
+} from './base';
 
-export { knob, text, boolean, number, color, object, array, date, button };
+export { knob, text, boolean, number, color, object, array, date, button, select };
 
 deprecate(() => {},
 'Using @storybook/addon-knobs directly is discouraged, please use @storybook/addon-knobs/{{framework}}');


### PR DESCRIPTION
Issue:

select got accidentally removed somewhere in the refactor #2209 

## What I did

added it back

## How to test

Is this testable with jest or storyshots?

Does this need a new example in the kitchen sink apps?

Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
