### PR TITLE
Fix Array Knob deserialization

### DIFF
--- a/addons/knobs/src/components/__tests__/Array.js
+++ b/addons/knobs/src/components/__tests__/Array.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme'; // eslint-disable-line
-import Array from '../types/Array';
+import ArrayType from '../types/Array';
 
 describe('Array', () => {
   it('should subscribe to setKnobs event of channel', () => {
     const onChange = jest.fn();
     const wrapper = shallow(
-      <Array
+      <ArrayType
         onChange={onChange}
         knob={{ name: 'passions', value: ['Fishing', 'Skiing'], separator: ',' }}
       />

--- a/addons/knobs/src/components/__tests__/Array.js
+++ b/addons/knobs/src/components/__tests__/Array.js
@@ -15,4 +15,21 @@ describe('Array', () => {
     wrapper.simulate('change', { target: { value: 'Fhishing,Skiing,Dancing' } });
     expect(onChange).toHaveBeenCalledWith(['Fhishing', 'Skiing', 'Dancing']);
   });
+
+  it('deserializes an Array to an Array', () => {
+    const array = ['a', 'b', 'c'];
+    const deserialized = ArrayType.deserialize(array);
+
+    expect(Array.isArray(deserialized)).toEqual(true);
+    expect(deserialized).toEqual(['a', 'b', 'c']);
+  });
+
+  it('deserializes an Object to an Array', () => {
+    const object = { 1: 'one', 0: 'zero', 2: 'two' };
+
+    const deserialized = ArrayType.deserialize(object);
+
+    expect(Array.isArray(deserialized)).toEqual(true);
+    expect(deserialized).toEqual(['zero', 'one', 'two']);
+  });
 });

--- a/addons/knobs/src/components/__tests__/Array.js
+++ b/addons/knobs/src/components/__tests__/Array.js
@@ -20,7 +20,6 @@ describe('Array', () => {
     const array = ['a', 'b', 'c'];
     const deserialized = ArrayType.deserialize(array);
 
-    expect(Array.isArray(deserialized)).toEqual(true);
     expect(deserialized).toEqual(['a', 'b', 'c']);
   });
 
@@ -29,7 +28,6 @@ describe('Array', () => {
 
     const deserialized = ArrayType.deserialize(object);
 
-    expect(Array.isArray(deserialized)).toEqual(true);
     expect(deserialized).toEqual(['zero', 'one', 'two']);
   });
 });

--- a/addons/knobs/src/components/types/Array.js
+++ b/addons/knobs/src/components/types/Array.js
@@ -47,6 +47,10 @@ ArrayType.propTypes = {
 };
 
 ArrayType.serialize = value => value;
-ArrayType.deserialize = value => value;
+ArrayType.deserialize = value => {
+  if (Array.isArray(value)) return value;
+
+  return Object.keys(value).reduce((array, key) => [...array, value[key]], []);
+};
 
 export default ArrayType;

--- a/addons/knobs/src/components/types/Array.js
+++ b/addons/knobs/src/components/types/Array.js
@@ -50,7 +50,9 @@ ArrayType.serialize = value => value;
 ArrayType.deserialize = value => {
   if (Array.isArray(value)) return value;
 
-  return Object.keys(value).reduce((array, key) => [...array, value[key]], []);
+  return Object.keys(value)
+    .sort()
+    .reduce((array, key) => [...array, value[key]], []);
 };
 
 export default ArrayType;


### PR DESCRIPTION
Issue: Array Knob data retrieved from the URL is stored as an Object

## What I did
Updated the Array knob's `deserialize` method to handle Objects.

## How to test
Without these changes, if you reload the page with a component using the `array` knob and expecting an Array; you'll get the error
```
warning.js:33 Warning: Failed prop type: Invalid prop `knob.value` of type `object` supplied to `ArrayType`, expected `array`.
```

### Is this testable with jest or storyshots?
Yes; unit tests have been added for Array's `deserialize`.

### Does this need a new example in the kitchen sink apps?
No.

### Does this need an update to the documentation?
No.
