### PR TITLE
Handle the fact that RN does not expose a dispose method on hot module

### DIFF
--- a/lib/core/src/client/preview/client_api.js
+++ b/lib/core/src/client/preview/client_api.js
@@ -49,11 +49,16 @@ export default class ClientApi {
       );
     }
 
-    if (m && m.hot && m.hot.dispose) {
-      m.hot.dispose(() => {
+    if (m && m.hot) {
+      if (m.hot.dispose) {
+        m.hot.dispose(() => {
+          this._storyStore.removeStoryKind(kind);
+          this._storyStore.incrementRevision();
+        });
+      } else {
         this._storyStore.removeStoryKind(kind);
         this._storyStore.incrementRevision();
-      });
+      }
     }
 
     const localDecorators = [];


### PR DESCRIPTION
Issue: #3348 

## What I did

I added a check for if the HMR module has a `.dispose` method and if not, just calls `.removeStoryKind` and `.incrementRevision` directly

## How to test

Is this testable with Jest or Chromatic screenshots? 

> It is, but I could use some help here. I tried simply implementing a new mock of `MockModule` and then looping over existing spec with new mock, as well as old mock, but got some errors:

```
Expected value to equal:
      []
    Received:
      [{"fileName": undefined, "kind": "kind", "stories": [{"name": "story", "render": [Function anonymous]}]}]

    Difference:

    - Expected
    + Received

    - Array []
    + Array [
    +   Object {
    +     "fileName": undefined,
    +     "kind": "kind",
    +     "stories": Array [
    +       Object {
    +         "name": "story",
    +         "render": [Function anonymous],
    +       },
    +     ],
    +   },
    + ]
```

I'm not familiar enough with the core code to dig deeper into this testing error.
