### PR TITLE
Addon-storyshots: upgrade puppeteer to 1.0.0

### DIFF
--- a/addons/storyshots/package.json
+++ b/addons/storyshots/package.json
@@ -24,7 +24,7 @@
     "jest-image-snapshot": "^2.3.0",
     "jest-specific-snapshot": "^0.3.0",
     "prop-types": "^15.6.0",
-    "puppeteer": "^0.13.0",
+    "puppeteer": "^1.0.0",
     "read-pkg-up": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12324,9 +12324,9 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
-puppeteer@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.13.0.tgz#2e6956205f2c640964c2107f620ae1eef8bde8fd"
+puppeteer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.0.0.tgz#20f3bb6ad6c6778b4d1fb750e808a29fec0a88a4"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"


### PR DESCRIPTION
Issue: #2731 

We don't actually use any of the changed APIs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storybooks/storybook/2853)
<!-- Reviewable:end -->
