### PR TITLE
Updated documentation wrt ejs exclusion

### DIFF
--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -87,6 +87,8 @@ Storybook uses the config returned from the above function. So, try to edit the 
 -   first loader in the module.loaders (Babel loader for JS)
 -   all existing plugins
 
+> If your custom webpack config uses a fallback `file-loader`, it is necessary to exclude the `.ejs` file extension.
+
 ## Full control mode + default
 
 You may want to keep Storybook's [default config](/configurations/default-config), but just need to extend it.

--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -87,7 +87,7 @@ Storybook uses the config returned from the above function. So, try to edit the 
 -   first loader in the module.loaders (Babel loader for JS)
 -   all existing plugins
 
-> If your custom webpack config uses a fallback `file-loader`, it is necessary to exclude the `.ejs` file extension.
+> If your custom webpack config uses a loader that does not explicitly include specific file extensions via the `test` property, it is necessary to `exclude` the `.ejs` file extension from that loader.
 
 ## Full control mode + default
 


### PR DESCRIPTION
Updated the documentation to indicate the need to exclude the `.ejs` file extension from webpack file loaders. https://github.com/storybooks/storybook/issues/2615

## How to test
N/A
