### PR TITLE
Remove @angular/core dep from knobs peer.

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -33,7 +33,6 @@
     "vue": "^2.5.13"
   },
   "peerDependencies": {
-    "@angular/core": ">=4.0.0",
     "@storybook/addons": "^3.3.0",
     "react": "*",
     "react-dom": "*"

--- a/addons/knobs/src/angular/helpers.js
+++ b/addons/knobs/src/angular/helpers.js
@@ -1,5 +1,5 @@
 /* eslint no-underscore-dangle: 0 */
-
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { Component, SimpleChange, ChangeDetectorRef } from '@angular/core';
 import { getParameters, getAnnotations, getPropMetadata } from './utils';
 

--- a/addons/knobs/src/angular/utils.js
+++ b/addons/knobs/src/angular/utils.js
@@ -1,5 +1,6 @@
-/* eslint-disable no-param-reassign */
 /* globals window */
+/* eslint-disable no-param-reassign */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { ɵReflectionCapabilities } from '@angular/core';
 
 // eslint-disable-next-line new-cap


### PR DESCRIPTION
Issue: I don't remember where it was mentioned

## What I did
We don't want people to install deps of every supported framework, that's why I remove @angular/core from the peer.