### PR TITLE
Fix broken storybook website link in viewport

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -1,6 +1,6 @@
 # Storybook Viewport Addon
 
-Storybook Viewport Addon allows your stories to be displayed in different sizes and layouts in [Storybook](https://storybookjs.org).  This helps build responsive components inside of Storybook.
+Storybook Viewport Addon allows your stories to be displayed in different sizes and layouts in [Storybook](https://storybook.js.org).  This helps build responsive components inside of Storybook.
 
 [Framework Support](https://github.com/storybooks/storybook/blob/master/ADDONS_SUPPORT.md)
 


### PR DESCRIPTION
Issue:
Same as #3173, the storybook link in `Viewport`'s README is broken (missing `.`)

## What I did
Fixed it

## How to test
Just follow the link

Is this testable with jest or storyshots?
No

Does this need a new example in the kitchen sink apps?
No

Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.
