### PR TITLE
Revert lerna to fix publishing problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest-enzyme": "^4.0.2",
     "jest-image-snapshot": "^2.3.0",
     "jest-jasmine2": "^22.0.6",
-    "lerna": "^2.7.0",
+    "lerna": "^2.6.0",
     "lint-staged": "^6.0.0",
     "lodash": "^4.17.4",
     "nodemon": "^1.14.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8566,7 +8566,7 @@ left-pad@^1.1.3, left-pad@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
 
-lerna@^2.7.0:
+lerna@^2.6.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.7.0.tgz#1df22aebaa82d8134b19303ac3e503146d1e4e9a"
   dependencies:


### PR DESCRIPTION
Issue: N/A

## What I did

This change to lerna broke our publishing flow, so I'm reverting it for now:

https://github.com/lerna/lerna/pull/1145

## How to test

Is this testable with jest or storyshots?

Does this need a new example in the kitchen sink apps?

Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
