### PR TITLE
Remove packages' devDependencies that duplicate the root ones

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -29,12 +29,6 @@
     "axe-core": "^2.0.7",
     "prop-types": "^15.6.0"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
-    "react-test-renderer": "^16.1.0",
-    "shelljs": "^0.7.8"
-  },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -28,12 +28,6 @@
     "react-inspector": "^2.2.1",
     "uuid": "^3.1.0"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
-    "react-test-renderer": "^16.1.0",
-    "shelljs": "^0.7.8"
-  },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"

--- a/addons/comments/package.json
+++ b/addons/comments/package.json
@@ -39,11 +39,7 @@
     "@kadira/storybook-database-cloud": "*",
     "@kadira/storybook-deployer": "*",
     "@storybook/addon-actions": "^3.2.15",
-    "@storybook/react": "^3.2.15",
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
-    "react-test-renderer": "^16.1.0",
-    "shelljs": "^0.7.8"
+    "@storybook/react": "^3.2.15"
   },
   "peerDependencies": {
     "react": "*"

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -27,10 +27,6 @@
     "react-textarea-autosize": "^5.2.0",
     "uuid": "^3.1.0"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0"
-  },
   "peerDependencies": {
     "react": "*"
   }

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -26,11 +26,6 @@
     "graphql": "^0.11.7",
     "prop-types": "^15.6.0"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
-    "shelljs": "^0.7.8"
-  },
   "peerDependencies": {
     "react": "*"
   }

--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -23,12 +23,8 @@
     "react-addons-create-fragment": "^15.5.3",
     "util-deprecate": "^1.0.2"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
-    "react-test-renderer": "^16.1.0"
-  },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -31,8 +31,6 @@
     "@types/node": "^8.0.51",
     "@types/react": "^16.0.22",
     "raw-loader": "^0.5.1",
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
     "style-loader": "^0.19.0",
     "typescript": "^2.6.1",
     "typescript-definition-tester": "^0.0.5",

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -23,11 +23,6 @@
   "dependencies": {
     "@storybook/addons": "^3.2.15"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
-    "shelljs": "^0.7.8"
-  },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"

--- a/addons/notes/package.json
+++ b/addons/notes/package.json
@@ -24,11 +24,6 @@
     "prop-types": "^15.6.0",
     "util-deprecate": "^1.0.2"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^16.1.0"
-  },
   "peerDependencies": {
     "react": "*"
   },

--- a/addons/options/package.json
+++ b/addons/options/package.json
@@ -22,12 +22,6 @@
   "dependencies": {
     "@storybook/addons": "^3.2.15"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
-    "react-test-renderer": "^16.1.0",
-    "shelljs": "^0.7.8"
-  },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"

--- a/addons/storyshots/package.json
+++ b/addons/storyshots/package.json
@@ -22,13 +22,7 @@
   "devDependencies": {
     "@storybook/addons": "^3.2.15",
     "@storybook/channels": "^3.2.15",
-    "@storybook/react": "^3.2.15",
-    "babel-cli": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.6.0",
-    "babel-preset-react": "^6.24.1",
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0"
+    "@storybook/react": "^3.2.15"
   },
   "peerDependencies": {
     "@storybook/addons": "^3.2.15",

--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -71,9 +71,6 @@
     "ws": "^3.3.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
     "react-native": "^0.50.3"
   },
   "peerDependencies": {

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -75,10 +75,7 @@
     "webpack-hot-middleware": "^2.20.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "nodemon": "^1.12.1",
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0"
+    "nodemon": "^1.12.1"
   },
   "peerDependencies": {
     "react": ">=15.0.0 || ^16.0.0",

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -76,7 +76,6 @@
     "webpack-hot-middleware": "^2.20.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
     "nodemon": "^1.12.1",
     "vue": "^2.5.3",
     "vue-loader": "^13.5.0",

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -17,8 +17,5 @@
   },
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"
-  },
-  "devDependencies": {
-    "shelljs": "^0.7.8"
   }
 }

--- a/lib/channel-postmessage/package.json
+++ b/lib/channel-postmessage/package.json
@@ -11,8 +11,5 @@
     "@storybook/channels": "^3.2.15",
     "global": "^4.3.2",
     "json-stringify-safe": "^5.0.1"
-  },
-  "devDependencies": {
-    "shelljs": "^0.7.8"
   }
 }

--- a/lib/channel-websocket/package.json
+++ b/lib/channel-websocket/package.json
@@ -10,8 +10,5 @@
   "dependencies": {
     "@storybook/channels": "^3.2.15",
     "global": "^4.3.2"
-  },
-  "devDependencies": {
-    "shelljs": "^0.7.8"
   }
 }

--- a/lib/channels/package.json
+++ b/lib/channels/package.json
@@ -6,8 +6,5 @@
   "main": "dist/index.js",
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"
-  },
-  "devDependencies": {
-    "shelljs": "^0.7.8"
   }
 }

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -13,8 +13,5 @@
   },
   "dependencies": {
     "jscodeshift": "^0.3.30"
-  },
-  "devDependencies": {
-    "shelljs": "^0.7.8"
   }
 }

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -18,10 +18,6 @@
     "glamorous": "^4.11.0",
     "prop-types": "^15.6.0"
   },
-  "devDependencies": {
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0"
-  },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9248,10 +9248,6 @@ react-addons-create-fragment@^15.5.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
 
-react-addons-test-utils@^15.5.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
-
 react-attr-converter@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/react-attr-converter/-/react-attr-converter-0.3.1.tgz#4a2abf6d907b7ddae4d862dfec80e489ce41ad6e"


### PR DESCRIPTION
Issue: we have a lot of unnecessary `devDependencies` entries (mostly on `react`, `react-dom`, and `shelljs`). Given that we use a monorepo architecture, it's enough to have those as root devDeps. Among other things, this will lower the pressure on dependencies.io (see https://github.com/storybooks/storybook/issues/1921#issuecomment-343544903)

I did `yarn bootstrap --reset --all`, and checked that all the three kitchen sink apps work correctly
