### PR TITLE
Add `viewport` addon to the Addon Gallery

### DIFF
--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -46,6 +46,10 @@ Redirects console output (logs, errors, warnings) into Action Logger Panel. `wit
 
 With this addon, you can switch between background colors and background images for your preview components. It is really helpful for styleguides.
 
+### [Viewport](https://github.com/storybooks/storybook/tree/master/addons/viewport)
+
+Viewport allows your stories to be displayed in different sizes and layouts in [Storybook](https://storybookjs.org).  This helps build responsive components inside of Storybook.
+
 ## Community Addons
 
 You need to install these addons directly from NPM in order to use them.

--- a/lib/cli/test/snapshots/react_native/package.json
+++ b/lib/cli/test/snapshots/react_native/package.json
@@ -23,7 +23,7 @@
     "babel-core": "^6.26.0",
     "babel-runtime": "^6.26.0",
     "react-dom": "16.0.0-alpha.12",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.1"
   },
   "jest": {
     "preset": "react-native"

--- a/lib/cli/test/snapshots/react_native_scripts/package.json
+++ b/lib/cli/test/snapshots/react_native_scripts/package.json
@@ -13,7 +13,7 @@
     "babel-core": "^6.26.0",
     "babel-runtime": "^6.26.0",
     "react-dom": "16.0.0-alpha.12",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.1"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
   "scripts": {


### PR DESCRIPTION
Issue: `viewport` addon is not shown as part of the Addon Gallery

## What I did
* I added it to the list with brief description (same as `README` file)

## How to test
* Just review the change for grammar mistakes or typos

Is this testable with jest or storyshots?
* No

Does this need a new example in the kitchen sink apps?
* No

Does this need an update to the documentation?
* It is an update to the documentation, so no

If your answer is yes to any of these, please make sure to include it in your PR.
