### PR TITLE
viewport-addon: configure => configureViewport

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -19,10 +19,10 @@ or with yarn:
 
 ## Configuration
 
-Import and use the `configure` function in your `config.js` file.
+Import and use the `configureViewport` function in your `config.js` file.
 
 ```js
-import { configure } from '@storybook/addon-viewport';
+import { configureViewport } from '@storybook/addon-viewport';
 ```
 
 ### defaultViewport : String
@@ -94,10 +94,10 @@ This will register the Viewport Addon to Storybook and will show up in the actio
 
 ### Use Custom Set of Devices
 
-This will replace all previous devices with `Kindle Fire 2` and `Kindle Fire HD` by simply calling `configure` with the two devices as `viewports` in `config.js` file in your `.storybook` directory.
+This will replace all previous devices with `Kindle Fire 2` and `Kindle Fire HD` by simply calling `configureViewport` with the two devices as `viewports` in `config.js` file in your `.storybook` directory.
 
 ```js
-import { configure } from '@storybook/addon-viewport';
+import { configureViewport } from '@storybook/addon-viewport';
 
 const newViewports = {
   kindleFire2: {
@@ -116,7 +116,7 @@ const newViewports = {
   }
 };
 
-configure({
+configureViewport({
   viewports: newViewports
 });
 ```
@@ -124,10 +124,10 @@ configure({
 
 ### Add New Device
 
-This will add both `Kindle Fire 2` and `Kindle Fire HD` to the list of devices. This is acheived by making use of the exported [`INITIAL_VIEWPORTS`](src/shared/index.js) property, by merging it with the new viewports and pass the result as `viewports` to `configure` function
+This will add both `Kindle Fire 2` and `Kindle Fire HD` to the list of devices. This is acheived by making use of the exported [`INITIAL_VIEWPORTS`](src/shared/index.js) property, by merging it with the new viewports and pass the result as `viewports` to `configureViewport` function
 
 ```js
-import { configure, INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { configureViewport, INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 const newViewports = {
   kindleFire2: {
@@ -146,7 +146,7 @@ const newViewports = {
   }
 };
 
-configure({
+configureViewport({
   viewports: {
     ...INITIAL_VIEWPORTS,
     ...newViewports
@@ -160,9 +160,9 @@ configure({
 This will make `iPhone 6` the default viewport for all stories.
 
 ```js
-import { configure } from '@storybook/addon-viewport';
+import { configureViewport } from '@storybook/addon-viewport';
 
-configure({
+configureViewport({
   defaultViewport: 'iphone6'
 });
 ```

--- a/addons/viewport/preview.js
+++ b/addons/viewport/preview.js
@@ -1,6 +1,6 @@
 const preview = require('./dist/preview');
 
-exports.configure = preview.configure;
+exports.configureViewport = preview.configureViewport;
 exports.DEFAULT_VIEWPORT = preview.DEFAULT_VIEWPORT;
 exports.INITIAL_VIEWPORTS = preview.INITIAL_VIEWPORTS;
 exports.withViewport = preview.withViewport;

--- a/addons/viewport/src/preview/index.js
+++ b/addons/viewport/src/preview/index.js
@@ -5,7 +5,7 @@ export { INITIAL_VIEWPORTS, DEFAULT_VIEWPORT } from '../shared';
 export { default as withViewport } from './withViewport';
 export { default as Viewport } from './components/Viewport';
 
-export function configure(configs = {}) {
+export function configureViewport(configs = {}) {
   const channel = addons.getChannel();
 
   if (channel) {

--- a/addons/viewport/src/preview/tests/index.test.js
+++ b/addons/viewport/src/preview/tests/index.test.js
@@ -1,5 +1,5 @@
 import addons from '@storybook/addons';
-import { configure } from '../';
+import { configureViewport } from '../';
 
 jest.mock('@storybook/addons');
 
@@ -10,13 +10,13 @@ describe('Viewport preview', () => {
   };
   addons.getChannel.mockReturnValue(channel);
 
-  describe('configure', () => {
+  describe('configureViewport', () => {
     it('publishes configure event with all passed configurations', () => {
       const configs = {
         foo: 'bar',
         john: 'Doe',
       };
-      configure(configs);
+      configureViewport(configs);
 
       expect(channel.emit).toHaveBeenCalledTimes(1);
       expect(channel.emit).toHaveBeenCalledWith('addon:viewport:configure', {

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -1,6 +1,6 @@
 import { configure } from '@storybook/react';
 import { setOptions } from '@storybook/addon-options';
-import { configure as configureViewport, INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { configureViewport, INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import 'react-chromatic/storybook-addon';
 import addHeadWarning from './head-warning';
 import extraViewports from './extra-viewports.json';


### PR DESCRIPTION
Issue:
`configureViewport` is more convenient by following a naming convention for addons and to avoid aliasing. (and to make @igor-dv happy 😉 )

## What I did
Added `configureViewport` function (should we drop the other one as it's an alpha version anyways?)

## How to test
`yarn test`

Is this testable with Jest or Chromatic screenshots?
Yes

Does this need a new example in the kitchen sink apps?
No

Does this need an update to the documentation?
Yes

If your answer is yes to any of these, please make sure to include it in your PR.

Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
