### PR TITLE
Add IE11 compatibility meta tag

### DIFF
--- a/app/angular/src/server/iframe.html.ejs
+++ b/app/angular/src/server/iframe.html.ejs
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
     <base target="_parent">
     <script>
         if (window.parent !== window) {

--- a/app/react/src/server/iframe.html.ejs
+++ b/app/react/src/server/iframe.html.ejs
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
     <base target="_parent">
     <script>
         if (window.parent !== window) {

--- a/app/vue/src/server/iframe.html.ejs
+++ b/app/vue/src/server/iframe.html.ejs
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
     <base target="_parent">
     <script>
         if (window.parent !== window) {


### PR DESCRIPTION
Issue:

## What I did
I could get IE11 to render the Storybook, but it would not render the iframe view.  It kept defaulting to older document modes which were too outdated to render our JS.

The only way I could reliably get IE11 to render the iframe view was to add the following meta tag, which is present in the Storybook template:

```<meta content="IE=edge" http-equiv="X-UA-Compatible" />```

I'm not well-versed in how this works; my reading suggests that an HTTP header is usually preferred but we're working with `webpack-dev-server` and don't have a ton of control over that.

If anyone has suggestions about how this should work, I'm open to hearing them.

## How to test
Open the iframe view in IE11 with and without the meta tag; observe that it does not render without.

Is this testable with jest or storyshots?
Not unless we use Browserstack or Saucelabs

## Does this need a new example in the kitchen sink apps?
No

## Does this need an update to the documentation?
No 
