### PR TITLE
Add import to webpack extends example

### DIFF
--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -97,6 +97,8 @@ Add following content to the `webpack.config.js` in your Storybook config direct
 > We plan to expose our default webpack-config as it's own package in the future.
 
 ```js
+const path = require('path');
+
 // load the default config generator.
 const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js');
 


### PR DESCRIPTION
Issue:

## What I did

Update code sample in docs

## How to test

Build website

Is this testable with jest or storyshots?

Don't think so?

Does this need a new example in the kitchen sink apps?

Don't think so?

Does this need an update to the documentation?

N/A

If your answer is yes to any of these, please make sure to include it in your PR.
