### PR TITLE
Update custom webpack config docs

### DIFF
--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -85,8 +85,7 @@ Storybook uses the config returned from the above function. So, try to edit the 
 -   entry
 -   output
 -   first loader in the module.loaders (Babel loader for JS)
-
-Other than that, you should try to keep the default set of plugins.
+-   all existing plugins
 
 ## Full control mode + default
 


### PR DESCRIPTION
As of https://github.com/storybooks/storybook/commit/f42248157b3cf9b49de98ea9bca1f88495d6d58a, the app will not load without the first two plugins in the config, so this should no longer read: "you should try to"; the preservation of those plugins is now a necessity, so I have added it to the list of "make sure to preserve"s.
