### PR TITLE
Clean out the store if `configure` fails

### DIFF
--- a/lib/core/src/client/preview/config_api.js
+++ b/lib/core/src/client/preview/config_api.js
@@ -46,6 +46,10 @@ export default class ConfigApi {
           // If we are accessing the site, but the error is not fixed yet.
           // There we can render the error.
           this._renderError(error);
+
+          // Clear out the store as chances as only some of the stories will have
+          // made it in before the error was thrown
+          this._storyStore.clean();
         }
       }
     };


### PR DESCRIPTION
### Issue: 

if a story file has an error in it at the top level (in the roughest possible way, try adding `throw new Error('foo')` inside a story file somewhere, or a component it imports), the story store ends up in a half-filled state (the `configure()` call has errored out half-way through after half the story files have run).

This isn't necessarily a problem for users (we render an error) but for 3rd party tools that examine the story store (like Chromatic) it's not great.

## What I did

Clear the story store if the configure call throws an exception.

Perhaps we should do more than this and indicate it is broken somehow? I think `getStorybook().length === 0` is enough for me however.

## How to test

I'm not sure how best to test this. It would be good to have a direct test for it. Any ideas?
