### PR TITLE
Fix issue when extending webpack config

### DIFF
--- a/app/vue/src/server/config.js
+++ b/app/vue/src/server/config.js
@@ -71,7 +71,10 @@ export default function(configType, baseConfig, configDir) {
       ...config.module,
       // We need to use our and custom rules.
       ...customConfig.module,
-      rules: [...config.module.rules, ...(customConfig.module.rules || [])],
+      rules: [
+        ...config.module.rules,
+        ...((customConfig.module && customConfig.module.rules) || []),
+      ],
     },
     resolve: {
       ...config.resolve,


### PR DESCRIPTION
Issue: #3215 

## What I did

Fix bug when property lookup is performed on undefined object

## How to test

Run storybook after extending the webpack config with the following (Assumes jquery is installed):

webpack.config.js:

```
const webpack = require('webpack');

module.exports = {
  plugins: [
    new webpack.ProvidePlugin({
      $: 'jquery',
    }),
  ],
};
```
