### PR TITLE
Fix HMR by saving the preview frame URL as the story changes.

### DIFF
--- a/app/angular/src/client/preview/init.js
+++ b/app/angular/src/client/preview/init.js
@@ -1,4 +1,6 @@
 import keyEvents from '@storybook/ui/dist/libs/key_events';
+import qs from 'qs';
+
 import { selectStory } from './actions';
 
 export default function(context) {
@@ -7,6 +9,19 @@ export default function(context) {
   if (queryParams.selectedKind) {
     reduxStore.dispatch(selectStory(queryParams.selectedKind, queryParams.selectedStory));
   }
+
+  // Keep whichever of these are set that we don't override when stories change
+  const originalQueryParams = queryParams;
+  reduxStore.subscribe(() => {
+    const { selectedKind, selectedStory } = reduxStore.getState();
+
+    const queryString = qs.stringify({
+      ...originalQueryParams,
+      selectedKind,
+      selectedStory,
+    });
+    window.history.pushState({}, '', `?${queryString}`);
+  });
 
   // Handle keyEvents and pass them to the parent.
   window.onkeydown = e => {

--- a/app/react/src/client/preview/init.js
+++ b/app/react/src/client/preview/init.js
@@ -1,4 +1,6 @@
 import keyEvents from '@storybook/ui/dist/libs/key_events';
+import qs from 'qs';
+
 import { selectStory } from './actions';
 
 export default function(context) {
@@ -7,6 +9,19 @@ export default function(context) {
   if (queryParams.selectedKind) {
     reduxStore.dispatch(selectStory(queryParams.selectedKind, queryParams.selectedStory));
   }
+
+  // Keep whichever of these are set that we don't override when stories change
+  const originalQueryParams = queryParams;
+  reduxStore.subscribe(() => {
+    const { selectedKind, selectedStory } = reduxStore.getState();
+
+    const queryString = qs.stringify({
+      ...originalQueryParams,
+      selectedKind,
+      selectedStory,
+    });
+    window.history.pushState({}, '', `?${queryString}`);
+  });
 
   // Handle keyEvents and pass them to the parent.
   window.onkeydown = e => {

--- a/app/vue/src/client/preview/init.js
+++ b/app/vue/src/client/preview/init.js
@@ -1,4 +1,6 @@
 import keyEvents from '@storybook/ui/dist/libs/key_events';
+import qs from 'qs';
+
 import { selectStory } from './actions';
 
 export default function(context) {
@@ -7,6 +9,19 @@ export default function(context) {
   if (queryParams.selectedKind) {
     reduxStore.dispatch(selectStory(queryParams.selectedKind, queryParams.selectedStory));
   }
+
+  // Keep whichever of these are set that we don't override when stories change
+  const originalQueryParams = queryParams;
+  reduxStore.subscribe(() => {
+    const { selectedKind, selectedStory } = reduxStore.getState();
+
+    const queryString = qs.stringify({
+      ...originalQueryParams,
+      selectedKind,
+      selectedStory,
+    });
+    window.history.pushState({}, '', `?${queryString}`);
+  });
 
   // Handle keyEvents and pass them to the parent.
   window.onkeydown = e => {


### PR DESCRIPTION
Sometimes when there are problems with HMR, we end up doing a
hard-reload of the preview iframe, whilst leaving the main window.

As the preview iframe didn't change its URL ever, this led to problems
where the old (usually original) story was loaded in such circumstances.

Issue: 

See #614 and #1328 -- and possibly some more, I'll have a hunt through the issue list.

## What I did

use `pushState` to change the preview's URL as stories change.

## How to test

See the [repro on #614](https://github.com/storybooks/storybook/issues/614#issuecomment-346250838)

### Is this testable with jest or storyshots?

No

### Does this need a new example in the kitchen sink apps?

No

### Does this need an update to the documentation?

No

If your answer is yes to any of these, please make sure to include it in your PR.
