### PR TITLE
Fix polymer static build

### DIFF
--- a/app/polymer/src/server/config/babel.prod.js
+++ b/app/polymer/src/server/config/babel.prod.js
@@ -13,7 +13,12 @@ module.exports = {
     ],
     require.resolve('babel-preset-stage-0'),
     require.resolve('babel-preset-react'),
-    require.resolve('babel-preset-minify'),
+    [
+      require.resolve('babel-preset-minify'),
+      {
+        mangle: false,
+      },
+    ],
   ],
   plugins: [
     require.resolve('babel-plugin-transform-regenerator'),


### PR DESCRIPTION
Issue: When browsing to Polymer static output it throws `caseMap is undefined` (I don't remember exactly the error) from the preview.

## What I did
Set mangle to false in babel-preset-minify