### PR TITLE
Fix broken storybook website link in Addon-gallery

### DIFF
--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -48,7 +48,7 @@ With this addon, you can switch between background colors and background images 
 
 ### [Viewport](https://github.com/storybooks/storybook/tree/master/addons/viewport)
 
-Viewport allows your stories to be displayed in different sizes and layouts in [Storybook](https://storybookjs.org).  This helps build responsive components inside of Storybook.
+Viewport allows your stories to be displayed in different sizes and layouts in [Storybook](https://storybook.js.org).  This helps build responsive components inside of Storybook.
 
 ## Community Addons
 


### PR DESCRIPTION
Issue:
The storybook link in `Viewport`'s description (Addon-Gallery) is broken (missing `.`)

## What I did
Fixed it

## How to test
Just follow the link

Is this testable with jest or storyshots?
No

Does this need a new example in the kitchen sink apps?
No

Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.
