### PR TITLE
Delaying update of height and width in Layout

### DIFF
--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -28,6 +28,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.pick": "^4.4.0",
     "lodash.sortby": "^4.7.0",
+    "lodash.throttle": "^4.1.1",
     "prop-types": "^15.6.1",
     "qs": "^6.5.1",
     "react-fuzzy": "^0.5.2",

--- a/lib/ui/src/modules/ui/components/layout/index.js
+++ b/lib/ui/src/modules/ui/components/layout/index.js
@@ -1,4 +1,4 @@
-import { localStorage, window } from 'global';
+import { localStorage } from 'global';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SplitPane from 'react-split-pane';
@@ -140,14 +140,6 @@ class Layout extends React.Component {
     this.onDragEnd = this.onDragEnd.bind(this);
   }
 
-  componentDidMount() {
-    window.addEventListener('resize', this.onResize);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.onResize);
-  }
-
   onDragStart() {
     this.setState({ isDragging: true });
   }
@@ -157,18 +149,22 @@ class Layout extends React.Component {
   }
 
   onResize(pane, mode) {
+    let resizeTimeout;
+
     return size => {
-      this.layerSizes[pane][mode] = size;
-      saveSizes(this.layerSizes);
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(() => {
+        this.layerSizes[pane][mode] = size;
+        saveSizes(this.layerSizes);
 
-      const { clientWidth, clientHeight } = this.previewPanelRef;
-
-      this.setState({
-        previewPanelDimensions: {
-          width: clientWidth,
-          height: clientHeight,
-        },
-      });
+        const { clientWidth, clientHeight } = this.previewPanelRef;
+        this.setState({
+          previewPanelDimensions: {
+            width: clientWidth,
+            height: clientHeight,
+          },
+        });
+      }, 50);
     };
   }
 

--- a/lib/ui/src/modules/ui/components/layout/index.js
+++ b/lib/ui/src/modules/ui/components/layout/index.js
@@ -2,6 +2,7 @@ import { localStorage } from 'global';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SplitPane from 'react-split-pane';
+import _ from 'lodash'; /* eslint-disable-line import/no-extraneous-dependencies */
 
 import USplit from './usplit';
 import Dimensions from './dimensions';
@@ -135,7 +136,7 @@ class Layout extends React.Component {
       isDragging: false,
     };
 
-    this.onResize = this.onResize.bind(this);
+    this.onThrottledResize = _.throttle(this.onResize.bind(this), 200);
     this.onDragStart = this.onDragStart.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
   }
@@ -148,24 +149,17 @@ class Layout extends React.Component {
     this.setState({ isDragging: false });
   }
 
-  onResize(pane, mode) {
-    let resizeTimeout;
+  onResize(pane, mode, size) {
+    this.layerSizes[pane][mode] = size;
+    saveSizes(this.layerSizes);
 
-    return size => {
-      clearTimeout(resizeTimeout);
-      resizeTimeout = setTimeout(() => {
-        this.layerSizes[pane][mode] = size;
-        saveSizes(this.layerSizes);
-
-        const { clientWidth, clientHeight } = this.previewPanelRef;
-        this.setState({
-          previewPanelDimensions: {
-            width: clientWidth,
-            height: clientHeight,
-          },
-        });
-      }, 50);
-    };
+    const { clientWidth, clientHeight } = this.previewPanelRef;
+    this.setState({
+      previewPanelDimensions: {
+        width: clientWidth,
+        height: clientHeight,
+      },
+    });
   }
 
   render() {
@@ -212,7 +206,9 @@ class Layout extends React.Component {
           resizerStyle={storiesResizerStyle(showStoriesPanel, storiesPanelOnTop)}
           onDragStarted={this.onDragStart}
           onDragFinished={this.onDragEnd}
-          onChange={this.onResize('storiesPanel', storiesPanelOnTop ? 'top' : 'left')}
+          onChange={size =>
+            this.onThrottledResize('storiesPanel', storiesPanelOnTop ? 'top' : 'left', size)
+          }
         >
           <div style={storiesPanelStyle(showStoriesPanel, storiesPanelOnTop)}>
             <div style={{ flexGrow: 1, height: '100%', width: '100%' }}>{storiesPanel()}</div>
@@ -229,7 +225,9 @@ class Layout extends React.Component {
             resizerStyle={addonResizerStyle(showAddonPanel, addonPanelInRight)}
             onDragStarted={this.onDragStart}
             onDragFinished={this.onDragEnd}
-            onChange={this.onResize('addonPanel', addonPanelInRight ? 'right' : 'down')}
+            onChange={size =>
+              this.onThrottledResize('addonPanel', addonPanelInRight ? 'right' : 'down', size)
+            }
           >
             <div style={contentPanelStyle(addonPanelInRight, storiesPanelOnTop)}>
               {/*

--- a/lib/ui/src/modules/ui/components/layout/index.js
+++ b/lib/ui/src/modules/ui/components/layout/index.js
@@ -2,7 +2,7 @@ import { localStorage, window } from 'global';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SplitPane from 'react-split-pane';
-import _ from 'lodash'; /* eslint-disable-line import/no-extraneous-dependencies */
+import throttle from 'lodash.throttle';
 
 import USplit from './usplit';
 import Dimensions from './dimensions';
@@ -136,17 +136,18 @@ class Layout extends React.Component {
       isDragging: false,
     };
 
-    this.onThrottledResize = _.throttle(this.onResize.bind(this), 200);
+    this.throttledUpdatePreviewPanelState = throttle(this.updatePrevewPanelState.bind(this), 200);
+    this.throttledSaveSizes = throttle(this.saveSizes, 25);
     this.onDragStart = this.onDragStart.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
   }
 
   componentDidMount() {
-    window.addEventListener('resize', this.onThrottledResize);
+    window.addEventListener('resize', this.throttledUpdatePreviewPanelState);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.onThrottledResize);
+    window.removeEventListener('resize', this.throttledUpdatePreviewPanelState);
   }
 
   onDragStart() {
@@ -158,12 +159,18 @@ class Layout extends React.Component {
   }
 
   onResize(pane, mode, size) {
-    if (pane && mode && size) {
-      this.layerSizes[pane][mode] = size;
-      saveSizes(this.layerSizes);
-    }
+    this.throttledSaveSizes(pane, mode, size);
+    this.throttledUpdatePreviewPanelState();
+  }
 
+  saveSizes(pane, mode, size) {
+    this.layerSizes[pane][mode] = size;
+    saveSizes(this.layerSizes);
+  }
+
+  updatePrevewPanelState() {
     const { clientWidth, clientHeight } = this.previewPanelRef;
+
     this.setState({
       previewPanelDimensions: {
         width: clientWidth,
@@ -216,9 +223,7 @@ class Layout extends React.Component {
           resizerStyle={storiesResizerStyle(showStoriesPanel, storiesPanelOnTop)}
           onDragStarted={this.onDragStart}
           onDragFinished={this.onDragEnd}
-          onChange={size =>
-            this.onThrottledResize('storiesPanel', storiesPanelOnTop ? 'top' : 'left', size)
-          }
+          onChange={size => this.onResize('storiesPanel', storiesPanelOnTop ? 'top' : 'left', size)}
         >
           <div style={storiesPanelStyle(showStoriesPanel, storiesPanelOnTop)}>
             <div style={{ flexGrow: 1, height: '100%', width: '100%' }}>{storiesPanel()}</div>
@@ -236,7 +241,7 @@ class Layout extends React.Component {
             onDragStarted={this.onDragStart}
             onDragFinished={this.onDragEnd}
             onChange={size =>
-              this.onThrottledResize('addonPanel', addonPanelInRight ? 'right' : 'down', size)
+              this.onResize('addonPanel', addonPanelInRight ? 'right' : 'down', size)
             }
           >
             <div style={contentPanelStyle(addonPanelInRight, storiesPanelOnTop)}>

--- a/lib/ui/src/modules/ui/components/layout/index.js
+++ b/lib/ui/src/modules/ui/components/layout/index.js
@@ -1,4 +1,4 @@
-import { localStorage } from 'global';
+import { localStorage, window } from 'global';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SplitPane from 'react-split-pane';
@@ -141,6 +141,14 @@ class Layout extends React.Component {
     this.onDragEnd = this.onDragEnd.bind(this);
   }
 
+  componentDidMount() {
+    window.addEventListener('resize', this.onThrottledResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.onThrottledResize);
+  }
+
   onDragStart() {
     this.setState({ isDragging: true });
   }
@@ -150,8 +158,10 @@ class Layout extends React.Component {
   }
 
   onResize(pane, mode, size) {
-    this.layerSizes[pane][mode] = size;
-    saveSizes(this.layerSizes);
+    if (pane && mode && size) {
+      this.layerSizes[pane][mode] = size;
+      saveSizes(this.layerSizes);
+    }
 
     const { clientWidth, clientHeight } = this.previewPanelRef;
     this.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -9729,6 +9729,10 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
 lodash.union@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"


### PR DESCRIPTION
Issue:

## What I did
fixes #1990 
Delayed the `setState` call so we don't rerender a billion times.

Plus removed adding un-needed event handlers to window

## How to test
use React inspector to check state updates

```sh
yarn start
```
resize the windows and see that the `previewPanelDimensions` state isn't updated thus doesn't rerender until after you stopped dragging for a little bit (50ms)

### Is this testable with jest or storyshots?
No

### Does this need a new example in the kitchen sink apps?
No

### Does this need an update to the documentation?
No

