### PR TITLE
Correcting Options Addon README.md

### DIFF
--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -66,12 +66,12 @@ setOptions({
    */
   showAddonPanel: true,
   /**
-   * display floating search box to search through stories
+   * show addon panel as a vertical panel on the right
    * @type {Boolean}
    */
   showSearchBox: false,
   /**
-   * show addon panel as a vertical panel on the right
+   * display floating search box to search through stories
    * @type {Boolean}
    */
   addonPanelInRight: false,


### PR DESCRIPTION
Issue:
The Options Addon Readme had comments in the wrong areas

## What I did
Moved the comments below the correct variables

## How to test

Is this testable with jest or storyshots? N/A

Does this need a new example in the kitchen sink apps? N/A

Does this need an update to the documentation? N/A

If your answer is yes to any of these, please make sure to include it in your PR.
