### PR TITLE
fix storyshots readme for image snapshotting

### DIFF
--- a/addons/storyshots/README.md
+++ b/addons/storyshots/README.md
@@ -164,7 +164,7 @@ Then you can either create a new Storyshots instance or edit the one you previou
 ```js
 import initStoryshots, { imageSnapshot } from '@storybook/addon-storyshots';
 
-initStoryshots({suite: 'Image storyshots', test: imageSnapshot});
+initStoryshots({suite: 'Image storyshots', test: imageSnapshot()});
 ```
 This will assume you have a storybook running on at _<http://localhost:6006>_.
 Internally here are the steps:  

--- a/addons/storyshots/src/test-body-image-snapshot.js
+++ b/addons/storyshots/src/test-body-image-snapshot.js
@@ -9,13 +9,22 @@ const defaultScreenshotOptions = () => ({ fullPage: true });
 
 const noop = () => {};
 
-export const imageSnapshot = ({
-  storybookUrl = 'http://localhost:6006',
-  getMatchOptions = noop,
-  getScreenshotOptions = defaultScreenshotOptions,
-  beforeScreenshot = noop,
-  getGotoOptions = noop,
-}) => {
+const defaultConfig = {
+  storybookUrl: 'http://localhost:6006',
+  getMatchOptions: noop,
+  getScreenshotOptions: defaultScreenshotOptions,
+  beforeScreenshot: noop,
+  getGotoOptions: noop,
+};
+
+export const imageSnapshot = (customConfig = {}) => {
+  const {
+    storybookUrl,
+    getMatchOptions,
+    getScreenshotOptions,
+    beforeScreenshot,
+    getGotoOptions,
+  } = { ...defaultConfig, ...customConfig };
   let browser; // holds ref to browser. (ie. Chrome)
   let page; // Hold ref to the page to screenshot.
 


### PR DESCRIPTION
## What I did
In storyshots 
- Update README to make it clear that you need to call the `imageSnapshot` fn.
- Make the config object optional. Before, you had to do `imageSnapshot({})` sadly.

## How to test
- Try to run `yarn test -image` to check everything is fine.