### PR TITLE
Integration tests: wait until stories appear

### DIFF
--- a/integration/examples.test.js
+++ b/integration/examples.test.js
@@ -23,18 +23,21 @@ const examples = [
   {
     name: 'cra-kitchen-sink',
     storybookUrl: pathToCraKitchenSink,
+    storySelector: '#root *',
   },
   {
     name: 'vue-kitchen-sink',
     storybookUrl: pathToVueKitchenSink,
+    storySelector: '#root *',
   },
   {
     name: 'angular-cli',
     storybookUrl: pathToAngularKitchenSink,
+    storySelector: 'storybook-dynamic-app-root *',
   },
 ];
 
-examples.forEach(({ name, storybookUrl }) => {
+examples.forEach(({ name, storybookUrl, storySelector }) => {
   let browser = puppeteer.launch();
   let page;
 
@@ -50,6 +53,8 @@ examples.forEach(({ name, storybookUrl }) => {
 
     it(`Take screenshots for '${name}'`, async () => {
       await page.goto(`file://${storybookUrl}`);
+      const iframe = page.mainFrame().childFrames()[0];
+      await iframe.waitFor(storySelector);
       const screenshot = await page.screenshot({ fullPage: true });
       expect(screenshot).toMatchImageSnapshot({
         failureThreshold: 0.04, // 4% threshold,


### PR DESCRIPTION
Issue: Integration test are failing randomly

## What I did
Used [`page.waitFor`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagewaitforselectororfunctionortimeout-options-args) API to ensure that stories are rendered before taking screenshot

@tmeasday maybe we can use a similar approach on chromatic?