### PR TITLE
Fix render order in preview

### DIFF
--- a/app/angular/src/client/preview/render.js
+++ b/app/angular/src/client/preview/render.js
@@ -1,6 +1,6 @@
 import { renderNgApp } from './angular/helpers';
 
 export default function render({ story, showMain }) {
-  renderNgApp(story);
   showMain();
+  renderNgApp(story);
 }

--- a/app/mithril/src/client/preview/render.js
+++ b/app/mithril/src/client/preview/render.js
@@ -21,6 +21,6 @@ export default function renderMain({ story, selectedKind, selectedStory, showMai
     return;
   }
 
-  m.mount(rootEl, { view: () => m(element) });
   showMain();
+  m.mount(rootEl, { view: () => m(element) });
 }

--- a/app/polymer/src/client/preview/render.js
+++ b/app/polymer/src/client/preview/render.js
@@ -17,6 +17,8 @@ export default function renderMain({ story, selectedKind, selectedStory, showMai
     });
     return;
   }
+
+  showMain();
   if (typeof component === 'string') {
     rootElement.innerHTML = component;
   } else if (component instanceof TemplateResult) {
@@ -28,5 +30,4 @@ export default function renderMain({ story, selectedKind, selectedStory, showMai
     rootElement.innerHTML = '';
     rootElement.appendChild(component);
   }
-  showMain();
 }

--- a/app/react/src/client/preview/render.js
+++ b/app/react/src/client/preview/render.js
@@ -43,6 +43,6 @@ export default function renderMain({ story, selectedKind, selectedStory, showMai
   // This could leads to issues like below:
   //    https://github.com/storybooks/react-storybook/issues/81
   ReactDOM.unmountComponentAtNode(rootEl);
-  render(element, rootEl);
   showMain();
+  render(element, rootEl);
 }

--- a/app/vue/src/client/preview/render.js
+++ b/app/vue/src/client/preview/render.js
@@ -32,11 +32,11 @@ export default function render({
     return;
   }
 
+  showMain();
   renderRoot({
     el: '#root',
     render(h) {
       return h('div', { attrs: { id: 'root' } }, [h(component)]);
     },
   });
-  showMain();
 }


### PR DESCRIPTION
Issue: parent `clientWidth` and `clientHeight` are equal to zero on page load (https://github.com/storybooks/storybook/issues/3516).

## What I did

Changed the order of component rendering and showing main so components are not rendered in `<body>` with `display` set to `none`.
