### PR TITLE
Angular: use resolveLoader from cliCommonConfig

### DIFF
--- a/app/angular/src/server/angular-cli_config.js
+++ b/app/angular/src/server/angular-cli_config.js
@@ -82,5 +82,6 @@ export function applyAngularCliWebpackConfig(baseConfig, cliWebpackConfigOptions
     entry,
     module: mod,
     plugins,
+    resolveLoader: cliCommonConfig.resolveLoader,
   };
 }


### PR DESCRIPTION
Issue: Angular CLI webpack config uses loaders as plain strings (e.g. `use: 'sass-loader'`). By default that means that webpack will try to resolve this loader relative to app root directory. Sometimes it happens to work, sometimes it [doesn't](https://circleci.com/gh/storybooks/storybook/43130)

To deal with it, angular CLI adds `resolveLoader` option which we should use as well