### PR TITLE
Change WithNotes to withNotes in using-addons docs

### DIFF
--- a/docs/src/pages/addons/using-addons/index.md
+++ b/docs/src/pages/addons/using-addons/index.md
@@ -32,7 +32,7 @@ Now when you are writing a story it like this and add some notes:
 ```js
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { WithNotes } from '@storybook/addon-notes';
+import { withNotes } from '@storybook/addon-notes';
 
 import Button from './Button';
 


### PR DESCRIPTION
Issue: an example in the `using-addons` docs throws a `withNotes is not defined` error, because of a capitalization error.

## What I did

Fixed a docs capitalization typo.
