### PR TITLE
Fix edit link on docs/examples

### DIFF
--- a/docs/src/components/Docs/Container/index.js
+++ b/docs/src/components/Docs/Container/index.js
@@ -9,7 +9,7 @@ const getEditUrl = (selectedSectionId, selectedItemId) => {
   const gitHubRepoUrl = 'https://github.com/storybooks/storybook';
   const docPath = `${selectedSectionId}/${selectedItemId}`;
 
-  return `${gitHubRepoUrl}/tree/master/docs/pages/${docPath}/index.md`;
+  return `${gitHubRepoUrl}/blob/master/docs/src/pages/${docPath}/index.md`;
 };
 
 const Container = ({ sections, selectedItem, selectedSectionId, selectedItemId }) => (

--- a/docs/src/components/Grid/Examples/index.js
+++ b/docs/src/components/Grid/Examples/index.js
@@ -9,7 +9,7 @@ const Examples = ({ items }) => (
       <h1>Storybook Examples</h1>
       <a
         className="edit-link"
-        href="https://github.com/storybooks/storybook/edit/master/docs/pages/examples/_examples.yml"
+        href="https://github.com/storybooks/storybook/blob/master/docs/src/pages/examples/_examples.yml"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
Right now, the Edit link on https://storybook.js.org/testing/structural-testing/ is pointing to an invalid link at https://github.com/storybooks/storybook/tree/master/docs/pages/testing/structural-testing/index.md
The correct link is https://github.com/storybooks/storybook/blob/master/docs/src/pages/testing/structural-testing/index.md

The examples page also have a similar problem.

## What I did
Change the strings to point to the valid link.

## How to test
Build the documentation and test the edit links.