### PR TITLE
fix typo

### DIFF
--- a/app/angular/README.md
+++ b/app/angular/README.md
@@ -1,6 +1,6 @@
 # Storybook for Angular
 
-Storybook for Angular is a UI development environment for your React components.
+Storybook for Angular is a UI development environment for your Angular components.
 With it, you can visualize different states of your UI components and develop them interactively.
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/storybooks/storybook.svg)](https://greenkeeper.io/)


### PR DESCRIPTION
Issue: Currently the 1st sentence in the Readme is wrong. Says "React components" while it should be "Angular components". Probably copy & paste error :wink:.

## What I did

Simply fix the typo

## How to test

Look at the README.

Is this testable with jest or storyshots? 
Nope

Does this need a new example in the kitchen sink apps? 
Nope

Does this need an update to the documentation? 
The PR itself is the update actually :)
