### PR TITLE
Use store revisions to ensure that stories re-render on HMR.

### DIFF
--- a/lib/core/src/client/preview/client_api.js
+++ b/lib/core/src/client/preview/client_api.js
@@ -47,6 +47,7 @@ export default class ClientApi {
     if (m && m.hot) {
       m.hot.dispose(() => {
         this._storyStore.removeStoryKind(kind);
+        this._storyStore.incrementRevision();
       });
     }
 

--- a/lib/core/src/client/preview/story_store.js
+++ b/lib/core/src/client/preview/story_store.js
@@ -12,6 +12,15 @@ export default class StoryStore extends EventEmitter {
   constructor() {
     super();
     this._data = {};
+    this._revision = 0;
+  }
+
+  getRevision() {
+    return this._revision;
+  }
+
+  incrementRevision() {
+    this._revision += 1;
   }
 
   addStory(kind, name, fn, fileName) {
@@ -88,7 +97,10 @@ export default class StoryStore extends EventEmitter {
   }
 
   dumpStoryBook() {
-    const data = this.getStoryKinds().map(kind => ({ kind, stories: this.getStories(kind) }));
+    const data = this.getStoryKinds().map(kind => ({
+      kind,
+      stories: this.getStories(kind),
+    }));
 
     return data;
   }


### PR DESCRIPTION
Reworking #2588 fro #2241.

I think we should also check the revision number on this line: https://github.com/storybooks/storybook/blob/10ed61dd9e82ad00bfa31872ffc140dfeebe9d42/app/vue/src/client/preview/render.js#L63

But I would prefer a Vue expert to weigh in on that.

Also we should probably rebase/something `shilman/refactor-core`. This should hopefully cleanly apply in any case.

Finally, @Hypnosphi perhaps suggested some objections to this approach. I think this is the place to discuss them.