### PR TITLE
Fix browser navigation again

### DIFF
--- a/lib/core/src/client/preview/syncUrlWithStore.js
+++ b/lib/core/src/client/preview/syncUrlWithStore.js
@@ -21,6 +21,6 @@ export default function syncUrlToStore(reduxStore) {
       selectedKind,
       selectedStory,
     });
-    window.history.pushState({}, '', `?${queryString}`);
+    window.history.replaceState({}, '', `?${queryString}`);
   });
 }


### PR DESCRIPTION
Issue: #2868 

Looks like using `pushState` in iframe creates new history entries in parent window