### PR TITLE
Serialize boolean type only for non-nullable values

### DIFF
--- a/addons/knobs/src/components/types/Boolean.js
+++ b/addons/knobs/src/components/types/Boolean.js
@@ -44,7 +44,7 @@ BooleanType.propTypes = {
   onChange: PropTypes.func,
 };
 
-BooleanType.serialize = value => String(value);
+BooleanType.serialize = value => (value ? String(value) : null);
 BooleanType.deserialize = value => value === 'true';
 
 export default BooleanType;


### PR DESCRIPTION
Issue: #3400 

## What I did
Serialized boolean type only for non-nullable values

## How to test

Is this testable with Jest or Chromatic screenshots?
No

Does this need a new example in the kitchen sink apps?
No

Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
