### PR TITLE
Fix storybook CLI for angular: dev dependencies and fix addon-notes usage

### DIFF
--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -1,15 +1,31 @@
 import mergeDirs from 'merge-dirs';
 import path from 'path';
-import { getVersion, getPackageJson, writePackageJson } from '../../lib/helpers';
+import { getVersions, getPackageJson, writePackageJson } from '../../lib/helpers';
 
 export default async () => {
-  const version = await getVersion('@storybook/angular');
+  const [
+    storybookVersion,
+    notesVersion,
+    actionsVersion,
+    linksVersion,
+    lodashTypesVersion,
+  ] = await getVersions(
+    '@storybook/angular',
+    '@storybook/addon-notes',
+    '@storybook/addon-actions',
+    '@storybook/addon-links',
+    '@types/lodash-es'
+  );
   mergeDirs(path.resolve(__dirname, 'template'), '.', 'overwrite');
 
   const packageJson = getPackageJson();
 
   packageJson.devDependencies = packageJson.devDependencies || {};
-  packageJson.devDependencies['@storybook/angular'] = version;
+  packageJson.devDependencies['@storybook/angular'] = storybookVersion;
+  packageJson.devDependencies['@storybook/addon-notes'] = notesVersion;
+  packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
+  packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@types/lodash-es'] = lodashTypesVersion;
 
   packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts.storybook = 'start-storybook -p 6006';

--- a/lib/cli/generators/ANGULAR/template/stories/index.stories.js
+++ b/lib/cli/generators/ANGULAR/template/stories/index.stories.js
@@ -19,7 +19,7 @@ storiesOf('Button', module)
   }))
   .add(
     'with some emoji',
-    withNotes({ notes: 'My notes on a button with emojis' })(() => ({
+    withNotes({ text: 'My notes on a button with emojis' })(() => ({
       component: Button,
       props: {
         text: '😀 😎 👍 💯',
@@ -28,7 +28,7 @@ storiesOf('Button', module)
   )
   .add(
     'with some emoji and action',
-    withNotes({ notes: 'My notes on a button with emojis' })(() => ({
+    withNotes({ text: 'My notes on a button with emojis' })(() => ({
       component: Button,
       props: {
         text: '😀 😎 👍 💯',

--- a/lib/cli/test/snapshots/angular-cli/package.json
+++ b/lib/cli/test/snapshots/angular-cli/package.json
@@ -44,6 +44,10 @@
     "ts-node": "1.2.1",
     "tslint": "^4.3.0",
     "typescript": "~2.4.0",
-    "@storybook/angular": "^3.3.0"
+    "@storybook/angular": "^3.3.0",
+    "@storybook/addon-notes": "^3.3.0",
+    "@storybook/addon-actions": "^3.3.0",
+    "@storybook/addon-links": "^3.3.0",
+    "@types/lodash-es": "^4.17.0"
   }
 }

--- a/lib/cli/test/snapshots/angular-cli/stories/index.stories.js
+++ b/lib/cli/test/snapshots/angular-cli/stories/index.stories.js
@@ -19,7 +19,7 @@ storiesOf('Button', module)
   }))
   .add(
     'with some emoji',
-    withNotes({ notes: 'My notes on a button with emojis' })(() => ({
+    withNotes({ text: 'My notes on a button with emojis' })(() => ({
       component: Button,
       props: {
         text: '😀 😎 👍 💯',
@@ -28,7 +28,7 @@ storiesOf('Button', module)
   )
   .add(
     'with some emoji and action',
-    withNotes({ notes: 'My notes on a button with emojis' })(() => ({
+    withNotes({ text: 'My notes on a button with emojis' })(() => ({
       component: Button,
       props: {
         text: '😀 😎 👍 💯',


### PR DESCRIPTION
Issue: #2569 

## What I did

- Angular CLI was missing some NPM dependencies that I had to install by hand. Added these to the CLI.
- Fixed the notes example installed by the CLI

## How to test

```
ng new angular-test
cd angular-test/
/path/to/storybook/lib/cli/bin/index.js
yarn run storybook
```

Is this testable with jest or storyshots?

Does this need a new example in the kitchen sink apps?

Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
