### PR TITLE
Fixed addon Knobs' `selectV2` example's `defaultValue`

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -311,7 +311,7 @@ const options = {
   Rainbow: ['red', 'orange', 'etc'],
   None: null,
 };
-const defaultValue = 'Red';
+const defaultValue = 'red';
 const groupId = 'GROUP-ID1';
 
 const value = selectV2(label, options, defaultValue, groupId);


### PR DESCRIPTION
Issue:

The example for addon Knob's new `selectV2` misleads users into thinking that the "label" is meant to be passed as the `defaultValue`.

## What I did

I fixed the capitalization, to make it clear that it's still the "value".

## How to test

Is this testable with Jest or Chromatic screenshots? **NO**
Does this need a new example in the kitchen sink apps? **NO**
Does this need an update to the documentation? **YES**

If your answer is yes to any of these, please make sure to include it in your PR.

**Included.**

Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
