### PR TITLE
Separate netlify instances

### DIFF
--- a/scripts/netlify-build.sh
+++ b/scripts/netlify-build.sh
@@ -1,28 +1,32 @@
 #!/bin/sh
 
-mkdir netlify-build
+# Make sure to set $BUILD_CONTEXT in the Netlify "Deploy Settings"
+echo "Building for Netlify. BUILD_CONTEXT: $BUILD_CONTEXT"
 
 yarn
-yarn add gauge --ignore-workspace-root-check # netlify quirk
+yarn add gauge --ignore-workspace-root-check # quirk with netlify build instance
 yarn bootstrap --core
 
-echo "netlify-build docs"
-pushd docs
-yarn install
-popd
-yarn docs:build
-mv docs/public/* netlify-build/
-
-echo "netlify-build React examples"
-pushd examples/cra-kitchen-sink
-yarn add tapable # netlify quirk
-yarn build-storybook
-mv storybook-static ../../netlify-build/cra-kitchen-sink
-popd
-
-echo "netlify-build Vue examples"
-pushd examples/vue-kitchen-sink
-yarn build-storybook
-mv storybook-static ../../netlify-build/vue-kitchen-sink
-popd
-
+if [ "$BUILD_CONTEXT" = "DOCS" ]; then
+  pushd docs
+  yarn install
+  popd
+  yarn docs:build
+  mv docs/public netlify-build
+elif [ "$BUILD_CONTEXT" = "CRA" ]; then
+  pushd examples/cra-kitchen-sink
+  yarn add tapable # quirk with netlify build instance
+  yarn build-storybook
+  mv storybook-static ../../netlify-build
+  popd
+elif [ "$BUILD_CONTEXT" = "VUE" ]; then
+  echo "netlify-build Vue examples"
+  pushd examples/vue-kitchen-sink
+  yarn build-storybook
+  mv storybook-static ../../netlify-build
+  popd
+else
+  RED='\033[0;31m'
+  NOCOLOR='\033[0m'
+  echo "Unrecognized BUILD_CONTEXT \"${RED}$BUILD_CONTEXT${NOCOLOR}\"" 1>&2
+fi


### PR DESCRIPTION
This is for having separate netlify instances for docs + each example

https://deploy-preview-2340--storybooks.netlify.com/
https://deploy-preview-2340--storybooks-cra.netlify.com/
https://deploy-preview-2340--storybooks-vue.netlify.com/

Once merged, we should be able to link to 

https://storybooks.netlify.com/
https://storybooks-cra.netlify.com/
https://storybooks-vue.netlify.com/

Note: 
1. Seems sometimes builds aren't deterministic. [This build](https://app.netlify.com/sites/storybooks-vue/deploys/5a10f5d4a6188f5294222989) failed due to "Cannot find module 'webpack'", but a rebuild (with no code changes) was successful
1.  The Github PR integration seems to only show the most recently added Netlify instance (Vue) ![image](https://user-images.githubusercontent.com/743976/32987096-0deb9818-ccaf-11e7-95b3-5b07c1798d5a.png)
