### PR TITLE
Fix addon Knobs: add array in Object PropTypes

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -161,7 +161,7 @@ const value = color(label, defaultValue);
 
 ### object
 
-Allows you to get a JSON object from the user.
+Allows you to get a JSON object or array from the user.
 
 ```js
 import { object } from '@storybook/addon-knobs';
@@ -178,7 +178,7 @@ const value = object(label, defaultValue);
 
 ### array
 
-Allows you to get an array from the user.
+Allows you to get an array of strings from the user.
 
 ```js
 import { array } from '@storybook/addon-knobs';

--- a/addons/knobs/src/components/types/Object.js
+++ b/addons/knobs/src/components/types/Object.js
@@ -88,7 +88,7 @@ ObjectType.defaultProps = {
 ObjectType.propTypes = {
   knob: PropTypes.shape({
     name: PropTypes.string,
-    value: PropTypes.object,
+    value: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   }),
   onChange: PropTypes.func,
 };


### PR DESCRIPTION
#### Knobs addon

`value` prop in `object` type of knob now accepts `PropTypes.array`, while only `PropTypes.object` was accepted.

We now avoid warnings when we use arrays of objects in `object` knobs, which actually works perfectly fine.

**Example** working fine but throwing warnings in browser console concerning Proptypes.

```js
const values = object('options', [
  {
    value: 'red',
    title: 'Red',
    condition: '1',
  },
  {
    value: 'blue',
    title: 'Blue',
    condition: '1',
  },
  {
    value: 'yellow',
    title: 'Yellow',
    condition: '1',
  },
  {
    value: 'green',
    title: 'Green',
    condition: '1',
  },
])
```

<img width="392" alt="screen shot 2017-11-03 at 5 17 09 pm" src="https://user-images.githubusercontent.com/4401230/32384356-f54d81e0-c0ba-11e7-99ca-76c5e226420d.png">
