### PR TITLE
Document return type of `date` knob (see #1489)

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -235,6 +235,16 @@ const value = date(label, defaultValue);
 
 > Note: the default value must not change - e.g., do not do `date('Label', new Date())` or `date('Label')`
 
+The `date` knob returns the selected date as stringified Unix timestamp (e.g. `"1510913096516"`).
+If your componentneeds the date in a different form you can wrap the `date` function:
+
+```
+function myDateKnob(name, defaultValue) {
+  const stringTimestamp = date(name, defaultValue)
+  return new Date(stringTimestamp)
+}
+```
+
 ### button
 
 Allows you to include a button and associated handler.

--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -236,7 +236,7 @@ const value = date(label, defaultValue);
 > Note: the default value must not change - e.g., do not do `date('Label', new Date())` or `date('Label')`
 
 The `date` knob returns the selected date as stringified Unix timestamp (e.g. `"1510913096516"`).
-If your componentneeds the date in a different form you can wrap the `date` function:
+If your component needs the date in a different form you can wrap the `date` function:
 
 ```
 function myDateKnob(name, defaultValue) {


### PR DESCRIPTION
Issue:

## What I did

Updated documentation of `date` knob according to the details in #1489 

## How to test

> Is this testable with jest or storyshots?

No

> Does this need a new example in the kitchen sink apps?

No

> Does this need an update to the documentation?

No

