### PR TITLE
Fix @storybook/client-logger import

### DIFF
--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import deprecate from 'util-deprecate';
 import nestedObjectAssign from 'nested-object-assign';
-import logger from '@storybook/client-logger';
+import { logger } from '@storybook/client-logger';
 import Story from './components/Story';
 import PropTable from './components/PropTable';
 import makeTableComponent from './components/makeTableComponent';


### PR DESCRIPTION
Issue:
`@storybook/client-logger` was imported incorrectly in `@storybook/addon-info`, which results in runtime error `TypeError: Cannot read property 'warn' of undefined`

## What I did
Replaced default import with named import.

## How to test
1. Use `marksyConf` in storybook configuration. 
2. When running storybook in the browser, proper warning message should be shown instead of the runtime error.

Is this testable with jest or storyshots? No

Does this need a new example in the kitchen sink apps? No

Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
