### PR TITLE
Fix auto focus of searchbox

### DIFF
--- a/lib/ui/src/modules/ui/components/search_box.js
+++ b/lib/ui/src/modules/ui/components/search_box.js
@@ -78,13 +78,7 @@ export default class SearchBox extends React.Component {
     this.fireOnStory = this.fireOnStory.bind(this);
     this.fireOnKind = this.fireOnKind.bind(this);
     this.inputRef = this.inputRef.bind(this);
-  }
-
-  componentDidUpdate(prevProps) {
-    // focus search box on opening
-    if (this.props.showSearchBox && !prevProps.showSearchBox && this.input != null) {
-      this.input.focus();
-    }
+    this.onModalOpen = this.onModalOpen.bind(this);
   }
 
   onSelect(selected) {
@@ -92,6 +86,12 @@ export default class SearchBox extends React.Component {
     if (selected.type === 'story') this.fireOnStory(selected.value, selected.kind);
     else this.fireOnKind(selected.value);
     onClose();
+  }
+
+  onModalOpen() {
+    if (this.input != null) {
+      this.input.focus();
+    }
   }
 
   fireOnKind(kind) {
@@ -114,6 +114,7 @@ export default class SearchBox extends React.Component {
     return (
       <ReactModal
         isOpen={this.props.showSearchBox}
+        onAfterOpen={this.onModalOpen}
         onRequestClose={this.props.onClose}
         style={modalStyle}
         contentLabel="Search"


### PR DESCRIPTION
Issue: Input of searchbox would not be autofocused after opening it with the `cmd+shift+o` shortcut. (#3486) 

## What I did
So previously, the focus of the Searchbox was performed in the `componentDidUpdate` lifecycle method. After some debugging, what would happen for me is that every time I opened the Searchbox `this.input` would be `null`, while after I close the modal it would contain the actual ref (like it was out of sync). In the end, I couldn't fix it through the lifecycle method, but found [the `onAfterOpen` property of `react-modal`](http://reactcommunity.org/react-modal/#usage), which solved the issue.  In the example in their [README](https://github.com/reactjs/react-modal#examples) it says in the API usage:  `references are now sync'd and can be accessed.`

## How to test
Open up the `examples/official-storybook`, use the corresponding shortcut to open the searchbox and observe that the input field is focused.
