### PR TITLE
Netlify for officialexample

### DIFF
--- a/scripts/netlify-build.sh
+++ b/scripts/netlify-build.sh
@@ -28,6 +28,13 @@ elif [ "$BUILD_CONTEXT" = "VUE" ]; then
   yarn build-storybook
   mv storybook-static ../../netlify-build
   popd
+elif [ "$BUILD_CONTEXT" = "OFFICIAL" ]; then
+  echo "netlify-build official examples"
+  pushd examples/official-storybook
+  yarn
+  yarn build-storybook
+  mv storybook-static ../../netlify-build
+  popd
 else
   RED='\033[0;31m'
   NOCOLOR='\033[0m'


### PR DESCRIPTION
Issue: Netlify example was missing for newly added official storybook example

## What I did
- Added a netlify site
- Added a if case for the pre-defined environment variable to deploy the right example