### PR TITLE
[documentation] fix view of addon gallery and api pages

### DIFF
--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -1,8 +1,7 @@
-* * *
-
+---
 id: 'addon-gallery'
-
-## title: 'Addon Gallery'
+title: 'Addon Gallery'
+---
 
 This is a list of available addons for Storybook.
 

--- a/docs/src/pages/addons/api/index.md
+++ b/docs/src/pages/addons/api/index.md
@@ -1,8 +1,7 @@
-* * *
-
+---
 id: 'api'
-
-## title: 'API'
+title: 'API'
+---
 
 ## Core Addon API
 


### PR DESCRIPTION
## Issue:
Current addon API and gallery pages look different than other pages.
![image](https://user-images.githubusercontent.com/6034955/34722720-9782e4cc-f550-11e7-9ea7-8fd2a0629e20.png)
I believe this is due to wrong formatting of these pages. This PR aims to fix this

## What I did
Change format for `title` and `id` for addon gallery and api pages

## How to test
Visual

  