### PR TITLE
Update dependencies.yml to include batch updates for docs dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -29,7 +29,7 @@ collectors:
     bootstrap_command: yarn
   actors:
   # pull requests for updates to our major version
-  - type: js-lerna:0.9.0-beta
+  - type: js-lerna
     versions: "L.Y.Y"
     settings:
       batch_mode: true
@@ -54,6 +54,7 @@ collectors:
   - type: js-npm
     versions: "L.Y.Y"
     settings:
+      batch_mode: true
       github_labels:
       - dependencies:update
       github_assignees:


### PR DESCRIPTION
@Hypnosphi we've added a `batch_mode` to npm, which you can now use on your docs dependencies which I assume is how you were wanting to do it. I also removed the version tag from the js-lerna actor, since we've now made that the default and pushed a few more updates to it.

I noticed that you're now on weekly builds? One thing that I noticed on my fork (and probably happened to you also) is that the batch lerna actor can timeout with so many updates to make. I was trying to think through some ways to speed that up and am wondering if we can use this: https://yarnpkg.com/en/docs/cli/generate-lock-entry The related question I have is: is your dependency workflow now more tied to yarn workspaces than lerna? Does lerna even matter anymore in terms of managing dependencies for this repo?
