### PR TITLE
Updated testIds in RN StoryListView to use kind

### DIFF
--- a/app/react-native/src/preview/components/StoryListView/index.js
+++ b/app/react-native/src/preview/components/StoryListView/index.js
@@ -28,6 +28,7 @@ const ListItem = ({ kind, title, selected, onPress }) => (
 
 ListItem.propTypes = {
   title: PropTypes.string.isRequired,
+  kind: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   selected: PropTypes.bool.isRequired,
 };

--- a/app/react-native/src/preview/components/StoryListView/index.js
+++ b/app/react-native/src/preview/components/StoryListView/index.js
@@ -14,12 +14,12 @@ SectionHeader.propTypes = {
   selected: PropTypes.bool.isRequired,
 };
 
-const ListItem = ({ title, selected, onPress }) => (
+const ListItem = ({ kind, title, selected, onPress }) => (
   <TouchableOpacity
     key={title}
     style={style.item}
     onPress={onPress}
-    testID={`Storybook.ListItem.${title}`}
+    testID={`Storybook.ListItem.${kind}.${title}`}
     accessibilityLabel={`Storybook.ListItem.${title}`}
   >
     <Text style={[style.itemText, selected && style.itemTextSelected]}>{title}</Text>
@@ -96,6 +96,7 @@ export default class StoryListView extends Component {
         renderRow={item => (
           <ListItem
             title={item.name}
+            kind={item.kind}
             selected={
               item.kind === this.props.selectedKind && item.name === this.props.selectedStory
             }

--- a/app/react-native/src/preview/components/StoryListView/index.js
+++ b/app/react-native/src/preview/components/StoryListView/index.js
@@ -93,6 +93,7 @@ export default class StoryListView extends Component {
   render() {
     return (
       <ListView
+        testID="Storybook.ListView"
         style={[style.list, { width: this.props.width }]}
         renderRow={item => (
           <ListItem


### PR DESCRIPTION
Hello,

I've been working on integrating [Detox](https://github.com/wix/detox) with storybook. Everything looks really promising because of included StoryListView in RN storybook. The only issue with it is that it doesn't scope stories by the kind. So if you have to stories with same name i.e. `Default state` they will both have same testIDs and it will be difficult to understand which story to click.

Issue: Not Scoped testIDS in StoryListView.

## What I did

Added kind to testID.

## How to test

N/A (no tests here)

Is this testable with jest or storyshots?

Could be.

Does this need a new example in the kitchen sink apps?

No.

Does this need an update to the documentation?

No.
