### PR TITLE
Added missing key prop to NoTests component.

### DIFF
--- a/addons/jest/src/components/Panel.js
+++ b/addons/jest/src/components/Panel.js
@@ -98,7 +98,7 @@ const Content = glamorous(({ tests, className }) => (
   <div className={className}>
     {tests.map(({ name, result }) => {
       if (!result) {
-        return <NoTests>This story has tests configured, but no file was found</NoTests>;
+        return <NoTests key={name}>This story has tests configured, but no file was found</NoTests>;
       }
 
       const successNumber = result.assertionResults.filter(({ status }) => status === 'passed')


### PR DESCRIPTION
Issue:
React is returning a warning about a missing `key` prop when rendering some Jest test results using the `NoTests` component (ie. tests could not be found).

## What I did
Add a `key` prop to `NoTests` containing the value of the name of the test being rendered.

## How to test
Add references to Jest test files inside `withTests` that are not yet present. For example, `withTests('somenoneexistenttestsfilename')`.

Is this testable with jest or storyshots?
Jest
Does this need a new example in the kitchen sink apps?
No
Does this need an update to the documentation?
No
~If your answer is yes to any of these, please make sure to include it in your PR.~
