### PR TITLE
Reflect the new peer dependencies in docs and CLI templates

### DIFF
--- a/docs/src/pages/addons/using-addons/index.md
+++ b/docs/src/pages/addons/using-addons/index.md
@@ -12,7 +12,7 @@ We are going to use an addon called [Notes](https://github.com/storybooks/storyb
 First, we need to install the addons:
 
 ```sh
-npm i --save-dev @storybook/addon-actions @storybook/addon-links @storybook/addon-notes
+npm i --save-dev @storybook-addons @storybook/addon-actions @storybook/addon-links @storybook/addon-notes
 ```
 
 Then, we need to create a file called `addons.js` inside the storybook config directory and add the following content:

--- a/docs/src/pages/basics/guide-angular/index.md
+++ b/docs/src/pages/basics/guide-angular/index.md
@@ -17,7 +17,7 @@ In this guide, we are trying to set up Storybook for your Angular project.
 ## Table of contents
 
 -   [Create Angular project](#create-angular-project)
--   [Add @storybook/angular](#add-storybookangular)
+-   [Add @storybook/angular and babel-core](#add-storybookangular-and-babel-core)
 -   [Create the config file](#create-the-config-file)
 -   [Write your stories](#write-your-stories)
 -   [Run your Storybook](#run-your-storybook)
@@ -32,12 +32,12 @@ ng new your-angular-prj
 cd your-angular-prj
 ```
 
-## Add @storybook/angular
+## Add @storybook/angular and babel-core
 
-Next, install `@storybook/angular` to your project:
+Next, install `@storybook/angular` and `babel-core` (it's a peerDependency) to your project:
 
 ```sh
-npm i --save-dev @storybook/angular
+npm i --save-dev @storybook/angular babel-core
 ```
 
 Then add the following NPM script to your package json in order to start the storybook later in this guide:

--- a/docs/src/pages/basics/guide-react/index.md
+++ b/docs/src/pages/basics/guide-react/index.md
@@ -16,7 +16,7 @@ In this guide, we are trying to set up Storybook for your React project.
 ## Table of contents
 
 -   [Add @storybook/react](#add-storybookreact)
--   [Add react and react-dom](#add-react-and-react-dom)
+-   [Add react, react-dom, and babel-core](#add-react-react-dom-and-babel-core)
 -   [Create the config file](#create-the-config-file)
 -   [Write your stories](#write-your-stories)
 -   [Run your Storybook](#run-your-storybook)
@@ -29,12 +29,13 @@ First of all, you need to add `@storybook/react` to your project. To do that, si
 npm i --save-dev @storybook/react
 ```
 
-## Add react and react-dom
+## Add react, react-dom, and babel-core
 
-Make sure that you have `react` and `react-dom` in your dependencies as well because we list these as a peerDependency:
+Make sure that you have `react`, `react-dom`, and `babel-core` in your dependencies as well because we list these as a peerDependency:
 
 ```sh
 npm i --save react react-dom
+npm i --save-dev babel-core
 ```
 
 Then add the following NPM script to your package json in order to start the storybook later in this guide:

--- a/docs/src/pages/basics/guide-vue/index.md
+++ b/docs/src/pages/basics/guide-vue/index.md
@@ -1,8 +1,7 @@
-* * *
-
+---
 id: 'guide-vue'
-
-## title: 'Storybook for Vue'
+title: 'Storybook for Vue'
+---
 
 You may have tried to use our quick start guide to setup your project for Storybook. If you want to set up Storybook manually, this is the guide for you.
 
@@ -18,7 +17,7 @@ In this guide, we are trying to set up Storybook for your Vue project.
 ## Table of contents
 
 -   [Add @storybook/vue](#add-storybookvue)
--   [Add vue](#add-vue)
+-   [Add vue and babel-core](#add-vue-and-babel-core)
 -   [Create the NPM script](#create-the-npm-script)
 -   [Create the config file](#create-the-config-file)
 -   [Write your stories](#write-your-stories)
@@ -32,12 +31,13 @@ First of all, you need to add `@storybook/vue` to your project. To do that, simp
 npm i --save-dev @storybook/vue
 ```
 
-## Add vue
+## Add vue and babel-core
 
-Make sure that you have `vue` in your dependencies as well because we list is as a peerDependency:
+Make sure that you have `vue` and `babel-core` in your dependencies as well because we list is as a peerDependency:
 
 ```sh
 npm i --save vue
+npm i --save-dev babel-core
 ```
 
 ## Create the NPM script

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -8,24 +8,31 @@ export default async () => {
     notesVersion,
     actionsVersion,
     linksVersion,
-    lodashTypesVersion,
+    addonsVersion,
+    babelCoreVersion,
   ] = await getVersions(
     '@storybook/angular',
     '@storybook/addon-notes',
     '@storybook/addon-actions',
     '@storybook/addon-links',
-    '@types/lodash-es'
+    '@storybook/addons',
+    'babel-core'
   );
   mergeDirs(path.resolve(__dirname, 'template'), '.', 'overwrite');
 
   const packageJson = getPackageJson();
 
+  packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
   packageJson.devDependencies['@storybook/angular'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-notes'] = notesVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
-  packageJson.devDependencies['@types/lodash-es'] = lodashTypesVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
+  }
 
   packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts.storybook = 'start-storybook -p 6006';

--- a/lib/cli/generators/METEOR/index.js
+++ b/lib/cli/generators/METEOR/index.js
@@ -9,8 +9,10 @@ export default async () => {
     storybookVersion,
     actionsVersion,
     linksVersion,
+    addonsVersion,
     reactVersion,
     reactDomVersion,
+    babelCoreVersion,
     presetEnvVersion,
     presetReactVersion,
     presetStage1Version,
@@ -19,8 +21,10 @@ export default async () => {
     '@storybook/react',
     '@storybook/addon-actions',
     '@storybook/addon-links',
+    '@storybook/addons',
     'react',
     'react-dom',
+    'babel-core',
     'babel-preset-env',
     'babel-preset-react',
     'babel-preset-stage-1',
@@ -51,6 +55,7 @@ export default async () => {
       plugins: ['babel-root-slash-import'],
     };
 
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
     packageJson.devDependencies['babel-preset-env'] = presetEnvVersion;
     packageJson.devDependencies['babel-preset-react'] = presetReactVersion;
     packageJson.devDependencies['babel-preset-stage-1'] = presetStage1Version;
@@ -63,6 +68,7 @@ export default async () => {
   packageJson.devDependencies['@storybook/react'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
   packageJson.scripts.storybook = 'start-storybook -p 6006';
   packageJson.scripts['build-storybook'] = 'build-storybook';
 

--- a/lib/cli/generators/REACT/index.js
+++ b/lib/cli/generators/REACT/index.js
@@ -3,20 +3,34 @@ import mergeDirs from 'merge-dirs';
 import { getVersions, getPackageJson, writePackageJson } from '../../lib/helpers';
 
 export default async () => {
-  const [storybookVersion, actionsVersion, linksVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    babelCoreVersion,
+  ] = await getVersions(
     '@storybook/react',
     '@storybook/addon-actions',
-    '@storybook/addon-links'
+    '@storybook/addon-links',
+    '@storybook/addons',
+    'babel-core'
   );
 
   mergeDirs(path.resolve(__dirname, 'template/'), '.', 'overwrite');
 
   const packageJson = getPackageJson();
 
+  packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
   packageJson.devDependencies['@storybook/react'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
+  }
 
   packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts.storybook = 'start-storybook -p 6006';

--- a/lib/cli/generators/REACT_NATIVE/index.js
+++ b/lib/cli/generators/REACT_NATIVE/index.js
@@ -5,10 +5,19 @@ import chalk from 'chalk';
 import { getVersions, getPackageJson, writePackageJson, paddedLog } from '../../lib/helpers';
 
 export default async () => {
-  const [storybookVersion, actionsVersion, linksVersion, propTypesVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    babelCoreVersion,
+    propTypesVersion,
+  ] = await getVersions(
     '@storybook/react-native',
     '@storybook/addon-actions',
     '@storybook/addon-links',
+    '@storybook/addons',
+    'babel-core',
     'prop-types'
   );
 
@@ -37,6 +46,11 @@ export default async () => {
   packageJson.devDependencies['@storybook/react-native'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
+  }
 
   if (!packageJson.dependencies['react-dom'] && !packageJson.devDependencies['react-dom']) {
     const reactVersion = packageJson.dependencies.react;

--- a/lib/cli/generators/REACT_NATIVE_SCRIPTS/index.js
+++ b/lib/cli/generators/REACT_NATIVE_SCRIPTS/index.js
@@ -3,10 +3,19 @@ import path from 'path';
 import { getVersions, getPackageJson, writePackageJson } from '../../lib/helpers';
 
 export default async () => {
-  const [storybookVersion, actionsVersion, linksVersion, propTypesVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    babelCoreVersion,
+    propTypesVersion,
+  ] = await getVersions(
     '@storybook/react-native',
     '@storybook/addon-actions',
     '@storybook/addon-links',
+    '@storybook/addons',
+    'babel-core',
     'prop-types'
   );
 
@@ -21,6 +30,11 @@ export default async () => {
   packageJson.devDependencies['@storybook/react-native'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
+  }
 
   if (!packageJson.dependencies['react-dom'] && !packageJson.devDependencies['react-dom']) {
     const reactVersion = packageJson.dependencies.react;

--- a/lib/cli/generators/REACT_SCRIPTS/index.js
+++ b/lib/cli/generators/REACT_SCRIPTS/index.js
@@ -4,21 +4,35 @@ import fs from 'fs';
 import { getVersions, getPackageJson, writePackageJson } from '../../lib/helpers';
 
 export default async () => {
-  const [storybookVersion, actionsVersion, linksVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    babelCoreVersion,
+  ] = await getVersions(
     '@storybook/react',
     '@storybook/addon-actions',
-    '@storybook/addon-links'
+    '@storybook/addon-links',
+    '@storybook/addons',
+    'babel-core'
   );
 
   mergeDirs(path.resolve(__dirname, 'template/'), '.', 'overwrite');
 
   const packageJson = getPackageJson();
 
+  packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
 
   packageJson.devDependencies['@storybook/react'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
+  }
 
   packageJson.scripts.storybook = 'start-storybook -p 9009';
   packageJson.scripts['build-storybook'] = 'build-storybook';

--- a/lib/cli/generators/SFC_VUE/index.js
+++ b/lib/cli/generators/SFC_VUE/index.js
@@ -9,10 +9,19 @@ import {
 } from '../../lib/helpers';
 
 export default async () => {
-  const [storybookVersion, actionsVersion, linksVersion, babelPresetVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    babelCoreVersion,
+    babelPresetVersion,
+  ] = await getVersions(
     '@storybook/vue',
     '@storybook/addon-actions',
     '@storybook/addon-links',
+    '@storybook/addons',
+    'babel-core',
     'babel-preset-vue'
   );
 
@@ -20,10 +29,16 @@ export default async () => {
 
   const packageJson = getPackageJson();
 
+  packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
   packageJson.devDependencies['@storybook/vue'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
+  }
   packageJson.devDependencies['babel-preset-vue'] = babelPresetVersion;
 
   packageJson.scripts = packageJson.scripts || {};

--- a/lib/cli/generators/UPDATE_PACKAGE_ORGANIZATIONS/index.js
+++ b/lib/cli/generators/UPDATE_PACKAGE_ORGANIZATIONS/index.js
@@ -27,17 +27,19 @@ async function updatePackageJson() {
   const packageJson = getPackageJson();
   const { devDependencies } = packageJson;
 
-  await Promise.all([
-    addPeerDependencies(packageJson),
-    ...Object.keys(packageNames).map(oldName => {
+  await Promise.all(
+    Object.keys(packageNames).map(oldName => {
       const newName = packageNames[oldName];
       return updatePackage(devDependencies, oldName, newName);
-    }),
-  ]);
+    })
+  );
 
   if (!devDependencies['@storybook/react'] && !devDependencies['@storybook/react-native']) {
     throw new Error('Expected to find `@kadira/[react-native]-storybook` in devDependencies');
   }
+
+  await addPeerDependencies(packageJson);
+
   writePackageJson(packageJson);
 }
 

--- a/lib/cli/generators/UPDATE_PACKAGE_ORGANIZATIONS/index.js
+++ b/lib/cli/generators/UPDATE_PACKAGE_ORGANIZATIONS/index.js
@@ -1,14 +1,25 @@
+/* eslint-disable no-param-reassign */
 import path from 'path';
 import { spawn } from 'child-process-promise';
 import { packageNames } from '@storybook/codemod';
-import { getVersion, getPackageJson, writePackageJson } from '../../lib/helpers';
+import { getVersion, getVersions, getPackageJson, writePackageJson } from '../../lib/helpers';
 
 async function updatePackage(devDependencies, oldName, newName) {
   if (devDependencies[oldName]) {
-    /* eslint-disable no-param-reassign */
     delete devDependencies[oldName];
     devDependencies[newName] = await getVersion(newName);
-    /* eslint-enable */
+  }
+}
+
+async function addPeerDependencies(packageJson) {
+  const [addonsVersion, babelCoreVersion] = await getVersions('@storybook/addons', 'babel-core');
+
+  packageJson.dependencies = packageJson.dependencies || {};
+
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
   }
 }
 
@@ -16,12 +27,13 @@ async function updatePackageJson() {
   const packageJson = getPackageJson();
   const { devDependencies } = packageJson;
 
-  await Promise.all(
-    Object.keys(packageNames).map(oldName => {
+  await Promise.all([
+    addPeerDependencies(packageJson),
+    ...Object.keys(packageNames).map(oldName => {
       const newName = packageNames[oldName];
       return updatePackage(devDependencies, oldName, newName);
-    })
-  );
+    }),
+  ]);
 
   if (!devDependencies['@storybook/react'] && !devDependencies['@storybook/react-native']) {
     throw new Error('Expected to find `@kadira/[react-native]-storybook` in devDependencies');

--- a/lib/cli/generators/VUE/index.js
+++ b/lib/cli/generators/VUE/index.js
@@ -9,10 +9,19 @@ import {
 } from '../../lib/helpers';
 
 export default async () => {
-  const [storybookVersion, actionsVersion, linksVersion, babelPresetVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    babelCoreVersion,
+    babelPresetVersion,
+  ] = await getVersions(
     '@storybook/vue',
     '@storybook/addon-actions',
     '@storybook/addon-links',
+    '@storybook/addons',
+    'babel-core',
     'babel-preset-vue'
   );
 
@@ -20,10 +29,16 @@ export default async () => {
 
   const packageJson = getPackageJson();
 
+  packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
   packageJson.devDependencies['@storybook/vue'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
+  }
   packageJson.devDependencies['babel-preset-vue'] = babelPresetVersion;
 
   packageJson.scripts = packageJson.scripts || {};

--- a/lib/cli/generators/WEBPACK_REACT/index.js
+++ b/lib/cli/generators/WEBPACK_REACT/index.js
@@ -3,20 +3,34 @@ import path from 'path';
 import { getVersions, getPackageJson, writePackageJson } from '../../lib/helpers';
 
 export default async () => {
-  const [storybookVersion, actionsVersion, linksVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    babelCoreVersion,
+  ] = await getVersions(
     '@storybook/react',
     '@storybook/addon-actions',
-    '@storybook/addon-links'
+    '@storybook/addon-links',
+    '@storybook/addons',
+    'babel-core'
   );
 
   mergeDirs(path.resolve(__dirname, 'template/'), '.', 'overwrite');
 
   const packageJson = getPackageJson();
 
+  packageJson.dependencies = packageJson.dependencies || {};
   packageJson.devDependencies = packageJson.devDependencies || {};
   packageJson.devDependencies['@storybook/react'] = storybookVersion;
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
+  packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  if (!packageJson.dependencies['babel-core'] && !packageJson.devDependencies['babel-core']) {
+    packageJson.devDependencies['babel-core'] = babelCoreVersion;
+  }
 
   packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts.storybook = 'start-storybook -p 6006';

--- a/lib/cli/test/snapshots/angular-cli/package.json
+++ b/lib/cli/test/snapshots/angular-cli/package.json
@@ -48,6 +48,7 @@
     "@storybook/addon-notes": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
     "@storybook/addon-links": "^3.4.0-alpha.1",
-    "@types/lodash-es": "^4.17.0"
+    "@storybook/addons": "^3.4.0-alpha.1",
+    "babel-core": "^6.26.0"
   }
 }

--- a/lib/cli/test/snapshots/meteor/package.json
+++ b/lib/cli/test/snapshots/meteor/package.json
@@ -14,12 +14,14 @@
     "react-dom": "^16.2.0"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
     "babel-root-slash-import": "^1.1.0",
     "@storybook/react": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
-    "@storybook/addon-links": "^3.4.0-alpha.1"
+    "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1"
   }
 }

--- a/lib/cli/test/snapshots/react/package.json
+++ b/lib/cli/test/snapshots/react/package.json
@@ -22,6 +22,8 @@
     "rollup-plugin-replace": "^1.1.1",
     "@storybook/react": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
-    "@storybook/addon-links": "^3.4.0-alpha.1"
+    "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1",
+    "babel-core": "^6.26.0"
   }
 }

--- a/lib/cli/test/snapshots/react_native/package.json
+++ b/lib/cli/test/snapshots/react_native/package.json
@@ -19,6 +19,8 @@
     "@storybook/react-native": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
     "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1",
+    "babel-core": "^6.26.0",
     "react-dom": "16.0.0-alpha.12",
     "prop-types": "^15.6.0"
   },

--- a/lib/cli/test/snapshots/react_native_scripts/package.json
+++ b/lib/cli/test/snapshots/react_native_scripts/package.json
@@ -9,6 +9,8 @@
     "@storybook/react-native": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
     "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1",
+    "babel-core": "^6.26.0",
     "react-dom": "16.0.0-alpha.12",
     "prop-types": "^15.6.0"
   },

--- a/lib/cli/test/snapshots/react_project/package.json
+++ b/lib/cli/test/snapshots/react_project/package.json
@@ -15,10 +15,13 @@
     "react-dom": "^15.6.1",
     "@storybook/react": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
-    "@storybook/addon-links": "^3.4.0-alpha.1"
+    "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1",
+    "babel-core": "^6.26.0"
   },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"
-  }
+  },
+  "dependencies": {}
 }

--- a/lib/cli/test/snapshots/react_scripts/package.json
+++ b/lib/cli/test/snapshots/react_scripts/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "@storybook/react": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
-    "@storybook/addon-links": "^3.4.0-alpha.1"
+    "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1",
+    "babel-core": "^6.26.0"
   }
 }

--- a/lib/cli/test/snapshots/sfc_vue/package.json
+++ b/lib/cli/test/snapshots/sfc_vue/package.json
@@ -52,6 +52,7 @@
     "@storybook/vue": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
     "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1",
     "babel-preset-vue": "^2.0.0"
   },
   "engines": {

--- a/lib/cli/test/snapshots/update_package_organisations/package.json
+++ b/lib/cli/test/snapshots/update_package_organisations/package.json
@@ -8,7 +8,9 @@
     "react-scripts": "0.9.x"
   },
   "devDependencies": {
-    "@storybook/react": "^3.4.0-alpha.1"
+    "@storybook/react": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1",
+    "babel-core": "^6.26.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/lib/cli/test/snapshots/vue/package.json
+++ b/lib/cli/test/snapshots/vue/package.json
@@ -37,6 +37,7 @@
     "@storybook/vue": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
     "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1",
     "babel-preset-vue": "^2.0.0"
   }
 }

--- a/lib/cli/test/snapshots/webpack_react/package.json
+++ b/lib/cli/test/snapshots/webpack_react/package.json
@@ -19,6 +19,7 @@
     "webpack": "^3.5.5",
     "@storybook/react": "^3.4.0-alpha.1",
     "@storybook/addon-actions": "^3.4.0-alpha.1",
-    "@storybook/addon-links": "^3.4.0-alpha.1"
+    "@storybook/addon-links": "^3.4.0-alpha.1",
+    "@storybook/addons": "^3.4.0-alpha.1"
   }
 }


### PR DESCRIPTION
Issue: As someone has pointed out, both quick and slow start guides don't work currently, because they're missing the newly added peerDependencies 