### PR TITLE
Fix introduction page header

### DIFF
--- a/docs/src/pages/basics/introduction/index.md
+++ b/docs/src/pages/basics/introduction/index.md
@@ -1,8 +1,7 @@
-* * *
-
+---
 id: 'introduction'
-
-## title: 'Introduction'
+title: 'Introduction'
+---
 
 Storybook is a UI development environment for your UI components.
 With it, you can visualize different states of your UI components and develop them interactively.


### PR DESCRIPTION
Issue: Introduction page on docs looks wrong.

I think this fixes it? :)

[Current intro page](https://storybook.js.org/basics/introduction/):
<img width="1033" alt="screen shot 2018-01-15 at 5 54 09 pm" src="https://user-images.githubusercontent.com/5074763/34964789-3a1481fc-fa1d-11e7-9d4d-92b0168b9143.png">