### PR TITLE
Updates storybook-start.js to use child_process instead of shelljs

### DIFF
--- a/app/react-native/src/bin/storybook-start.js
+++ b/app/react-native/src/bin/storybook-start.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
-/* eslint-disable-next-line no-camelcase */
+/* eslint-disable-next-line camelcase */
 import child_process from 'child_process';
 import path from 'path';
 import program from 'commander';

--- a/app/react-native/src/bin/storybook-start.js
+++ b/app/react-native/src/bin/storybook-start.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
-
+/* eslint-disable-next-line no-camelcase */
+import child_process from 'child_process';
 import path from 'path';
 import program from 'commander';
-import shelljs from 'shelljs';
 import Server from '../server';
 
 program
@@ -95,7 +95,7 @@ if (!program.skipPackager) {
     cliCommand = `haul start --config ${program.haul} --platform ${platform}`;
   }
   // RN packager
-  shelljs.exec(
+  child_process.exec(
     [
       cliCommand,
       `--projectRoots ${projectRoots.join(',')}`,

--- a/app/react-native/src/bin/storybook-start.js
+++ b/app/react-native/src/bin/storybook-start.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
-/* eslint-disable-next-line camelcase */
-import child_process from 'child_process';
+import { exec } from 'child_process';
 import path from 'path';
 import program from 'commander';
 import Server from '../server';
@@ -95,7 +94,7 @@ if (!program.skipPackager) {
     cliCommand = `haul start --config ${program.haul} --platform ${platform}`;
   }
   // RN packager
-  child_process.exec(
+  exec(
     [
       cliCommand,
       `--projectRoots ${projectRoots.join(',')}`,


### PR DESCRIPTION
## Issue
```
ERROR  Error running yarn run storybook -- --config haul.config.js --platform all
Error: Given stream is not a TTY
at makeTTYAdapter (node_modules/react-stream-renderer/src/adapters/TTY/makeTTYAdapter.js:13:11)
at initUI (node_modules/haul/src/server/ui.js:72:9)
at createServer (node_modules/haul/src/server/index.js:54:28)
at Object.start [as action] (node_modules/haul/src/commands/start.js:51:3)
at <anonymous>
at process._tickCallback (internal/process/next_tick.js:188:7)
at Function.Module.runMain (module.js:678:11)
at startup (bootstrap_node.js:187:16)
at bootstrap_node.js:608:3
```
## What I did
Updated react-native's `storybook-start.js` to use `child_process` instead of ShellJS. This is because the later does not support running commands that require interactive input, as you can see [here](https://github.com/shelljs/shelljs/wiki/FAQ#running-interactive-programs-with-exec).

The need to use these type of commands, started when I updated both Haul and Storybook to their last versions. 

## How to test

To test this you should update Haul to v1.0.0-rc.0 and Storybook to v4.0.0-alpha.4. Then you should perform `storybook start -p 7007 --haul haul.config.js --platform all`. Where the config file follows Haul's new configuration style.

Please let me know if I can improve this PR in anyway.