### PR TITLE
#3324 fix double quotes in prop table and add additional examples

### DIFF
--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -1634,6 +1634,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                           <span
                                             style={Object {}}
                                           >
+                                            "
                                             <ThemedComponent
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
@@ -1747,6 +1748,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                 </span>
                                               </PropVal>
                                             </ThemedComponent>
+                                            "
                                           </span>
                                         </span>
                                       </span>

--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -1105,9 +1105,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                           }
                                                         }
                                                       >
-                                                        "
                                                         a
-                                                        "
                                                       </span>
                                                     </PropVal>
                                                     , 
@@ -1167,9 +1165,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                           }
                                                         }
                                                       >
-                                                        "
                                                         b
-                                                        "
                                                       </span>
                                                     </PropVal>
                                                     }
@@ -1747,9 +1743,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                     }
                                                   }
                                                 >
-                                                  "
                                                   seven
-                                                  "
                                                 </span>
                                               </PropVal>
                                             </ThemedComponent>

--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -89,7 +89,7 @@ function PropVal(props) {
     if (val.length > maxPropStringLength) {
       val = `${val.slice(0, maxPropStringLength)}…`;
     }
-    content = <span style={valueStyles.string}>"{val}"</span>;
+    content = <span style={valueStyles.string}>{val}</span>;
     braceWrap = false;
   } else if (typeof val === 'boolean') {
     content = <span style={valueStyles.bool}>{`${val}`}</span>;

--- a/addons/info/src/components/Props.js
+++ b/addons/info/src/components/Props.js
@@ -45,12 +45,14 @@ export default function Props(props) {
           <span>
             =
             <span style={propValueStyle}>
+              {typeof nodeProps[name] === 'string' && '"'}
               <PropVal
                 val={nodeProps[name]}
                 maxPropObjectKeys={maxPropObjectKeys}
                 maxPropArrayLength={maxPropArrayLength}
                 maxPropStringLength={maxPropStringLength}
               />
+              {typeof nodeProps[name] === 'string' && '"'}
             </span>
           </span>
         )}

--- a/examples/cra-kitchen-sink/src/stories/__snapshots__/index.stories.storyshot
+++ b/examples/cra-kitchen-sink/src/stories/__snapshots__/index.stories.storyshot
@@ -592,7 +592,7 @@ exports[`Storyshots Button with new info 1`] = `
                     <span
                       style="color:#22a;word-break:break-word"
                     >
-                      "the best container ever"
+                      the best container ever
                     </span>
                   </td>
                   <td
@@ -1004,7 +1004,7 @@ exports[`Storyshots Button with some info 1`] = `
                     <span
                       style="color:#22a;word-break:break-word"
                     >
-                      "the best container ever"
+                      the best container ever
                     </span>
                   </td>
                   <td

--- a/examples/official-storybook/components/DocgenButton.js
+++ b/examples/official-storybook/components/DocgenButton.js
@@ -8,10 +8,6 @@ const DocgenButton = ({ disabled, label, onClick }) => (
   </button>
 );
 
-const Message = {
-  hello: 'world',
-};
-
 DocgenButton.defaultProps = {
   disabled: false,
   onClick: () => {},
@@ -38,7 +34,7 @@ DocgenButton.defaultProps = {
     },
   },
   arrayOf: [1, 2, 3],
-  msg: Message,
+  msg: new Set(),
   enm: 'News',
   enmEval: 'Photos',
   union: 'hello',
@@ -132,7 +128,7 @@ DocgenButton.propTypes = {
   /**
    * `instanceOf` is also supported and the custom type will be shown instead of `instanceOf`
    */
-  msg: PropTypes.instanceOf(Message),
+  msg: PropTypes.instanceOf(Set),
   /**
    * `oneOf` is basically an Enum which is also supported but can be pretty big.
    */
@@ -141,7 +137,7 @@ DocgenButton.propTypes = {
   /**
    *  A multi-type prop is also valid and is displayed as `Union<String|Message>`
    */
-  union: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Message)]),
+  union: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Set)]),
   /**
    * test string
    */

--- a/examples/official-storybook/components/DocgenButton.js
+++ b/examples/official-storybook/components/DocgenButton.js
@@ -8,14 +8,43 @@ const DocgenButton = ({ disabled, label, onClick }) => (
   </button>
 );
 
+const Message = {
+  hello: 'world',
+};
+
 DocgenButton.defaultProps = {
   disabled: false,
   onClick: () => {},
+  optionalString: 'Default String',
+  one: { key: 1 },
+  two: {
+    thing: {
+      id: 2,
+      func: () => {},
+      arr: [],
+    },
+  },
+  obj: {
+    key: 'value',
+  },
+  shape: {
+    id: 3,
+    func: () => {},
+    arr: [],
+    shape: {
+      shape: {
+        foo: 'bar',
+      },
+    },
+  },
+  arrayOf: [1, 2, 3],
+  msg: Message,
+  enm: 'News',
+  enmEval: 'Photos',
+  union: 'hello',
 };
 
-/* eslint-disable react/no-unused-prop-types,react/require-default-props */
-
-const Message = {};
+/* eslint-disable react/no-unused-prop-types */
 
 DocgenButton.propTypes = {
   /** Boolean indicating whether the button should render as disabled */
@@ -95,6 +124,9 @@ DocgenButton.propTypes = {
     }),
   }),
 
+  /**
+   * array of a certain type
+   */
   arrayOf: PropTypes.arrayOf(PropTypes.number),
 
   /**
@@ -110,6 +142,10 @@ DocgenButton.propTypes = {
    *  A multi-type prop is also valid and is displayed as `Union<String|Message>`
    */
   union: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Message)]),
+  /**
+   * test string
+   */
+  optionalString: PropTypes.string,
 };
 
 export default DocgenButton;

--- a/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
@@ -81,7 +81,7 @@ exports[`Storyshots Addons|Info.Decorator Use Info as story decorator 1`] = `
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Button"
+                          Button
                         </span>
                       </span>
                     </span>
@@ -596,7 +596,7 @@ exports[`Storyshots Addons|Info.Markdown Displays Markdown in description 1`] = 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Button"
+                          Button
                         </span>
                       </span>
                     </span>
@@ -879,7 +879,7 @@ exports[`Storyshots Addons|Info.Options.TableComponent Use a custom component fo
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Button"
+                          Button
                         </span>
                       </span>
                     </span>
@@ -1059,7 +1059,7 @@ exports[`Storyshots Addons|Info.Options.header Shows or hides Info Addon header 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Button"
+                          Button
                         </span>
                       </span>
                     </span>
@@ -1340,7 +1340,7 @@ exports[`Storyshots Addons|Info.Options.inline Inlines component inside story 1`
                       <span
                         style="color:#22a;word-break:break-word"
                       >
-                        "Button"
+                        Button
                       </span>
                     </span>
                   </span>
@@ -1631,7 +1631,7 @@ exports[`Storyshots Addons|Info.Options.propTables Shows additional component pr
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Button"
+                          Button
                         </span>
                       </span>
                     </span>
@@ -2056,7 +2056,7 @@ exports[`Storyshots Addons|Info.Options.propTablesExclude Exclude component from
                           <span
                             style="color:#22a;word-break:break-word"
                           >
-                            "Button"
+                            Button
                           </span>
                         </span>
                       </span>
@@ -2089,7 +2089,7 @@ exports[`Storyshots Addons|Info.Options.propTablesExclude Exclude component from
                           <span
                             style="color:#22a;word-break:break-word"
                           >
-                            "Flow Typed Button"
+                            Flow Typed Button
                           </span>
                         </span>
                       </span>
@@ -2612,7 +2612,7 @@ exports[`Storyshots Addons|Info.Options.styles Extend info styles with an object
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Button"
+                          Button
                         </span>
                       </span>
                     </span>
@@ -2895,7 +2895,7 @@ exports[`Storyshots Addons|Info.Options.styles Full control over styles using a 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Button"
+                          Button
                         </span>
                       </span>
                     </span>
@@ -3207,7 +3207,7 @@ exports[`Storyshots Addons|Info.React Docgen Comments from Flow declarations 1`]
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Flow Typed Button"
+                          Flow Typed Button
                         </span>
                       </span>
                     </span>
@@ -3465,7 +3465,7 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Docgen Button"
+                          Docgen Button
                         </span>
                       </span>
                     </span>
@@ -3652,7 +3652,31 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    -
+                    <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        {
+                        <span
+                          style="color:#666"
+                        >
+                          key
+                        </span>
+                        : 
+                        <span>
+                          {
+                          <span
+                            style="color:#a11"
+                          >
+                            1
+                          </span>
+                          }
+                        </span>
+                        }
+                      </span>
+                      }
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3677,7 +3701,79 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    -
+                    <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        {
+                        <span
+                          style="color:#666"
+                        >
+                          thing
+                        </span>
+                        : 
+                        <span>
+                          {
+                          <span
+                            style="color:#666"
+                          >
+                            {
+                            <span
+                              style="color:#666"
+                            >
+                              id
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style="color:#a11"
+                              >
+                                2
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style="color:#666"
+                            >
+                              func
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style="color:#170"
+                              >
+                                func()
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style="color:#666"
+                            >
+                              arr
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style="color:#666"
+                              >
+                                []
+                              </span>
+                              }
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                        }
+                      </span>
+                      }
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3702,7 +3798,27 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    -
+                    <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        {
+                        <span
+                          style="color:#666"
+                        >
+                          key
+                        </span>
+                        : 
+                        <span
+                          style="color:#22a;word-break:break-word"
+                        >
+                          value
+                        </span>
+                        }
+                      </span>
+                      }
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3727,7 +3843,63 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    -
+                    <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        {
+                        <span
+                          style="color:#666"
+                        >
+                          id
+                        </span>
+                        : 
+                        <span>
+                          {
+                          <span
+                            style="color:#a11"
+                          >
+                            3
+                          </span>
+                          }
+                        </span>
+                        , 
+                        <span
+                          style="color:#666"
+                        >
+                          func
+                        </span>
+                        : 
+                        <span>
+                          {
+                          <span
+                            style="color:#170"
+                          >
+                            func()
+                          </span>
+                          }
+                        </span>
+                        , 
+                        <span
+                          style="color:#666"
+                        >
+                          arr
+                        </span>
+                        : 
+                        <span>
+                          {
+                          <span
+                            style="color:#666"
+                          >
+                            []
+                          </span>
+                          }
+                        </span>
+                        , …}
+                      </span>
+                      }
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3752,7 +3924,45 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    -
+                    <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        [
+                        <span>
+                          {
+                          <span
+                            style="color:#a11"
+                          >
+                            1
+                          </span>
+                          }
+                        </span>
+                        , 
+                        <span>
+                          {
+                          <span
+                            style="color:#a11"
+                          >
+                            2
+                          </span>
+                          }
+                        </span>
+                        , 
+                        <span>
+                          {
+                          <span
+                            style="color:#a11"
+                          >
+                            3
+                          </span>
+                          }
+                        </span>
+                        ]
+                      </span>
+                      }
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3777,7 +3987,15 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    -
+                    <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        {}
+                      </span>
+                      }
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3802,7 +4020,11 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    -
+                    <span
+                      style="color:#22a;word-break:break-word"
+                    >
+                      News
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3827,7 +4049,11 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    -
+                    <span
+                      style="color:#22a;word-break:break-word"
+                    >
+                      Photos
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3852,7 +4078,40 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
+                    <span
+                      style="color:#22a;word-break:break-word"
+                    >
+                      hello
+                    </span>
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  />
+                </tr>
+                <tr>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    optionalString
+                  </td>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
                     -
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    <span
+                      style="color:#22a;word-break:break-word"
+                    >
+                      Default String
+                    </span>
                   </td>
                   <td
                     class="css-d52hbj"
@@ -3969,7 +4228,7 @@ exports[`Storyshots Addons|Info.React Docgen Comments from component declaration
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Button"
+                          Button
                         </span>
                       </span>
                     </span>

--- a/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
@@ -78,11 +78,13 @@ exports[`Storyshots Addons|Info.Decorator Use Info as story decorator 1`] = `
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -593,11 +595,13 @@ exports[`Storyshots Addons|Info.Markdown Displays Markdown in description 1`] = 
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -876,11 +880,13 @@ exports[`Storyshots Addons|Info.Options.TableComponent Use a custom component fo
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -1056,11 +1062,13 @@ exports[`Storyshots Addons|Info.Options.header Shows or hides Info Addon header 
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -1337,11 +1345,13 @@ exports[`Storyshots Addons|Info.Options.inline Inlines component inside story 1`
                   <span>
                     =
                     <span>
+                      "
                       <span
                         style="color:#22a;word-break:break-word"
                       >
                         Button
                       </span>
+                      "
                     </span>
                   </span>
                    
@@ -1628,11 +1638,13 @@ exports[`Storyshots Addons|Info.Options.propTables Shows additional component pr
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -2053,11 +2065,13 @@ exports[`Storyshots Addons|Info.Options.propTablesExclude Exclude component from
                       <span>
                         =
                         <span>
+                          "
                           <span
                             style="color:#22a;word-break:break-word"
                           >
                             Button
                           </span>
+                          "
                         </span>
                       </span>
                        
@@ -2086,11 +2100,13 @@ exports[`Storyshots Addons|Info.Options.propTablesExclude Exclude component from
                       <span>
                         =
                         <span>
+                          "
                           <span
                             style="color:#22a;word-break:break-word"
                           >
                             Flow Typed Button
                           </span>
+                          "
                         </span>
                       </span>
                        
@@ -2609,11 +2625,13 @@ exports[`Storyshots Addons|Info.Options.styles Extend info styles with an object
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -2892,11 +2910,13 @@ exports[`Storyshots Addons|Info.Options.styles Full control over styles using a 
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -3204,11 +3224,13 @@ exports[`Storyshots Addons|Info.React Docgen Comments from Flow declarations 1`]
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Flow Typed Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -3462,11 +3484,13 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Docgen Button
                         </span>
+                        "
                       </span>
                     </span>
                      
@@ -4225,11 +4249,13 @@ exports[`Storyshots Addons|Info.React Docgen Comments from component declaration
                     <span>
                       =
                       <span>
+                        "
                         <span
                           style="color:#22a;word-break:break-word"
                         >
                           Button
                         </span>
+                        "
                       </span>
                     </span>
                      


### PR DESCRIPTION
Issue: fix #3324 

![screen shot 2018-04-11 at 3 15 21 pm](https://user-images.githubusercontent.com/1474548/38638112-3349db80-3d9b-11e8-9d5a-f48d580365a1.png)

## What I did

removed quotes and added examples for default props

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
yes
Does this need an update to the documentation?

Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
