### PR TITLE
(#2516) Add disclaimer that egghead link is paid content

### DIFF
--- a/addons/storyshots/README.md
+++ b/addons/storyshots/README.md
@@ -29,8 +29,12 @@ npm install --save-dev @storybook/addon-storyshots
 
 Usually, you might already have completed this step. If not, here are some resources for you.
 
--   If you are using Create React App, it's already configured for Jest. You just need to create a filename with the extension `.test.js`.
--   Otherwise check this Egghead [lesson](https://egghead.io/lessons/javascript-test-javascript-with-jest).
+If you are using Create React App, it's already configured for Jest. You just need to create a filename with the extension `.test.js`.
+
+Otherwise check these links:
+
+-   [Egghead lesson](https://egghead.io/lessons/javascript-test-javascript-with-jest). ***paid content***
+-   [Official Docs](https://facebook.github.io/jest/docs/en/getting-started.html) 
 
 > Note: If you use React 16, you'll need to follow [these additional instructions](https://github.com/facebook/react/issues/9102#issuecomment-283873039).
 


### PR DESCRIPTION
Issue: #2516

## What I did
Update the docs for storyshots to note that the egghead link is paid content

## How to test
N/A

Is this testable with jest or storyshots?
N/A
Does this need a new example in the kitchen sink apps?
No
Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.
