### PR TITLE
Remove stale `git-url-parse` dependency

### DIFF
--- a/addons/comments/package.json
+++ b/addons/comments/package.json
@@ -40,7 +40,6 @@
     "@kadira/storybook-deployer": "*",
     "@storybook/addon-actions": "^3.2.14",
     "@storybook/react": "^3.2.14",
-    "git-url-parse": "^6.2.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",

--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -24,7 +24,6 @@
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
-    "git-url-parse": "^6.2.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0"

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@types/node": "^7.0.46",
     "@types/react": "^16.0.19",
-    "git-url-parse": "^6.2.2",
     "raw-loader": "^0.5.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/addons/notes/package.json
+++ b/addons/notes/package.json
@@ -25,7 +25,6 @@
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
-    "git-url-parse": "^6.2.2",
     "react": "^16.0.0",
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4946,7 +4946,7 @@ git-up@^2.0.0:
     is-ssh "^1.3.0"
     parse-url "^1.3.0"
 
-git-url-parse@^6.0.2, git-url-parse@^6.2.2:
+git-url-parse@^6.0.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-6.2.2.tgz#be49024e14b8487553436b4572b8b439532fa871"
   dependencies:


### PR DESCRIPTION
Looks like this package isn't actually used (see https://github.com/storybooks/storybook/issues/2160#issuecomment-340364328)

I checked example apps, and addons seem to work OK

Fixes #2160 in a way =)