### PR TITLE
Feature/config custom chrome executable path

### DIFF
--- a/addons/storyshots/README.md
+++ b/addons/storyshots/README.md
@@ -243,6 +243,18 @@ initStoryshots({suite: 'Image storyshots', test: imageSnapshot({storybookUrl: 'h
 
 `getScreenshotOptions` receives an object `{ context: {kind, story}, url}`. _kind_ is the kind of the story and the _story_ its name. _url_ is the URL the browser will use to screenshot.
 
+### Specifying custom Chrome executable path (puppeteer API)
+
+You might use `chromeExecutablePath` to specify the path to a different version of Chrome, without downloading Chromium. Will be passed to [Runs a bundled version of Chromium](https://github.com/GoogleChrome/puppeteer#default-runtime-settings)
+
+```js
+import initStoryshots, { imageSnapshot } from '@storybook/addon-storyshots';
+
+const chromeExecutablePath = '/usr/local/bin/chrome';
+
+initStoryshots({suite: 'Image storyshots', test: imageSnapshot({storybookUrl: 'http://localhost:6006', chromeExecutablePath})});
+```
+
 ### Integrate image storyshots with regular app
 
 You may want to use another Jest project to run your image snapshots as they require more resources: Chrome and Storybook built/served.

--- a/addons/storyshots/src/test-body-image-snapshot.js
+++ b/addons/storyshots/src/test-body-image-snapshot.js
@@ -11,6 +11,7 @@ const noop = () => {};
 
 const defaultConfig = {
   storybookUrl: 'http://localhost:6006',
+  chromeExecutablePath: undefined,
   getMatchOptions: noop,
   getScreenshotOptions: defaultScreenshotOptions,
   beforeScreenshot: noop,
@@ -20,6 +21,7 @@ const defaultConfig = {
 export const imageSnapshot = (customConfig = {}) => {
   const {
     storybookUrl,
+    chromeExecutablePath,
     getMatchOptions,
     getScreenshotOptions,
     beforeScreenshot,
@@ -70,7 +72,10 @@ export const imageSnapshot = (customConfig = {}) => {
   testFn.beforeAll = () =>
     puppeteer
       // add some options "no-sandbox" to make it work properly on some Linux systems as proposed here: https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322851507
-      .launch({ args: ['--no-sandbox ', '--disable-setuid-sandbox'] })
+      .launch({
+        args: ['--no-sandbox ', '--disable-setuid-sandbox'],
+        executablePath: chromeExecutablePath,
+      })
       .then(b => {
         browser = b;
       })


### PR DESCRIPTION
Issue:
When running a custom install of Chrome, and not downloading Chromium (with the PUPPETEER_SKIP_CHROMIUM_DOWNLOAD, image snapshots are unable to start up.  I ran across this issue when running Storyshots inside a Docker container already containing a Chrome installation.

## What I did
Add a config parameter to use a Chrome executable path, instead of downloading Chromium inside of Puppeteer.  If no parameter is selected, defaults to undefined and operates as normal.

## How to test
Add a parameter and check if it references the correct Chrome.  In my case:
`/usr/local/bin/chrome`
