### PR TITLE
return the test in storyshots to respect promises.

### DIFF
--- a/addons/storyshots/src/index.js
+++ b/addons/storyshots/src/index.js
@@ -88,7 +88,7 @@ export default function testStorySnapshots(options = {}) {
 
           it(story.name, () => {
             const context = { kind: group.kind, story: story.name };
-            options.test({ story, context });
+            return options.test({ story, context });
           });
         }
       });


### PR DESCRIPTION
## What I did
Jest will wait for promises to resolve before evaluating a test if you return one. This change allows developers to do async work in their test fn

## How to test
```javascript
initStoryshots({
    test: ({ story, context }) => {
        // In the component that is rendered, do some async task that updates the UI after initial render
        const storyElement = story.render(context);
        const tree = renderer.create(storyElement, {});
        return new Promise(resolve => {
            setTimeout(() => {
                const json = tree.toJSON();
                expect(json).toMatchSnapshot();
                resolve();
            }, 0);
        });
    },
});
```
