### PR TITLE
fix missing supported extension check in case when asset is a string

### DIFF
--- a/app/vue/src/server/iframe.html.js
+++ b/app/vue/src/server/iframe.html.js
@@ -29,7 +29,7 @@ const urlsFromAssets = assets => {
     .forEach(key => {
       let asset = assets[key];
       if (typeof asset === 'string') {
-        if (Boolean(urls[getExtensionForFilename(asset)])) {
+        if (urls[getExtensionForFilename(asset)]) {
           urls[getExtensionForFilename(asset)].push(asset);
         }
       } else {

--- a/app/vue/src/server/iframe.html.js
+++ b/app/vue/src/server/iframe.html.js
@@ -29,7 +29,9 @@ const urlsFromAssets = assets => {
     .forEach(key => {
       let asset = assets[key];
       if (typeof asset === 'string') {
-        urls[getExtensionForFilename(asset)].push(asset);
+        if (Boolean(urls[getExtensionForFilename(asset)])) {
+          urls[getExtensionForFilename(asset)].push(asset);
+        }
       } else {
         if (!Array.isArray(asset)) {
           asset = [asset];


### PR DESCRIPTION
I've came across this inconsistent logic while investigating my own issue: [https://github.com/storybooks/storybook/issues/2363](https://github.com/storybooks/storybook/issues/2363)

There is a check in case of an Object, but there is none in case of String. This might lead to hardly explainable errors.

## What I did
**I've added the missing check.**

## How to test
**See the issue.**

Is this testable with jest or storyshots?
**Yes.**

Does this need a new example in the kitchen sink apps?
**No.**

Does this need an update to the documentation?
**No.**
