### PR TITLE
Add IStory interface.

### DIFF
--- a/app/angular/index.d.ts
+++ b/app/angular/index.d.ts
@@ -18,7 +18,7 @@ export interface IStoryContext {
   parameters: any;
 }
 
-export type IStory = {
+export interface IStory {
   props?: ICollection;
   moduleMetadata?: Partial<NgModuleMetadata>;
   component?: any;

--- a/app/angular/index.d.ts
+++ b/app/angular/index.d.ts
@@ -6,6 +6,7 @@ export interface IStorybookStory {
   render: () => any;
 }
 
+/** @todo typo in Storibook */
 export interface IStoribookSection {
   kind: string;
   stories: IStorybookStory[];
@@ -17,14 +18,14 @@ export interface IStoryContext {
   parameters: any;
 }
 
-export type IGetStory = (
-  IStoryContext
-) => {
+export type IStory = {
   props?: ICollection;
   moduleMetadata?: Partial<NgModuleMetadata>;
   component?: any;
   template?: string;
-};
+}
+
+export type IGetStory = (context: IStoryContext) => IStory;
 
 export interface IApi {
   kind: string;


### PR DESCRIPTION
This interface would be very useful for creation of functions which are called in IGetStory function. For example:
```typescript
interface IFooProps {
  bar: number;
  baz: string;
}

function getFooStory(props: IFooProps): IStory {
  // do other logic here
  return {
    moduleMetadata: {
      imports: [FooModule]
    },
    component: FooComponent,
    props
  };
}

storiesOf('Foo', module)
  .add('super awesome', () =>
    getFooStory({
      bar: 10,
      baz: 'baz'
    })
  )
  .add('disabled', () =>
    getFooStory({
      bar: 0,
      baz: 'lll'
    })
  );
```