### PR TITLE
Add .ts compatibility to storyshots

### DIFF
--- a/addons/storyshots/src/utils.js
+++ b/addons/storyshots/src/utils.js
@@ -11,6 +11,8 @@ export function getPossibleStoriesFiles(storyshotFile) {
   return [
     path.format({ dir: path.dirname(dir), name, ext: '.js' }),
     path.format({ dir: path.dirname(dir), name, ext: '.jsx' }),
+    path.format({ dir: path.dirname(dir), name, ext: '.ts' }),
+    path.format({ dir: path.dirname(dir), name, ext: '.tsx' }),
   ];
 }
 


### PR DESCRIPTION
Issue: #2630

## What I did

A quick fix to make ts stories to work well with stoyshots and `multiSnapshotWithOptions`.
#2517 might revisit the ability to customize stoyshots file names. 
