### PR TITLE
jest-image-snapshot version to ^2.4.1

### DIFF
--- a/addons/storyshots/package.json
+++ b/addons/storyshots/package.json
@@ -22,7 +22,7 @@
     "babel-runtime": "^6.26.0",
     "glob": "^7.1.2",
     "global": "^4.3.2",
-    "jest-image-snapshot": "^2.4.0",
+    "jest-image-snapshot": "^2.4.1",
     "jest-specific-snapshot": "^0.5.0",
     "puppeteer": "^1.3.0",
     "read-pkg-up": "^3.0.0"


### PR DESCRIPTION
Issue:
JSON.stringify failing inside jest-image-snapshot with Node 9

## What I did
Rollup jest-image-snapshot to include https://github.com/americanexpress/jest-image-snapshot/pull/72

## How to test

Is this testable with Jest or Chromatic screenshots? no
Does this need a new example in the kitchen sink apps? no
Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.
