### PR TITLE
Addons: avoid mixing manager and preview code together

### DIFF
--- a/addons/actions/register.js
+++ b/addons/actions/register.js
@@ -1,1 +1,1 @@
-require('./dist').register();
+require('./dist/manager').register();

--- a/addons/actions/src/index.js
+++ b/addons/actions/src/index.js
@@ -3,5 +3,4 @@ export const ADDON_ID = 'storybook/actions';
 export const PANEL_ID = `${ADDON_ID}/actions-panel`;
 export const EVENT_ID = `${ADDON_ID}/action-event`;
 
-export { register } from './manager';
 export { action, decorateAction } from './preview';

--- a/addons/events/README.md
+++ b/addons/events/README.md
@@ -27,8 +27,8 @@ Then create a file called `addons.js` in your storybook config.
 Add following content to it:
 
 ```js
-import '@storybook/addon-actions';
-import '@storybook/addon-links';
+import '@storybook/addon-actions/register';
+import '@storybook/addon-links/register';
 import '@storybook/addon-events/register';
 ```
 

--- a/addons/events/register.js
+++ b/addons/events/register.js
@@ -1,1 +1,1 @@
-require('./dist').register();
+require('./dist/manager').register();

--- a/addons/events/src/index.js
+++ b/addons/events/src/index.js
@@ -1,3 +1,1 @@
 export default from './preview';
-
-export { register } from './manager';

--- a/addons/links/register.js
+++ b/addons/links/register.js
@@ -1,1 +1,1 @@
-require('./dist').register();
+require('./dist/manager').register();

--- a/addons/links/src/index.js
+++ b/addons/links/src/index.js
@@ -3,7 +3,6 @@ export const EVENT_ID = `${ADDON_ID}/link-event`;
 export const REQUEST_HREF_EVENT_ID = `${ADDON_ID}/request-href-event`;
 export const RECEIVE_HREF_EVENT_ID = `${ADDON_ID}/receive-href-event`;
 
-export { register } from './manager';
 export { linkTo, hrefTo } from './preview';
 
 let hasWarned = false;

--- a/addons/storysource/register.js
+++ b/addons/storysource/register.js
@@ -1,1 +1,1 @@
-require('./dist').register();
+require('./dist/manager').register();

--- a/addons/storysource/src/index.js
+++ b/addons/storysource/src/index.js
@@ -2,5 +2,4 @@ export const ADDON_ID = 'storybook/stories';
 export const PANEL_ID = `${ADDON_ID}/stories-panel`;
 export const EVENT_ID = `${ADDON_ID}/story-event`;
 
-export { register } from './manager';
 export { withStorySource } from './preview';


### PR DESCRIPTION
Issue: #2275 accidentally broke React Native. The problem is that glamorous contains browser-specific code, and this line makes it leak into RN: https://github.com/storybooks/storybook/blob/master/addons/actions/src/index.js#L6

## What I did
Ensured that manager and preview code is separated in all existing addons

