### PR TITLE
Select the first story in tree when opening a tree item

### DIFF
--- a/lib/ui/src/modules/ui/components/stories_panel/stories_tree/index.js
+++ b/lib/ui/src/modules/ui/components/stories_panel/stories_tree/index.js
@@ -77,6 +77,11 @@ class Stories extends React.Component {
   onToggle(node, toggled) {
     if (node.story) {
       this.fireOnKindAndStory(node.kind, node.story);
+    } else if (node.children.length) {
+      const defaultStory = node.children[0];
+      if (defaultStory.story) {
+        this.fireOnKindAndStory(defaultStory.kind, defaultStory.story)
+      }
     }
 
     if (!node.namespaces) {


### PR DESCRIPTION
## What I did

I improved the tree view to automatically select the first story (leaf) when opening a group if possible. It allows the styleguide to open a section more easily so an user could go to the content faster.

## How to test

Is this testable with jest or storyshots? Not sure

Does this need a new example in the kitchen sink apps? No

Does this need an update to the documentation? No