### PR TITLE
Force re-render event

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -30,6 +30,7 @@
     "@storybook/addons": "4.0.0-alpha.4",
     "@storybook/channel-websocket": "4.0.0-alpha.4",
     "@storybook/core": "4.0.0-alpha.4",
+    "@storybook/core-events": "4.0.0-alpha.4",
     "@storybook/react-dev-utils": "^5.0.0",
     "@storybook/ui": "4.0.0-alpha.4",
     "babel-loader": "^7.1.4",

--- a/app/react-native/src/manager/provider.js
+++ b/app/react-native/src/manager/provider.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from '@storybook/ui';
 import createChannel from '@storybook/channel-websocket';
 import addons from '@storybook/addons';
+import Events from '@storybook/core-events';
 import uuid from 'uuid';
 import PreviewHelp from './components/PreviewHelp';
 
@@ -28,7 +29,7 @@ export default class ReactProvider extends Provider {
       this.channel = createChannel({ url });
       addons.setChannel(this.channel);
 
-      this.channel.emit('channelCreated', {
+      this.channel.emit(Events.CHANNEL_CREATED, {
         pairedId: this.pairedId,
         secured,
         host,
@@ -43,7 +44,7 @@ export default class ReactProvider extends Provider {
 
   renderPreview(kind, story) {
     this.selection = { kind, story };
-    this.channel.emit('setCurrentStory', { kind, story });
+    this.channel.emit(Events.SET_CURRENT_STORY, { kind, story });
     const renderPreview = addons.getPreview();
 
     const innerPreview = renderPreview ? renderPreview(kind, story) : null;
@@ -53,15 +54,15 @@ export default class ReactProvider extends Provider {
   handleAPI(api) {
     api.onStory((kind, story) => {
       this.selection = { kind, story };
-      this.channel.emit('setCurrentStory', this.selection);
+      this.channel.emit(Events.SET_CURRENT_STORY, this.selection);
     });
-    this.channel.on('setStories', data => {
+    this.channel.on(Events.SET_STORIES, data => {
       api.setStories(data.stories);
     });
-    this.channel.on('getCurrentStory', () => {
-      this.channel.emit('setCurrentStory', this.selection);
+    this.channel.on(Events.GET_CURRENT_STORY, () => {
+      this.channel.emit(Events.SET_CURRENT_STORY, this.selection);
     });
-    this.channel.emit('getStories');
+    this.channel.emit(Events.GET_STORIES);
     addons.loadAddons(api);
   }
 }

--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { ifIphoneX } from 'react-native-iphone-x-helper';
 
 import { Dimensions, View, TouchableWithoutFeedback, Image, Text, StatusBar } from 'react-native';
+import Events from '@storybook/core-events';
 import style from './style';
 import StoryListView from '../StoryListView';
 import StoryView from '../StoryView';
@@ -34,13 +35,13 @@ export default class OnDeviceUI extends Component {
 
   componentDidMount() {
     Dimensions.addEventListener('change', this.handleDeviceRotation);
-    this.props.events.on('story', this.handleStoryChange);
+    this.props.events.on(Events.SELECT_STORY, this.handleStoryChange);
     StatusBar.setHidden(true);
   }
 
   componentWillUnmount() {
     Dimensions.removeEventListener('change', this.handleDeviceRotation);
-    this.props.events.removeListener('story', this.handleStoryChange);
+    this.props.events.removeListener(Events.SELECT_STORY, this.handleStoryChange);
   }
 
   handleDeviceRotation = () => {

--- a/app/react-native/src/preview/components/StoryListView/index.js
+++ b/app/react-native/src/preview/components/StoryListView/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { ListView, View, Text, TouchableOpacity } from 'react-native';
+import Events from '@storybook/core-events';
 import style from './style';
 
 const SectionHeader = ({ title, selected }) => (
@@ -49,7 +50,7 @@ export default class StoryListView extends Component {
     this.storyAddedHandler = this.handleStoryAdded.bind(this);
     this.changeStoryHandler = this.changeStory.bind(this);
 
-    this.props.stories.on('storyAdded', this.storyAddedHandler);
+    this.props.stories.on(Events.STORY_ADDED, this.storyAddedHandler);
   }
 
   componentDidMount() {
@@ -62,7 +63,7 @@ export default class StoryListView extends Component {
   }
 
   componentWillUnmount() {
-    this.props.stories.removeListener('storyAdded', this.storyAddedHandler);
+    this.props.stories.removeListener(Events.STORY_ADDED, this.storyAddedHandler);
   }
 
   handleStoryAdded() {
@@ -87,7 +88,7 @@ export default class StoryListView extends Component {
   }
 
   changeStory(kind, story) {
-    this.props.events.emit('setCurrentStory', { kind, story });
+    this.props.events.emit(Events.SET_CURRENT_STORY, { kind, story });
   }
 
   render() {

--- a/app/react-native/src/preview/components/StoryView/index.js
+++ b/app/react-native/src/preview/components/StoryView/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { View, Text } from 'react-native';
+import Events from '@storybook/core-events';
 import style from './style';
 
 export default class StoryView extends Component {
@@ -10,11 +11,11 @@ export default class StoryView extends Component {
 
     this.storyHandler = this.selectStory.bind(this);
 
-    this.props.events.on('story', this.storyHandler);
+    this.props.events.on(Events.SELECT_STORY, this.storyHandler);
   }
 
   componentWillUnmount() {
-    this.props.events.removeListener('story', this.storyHandler);
+    this.props.events.removeListener(Events.SELECT_STORY, this.storyHandler);
   }
 
   selectStory(storyFn, selection) {

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { NativeModules } from 'react-native';
 import parse from 'url-parse';
 import addons from '@storybook/addons';
+import Events from '@storybook/core-events';
 import createChannel from '@storybook/channel-websocket';
 import { EventEmitter } from 'events';
 import { StoryStore, ClientApi } from '@storybook/core/client';
@@ -64,11 +65,11 @@ export default class Preview {
         channel = createChannel({ url });
         addons.setChannel(channel);
 
-        channel.emit('channelCreated');
+        channel.emit(Events.CHANNEL_CREATED);
       }
-      channel.on('getStories', () => this._sendSetStories());
-      channel.on('setCurrentStory', d => this._selectStory(d));
-      this._events.on('setCurrentStory', d => this._selectStory(d));
+      channel.on(Events.GET_STORIES, () => this._sendSetStories());
+      channel.on(Events.SET_CURRENT_STORY, d => this._selectStory(d));
+      this._events.on(Events.SET_CURRENT_STORY, d => this._selectStory(d));
       this._sendSetStories();
       this._sendGetCurrentStory();
 
@@ -84,17 +85,17 @@ export default class Preview {
   _sendSetStories() {
     const channel = addons.getChannel();
     const stories = this._stories.dumpStoryBook();
-    channel.emit('setStories', { stories });
+    channel.emit(Events.SET_STORIES, { stories });
   }
 
   _sendGetCurrentStory() {
     const channel = addons.getChannel();
-    channel.emit('getCurrentStory');
+    channel.emit(Events.GET_CURRENT_STORY);
   }
 
   _selectStory(selection) {
     const { kind, story } = selection;
     const storyFn = this._stories.getStoryWithContext(kind, story);
-    this._events.emit('story', storyFn, selection);
+    this._events.emit(Events.SELECT_STORY, storyFn, selection);
   }
 }

--- a/examples/crna-kitchen-sink/package.json
+++ b/examples/crna-kitchen-sink/package.json
@@ -14,6 +14,7 @@
     "@storybook/client-logger": "file:../../packs/storybook-client-logger.tgz",
     "@storybook/components": "file:../../packs/storybook-components.tgz",
     "@storybook/core": "file:../../packs/storybook-core.tgz",
+    "@storybook/core-events": "file:../../packs/storybook-core-events.tgz",
     "@storybook/node-logger": "file:../../packs/storybook-node-logger.tgz",
     "@storybook/react-native": "file:../../packs/storybook-react-native.tgz",
     "@storybook/ui": "file:../../packs/storybook-ui.tgz",

--- a/examples/react-native-vanilla/package.json
+++ b/examples/react-native-vanilla/package.json
@@ -29,6 +29,7 @@
     "@storybook/channel-websocket": "file:../../packs/storybook-channel-websocket.tgz",
     "@storybook/components": "file:../../packs/storybook-components.tgz",
     "@storybook/core": "file:../../packs/storybook-core.tgz",
+    "@storybook/core-events": "file:../../packs/storybook-core-events.tgz",
     "@storybook/node-logger": "file:../../packs/storybook-node-logger.tgz",
     "@storybook/react-native": "file:../../packs/storybook-react-native.tgz",
     "@storybook/ui": "file:../../packs/storybook-ui.tgz",

--- a/lib/core-events/index.js
+++ b/lib/core-events/index.js
@@ -7,4 +7,5 @@ export default {
   SELECT_STORY: 'selectStory',
   APPLY_SHORTCUT: 'applyShortcut',
   STORY_ADDED: 'storyAdded',
+  FORCE_RE_RENDER: 'forceReRender',
 };

--- a/lib/core-events/index.js
+++ b/lib/core-events/index.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   CHANNEL_CREATED: 'channelCreated',
   GET_CURRENT_STORY: 'getCurrentStory',
   SET_CURRENT_STORY: 'setCurrentStory',

--- a/lib/core-events/index.js
+++ b/lib/core-events/index.js
@@ -1,0 +1,10 @@
+export default {
+  CHANNEL_CREATED: 'channelCreated',
+  GET_CURRENT_STORY: 'getCurrentStory',
+  SET_CURRENT_STORY: 'setCurrentStory',
+  GET_STORIES: 'getStories',
+  SET_STORIES: 'setStories',
+  SELECT_STORY: 'selectStory',
+  APPLY_SHORTCUT: 'applyShortcut',
+  STORY_ADDED: 'storyAdded',
+};

--- a/lib/core-events/package.json
+++ b/lib/core-events/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@storybook/core-events",
+  "version": "4.0.0-alpha.4",
+  "description": "Event names used in storybook core",
+  "license": "MIT",
+  "main": "index.js"
+}

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -19,6 +19,7 @@
     "@storybook/addons": "4.0.0-alpha.4",
     "@storybook/channel-postmessage": "4.0.0-alpha.4",
     "@storybook/client-logger": "4.0.0-alpha.4",
+    "@storybook/core-events": "4.0.0-alpha.4",
     "@storybook/node-logger": "4.0.0-alpha.4",
     "@storybook/ui": "4.0.0-alpha.4",
     "autoprefixer": "^8.3.0",

--- a/lib/core/src/client/manager/provider.js
+++ b/lib/core/src/client/manager/provider.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { Provider } from '@storybook/ui';
 import addons from '@storybook/addons';
 import createChannel from '@storybook/channel-postmessage';
+import Events from '@storybook/core-events';
 import Preview from './preview';
 
 export default class ReactProvider extends Provider {
@@ -12,7 +13,7 @@ export default class ReactProvider extends Provider {
     this.channel = createChannel({ page: 'manager' });
     addons.setChannel(this.channel);
 
-    this.channel.emit('channelCreated');
+    this.channel.emit(Events.CHANNEL_CREATED);
   }
 
   getPanels() {
@@ -37,15 +38,15 @@ export default class ReactProvider extends Provider {
 
   handleAPI(api) {
     api.onStory((kind, story) => {
-      this.channel.emit('setCurrentStory', { kind, story });
+      this.channel.emit(Events.SET_CURRENT_STORY, { kind, story });
     });
-    this.channel.on('setStories', data => {
+    this.channel.on(Events.SET_STORIES, data => {
       api.setStories(data.stories);
     });
-    this.channel.on('selectStory', data => {
+    this.channel.on(Events.SELECT_STORY, data => {
       api.selectStory(data.kind, data.story);
     });
-    this.channel.on('applyShortcut', data => {
+    this.channel.on(Events.APPLY_SHORTCUT, data => {
       api.handleShortcut(data.event);
     });
     addons.loadAddons(api);

--- a/lib/core/src/client/preview/config_api.js
+++ b/lib/core/src/client/preview/config_api.js
@@ -1,6 +1,7 @@
 /* eslint no-underscore-dangle: 0 */
 
 import { location } from 'global';
+import Events from '@storybook/core-events';
 import { setInitialStory, setError, clearError } from './actions';
 
 export default class ConfigApi {
@@ -18,7 +19,7 @@ export default class ConfigApi {
 
     const stories = this._storyStore.dumpStoryBook();
     // send to the parent frame.
-    this._channel.emit('setStories', { stories });
+    this._channel.emit(Events.SET_STORIES, { stories });
 
     // clear the error if exists.
     this._reduxStore.dispatch(clearError());

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -171,6 +171,10 @@ export default function start(render, { decorateStory } = {}) {
 
   renderUI();
   reduxStore.subscribe(renderUI);
+  const forceReRender = () => renderUI(true);
+  if (isBrowser) {
+    channel.on(Events.FORCE_RE_RENDER, () => renderUI(true));
+  }
 
-  return { context, clientApi, configApi, forceReRender: () => renderUI(true) };
+  return { context, clientApi, configApi, forceReRender };
 }

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -4,6 +4,7 @@ import { navigator, window, document } from 'global';
 import createChannel from '@storybook/channel-postmessage';
 import { handleKeyboardShortcuts } from '@storybook/ui/dist/libs/key_events';
 import { logger } from '@storybook/client-logger';
+import Events from '@storybook/core-events';
 
 import StoryStore from './story_store';
 import ClientApi from './client_api';
@@ -82,7 +83,7 @@ export default function start(render, { decorateStory } = {}) {
   if (isBrowser) {
     // setup preview channel
     channel = createChannel({ page: 'preview' });
-    channel.on('setCurrentStory', data => {
+    channel.on(Events.SET_CURRENT_STORY, data => {
       reduxStore.dispatch(Actions.selectStory(data.kind, data.story));
     });
     addons.setChannel(channel);

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -173,7 +173,7 @@ export default function start(render, { decorateStory } = {}) {
   reduxStore.subscribe(renderUI);
   const forceReRender = () => renderUI(true);
   if (isBrowser) {
-    channel.on(Events.FORCE_RE_RENDER, () => renderUI(true));
+    channel.on(Events.FORCE_RE_RENDER, forceReRender);
   }
 
   return { context, clientApi, configApi, forceReRender };

--- a/lib/core/src/client/preview/story_store.js
+++ b/lib/core/src/client/preview/story_store.js
@@ -1,5 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
 import { EventEmitter } from 'events';
+import Events from '@storybook/core-events';
 
 let count = 0;
 
@@ -40,7 +41,7 @@ export default class StoryStore extends EventEmitter {
       parameters,
     };
 
-    this.emit('storyAdded', kind, name, fn, parameters);
+    this.emit(Events.STORY_ADDED, kind, name, fn, parameters);
   }
 
   getStoryKinds() {

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@storybook/components": "4.0.0-alpha.4",
+    "@storybook/core-events": "4.0.0-alpha.4",
     "@storybook/mantra-core": "^1.7.2",
     "@storybook/podda": "^1.2.3",
     "@storybook/react-komposer": "^2.0.4",

--- a/lib/ui/src/libs/key_events.js
+++ b/lib/ui/src/libs/key_events.js
@@ -1,4 +1,5 @@
 import keycode from 'keycode';
+import Events from '@storybook/core-events';
 
 export const features = {
   FULLSCREEN: 'FULLSCREEN',
@@ -68,7 +69,7 @@ export function handleKeyboardShortcuts(channel) {
   return event => {
     const parsedEvent = handle(event);
     if (parsedEvent) {
-      channel.emit('applyShortcut', { event: parsedEvent });
+      channel.emit(Events.APPLY_SHORTCUT, { event: parsedEvent });
     }
   };
 }


### PR DESCRIPTION
Issue: #1736 introduced an ability to force rerender story, but you have to depend on a particular framework to use it. I've introduced a `'forceReRender'` event that addons could use in a framework-agnostic way.

This also introduces constants for core events as a separate package (to avoid circular dependency between `core` and `ui`)