### PR TITLE
Ignore home package.json no license field

### DIFF
--- a/lib/cli/lib/latest_version.js
+++ b/lib/cli/lib/latest_version.js
@@ -1,5 +1,6 @@
 import { spawn } from 'cross-spawn';
 import hasYarn from './has_yarn';
+import whitelistedWarnings from './whitelisted_warnings';
 
 const packageManager = hasYarn() ? 'yarn' : 'npm';
 
@@ -34,7 +35,11 @@ export default function latestVersion(packageName) {
     command.stderr.on('data', data => {
       // yarn error
       const info = JSON.parse(data);
-      reject(new Error(info.data));
+      whitelistedWarnings.forEach(whitelistedWarning => {
+        if (!info.data.includes(whitelistedWarning)) {
+          reject(new Error(info.data));
+        }
+      });
     });
   });
 }

--- a/lib/cli/lib/latest_version.js
+++ b/lib/cli/lib/latest_version.js
@@ -1,6 +1,5 @@
 import { spawn } from 'cross-spawn';
 import hasYarn from './has_yarn';
-import whitelistedWarnings from './whitelisted_warnings';
 
 const packageManager = hasYarn() ? 'yarn' : 'npm';
 
@@ -35,11 +34,9 @@ export default function latestVersion(packageName) {
     command.stderr.on('data', data => {
       // yarn error
       const info = JSON.parse(data);
-      whitelistedWarnings.forEach(whitelistedWarning => {
-        if (!info.data.includes(whitelistedWarning)) {
-          reject(new Error(info.data));
-        }
-      });
+      if (info.type !== 'warning') {
+        reject(new Error(info.data));
+      }
     });
   });
 }

--- a/lib/cli/lib/latest_version.js
+++ b/lib/cli/lib/latest_version.js
@@ -34,7 +34,7 @@ export default function latestVersion(packageName) {
     command.stderr.on('data', data => {
       // yarn error
       const info = JSON.parse(data);
-      if (info.type !== 'warning') {
+      if (info.type === 'error') {
         reject(new Error(info.data));
       }
     });

--- a/lib/cli/lib/whitelisted_warnings.js
+++ b/lib/cli/lib/whitelisted_warnings.js
@@ -1,1 +1,0 @@
-export default ['package.json: No license field'];

--- a/lib/cli/lib/whitelisted_warnings.js
+++ b/lib/cli/lib/whitelisted_warnings.js
@@ -1,0 +1,1 @@
+export default ['package.json: No license field'];


### PR DESCRIPTION
Issue: Fixes #3446 

If the `/home/user` folder contained a `package.json` without a `license` field, the installation of `getstorybook` is cancelled. This warning is thrown regardless of anything in the current folder that you're running `getstorybook` in. 

Reproduction would be to [create a package.json without a license field in your home directory](https://github.com/storybooks/storybook/issues/3446#issuecomment-382553884), initialize a project that would normally work with `getstorybook`, like through `create-react-app`, and then run `getstorybook`.

This is caused by the [checking of the version of the generator dependencies](https://github.com/storybooks/storybook/blob/master/lib/cli/lib/latest_version.js#L8) which resulted in the warning being thrown and thus existing the installation at https://github.com/storybooks/storybook/blob/3539625d7f801a0fee1fb8c58f1ff57016c9513f/lib/cli/lib/latest_version.js#L34
(Thanks to @sunilhari for pointing this out).  
In fact, if you for whatever reason have a `package.json` at your home directory without a `license` field (or anywhere along the path towards the current directory), the warning will be thrown at any `yarn` command. The result of actually running the command, however, is then outputted after the warning:
![image](https://user-images.githubusercontent.com/5955441/39652736-d4804b14-4fee-11e8-9132-9e07ac858c8c.png)

## What I did
Using the knowledge from the screenshot above, I basically added an array of warning texts that will not stop the entire installation process.

This fix is entirely based on `yarn` and I did not check yet how this works with `npm` and if there are any differences. But I wanted to open this PR in order to see whether this solution is desired before spending more time on it.