### PR TITLE
Tweaks for range labels

### DIFF
--- a/addons/knobs/src/components/types/Number.js
+++ b/addons/knobs/src/components/types/Number.js
@@ -23,6 +23,8 @@ const styles = {
   rangeLabel: {
     paddingLeft: 5,
     paddingRight: 5,
+    fontSize: 12,
+    whiteSpace: 'nowrap',
   },
   rangeWrapper: {
     display: 'flex',


### PR DESCRIPTION
Aligns the font size with the knob label and ensures the range label doesn't wrap.

## How to test
Add addon-knobs and a number range knob and observe result.