### PR TITLE
Expose style for customisation

### DIFF
--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -152,11 +152,11 @@ export default class Story extends React.Component {
 
   _renderOverlay() {
     const buttonStyle = {
-      ...stylesheet.button.base,
-      ...stylesheet.button.topRight,
+      ...this.state.stylesheet.button.base,
+      ...this.state.stylesheet.button.topRight,
     };
 
-    const infoStyle = Object.assign({}, stylesheet.info);
+    const infoStyle = Object.assign({}, this.state.stylesheet.info);
     if (!this.state.open) {
       infoStyle.display = 'none';
     }
@@ -215,7 +215,7 @@ export default class Story extends React.Component {
 
     if (React.isValidElement(this.props.info)) {
       return (
-        <div style={this.props.showInline ? stylesheet.jsxInfoContent : stylesheet.infoContent}>
+        <div style={this.props.showInline ? this.state.stylesheet.jsxInfoContent : this.state.stylesheet.infoContent}>
           {this.props.info}
         </div>
       );


### PR DESCRIPTION
Issue:

## What I did
Cannot modify `button.topRight` style from storybook config.js

example:
```jsx
import { setDefaults } from '@storybook/addon-info';
import deepmerge from 'deepmerge';

setDefaults({
  styles: (defaultStyles) => {
    return deepmerge(defaultStyles, {
      button: {
        topRight: {
          right: 'auto',
          borderRadius: '0 0 5px 0',
          left: 0,
        },
      },
    });
  },
});
```

## How to test

Is this testable with jest or storyshots?

Does this need a new example in the kitchen sink apps?

Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
