### PR TITLE
Add warning about importing CSS in Angular CLI projects

### DIFF
--- a/docs/src/pages/configurations/default-config/index.md
+++ b/docs/src/pages/configurations/default-config/index.md
@@ -56,6 +56,11 @@ import './styles.css';
 
 > **Note:** this is plain CSS only. If you need a preprocessor like SASS, you need to [customize the webpack config](/configurations/custom-webpack-config/).
 
+> **Warning:** storybooks for projects that use Angular CLI must use the inline loader syntax:
+> ```js
+> import '!style-loader!css-loader!./styles.css';
+> ```
+
 ### Image and Static File Support
 
 You can also import images and media files directly via JavaScript.

--- a/docs/src/pages/configurations/default-config/index.md
+++ b/docs/src/pages/configurations/default-config/index.md
@@ -56,7 +56,7 @@ import './styles.css';
 
 > **Note:** this is plain CSS only. If you need a preprocessor like SASS, you need to [customize the webpack config](/configurations/custom-webpack-config/).
 
-> **Warning:** storybooks for projects that use Angular CLI must use the inline loader syntax:
+> **Warning:** storybooks for projects that use Angular CLI cannot import CSS by default. They must either [customize the webpack config](/configurations/custom-webpack-config/), or use the inline loader syntax:
 > ```js
 > import '!style-loader!css-loader!./styles.css';
 > ```


### PR DESCRIPTION
The changes in https://github.com/storybooks/storybook/pull/2735 mean that the CSS loader is not available when creating a storybook for an Angular CLI project, so CSS cannot be imported directly within a story with using the inline loader syntax.

## What I did

Added a note to the docs.

## How to test

 1. `yarn docs:dev`
 2. Check the configurations/default-config page.
