### PR TITLE
Viewport-addon Allow setting callback to be called whenever viewport changes

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -31,7 +31,53 @@ Setting this property to, let say `iphone6`, will make `iPhone 6` the default de
 
 ### viewports : Object
 ----
-A key-value pair of viewport's key and properties for all viewports to be displayed. Default is [`INITIAL_VIEWPORTS`](src/shared/index.js)
+A key-value pair of viewport's key and properties (see `Viewport` definition below) for all viewports to be displayed. Default is [`INITIAL_VIEWPORTS`](src/shared/index.js)
+
+#### Viewport Model
+```js
+{
+  /**
+   * name to display in the dropdown
+   * @type {String}
+   */
+  name: 'Responsive',
+
+  /**
+   * Inline styles to be applied to the story (iframe).
+   * styles is an object whose key is the camelCased version of the style name, and whose
+   * value is the style’s value, usually a string
+   * @type {Object}
+   */
+  styles: {
+    width: '100%',
+    height: '100%',
+  },
+
+  /**
+   * type of the device (e.g. desktop, mobile, or tablet)
+   * @type {String}
+   */
+  type: 'desktop',
+}
+```
+
+## Decorators
+
+Sometimes you want to show collection of mobile stories, and you know those stories look horible on desktop (`responsive`), so you think you need to change the default viewport only for those?
+
+Here is the answer, with `withViewport` decorator, you can change the default viewport of single, multiple, or all stories.
+
+`withViewport` accepts either
+* A `String`, which represents the default viewport, or
+* An `Object`, which looks like
+```js
+{
+  name: 'iphone6', // default viewport
+  onViewportChange({ viewport }) { // called whenever different viewport is selected from the dropdown
+
+  }
+}
+```
 
 ## Examples
 
@@ -119,4 +165,57 @@ import { configure } from '@storybook/addon-viewport';
 configure({
   defaultViewport: 'iphone6'
 });
+```
+
+## withViewport Decorator
+
+Change the default viewport for single/multiple/global stories, or listen to viewport selection changes
+
+```js
+import React from 'react';
+import { storiesOf, addDecorator } from '@storybook/react';
+import { withViewport } from '@storybook/addon-viewport';
+
+// Globablly
+addDecorator(withViewport('iphone5'));
+
+// Collection
+storiesOf('Decorator with string', module)
+  .addDecorator(withViewport('iphone6'))
+  .add('iPhone 6', () => (
+    <h1>
+      Do I look good on <b>iPhone 6</b>?
+    </h1>
+  ));
+
+storiesOf('Decorator with object', module)
+  .addDecorator(
+    withViewport({
+      onViewportChange({ viewport }) {
+        console.log(`Viewport changed: ${viewport.name} (${viewport.type})`); // e.g. Viewport changed: iphone6 (mobile)
+      },
+    })
+  )
+  .add('onViewportChange', () => <MobileFirstComponent />);
+
+```
+
+## Viewport Component
+
+You can also change the default viewport for a single story using `Viewport` component
+
+```js
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Viewport } from '@storybook/addon-viewport';
+
+// Collection
+storiesOf('Custom Default', module)
+  .add('iphone6p', () => (
+    <Viewport name="iphone6p">
+      <h1>
+        Do I look good on <b>iPhone 6 Plus</b>?
+      </h1>
+    </Viewport>
+  ));
 ```

--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -14,6 +14,7 @@
     "@storybook/components": "3.4.0-rc.3",
     "babel-runtime": "^6.26.0",
     "global": "^4.3.2",
+    "lodash.debounce": "^4.0.8",
     "prop-types": "^15.6.1"
   },
   "peerDependencies": {

--- a/addons/viewport/src/manager/components/Panel.js
+++ b/addons/viewport/src/manager/components/Panel.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { baseFonts } from '@storybook/components';
 import { document } from 'global';
+import debounce from 'lodash.debounce';
 
 import { resetViewport, viewportsTransformer } from './viewportInfo';
 import { SelectViewport } from './SelectViewport';
@@ -30,6 +31,8 @@ const getDefaultViewport = (viewports, candidateViewport) =>
 const getViewports = viewports =>
   Object.keys(viewports).length > 0 ? viewports : INITIAL_VIEWPORTS;
 
+const setStoryDefaultViewportWait = 100;
+
 export class Panel extends Component {
   static propTypes = {
     channel: PropTypes.shape({}).isRequired,
@@ -49,6 +52,11 @@ export class Panel extends Component {
       viewports: viewportsTransformer(INITIAL_VIEWPORTS),
       isLandscape: false,
     };
+
+    this.setStoryDefaultViewport = debounce(
+      this.setStoryDefaultViewport,
+      setStoryDefaultViewportWait
+    );
   }
 
   componentDidMount() {

--- a/addons/viewport/src/manager/components/Panel.js
+++ b/addons/viewport/src/manager/components/Panel.js
@@ -8,7 +8,6 @@ import { SelectViewport } from './SelectViewport';
 import { RotateViewport } from './RotateViewport';
 import {
   SET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
-  UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
   CONFIGURE_VIEWPORT_EVENT_ID,
   UPDATE_VIEWPORT_EVENT_ID,
   INITIAL_VIEWPORTS,
@@ -60,10 +59,9 @@ export class Panel extends Component {
     channel.on(UPDATE_VIEWPORT_EVENT_ID, this.changeViewport);
     channel.on(CONFIGURE_VIEWPORT_EVENT_ID, this.configure);
     channel.on(SET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.setStoryDefaultViewport);
-    channel.on(UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.unsetStoryDefaultViewport);
 
     this.unsubscribeFromOnStory = api.onStory(() => {
-      this.changeViewport(this.state.defaultViewport);
+      this.setStoryDefaultViewport(this.state.defaultViewport);
     });
   }
 
@@ -77,30 +75,16 @@ export class Panel extends Component {
     channel.removeListener(UPDATE_VIEWPORT_EVENT_ID, this.changeViewport);
     channel.removeListener(CONFIGURE_VIEWPORT_EVENT_ID, this.configure);
     channel.removeListener(SET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.setStoryDefaultViewport);
-    channel.removeListener(UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.unsetStoryDefaultViewport);
   }
 
   setStoryDefaultViewport = viewport => {
     const { viewports } = this.state;
     const defaultViewport = getDefaultViewport(viewports, viewport);
 
-    this.setState(
-      {
-        storyDefaultViewport: defaultViewport,
-        viewport: defaultViewport,
-      },
-      this.updateIframe
-    );
-  };
-
-  unsetStoryDefaultViewport = () => {
-    this.setState(
-      {
-        storyDefaultViewport: undefined,
-        viewport: this.state.defaultViewport,
-      },
-      this.updateIframe
-    );
+    this.setState({
+      storyDefaultViewport: defaultViewport,
+    });
+    this.changeViewport(defaultViewport);
   };
 
   configure = (options = Panel.defaultOptions) => {

--- a/addons/viewport/src/manager/components/Panel.js
+++ b/addons/viewport/src/manager/components/Panel.js
@@ -11,6 +11,7 @@ import {
   SET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
   CONFIGURE_VIEWPORT_EVENT_ID,
   UPDATE_VIEWPORT_EVENT_ID,
+  VIEWPORT_CHANGED_EVENT_ID,
   INITIAL_VIEWPORTS,
   DEFAULT_VIEWPORT,
 } from '../../shared';
@@ -52,6 +53,8 @@ export class Panel extends Component {
       viewports: viewportsTransformer(INITIAL_VIEWPORTS),
       isLandscape: false,
     };
+
+    this.previousViewport = DEFAULT_VIEWPORT;
 
     this.setStoryDefaultViewport = debounce(
       this.setStoryDefaultViewport,
@@ -120,10 +123,30 @@ export class Panel extends Component {
           viewport,
           isLandscape: false,
         },
-        this.updateIframe
+        () => {
+          this.updateIframe();
+          this.emitViewportChanged();
+        }
       );
     }
   };
+
+  emitViewportChanged = () => {
+    const { channel } = this.props;
+    const { viewport, viewports } = this.state;
+
+    if (!this.shouldNotify()) {
+      return;
+    }
+
+    this.previousViewport = viewport;
+
+    channel.emit(VIEWPORT_CHANGED_EVENT_ID, {
+      viewport: viewports[viewport],
+    });
+  };
+
+  shouldNotify = () => this.previousViewport !== this.state.viewport;
 
   toggleLandscape = () => {
     const { isLandscape } = this.state;

--- a/addons/viewport/src/manager/components/tests/Panel.test.js
+++ b/addons/viewport/src/manager/components/tests/Panel.test.js
@@ -75,13 +75,6 @@ describe('Viewport/Panel', () => {
         subject.instance().setStoryDefaultViewport
       );
     });
-
-    it('listens on `unsetStoryDefaultViewport` channel', () => {
-      expect(props.channel.on).toHaveBeenCalledWith(
-        'addon:viewport:unsetStoryDefaultViewport',
-        subject.instance().unsetStoryDefaultViewport
-      );
-    });
   });
 
   describe('componentWillUnmount', () => {
@@ -107,13 +100,6 @@ describe('Viewport/Panel', () => {
       expect(props.channel.removeListener).toHaveBeenCalledWith(
         'addon:viewport:setStoryDefaultViewport',
         subject.instance().setStoryDefaultViewport
-      );
-    });
-
-    it('removes `unsetStoryDefaultViewport` channel listener', () => {
-      expect(props.channel.removeListener).toHaveBeenCalledWith(
-        'addon:viewport:unsetStoryDefaultViewport',
-        subject.instance().unsetStoryDefaultViewport
       );
     });
   });
@@ -223,29 +209,20 @@ describe('Viewport/Panel', () => {
     });
 
     it('sets the state with the new information', () => {
-      expect(subject.instance().setState).toHaveBeenCalledWith(
+      expect(subject.instance().setState.mock.calls.length).toBe(2);
+      expect(subject.instance().setState.mock.calls[0][0]).toEqual(
+        {
+          storyDefaultViewport: 'iphone5'
+        }
+      );
+
+      expect(subject.instance().setState.mock.calls[1][0]).toEqual(
         {
           viewport: initialViewportAt(1),
-          storyDefaultViewport: initialViewportAt(1),
-        },
-        subject.instance().updateIframe
+          isLandscape: false
+        }
       );
-    });
-  });
-
-  describe('unsetStoryDefaultViewport', () => {
-    beforeEach(() => {
-      subject.instance().setState = jest.fn();
-      subject.instance().updateIframe = jest.fn();
-      subject.instance().unsetStoryDefaultViewport();
-    });
-
-    it('resets the state', () => {
-      expect(subject.instance().setState).toHaveBeenCalledWith(
-        {
-          viewport: DEFAULT_VIEWPORT,
-          storyDefaultViewport: undefined,
-        },
+      expect(subject.instance().setState.mock.calls[1][1]).toEqual(
         subject.instance().updateIframe
       );
     });

--- a/addons/viewport/src/preview/components/Viewport.js
+++ b/addons/viewport/src/preview/components/Viewport.js
@@ -1,29 +1,50 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import addons from '@storybook/addons';
-import { SET_STORY_DEFAULT_VIEWPORT_EVENT_ID, DEFAULT_VIEWPORT } from '../../shared';
+import {
+  SET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
+  VIEWPORT_CHANGED_EVENT_ID,
+  DEFAULT_VIEWPORT,
+} from '../../shared';
+
+const noop = () => {};
 
 export default class Viewport extends React.Component {
   static propTypes = {
     name: PropTypes.string,
     children: PropTypes.node.isRequired,
+    onViewportChange: PropTypes.func,
   };
 
   static defaultProps = {
     name: DEFAULT_VIEWPORT,
+    onViewportChange: noop
   };
 
   constructor(props) {
     super(props);
 
     this.channel = addons.getChannel();
+    const { onViewportChange } = props;
+
+    if (typeof this.props.onViewportChange === 'function') {
+      this.onViewportChange = onViewportChange;
+    }
   }
 
   componentWillMount() {
+    if (this.onViewportChange) {
+      this.channel.on(VIEWPORT_CHANGED_EVENT_ID, this.onViewportChange);
+    }
+
     this.channel.emit(SET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.props.name);
   }
 
-  componentWillUnmount() {}
+  componentWillUnmount() {
+    if (this.onViewportChange) {
+      this.channel.removeListener(VIEWPORT_CHANGED_EVENT_ID, this.onViewportChange);
+    }
+  }
 
   render() {
     return this.props.children;

--- a/addons/viewport/src/preview/components/Viewport.js
+++ b/addons/viewport/src/preview/components/Viewport.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import addons from '@storybook/addons';
+import {
+  SET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
+  UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
+  DEFAULT_VIEWPORT,
+} from '../../shared';
+
+export default class Viewport extends React.Component {
+  static propTypes = {
+    name: PropTypes.string,
+    children: PropTypes.node.isRequired,
+  };
+
+  static defaultProps = {
+    name: DEFAULT_VIEWPORT,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.channel = addons.getChannel();
+  }
+
+  componentWillMount() {
+    this.channel.emit(SET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.props.name);
+  }
+
+  componentWillUnmount() {
+    this.channel.emit(UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.props.name);
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/addons/viewport/src/preview/components/Viewport.js
+++ b/addons/viewport/src/preview/components/Viewport.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import addons from '@storybook/addons';
-import {
-  SET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
-  UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
-  DEFAULT_VIEWPORT,
-} from '../../shared';
+import { SET_STORY_DEFAULT_VIEWPORT_EVENT_ID, DEFAULT_VIEWPORT } from '../../shared';
 
 export default class Viewport extends React.Component {
   static propTypes = {
@@ -27,9 +23,7 @@ export default class Viewport extends React.Component {
     this.channel.emit(SET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.props.name);
   }
 
-  componentWillUnmount() {
-    this.channel.emit(UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.props.name);
-  }
+  componentWillUnmount() {}
 
   render() {
     return this.props.children;

--- a/addons/viewport/src/preview/components/tests/Viewport.test.js
+++ b/addons/viewport/src/preview/components/tests/Viewport.test.js
@@ -1,14 +1,19 @@
 import React from 'react';
 import addons from '@storybook/addons';
 import { shallow } from 'enzyme';
+import { EventEmitter } from 'events';
 import Viewport from '../Viewport';
+import { VIEWPORT_CHANGED_EVENT_ID, INITIAL_VIEWPORTS } from '../../../shared';
 
 jest.mock('@storybook/addons');
+
+const noop = () => {};
 
 describe('Viewport', () => {
   const channel = {
     emit: jest.fn(),
     on: jest.fn(),
+    removeListener: jest.fn(),
   };
 
   addons.getChannel.mockReturnValue(channel);
@@ -26,6 +31,8 @@ describe('Viewport', () => {
 
   afterEach(() => {
     channel.emit.mockReset();
+    channel.on.mockReset();
+    channel.removeListener.mockReset();
   });
 
   describe('componentWillMount', () => {
@@ -34,6 +41,60 @@ describe('Viewport', () => {
       expect(channel.emit).toHaveBeenCalledWith(
         'addon:viewport:setStoryDefaultViewport',
         'iphone6'
+      );
+    });
+
+    it('should listen to viewport changes', () => {
+      channel.on.mockReset();
+      subject = shallow(<Viewport {...props} onViewportChange={noop} />);
+
+      expect(channel.on).toHaveBeenCalledTimes(1);
+      expect(channel.on).toHaveBeenCalledWith(
+        'addon:viewport:viewportChanged',
+        noop
+      );
+    });
+  });
+
+  describe('componentWillUnmount', () => {
+    it('removes viewport changes listener', () => {
+      subject = shallow(<Viewport {...props} onViewportChange={noop} />);
+      subject.unmount();
+      
+      expect(channel.removeListener).toHaveBeenCalledTimes(1);
+      expect(channel.removeListener).toHaveBeenCalledWith(
+        'addon:viewport:viewportChanged',
+        noop
+      );
+    });
+  });
+
+  describe('onViewportChange', () => {
+    const emitter = new EventEmitter();
+    const propsWithCallback = {
+      name: 'unknown',
+      children: 'do not exist',
+      onViewportChange: jest.fn()
+    };
+
+    beforeAll(() => {
+      addons.getChannel.mockReturnValue(emitter);
+    });
+
+    beforeEach(() => {
+      subject = shallow(<Viewport {...propsWithCallback} />);
+    });
+
+    it('calls onViewportChange with the newly selected viewport', () => {
+      emitter.emit(VIEWPORT_CHANGED_EVENT_ID, {
+        viewport: INITIAL_VIEWPORTS.iphone5
+      });
+
+      expect(propsWithCallback.onViewportChange).toHaveBeenCalled();
+      expect(propsWithCallback.onViewportChange).toHaveBeenCalledWith(
+        {
+          viewport: INITIAL_VIEWPORTS.iphone5
+        }
       );
     });
   });

--- a/addons/viewport/src/preview/components/tests/Viewport.test.js
+++ b/addons/viewport/src/preview/components/tests/Viewport.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import addons from '@storybook/addons';
+import { shallow } from 'enzyme';
+import Viewport from '../Viewport';
+
+jest.mock('@storybook/addons');
+
+describe('Viewport', () => {
+  const channel = {
+    emit: jest.fn(),
+    on: jest.fn(),
+  };
+
+  addons.getChannel.mockReturnValue(channel);
+
+  const props = {
+    name: 'iphone6',
+    children: '1337',
+  };
+
+  let subject;
+
+  beforeEach(() => {
+    subject = shallow(<Viewport {...props} />);
+  });
+
+  afterEach(() => {
+    channel.emit.mockReset();
+  });
+
+  describe('componentWillMount', () => {
+    it('publishes `set` event with `iphone6`', () => {
+      expect(channel.emit).toHaveBeenCalledTimes(1);
+      expect(channel.emit).toHaveBeenCalledWith(
+        'addon:viewport:setStoryDefaultViewport',
+        'iphone6'
+      );
+    });
+  });
+
+  describe('componentWillUnmount', () => {
+    beforeEach(() => {
+      channel.emit.mockReset();
+      subject.unmount();
+    });
+
+    it('publishes `unset` event', () => {
+      expect(channel.emit).toHaveBeenCalledTimes(1);
+      expect(channel.emit).toHaveBeenCalledWith(
+        'addon:viewport:unsetStoryDefaultViewport',
+        'iphone6'
+      );
+    });
+  });
+});

--- a/addons/viewport/src/preview/components/tests/Viewport.test.js
+++ b/addons/viewport/src/preview/components/tests/Viewport.test.js
@@ -37,19 +37,4 @@ describe('Viewport', () => {
       );
     });
   });
-
-  describe('componentWillUnmount', () => {
-    beforeEach(() => {
-      channel.emit.mockReset();
-      subject.unmount();
-    });
-
-    it('publishes `unset` event', () => {
-      expect(channel.emit).toHaveBeenCalledTimes(1);
-      expect(channel.emit).toHaveBeenCalledWith(
-        'addon:viewport:unsetStoryDefaultViewport',
-        'iphone6'
-      );
-    });
-  });
 });

--- a/addons/viewport/src/preview/index.js
+++ b/addons/viewport/src/preview/index.js
@@ -1,47 +1,14 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import addons from '@storybook/addons';
-import {
-  CONFIGURE_VIEWPORT_EVENT_ID,
-  SET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
-  UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID,
-} from '../shared';
+import { CONFIGURE_VIEWPORT_EVENT_ID } from '../shared';
 
 export { INITIAL_VIEWPORTS, DEFAULT_VIEWPORT } from '../shared';
+export { default as withViewport } from './withViewport';
+export { default as Viewport } from './components/Viewport';
 
 export function configure(configs = {}) {
   const channel = addons.getChannel();
 
   if (channel) {
     channel.emit(CONFIGURE_VIEWPORT_EVENT_ID, configs);
-  }
-}
-
-export function withViewport(name) {
-  return getStory => <Viewport name={name}>{getStory()}</Viewport>;
-}
-
-export class Viewport extends React.Component {
-  static propTypes = {
-    name: PropTypes.string.isRequired,
-    children: PropTypes.node.isRequired,
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.channel = addons.getChannel();
-  }
-
-  componentWillMount() {
-    this.channel.emit(SET_STORY_DEFAULT_VIEWPORT_EVENT_ID, this.props.name);
-  }
-
-  componentWillUnmount() {
-    this.channel.emit(UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID);
-  }
-
-  render() {
-    return this.props.children;
   }
 }

--- a/addons/viewport/src/preview/tests/index.test.js
+++ b/addons/viewport/src/preview/tests/index.test.js
@@ -1,7 +1,5 @@
-import React from 'react';
 import addons from '@storybook/addons';
-import { shallow } from 'enzyme';
-import { configure, Viewport } from '../';
+import { configure } from '../';
 
 jest.mock('@storybook/addons');
 
@@ -23,41 +21,6 @@ describe('Viewport preview', () => {
       expect(channel.emit).toHaveBeenCalledWith('addon:viewport:configure', {
         foo: 'bar',
         john: 'Doe',
-      });
-    });
-  });
-
-  describe('Viewport', () => {
-    const props = {
-      name: 'iphone6',
-      children: '1337',
-    };
-
-    let subject;
-
-    beforeEach(() => {
-      subject = shallow(<Viewport {...props} />);
-    });
-
-    describe('componentWillMount', () => {
-      it('publishes `set` event with `iphone6`', () => {
-        expect(channel.emit).toHaveBeenCalledTimes(1);
-        expect(channel.emit).toHaveBeenCalledWith(
-          'addon:viewport:setStoryDefaultViewport',
-          'iphone6'
-        );
-      });
-    });
-
-    describe('componentWillUnmount', () => {
-      beforeEach(() => {
-        channel.emit.mockReset();
-        subject.unmount();
-      });
-
-      it('publishes `unset` event', () => {
-        expect(channel.emit).toHaveBeenCalledTimes(1);
-        expect(channel.emit).toHaveBeenCalledWith('addon:viewport:unsetStoryDefaultViewport');
       });
     });
   });

--- a/addons/viewport/src/preview/tests/index.test.js
+++ b/addons/viewport/src/preview/tests/index.test.js
@@ -6,6 +6,7 @@ jest.mock('@storybook/addons');
 describe('Viewport preview', () => {
   const channel = {
     emit: jest.fn(),
+    on: jest.fn(),
   };
   addons.getChannel.mockReturnValue(channel);
 

--- a/addons/viewport/src/preview/withViewport.js
+++ b/addons/viewport/src/preview/withViewport.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import Viewport from './components/Viewport';
+
+export default function withViewport(nameOrOptions) {
+  const options = typeof nameOrOptions === 'string' ? { name: nameOrOptions } : nameOrOptions;
+
+  const decorator = getStory => context => (
+    <Viewport context={context} {...options}>
+      {getStory()}
+    </Viewport>
+  );
+
+  return (getStory, context) => {
+    if (typeof context === 'undefined') {
+      return decorator(getStory);
+    }
+    return decorator(getStory)(context);
+  };
+}

--- a/addons/viewport/src/shared/index.js
+++ b/addons/viewport/src/shared/index.js
@@ -3,6 +3,7 @@ export const PANEL_ID = `${ADDON_ID}/addon-panel`;
 export const UPDATE_VIEWPORT_EVENT_ID = 'addon:viewport:update';
 export const CONFIGURE_VIEWPORT_EVENT_ID = 'addon:viewport:configure';
 export const SET_STORY_DEFAULT_VIEWPORT_EVENT_ID = 'addon:viewport:setStoryDefaultViewport';
+export const VIEWPORT_CHANGED_EVENT_ID = 'addon:viewport:viewportChanged';
 export const INITIAL_VIEWPORTS = {
   responsive: {
     name: 'Responsive',

--- a/addons/viewport/src/shared/index.js
+++ b/addons/viewport/src/shared/index.js
@@ -3,7 +3,6 @@ export const PANEL_ID = `${ADDON_ID}/addon-panel`;
 export const UPDATE_VIEWPORT_EVENT_ID = 'addon:viewport:update';
 export const CONFIGURE_VIEWPORT_EVENT_ID = 'addon:viewport:configure';
 export const SET_STORY_DEFAULT_VIEWPORT_EVENT_ID = 'addon:viewport:setStoryDefaultViewport';
-export const UNSET_STORY_DEFAULT_VIEWPORT_EVENT_ID = 'addon:viewport:unsetStoryDefaultViewport';
 export const INITIAL_VIEWPORTS = {
   responsive: {
     name: 'Responsive',

--- a/addons/viewport/src/shared/index.js
+++ b/addons/viewport/src/shared/index.js
@@ -15,6 +15,7 @@ export const INITIAL_VIEWPORTS = {
       margin: '0',
       boxShadow: 'none',
     },
+    type: 'desktop',
   },
   iphone5: {
     name: 'iPhone 5',
@@ -22,6 +23,7 @@ export const INITIAL_VIEWPORTS = {
       height: '568px',
       width: '320px',
     },
+    type: 'mobile',
   },
   iphone6: {
     name: 'iPhone 6',
@@ -29,6 +31,7 @@ export const INITIAL_VIEWPORTS = {
       height: '667px',
       width: '375px',
     },
+    type: 'mobile',
   },
   iphone6p: {
     name: 'iPhone 6 Plus',
@@ -36,6 +39,7 @@ export const INITIAL_VIEWPORTS = {
       height: '736px',
       width: '414px',
     },
+    type: 'mobile',
   },
   ipad: {
     name: 'iPad',
@@ -43,6 +47,7 @@ export const INITIAL_VIEWPORTS = {
       height: '1024px',
       width: '768px',
     },
+    type: 'tablet',
   },
   galaxys5: {
     name: 'Galaxy S5',
@@ -50,6 +55,7 @@ export const INITIAL_VIEWPORTS = {
       height: '640px',
       width: '360px',
     },
+    type: 'mobile',
   },
   nexus5x: {
     name: 'Nexus 5X',
@@ -57,6 +63,7 @@ export const INITIAL_VIEWPORTS = {
       height: '660px',
       width: '412px',
     },
+    type: 'mobile',
   },
   nexus6p: {
     name: 'Nexus 6P',
@@ -64,6 +71,7 @@ export const INITIAL_VIEWPORTS = {
       height: '732px',
       width: '412px',
     },
+    type: 'mobile',
   },
 };
 export const DEFAULT_VIEWPORT = 'responsive';

--- a/examples/official-storybook/extra-viewports.json
+++ b/examples/official-storybook/extra-viewports.json
@@ -4,13 +4,15 @@
     "styles": {
       "width": "600px",
       "height": "963px"
-    }
+    },
+    "type": "tablet"
   },
   "kindleFireHD": {
     "name": "Kindle Fire HD",
     "styles": {
       "width": "533px",
       "height": "801px"
-    }
+    },
+    "type": "tablet"
   }
 }

--- a/examples/official-storybook/stories/Logger.js
+++ b/examples/official-storybook/stories/Logger.js
@@ -2,15 +2,7 @@ import React, { Component } from 'react';
 import json from 'format-json';
 import PropTypes from 'prop-types';
 import EventEmitter from 'eventemitter3';
-
 import uuid from 'uuid/v4';
-
-const EVENTS = {
-  TEST_EVENT_1: 'test-event-1',
-  TEST_EVENT_2: 'test-event-2',
-  TEST_EVENT_3: 'test-event-3',
-  TEST_EVENT_4: 'test-event-4',
-};
 
 const styles = {
   wrapper: {
@@ -21,6 +13,9 @@ const styles = {
     `,
     color: 'rgb(51, 51, 51)',
   },
+  title: {
+    margin: 0,
+  },
   item: {
     listStyle: 'none',
     marginBottom: 10,
@@ -28,8 +23,15 @@ const styles = {
 };
 
 export default class Logger extends Component {
+  static LOG_EVENT = 'Logger:log';
+
   static propTypes = {
     emitter: PropTypes.instanceOf(EventEmitter).isRequired,
+    title: PropTypes.string,
+  };
+
+  static defaultProps = {
+    title: 'Logger',
   };
 
   state = {
@@ -37,15 +39,14 @@ export default class Logger extends Component {
   };
 
   componentWillMount() {
-    const { emitter } = this.props;
-
-    emitter.on(EVENTS.TEST_EVENT_1, this.onEventHandler(EVENTS.TEST_EVENT_1));
-    emitter.on(EVENTS.TEST_EVENT_2, this.onEventHandler(EVENTS.TEST_EVENT_2));
-    emitter.on(EVENTS.TEST_EVENT_3, this.onEventHandler(EVENTS.TEST_EVENT_3));
-    emitter.on(EVENTS.TEST_EVENT_4, this.onEventHandler(EVENTS.TEST_EVENT_4));
+    this.props.emitter.on(Logger.LOG_EVENT, this.onEventHandler);
   }
 
-  onEventHandler = name => payload => {
+  componentWillUnmount() {
+    this.props.emitter.removeListener(Logger.LOG_EVENT, this.onEventHandler);
+  }
+
+  onEventHandler = ({ name, payload }) => {
     this.setState(({ events }) => ({
       events: [...events, { name, id: uuid(), payload }],
     }));
@@ -53,10 +54,11 @@ export default class Logger extends Component {
 
   render() {
     const { events } = this.state;
+    const { title } = this.props;
 
     return (
       <div style={styles.wrapper}>
-        <h1>Logger</h1>
+        <h1 style={styles.title}>{title}</h1>
         <dl>
           {events.map(({ id, name, payload }) => (
             <div style={styles.item} key={id}>

--- a/examples/official-storybook/stories/__snapshots__/addon-events.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-events.stories.storyshot
@@ -5,7 +5,9 @@ exports[`Storyshots Addons|Events Logger 1`] = `
   style="padding:20px;font-family:-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", \\"Roboto\\",
       \\"Segoe UI\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", sans-serif;color:rgb(51, 51, 51)"
 >
-  <h1>
+  <h1
+    style="margin:0"
+  >
     Logger
   </h1>
   <dl />

--- a/examples/official-storybook/stories/__snapshots__/addon-viewport.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-viewport.stories.storyshot
@@ -20,7 +20,19 @@ exports[`Storyshots Addons|Viewport.Custom Default (Kindle Fire 2) Inherited 1`]
 </div>
 `;
 
-exports[`Storyshots Addons|Viewport.Custom Default (Kindle Fire 2) Overridden 1`] = `
+exports[`Storyshots Addons|Viewport.Custom Default (Kindle Fire 2) Overridden via "Viewport" component 1`] = `
+<div
+  style="font-family:-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif;color:#444;-webkit-font-smoothing:antialiased"
+>
+  I respect my parents but I should be looking good on 
+  <b>
+    iPhone 6 Plus
+  </b>
+  .
+</div>
+`;
+
+exports[`Storyshots Addons|Viewport.Custom Default (Kindle Fire 2) Overridden via "withViewport" decorator 1`] = `
 <div
   style="font-family:-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif;color:#444;-webkit-font-smoothing:antialiased"
 >

--- a/examples/official-storybook/stories/__snapshots__/addon-viewport.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-viewport.stories.storyshot
@@ -43,3 +43,17 @@ exports[`Storyshots Addons|Viewport.Custom Default (Kindle Fire 2) Overridden vi
   .
 </div>
 `;
+
+exports[`Storyshots Addons|Viewport.withViewport onViewportChange 1`] = `
+<div
+  style="padding:20px;font-family:-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", \\"Roboto\\",
+      \\"Segoe UI\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", sans-serif;color:rgb(51, 51, 51)"
+>
+  <h1
+    style="margin:0"
+  >
+    Select device/viewport
+  </h1>
+  <dl />
+</div>
+`;

--- a/examples/official-storybook/stories/addon-events.stories.js
+++ b/examples/official-storybook/stories/addon-events.stories.js
@@ -15,6 +15,10 @@ const EVENTS = {
 const emitter = new EventEmitter();
 const emit = emitter.emit.bind(emitter);
 
+const eventHandler = name => payload => emit(Logger.LOG_EVENT, { name, payload });
+
+Object.keys(EVENTS).forEach(event => emitter.on(EVENTS[event], eventHandler(EVENTS[event])));
+
 storiesOf('Addons|Events', module)
   .addDecorator(getStory => (
     <WithEvents

--- a/examples/official-storybook/stories/addon-viewport.stories.js
+++ b/examples/official-storybook/stories/addon-viewport.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { baseFonts } from '@storybook/components';
 
-import { withViewport, Viewport } from '@storybook/addon-viewport';
+import { Viewport, withViewport } from '@storybook/addon-viewport';
 
 // eslint-disable-next-line react/prop-types
 const Panel = ({ children }) => <div style={baseFonts}>{children}</div>;
@@ -18,10 +18,18 @@ storiesOf('Addons|Viewport.Custom Default (Kindle Fire 2)', module)
       I've inherited <b>Kindle Fire 2</b> viewport from my parent.
     </Panel>
   ))
-  .add('Overridden', () => (
-    <Viewport name="iphone6">
+  .add(
+    'Overridden via "withViewport" decorator',
+    withViewport('iphone6')(() => (
       <Panel>
         I respect my parents but I should be looking good on <b>iPhone 6</b>.
+      </Panel>
+    ))
+  )
+  .add('Overridden via "Viewport" component', () => (
+    <Viewport name="iphone6p">
+      <Panel>
+        I respect my parents but I should be looking good on <b>iPhone 6 Plus</b>.
       </Panel>
     </Viewport>
   ));

--- a/examples/official-storybook/stories/addon-viewport.stories.js
+++ b/examples/official-storybook/stories/addon-viewport.stories.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { baseFonts } from '@storybook/components';
-
 import { Viewport, withViewport } from '@storybook/addon-viewport';
+import EventEmitter from 'eventemitter3';
+
+import Logger from './Logger';
 
 // eslint-disable-next-line react/prop-types
 const Panel = ({ children }) => <div style={baseFonts}>{children}</div>;
@@ -33,3 +35,18 @@ storiesOf('Addons|Viewport.Custom Default (Kindle Fire 2)', module)
       </Panel>
     </Viewport>
   ));
+
+const emitter = new EventEmitter();
+
+storiesOf('Addons|Viewport.withViewport', module)
+  .addDecorator(
+    withViewport({
+      onViewportChange({ viewport }) {
+        emitter.emit(Logger.LOG_EVENT, {
+          name: 'Viewport Changed',
+          payload: `${viewport.name} (${viewport.type})`,
+        });
+      },
+    })
+  )
+  .add('onViewportChange', () => <Logger title="Select device/viewport" emitter={emitter} />);


### PR DESCRIPTION
Issue: #3223 
@SimenB Please also review

## What I did
Add the ability to pass `onViewportChange` callback to `withViewport` decorator, which will be called whenever viewport changes.

### Signature
It has the following signature
```javascript
function onViewportChange( { viewport } ) {
  // React upon changes
}
```

### How to use
Either with global decorator (`recommended`), or per story

```javascript
import { withViewport } from '@storybook/addon-viewport';

addDecorator(withViewport({
  onViewportChange({ viewport }) {
    console.log('Viewport changed:', viewport);
  }
}));
```

... and below is a screenshot from the storybook

<img width="801" alt="screen shot 2018-03-28 at 00 57 44" src="https://user-images.githubusercontent.com/3688136/38000138-7d6088fc-3226-11e8-90f2-232ea6e6a8f9.png">

## How to test
`yarn test`

Is this testable with jest or storyshots?
Yes

Does this need a new example in the kitchen sink apps?
Yes and added to `Viewports`-addon stories

Does this need an update to the documentation?
Yes and added

If your answer is yes to any of these, please make sure to include it in your PR.
