### PR TITLE
unmount after storyshot snapshot

### DIFF
--- a/addons/storyshots/src/test-bodies.js
+++ b/addons/storyshots/src/test-bodies.js
@@ -10,21 +10,19 @@ function getRenderedTree(story, context, { renderer, serializer, ...rendererOpti
   return serializer ? serializer(tree) : tree;
 }
 
-export const snapshotWithOptions = options => ({ story, context }) => {
+export const snapshotWithOptions = options => ({ story, context, snapshotFileName }) => {
   const tree = getRenderedTree(story, context, options);
-  expect(tree).toMatchSnapshot();
+
+  if (snapshotFileName) {
+    expect(tree).toMatchSpecificSnapshot(snapshotFileName);
+  } else {
+    expect(tree).toMatchSnapshot();
+  }
+  tree.unmount();
 };
 
-export const multiSnapshotWithOptions = options => ({ story, context }) => {
-  const tree = getRenderedTree(story, context, options);
-  const snapshotFileName = getSnapshotFileName(context);
-
-  if (!snapshotFileName) {
-    expect(tree).toMatchSnapshot();
-    return;
-  }
-
-  expect(tree).toMatchSpecificSnapshot(snapshotFileName);
+export const multiSnapshotWithOptions = options => ({ context }) => {
+  snapshotWithOptions({ ...options, snapshotFileName: getSnapshotFileName(context) });
 };
 
 export const snapshot = snapshotWithOptions({});

--- a/addons/storyshots/src/test-bodies.js
+++ b/addons/storyshots/src/test-bodies.js
@@ -18,6 +18,7 @@ export const snapshotWithOptions = options => ({ story, context, snapshotFileNam
   } else {
     expect(tree).toMatchSnapshot();
   }
+
   tree.unmount();
 };
 


### PR DESCRIPTION
Issue: Not unmounting after test causes failures when running multiple tests with a shared decorator. Running the test on its own passes. 

Possibly a decorator running causes a tested React component to re-render. If that decorator changes the underlying data assumptions of said component, problems arise.

## What I did

Fix #2417 which I reported several minor versions ago and included more details on.

1. `unmount` after finished with rendered tree
2. small refactoring so I would only have to call unmount once instead of 3x

## How to test

I have an app which this fixes. I could potentially come up with a smaller reproducing app if there are doubts about what this change does.

In my case, the decorator resets my Redux state; each story adds the data its component depends on. (Maybe not an expected use of Storybook but I find it a great way to get a lot of integration testing of reducers+selectors+containers along with presentational components.)

I was getting failures from a random component (always the same one so long as the stories don't change) because its data was wiped away by the decorator's reset and it tried to re-render.

Is this testable with jest or storyshots?

Possibly with jest mock function, counting number of times it is called.

Does this need a new example in the kitchen sink apps?

I don't know.

Does this need an update to the documentation?

I don't think so. 

If your answer is yes to any of these, please make sure to include it in your PR.
