### PR TITLE
Remove noise in CI tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
     'app/**/*.{js,jsx}',
     'lib/**/*.{js,jsx}',
     'addons/**/*.{js,jsx}',
+    '!**/cli/test/**',
     '!**/generators/**',
   ],
   coverageDirectory: 'coverage',

--- a/lib/cli/test/fixtures/sfc_vue/.postcssrc.js
+++ b/lib/cli/test/fixtures/sfc_vue/.postcssrc.js
@@ -1,8 +1,0 @@
-// https://github.com/michael-ciniawsky/postcss-load-config
-
-module.exports = {
-  "plugins": {
-    // to edit target browsers: use "browserslist" field in package.json
-    "autoprefixer": {}
-  }
-}

--- a/lib/cli/test/snapshots/sfc_vue/.postcssrc.js
+++ b/lib/cli/test/snapshots/sfc_vue/.postcssrc.js
@@ -1,8 +1,0 @@
-// https://github.com/michael-ciniawsky/postcss-load-config
-
-module.exports = {
-  "plugins": {
-    // to edit target browsers: use "browserslist" field in package.json
-    "autoprefixer": {}
-  }
-}


### PR DESCRIPTION
Issue: [CI unit tests](https://circleci.com/gh/storybooks/storybook/20732?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) on release/3.3 have a lot of `Failed to collect coverage` noise. This PR removes it by ignoring CLI snapshots and fixtures