### PR TITLE
Number knob: apply default min/max/step values only in range mode

### DIFF
--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -19,14 +19,18 @@ export function boolean(name, value) {
 }
 
 export function number(name, value, options = {}) {
-  const defaults = {
-    range: false,
+  const rangeDefaults = {
     min: 0,
     max: 10,
     step: 1,
   };
 
-  const mergedOptions = { ...defaults, ...options };
+  const mergedOptions = options.range
+    ? {
+        ...rangeDefaults,
+        ...options,
+      }
+    : options;
 
   const finalOptions = {
     ...mergedOptions,

--- a/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
+++ b/examples/cra-kitchen-sink/src/__snapshots__/storyshots.test.js.snap
@@ -5030,6 +5030,11 @@ exports[`Storyshots Addon Knobs.withKnobs tweaks static values 1`] = `
     January 20, 2017
   </p>
   <p>
+    I live in NY for 
+    9
+     years.
+  </p>
+  <p>
     My wallet contains: $
     12.50
   </p>

--- a/examples/cra-kitchen-sink/src/stories/addon-knobs.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/addon-knobs.stories.js
@@ -57,6 +57,7 @@ storiesOf('Addon Knobs.withKnobs', module)
     };
     const fruit = select('Fruit', fruits, 'apple');
     const dollars = number('Dollars', 12.5, { min: 0, max: 100, step: 0.01 });
+    const years = number('Years in NY', 9);
 
     const backgroundColor = color('background', '#ffff00');
     const items = array('Items', ['Laptop', 'Book', 'Whiskey']);
@@ -79,6 +80,7 @@ storiesOf('Addon Knobs.withKnobs', module)
       <div style={style}>
         <p>{intro}</p>
         <p>My birthday is: {new Date(birthday).toLocaleDateString('en-US', dateOptions)}</p>
+        <p>I live in NY for {years} years.</p>
         <p>My wallet contains: ${dollars.toFixed(2)}</p>
         <p>In my backpack, I have:</p>
         <ul>{items.map(item => <li key={item}>{item}</li>)}</ul>


### PR DESCRIPTION
Issue: #2431 

## How to test
Open "Addon Knobs / withKnobs / tweaks static values" in [`cra-kitchen-sink`](https://deploy-preview-2437--storybooks-cra.netlify.com/?knob-Dollars=12.5&knob-Name=Storyteller&knob-Years%20in%20NY=9&knob-background=%23ffff00&knob-Age=70&knob-Items%5B0%5D=Laptop&knob-Items%5B1%5D=Book&knob-Items%5B2%5D=Whiskey&knob-Birthday=1484859600000&knob-Nice=true&knob-Styles=%7B%22border%22%3A%223px%20solid%20%23ff00ff%22%2C%22padding%22%3A%2210px%22%7D&knob-Fruit=apple&selectedKind=Addon%20Knobs.withKnobs&selectedStory=tweaks%20static%20values&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs). You should be able to raise `Years in NY` number above 10.