### PR TITLE
Replace decorate with decorateAction

### DIFF
--- a/addons/actions/README.md
+++ b/addons/actions/README.md
@@ -71,14 +71,14 @@ storiesOf('Button', module)
 
 If you wish to process action data before sending them over to the logger, you can do it with action decorators.
 
-`decorate` takes an array of decorator functions. Each decorator function is passed an array of arguments, and should return a new arguments array to use. `decorate` returns a object with two functions: `action` and `actions`, that act like the above, except they log the modified arguments instead of the original arguments.
+`decorateAction` takes an array of decorator functions. Each decorator function is passed an array of arguments, and should return a new arguments array to use. `decorateAction` returns a object with two functions: `action` and `actions`, that act like the above, except they log the modified arguments instead of the original arguments.
 
 ```js
-import { decorate } from '@storybook/addon-actions';
+import { decorateAction } from '@storybook/addon-actions';
 
 import Button from './button';
 
-const firstArg = decorate([args => args.slice(0, 1)]);
+const firstArg = decorateAction([args => args.slice(0, 1)]);
 
 storiesOf('Button', module).add('default view', () => (
   <Button onClick={firstArg.action('button-click')}>Hello World!</Button>


### PR DESCRIPTION
Issue: `decorate` is undefined

## What I did

Rename `decorate` with `decorateAction`.

## How to test

No tests, only documentation update.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
