### PR TITLE
Don't use direct react dependency in core

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -37,8 +37,6 @@
     "postcss-loader": "^2.1.2",
     "prop-types": "^15.6.1",
     "qs": "^6.5.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
     "serve-favicon": "^2.4.5",
     "shelljs": "^0.8.1",
     "style-loader": "^0.20.3",
@@ -46,5 +44,9 @@
     "webpack": "^3.11.0",
     "webpack-dev-middleware": "^1.12.2",
     "webpack-hot-middleware": "^2.21.2"
+  },
+  "peerDependencies": {
+    "react": ">=15.0.0",
+    "react-dom": ">=15.0.0"
   }
 }


### PR DESCRIPTION
Issue: #3381 

It's already done on master via #3327, just need to do the same for release branch