### PR TITLE
Ignore any unstructured output from the package managers

### DIFF
--- a/lib/cli/lib/latest_version.js
+++ b/lib/cli/lib/latest_version.js
@@ -32,10 +32,14 @@ export default function latestVersion(packageName) {
     });
 
     command.stderr.on('data', data => {
-      // yarn error
-      const info = JSON.parse(data);
-      if (info.type === 'error') {
-        reject(new Error(info.data));
+      try {
+        // yarn error
+        const info = JSON.parse(data);
+        if (info.type === 'error') {
+          reject(new Error(info.data));
+        }
+      } catch (e) {
+        // package manager unstructured info/warnings output
       }
     });
   });


### PR DESCRIPTION
Issue: Addresses #3529 

## What I did
See https://github.com/storybooks/storybook/issues/3529#issuecomment-387322950 for my understanding of the issue. TLDR: Installation process of storybook gets halted on Windows due to [unstructured warning of npm about a `npm update check failed`](https://github.com/storybooks/storybook/issues/3529#issuecomment-387106175) and [a warning in the implementation of `yarn`](https://github.com/storybooks/storybook/issues/3529#issuecomment-387043390). 

The easiest fix is to just ignore those warnings as they are not the responsibility of Storybook and are not specific to the installation of Storybook, which is what I have done. Another solution would be to print these warnings during the installation (with a special note), potentially under a parameter flag of some kind, to either show or hide it. 
