### PR TITLE
Fix the timezone for example dates

### DIFF
--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -68,7 +68,7 @@ storiesOf('Addons|Knobs.withKnobs', module)
     const nice = boolean('Nice', true);
 
     // NOTE: the default value must not change - e.g., do not do date('Label', new Date()) or date('Label')
-    const defaultBirthday = new Date('Jan 20 2017');
+    const defaultBirthday = new Date('Jan 20 2017 GMT+0');
     const birthday = date('Birthday', defaultBirthday);
 
     const intro = `My name is ${name}, I'm ${age} years old, and my favorite fruit is ${fruit}.`;
@@ -124,7 +124,7 @@ storiesOf('Addons|Knobs.withKnobsOptions', module)
     const nice = boolean('Nice', true);
 
     // NOTE: the default value must not change - e.g., do not do date('Label', new Date()) or date('Label')
-    const defaultBirthday = new Date('Jan 20 2017');
+    const defaultBirthday = new Date('Jan 20 2017 GMT+0');
     const birthday = date('Birthday', defaultBirthday);
 
     const intro = `My name is ${name}, I'm ${age} years old, and my favorite fruit is ${fruit}.`;


### PR DESCRIPTION
Issue: Unit tests were failing in Australia

(20 Jan in Australia is 19th Jan in "en-US". I know this! It is my birthday, and I have colleagues in the US!!)

## What I did

Ensure a consistent created date that doesn't depend on local TZ.
