### PR TITLE
Provide a configuration option to limit the number of actions logged

### DIFF
--- a/addons/actions/README.md
+++ b/addons/actions/README.md
@@ -109,3 +109,4 @@ action('my-action', {
 |---|---|---|---|
 |`depth`|Number|Configures the transfered depth of any logged objects.|`10`|
 |`clearOnStoryChange`|Boolean|Flag whether to clear the action logger when switching away from the current story.|`true`|
+|`limit`|Number|Limits the number of items logged in the action logger|`50`|

--- a/addons/actions/README.md
+++ b/addons/actions/README.md
@@ -80,20 +80,26 @@ over the channel.
 This is not very optimal and can cause lag when large objects are being logged, for this reason it is possible 
 to configure a maximum depth.
 
+The action logger, by default, will log all actions fired during the lifetime of the story. After a while
+this can make the storybook laggy. As a workaround, you can configure an upper limit to how many actions should 
+be logged.
+
 To apply the configuration globally use the `configureActions` function in your `config.js` file.
 
 ```js
 import { configureActions } from '@storybook/addon-actions';
 
 configureActions({
-  depth: 100
+  depth: 100,
+  // Limit the number of items logged into the actions panel
+  limit: 20,
 })
 ```
 
 To apply the configuration per action use:
 ```js
 action('my-action', {
-  depth: 5 
+  depth: 5,
 })
 ```
 

--- a/addons/actions/src/containers/ActionLogger/index.js
+++ b/addons/actions/src/containers/ActionLogger/index.js
@@ -48,7 +48,7 @@ export default class ActionLogger extends React.Component {
       action.count = 1; // eslint-disable-line
       actions.unshift(action);
     }
-    this.setState({ actions });
+    this.setState({ actions: actions.slice(0, action.options.limit) });
   }
 
   clearActions() {

--- a/addons/actions/src/preview/__tests__/configureActions.test.js
+++ b/addons/actions/src/preview/__tests__/configureActions.test.js
@@ -5,15 +5,18 @@ describe('Configure Actions', () => {
   it('can configure actions', () => {
     const depth = 100;
     const clearOnStoryChange = false;
+    const limit = 20;
 
     configureActions({
       depth,
       clearOnStoryChange,
+      limit,
     });
 
     expect(config).toEqual({
       depth,
       clearOnStoryChange,
+      limit,
     });
   });
 });

--- a/addons/actions/src/preview/configureActions.js
+++ b/addons/actions/src/preview/configureActions.js
@@ -1,6 +1,7 @@
 export const config = {
   depth: 10,
   clearOnStoryChange: true,
+  limit: 50,
 };
 
 export function configureActions(options = {}) {

--- a/examples/official-storybook/stories/__snapshots__/addon-actions.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-actions.stories.storyshot
@@ -137,6 +137,21 @@ exports[`Storyshots Addons|Actions Hello World 1`] = `
 </button>
 `;
 
+exports[`Storyshots Addons|Actions Limit Action Output 1`] = `
+<div>
+  <button
+    class="css-1yjiefr"
+  >
+    False
+  </button>
+  <button
+    class="css-1yjiefr"
+  >
+    True
+  </button>
+</div>
+`;
+
 exports[`Storyshots Addons|Actions Persisting the action logger 1`] = `
 <div>
   <p>
@@ -158,7 +173,7 @@ exports[`Storyshots Addons|Actions Reserved keyword as name 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions configureActions 1`] = `
+exports[`Storyshots Addons|Actions configureActionsDepth 1`] = `
 <button
   class="css-1yjiefr"
 >

--- a/examples/official-storybook/stories/addon-actions.stories.js
+++ b/examples/official-storybook/stories/addon-actions.stories.js
@@ -85,7 +85,7 @@ storiesOf('Addons|Actions', module)
       </div>
     );
   })
-  .add('configureActions', () => {
+  .add('configureActionsDepth', () => {
     configureActions({
       depth: 2,
     });
@@ -105,4 +105,16 @@ storiesOf('Addons|Actions', module)
         Object (configured clearOnStoryChange: false)
       </Button>
     </div>
-  ));
+  ))
+  .add('Limit Action Output', () => {
+    configureActions({
+      limit: 2,
+    });
+
+    return (
+      <div>
+        <Button onClick={() => action('False')(false)}>False</Button>
+        <Button onClick={() => action('True')(true)}>True</Button>
+      </div>
+    );
+  });


### PR DESCRIPTION
Issue: The actions logger panel accumulates actions for a story endlessly. After a while, this creates quite a bit of lag. You can hit the clear button to clear out the logger and performance improves again, but it'd be nice to have a configuration hook to set a hard upper bound on the number of actions that should be logged.

## What I did
Added a configuration option called `limit` to the `configureActions` call.

