### PR TITLE
Update inquirer to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "github-release-from-changelog": "^1.2.1",
     "glob": "^7.1.2",
     "husky": "^0.14.3",
-    "inquirer": "^3.2.3",
+    "inquirer": "^4.0.0",
     "jest": "^21.2.0",
     "jest-cli": "^21.2.1",
     "jest-enzyme": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5778,7 +5778,7 @@ inline-style-prefixer@^3.0.6:
     bowser "^1.7.3"
     css-in-js-utils "^2.0.0"
 
-inquirer@3.3.0, inquirer@^3.0.6, inquirer@^3.2.2, inquirer@^3.2.3:
+inquirer@3.3.0, inquirer@^3.0.6, inquirer@^3.2.2:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
@@ -5831,6 +5831,25 @@ inquirer@^0.12.0:
     rx-lite "^3.1.2"
     string-width "^1.0.1"
     strip-ansi "^3.0.0"
+    through "^2.3.6"
+
+inquirer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-4.0.0.tgz#56c6354ae4e6201917027249bbd7667fca2cc031"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
 insert-css@^2.0.0:


### PR DESCRIPTION
Fixes #2296 

The only breaking change is deprecation of node 4, which we don't support anyway