### PR TITLE
Remove onDeviceUI animation to support Detox screenshots

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -2,16 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ifIphoneX } from 'react-native-iphone-x-helper';
 
-import {
-  Animated,
-  Dimensions,
-  Easing,
-  View,
-  TouchableWithoutFeedback,
-  Image,
-  Text,
-  StatusBar,
-} from 'react-native';
+import { Dimensions, View, TouchableWithoutFeedback, Image, Text, StatusBar } from 'react-native';
 import style from './style';
 import StoryListView from '../StoryListView';
 import StoryView from '../StoryView';
@@ -34,7 +25,6 @@ export default class OnDeviceUI extends Component {
     super(...args);
 
     this.state = {
-      menuAnimation: new Animated.Value(0),
       isMenuOpen: false,
       selectedKind: null,
       selectedStory: null,
@@ -71,24 +61,14 @@ export default class OnDeviceUI extends Component {
   };
 
   handleToggleMenu = () => {
-    const isMenuOpen = !this.state.isMenuOpen;
-
-    if (this.props.animated) {
-      Animated.timing(this.state.menuAnimation, {
-        toValue: isMenuOpen ? 1 : 0,
-        duration: 150,
-        easing: Easing.linear,
-      }).start();
-    }
-
     this.setState({
-      isMenuOpen,
+      isMenuOpen: !this.state.isMenuOpen,
     });
   };
 
   render() {
-    const { stories, animated, events, url } = this.props;
-    const { isPortrait, isMenuOpen, menuAnimation, selectedKind, selectedStory } = this.state;
+    const { stories, events, url } = this.props;
+    const { isPortrait, isMenuOpen, selectedKind, selectedStory } = this.state;
 
     const iPhoneXStyles = ifIphoneX(
       isPortrait
@@ -101,23 +81,12 @@ export default class OnDeviceUI extends Component {
       {}
     );
 
-    let translateX;
-
-    if (animated) {
-      translateX = menuAnimation.interpolate({
-        inputRange: [0, 1],
-        outputRange: [-DRAWER_WIDTH - 30, 0],
-      });
-    } else {
-      translateX = isMenuOpen ? 0 : -DRAWER_WIDTH - 30;
-    }
-
     const menuStyles = [
       style.menuContainer,
       {
         transform: [
           {
-            translateX,
+            translateX: isMenuOpen ? 0 : -DRAWER_WIDTH - 30,
           },
         ],
       },
@@ -127,12 +96,7 @@ export default class OnDeviceUI extends Component {
     const headerStyles = [
       style.headerContainer,
       {
-        opacity: animated
-          ? menuAnimation.interpolate({
-              inputRange: [0, 1],
-              outputRange: [1, 0],
-            })
-          : +!isMenuOpen,
+        opacity: +!isMenuOpen,
       },
     ];
 
@@ -156,7 +120,7 @@ export default class OnDeviceUI extends Component {
     return (
       <View style={style.main}>
         <View style={previewContainerStyles}>
-          <Animated.View style={headerStyles}>
+          <View style={headerStyles}>
             <TouchableWithoutFeedback
               onPress={this.handleToggleMenu}
               testID="Storybook.OnDeviceUI.open"
@@ -169,14 +133,14 @@ export default class OnDeviceUI extends Component {
             <Text style={style.headerText} numberOfLines={1}>
               {selectedKind} {selectedStory}
             </Text>
-          </Animated.View>
+          </View>
           <View style={previewWrapperStyles}>
             <View style={style.preview}>
               <StoryView url={url} events={events} />
             </View>
           </View>
         </View>
-        <Animated.View style={menuStyles}>
+        <View style={menuStyles}>
           <TouchableWithoutFeedback
             onPress={this.handleToggleMenu}
             testID="Storybook.OnDeviceUI.close"
@@ -193,7 +157,7 @@ export default class OnDeviceUI extends Component {
             selectedKind={selectedKind}
             selectedStory={selectedStory}
           />
-        </Animated.View>
+        </View>
       </View>
     );
   }
@@ -212,10 +176,8 @@ OnDeviceUI.propTypes = {
     removeListener: PropTypes.func.isRequired,
   }).isRequired,
   url: PropTypes.string,
-  animated: PropTypes.bool,
 };
 
 OnDeviceUI.defaultProps = {
   url: '',
-  animated: true,
 };

--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -73,11 +73,13 @@ export default class OnDeviceUI extends Component {
   handleToggleMenu = () => {
     const isMenuOpen = !this.state.isMenuOpen;
 
-    Animated.timing(this.state.menuAnimation, {
-      toValue: isMenuOpen ? 1 : 0,
-      duration: 150,
-      easing: Easing.linear,
-    }).start();
+    if (this.props.animated) {
+      Animated.timing(this.state.menuAnimation, {
+        toValue: isMenuOpen ? 1 : 0,
+        duration: 150,
+        easing: Easing.linear,
+      }).start();
+    }
 
     this.setState({
       isMenuOpen,
@@ -85,8 +87,8 @@ export default class OnDeviceUI extends Component {
   };
 
   render() {
-    const { stories, events, url } = this.props;
-    const { isPortrait, menuAnimation, selectedKind, selectedStory } = this.state;
+    const { stories, animated, events, url } = this.props;
+    const { isPortrait, isMenuOpen, menuAnimation, selectedKind, selectedStory } = this.state;
 
     const iPhoneXStyles = ifIphoneX(
       isPortrait
@@ -99,15 +101,23 @@ export default class OnDeviceUI extends Component {
       {}
     );
 
+    let translateX;
+
+    if (animated) {
+      translateX = menuAnimation.interpolate({
+        inputRange: [0, 1],
+        outputRange: [-DRAWER_WIDTH - 30, 0],
+      });
+    } else {
+      translateX = isMenuOpen ? 0 : -DRAWER_WIDTH - 30;
+    }
+
     const menuStyles = [
       style.menuContainer,
       {
         transform: [
           {
-            translateX: menuAnimation.interpolate({
-              inputRange: [0, 1],
-              outputRange: [-DRAWER_WIDTH - 30, 0],
-            }),
+            translateX,
           },
         ],
       },
@@ -117,10 +127,12 @@ export default class OnDeviceUI extends Component {
     const headerStyles = [
       style.headerContainer,
       {
-        opacity: menuAnimation.interpolate({
-          inputRange: [0, 1],
-          outputRange: [1, 0],
-        }),
+        opacity: animated
+          ? menuAnimation.interpolate({
+              inputRange: [0, 1],
+              outputRange: [1, 0],
+            })
+          : +!isMenuOpen,
       },
     ];
 
@@ -200,8 +212,10 @@ OnDeviceUI.propTypes = {
     removeListener: PropTypes.func.isRequired,
   }).isRequired,
   url: PropTypes.string,
+  animated: PropTypes.bool,
 };
 
 OnDeviceUI.defaultProps = {
   url: '',
+  animated: true,
 };

--- a/app/react-native/src/preview/components/OnDeviceUI/style.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/style.js
@@ -25,7 +25,7 @@ export default {
     right: null,
     paddingHorizontal: 10,
     paddingBottom: 10,
-    backgroundColor: 'rgba(255, 255, 255, 0.8)',
+    backgroundColor: 'white',
   },
   previewContainer: {
     flex: 1,

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -73,11 +73,14 @@ export default class Preview {
       this._sendGetCurrentStory();
 
       // finally return the preview component
-      return params.onDeviceUI ? (
-        <OnDeviceUI stories={this._stories} events={this._events} url={webUrl} />
-      ) : (
-        <StoryView url={webUrl} events={this._events} />
-      );
+      return params.onDeviceUI
+        ? <OnDeviceUI
+            stories={this._stories}
+            events={this._events}
+            url={webUrl}
+            animated={params.animated}
+          />
+        : <StoryView url={webUrl} events={this._events} />;
     };
   }
 

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -78,7 +78,7 @@ export default class Preview {
             stories={this._stories}
             events={this._events}
             url={webUrl}
-            animated={params.animated}
+            animated={params.onDeviceUIAnimated}
           />
         : <StoryView url={webUrl} events={this._events} />;
     };

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -74,12 +74,7 @@ export default class Preview {
 
       // finally return the preview component
       return params.onDeviceUI
-        ? <OnDeviceUI
-            stories={this._stories}
-            events={this._events}
-            url={webUrl}
-            animated={params.onDeviceUIAnimated}
-          />
+        ? <OnDeviceUI stories={this._stories} events={this._events} url={webUrl} />
         : <StoryView url={webUrl} events={this._events} />;
     };
   }


### PR DESCRIPTION
Issue:

I am implementing Detox and storybook integration to do screenshot tests on React Native. There is a really funny issue with onDeviceUI. Because it is using animation, every single time animation happens the shadows are redrawn in view below the sidebar. Because of that comparing screenshots fails every time since few pixels of shadow look different. To avoid this problem I've added opt in option for animation onDeviceUIAnimated. By default it is set to true.

## What I did

Added option to disable animation (onDeviceUIAnimated=true/false).

## How to test

Is this testable with jest or storyshots?

Could be.

Does this need a new example in the kitchen sink apps?

Not really.

Does this need an update to the documentation?

I think we need it. Currently I am not sure we have somewhere all the possible options for StorybookUI documented.