### PR TITLE
Add missing lang attribute

### DIFF
--- a/app/react/src/server/iframe.html.js
+++ b/app/react/src/server/iframe.html.js
@@ -58,7 +58,7 @@ export default function({ assets, publicPath, headHtml }) {
 
   return `
     <!DOCTYPE html>
-    <html>
+    <html lang="en">
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Issue: #2351 

## What I did

Accessibility tests warn that the HTML element requires a lang attribute. See: https://dequeuniversity.com/rules/axe/2.4/html-has-lang?application=AxeChrome

Ideally the lang attribute's value would be set to whatever language the user is using for Storybook, but that would require adding configuration, so this seems like a short term fix that addresses the immediate issue.

## How to test

Run accessibility tests on the iframe and find that they no longer warn about the HTML lang attribute.