### PR TITLE
remove entryComponents prop from metadata

### DIFF
--- a/examples/angular-cli/src/stories/index.ts
+++ b/examples/angular-cli/src/stories/index.ts
@@ -9,7 +9,6 @@ storiesOf('Welcome', module).add('to Storybook', () => ({
 storiesOf('Button', module)
   .add('with text', () => ({
     moduleMetadata: {
-      entryComponents: [Button, Welcome],
       declarations: [Button, Welcome],
     },
     props: {


### PR DESCRIPTION
Issue:

It seems that `entryComponents` is not reeded the Angular example's story. 
It's misleading and users may think `entryComponents` is required to use template.

## What I did

- remove the prop from example stories' metadata