### PR TITLE
Refactor CLI to use `npm` and `yarn` instead of third party packages

### DIFF
--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -1,9 +1,9 @@
 import path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
-import latestVersion from 'latest-version';
 import { sync as spawnSync } from 'cross-spawn';
 import { gt } from 'semver';
+import latestVersion from './latest_version';
 
 import { version, devDependencies } from '../package.json';
 

--- a/lib/cli/lib/latest_version.js
+++ b/lib/cli/lib/latest_version.js
@@ -1,0 +1,17 @@
+import { sync as spawnSync } from 'cross-spawn';
+import hasYarn from './has_yarn';
+
+const packageManager = hasYarn() ? 'yarn' : 'npm';
+
+export default async function latestVersion(packageName) {
+  const result = spawnSync(packageManager, ['info', packageName, '--json'], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'pipe',
+    encoding: 'utf-8',
+    silent: true,
+  });
+
+  const info = JSON.parse(result.output[1].toString());
+  return info.data.version;
+}

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -36,7 +36,6 @@
     "cross-spawn": "^6.0.5",
     "jscodeshift": "^0.5.0",
     "json5": "^0.5.1",
-    "latest-version": "^3.1.0",
     "merge-dirs": "^0.2.1",
     "semver": "^5.5.0",
     "shelljs": "^0.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9304,7 +9304,7 @@ latest-version@^2.0.0:
   dependencies:
     package-json "^2.0.0"
 
-latest-version@^3.0.0, latest-version@^3.1.0:
+latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
   dependencies:


### PR DESCRIPTION
Issue: #3274 and #3060

## What I did
1. ```yarn remove latest-version``` on the ```lib/cli``` folder
2. Created a new file ```lib/cli/lib/latest_version.js``` and used the ```has_yarn.js``` to check if yarn is actually available.
3. ```yarn test``` on root folder.

## How to test

Is this testable with jest or storyshots?
I didn't touched on tests, seems that tests are already written.

Does this need a new example in the kitchen sink apps?
No.

Does this need an update to the documentation?
No.

@danielduan you're the man to contact, so can you review if everything is fine here? If not, please let me know and I am going to fix it.