### PR TITLE
Scroll preview pane for non-percentage heights

### DIFF
--- a/addons/viewport/src/manager/components/Panel.js
+++ b/addons/viewport/src/manager/components/Panel.js
@@ -170,6 +170,11 @@ export class Panel extends Component {
       this.iframe.style.height = viewport.styles.width;
       this.iframe.style.width = viewport.styles.height;
     }
+
+    // Always make parent's height equals iframe
+    if (this.iframe.parentElement) {
+      this.iframe.parentElement.style.height = this.iframe.style.height;
+    }
   };
 
   render() {

--- a/lib/ui/src/modules/ui/components/layout/__snapshots__/index.stories.storyshot
+++ b/lib/ui/src/modules/ui/components/layout/__snapshots__/index.stories.storyshot
@@ -47,7 +47,7 @@ exports[`Storyshots ui/Layout addon panel in right 1`] = `
       >
         <div
           class="Pane vertical Pane1  "
-          style="flex:1;position:relative;outline:none"
+          style="overflow:auto;flex:1;position:relative;outline:none"
         >
           <div
             style="position:absolute;box-sizing:border-box;width:100%;height:100%;padding:10px 2px 10px 0;padding-top:10px"
@@ -144,7 +144,7 @@ exports[`Storyshots ui/Layout default 1`] = `
       >
         <div
           class="Pane horizontal Pane1  "
-          style="flex:1;position:relative;outline:none"
+          style="overflow:auto;flex:1;position:relative;outline:none"
         >
           <div
             style="position:absolute;box-sizing:border-box;width:100%;height:100%;padding:10px 10px 2px 0;padding-top:10px"
@@ -241,7 +241,7 @@ exports[`Storyshots ui/Layout full screen 1`] = `
       >
         <div
           class="Pane horizontal Pane1  "
-          style="flex:1;position:relative;outline:none"
+          style="overflow:auto;flex:1;position:relative;outline:none"
         >
           <div
             style="position:absolute;box-sizing:border-box;width:100%;height:100%;padding:10px 10px 2px 0;padding-top:10px"
@@ -338,7 +338,7 @@ exports[`Storyshots ui/Layout no addon panel 1`] = `
       >
         <div
           class="Pane horizontal Pane1  "
-          style="flex:1;position:relative;outline:none"
+          style="overflow:auto;flex:1;position:relative;outline:none"
         >
           <div
             style="position:absolute;box-sizing:border-box;width:100%;height:100%;padding:10px 10px 2px 0;padding-top:10px"
@@ -435,7 +435,7 @@ exports[`Storyshots ui/Layout no stories panel 1`] = `
       >
         <div
           class="Pane horizontal Pane1  "
-          style="flex:1;position:relative;outline:none"
+          style="overflow:auto;flex:1;position:relative;outline:none"
         >
           <div
             style="position:absolute;box-sizing:border-box;width:100%;height:100%;padding:10px 10px 2px 0;padding-top:10px"

--- a/lib/ui/src/modules/ui/components/layout/index.js
+++ b/lib/ui/src/modules/ui/components/layout/index.js
@@ -88,6 +88,10 @@ const overlayStyle = isDragging => ({
   left: '0px',
 });
 
+const previewPaneStyle = {
+  overflow: 'auto',
+};
+
 const defaultSizes = {
   addonPanel: {
     down: 200,
@@ -243,6 +247,7 @@ class Layout extends React.Component {
             onChange={size =>
               this.onResize('addonPanel', addonPanelInRight ? 'right' : 'down', size)
             }
+            pane1Style={previewPaneStyle}
           >
             <div style={contentPanelStyle(addonPanelInRight, storiesPanelOnTop)}>
               {/*


### PR DESCRIPTION
Issues: #3326 #3341

While investigating this issue #3326, I found out that this is caused by this [scrollIntoView](https://github.com/storybooks/storybook/blob/master/addons/storysource/src/StoryPanel.js#L71) call inside StorySource addon, which weirdly makes the entire right split panel (preview + addon panels) to scroll up whenever you go back to `storysource` panel after changing the viewport. 

Added to that, on small screens (issue #3341), part of the viewport is hidden behind the addon's panel, that's because the iframe container is not scrollable and is less in height than the iframe

Both issues are correlated to each other though

## What I did
- Make the preview pane (iframe's container) scrollable
- Make the preview pane's height same as the iframe height

## How to test
Make the steps described in #3326 but without the misplacement of the story panel

Is this testable with Jest or Chromatic screenshots?
No

Does this need a new example in the kitchen sink apps?
No

Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.
