### PR TITLE
Feature request: adding aXe configuration for a11y addon

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -42,6 +42,31 @@ storiesOf('button', module)
   ));
 ```
 
+For more customizability. Use the `'configure'` function to configure [aXe options](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure).
+
+```js
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { checkA11y, configure } from '@storybook/addon-a11y';
+
+const whateverOptionsYouWant = {};
+configure(whateverOptionsYouWant);
+
+storiesOf('button', module)
+  .addDecorator(checkA11y)
+  .add('Accessible', () => (
+    <button>
+      Accessible button
+    </button>
+  ))
+  .add('Inaccessible', () => (
+    <button style={{ backgroundColor: 'red', color: 'darkRed', }}>
+      Inaccessible button
+    </button>
+  ));
+```
+
 ## Roadmap
 
 * Make UI accessibile

--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -42,16 +42,16 @@ storiesOf('button', module)
   ));
 ```
 
-For more customizability. Use the `'configure'` function to configure [aXe options](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure).
+For more customizability. Use the `'configureA11y'` function to configure [aXe options](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure).
 
 ```js
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { checkA11y, configure } from '@storybook/addon-a11y';
+import { checkA11y, configureA11y } from '@storybook/addon-a11y';
 
 const whateverOptionsYouWant = {};
-configure(whateverOptionsYouWant);
+configureA11y(whateverOptionsYouWant);
 
 storiesOf('button', module)
   .addDecorator(checkA11y)

--- a/addons/a11y/src/A11yManager.js
+++ b/addons/a11y/src/A11yManager.js
@@ -4,8 +4,8 @@ import WrapStory from './components/WrapStory';
 
 // Run all a11y checks inside
 class A11yManager {
-  wrapStory(channel, storyFn, context) {
-    const props = { context, storyFn, channel };
+  wrapStory(channel, storyFn, context, axeOptions) {
+    const props = { context, storyFn, channel, axeOptions };
 
     return <WrapStory {...props} />;
   }

--- a/addons/a11y/src/components/WrapStory.js
+++ b/addons/a11y/src/components/WrapStory.js
@@ -8,11 +8,13 @@ class WrapStory extends Component {
     context: PropTypes.shape({}),
     storyFn: PropTypes.func,
     channel: PropTypes.shape({}),
+    axeOptions: PropTypes.shape({}),
   };
   static defaultProps = {
     context: {},
     storyFn: () => {},
     channel: {},
+    axeOptions: {},
   };
 
   constructor(props) {
@@ -33,10 +35,12 @@ class WrapStory extends Component {
 
   /* eslint-disable react/no-find-dom-node */
   runA11yCheck() {
-    const { channel } = this.props;
+    const { channel, axeOptions } = this.props;
     const wrapper = findDOMNode(this);
 
     if (wrapper !== null) {
+      axe.reset();
+      axe.configure(axeOptions);
       axe.a11yCheck(wrapper, {}, results => {
         channel.emit('addon:a11y:check', results);
       });

--- a/addons/a11y/src/index.js
+++ b/addons/a11y/src/index.js
@@ -11,8 +11,8 @@ function checkA11y(storyFn, context) {
   return manager.wrapStory(channel, storyFn, context, axeOptions);
 }
 
-function configure(options = {}) {
+function configureA11y(options = {}) {
   axeOptions = options;
 }
 
-export { checkA11y, shared, configure };
+export { checkA11y, shared, configureA11y };

--- a/addons/a11y/src/index.js
+++ b/addons/a11y/src/index.js
@@ -4,10 +4,15 @@ import A11yManager from './A11yManager';
 import * as shared from './shared';
 
 const manager = new A11yManager();
+let axeOptions = {};
 
 function checkA11y(storyFn, context) {
   const channel = addons.getChannel();
-  return manager.wrapStory(channel, storyFn, context);
+  return manager.wrapStory(channel, storyFn, context, axeOptions);
 }
 
-export { checkA11y, shared };
+function configure(options = {}) {
+  axeOptions = options;
+}
+
+export { checkA11y, shared, configure };


### PR DESCRIPTION
Issue: #2830

## What I did
Added an extra export function `configure` to the a11y addon for users to configure aXe

usage:

```js
import React from 'react';
import { storiesOf } from '@storybook/react';

import { checkA11y, configure } from '@storybook/addon-a11y';

const whateverConfigYouWant = {};

configure(whateverConfigYouWant);

storiesOf('button', module)
  .addDecorator(checkA11y)
  .add('Accessible', () => (
    <button>
      Accessible button
    </button>
  ))
  .add('Inaccessible', () => (
    <button style={{ backgroundColor: 'red', color: 'darkRed', }}>
      Inaccessible button
    </button>
  ));
```

## How to test
I used the official storybook to test configuring axe.

Is this testable with jest or storyshots?
N
Does this need a new example in the kitchen sink apps?
N
Does this need an update to the documentation?
Y
If your answer is yes to any of these, please make sure to include it in your PR.
