### PR TITLE
Don't read app code from Circle env.

### DIFF
--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build-storybook": "build-storybook -c ./",
     "storybook": "start-storybook -p 9010 -c ./",
-    "chromatic": "chromatic test --storybook-addon --exit-zero-on-changes --app-code $CHROMATIC_APP_CODE"
+    "chromatic": "chromatic test --storybook-addon --exit-zero-on-changes --app-code ab7m45tp9p"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^3.3.3",


### PR DESCRIPTION
In order to make external PRs work w/ Chromatic, we need to grant the right for non-storybook-org users to kick off builds.

The app code only allows you to start builds, so is safe enough to share in this situation. I will write some docs at https://docs.chromaticqa.com about this.
