### PR TITLE
Change addon panel keyboard shortcut to shift-meta-z

### DIFF
--- a/lib/ui/src/libs/key_events.js
+++ b/lib/ui/src/libs/key_events.js
@@ -41,7 +41,7 @@ export default function handle(e) {
     case keycode('F'):
       e.preventDefault();
       return features.FULLSCREEN;
-    case keycode('C'):
+    case keycode('Z'):
     // backward-compatibility
     case keycode('D'):
       e.preventDefault();

--- a/lib/ui/src/modules/ui/components/shortcuts_help.js
+++ b/lib/ui/src/modules/ui/components/shortcuts_help.js
@@ -43,7 +43,7 @@ export function getShortcuts(platform) {
       { name: 'Toggle Addon panel position', keys: ['⌘ ⇧ G', '⌃ ⇧ G'] },
       { name: 'Toggle Fullscreen Mode', keys: ['⌘ ⇧ F', '⌃ ⇧ F'] },
       { name: 'Toggle Stories Panel', keys: ['⌘ ⇧ X', '⌃ ⇧ X'] },
-      { name: 'Toggle Addon panel', keys: ['⌘ ⇧ C', '⌃ ⇧ C'] },
+      { name: 'Toggle Addon panel', keys: ['⌘ ⇧ Z', '⌃ ⇧ Z'] },
       { name: 'Next Story', keys: ['⌘ ⇧ →', '⌃ ⇧ →'] },
       { name: 'Previous Story', keys: ['⌘ ⇧ ←', '⌃ ⇧ ←'] },
     ];
@@ -54,7 +54,7 @@ export function getShortcuts(platform) {
     { name: 'Toggle Addon panel position', keys: ['Ctrl + Shift + G'] },
     { name: 'Toggle Fullscreen Mode', keys: ['Ctrl + Shift + F'] },
     { name: 'Toggle Stories Panel', keys: ['Ctrl + Shift + X'] },
-    { name: 'Toggle Addon panel', keys: ['Ctrl + Shift + C'] },
+    { name: 'Toggle Addon panel', keys: ['Ctrl + Shift + Z'] },
     { name: 'Next Story', keys: ['Ctrl + Shift + →'] },
     { name: 'Previous Story', keys: ['Ctrl + Shift + ←'] },
   ];


### PR DESCRIPTION
Issue:
Chrome and Safari both use `SHIFT-CMD-C` to toggle the element inspector in dev-tools. The current hotkey for toggling the Addons Panel clobbers the native browser shortcut. `SHIFT-CMD-Z` appears to be unused in chrome, firefox, and safari, so should be a safe alternative.

Please tag your pull request with at least one of the following:
`["feature request"]`
