### PR TITLE
Pin node version to avoid error /bin/bash: yarn: command not found 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /tmp/storybook
   docker:
-    - image: circleci/node:8
+    - image: circleci/node:8.9.4
 
 version: 2
 dependencies:


### PR DESCRIPTION
## What I did

There is a problem with the latest version of node 8 that is causing circle builds to fail with the error
`/bin/bash: yarn: command not found`  

This pins our version of node in circle to `8.9.4`, which should work.

Issue: https://github.com/nodejs/docker-node/issues/649

## How to test
N/A

Is this testable with jest or storyshots?
No

Does this need a new example in the kitchen sink apps?
No

Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.
