### PR TITLE
Channel-postmessage: handle events from the same window

### DIFF
--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -29,6 +29,7 @@
     "@storybook/addon-viewport": "4.0.0-alpha.4",
     "@storybook/addons": "4.0.0-alpha.4",
     "@storybook/components": "4.0.0-alpha.4",
+    "@storybook/core-events": "4.0.0-alpha.4",
     "@storybook/node-logger": "4.0.0-alpha.4",
     "@storybook/react": "4.0.0-alpha.4",
     "babel-runtime": "^6.26.0",

--- a/examples/official-storybook/stories/__snapshots__/core.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/core.stories.storyshot
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Core|Events Force re-render 1`] = `
+Array [
+  "Random number is 0.07705746569617533 ",
+  <button
+    class="css-1ibnlbj"
+    type="button"
+  >
+    Refresh
+  </button>,
+]
+`;
+
 exports[`Storyshots Core|Parameters passed to story 1`] = `
 <div>
   Parameters are {"globalParameter":"globalParameter","chapterParameter":"chapterParameter","storyParameter":"storyParameter"}

--- a/examples/official-storybook/stories/__snapshots__/core.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/core.stories.storyshot
@@ -1,15 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Core|Events Force re-render 1`] = `
-Array [
-  "Random number is 0.07705746569617533 ",
-  <button
-    class="css-1ibnlbj"
-    type="button"
-  >
-    Refresh
-  </button>,
-]
+<button
+  class="css-1ibnlbj"
+  type="button"
+>
+  Clicked: 0
+</button>
 `;
 
 exports[`Storyshots Core|Parameters passed to story 1`] = `

--- a/examples/official-storybook/stories/core.stories.js
+++ b/examples/official-storybook/stories/core.stories.js
@@ -22,10 +22,12 @@ storiesOf('Core|Parameters', module)
     }
   );
 
-const forceReRender = () => addons.getChannel().emit(Events.FORCE_RE_RENDER);
+let timesClicked = 0;
+const increment = () => {
+  timesClicked += 1;
+  addons.getChannel().emit(Events.FORCE_RE_RENDER);
+};
 
 storiesOf('Core|Events', module).add('Force re-render', () => (
-  <React.Fragment>
-    Random number is {Math.random()} <Button onClick={forceReRender}>Refresh</Button>
-  </React.Fragment>
+  <Button onClick={increment}>Clicked: {timesClicked}</Button>
 ));

--- a/examples/official-storybook/stories/core.stories.js
+++ b/examples/official-storybook/stories/core.stories.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import { storiesOf, addParameters } from '@storybook/react';
+import addons from '@storybook/addons';
+import Events from '@storybook/core-events';
+import { Button } from '@storybook/components';
 
 const globalParameter = 'globalParameter';
 const chapterParameter = 'chapterParameter';
@@ -18,3 +21,11 @@ storiesOf('Core|Parameters', module)
       storyParameter,
     }
   );
+
+const forceReRender = () => addons.getChannel().emit(Events.FORCE_RE_RENDER);
+
+storiesOf('Core|Events', module).add('Force re-render', () => (
+  <React.Fragment>
+    Random number is {Math.random()} <Button onClick={forceReRender}>Refresh</Button>
+  </React.Fragment>
+));

--- a/lib/channel-postmessage/src/index.js
+++ b/lib/channel-postmessage/src/index.js
@@ -32,7 +32,7 @@ export class PostmsgTransport {
     }
     const data = stringify({ key: KEY, event });
     iframeWindow.postMessage(data, '*');
-    window.postMessage(data, '*');
+    this._handler(event);
     return Promise.resolve(null);
   }
 

--- a/lib/channel-postmessage/src/index.js
+++ b/lib/channel-postmessage/src/index.js
@@ -32,6 +32,7 @@ export class PostmsgTransport {
     }
     const data = stringify({ key: KEY, event });
     iframeWindow.postMessage(data, '*');
+    window.postMessage(data, '*');
     return Promise.resolve(null);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16570,7 +16570,7 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-"vm2@github:patriksimek/vm2#custom_files":
+vm2@patriksimek/vm2#custom_files:
   version "3.5.0"
   resolved "https://codeload.github.com/patriksimek/vm2/tar.gz/7e82f90ac705fc44fad044147cb0df09b4c79a57"
 


### PR DESCRIPTION
Issue: #1407 was intended to add an ability to use channel as an event bus working regardless of whether events comes to the same or to another (preview vs manager) window. But right now it works only with channel-websocket. This PR adds this ability to channel-postmessage as well