### PR TITLE
Add option to clear action logger

### DIFF
--- a/addons/actions/README.md
+++ b/addons/actions/README.md
@@ -102,4 +102,4 @@ action('my-action', {
 |Name|Type|Description|Default|
 |---|---|---|---|
 |`depth`|Number|Configures the transfered depth of any logged objects.|`10`|
-|`clearActionLogger`|Boolean|Flag whether to clear the action logger when switching away from the current story.|`false`|
+|`clearOnStoryChange`|Boolean|Flag whether to clear the action logger when switching away from the current story.|`true`|

--- a/addons/actions/README.md
+++ b/addons/actions/README.md
@@ -102,3 +102,4 @@ action('my-action', {
 |Name|Type|Description|Default|
 |---|---|---|---|
 |`depth`|Number|Configures the transfered depth of any logged objects.|`10`|
+|`clearActionLogger`|Boolean|Flag whether to clear the action logger when switching away from the current story.|`false`|

--- a/addons/actions/src/containers/ActionLogger/index.js
+++ b/addons/actions/src/containers/ActionLogger/index.js
@@ -63,9 +63,10 @@ export default class ActionLogger extends React.Component {
 
 ActionLogger.propTypes = {
   channel: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  api: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  api: PropTypes.shape({
+    onStory: PropTypes.func.isRequired,
+  }).isRequired,
 };
 ActionLogger.defaultProps = {
   channel: {},
-  api: {},
 };

--- a/addons/actions/src/containers/ActionLogger/index.js
+++ b/addons/actions/src/containers/ActionLogger/index.js
@@ -7,21 +7,31 @@ import { CYCLIC_KEY, retrocycle } from '../../lib';
 import { isObject } from '../../lib/util';
 
 import ActionLoggerComponent from '../../components/ActionLogger/';
-import { EVENT_ID } from '../../';
+import { EVENT_ID, STORY_CHANGE_ID } from '../../';
 
 export default class ActionLogger extends React.Component {
   constructor(props, ...args) {
     super(props, ...args);
     this.state = { actions: [] };
     this._actionListener = action => this.addAction(action);
+    this._storyChangeListener = () => this.handleStoryChange();
   }
 
   componentDidMount() {
     this.props.channel.on(EVENT_ID, this._actionListener);
+    this.props.channel.on(STORY_CHANGE_ID, this._storyChangeListener);
   }
 
   componentWillUnmount() {
     this.props.channel.removeListener(EVENT_ID, this._actionListener);
+    this.props.channel.removeListener(STORY_CHANGE_ID, this._storyChangeListener);
+  }
+
+  handleStoryChange() {
+    const { actions } = this.state;
+    if (actions.length > 0 && actions[0].options.clearActionLogger) {
+      this.clearActions();
+    }
   }
 
   addAction(action) {

--- a/addons/actions/src/containers/ActionLogger/index.js
+++ b/addons/actions/src/containers/ActionLogger/index.js
@@ -7,7 +7,7 @@ import { CYCLIC_KEY, retrocycle } from '../../lib';
 import { isObject } from '../../lib/util';
 
 import ActionLoggerComponent from '../../components/ActionLogger/';
-import { EVENT_ID, STORY_CHANGE_ID } from '../../';
+import { EVENT_ID } from '../../';
 
 export default class ActionLogger extends React.Component {
   constructor(props, ...args) {
@@ -19,12 +19,11 @@ export default class ActionLogger extends React.Component {
 
   componentDidMount() {
     this.props.channel.on(EVENT_ID, this._actionListener);
-    this.props.channel.on(STORY_CHANGE_ID, this._storyChangeListener);
+    this.props.api.onStory(this._storyChangeListener);
   }
 
   componentWillUnmount() {
     this.props.channel.removeListener(EVENT_ID, this._actionListener);
-    this.props.channel.removeListener(STORY_CHANGE_ID, this._storyChangeListener);
   }
 
   handleStoryChange() {
@@ -64,7 +63,9 @@ export default class ActionLogger extends React.Component {
 
 ActionLogger.propTypes = {
   channel: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  api: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 ActionLogger.defaultProps = {
   channel: {},
+  api: {},
 };

--- a/addons/actions/src/containers/ActionLogger/index.js
+++ b/addons/actions/src/containers/ActionLogger/index.js
@@ -29,7 +29,7 @@ export default class ActionLogger extends React.Component {
 
   handleStoryChange() {
     const { actions } = this.state;
-    if (actions.length > 0 && actions[0].options.clearActionLogger) {
+    if (actions.length > 0 && actions[0].options.clearOnStoryChange) {
       this.clearActions();
     }
   }

--- a/addons/actions/src/containers/ActionLogger/index.js
+++ b/addons/actions/src/containers/ActionLogger/index.js
@@ -19,11 +19,14 @@ export default class ActionLogger extends React.Component {
 
   componentDidMount() {
     this.props.channel.on(EVENT_ID, this._actionListener);
-    this.props.api.onStory(this._storyChangeListener);
+    this.stopListeningOnStory = this.props.api.onStory(this._storyChangeListener);
   }
 
   componentWillUnmount() {
     this.props.channel.removeListener(EVENT_ID, this._actionListener);
+    if (this.stopListeningOnStory) {
+      this.stopListeningOnStory();
+    }
   }
 
   handleStoryChange() {

--- a/addons/actions/src/index.js
+++ b/addons/actions/src/index.js
@@ -4,5 +4,6 @@ import { action, configureActions, decorateAction } from './preview';
 export const ADDON_ID = 'storybook/actions';
 export const PANEL_ID = `${ADDON_ID}/actions-panel`;
 export const EVENT_ID = `${ADDON_ID}/action-event`;
+export const STORY_CHANGE_ID = `storybook/stories/story-event`;
 
 export { action, configureActions, decorateAction };

--- a/addons/actions/src/index.js
+++ b/addons/actions/src/index.js
@@ -4,6 +4,5 @@ import { action, configureActions, decorateAction } from './preview';
 export const ADDON_ID = 'storybook/actions';
 export const PANEL_ID = `${ADDON_ID}/actions-panel`;
 export const EVENT_ID = `${ADDON_ID}/action-event`;
-export const STORY_CHANGE_ID = `storybook/stories/story-event`;
 
 export { action, configureActions, decorateAction };

--- a/addons/actions/src/manager.js
+++ b/addons/actions/src/manager.js
@@ -4,11 +4,11 @@ import ActionLogger from './containers/ActionLogger';
 import { ADDON_ID, PANEL_ID } from './';
 
 export function register() {
-  addons.register(ADDON_ID, () => {
+  addons.register(ADDON_ID, api => {
     const channel = addons.getChannel();
     addons.addPanel(PANEL_ID, {
       title: 'Action Logger',
-      render: () => <ActionLogger channel={channel} />,
+      render: () => <ActionLogger channel={channel} api={api} />,
     });
   });
 }

--- a/addons/actions/src/preview/__tests__/configureActions.test.js
+++ b/addons/actions/src/preview/__tests__/configureActions.test.js
@@ -4,13 +4,16 @@ import { configureActions } from '../../';
 describe('Configure Actions', () => {
   it('can configure actions', () => {
     const depth = 100;
+    const clearActionLogger = true;
 
     configureActions({
       depth,
+      clearActionLogger,
     });
 
     expect(config).toEqual({
       depth,
+      clearActionLogger,
     });
   });
 });

--- a/addons/actions/src/preview/__tests__/configureActions.test.js
+++ b/addons/actions/src/preview/__tests__/configureActions.test.js
@@ -4,16 +4,16 @@ import { configureActions } from '../../';
 describe('Configure Actions', () => {
   it('can configure actions', () => {
     const depth = 100;
-    const clearActionLogger = true;
+    const clearOnStoryChange = false;
 
     configureActions({
       depth,
-      clearActionLogger,
+      clearOnStoryChange,
     });
 
     expect(config).toEqual({
       depth,
-      clearActionLogger,
+      clearOnStoryChange,
     });
   });
 });

--- a/addons/actions/src/preview/action.js
+++ b/addons/actions/src/preview/action.js
@@ -18,6 +18,7 @@ export default function action(name, options = {}) {
     channel.emit(EVENT_ID, {
       id,
       data: { name, args },
+      options: actionOptions,
     });
   };
 

--- a/addons/actions/src/preview/configureActions.js
+++ b/addons/actions/src/preview/configureActions.js
@@ -1,5 +1,6 @@
 export const config = {
   depth: 10,
+  clearActionLogger: false,
 };
 
 export function configureActions(options = {}) {

--- a/addons/actions/src/preview/configureActions.js
+++ b/addons/actions/src/preview/configureActions.js
@@ -1,6 +1,6 @@
 export const config = {
   depth: 10,
-  clearActionLogger: false,
+  clearOnStoryChange: true,
 };
 
 export function configureActions(options = {}) {

--- a/examples/official-storybook/stories/__snapshots__/addon-actions.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-actions.stories.storyshot
@@ -137,6 +137,19 @@ exports[`Storyshots Addons|Actions Hello World 1`] = `
 </button>
 `;
 
+exports[`Storyshots Addons|Actions Persisting the action logger 1`] = `
+<div>
+  <p>
+    Moving away from this story will persist the action logger
+  </p>
+  <button
+    class="css-1yjiefr"
+  >
+    Object (configured clearOnStoryChange: false)
+  </button>
+</div>
+`;
+
 exports[`Storyshots Addons|Actions Reserved keyword as name 1`] = `
 <button
   class="css-1yjiefr"

--- a/examples/official-storybook/stories/addon-actions.stories.js
+++ b/examples/official-storybook/stories/addon-actions.stories.js
@@ -98,11 +98,11 @@ storiesOf('Addons|Actions', module)
       </Button>
     );
   })
-  .add('Clearing the action logger', () => (
+  .add('Persisting the action logger', () => (
     <div>
-      <p>Moving away from this story will clear the action logger</p>
-      <Button onClick={action('clear-action-logger', { clearActionLogger: true })}>
-        Object (clearActionLogger: true)
+      <p>Moving away from this story will persist the action logger</p>
+      <Button onClick={action('clear-action-logger', { clearOnStoryChange: false })}>
+        Object (configured clearOnStoryChange: false)
       </Button>
     </div>
   ));

--- a/examples/official-storybook/stories/addon-actions.stories.js
+++ b/examples/official-storybook/stories/addon-actions.stories.js
@@ -97,4 +97,12 @@ storiesOf('Addons|Actions', module)
         Object (configured depth: 2)
       </Button>
     );
-  });
+  })
+  .add('Clearing the action logger', () => (
+    <div>
+      <p>Moving away from this story will clear the action logger</p>
+      <Button onClick={action('clear-action-logger', { clearActionLogger: true })}>
+        Object (clearActionLogger: true)
+      </Button>
+    </div>
+  ));


### PR DESCRIPTION
Issue: Currently, the action loggers stacks up all the events without limit and across all stories. There is already a PR (#3447) open for a limiting option. In the same way, this introduces an optional feature that will clear the action logger when switching away from a story. (Fixes #3443)

## What I did
Added a `clearActionLogger` option to the actions addon that clears the action logger when switching away from a story. It uses the `storybook/stories/story-event` event for detecting a switch in story.

## How to test
I updated the `configureAction` unit test and the documentation on action options.