### PR TITLE
Update prereq yarn install level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in improving Storybook! We are a community-driven proje
 
 Please review this document to help to streamline the process and save everyone's precious time.
 
-This repo uses yarn workspaces, so you should `yarn@1.0.0` or higher as package manager. See [installation guide](https://yarnpkg.com/en/docs/install).
+This repo uses yarn workspaces, so you should `yarn@1.3.2` or higher as package manager. See [installation guide](https://yarnpkg.com/en/docs/install).
 
 ## Issues
 
@@ -217,7 +217,7 @@ Please have the **_latest_** stable versions of the following on your machine
 
 ### Initial Setup
 
-If you run into trouble here, make sure your node, npm, and **_yarn_** are on the latest versions (yarn at least v1.0.0).
+If you run into trouble here, make sure your node, npm, and **_yarn_** are on the latest versions (yarn at least v1.3.2).
 
 1.  `cd ~` (optional)
 2.  `git clone https://github.com/storybooks/storybook.git` _bonus_: use your own fork for this step
@@ -296,7 +296,7 @@ If you don't see the changes rerun `yarn storybook` again in your sandbox app
 
 This section is for Storybook maintainers who will be creating releases. It assumes:
 
--   yarn >= 1.0.0
+-   yarn >= 1.3.2
 -   you've yarn linked `pr-log` from <https://github.com/storybooks/pr-log/pull/2>
 
 The current manual release sequence is as follows:

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "engines": {
     "node": ">=8.0.0",
-    "yarn": ">=1.0.0"
+    "yarn": ">=1.3.2"
   },
   "private": true,
   "collective": {


### PR DESCRIPTION
Yarn 1.0.0 contains a linking bug that is fixed in 1.3.0 (released 1.3.2), creates failures otherwise

yarn revision: https://github.com/yarnpkg/yarn/releases/tag/v1.3.0 

Issue:
https://github.com/storybooks/storybook/issues/2382#issue-276990637
## What I did

## How to test

Is this testable with jest or storyshots?

Does this need a new example in the kitchen sink apps?

Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
