### PR TITLE
Do not remove debugger-statements during development

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
         singleQuote: true,
       },
     ],
+    'no-debugger': process.env.NODE_ENV === 'production' ? error : ignore,
     quotes: [warn, 'single', { avoidEscape: true }],
     'class-methods-use-this': ignore,
     'arrow-parens': [warn, 'as-needed'],

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "docs:dev": "npm --prefix docs run dev",
     "github-release": "github-release-from-changelog",
     "lint": "yarn lint:js . && yarn lint:md .",
-    "lint:js": "eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.json",
+    "lint:js": "NODE_ENV=production eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.json",
     "lint:md": "remark",
     "publish": "lerna publish",
     "test": "node ./scripts/test.js",


### PR DESCRIPTION
Our current eslint config removes `debugger`-statements on file-safe.

I find this -to stay polite- absolute horse-shit.

This PR changes eslint to not fix (remove) debugger statements during development
But it's still enforced and removing them when validating via the npm script.

This is achieved via the `NODE_ENV`