### PR TITLE
feat: Add 'component' option to @addons/info

### DIFF
--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -137,6 +137,7 @@ setDefaults({
   maxPropArrayLength: 10, // Displays the first 10 items in the default prop array
   maxPropStringLength: 100, // Displays the first 100 characters in the default prop string,
   TableComponent: props => {}, // Override the component used to render the props table
+  component: null, // Override the component analyzed in the story. Ex: the inner component of a wrapped component
 }
 ```
 

--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -4,6 +4,7 @@ exports[`addon Info should render <Info /> and markdown 1`] = `
 <Component>
   <Story
     PropTable={[Function]}
+    component={null}
     components={
       Object {
         "a": [Function],

--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -263,11 +263,13 @@ class Story extends React.Component {
       maxPropStringLength,
     } = this.props;
 
+    const children = this.props.component ? this.props.component : this.props.children;
+
     return (
       <div>
         <h1 style={this.state.stylesheet.source.h1}>Story Source</h1>
         <Pre>
-          {React.Children.map(this.props.children, (root, idx) => (
+          {React.Children.map(children, (root, idx) => (
             <Node
               key={idx}
               node={root}
@@ -325,8 +327,12 @@ class Story extends React.Component {
       }
     };
 
-    // extract components from children
-    extract(this.props.children);
+    // extract components from children or from specified `component`
+    if (this.props.component) {
+      extract(this.props.component);
+    } else {
+      extract(this.props.children);
+    }
 
     const array = Array.from(types.keys());
     array.sort((a, b) => getName(a) > getName(b));
@@ -389,6 +395,7 @@ Story.propTypes = {
   maxPropObjectKeys: PropTypes.number.isRequired,
   maxPropArrayLength: PropTypes.number.isRequired,
   maxPropStringLength: PropTypes.number.isRequired,
+  component: PropTypes.node,
 };
 
 Story.defaultProps = {
@@ -401,6 +408,7 @@ Story.defaultProps = {
   showHeader: true,
   showSource: true,
   components: {},
+  component: null,
 };
 
 polyfill(Story);

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -17,6 +17,7 @@ const defaultOptions = {
   maxPropObjectKeys: 3,
   maxPropArrayLength: 3,
   maxPropStringLength: 50,
+  component: null,
 };
 
 const defaultComponents = {
@@ -78,6 +79,10 @@ function addInfo(storyFn, context, infoOptions) {
     maxPropArrayLength: options.maxPropArrayLength,
     maxPropsIntoLine: options.maxPropsIntoLine,
     maxPropStringLength: options.maxPropStringLength,
+    component:
+      options.component && typeof options.component === 'function'
+        ? options.component(context)
+        : null,
   };
   return <Story {...props}>{storyFn(context)}</Story>;
 }

--- a/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
@@ -1328,6 +1328,291 @@ exports[`Storyshots Addons|Info.Options.TableComponent Use a custom component fo
 </div>
 `;
 
+exports[`Storyshots Addons|Info.Options.component Specify another component to be analyzed 1`] = `
+<div>
+  <div
+    style="position:relative;z-index:0"
+  >
+    <button>
+      random button
+    </button>
+  </div>
+  <button
+    style="font-family:sans-serif;font-size:12px;display:block;position:fixed;border:none;background:#28c;color:#fff;padding:5px 15px;cursor:pointer;top:0;right:0;border-radius:0 0 0 5px"
+    type="button"
+  >
+    Show Info
+  </button>
+  <div
+    style="position:fixed;background:white;top:0;bottom:0;left:0;right:0;padding:0 40px;overflow:auto;z-index:99999;display:none"
+  >
+    <button
+      style="font-family:sans-serif;font-size:12px;display:block;position:fixed;border:none;background:#28c;color:#fff;padding:5px 15px;cursor:pointer;top:0;right:0;border-radius:0 0 0 5px"
+      type="button"
+    >
+      ×
+    </button>
+    <div>
+      <div
+        style="font-family:-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif;color:#444;-webkit-font-smoothing:antialiased;font-weight:300;line-height:1.45;font-size:15px;border:1px solid #eee;padding:20px 40px 40px;border-radius:2px;background-color:#fff;margin-top:20px;margin-bottom:20px"
+      >
+        <div
+          style="border-bottom:1px solid #eee;padding-top:10px;margin-bottom:10px"
+        >
+          <h1
+            style="margin:0;padding:0;font-size:35px"
+          >
+            Addons|Info.Options.component
+          </h1>
+          <h2
+            style="margin:0 0 10px 0;padding:0;font-weight:400;font-size:22px"
+          >
+            Specify another component to be analyzed
+          </h2>
+        </div>
+        <div>
+          <h1
+            style="margin:20px 0 0 0;padding:0 0 5px 0;font-size:25px;border-bottom:1px solid #EEE"
+          >
+            Story Source
+          </h1>
+          <pre
+            class="css-4akams"
+          >
+            <div>
+              <div
+                style="padding-left:18px;padding-right:3px"
+              >
+                <span
+                  style="color:#777"
+                >
+                  &lt;BaseButton
+                </span>
+                <span>
+                  <span>
+                     
+                    <span>
+                      label
+                    </span>
+                    <span>
+                      =
+                      <span>
+                        "
+                        <span
+                          style="color:#22a;word-break:break-word"
+                        >
+                          specified button
+                        </span>
+                        "
+                      </span>
+                    </span>
+                     
+                  </span>
+                </span>
+                <span
+                  style="color:#777"
+                >
+                  /&gt;
+                </span>
+              </div>
+            </div>
+            <button
+              class="css-gydez8"
+            >
+              <div
+                class="css-kv47nt"
+              >
+                <div
+                  style="margin-bottom:6px"
+                >
+                  Copied!
+                </div>
+                <div>
+                  Copy
+                </div>
+              </div>
+            </button>
+          </pre>
+        </div>
+        <div>
+          <h1
+            style="margin:20px 0 0 0;padding:0 0 5px 0;font-size:25px;border-bottom:1px solid #EEE"
+          >
+            Prop Types
+          </h1>
+          <div>
+            <h2
+              style="margin:20px 0 0 0"
+            >
+              "BaseButton" Component
+            </h2>
+            <table
+              class="css-1ytzlk7"
+            >
+              <thead>
+                <tr>
+                  <th
+                    class="css-d52hbj"
+                  >
+                    property
+                  </th>
+                  <th
+                    class="css-d52hbj"
+                  >
+                    propType
+                  </th>
+                  <th
+                    class="css-d52hbj"
+                  >
+                    required
+                  </th>
+                  <th
+                    class="css-d52hbj"
+                  >
+                    default
+                  </th>
+                  <th
+                    class="css-d52hbj"
+                  >
+                    description
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    disabled
+                  </td>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    -
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    <span>
+                      {
+                      <span
+                        style="color:#a11"
+                      >
+                        false
+                      </span>
+                      }
+                    </span>
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  />
+                </tr>
+                <tr>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    label
+                  </td>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    yes
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    -
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  />
+                </tr>
+                <tr>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    onClick
+                  </td>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    -
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    <span>
+                      {
+                      <span
+                        style="color:#170"
+                      >
+                        onClick()
+                      </span>
+                      }
+                    </span>
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  />
+                </tr>
+                <tr>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    style
+                  </td>
+                  <td
+                    class="css-1ygfcef"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    -
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  >
+                    <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        {}
+                      </span>
+                      }
+                    </span>
+                  </td>
+                  <td
+                    class="css-d52hbj"
+                  />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Addons|Info.Options.header Shows or hides Info Addon header 1`] = `
 <div>
   <div

--- a/examples/official-storybook/stories/addon-info.stories.js
+++ b/examples/official-storybook/stories/addon-info.stories.js
@@ -68,11 +68,22 @@ const JSXDescription = (
   </div>
 );
 
+const myHOC = WrappedComponent => (
+  <WrappedComponent randomProp="randomValue" label="random button" />
+);
+
 storiesOf('Addons|Info.JSX', module).add(
   'Displays JSX in description',
   withInfo({ text: JSXDescription })(() => (
     <BaseButton onClick={action('clicked')} label="Button" />
   ))
+);
+
+storiesOf('Addons|Info.Options.component', module).add(
+  'Specify another component to be analyzed',
+  withInfo({
+    component: () => <BaseButton label="specified button" />,
+  })(() => myHOC(BaseButton))
 );
 
 storiesOf('Addons|Info.Options.inline', module).add(


### PR DESCRIPTION
Issue:
fixes #2893 
## What I did
added a `component` option that allows users to specify what component is analyzed

Usage:

```js
storiesOf('Addons|Info.Options.component', module).add(
  'Specify another component to be analyzed',
  withInfo({
    component: () => <BaseButton label="specified button" />,
  })(() => myHOC(BaseButton))
);
```

## How to test

Is this testable with Jest or Chromatic screenshots? n/a
Does this need a new example in the kitchen sink apps? y
Does this need an update to the documentation? y

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
