### PR TITLE
Improve yarn detection

### DIFF
--- a/lib/cli/lib/has_yarn.js
+++ b/lib/cli/lib/has_yarn.js
@@ -1,10 +1,13 @@
+import { sync as spawnSync } from 'cross-spawn';
 import path from 'path';
 import fs from 'fs';
 
 export default function hasYarn() {
+  const yarnAvailable = spawnSync('yarn', ['--version'], { silent: true });
+  const npmAvailable = spawnSync('npm', ['--version'], { silent: true });
   const yarnLockPath = path.resolve('yarn.lock');
-  if (!fs.existsSync(yarnLockPath)) {
-    return false;
+  if ((fs.existsSync(yarnLockPath) || npmAvailable.status !== 0) && yarnAvailable.status === 0) {
+    return true;
   }
-  return true;
+  return false;
 }

--- a/lib/cli/lib/has_yarn.js
+++ b/lib/cli/lib/has_yarn.js
@@ -1,6 +1,10 @@
-import { sync as spawnSync } from 'cross-spawn';
+import path from 'path';
+import fs from 'fs';
 
 export default function hasYarn() {
-  const result = spawnSync('yarn', ['--version'], { silent: true });
-  return result.status === 0;
+  const yarnLockPath = path.resolve('yarn.lock');
+  if (!fs.existsSync(yarnLockPath)) {
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
Issue: Currently, `getstorybook` uses yarn when it's available on the system even in cases where `npm` is used in the current project, causing errors. (closes #3384)

## What I did
I changed the condition for using `yarn` from checking `yarn --version` to looking for a `yarn.lock` file in the current project. 

## How to test
- I ran the e2e tests and all of them passed. Testing this with a (additional) fixture seemed excessive based on the fixtures, but please correct me if I'm wrong. 