### PR TITLE
add support for storyshots to save files according to different patterns

### DIFF
--- a/addons/storyshots/README.md
+++ b/addons/storyshots/README.md
@@ -127,6 +127,18 @@ initStoryshots({
 
 If you are running tests from outside of your app's directory, storyshots' detection of which framework you are using may fail. Pass `"react"` or `"react-native"` to short-circuit this.
 
+### `filesPattern`
+
+It allows you to generate separate snapshot files according to your needs. Please check [snapshotPerStoryFile](#snapshotPerStoryFile) and [snapshotPerStoryAdded](#snapshotPerStoryAdded) below.
+
+```js
+import initStoryshots, { snapshotPerStoryAdded } from '@storybook/addon-storyshots';
+
+initStoryshots({
+  filesPattern: snapshotPerStoryAdded,
+});
+```
+
 ### `test`
 
 Run a custom test function for each story, rather than the default (a vanilla snapshot test). Setting `test` will take precedence over the `renderer` option. See the exports section below for more details.
@@ -191,30 +203,34 @@ Just render the story, don't check the output at all (useful if you just want to
 
 Like the default, but allows you to specify a set of options for the test renderer. [See for example here](https://github.com/storybooks/storybook/blob/b915b5439786e0edb17d7f5ab404bba9f7919381/examples/test-cra/src/storyshots.test.js#L14-L16).
 
-### `multiSnapshotWithOptions(options)`
+### `snapshotPerStoryFile`
 
-Like `snapshotWithOptions`, but generate a separate snapshot file for each stories file rather than a single monolithic file (as is the convention in Jest). This makes it dramatically easier to review changes.
+It generates a separate snapshot file for each stories file rather than a single monolithic file (as is the convention in Jest). This makes it dramatically easier to review changes.
+
+### `snapshotPerStoryAdded`
+
+Like `snapshotPerStoryFile`, but generate a separate snapshot file for each stories added, rather than a single file snapshopt per story file. This makes it even easier to review changes.
 
 ### `shallowSnapshot`
 
 Take a snapshot of a shallow-rendered version of the component. Note that this option will be overriden if you pass a `renderer` option.
 
-### `getSnapshotFileName`
+### `filesPattern.getSnapshotFileName`
 
-Utility function used in `multiSnapshotWithOptions`. This is made available for users who implement custom test functions that also want to take advantage of multi-file storyshots.
+Utility function used in `snapshotWithOptions`. This is made available for users who implement custom test functions that also want to take advantage of multi-file storyshots.
 
 ###### Example:
 
 Let's say we wanted to create a test function for shallow && multi-file snapshots:
 
 ```js
-import initStoryshots, { getSnapshotFileName } from '@storybook/addon-storyshots';
+import initStoryshots, { snapshotPerStoryFile } from '@storybook/addon-storyshots';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 initStoryshots({
   test: ({ story, context }) => {
-    const snapshotFileName = getSnapshotFileName(context);
+    const snapshotFileName = snapshotPerStoryFile.getSnapshotFileName(context);
     const storyElement = story.render(context);
     const shallowTree = shallow(storyElement);
 

--- a/addons/storyshots/package.json
+++ b/addons/storyshots/package.json
@@ -22,7 +22,8 @@
     "global": "^4.3.2",
     "jest-specific-snapshot": "^0.2.0",
     "prop-types": "^15.6.0",
-    "read-pkg-up": "^3.0.0"
+    "read-pkg-up": "^3.0.0",
+    "sanitize-filename": "^1.6.1"
   },
   "devDependencies": {
     "@storybook/addons": "^3.3.0-alpha.4",

--- a/addons/storyshots/src/index.js
+++ b/addons/storyshots/src/index.js
@@ -9,12 +9,7 @@ import runWithRequireContext from './require_context';
 import createChannel from './storybook-channel-mock';
 import { snapshotWithOptions } from './test-bodies';
 
-export {
-  snapshot,
-  snapshotWithOptions,
-  shallowSnapshot,
-  renderOnly,
-} from './test-bodies';
+export { snapshot, snapshotWithOptions, shallowSnapshot, renderOnly } from './test-bodies';
 
 export { snapshotPerStoryFile, snapshotPerStoryAdded } from './utils';
 
@@ -33,6 +28,8 @@ const hasDependency = name =>
 
 export default function testStorySnapshots(options = {}) {
   addons.setChannel(createChannel());
+
+  const filesPattern = options.filesPattern || {};
 
   const isStorybook =
     options.framework === 'react' || (!options.framework && hasDependency('@storybook/react'));
@@ -89,23 +86,21 @@ export default function testStorySnapshots(options = {}) {
     options.test || snapshotWithOptions({ options: snapshotOptions });
 
   const storyFileExists = fileName =>
-    options.filesPattern.getPossibleStoriesFiles(fileName).some(fs.existsSync);
+    filesPattern.getPossibleStoriesFiles(fileName).some(fs.existsSync);
 
-  if (options.filesPattern && options.filesPattern.getPossibleStoriesFiles) {
+  if (filesPattern.getPossibleStoriesFiles) {
     describe('Storyshots Integrity', () => {
       describe('Abandoned Storyshots', () => {
         const storyshots = glob.sync('**/*.storyshot');
 
-        const abandonedStoryshots = storyshots.filter(fileName => 
-          !storyFileExists(fileName)
-        );
+        const abandonedStoryshots = storyshots.filter(fileName => !storyFileExists(fileName));
 
         expect(abandonedStoryshots).toHaveLength(0);
       });
     });
   }
 
-  const { getSnapshotFileName } = options.filesPattern;
+  const { getSnapshotFileName } = filesPattern;
 
   // eslint-disable-next-line
   for (const group of stories) {

--- a/addons/storyshots/src/test-bodies.js
+++ b/addons/storyshots/src/test-bodies.js
@@ -1,7 +1,6 @@
 import reactTestRenderer from 'react-test-renderer';
 import shallow from 'react-test-renderer/shallow';
 import 'jest-specific-snapshot';
-import { getSnapshotFileName } from './utils';
 
 function getRenderedTree(story, context, { renderer, serializer, ...rendererOptions }) {
   const currentRenderer = renderer || reactTestRenderer.create;
@@ -10,10 +9,14 @@ function getRenderedTree(story, context, { renderer, serializer, ...rendererOpti
   return serializer ? serializer(tree) : tree;
 }
 
-export const snapshotWithOptions = options => ({ story, context, snapshotFileName }) => {
+export const snapshotWithOptions = options => ({ story, context, snapshotFileName, getSnapshotFileName }) => {
   const tree = getRenderedTree(story, context, options);
 
   if (snapshotFileName) {
+    expect(tree).toMatchSpecificSnapshot(snapshotFileName);
+  } else if (getSnapshotFileName) {
+    snapshotFileName = getSnapshotFileName(context);
+
     expect(tree).toMatchSpecificSnapshot(snapshotFileName);
   } else {
     expect(tree).toMatchSnapshot();
@@ -22,10 +25,6 @@ export const snapshotWithOptions = options => ({ story, context, snapshotFileNam
   if (typeof tree.unmount === 'function') {
     tree.unmount();
   }
-};
-
-export const multiSnapshotWithOptions = options => ({ story, context }) => {
-  snapshotWithOptions(options)({ story, context, snapshotFileName: getSnapshotFileName(context) });
 };
 
 export const snapshot = snapshotWithOptions({});

--- a/addons/storyshots/src/utils.js
+++ b/addons/storyshots/src/utils.js
@@ -1,25 +1,47 @@
 import path from 'path';
+import sanitize from 'sanitize-filename';
 
-function getStoryshotFile(fileName) {
-  const { dir, name } = path.parse(fileName);
-  return path.format({ dir: path.join(dir, '__snapshots__'), name, ext: '.storyshot' });
-}
+export const snapshotPerStoryFile = {
+  getSnapshotFileName(context) {
+    const { fileName } = context;
 
-export function getPossibleStoriesFiles(storyshotFile) {
-  const { dir, name } = path.parse(storyshotFile);
+    if (!fileName) {
+      return null;
+    }
 
-  return [
-    path.format({ dir: path.dirname(dir), name, ext: '.js' }),
-    path.format({ dir: path.dirname(dir), name, ext: '.jsx' }),
-  ];
-}
+    const { dir, name } = path.parse(fileName);
+    return path.format({ dir: path.join(dir, '__snapshots__'), name, ext: '.storyshot' });
+  },
+  getPossibleStoriesFiles(storyshotFile) {
+    const { dir, name } = path.parse(storyshotFile);
 
-export function getSnapshotFileName(context) {
-  const { fileName } = context;
-
-  if (!fileName) {
-    return null;
+    return [
+      path.format({ dir: path.dirname(dir), name, ext: '.js' }),
+      path.format({ dir: path.dirname(dir), name, ext: '.jsx' }),
+    ];
   }
+};
 
-  return getStoryshotFile(fileName);
-}
+export const snapshotPerStoryAdded = {
+  getSnapshotFileName(context) {
+    const { fileName, kind, story } = context;
+
+    if (!fileName) {
+      return null;
+    }
+
+    const { dir } = path.parse(fileName);
+    const name = sanitize(`${kind}--${story}`)
+    return path.format({ dir: path.join(dir, '__snapshots__'), name, ext: '.storyshot' });
+  },
+  getPossibleStoriesFiles(storyshotFile) {
+    const { dir } = path.parse(storyshotFile);
+
+    return [
+      path.format({ dir: path.dirname(dir), name: 'stories', ext: '.js' }),
+      path.format({ dir: path.dirname(dir), name: 'stories', ext: '.js' }),
+      path.format({ dir: path.dirname(dir), name: '.stories', ext: '.jsx' }),
+      path.format({ dir: path.dirname(dir), name: '.stories', ext: '.jsx' }),
+    ];
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -11872,6 +11872,12 @@ sane@~1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
+sanitize-filename@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a"
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
+
 sass-graph@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
@@ -13124,6 +13130,12 @@ trough@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
 
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
 try-catch@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/try-catch/-/try-catch-1.0.0.tgz#3797dab39a266775f4d0da5cbf42aca3f03608e6"
@@ -13582,6 +13594,10 @@ useragent@^2.1.12:
   dependencies:
     lru-cache "2.2.x"
     tmp "0.0.x"
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
 
 util-deprecate@1.0.2, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
# The issue

In my setup, I always have a `cases.spec.js` that contains different props for my components. This file provides cases scenarios for both unit tests and storybook. With that in place, my components always have a standard `stories.js` file next to it, that looks like that:

```js
import React from 'react';
import { storiesOf } from '@storybook/react';

import Component from './component';
import cases from './cases.spec.js';

const stories = storiesOf('Category Icon Hover Menu', module)

for (const [caseName, caseData] of cases) {
  stories.addCentered(caseName, () => (
    <Component {...caseData} />
  ));
}
```

I like organising the project like this because I get storybook "for free" while writing tests. However, the `multiSnapshotWithOptions` does not work the way I intended with such setup. I don't like that it always create a `__snapshots__` folder with a **single file** on it.

![screen shot 2017-11-30 at 13 25 24](https://user-images.githubusercontent.com/181076/33431047-2d2c6194-d5d3-11e7-9695-a2068e3b494a.png)

# The alternative

I rewrote `getStoryshotFileName` to use the stories `kind` and `name` instead of the original filename:

![screen shot 2017-11-30 at 13 31 20](https://user-images.githubusercontent.com/181076/33431649-79a5ab14-d5d5-11e7-86f1-6796af2a71a9.png)

The API is quite simple:

```js
import initStoryshots, { snapshotPerStoryAdded, snapshotPerStoryFile  } from '@storybook/addon-storyshots';

initStoryshots({
  // filesPattern: snapshotPerStoryAdded,
  filesPattern: snapshotPerStoryFile,
});
```

with that I also killed the `multiSnapshotWithOptions`. I hope nobody minds 😄