### PR TITLE
Addon-backgrounds: remove redundant scrollbars

### DIFF
--- a/addons/background/src/index.js
+++ b/addons/background/src/index.js
@@ -5,7 +5,7 @@ import addons from '@storybook/addons';
 
 const style = {
   wrapper: {
-    overflow: 'scroll',
+    overflow: 'auto',
     position: 'fixed',
     top: 0,
     bottom: 0,

--- a/examples/official-storybook/stories/__snapshots__/addon-backgrounds.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-backgrounds.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Addons|Backgrounds story 1 1`] = `
 <div
-  style="overflow:scroll;position:fixed;top:0;bottom:0;right:0;left:0;transition:background 0.25s ease-in-out;background-position:center;background-size:cover;background:transparent"
+  style="overflow:auto;position:fixed;top:0;bottom:0;right:0;left:0;transition:background 0.25s ease-in-out;background-position:center;background-size:cover;background:transparent"
 >
   <button>
     You should be able to switch backgrounds for this story
@@ -12,7 +12,7 @@ exports[`Storyshots Addons|Backgrounds story 1 1`] = `
 
 exports[`Storyshots Addons|Backgrounds story 2 1`] = `
 <div
-  style="overflow:scroll;position:fixed;top:0;bottom:0;right:0;left:0;transition:background 0.25s ease-in-out;background-position:center;background-size:cover;background:transparent"
+  style="overflow:auto;position:fixed;top:0;bottom:0;right:0;left:0;transition:background 0.25s ease-in-out;background-position:center;background-size:cover;background:transparent"
 >
   <button>
     This one too!


### PR DESCRIPTION
Fixes the first part of #2655 

## How to test
Open addon-backgrounds example

Note for mac users: to see the difference, you may need to go to Settings -> General and select "Always" as "Show scroll bars" option