### PR TITLE
remove nested braces in Story Source block

### DIFF
--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -700,8 +700,8 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                           <span
                                             style={Object {}}
                                           >
+                                            {
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -709,7 +709,6 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               val={[Function]}
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -806,21 +805,18 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                 val={[Function]}
                                                 valueStyles={null}
                                               >
-                                                <span>
-                                                  {
-                                                  <span
-                                                    style={
-                                                      Object {
-                                                        "color": "#170",
-                                                      }
+                                                <span
+                                                  style={
+                                                    Object {
+                                                      "color": "#170",
                                                     }
-                                                  >
-                                                    func()
-                                                  </span>
                                                   }
+                                                >
+                                                  func()
                                                 </span>
                                               </PropVal>
                                             </ThemedComponent>
+                                            }
                                           </span>
                                         </span>
                                       </span>
@@ -841,8 +837,8 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                           <span
                                             style={Object {}}
                                           >
+                                            {
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -855,7 +851,6 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               }
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -957,195 +952,190 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                 }
                                                 valueStyles={null}
                                               >
-                                                <span>
-                                                  {
-                                                  <PreviewObject
-                                                    level={1}
-                                                    maxPropObjectKeys={3}
-                                                    maxPropStringLength={50}
-                                                    maxPropsIntoLine={3}
-                                                    val={
-                                                      Object {
-                                                        "a": "a",
-                                                        "b": "b",
-                                                      }
+                                                <PreviewObject
+                                                  level={1}
+                                                  maxPropObjectKeys={3}
+                                                  maxPropStringLength={50}
+                                                  maxPropsIntoLine={3}
+                                                  val={
+                                                    Object {
+                                                      "a": "a",
+                                                      "b": "b",
                                                     }
-                                                    valueStyles={
+                                                  }
+                                                  valueStyles={
+                                                    Object {
+                                                      "array": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "attr": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "bool": Object {
+                                                        "color": "#a11",
+                                                      },
+                                                      "empty": Object {
+                                                        "color": "#777",
+                                                      },
+                                                      "func": Object {
+                                                        "color": "#170",
+                                                      },
+                                                      "number": Object {
+                                                        "color": "#a11",
+                                                      },
+                                                      "object": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "string": Object {
+                                                        "color": "#22a",
+                                                        "wordBreak": "break-word",
+                                                      },
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    style={
                                                       Object {
-                                                        "array": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "attr": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "bool": Object {
-                                                          "color": "#a11",
-                                                        },
-                                                        "empty": Object {
-                                                          "color": "#777",
-                                                        },
-                                                        "func": Object {
-                                                          "color": "#170",
-                                                        },
-                                                        "number": Object {
-                                                          "color": "#a11",
-                                                        },
-                                                        "object": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "string": Object {
-                                                          "color": "#22a",
-                                                          "wordBreak": "break-word",
-                                                        },
+                                                        "color": "#666",
                                                       }
                                                     }
                                                   >
+                                                    {
                                                     <span
-                                                      style={
+                                                      key="k0/.0"
+                                                    >
+                                                      <span
+                                                        style={
+                                                          Object {
+                                                            "color": "#666",
+                                                          }
+                                                        }
+                                                      >
+                                                        a
+                                                      </span>
+                                                    </span>
+                                                    : 
+                                                    <PropVal
+                                                      key="v0/.0"
+                                                      level={2}
+                                                      maxPropArrayLength={3}
+                                                      maxPropObjectKeys={3}
+                                                      maxPropStringLength={50}
+                                                      maxPropsIntoLine={3}
+                                                      theme={Object {}}
+                                                      val="a"
+                                                      valueStyles={
                                                         Object {
-                                                          "color": "#666",
+                                                          "array": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "attr": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "bool": Object {
+                                                            "color": "#a11",
+                                                          },
+                                                          "empty": Object {
+                                                            "color": "#777",
+                                                          },
+                                                          "func": Object {
+                                                            "color": "#170",
+                                                          },
+                                                          "number": Object {
+                                                            "color": "#a11",
+                                                          },
+                                                          "object": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "string": Object {
+                                                            "color": "#22a",
+                                                            "wordBreak": "break-word",
+                                                          },
                                                         }
                                                       }
                                                     >
-                                                      {
                                                       <span
-                                                        key="k0/.0"
-                                                      >
-                                                        <span
-                                                          style={
-                                                            Object {
-                                                              "color": "#666",
-                                                            }
-                                                          }
-                                                        >
-                                                          a
-                                                        </span>
-                                                      </span>
-                                                      : 
-                                                      <PropVal
-                                                        braceWrapped={false}
-                                                        key="v0/.0"
-                                                        level={2}
-                                                        maxPropArrayLength={3}
-                                                        maxPropObjectKeys={3}
-                                                        maxPropStringLength={50}
-                                                        maxPropsIntoLine={3}
-                                                        theme={Object {}}
-                                                        val="a"
-                                                        valueStyles={
+                                                        style={
                                                           Object {
-                                                            "array": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "attr": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "bool": Object {
-                                                              "color": "#a11",
-                                                            },
-                                                            "empty": Object {
-                                                              "color": "#777",
-                                                            },
-                                                            "func": Object {
-                                                              "color": "#170",
-                                                            },
-                                                            "number": Object {
-                                                              "color": "#a11",
-                                                            },
-                                                            "object": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "string": Object {
-                                                              "color": "#22a",
-                                                              "wordBreak": "break-word",
-                                                            },
+                                                            "color": "#22a",
+                                                            "wordBreak": "break-word",
                                                           }
                                                         }
                                                       >
-                                                        <span
-                                                          style={
-                                                            Object {
-                                                              "color": "#22a",
-                                                              "wordBreak": "break-word",
-                                                            }
-                                                          }
-                                                        >
-                                                          a
-                                                        </span>
-                                                      </PropVal>
-                                                      ,
-                                                      <span
-                                                        key="k1/.0"
-                                                      >
-                                                        <span
-                                                          style={
-                                                            Object {
-                                                              "color": "#666",
-                                                            }
-                                                          }
-                                                        >
-                                                          b
-                                                        </span>
+                                                        "a"
                                                       </span>
-                                                      : 
-                                                      <PropVal
-                                                        braceWrapped={false}
-                                                        key="v1/.0"
-                                                        level={2}
-                                                        maxPropArrayLength={3}
-                                                        maxPropObjectKeys={3}
-                                                        maxPropStringLength={50}
-                                                        maxPropsIntoLine={3}
-                                                        theme={Object {}}
-                                                        val="b"
-                                                        valueStyles={
+                                                    </PropVal>
+                                                    ,
+                                                    <span
+                                                      key="k1/.0"
+                                                    >
+                                                      <span
+                                                        style={
                                                           Object {
-                                                            "array": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "attr": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "bool": Object {
-                                                              "color": "#a11",
-                                                            },
-                                                            "empty": Object {
-                                                              "color": "#777",
-                                                            },
-                                                            "func": Object {
-                                                              "color": "#170",
-                                                            },
-                                                            "number": Object {
-                                                              "color": "#a11",
-                                                            },
-                                                            "object": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "string": Object {
-                                                              "color": "#22a",
-                                                              "wordBreak": "break-word",
-                                                            },
+                                                            "color": "#666",
                                                           }
                                                         }
                                                       >
-                                                        <span
-                                                          style={
-                                                            Object {
-                                                              "color": "#22a",
-                                                              "wordBreak": "break-word",
-                                                            }
-                                                          }
-                                                        >
-                                                          b
-                                                        </span>
-                                                      </PropVal>
-                                                      }
+                                                        b
+                                                      </span>
                                                     </span>
-                                                  </PreviewObject>
-                                                  }
-                                                </span>
+                                                    : 
+                                                    <PropVal
+                                                      key="v1/.0"
+                                                      level={2}
+                                                      maxPropArrayLength={3}
+                                                      maxPropObjectKeys={3}
+                                                      maxPropStringLength={50}
+                                                      maxPropsIntoLine={3}
+                                                      theme={Object {}}
+                                                      val="b"
+                                                      valueStyles={
+                                                        Object {
+                                                          "array": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "attr": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "bool": Object {
+                                                            "color": "#a11",
+                                                          },
+                                                          "empty": Object {
+                                                            "color": "#777",
+                                                          },
+                                                          "func": Object {
+                                                            "color": "#170",
+                                                          },
+                                                          "number": Object {
+                                                            "color": "#a11",
+                                                          },
+                                                          "object": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "string": Object {
+                                                            "color": "#22a",
+                                                            "wordBreak": "break-word",
+                                                          },
+                                                        }
+                                                      }
+                                                    >
+                                                      <span
+                                                        style={
+                                                          Object {
+                                                            "color": "#22a",
+                                                            "wordBreak": "break-word",
+                                                          }
+                                                        }
+                                                      >
+                                                        "b"
+                                                      </span>
+                                                    </PropVal>
+                                                    }
+                                                  </span>
+                                                </PreviewObject>
                                               </PropVal>
                                             </ThemedComponent>
+                                            }
                                           </span>
                                         </span>
                                       </span>
@@ -1166,8 +1156,8 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                           <span
                                             style={Object {}}
                                           >
+                                            {
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -1181,7 +1171,6 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               }
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -1284,226 +1273,220 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                 }
                                                 valueStyles={null}
                                               >
-                                                <span>
-                                                  {
-                                                  <PreviewArray
-                                                    level={1}
-                                                    maxPropArrayLength={3}
-                                                    maxPropStringLength={50}
-                                                    maxPropsIntoLine={3}
-                                                    val={
-                                                      Array [
-                                                        1,
-                                                        2,
-                                                        3,
-                                                      ]
+                                                <PreviewArray
+                                                  level={1}
+                                                  maxPropArrayLength={3}
+                                                  maxPropStringLength={50}
+                                                  maxPropsIntoLine={3}
+                                                  val={
+                                                    Array [
+                                                      1,
+                                                      2,
+                                                      3,
+                                                    ]
+                                                  }
+                                                  valueStyles={
+                                                    Object {
+                                                      "array": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "attr": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "bool": Object {
+                                                        "color": "#a11",
+                                                      },
+                                                      "empty": Object {
+                                                        "color": "#777",
+                                                      },
+                                                      "func": Object {
+                                                        "color": "#170",
+                                                      },
+                                                      "number": Object {
+                                                        "color": "#a11",
+                                                      },
+                                                      "object": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "string": Object {
+                                                        "color": "#22a",
+                                                        "wordBreak": "break-word",
+                                                      },
                                                     }
-                                                    valueStyles={
+                                                  }
+                                                >
+                                                  <span
+                                                    style={
                                                       Object {
-                                                        "array": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "attr": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "bool": Object {
-                                                          "color": "#a11",
-                                                        },
-                                                        "empty": Object {
-                                                          "color": "#777",
-                                                        },
-                                                        "func": Object {
-                                                          "color": "#170",
-                                                        },
-                                                        "number": Object {
-                                                          "color": "#a11",
-                                                        },
-                                                        "object": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "string": Object {
-                                                          "color": "#22a",
-                                                          "wordBreak": "break-word",
-                                                        },
+                                                        "color": "#666",
                                                       }
                                                     }
                                                   >
+                                                    [
                                                     <span
-                                                      style={
-                                                        Object {
-                                                          "color": "#666",
-                                                        }
-                                                      }
+                                                      key="n0/.0"
                                                     >
-                                                      [
-                                                      <span
-                                                        key="n0/.0"
+                                                      <PropVal
+                                                        level={2}
+                                                        maxPropArrayLength={3}
+                                                        maxPropObjectKeys={3}
+                                                        maxPropStringLength={50}
+                                                        maxPropsIntoLine={3}
+                                                        theme={Object {}}
+                                                        val={1}
+                                                        valueStyles={
+                                                          Object {
+                                                            "array": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "attr": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "bool": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "empty": Object {
+                                                              "color": "#777",
+                                                            },
+                                                            "func": Object {
+                                                              "color": "#170",
+                                                            },
+                                                            "number": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "object": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "string": Object {
+                                                              "color": "#22a",
+                                                              "wordBreak": "break-word",
+                                                            },
+                                                          }
+                                                        }
                                                       >
-                                                        <PropVal
-                                                          braceWrapped={false}
-                                                          level={2}
-                                                          maxPropArrayLength={3}
-                                                          maxPropObjectKeys={3}
-                                                          maxPropStringLength={50}
-                                                          maxPropsIntoLine={3}
-                                                          theme={Object {}}
-                                                          val={1}
-                                                          valueStyles={
+                                                        <span
+                                                          style={
                                                             Object {
-                                                              "array": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "attr": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "bool": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "empty": Object {
-                                                                "color": "#777",
-                                                              },
-                                                              "func": Object {
-                                                                "color": "#170",
-                                                              },
-                                                              "number": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "object": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "string": Object {
-                                                                "color": "#22a",
-                                                                "wordBreak": "break-word",
-                                                              },
+                                                              "color": "#a11",
                                                             }
                                                           }
                                                         >
-                                                          <span
-                                                            style={
-                                                              Object {
-                                                                "color": "#a11",
-                                                              }
-                                                            }
-                                                          >
-                                                            1
-                                                          </span>
-                                                        </PropVal>
-                                                      </span>
-                                                      ,
-                                                      <span
-                                                        key="n1/.0"
-                                                      >
-                                                        <PropVal
-                                                          braceWrapped={false}
-                                                          level={2}
-                                                          maxPropArrayLength={3}
-                                                          maxPropObjectKeys={3}
-                                                          maxPropStringLength={50}
-                                                          maxPropsIntoLine={3}
-                                                          theme={Object {}}
-                                                          val={2}
-                                                          valueStyles={
-                                                            Object {
-                                                              "array": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "attr": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "bool": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "empty": Object {
-                                                                "color": "#777",
-                                                              },
-                                                              "func": Object {
-                                                                "color": "#170",
-                                                              },
-                                                              "number": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "object": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "string": Object {
-                                                                "color": "#22a",
-                                                                "wordBreak": "break-word",
-                                                              },
-                                                            }
-                                                          }
-                                                        >
-                                                          <span
-                                                            style={
-                                                              Object {
-                                                                "color": "#a11",
-                                                              }
-                                                            }
-                                                          >
-                                                            2
-                                                          </span>
-                                                        </PropVal>
-                                                      </span>
-                                                      ,
-                                                      <span
-                                                        key="n2/.0"
-                                                      >
-                                                        <PropVal
-                                                          braceWrapped={false}
-                                                          level={2}
-                                                          maxPropArrayLength={3}
-                                                          maxPropObjectKeys={3}
-                                                          maxPropStringLength={50}
-                                                          maxPropsIntoLine={3}
-                                                          theme={Object {}}
-                                                          val={3}
-                                                          valueStyles={
-                                                            Object {
-                                                              "array": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "attr": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "bool": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "empty": Object {
-                                                                "color": "#777",
-                                                              },
-                                                              "func": Object {
-                                                                "color": "#170",
-                                                              },
-                                                              "number": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "object": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "string": Object {
-                                                                "color": "#22a",
-                                                                "wordBreak": "break-word",
-                                                              },
-                                                            }
-                                                          }
-                                                        >
-                                                          <span
-                                                            style={
-                                                              Object {
-                                                                "color": "#a11",
-                                                              }
-                                                            }
-                                                          >
-                                                            3
-                                                          </span>
-                                                        </PropVal>
-                                                      </span>
-                                                      ]
+                                                          1
+                                                        </span>
+                                                      </PropVal>
                                                     </span>
-                                                  </PreviewArray>
-                                                  }
-                                                </span>
+                                                    ,
+                                                    <span
+                                                      key="n1/.0"
+                                                    >
+                                                      <PropVal
+                                                        level={2}
+                                                        maxPropArrayLength={3}
+                                                        maxPropObjectKeys={3}
+                                                        maxPropStringLength={50}
+                                                        maxPropsIntoLine={3}
+                                                        theme={Object {}}
+                                                        val={2}
+                                                        valueStyles={
+                                                          Object {
+                                                            "array": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "attr": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "bool": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "empty": Object {
+                                                              "color": "#777",
+                                                            },
+                                                            "func": Object {
+                                                              "color": "#170",
+                                                            },
+                                                            "number": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "object": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "string": Object {
+                                                              "color": "#22a",
+                                                              "wordBreak": "break-word",
+                                                            },
+                                                          }
+                                                        }
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "color": "#a11",
+                                                            }
+                                                          }
+                                                        >
+                                                          2
+                                                        </span>
+                                                      </PropVal>
+                                                    </span>
+                                                    ,
+                                                    <span
+                                                      key="n2/.0"
+                                                    >
+                                                      <PropVal
+                                                        level={2}
+                                                        maxPropArrayLength={3}
+                                                        maxPropObjectKeys={3}
+                                                        maxPropStringLength={50}
+                                                        maxPropsIntoLine={3}
+                                                        theme={Object {}}
+                                                        val={3}
+                                                        valueStyles={
+                                                          Object {
+                                                            "array": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "attr": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "bool": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "empty": Object {
+                                                              "color": "#777",
+                                                            },
+                                                            "func": Object {
+                                                              "color": "#170",
+                                                            },
+                                                            "number": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "object": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "string": Object {
+                                                              "color": "#22a",
+                                                              "wordBreak": "break-word",
+                                                            },
+                                                          }
+                                                        }
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "color": "#a11",
+                                                            }
+                                                          }
+                                                        >
+                                                          3
+                                                        </span>
+                                                      </PropVal>
+                                                    </span>
+                                                    ]
+                                                  </span>
+                                                </PreviewArray>
                                               </PropVal>
                                             </ThemedComponent>
+                                            }
                                           </span>
                                         </span>
                                       </span>
@@ -1524,8 +1507,8 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                           <span
                                             style={Object {}}
                                           >
+                                            {
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -1533,7 +1516,6 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               val={7}
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -1630,21 +1612,18 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                 val={7}
                                                 valueStyles={null}
                                               >
-                                                <span>
-                                                  {
-                                                  <span
-                                                    style={
-                                                      Object {
-                                                        "color": "#a11",
-                                                      }
+                                                <span
+                                                  style={
+                                                    Object {
+                                                      "color": "#a11",
                                                     }
-                                                  >
-                                                    7
-                                                  </span>
                                                   }
+                                                >
+                                                  7
                                                 </span>
                                               </PropVal>
                                             </ThemedComponent>
+                                            }
                                           </span>
                                         </span>
                                       </span>
@@ -1667,7 +1646,6 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                           >
                                             "
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -1675,7 +1653,6 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               val="seven"
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -2822,8 +2799,8 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                           <span
                                             style={Object {}}
                                           >
+                                            {
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -2831,7 +2808,6 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               val={[Function]}
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -2928,21 +2904,18 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                 val={[Function]}
                                                 valueStyles={null}
                                               >
-                                                <span>
-                                                  {
-                                                  <span
-                                                    style={
-                                                      Object {
-                                                        "color": "#170",
-                                                      }
+                                                <span
+                                                  style={
+                                                    Object {
+                                                      "color": "#170",
                                                     }
-                                                  >
-                                                    func()
-                                                  </span>
                                                   }
+                                                >
+                                                  func()
                                                 </span>
                                               </PropVal>
                                             </ThemedComponent>
+                                            }
                                           </span>
                                         </span>
                                       </span>
@@ -2963,8 +2936,8 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                           <span
                                             style={Object {}}
                                           >
+                                            {
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -2977,7 +2950,6 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               }
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -3079,195 +3051,190 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                 }
                                                 valueStyles={null}
                                               >
-                                                <span>
-                                                  {
-                                                  <PreviewObject
-                                                    level={1}
-                                                    maxPropObjectKeys={3}
-                                                    maxPropStringLength={50}
-                                                    maxPropsIntoLine={3}
-                                                    val={
-                                                      Object {
-                                                        "a": "a",
-                                                        "b": "b",
-                                                      }
+                                                <PreviewObject
+                                                  level={1}
+                                                  maxPropObjectKeys={3}
+                                                  maxPropStringLength={50}
+                                                  maxPropsIntoLine={3}
+                                                  val={
+                                                    Object {
+                                                      "a": "a",
+                                                      "b": "b",
                                                     }
-                                                    valueStyles={
+                                                  }
+                                                  valueStyles={
+                                                    Object {
+                                                      "array": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "attr": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "bool": Object {
+                                                        "color": "#a11",
+                                                      },
+                                                      "empty": Object {
+                                                        "color": "#777",
+                                                      },
+                                                      "func": Object {
+                                                        "color": "#170",
+                                                      },
+                                                      "number": Object {
+                                                        "color": "#a11",
+                                                      },
+                                                      "object": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "string": Object {
+                                                        "color": "#22a",
+                                                        "wordBreak": "break-word",
+                                                      },
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    style={
                                                       Object {
-                                                        "array": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "attr": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "bool": Object {
-                                                          "color": "#a11",
-                                                        },
-                                                        "empty": Object {
-                                                          "color": "#777",
-                                                        },
-                                                        "func": Object {
-                                                          "color": "#170",
-                                                        },
-                                                        "number": Object {
-                                                          "color": "#a11",
-                                                        },
-                                                        "object": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "string": Object {
-                                                          "color": "#22a",
-                                                          "wordBreak": "break-word",
-                                                        },
+                                                        "color": "#666",
                                                       }
                                                     }
                                                   >
+                                                    {
                                                     <span
-                                                      style={
+                                                      key="k0/.0"
+                                                    >
+                                                      <span
+                                                        style={
+                                                          Object {
+                                                            "color": "#666",
+                                                          }
+                                                        }
+                                                      >
+                                                        a
+                                                      </span>
+                                                    </span>
+                                                    : 
+                                                    <PropVal
+                                                      key="v0/.0"
+                                                      level={2}
+                                                      maxPropArrayLength={3}
+                                                      maxPropObjectKeys={3}
+                                                      maxPropStringLength={50}
+                                                      maxPropsIntoLine={3}
+                                                      theme={Object {}}
+                                                      val="a"
+                                                      valueStyles={
                                                         Object {
-                                                          "color": "#666",
+                                                          "array": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "attr": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "bool": Object {
+                                                            "color": "#a11",
+                                                          },
+                                                          "empty": Object {
+                                                            "color": "#777",
+                                                          },
+                                                          "func": Object {
+                                                            "color": "#170",
+                                                          },
+                                                          "number": Object {
+                                                            "color": "#a11",
+                                                          },
+                                                          "object": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "string": Object {
+                                                            "color": "#22a",
+                                                            "wordBreak": "break-word",
+                                                          },
                                                         }
                                                       }
                                                     >
-                                                      {
                                                       <span
-                                                        key="k0/.0"
-                                                      >
-                                                        <span
-                                                          style={
-                                                            Object {
-                                                              "color": "#666",
-                                                            }
-                                                          }
-                                                        >
-                                                          a
-                                                        </span>
-                                                      </span>
-                                                      : 
-                                                      <PropVal
-                                                        braceWrapped={false}
-                                                        key="v0/.0"
-                                                        level={2}
-                                                        maxPropArrayLength={3}
-                                                        maxPropObjectKeys={3}
-                                                        maxPropStringLength={50}
-                                                        maxPropsIntoLine={3}
-                                                        theme={Object {}}
-                                                        val="a"
-                                                        valueStyles={
+                                                        style={
                                                           Object {
-                                                            "array": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "attr": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "bool": Object {
-                                                              "color": "#a11",
-                                                            },
-                                                            "empty": Object {
-                                                              "color": "#777",
-                                                            },
-                                                            "func": Object {
-                                                              "color": "#170",
-                                                            },
-                                                            "number": Object {
-                                                              "color": "#a11",
-                                                            },
-                                                            "object": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "string": Object {
-                                                              "color": "#22a",
-                                                              "wordBreak": "break-word",
-                                                            },
+                                                            "color": "#22a",
+                                                            "wordBreak": "break-word",
                                                           }
                                                         }
                                                       >
-                                                        <span
-                                                          style={
-                                                            Object {
-                                                              "color": "#22a",
-                                                              "wordBreak": "break-word",
-                                                            }
-                                                          }
-                                                        >
-                                                          a
-                                                        </span>
-                                                      </PropVal>
-                                                      ,
-                                                      <span
-                                                        key="k1/.0"
-                                                      >
-                                                        <span
-                                                          style={
-                                                            Object {
-                                                              "color": "#666",
-                                                            }
-                                                          }
-                                                        >
-                                                          b
-                                                        </span>
+                                                        "a"
                                                       </span>
-                                                      : 
-                                                      <PropVal
-                                                        braceWrapped={false}
-                                                        key="v1/.0"
-                                                        level={2}
-                                                        maxPropArrayLength={3}
-                                                        maxPropObjectKeys={3}
-                                                        maxPropStringLength={50}
-                                                        maxPropsIntoLine={3}
-                                                        theme={Object {}}
-                                                        val="b"
-                                                        valueStyles={
+                                                    </PropVal>
+                                                    ,
+                                                    <span
+                                                      key="k1/.0"
+                                                    >
+                                                      <span
+                                                        style={
                                                           Object {
-                                                            "array": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "attr": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "bool": Object {
-                                                              "color": "#a11",
-                                                            },
-                                                            "empty": Object {
-                                                              "color": "#777",
-                                                            },
-                                                            "func": Object {
-                                                              "color": "#170",
-                                                            },
-                                                            "number": Object {
-                                                              "color": "#a11",
-                                                            },
-                                                            "object": Object {
-                                                              "color": "#666",
-                                                            },
-                                                            "string": Object {
-                                                              "color": "#22a",
-                                                              "wordBreak": "break-word",
-                                                            },
+                                                            "color": "#666",
                                                           }
                                                         }
                                                       >
-                                                        <span
-                                                          style={
-                                                            Object {
-                                                              "color": "#22a",
-                                                              "wordBreak": "break-word",
-                                                            }
-                                                          }
-                                                        >
-                                                          b
-                                                        </span>
-                                                      </PropVal>
-                                                      }
+                                                        b
+                                                      </span>
                                                     </span>
-                                                  </PreviewObject>
-                                                  }
-                                                </span>
+                                                    : 
+                                                    <PropVal
+                                                      key="v1/.0"
+                                                      level={2}
+                                                      maxPropArrayLength={3}
+                                                      maxPropObjectKeys={3}
+                                                      maxPropStringLength={50}
+                                                      maxPropsIntoLine={3}
+                                                      theme={Object {}}
+                                                      val="b"
+                                                      valueStyles={
+                                                        Object {
+                                                          "array": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "attr": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "bool": Object {
+                                                            "color": "#a11",
+                                                          },
+                                                          "empty": Object {
+                                                            "color": "#777",
+                                                          },
+                                                          "func": Object {
+                                                            "color": "#170",
+                                                          },
+                                                          "number": Object {
+                                                            "color": "#a11",
+                                                          },
+                                                          "object": Object {
+                                                            "color": "#666",
+                                                          },
+                                                          "string": Object {
+                                                            "color": "#22a",
+                                                            "wordBreak": "break-word",
+                                                          },
+                                                        }
+                                                      }
+                                                    >
+                                                      <span
+                                                        style={
+                                                          Object {
+                                                            "color": "#22a",
+                                                            "wordBreak": "break-word",
+                                                          }
+                                                        }
+                                                      >
+                                                        "b"
+                                                      </span>
+                                                    </PropVal>
+                                                    }
+                                                  </span>
+                                                </PreviewObject>
                                               </PropVal>
                                             </ThemedComponent>
+                                            }
                                           </span>
                                         </span>
                                       </span>
@@ -3288,8 +3255,8 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                           <span
                                             style={Object {}}
                                           >
+                                            {
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -3303,7 +3270,6 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               }
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -3406,226 +3372,220 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                 }
                                                 valueStyles={null}
                                               >
-                                                <span>
-                                                  {
-                                                  <PreviewArray
-                                                    level={1}
-                                                    maxPropArrayLength={3}
-                                                    maxPropStringLength={50}
-                                                    maxPropsIntoLine={3}
-                                                    val={
-                                                      Array [
-                                                        1,
-                                                        2,
-                                                        3,
-                                                      ]
+                                                <PreviewArray
+                                                  level={1}
+                                                  maxPropArrayLength={3}
+                                                  maxPropStringLength={50}
+                                                  maxPropsIntoLine={3}
+                                                  val={
+                                                    Array [
+                                                      1,
+                                                      2,
+                                                      3,
+                                                    ]
+                                                  }
+                                                  valueStyles={
+                                                    Object {
+                                                      "array": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "attr": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "bool": Object {
+                                                        "color": "#a11",
+                                                      },
+                                                      "empty": Object {
+                                                        "color": "#777",
+                                                      },
+                                                      "func": Object {
+                                                        "color": "#170",
+                                                      },
+                                                      "number": Object {
+                                                        "color": "#a11",
+                                                      },
+                                                      "object": Object {
+                                                        "color": "#666",
+                                                      },
+                                                      "string": Object {
+                                                        "color": "#22a",
+                                                        "wordBreak": "break-word",
+                                                      },
                                                     }
-                                                    valueStyles={
+                                                  }
+                                                >
+                                                  <span
+                                                    style={
                                                       Object {
-                                                        "array": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "attr": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "bool": Object {
-                                                          "color": "#a11",
-                                                        },
-                                                        "empty": Object {
-                                                          "color": "#777",
-                                                        },
-                                                        "func": Object {
-                                                          "color": "#170",
-                                                        },
-                                                        "number": Object {
-                                                          "color": "#a11",
-                                                        },
-                                                        "object": Object {
-                                                          "color": "#666",
-                                                        },
-                                                        "string": Object {
-                                                          "color": "#22a",
-                                                          "wordBreak": "break-word",
-                                                        },
+                                                        "color": "#666",
                                                       }
                                                     }
                                                   >
+                                                    [
                                                     <span
-                                                      style={
-                                                        Object {
-                                                          "color": "#666",
-                                                        }
-                                                      }
+                                                      key="n0/.0"
                                                     >
-                                                      [
-                                                      <span
-                                                        key="n0/.0"
+                                                      <PropVal
+                                                        level={2}
+                                                        maxPropArrayLength={3}
+                                                        maxPropObjectKeys={3}
+                                                        maxPropStringLength={50}
+                                                        maxPropsIntoLine={3}
+                                                        theme={Object {}}
+                                                        val={1}
+                                                        valueStyles={
+                                                          Object {
+                                                            "array": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "attr": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "bool": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "empty": Object {
+                                                              "color": "#777",
+                                                            },
+                                                            "func": Object {
+                                                              "color": "#170",
+                                                            },
+                                                            "number": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "object": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "string": Object {
+                                                              "color": "#22a",
+                                                              "wordBreak": "break-word",
+                                                            },
+                                                          }
+                                                        }
                                                       >
-                                                        <PropVal
-                                                          braceWrapped={false}
-                                                          level={2}
-                                                          maxPropArrayLength={3}
-                                                          maxPropObjectKeys={3}
-                                                          maxPropStringLength={50}
-                                                          maxPropsIntoLine={3}
-                                                          theme={Object {}}
-                                                          val={1}
-                                                          valueStyles={
+                                                        <span
+                                                          style={
                                                             Object {
-                                                              "array": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "attr": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "bool": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "empty": Object {
-                                                                "color": "#777",
-                                                              },
-                                                              "func": Object {
-                                                                "color": "#170",
-                                                              },
-                                                              "number": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "object": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "string": Object {
-                                                                "color": "#22a",
-                                                                "wordBreak": "break-word",
-                                                              },
+                                                              "color": "#a11",
                                                             }
                                                           }
                                                         >
-                                                          <span
-                                                            style={
-                                                              Object {
-                                                                "color": "#a11",
-                                                              }
-                                                            }
-                                                          >
-                                                            1
-                                                          </span>
-                                                        </PropVal>
-                                                      </span>
-                                                      ,
-                                                      <span
-                                                        key="n1/.0"
-                                                      >
-                                                        <PropVal
-                                                          braceWrapped={false}
-                                                          level={2}
-                                                          maxPropArrayLength={3}
-                                                          maxPropObjectKeys={3}
-                                                          maxPropStringLength={50}
-                                                          maxPropsIntoLine={3}
-                                                          theme={Object {}}
-                                                          val={2}
-                                                          valueStyles={
-                                                            Object {
-                                                              "array": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "attr": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "bool": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "empty": Object {
-                                                                "color": "#777",
-                                                              },
-                                                              "func": Object {
-                                                                "color": "#170",
-                                                              },
-                                                              "number": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "object": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "string": Object {
-                                                                "color": "#22a",
-                                                                "wordBreak": "break-word",
-                                                              },
-                                                            }
-                                                          }
-                                                        >
-                                                          <span
-                                                            style={
-                                                              Object {
-                                                                "color": "#a11",
-                                                              }
-                                                            }
-                                                          >
-                                                            2
-                                                          </span>
-                                                        </PropVal>
-                                                      </span>
-                                                      ,
-                                                      <span
-                                                        key="n2/.0"
-                                                      >
-                                                        <PropVal
-                                                          braceWrapped={false}
-                                                          level={2}
-                                                          maxPropArrayLength={3}
-                                                          maxPropObjectKeys={3}
-                                                          maxPropStringLength={50}
-                                                          maxPropsIntoLine={3}
-                                                          theme={Object {}}
-                                                          val={3}
-                                                          valueStyles={
-                                                            Object {
-                                                              "array": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "attr": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "bool": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "empty": Object {
-                                                                "color": "#777",
-                                                              },
-                                                              "func": Object {
-                                                                "color": "#170",
-                                                              },
-                                                              "number": Object {
-                                                                "color": "#a11",
-                                                              },
-                                                              "object": Object {
-                                                                "color": "#666",
-                                                              },
-                                                              "string": Object {
-                                                                "color": "#22a",
-                                                                "wordBreak": "break-word",
-                                                              },
-                                                            }
-                                                          }
-                                                        >
-                                                          <span
-                                                            style={
-                                                              Object {
-                                                                "color": "#a11",
-                                                              }
-                                                            }
-                                                          >
-                                                            3
-                                                          </span>
-                                                        </PropVal>
-                                                      </span>
-                                                      ]
+                                                          1
+                                                        </span>
+                                                      </PropVal>
                                                     </span>
-                                                  </PreviewArray>
-                                                  }
-                                                </span>
+                                                    ,
+                                                    <span
+                                                      key="n1/.0"
+                                                    >
+                                                      <PropVal
+                                                        level={2}
+                                                        maxPropArrayLength={3}
+                                                        maxPropObjectKeys={3}
+                                                        maxPropStringLength={50}
+                                                        maxPropsIntoLine={3}
+                                                        theme={Object {}}
+                                                        val={2}
+                                                        valueStyles={
+                                                          Object {
+                                                            "array": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "attr": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "bool": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "empty": Object {
+                                                              "color": "#777",
+                                                            },
+                                                            "func": Object {
+                                                              "color": "#170",
+                                                            },
+                                                            "number": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "object": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "string": Object {
+                                                              "color": "#22a",
+                                                              "wordBreak": "break-word",
+                                                            },
+                                                          }
+                                                        }
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "color": "#a11",
+                                                            }
+                                                          }
+                                                        >
+                                                          2
+                                                        </span>
+                                                      </PropVal>
+                                                    </span>
+                                                    ,
+                                                    <span
+                                                      key="n2/.0"
+                                                    >
+                                                      <PropVal
+                                                        level={2}
+                                                        maxPropArrayLength={3}
+                                                        maxPropObjectKeys={3}
+                                                        maxPropStringLength={50}
+                                                        maxPropsIntoLine={3}
+                                                        theme={Object {}}
+                                                        val={3}
+                                                        valueStyles={
+                                                          Object {
+                                                            "array": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "attr": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "bool": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "empty": Object {
+                                                              "color": "#777",
+                                                            },
+                                                            "func": Object {
+                                                              "color": "#170",
+                                                            },
+                                                            "number": Object {
+                                                              "color": "#a11",
+                                                            },
+                                                            "object": Object {
+                                                              "color": "#666",
+                                                            },
+                                                            "string": Object {
+                                                              "color": "#22a",
+                                                              "wordBreak": "break-word",
+                                                            },
+                                                          }
+                                                        }
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "color": "#a11",
+                                                            }
+                                                          }
+                                                        >
+                                                          3
+                                                        </span>
+                                                      </PropVal>
+                                                    </span>
+                                                    ]
+                                                  </span>
+                                                </PreviewArray>
                                               </PropVal>
                                             </ThemedComponent>
+                                            }
                                           </span>
                                         </span>
                                       </span>
@@ -3646,8 +3606,8 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                           <span
                                             style={Object {}}
                                           >
+                                            {
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -3655,7 +3615,6 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               val={7}
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -3752,21 +3711,18 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                 val={7}
                                                 valueStyles={null}
                                               >
-                                                <span>
-                                                  {
-                                                  <span
-                                                    style={
-                                                      Object {
-                                                        "color": "#a11",
-                                                      }
+                                                <span
+                                                  style={
+                                                    Object {
+                                                      "color": "#a11",
                                                     }
-                                                  >
-                                                    7
-                                                  </span>
                                                   }
+                                                >
+                                                  7
                                                 </span>
                                               </PropVal>
                                             </ThemedComponent>
+                                            }
                                           </span>
                                         </span>
                                       </span>
@@ -3789,7 +3745,6 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                           >
                                             "
                                             <ThemedComponent
-                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -3797,7 +3752,6 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               val="seven"
                                             >
                                               <PropVal
-                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}

--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -701,6 +701,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                             style={Object {}}
                                           >
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -708,6 +709,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               val={[Function]}
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -840,6 +842,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                             style={Object {}}
                                           >
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -852,6 +855,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               }
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -1019,6 +1023,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                       </span>
                                                       : 
                                                       <PropVal
+                                                        braceWrapped={false}
                                                         key="v0/.0"
                                                         level={2}
                                                         maxPropArrayLength={3}
@@ -1084,6 +1089,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                       </span>
                                                       : 
                                                       <PropVal
+                                                        braceWrapped={false}
                                                         key="v1/.0"
                                                         level={2}
                                                         maxPropArrayLength={3}
@@ -1161,6 +1167,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                             style={Object {}}
                                           >
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -1174,6 +1181,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               }
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -1332,6 +1340,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                         key="n0/.0"
                                                       >
                                                         <PropVal
+                                                          braceWrapped={false}
                                                           level={2}
                                                           maxPropArrayLength={3}
                                                           maxPropObjectKeys={3}
@@ -1369,18 +1378,14 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                             }
                                                           }
                                                         >
-                                                          <span>
-                                                            {
-                                                            <span
-                                                              style={
-                                                                Object {
-                                                                  "color": "#a11",
-                                                                }
+                                                          <span
+                                                            style={
+                                                              Object {
+                                                                "color": "#a11",
                                                               }
-                                                            >
-                                                              1
-                                                            </span>
                                                             }
+                                                          >
+                                                            1
                                                           </span>
                                                         </PropVal>
                                                       </span>
@@ -1389,6 +1394,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                         key="n1/.0"
                                                       >
                                                         <PropVal
+                                                          braceWrapped={false}
                                                           level={2}
                                                           maxPropArrayLength={3}
                                                           maxPropObjectKeys={3}
@@ -1426,18 +1432,14 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                             }
                                                           }
                                                         >
-                                                          <span>
-                                                            {
-                                                            <span
-                                                              style={
-                                                                Object {
-                                                                  "color": "#a11",
-                                                                }
+                                                          <span
+                                                            style={
+                                                              Object {
+                                                                "color": "#a11",
                                                               }
-                                                            >
-                                                              2
-                                                            </span>
                                                             }
+                                                          >
+                                                            2
                                                           </span>
                                                         </PropVal>
                                                       </span>
@@ -1446,6 +1448,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                         key="n2/.0"
                                                       >
                                                         <PropVal
+                                                          braceWrapped={false}
                                                           level={2}
                                                           maxPropArrayLength={3}
                                                           maxPropObjectKeys={3}
@@ -1483,18 +1486,14 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                             }
                                                           }
                                                         >
-                                                          <span>
-                                                            {
-                                                            <span
-                                                              style={
-                                                                Object {
-                                                                  "color": "#a11",
-                                                                }
+                                                          <span
+                                                            style={
+                                                              Object {
+                                                                "color": "#a11",
                                                               }
-                                                            >
-                                                              3
-                                                            </span>
                                                             }
+                                                          >
+                                                            3
                                                           </span>
                                                         </PropVal>
                                                       </span>
@@ -1526,6 +1525,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                             style={Object {}}
                                           >
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -1533,6 +1533,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               val={7}
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -1666,6 +1667,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                           >
                                             "
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -1673,6 +1675,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                               val="seven"
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -2820,6 +2823,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                             style={Object {}}
                                           >
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -2827,6 +2831,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               val={[Function]}
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -2959,6 +2964,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                             style={Object {}}
                                           >
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -2971,6 +2977,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               }
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -3138,6 +3145,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                       </span>
                                                       : 
                                                       <PropVal
+                                                        braceWrapped={false}
                                                         key="v0/.0"
                                                         level={2}
                                                         maxPropArrayLength={3}
@@ -3203,6 +3211,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                       </span>
                                                       : 
                                                       <PropVal
+                                                        braceWrapped={false}
                                                         key="v1/.0"
                                                         level={2}
                                                         maxPropArrayLength={3}
@@ -3280,6 +3289,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                             style={Object {}}
                                           >
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -3293,6 +3303,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               }
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -3451,6 +3462,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                         key="n0/.0"
                                                       >
                                                         <PropVal
+                                                          braceWrapped={false}
                                                           level={2}
                                                           maxPropArrayLength={3}
                                                           maxPropObjectKeys={3}
@@ -3488,18 +3500,14 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                             }
                                                           }
                                                         >
-                                                          <span>
-                                                            {
-                                                            <span
-                                                              style={
-                                                                Object {
-                                                                  "color": "#a11",
-                                                                }
+                                                          <span
+                                                            style={
+                                                              Object {
+                                                                "color": "#a11",
                                                               }
-                                                            >
-                                                              1
-                                                            </span>
                                                             }
+                                                          >
+                                                            1
                                                           </span>
                                                         </PropVal>
                                                       </span>
@@ -3508,6 +3516,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                         key="n1/.0"
                                                       >
                                                         <PropVal
+                                                          braceWrapped={false}
                                                           level={2}
                                                           maxPropArrayLength={3}
                                                           maxPropObjectKeys={3}
@@ -3545,18 +3554,14 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                             }
                                                           }
                                                         >
-                                                          <span>
-                                                            {
-                                                            <span
-                                                              style={
-                                                                Object {
-                                                                  "color": "#a11",
-                                                                }
+                                                          <span
+                                                            style={
+                                                              Object {
+                                                                "color": "#a11",
                                                               }
-                                                            >
-                                                              2
-                                                            </span>
                                                             }
+                                                          >
+                                                            2
                                                           </span>
                                                         </PropVal>
                                                       </span>
@@ -3565,6 +3570,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                         key="n2/.0"
                                                       >
                                                         <PropVal
+                                                          braceWrapped={false}
                                                           level={2}
                                                           maxPropArrayLength={3}
                                                           maxPropObjectKeys={3}
@@ -3602,18 +3608,14 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                             }
                                                           }
                                                         >
-                                                          <span>
-                                                            {
-                                                            <span
-                                                              style={
-                                                                Object {
-                                                                  "color": "#a11",
-                                                                }
+                                                          <span
+                                                            style={
+                                                              Object {
+                                                                "color": "#a11",
                                                               }
-                                                            >
-                                                              3
-                                                            </span>
                                                             }
+                                                          >
+                                                            3
                                                           </span>
                                                         </PropVal>
                                                       </span>
@@ -3645,6 +3647,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                             style={Object {}}
                                           >
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -3652,6 +3655,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               val={7}
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}
@@ -3785,6 +3789,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                           >
                                             "
                                             <ThemedComponent
+                                              braceWrapped={true}
                                               maxPropArrayLength={3}
                                               maxPropObjectKeys={3}
                                               maxPropStringLength={50}
@@ -3792,6 +3797,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                               val="seven"
                                             >
                                               <PropVal
+                                                braceWrapped={true}
                                                 level={1}
                                                 maxPropArrayLength={3}
                                                 maxPropObjectKeys={3}

--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -1062,7 +1062,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                           }
                                                         }
                                                       >
-                                                        "a"
+                                                        'a'
                                                       </span>
                                                     </PropVal>
                                                     ,
@@ -1127,7 +1127,7 @@ exports[`addon Info should render <Info /> and external markdown 1`] = `
                                                           }
                                                         }
                                                       >
-                                                        "b"
+                                                        'b'
                                                       </span>
                                                     </PropVal>
                                                     }
@@ -3161,7 +3161,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                           }
                                                         }
                                                       >
-                                                        "a"
+                                                        'a'
                                                       </span>
                                                     </PropVal>
                                                     ,
@@ -3226,7 +3226,7 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)"
                                                           }
                                                         }
                                                       >
-                                                        "b"
+                                                        'b'
                                                       </span>
                                                     </PropVal>
                                                     }

--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -201,7 +201,7 @@ function PropVal(props) {
       val = `${val.slice(0, maxPropStringLength)}…`;
     }
     if (level > 1) {
-      val = `"${val}"`;
+      val = `'${val}'`;
     }
     content = <span style={valueStyles.string}>{val}</span>;
   } else if (typeof val === 'boolean') {

--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -188,11 +188,9 @@ function PropVal(props) {
     maxPropStringLength,
     maxPropsIntoLine,
     theme,
-    braceWrapped,
   } = props;
   let { val } = props;
   const { codeColors } = theme || {};
-  let braceWrap = braceWrapped;
   let content = null;
   const valueStyles = props.valueStyles || getValueStyles(codeColors);
 
@@ -202,8 +200,10 @@ function PropVal(props) {
     if (val.length > maxPropStringLength) {
       val = `${val.slice(0, maxPropStringLength)}…`;
     }
+    if (level > 1) {
+      val = `"${val}"`;
+    }
     content = <span style={valueStyles.string}>{val}</span>;
-    braceWrap = false;
   } else if (typeof val === 'boolean') {
     content = <span style={valueStyles.bool}>{`${val}`}</span>;
   } else if (Array.isArray(val)) {
@@ -246,9 +246,7 @@ function PropVal(props) {
     );
   }
 
-  if (!braceWrap) return content;
-
-  return <span>&#123;{content}&#125;</span>;
+  return content;
 }
 
 PropVal.defaultProps = {
@@ -260,7 +258,6 @@ PropVal.defaultProps = {
   level: 1,
   theme: {},
   valueStyles: null,
-  braceWrapped: false,
 };
 
 PropVal.propTypes = {
@@ -283,7 +280,6 @@ PropVal.propTypes = {
     bool: PropTypes.object,
     empty: PropTypes.object,
   }),
-  braceWrapped: PropTypes.bool,
 };
 
 export default withTheme(PropVal);

--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -188,10 +188,11 @@ function PropVal(props) {
     maxPropStringLength,
     maxPropsIntoLine,
     theme,
+    braceWrapped,
   } = props;
   let { val } = props;
   const { codeColors } = theme || {};
-  let braceWrap = true;
+  let braceWrap = braceWrapped;
   let content = null;
   const valueStyles = props.valueStyles || getValueStyles(codeColors);
 
@@ -259,6 +260,7 @@ PropVal.defaultProps = {
   level: 1,
   theme: {},
   valueStyles: null,
+  braceWrapped: false,
 };
 
 PropVal.propTypes = {
@@ -281,6 +283,7 @@ PropVal.propTypes = {
     bool: PropTypes.object,
     empty: PropTypes.object,
   }),
+  braceWrapped: PropTypes.bool,
 };
 
 export default withTheme(PropVal);

--- a/addons/info/src/components/Props.js
+++ b/addons/info/src/components/Props.js
@@ -45,16 +45,15 @@ export default function Props(props) {
           <span>
             =
             <span style={propValueStyle}>
-              {typeof nodeProps[name] === 'string' && '"'}
+              {typeof nodeProps[name] === 'string' ? '"' : '{'}
               <PropVal
                 val={nodeProps[name]}
                 maxPropObjectKeys={maxPropObjectKeys}
                 maxPropArrayLength={maxPropArrayLength}
                 maxPropStringLength={maxPropStringLength}
                 maxPropsIntoLine={maxPropsIntoLine}
-                braceWrapped
               />
-              {typeof nodeProps[name] === 'string' && '"'}
+              {typeof nodeProps[name] === 'string' ? '"' : '}'}
             </span>
           </span>
         )}

--- a/addons/info/src/components/Props.js
+++ b/addons/info/src/components/Props.js
@@ -52,6 +52,7 @@ export default function Props(props) {
                 maxPropArrayLength={maxPropArrayLength}
                 maxPropStringLength={maxPropStringLength}
                 maxPropsIntoLine={maxPropsIntoLine}
+                braceWrapped
               />
               {typeof nodeProps[name] === 'string' && '"'}
             </span>

--- a/examples/cra-kitchen-sink/src/stories/__snapshots__/index.stories.storyshot
+++ b/examples/cra-kitchen-sink/src/stories/__snapshots__/index.stories.storyshot
@@ -491,14 +491,10 @@ exports[`Storyshots Button with new info 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -524,48 +520,36 @@ exports[`Storyshots Button with new info 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
+                    <span
+                      style="color:#666"
+                    >
                       {
+                      <span>
+                        <span
+                          style="color:#666"
+                        >
+                          isOld
+                        </span>
+                      </span>
+                      : 
                       <span
-                        style="color:#666"
+                        style="color:#a11"
                       >
-                        {
-                        <span>
-                          <span
-                            style="color:#666"
-                          >
-                            isOld
-                          </span>
+                        false
+                      </span>
+                      ,
+                      <span>
+                        <span
+                          style="color:#666"
+                        >
+                          value
                         </span>
-                        : 
-                        <span>
-                          {
-                          <span
-                            style="color:#a11"
-                          >
-                            false
-                          </span>
-                          }
-                        </span>
-                        ,
-                        <span>
-                          <span
-                            style="color:#666"
-                          >
-                            value
-                          </span>
-                        </span>
-                        : 
-                        <span>
-                          {
-                          <span
-                            style="color:#a11"
-                          >
-                            0
-                          </span>
-                          }
-                        </span>
-                        }
+                      </span>
+                      : 
+                      <span
+                        style="color:#a11"
+                      >
+                        0
                       </span>
                       }
                     </span>
@@ -907,14 +891,10 @@ exports[`Storyshots Button with some info 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -940,48 +920,36 @@ exports[`Storyshots Button with some info 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
+                    <span
+                      style="color:#666"
+                    >
                       {
+                      <span>
+                        <span
+                          style="color:#666"
+                        >
+                          isOld
+                        </span>
+                      </span>
+                      : 
                       <span
-                        style="color:#666"
+                        style="color:#a11"
                       >
-                        {
-                        <span>
-                          <span
-                            style="color:#666"
-                          >
-                            isOld
-                          </span>
+                        false
+                      </span>
+                      ,
+                      <span>
+                        <span
+                          style="color:#666"
+                        >
+                          value
                         </span>
-                        : 
-                        <span>
-                          {
-                          <span
-                            style="color:#a11"
-                          >
-                            false
-                          </span>
-                          }
-                        </span>
-                        ,
-                        <span>
-                          <span
-                            style="color:#666"
-                          >
-                            value
-                          </span>
-                        </span>
-                        : 
-                        <span>
-                          {
-                          <span
-                            style="color:#a11"
-                          >
-                            0
-                          </span>
-                          }
-                        </span>
-                        }
+                      </span>
+                      : 
+                      <span
+                        style="color:#a11"
+                      >
+                        0
                       </span>
                       }
                     </span>

--- a/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
@@ -179,14 +179,10 @@ exports[`Storyshots Addons|Info.Decorator Use Info as story decorator 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -237,14 +233,10 @@ exports[`Storyshots Addons|Info.Decorator Use Info as story decorator 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -270,14 +262,10 @@ exports[`Storyshots Addons|Info.Decorator Use Info as story decorator 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -681,14 +669,10 @@ exports[`Storyshots Addons|Info.JSX Displays JSX in description 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -739,14 +723,10 @@ exports[`Storyshots Addons|Info.JSX Displays JSX in description 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -772,14 +752,10 @@ exports[`Storyshots Addons|Info.JSX Displays JSX in description 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -1026,14 +1002,10 @@ exports[`Storyshots Addons|Info.Markdown Displays Markdown in description 1`] = 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -1084,14 +1056,10 @@ exports[`Storyshots Addons|Info.Markdown Displays Markdown in description 1`] = 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -1117,14 +1085,10 @@ exports[`Storyshots Addons|Info.Markdown Displays Markdown in description 1`] = 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -1340,14 +1304,10 @@ exports[`Storyshots Addons|Info.Markdown From external Markdown file 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -1398,14 +1358,10 @@ exports[`Storyshots Addons|Info.Markdown From external Markdown file 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -1431,14 +1387,10 @@ exports[`Storyshots Addons|Info.Markdown From external Markdown file 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -1666,14 +1618,10 @@ exports[`Storyshots Addons|Info.Markdown From internal Markdown file 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -1724,14 +1672,10 @@ exports[`Storyshots Addons|Info.Markdown From internal Markdown file 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -1757,14 +1701,10 @@ exports[`Storyshots Addons|Info.Markdown From internal Markdown file 1`] = `
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -2147,14 +2087,10 @@ exports[`Storyshots Addons|Info.Options.excludedPropTypes Excludes propTypes tha
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -2180,14 +2116,10 @@ exports[`Storyshots Addons|Info.Options.excludedPropTypes Excludes propTypes tha
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -2213,14 +2145,10 @@ exports[`Storyshots Addons|Info.Options.excludedPropTypes Excludes propTypes tha
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -2402,14 +2330,10 @@ exports[`Storyshots Addons|Info.Options.header Shows or hides Info Addon header 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -2460,14 +2384,10 @@ exports[`Storyshots Addons|Info.Options.header Shows or hides Info Addon header 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -2493,14 +2413,10 @@ exports[`Storyshots Addons|Info.Options.header Shows or hides Info Addon header 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -2685,14 +2601,10 @@ exports[`Storyshots Addons|Info.Options.inline Inlines component inside story 1`
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#a11"
-                    >
-                      false
-                    </span>
-                    }
+                  <span
+                    style="color:#a11"
+                  >
+                    false
                   </span>
                 </td>
                 <td
@@ -2743,14 +2655,10 @@ exports[`Storyshots Addons|Info.Options.inline Inlines component inside story 1`
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#170"
-                    >
-                      onClick()
-                    </span>
-                    }
+                  <span
+                    style="color:#170"
+                  >
+                    onClick()
                   </span>
                 </td>
                 <td
@@ -2776,14 +2684,10 @@ exports[`Storyshots Addons|Info.Options.inline Inlines component inside story 1`
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#666"
-                    >
-                      {}
-                    </span>
-                    }
+                  <span
+                    style="color:#666"
+                  >
+                    {}
                   </span>
                 </td>
                 <td
@@ -3053,8 +2957,58 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                               <br />
                                   
                             </span>
-                            <span>
+                            <span
+                              style="color:#666"
+                            >
                               {
+                              <span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  one
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#22a;word-break:break-word"
+                              >
+                                Object and array properties will be broken to diff…
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  two
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#22a;word-break:break-word"
+                              >
+                                if greater than \`maxPropsIntoLine\` option threshol…
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  object
+                                </span>
+                              </span>
+                              : 
                               <span
                                 style="color:#666"
                               >
@@ -3062,53 +3016,165 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                 <span>
                                   <span>
                                     <br />
-                                          
+                                            
                                   </span>
                                   <span
                                     style="color:#666"
+                                  >
+                                    object1
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#666"
+                                >
+                                  {
+                                  <span>
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      one
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style="color:#22a;word-break:break-word"
                                   >
                                     one
                                   </span>
-                                </span>
-                                : 
-                                <span
-                                  style="color:#22a;word-break:break-word"
-                                >
-                                  Object and array properties will be broken to diff…
-                                </span>
-                                ,
-                                <span>
+                                  ,
                                   <span>
-                                    <br />
-                                          
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      two
+                                    </span>
                                   </span>
+                                  : 
                                   <span
-                                    style="color:#666"
+                                    style="color:#22a;word-break:break-word"
                                   >
                                     two
                                   </span>
-                                </span>
-                                : 
-                                <span
-                                  style="color:#22a;word-break:break-word"
-                                >
-                                  if greater than \`maxPropsIntoLine\` option threshol…
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      three
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    three
+                                  </span>
+                                  <span>
+                                    <br />
+                                            
+                                  </span>
+                                  }
                                 </span>
                                 ,
                                 <span>
                                   <span>
                                     <br />
-                                          
+                                            
                                   </span>
                                   <span
                                     style="color:#666"
                                   >
-                                    object
+                                    array
                                   </span>
                                 </span>
                                 : 
+                                <span
+                                  style="color:#666"
+                                >
+                                  [
+                                  <span>
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      one
+                                    </span>
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      two
+                                    </span>
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      three
+                                    </span>
+                                  </span>
+                                  <span>
+                                    <br />
+                                            
+                                  </span>
+                                  ]
+                                </span>
+                                ,
                                 <span>
+                                  <span>
+                                    <br />
+                                            
+                                  </span>
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    object2
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#666"
+                                >
                                   {
+                                  <span>
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      object
+                                    </span>
+                                  </span>
+                                  : 
                                   <span
                                     style="color:#666"
                                   >
@@ -3116,17 +3182,108 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                     <span>
                                       <span>
                                         <br />
-                                                
+                                                    
                                       </span>
                                       <span
                                         style="color:#666"
                                       >
-                                        object1
+                                        one
                                       </span>
                                     </span>
                                     : 
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      one
+                                    </span>
+                                    ,
                                     <span>
-                                      {
+                                      <span>
+                                        <br />
+                                                    
+                                      </span>
+                                      <span
+                                        style="color:#666"
+                                      >
+                                        two
+                                      </span>
+                                    </span>
+                                    : 
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      two
+                                    </span>
+                                    ,
+                                    <span>
+                                      <span>
+                                        <br />
+                                                    
+                                      </span>
+                                      <span
+                                        style="color:#666"
+                                      >
+                                        three
+                                      </span>
+                                    </span>
+                                    : 
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      three
+                                    </span>
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    }
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                                
+                                    </span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      array
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    [
+                                    <span>
+                                      <span>
+                                        <br />
+                                                    
+                                      </span>
+                                      <span
+                                        style="color:#22a;word-break:break-word"
+                                      >
+                                        one
+                                      </span>
+                                    </span>
+                                    ,
+                                    <span>
+                                      <span>
+                                        <br />
+                                                    
+                                      </span>
+                                      <span
+                                        style="color:#22a;word-break:break-word"
+                                      >
+                                        two
+                                      </span>
+                                    </span>
+                                    ,
+                                    <span>
+                                      <span>
+                                        <br />
+                                                    
+                                      </span>
                                       <span
                                         style="color:#666"
                                       >
@@ -3134,149 +3291,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                         <span>
                                           <span>
                                             <br />
-                                                      
-                                          </span>
-                                          <span
-                                            style="color:#666"
-                                          >
-                                            one
-                                          </span>
-                                        </span>
-                                        : 
-                                        <span
-                                          style="color:#22a;word-break:break-word"
-                                        >
-                                          one
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span>
-                                            <br />
-                                                      
-                                          </span>
-                                          <span
-                                            style="color:#666"
-                                          >
-                                            two
-                                          </span>
-                                        </span>
-                                        : 
-                                        <span
-                                          style="color:#22a;word-break:break-word"
-                                        >
-                                          two
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span>
-                                            <br />
-                                                      
-                                          </span>
-                                          <span
-                                            style="color:#666"
-                                          >
-                                            three
-                                          </span>
-                                        </span>
-                                        : 
-                                        <span
-                                          style="color:#22a;word-break:break-word"
-                                        >
-                                          three
-                                        </span>
-                                        <span>
-                                          <br />
-                                                  
-                                        </span>
-                                        }
-                                      </span>
-                                      }
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span>
-                                        <br />
-                                                
-                                      </span>
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        array
-                                      </span>
-                                    </span>
-                                    : 
-                                    <span>
-                                      {
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        [
-                                        <span>
-                                          <span>
-                                            <br />
-                                                      
-                                          </span>
-                                          <span
-                                            style="color:#22a;word-break:break-word"
-                                          >
-                                            one
-                                          </span>
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span>
-                                            <br />
-                                                      
-                                          </span>
-                                          <span
-                                            style="color:#22a;word-break:break-word"
-                                          >
-                                            two
-                                          </span>
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span>
-                                            <br />
-                                                      
-                                          </span>
-                                          <span
-                                            style="color:#22a;word-break:break-word"
-                                          >
-                                            three
-                                          </span>
-                                        </span>
-                                        <span>
-                                          <br />
-                                                  
-                                        </span>
-                                        ]
-                                      </span>
-                                      }
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span>
-                                        <br />
-                                                
-                                      </span>
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        object2
-                                      </span>
-                                    </span>
-                                    : 
-                                    <span>
-                                      {
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        {
-                                        <span>
-                                          <span>
-                                            <br />
-                                                      
+                                                          
                                           </span>
                                           <span
                                             style="color:#666"
@@ -3285,8 +3300,22 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                           </span>
                                         </span>
                                         : 
-                                        <span>
+                                        <span
+                                          style="color:#666"
+                                        >
                                           {
+                                          <span>
+                                            <span>
+                                              <br />
+                                                              
+                                            </span>
+                                            <span
+                                              style="color:#666"
+                                            >
+                                              object
+                                            </span>
+                                          </span>
+                                          : 
                                           <span
                                             style="color:#666"
                                           >
@@ -3294,7 +3323,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span>
                                               <span>
                                                 <br />
-                                                            
+                                                                  
                                               </span>
                                               <span
                                                 style="color:#666"
@@ -3312,7 +3341,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span>
                                               <span>
                                                 <br />
-                                                            
+                                                                  
                                               </span>
                                               <span
                                                 style="color:#666"
@@ -3330,7 +3359,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span>
                                               <span>
                                                 <br />
-                                                            
+                                                                  
                                               </span>
                                               <span
                                                 style="color:#666"
@@ -3346,27 +3375,23 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             </span>
                                             <span>
                                               <br />
-                                                        
+                                                              
                                             </span>
                                             }
                                           </span>
-                                          }
-                                        </span>
-                                        ,
-                                        <span>
+                                          ,
                                           <span>
-                                            <br />
-                                                      
+                                            <span>
+                                              <br />
+                                                              
+                                            </span>
+                                            <span
+                                              style="color:#666"
+                                            >
+                                              array
+                                            </span>
                                           </span>
-                                          <span
-                                            style="color:#666"
-                                          >
-                                            array
-                                          </span>
-                                        </span>
-                                        : 
-                                        <span>
-                                          {
+                                          : 
                                           <span
                                             style="color:#666"
                                           >
@@ -3374,7 +3399,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span>
                                               <span>
                                                 <br />
-                                                            
+                                                                  
                                               </span>
                                               <span
                                                 style="color:#22a;word-break:break-word"
@@ -3386,7 +3411,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span>
                                               <span>
                                                 <br />
-                                                            
+                                                                  
                                               </span>
                                               <span
                                                 style="color:#22a;word-break:break-word"
@@ -3398,219 +3423,54 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span>
                                               <span>
                                                 <br />
-                                                            
+                                                                  
                                               </span>
-                                              <span>
-                                                {
-                                                <span
-                                                  style="color:#666"
-                                                >
-                                                  {
-                                                  <span>
-                                                    <span>
-                                                      <br />
-                                                                    
-                                                    </span>
-                                                    <span
-                                                      style="color:#666"
-                                                    >
-                                                      object
-                                                    </span>
-                                                  </span>
-                                                  : 
-                                                  <span>
-                                                    {
-                                                    <span
-                                                      style="color:#666"
-                                                    >
-                                                      {
-                                                      <span>
-                                                        <span>
-                                                          <br />
-                                                                          
-                                                        </span>
-                                                        <span
-                                                          style="color:#666"
-                                                        >
-                                                          object
-                                                        </span>
-                                                      </span>
-                                                      : 
-                                                      <span>
-                                                        {
-                                                        <span
-                                                          style="color:#666"
-                                                        >
-                                                          {
-                                                          <span>
-                                                            <span>
-                                                              <br />
-                                                                                
-                                                            </span>
-                                                            <span
-                                                              style="color:#666"
-                                                            >
-                                                              one
-                                                            </span>
-                                                          </span>
-                                                          : 
-                                                          <span
-                                                            style="color:#22a;word-break:break-word"
-                                                          >
-                                                            one
-                                                          </span>
-                                                          ,
-                                                          <span>
-                                                            <span>
-                                                              <br />
-                                                                                
-                                                            </span>
-                                                            <span
-                                                              style="color:#666"
-                                                            >
-                                                              two
-                                                            </span>
-                                                          </span>
-                                                          : 
-                                                          <span
-                                                            style="color:#22a;word-break:break-word"
-                                                          >
-                                                            two
-                                                          </span>
-                                                          ,
-                                                          <span>
-                                                            <span>
-                                                              <br />
-                                                                                
-                                                            </span>
-                                                            <span
-                                                              style="color:#666"
-                                                            >
-                                                              three
-                                                            </span>
-                                                          </span>
-                                                          : 
-                                                          <span
-                                                            style="color:#22a;word-break:break-word"
-                                                          >
-                                                            three
-                                                          </span>
-                                                          <span>
-                                                            <br />
-                                                                            
-                                                          </span>
-                                                          }
-                                                        </span>
-                                                        }
-                                                      </span>
-                                                      ,
-                                                      <span>
-                                                        <span>
-                                                          <br />
-                                                                          
-                                                        </span>
-                                                        <span
-                                                          style="color:#666"
-                                                        >
-                                                          array
-                                                        </span>
-                                                      </span>
-                                                      : 
-                                                      <span>
-                                                        {
-                                                        <span
-                                                          style="color:#666"
-                                                        >
-                                                          [
-                                                          <span>
-                                                            <span>
-                                                              <br />
-                                                                                
-                                                            </span>
-                                                            <span
-                                                              style="color:#22a;word-break:break-word"
-                                                            >
-                                                              one
-                                                            </span>
-                                                          </span>
-                                                          ,
-                                                          <span>
-                                                            <span>
-                                                              <br />
-                                                                                
-                                                            </span>
-                                                            <span
-                                                              style="color:#22a;word-break:break-word"
-                                                            >
-                                                              two
-                                                            </span>
-                                                          </span>
-                                                          ,
-                                                          <span>
-                                                            <span>
-                                                              <br />
-                                                                                
-                                                            </span>
-                                                            <span
-                                                              style="color:#22a;word-break:break-word"
-                                                            >
-                                                              three
-                                                            </span>
-                                                          </span>
-                                                          <span>
-                                                            <br />
-                                                                            
-                                                          </span>
-                                                          ]
-                                                        </span>
-                                                        }
-                                                      </span>
-                                                      <span>
-                                                        <br />
-                                                                      
-                                                      </span>
-                                                      }
-                                                    </span>
-                                                    }
-                                                  </span>
-                                                  <span>
-                                                    <br />
-                                                                
-                                                  </span>
-                                                  }
-                                                </span>
-                                                }
+                                              <span
+                                                style="color:#22a;word-break:break-word"
+                                              >
+                                                three
                                               </span>
                                             </span>
                                             <span>
                                               <br />
-                                                        
+                                                              
                                             </span>
                                             ]
+                                          </span>
+                                          <span>
+                                            <br />
+                                                          
                                           </span>
                                           }
                                         </span>
                                         <span>
                                           <br />
-                                                  
+                                                      
                                         </span>
                                         }
                                       </span>
-                                      }
                                     </span>
                                     <span>
                                       <br />
-                                            
+                                                
                                     </span>
-                                    }
+                                    ]
+                                  </span>
+                                  <span>
+                                    <br />
+                                            
                                   </span>
                                   }
                                 </span>
                                 <span>
                                   <br />
-                                      
+                                        
                                 </span>
                                 }
+                              </span>
+                              <span>
+                                <br />
+                                    
                               </span>
                               }
                             </span>
@@ -3717,14 +3577,10 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#a11"
-                    >
-                      false
-                    </span>
-                    }
+                  <span
+                    style="color:#a11"
+                  >
+                    false
                   </span>
                 </td>
                 <td
@@ -3775,14 +3631,10 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#170"
-                    >
-                      onClick()
-                    </span>
-                    }
+                  <span
+                    style="color:#170"
+                  >
+                    onClick()
                   </span>
                 </td>
                 <td
@@ -3808,14 +3660,10 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#666"
-                    >
-                      {}
-                    </span>
-                    }
+                  <span
+                    style="color:#666"
+                  >
+                    {}
                   </span>
                 </td>
                 <td
@@ -4065,8 +3913,46 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                         >
                           [
                           <span>
-                            <span>
+                            <span
+                              style="color:#666"
+                            >
                               {
+                              <span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  one
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#22a;word-break:break-word"
+                              >
+                                Object and array properties will be broken to diff…
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  two
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#22a;word-break:break-word"
+                              >
+                                if greater than \`maxPropsIntoLine\` option threshol…
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  object
+                                </span>
+                              </span>
+                              : 
                               <span
                                 style="color:#666"
                               >
@@ -4075,40 +3961,116 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#666"
                                   >
-                                    one
+                                    object1
                                   </span>
                                 </span>
                                 : 
                                 <span
-                                  style="color:#22a;word-break:break-word"
+                                  style="color:#666"
                                 >
-                                  Object and array properties will be broken to diff…
-                                </span>
-                                ,
-                                <span>
+                                  {
+                                  <span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      one
+                                    </span>
+                                  </span>
+                                  : 
                                   <span
-                                    style="color:#666"
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    one
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      two
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style="color:#22a;word-break:break-word"
                                   >
                                     two
                                   </span>
-                                </span>
-                                : 
-                                <span
-                                  style="color:#22a;word-break:break-word"
-                                >
-                                  if greater than \`maxPropsIntoLine\` option threshol…
+                                  ,
+                                  <span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      three
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    three
+                                  </span>
+                                  }
                                 </span>
                                 ,
                                 <span>
                                   <span
                                     style="color:#666"
                                   >
-                                    object
+                                    array
                                   </span>
                                 </span>
                                 : 
+                                <span
+                                  style="color:#666"
+                                >
+                                  [
+                                  <span>
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      one
+                                    </span>
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      two
+                                    </span>
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      three
+                                    </span>
+                                  </span>
+                                  ]
+                                </span>
+                                ,
                                 <span>
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    object2
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#666"
+                                >
                                   {
+                                  <span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      object
+                                    </span>
+                                  </span>
+                                  : 
                                   <span
                                     style="color:#666"
                                   >
@@ -4117,114 +4079,75 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                       <span
                                         style="color:#666"
                                       >
-                                        object1
+                                        one
                                       </span>
                                     </span>
                                     : 
-                                    <span>
-                                      {
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        {
-                                        <span>
-                                          <span
-                                            style="color:#666"
-                                          >
-                                            one
-                                          </span>
-                                        </span>
-                                        : 
-                                        <span
-                                          style="color:#22a;word-break:break-word"
-                                        >
-                                          one
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span
-                                            style="color:#666"
-                                          >
-                                            two
-                                          </span>
-                                        </span>
-                                        : 
-                                        <span
-                                          style="color:#22a;word-break:break-word"
-                                        >
-                                          two
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span
-                                            style="color:#666"
-                                          >
-                                            three
-                                          </span>
-                                        </span>
-                                        : 
-                                        <span
-                                          style="color:#22a;word-break:break-word"
-                                        >
-                                          three
-                                        </span>
-                                        }
-                                      </span>
-                                      }
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      one
                                     </span>
                                     ,
                                     <span>
                                       <span
                                         style="color:#666"
                                       >
-                                        array
+                                        two
                                       </span>
                                     </span>
                                     : 
-                                    <span>
-                                      {
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        [
-                                        <span>
-                                          <span
-                                            style="color:#22a;word-break:break-word"
-                                          >
-                                            one
-                                          </span>
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span
-                                            style="color:#22a;word-break:break-word"
-                                          >
-                                            two
-                                          </span>
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span
-                                            style="color:#22a;word-break:break-word"
-                                          >
-                                            three
-                                          </span>
-                                        </span>
-                                        ]
-                                      </span>
-                                      }
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      two
                                     </span>
                                     ,
                                     <span>
                                       <span
                                         style="color:#666"
                                       >
-                                        object2
+                                        three
                                       </span>
                                     </span>
                                     : 
+                                    <span
+                                      style="color:#22a;word-break:break-word"
+                                    >
+                                      three
+                                    </span>
+                                    }
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span
+                                      style="color:#666"
+                                    >
+                                      array
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    [
                                     <span>
-                                      {
+                                      <span
+                                        style="color:#22a;word-break:break-word"
+                                      >
+                                        one
+                                      </span>
+                                    </span>
+                                    ,
+                                    <span>
+                                      <span
+                                        style="color:#22a;word-break:break-word"
+                                      >
+                                        two
+                                      </span>
+                                    </span>
+                                    ,
+                                    <span>
                                       <span
                                         style="color:#666"
                                       >
@@ -4237,8 +4160,18 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                           </span>
                                         </span>
                                         : 
-                                        <span>
+                                        <span
+                                          style="color:#666"
+                                        >
                                           {
+                                          <span>
+                                            <span
+                                              style="color:#666"
+                                            >
+                                              object
+                                            </span>
+                                          </span>
+                                          : 
                                           <span
                                             style="color:#666"
                                           >
@@ -4286,19 +4219,15 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                             </span>
                                             }
                                           </span>
-                                          }
-                                        </span>
-                                        ,
-                                        <span>
-                                          <span
-                                            style="color:#666"
-                                          >
-                                            array
+                                          ,
+                                          <span>
+                                            <span
+                                              style="color:#666"
+                                            >
+                                              array
+                                            </span>
                                           </span>
-                                        </span>
-                                        : 
-                                        <span>
-                                          {
+                                          : 
                                           <span
                                             style="color:#666"
                                           >
@@ -4320,134 +4249,10 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                             </span>
                                             ,
                                             <span>
-                                              <span>
-                                                {
-                                                <span
-                                                  style="color:#666"
-                                                >
-                                                  {
-                                                  <span>
-                                                    <span
-                                                      style="color:#666"
-                                                    >
-                                                      object
-                                                    </span>
-                                                  </span>
-                                                  : 
-                                                  <span>
-                                                    {
-                                                    <span
-                                                      style="color:#666"
-                                                    >
-                                                      {
-                                                      <span>
-                                                        <span
-                                                          style="color:#666"
-                                                        >
-                                                          object
-                                                        </span>
-                                                      </span>
-                                                      : 
-                                                      <span>
-                                                        {
-                                                        <span
-                                                          style="color:#666"
-                                                        >
-                                                          {
-                                                          <span>
-                                                            <span
-                                                              style="color:#666"
-                                                            >
-                                                              one
-                                                            </span>
-                                                          </span>
-                                                          : 
-                                                          <span
-                                                            style="color:#22a;word-break:break-word"
-                                                          >
-                                                            one
-                                                          </span>
-                                                          ,
-                                                          <span>
-                                                            <span
-                                                              style="color:#666"
-                                                            >
-                                                              two
-                                                            </span>
-                                                          </span>
-                                                          : 
-                                                          <span
-                                                            style="color:#22a;word-break:break-word"
-                                                          >
-                                                            two
-                                                          </span>
-                                                          ,
-                                                          <span>
-                                                            <span
-                                                              style="color:#666"
-                                                            >
-                                                              three
-                                                            </span>
-                                                          </span>
-                                                          : 
-                                                          <span
-                                                            style="color:#22a;word-break:break-word"
-                                                          >
-                                                            three
-                                                          </span>
-                                                          }
-                                                        </span>
-                                                        }
-                                                      </span>
-                                                      ,
-                                                      <span>
-                                                        <span
-                                                          style="color:#666"
-                                                        >
-                                                          array
-                                                        </span>
-                                                      </span>
-                                                      : 
-                                                      <span>
-                                                        {
-                                                        <span
-                                                          style="color:#666"
-                                                        >
-                                                          [
-                                                          <span>
-                                                            <span
-                                                              style="color:#22a;word-break:break-word"
-                                                            >
-                                                              one
-                                                            </span>
-                                                          </span>
-                                                          ,
-                                                          <span>
-                                                            <span
-                                                              style="color:#22a;word-break:break-word"
-                                                            >
-                                                              two
-                                                            </span>
-                                                          </span>
-                                                          ,
-                                                          <span>
-                                                            <span
-                                                              style="color:#22a;word-break:break-word"
-                                                            >
-                                                              three
-                                                            </span>
-                                                          </span>
-                                                          ]
-                                                        </span>
-                                                        }
-                                                      </span>
-                                                      }
-                                                    </span>
-                                                    }
-                                                  </span>
-                                                  }
-                                                </span>
-                                                }
+                                              <span
+                                                style="color:#22a;word-break:break-word"
+                                              >
+                                                three
                                               </span>
                                             </span>
                                             ]
@@ -4456,9 +4261,8 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                         </span>
                                         }
                                       </span>
-                                      }
                                     </span>
-                                    }
+                                    ]
                                   </span>
                                   }
                                 </span>
@@ -4565,14 +4369,10 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#a11"
-                    >
-                      false
-                    </span>
-                    }
+                  <span
+                    style="color:#a11"
+                  >
+                    false
                   </span>
                 </td>
                 <td
@@ -4623,14 +4423,10 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#170"
-                    >
-                      onClick()
-                    </span>
-                    }
+                  <span
+                    style="color:#170"
+                  >
+                    onClick()
                   </span>
                 </td>
                 <td
@@ -4656,14 +4452,10 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                 <td
                   class="css-d52hbj"
                 >
-                  <span>
-                    {
-                    <span
-                      style="color:#666"
-                    >
-                      {}
-                    </span>
-                    }
+                  <span
+                    style="color:#666"
+                  >
+                    {}
                   </span>
                 </td>
                 <td
@@ -4858,14 +4650,10 @@ exports[`Storyshots Addons|Info.Options.propTables Shows additional component pr
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -4916,14 +4704,10 @@ exports[`Storyshots Addons|Info.Options.propTables Shows additional component pr
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -4949,14 +4733,10 @@ exports[`Storyshots Addons|Info.Options.propTables Shows additional component pr
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -5026,14 +4806,10 @@ exports[`Storyshots Addons|Info.Options.propTables Shows additional component pr
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -5061,14 +4837,10 @@ exports[`Storyshots Addons|Info.Options.propTables Shows additional component pr
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -5330,14 +5102,10 @@ exports[`Storyshots Addons|Info.Options.propTablesExclude Exclude component from
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -5388,14 +5156,10 @@ exports[`Storyshots Addons|Info.Options.propTablesExclude Exclude component from
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -5421,14 +5185,10 @@ exports[`Storyshots Addons|Info.Options.propTablesExclude Exclude component from
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -5560,14 +5320,10 @@ exports[`Storyshots Addons|Info.Options.source Shows or hides Info Addon source 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -5618,14 +5374,10 @@ exports[`Storyshots Addons|Info.Options.source Shows or hides Info Addon source 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -5651,14 +5403,10 @@ exports[`Storyshots Addons|Info.Options.source Shows or hides Info Addon source 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -5845,14 +5593,10 @@ exports[`Storyshots Addons|Info.Options.styles Extend info styles with an object
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -5903,14 +5647,10 @@ exports[`Storyshots Addons|Info.Options.styles Extend info styles with an object
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -5936,14 +5676,10 @@ exports[`Storyshots Addons|Info.Options.styles Extend info styles with an object
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -6130,14 +5866,10 @@ exports[`Storyshots Addons|Info.Options.styles Full control over styles using a 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -6188,14 +5920,10 @@ exports[`Storyshots Addons|Info.Options.styles Full control over styles using a 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -6221,14 +5949,10 @@ exports[`Storyshots Addons|Info.Options.styles Full control over styles using a 
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -6446,14 +6170,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from Flow declarations 1`]
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -6481,14 +6201,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from Flow declarations 1`]
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -6704,14 +6420,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -6762,14 +6474,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -6795,30 +6503,22 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
+                    <span
+                      style="color:#666"
+                    >
                       {
+                      <span>
+                        <span
+                          style="color:#666"
+                        >
+                          key
+                        </span>
+                      </span>
+                      : 
                       <span
-                        style="color:#666"
+                        style="color:#a11"
                       >
-                        {
-                        <span>
-                          <span
-                            style="color:#666"
-                          >
-                            key
-                          </span>
-                        </span>
-                        : 
-                        <span>
-                          {
-                          <span
-                            style="color:#a11"
-                          >
-                            1
-                          </span>
-                          }
-                        </span>
-                        }
+                        1
                       </span>
                       }
                     </span>
@@ -6846,8 +6546,18 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
+                    <span
+                      style="color:#666"
+                    >
                       {
+                      <span>
+                        <span
+                          style="color:#666"
+                        >
+                          thing
+                        </span>
+                      </span>
+                      : 
                       <span
                         style="color:#666"
                       >
@@ -6856,72 +6566,42 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                           <span
                             style="color:#666"
                           >
-                            thing
+                            id
                           </span>
                         </span>
                         : 
+                        <span
+                          style="color:#a11"
+                        >
+                          2
+                        </span>
+                        ,
                         <span>
-                          {
                           <span
                             style="color:#666"
                           >
-                            {
-                            <span>
-                              <span
-                                style="color:#666"
-                              >
-                                id
-                              </span>
-                            </span>
-                            : 
-                            <span>
-                              {
-                              <span
-                                style="color:#a11"
-                              >
-                                2
-                              </span>
-                              }
-                            </span>
-                            ,
-                            <span>
-                              <span
-                                style="color:#666"
-                              >
-                                func
-                              </span>
-                            </span>
-                            : 
-                            <span>
-                              {
-                              <span
-                                style="color:#170"
-                              >
-                                func()
-                              </span>
-                              }
-                            </span>
-                            ,
-                            <span>
-                              <span
-                                style="color:#666"
-                              >
-                                arr
-                              </span>
-                            </span>
-                            : 
-                            <span>
-                              {
-                              <span
-                                style="color:#666"
-                              >
-                                []
-                              </span>
-                              }
-                            </span>
-                            }
+                            func
                           </span>
-                          }
+                        </span>
+                        : 
+                        <span
+                          style="color:#170"
+                        >
+                          func()
+                        </span>
+                        ,
+                        <span>
+                          <span
+                            style="color:#666"
+                          >
+                            arr
+                          </span>
+                        </span>
+                        : 
+                        <span
+                          style="color:#666"
+                        >
+                          []
                         </span>
                         }
                       </span>
@@ -6951,26 +6631,22 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
+                    <span
+                      style="color:#666"
+                    >
                       {
-                      <span
-                        style="color:#666"
-                      >
-                        {
-                        <span>
-                          <span
-                            style="color:#666"
-                          >
-                            key
-                          </span>
-                        </span>
-                        : 
+                      <span>
                         <span
-                          style="color:#22a;word-break:break-word"
+                          style="color:#666"
                         >
-                          value
+                          key
                         </span>
-                        }
+                      </span>
+                      : 
+                      <span
+                        style="color:#22a;word-break:break-word"
+                      >
+                        value
                       </span>
                       }
                     </span>
@@ -6998,90 +6674,74 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
+                    <span
+                      style="color:#666"
+                    >
                       {
+                      <span>
+                        <span>
+                          <br />
+                              
+                        </span>
+                        <span
+                          style="color:#666"
+                        >
+                          id
+                        </span>
+                      </span>
+                      : 
+                      <span
+                        style="color:#a11"
+                      >
+                        3
+                      </span>
+                      ,
+                      <span>
+                        <span>
+                          <br />
+                              
+                        </span>
+                        <span
+                          style="color:#666"
+                        >
+                          func
+                        </span>
+                      </span>
+                      : 
+                      <span
+                        style="color:#170"
+                      >
+                        func()
+                      </span>
+                      ,
+                      <span>
+                        <span>
+                          <br />
+                              
+                        </span>
+                        <span
+                          style="color:#666"
+                        >
+                          arr
+                        </span>
+                      </span>
+                      : 
                       <span
                         style="color:#666"
                       >
-                        {
-                        <span>
-                          <span>
-                            <br />
-                                
-                          </span>
-                          <span
-                            style="color:#666"
-                          >
-                            id
-                          </span>
-                        </span>
-                        : 
-                        <span>
-                          {
-                          <span
-                            style="color:#a11"
-                          >
-                            3
-                          </span>
-                          }
-                        </span>
-                        ,
-                        <span>
-                          <span>
-                            <br />
-                                
-                          </span>
-                          <span
-                            style="color:#666"
-                          >
-                            func
-                          </span>
-                        </span>
-                        : 
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            func()
-                          </span>
-                          }
-                        </span>
-                        ,
-                        <span>
-                          <span>
-                            <br />
-                                
-                          </span>
-                          <span
-                            style="color:#666"
-                          >
-                            arr
-                          </span>
-                        </span>
-                        : 
-                        <span>
-                          {
-                          <span
-                            style="color:#666"
-                          >
-                            []
-                          </span>
-                          }
-                        </span>
-                        ,
-                        <span>
-                          <span>
-                            <br />
-                                
-                          </span>
-                          …
-                        </span>
+                        []
+                      </span>
+                      ,
+                      <span>
                         <span>
                           <br />
-                            
+                              
                         </span>
-                        }
+                        …
+                      </span>
+                      <span>
+                        <br />
+                          
                       </span>
                       }
                     </span>
@@ -7109,50 +6769,34 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        [
-                        <span>
-                          <span>
-                            {
-                            <span
-                              style="color:#a11"
-                            >
-                              1
-                            </span>
-                            }
-                          </span>
+                    <span
+                      style="color:#666"
+                    >
+                      [
+                      <span>
+                        <span
+                          style="color:#a11"
+                        >
+                          1
                         </span>
-                        ,
-                        <span>
-                          <span>
-                            {
-                            <span
-                              style="color:#a11"
-                            >
-                              2
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        ,
-                        <span>
-                          <span>
-                            {
-                            <span
-                              style="color:#a11"
-                            >
-                              3
-                            </span>
-                            }
-                          </span>
-                        </span>
-                        ]
                       </span>
-                      }
+                      ,
+                      <span>
+                        <span
+                          style="color:#a11"
+                        >
+                          2
+                        </span>
+                      </span>
+                      ,
+                      <span>
+                        <span
+                          style="color:#a11"
+                        >
+                          3
+                        </span>
+                      </span>
+                      ]
                     </span>
                   </td>
                   <td
@@ -7178,14 +6822,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -7517,14 +7157,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from component declaration
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -7575,14 +7211,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from component declaration
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -7608,14 +7240,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from component declaration
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td
@@ -7833,14 +7461,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from named export componen
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#a11"
-                      >
-                        false
-                      </span>
-                      }
+                    <span
+                      style="color:#a11"
+                    >
+                      false
                     </span>
                   </td>
                   <td
@@ -7891,14 +7515,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from named export componen
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#170"
-                      >
-                        onClick()
-                      </span>
-                      }
+                    <span
+                      style="color:#170"
+                    >
+                      onClick()
                     </span>
                   </td>
                   <td
@@ -7924,14 +7544,10 @@ exports[`Storyshots Addons|Info.React Docgen Comments from named export componen
                   <td
                     class="css-d52hbj"
                   >
-                    <span>
-                      {
-                      <span
-                        style="color:#666"
-                      >
-                        {}
-                      </span>
-                      }
+                    <span
+                      style="color:#666"
+                    >
+                      {}
                     </span>
                   </td>
                   <td

--- a/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
@@ -548,15 +548,13 @@ exports[`Storyshots Addons|Info.JSX Displays JSX in description 1`] = `
                     <span>
                       =
                       <span>
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            clicked()
-                          </span>
-                          }
+                        {
+                        <span
+                          style="color:#170"
+                        >
+                          clicked()
                         </span>
+                        }
                       </span>
                     </span>
                   </span>
@@ -881,15 +879,13 @@ exports[`Storyshots Addons|Info.Markdown Displays Markdown in description 1`] = 
                     <span>
                       =
                       <span>
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            clicked()
-                          </span>
-                          }
+                        {
+                        <span
+                          style="color:#170"
+                        >
+                          clicked()
                         </span>
+                        }
                       </span>
                     </span>
                   </span>
@@ -1183,15 +1179,13 @@ exports[`Storyshots Addons|Info.Markdown From external Markdown file 1`] = `
                     <span>
                       =
                       <span>
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            clicked()
-                          </span>
-                          }
+                        {
+                        <span
+                          style="color:#170"
+                        >
+                          clicked()
                         </span>
+                        }
                       </span>
                     </span>
                   </span>
@@ -1497,15 +1491,13 @@ exports[`Storyshots Addons|Info.Markdown From internal Markdown file 1`] = `
                     <span>
                       =
                       <span>
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            clicked()
-                          </span>
-                          }
+                        {
+                        <span
+                          style="color:#170"
+                        >
+                          clicked()
                         </span>
+                        }
                       </span>
                     </span>
                   </span>
@@ -2794,73 +2786,71 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                   <span>
                     =
                     <span>
-                      <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
                         {
-                        <span
-                          style="color:#666"
-                        >
-                          {
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#666"
-                            >
-                              one
-                            </span>
-                          </span>
-                          : 
-                          <span
-                            style="color:#22a;word-break:break-word"
-                          >
-                            Object and array properties
-                          </span>
-                          ,
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#666"
-                            >
-                              two
-                            </span>
-                          </span>
-                          : 
-                          <span
-                            style="color:#22a;word-break:break-word"
-                          >
-                            will be broken to different lines
-                          </span>
-                          ,
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#666"
-                            >
-                              three
-                            </span>
-                          </span>
-                          : 
-                          <span
-                            style="color:#22a;word-break:break-word"
-                          >
-                            if greater than \`maxPropsIntoLine\` option threshol…
-                          </span>
+                        <span>
                           <span>
                             <br />
-                              
+                                
                           </span>
-                          }
+                          <span
+                            style="color:#666"
+                          >
+                            one
+                          </span>
+                        </span>
+                        : 
+                        <span
+                          style="color:#22a;word-break:break-word"
+                        >
+                          "Object and array properties"
+                        </span>
+                        ,
+                        <span>
+                          <span>
+                            <br />
+                                
+                          </span>
+                          <span
+                            style="color:#666"
+                          >
+                            two
+                          </span>
+                        </span>
+                        : 
+                        <span
+                          style="color:#22a;word-break:break-word"
+                        >
+                          "will be broken to different lines"
+                        </span>
+                        ,
+                        <span>
+                          <span>
+                            <br />
+                                
+                          </span>
+                          <span
+                            style="color:#666"
+                          >
+                            three
+                          </span>
+                        </span>
+                        : 
+                        <span
+                          style="color:#22a;word-break:break-word"
+                        >
+                          "if greater than \`maxPropsIntoLine\` option threshol…"
+                        </span>
+                        <span>
+                          <br />
+                            
                         </span>
                         }
                       </span>
+                      }
                     </span>
                   </span>
                 </span>
@@ -2875,63 +2865,61 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                   <span>
                     =
                     <span>
-                      <span>
-                        {
-                        <span
-                          style="color:#666"
-                        >
-                          [
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#22a;word-break:break-word"
-                            >
-                              one
-                            </span>
-                          </span>
-                          ,
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#22a;word-break:break-word"
-                            >
-                              two
-                            </span>
-                          </span>
-                          ,
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#22a;word-break:break-word"
-                            >
-                              three
-                            </span>
-                          </span>
-                          ,
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            …
-                          </span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        [
+                        <span>
                           <span>
                             <br />
-                              
+                                
                           </span>
-                          ]
+                          <span
+                            style="color:#22a;word-break:break-word"
+                          >
+                            "one"
+                          </span>
                         </span>
-                        }
+                        ,
+                        <span>
+                          <span>
+                            <br />
+                                
+                          </span>
+                          <span
+                            style="color:#22a;word-break:break-word"
+                          >
+                            "two"
+                          </span>
+                        </span>
+                        ,
+                        <span>
+                          <span>
+                            <br />
+                                
+                          </span>
+                          <span
+                            style="color:#22a;word-break:break-word"
+                          >
+                            "three"
+                          </span>
+                        </span>
+                        ,
+                        <span>
+                          <span>
+                            <br />
+                                
+                          </span>
+                          …
+                        </span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        ]
                       </span>
+                      }
                     </span>
                   </span>
                 </span>
@@ -2946,17 +2934,68 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                   <span>
                     =
                     <span>
-                      <span>
-                        {
-                        <span
-                          style="color:#666"
-                        >
-                          [
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        [
+                        <span>
                           <span>
+                            <br />
+                                
+                          </span>
+                          <span
+                            style="color:#666"
+                          >
+                            {
                             <span>
-                              <br />
-                                  
+                              <span>
+                                <br />
+                                      
+                              </span>
+                              <span
+                                style="color:#666"
+                              >
+                                one
+                              </span>
                             </span>
+                            : 
+                            <span
+                              style="color:#22a;word-break:break-word"
+                            >
+                              "Object and array properties will be broken to diff…"
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                      
+                              </span>
+                              <span
+                                style="color:#666"
+                              >
+                                two
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style="color:#22a;word-break:break-word"
+                            >
+                              "if greater than \`maxPropsIntoLine\` option threshol…"
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                      
+                              </span>
+                              <span
+                                style="color:#666"
+                              >
+                                object
+                              </span>
+                            </span>
+                            : 
                             <span
                               style="color:#666"
                             >
@@ -2964,48 +3003,12 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                               <span>
                                 <span>
                                   <br />
-                                        
+                                          
                                 </span>
                                 <span
                                   style="color:#666"
                                 >
-                                  one
-                                </span>
-                              </span>
-                              : 
-                              <span
-                                style="color:#22a;word-break:break-word"
-                              >
-                                Object and array properties will be broken to diff…
-                              </span>
-                              ,
-                              <span>
-                                <span>
-                                  <br />
-                                        
-                                </span>
-                                <span
-                                  style="color:#666"
-                                >
-                                  two
-                                </span>
-                              </span>
-                              : 
-                              <span
-                                style="color:#22a;word-break:break-word"
-                              >
-                                if greater than \`maxPropsIntoLine\` option threshol…
-                              </span>
-                              ,
-                              <span>
-                                <span>
-                                  <br />
-                                        
-                                </span>
-                                <span
-                                  style="color:#666"
-                                >
-                                  object
+                                  object1
                                 </span>
                               </span>
                               : 
@@ -3016,12 +3019,146 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                 <span>
                                   <span>
                                     <br />
-                                            
+                                              
                                   </span>
                                   <span
                                     style="color:#666"
                                   >
-                                    object1
+                                    one
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#22a;word-break:break-word"
+                                >
+                                  "one"
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                              
+                                  </span>
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    two
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#22a;word-break:break-word"
+                                >
+                                  "two"
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                              
+                                  </span>
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    three
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#22a;word-break:break-word"
+                                >
+                                  "three"
+                                </span>
+                                <span>
+                                  <br />
+                                          
+                                </span>
+                                }
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                          
+                                </span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  array
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#666"
+                              >
+                                [
+                                <span>
+                                  <span>
+                                    <br />
+                                              
+                                  </span>
+                                  <span
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    "one"
+                                  </span>
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                              
+                                  </span>
+                                  <span
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    "two"
+                                  </span>
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                              
+                                  </span>
+                                  <span
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    "three"
+                                  </span>
+                                </span>
+                                <span>
+                                  <br />
+                                          
+                                </span>
+                                ]
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                          
+                                </span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  object2
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#666"
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                              
+                                  </span>
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    object
                                   </span>
                                 </span>
                                 : 
@@ -3032,7 +3169,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span>
                                     <span>
                                       <br />
-                                                
+                                                  
                                     </span>
                                     <span
                                       style="color:#666"
@@ -3044,13 +3181,13 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    one
+                                    "one"
                                   </span>
                                   ,
                                   <span>
                                     <span>
                                       <br />
-                                                
+                                                  
                                     </span>
                                     <span
                                       style="color:#666"
@@ -3062,13 +3199,13 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    two
+                                    "two"
                                   </span>
                                   ,
                                   <span>
                                     <span>
                                       <br />
-                                                
+                                                  
                                     </span>
                                     <span
                                       style="color:#666"
@@ -3080,11 +3217,11 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    three
+                                    "three"
                                   </span>
                                   <span>
                                     <br />
-                                            
+                                              
                                   </span>
                                   }
                                 </span>
@@ -3092,7 +3229,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                 <span>
                                   <span>
                                     <br />
-                                            
+                                              
                                   </span>
                                   <span
                                     style="color:#666"
@@ -3108,182 +3245,48 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span>
                                     <span>
                                       <br />
-                                                
+                                                  
                                     </span>
                                     <span
                                       style="color:#22a;word-break:break-word"
                                     >
-                                      one
+                                      "one"
                                     </span>
                                   </span>
                                   ,
                                   <span>
                                     <span>
                                       <br />
-                                                
+                                                  
                                     </span>
                                     <span
                                       style="color:#22a;word-break:break-word"
                                     >
-                                      two
+                                      "two"
                                     </span>
                                   </span>
                                   ,
                                   <span>
                                     <span>
                                       <br />
-                                                
-                                    </span>
-                                    <span
-                                      style="color:#22a;word-break:break-word"
-                                    >
-                                      three
-                                    </span>
-                                  </span>
-                                  <span>
-                                    <br />
-                                            
-                                  </span>
-                                  ]
-                                </span>
-                                ,
-                                <span>
-                                  <span>
-                                    <br />
-                                            
-                                  </span>
-                                  <span
-                                    style="color:#666"
-                                  >
-                                    object2
-                                  </span>
-                                </span>
-                                : 
-                                <span
-                                  style="color:#666"
-                                >
-                                  {
-                                  <span>
-                                    <span>
-                                      <br />
-                                                
+                                                  
                                     </span>
                                     <span
                                       style="color:#666"
                                     >
-                                      object
-                                    </span>
-                                  </span>
-                                  : 
-                                  <span
-                                    style="color:#666"
-                                  >
-                                    {
-                                    <span>
+                                      {
                                       <span>
-                                        <br />
-                                                    
+                                        <span>
+                                          <br />
+                                                        
+                                        </span>
+                                        <span
+                                          style="color:#666"
+                                        >
+                                          object
+                                        </span>
                                       </span>
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        one
-                                      </span>
-                                    </span>
-                                    : 
-                                    <span
-                                      style="color:#22a;word-break:break-word"
-                                    >
-                                      one
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span>
-                                        <br />
-                                                    
-                                      </span>
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        two
-                                      </span>
-                                    </span>
-                                    : 
-                                    <span
-                                      style="color:#22a;word-break:break-word"
-                                    >
-                                      two
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span>
-                                        <br />
-                                                    
-                                      </span>
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        three
-                                      </span>
-                                    </span>
-                                    : 
-                                    <span
-                                      style="color:#22a;word-break:break-word"
-                                    >
-                                      three
-                                    </span>
-                                    <span>
-                                      <br />
-                                                
-                                    </span>
-                                    }
-                                  </span>
-                                  ,
-                                  <span>
-                                    <span>
-                                      <br />
-                                                
-                                    </span>
-                                    <span
-                                      style="color:#666"
-                                    >
-                                      array
-                                    </span>
-                                  </span>
-                                  : 
-                                  <span
-                                    style="color:#666"
-                                  >
-                                    [
-                                    <span>
-                                      <span>
-                                        <br />
-                                                    
-                                      </span>
-                                      <span
-                                        style="color:#22a;word-break:break-word"
-                                      >
-                                        one
-                                      </span>
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span>
-                                        <br />
-                                                    
-                                      </span>
-                                      <span
-                                        style="color:#22a;word-break:break-word"
-                                      >
-                                        two
-                                      </span>
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span>
-                                        <br />
-                                                    
-                                      </span>
+                                      : 
                                       <span
                                         style="color:#666"
                                       >
@@ -3291,7 +3294,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                         <span>
                                           <span>
                                             <br />
-                                                          
+                                                            
                                           </span>
                                           <span
                                             style="color:#666"
@@ -3307,182 +3310,165 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                           <span>
                                             <span>
                                               <br />
-                                                              
+                                                                
                                             </span>
                                             <span
                                               style="color:#666"
                                             >
-                                              object
+                                              one
                                             </span>
                                           </span>
                                           : 
                                           <span
-                                            style="color:#666"
+                                            style="color:#22a;word-break:break-word"
                                           >
-                                            {
-                                            <span>
-                                              <span>
-                                                <br />
-                                                                  
-                                              </span>
-                                              <span
-                                                style="color:#666"
-                                              >
-                                                one
-                                              </span>
-                                            </span>
-                                            : 
-                                            <span
-                                              style="color:#22a;word-break:break-word"
-                                            >
-                                              one
-                                            </span>
-                                            ,
-                                            <span>
-                                              <span>
-                                                <br />
-                                                                  
-                                              </span>
-                                              <span
-                                                style="color:#666"
-                                              >
-                                                two
-                                              </span>
-                                            </span>
-                                            : 
-                                            <span
-                                              style="color:#22a;word-break:break-word"
-                                            >
-                                              two
-                                            </span>
-                                            ,
-                                            <span>
-                                              <span>
-                                                <br />
-                                                                  
-                                              </span>
-                                              <span
-                                                style="color:#666"
-                                              >
-                                                three
-                                              </span>
-                                            </span>
-                                            : 
-                                            <span
-                                              style="color:#22a;word-break:break-word"
-                                            >
-                                              three
-                                            </span>
-                                            <span>
-                                              <br />
-                                                              
-                                            </span>
-                                            }
+                                            "one"
                                           </span>
                                           ,
                                           <span>
                                             <span>
                                               <br />
-                                                              
+                                                                
                                             </span>
                                             <span
                                               style="color:#666"
                                             >
-                                              array
+                                              two
                                             </span>
                                           </span>
                                           : 
                                           <span
-                                            style="color:#666"
+                                            style="color:#22a;word-break:break-word"
                                           >
-                                            [
-                                            <span>
-                                              <span>
-                                                <br />
-                                                                  
-                                              </span>
-                                              <span
-                                                style="color:#22a;word-break:break-word"
-                                              >
-                                                one
-                                              </span>
-                                            </span>
-                                            ,
-                                            <span>
-                                              <span>
-                                                <br />
-                                                                  
-                                              </span>
-                                              <span
-                                                style="color:#22a;word-break:break-word"
-                                              >
-                                                two
-                                              </span>
-                                            </span>
-                                            ,
-                                            <span>
-                                              <span>
-                                                <br />
-                                                                  
-                                              </span>
-                                              <span
-                                                style="color:#22a;word-break:break-word"
-                                              >
-                                                three
-                                              </span>
-                                            </span>
+                                            "two"
+                                          </span>
+                                          ,
+                                          <span>
                                             <span>
                                               <br />
-                                                              
+                                                                
                                             </span>
-                                            ]
+                                            <span
+                                              style="color:#666"
+                                            >
+                                              three
+                                            </span>
+                                          </span>
+                                          : 
+                                          <span
+                                            style="color:#22a;word-break:break-word"
+                                          >
+                                            "three"
                                           </span>
                                           <span>
                                             <br />
-                                                          
+                                                            
                                           </span>
                                           }
                                         </span>
+                                        ,
+                                        <span>
+                                          <span>
+                                            <br />
+                                                            
+                                          </span>
+                                          <span
+                                            style="color:#666"
+                                          >
+                                            array
+                                          </span>
+                                        </span>
+                                        : 
+                                        <span
+                                          style="color:#666"
+                                        >
+                                          [
+                                          <span>
+                                            <span>
+                                              <br />
+                                                                
+                                            </span>
+                                            <span
+                                              style="color:#22a;word-break:break-word"
+                                            >
+                                              "one"
+                                            </span>
+                                          </span>
+                                          ,
+                                          <span>
+                                            <span>
+                                              <br />
+                                                                
+                                            </span>
+                                            <span
+                                              style="color:#22a;word-break:break-word"
+                                            >
+                                              "two"
+                                            </span>
+                                          </span>
+                                          ,
+                                          <span>
+                                            <span>
+                                              <br />
+                                                                
+                                            </span>
+                                            <span
+                                              style="color:#22a;word-break:break-word"
+                                            >
+                                              "three"
+                                            </span>
+                                          </span>
+                                          <span>
+                                            <br />
+                                                            
+                                          </span>
+                                          ]
+                                        </span>
                                         <span>
                                           <br />
-                                                      
+                                                        
                                         </span>
                                         }
                                       </span>
+                                      <span>
+                                        <br />
+                                                    
+                                      </span>
+                                      }
                                     </span>
-                                    <span>
-                                      <br />
-                                                
-                                    </span>
-                                    ]
                                   </span>
                                   <span>
                                     <br />
-                                            
+                                              
                                   </span>
-                                  }
+                                  ]
                                 </span>
                                 <span>
                                   <br />
-                                        
+                                          
                                 </span>
                                 }
                               </span>
                               <span>
                                 <br />
-                                    
+                                      
                               </span>
                               }
                             </span>
+                            <span>
+                              <br />
+                                  
+                            </span>
+                            }
                           </span>
-                          <span>
-                            <br />
-                              
-                          </span>
-                          ]
                         </span>
-                        }
+                        <span>
+                          <br />
+                            
+                        </span>
+                        ]
                       </span>
+                      }
                     </span>
                   </span>
                   <br />
@@ -3770,57 +3756,55 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                   <span>
                     =
                     <span>
-                      <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
                         {
+                        <span>
+                          <span
+                            style="color:#666"
+                          >
+                            one
+                          </span>
+                        </span>
+                        : 
                         <span
-                          style="color:#666"
+                          style="color:#22a;word-break:break-word"
                         >
-                          {
-                          <span>
-                            <span
-                              style="color:#666"
-                            >
-                              one
-                            </span>
-                          </span>
-                          : 
+                          "Object and array properties"
+                        </span>
+                        ,
+                        <span>
                           <span
-                            style="color:#22a;word-break:break-word"
+                            style="color:#666"
                           >
-                            Object and array properties
+                            two
                           </span>
-                          ,
-                          <span>
-                            <span
-                              style="color:#666"
-                            >
-                              two
-                            </span>
-                          </span>
-                          : 
+                        </span>
+                        : 
+                        <span
+                          style="color:#22a;word-break:break-word"
+                        >
+                          "will be broken to different lines"
+                        </span>
+                        ,
+                        <span>
                           <span
-                            style="color:#22a;word-break:break-word"
+                            style="color:#666"
                           >
-                            will be broken to different lines
+                            three
                           </span>
-                          ,
-                          <span>
-                            <span
-                              style="color:#666"
-                            >
-                              three
-                            </span>
-                          </span>
-                          : 
-                          <span
-                            style="color:#22a;word-break:break-word"
-                          >
-                            if greater than \`maxPropsIntoLine\` option threshol…
-                          </span>
-                          }
+                        </span>
+                        : 
+                        <span
+                          style="color:#22a;word-break:break-word"
+                        >
+                          "if greater than \`maxPropsIntoLine\` option threshol…"
                         </span>
                         }
                       </span>
+                      }
                     </span>
                   </span>
                 </span>
@@ -3835,63 +3819,61 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                   <span>
                     =
                     <span>
-                      <span>
-                        {
-                        <span
-                          style="color:#666"
-                        >
-                          [
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#22a;word-break:break-word"
-                            >
-                              one
-                            </span>
-                          </span>
-                          ,
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#22a;word-break:break-word"
-                            >
-                              two
-                            </span>
-                          </span>
-                          ,
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            <span
-                              style="color:#22a;word-break:break-word"
-                            >
-                              three
-                            </span>
-                          </span>
-                          ,
-                          <span>
-                            <span>
-                              <br />
-                                  
-                            </span>
-                            …
-                          </span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        [
+                        <span>
                           <span>
                             <br />
-                              
+                                
                           </span>
-                          ]
+                          <span
+                            style="color:#22a;word-break:break-word"
+                          >
+                            "one"
+                          </span>
                         </span>
-                        }
+                        ,
+                        <span>
+                          <span>
+                            <br />
+                                
+                          </span>
+                          <span
+                            style="color:#22a;word-break:break-word"
+                          >
+                            "two"
+                          </span>
+                        </span>
+                        ,
+                        <span>
+                          <span>
+                            <br />
+                                
+                          </span>
+                          <span
+                            style="color:#22a;word-break:break-word"
+                          >
+                            "three"
+                          </span>
+                        </span>
+                        ,
+                        <span>
+                          <span>
+                            <br />
+                                
+                          </span>
+                          …
+                        </span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        ]
                       </span>
+                      }
                     </span>
                   </span>
                 </span>
@@ -3906,13 +3888,52 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                   <span>
                     =
                     <span>
-                      <span>
-                        {
-                        <span
-                          style="color:#666"
-                        >
-                          [
-                          <span>
+                      {
+                      <span
+                        style="color:#666"
+                      >
+                        [
+                        <span>
+                          <span
+                            style="color:#666"
+                          >
+                            {
+                            <span>
+                              <span
+                                style="color:#666"
+                              >
+                                one
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style="color:#22a;word-break:break-word"
+                            >
+                              "Object and array properties will be broken to diff…"
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style="color:#666"
+                              >
+                                two
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style="color:#22a;word-break:break-word"
+                            >
+                              "if greater than \`maxPropsIntoLine\` option threshol…"
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style="color:#666"
+                              >
+                                object
+                              </span>
+                            </span>
+                            : 
                             <span
                               style="color:#666"
                             >
@@ -3921,35 +3942,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                 <span
                                   style="color:#666"
                                 >
-                                  one
-                                </span>
-                              </span>
-                              : 
-                              <span
-                                style="color:#22a;word-break:break-word"
-                              >
-                                Object and array properties will be broken to diff…
-                              </span>
-                              ,
-                              <span>
-                                <span
-                                  style="color:#666"
-                                >
-                                  two
-                                </span>
-                              </span>
-                              : 
-                              <span
-                                style="color:#22a;word-break:break-word"
-                              >
-                                if greater than \`maxPropsIntoLine\` option threshol…
-                              </span>
-                              ,
-                              <span>
-                                <span
-                                  style="color:#666"
-                                >
-                                  object
+                                  object1
                                 </span>
                               </span>
                               : 
@@ -3961,7 +3954,101 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#666"
                                   >
-                                    object1
+                                    one
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#22a;word-break:break-word"
+                                >
+                                  "one"
+                                </span>
+                                ,
+                                <span>
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    two
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#22a;word-break:break-word"
+                                >
+                                  "two"
+                                </span>
+                                ,
+                                <span>
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    three
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style="color:#22a;word-break:break-word"
+                                >
+                                  "three"
+                                </span>
+                                }
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  array
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#666"
+                              >
+                                [
+                                <span>
+                                  <span
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    "one"
+                                  </span>
+                                </span>
+                                ,
+                                <span>
+                                  <span
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    "two"
+                                  </span>
+                                </span>
+                                ,
+                                <span>
+                                  <span
+                                    style="color:#22a;word-break:break-word"
+                                  >
+                                    "three"
+                                  </span>
+                                </span>
+                                ]
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  object2
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#666"
+                              >
+                                {
+                                <span>
+                                  <span
+                                    style="color:#666"
+                                  >
+                                    object
                                   </span>
                                 </span>
                                 : 
@@ -3980,7 +4067,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    one
+                                    "one"
                                   </span>
                                   ,
                                   <span>
@@ -3994,7 +4081,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    two
+                                    "two"
                                   </span>
                                   ,
                                   <span>
@@ -4008,7 +4095,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    three
+                                    "three"
                                   </span>
                                   }
                                 </span>
@@ -4029,7 +4116,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                     <span
                                       style="color:#22a;word-break:break-word"
                                     >
-                                      one
+                                      "one"
                                     </span>
                                   </span>
                                   ,
@@ -4037,117 +4124,23 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                     <span
                                       style="color:#22a;word-break:break-word"
                                     >
-                                      two
+                                      "two"
                                     </span>
-                                  </span>
-                                  ,
-                                  <span>
-                                    <span
-                                      style="color:#22a;word-break:break-word"
-                                    >
-                                      three
-                                    </span>
-                                  </span>
-                                  ]
-                                </span>
-                                ,
-                                <span>
-                                  <span
-                                    style="color:#666"
-                                  >
-                                    object2
-                                  </span>
-                                </span>
-                                : 
-                                <span
-                                  style="color:#666"
-                                >
-                                  {
-                                  <span>
-                                    <span
-                                      style="color:#666"
-                                    >
-                                      object
-                                    </span>
-                                  </span>
-                                  : 
-                                  <span
-                                    style="color:#666"
-                                  >
-                                    {
-                                    <span>
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        one
-                                      </span>
-                                    </span>
-                                    : 
-                                    <span
-                                      style="color:#22a;word-break:break-word"
-                                    >
-                                      one
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        two
-                                      </span>
-                                    </span>
-                                    : 
-                                    <span
-                                      style="color:#22a;word-break:break-word"
-                                    >
-                                      two
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span
-                                        style="color:#666"
-                                      >
-                                        three
-                                      </span>
-                                    </span>
-                                    : 
-                                    <span
-                                      style="color:#22a;word-break:break-word"
-                                    >
-                                      three
-                                    </span>
-                                    }
                                   </span>
                                   ,
                                   <span>
                                     <span
                                       style="color:#666"
                                     >
-                                      array
-                                    </span>
-                                  </span>
-                                  : 
-                                  <span
-                                    style="color:#666"
-                                  >
-                                    [
-                                    <span>
-                                      <span
-                                        style="color:#22a;word-break:break-word"
-                                      >
-                                        one
+                                      {
+                                      <span>
+                                        <span
+                                          style="color:#666"
+                                        >
+                                          object
+                                        </span>
                                       </span>
-                                    </span>
-                                    ,
-                                    <span>
-                                      <span
-                                        style="color:#22a;word-break:break-word"
-                                      >
-                                        two
-                                      </span>
-                                    </span>
-                                    ,
-                                    <span>
+                                      : 
                                       <span
                                         style="color:#666"
                                       >
@@ -4168,113 +4161,100 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                             <span
                                               style="color:#666"
                                             >
-                                              object
+                                              one
                                             </span>
                                           </span>
                                           : 
                                           <span
-                                            style="color:#666"
+                                            style="color:#22a;word-break:break-word"
                                           >
-                                            {
-                                            <span>
-                                              <span
-                                                style="color:#666"
-                                              >
-                                                one
-                                              </span>
-                                            </span>
-                                            : 
-                                            <span
-                                              style="color:#22a;word-break:break-word"
-                                            >
-                                              one
-                                            </span>
-                                            ,
-                                            <span>
-                                              <span
-                                                style="color:#666"
-                                              >
-                                                two
-                                              </span>
-                                            </span>
-                                            : 
-                                            <span
-                                              style="color:#22a;word-break:break-word"
-                                            >
-                                              two
-                                            </span>
-                                            ,
-                                            <span>
-                                              <span
-                                                style="color:#666"
-                                              >
-                                                three
-                                              </span>
-                                            </span>
-                                            : 
-                                            <span
-                                              style="color:#22a;word-break:break-word"
-                                            >
-                                              three
-                                            </span>
-                                            }
+                                            "one"
                                           </span>
                                           ,
                                           <span>
                                             <span
                                               style="color:#666"
                                             >
-                                              array
+                                              two
                                             </span>
                                           </span>
                                           : 
                                           <span
-                                            style="color:#666"
+                                            style="color:#22a;word-break:break-word"
                                           >
-                                            [
-                                            <span>
-                                              <span
-                                                style="color:#22a;word-break:break-word"
-                                              >
-                                                one
-                                              </span>
+                                            "two"
+                                          </span>
+                                          ,
+                                          <span>
+                                            <span
+                                              style="color:#666"
+                                            >
+                                              three
                                             </span>
-                                            ,
-                                            <span>
-                                              <span
-                                                style="color:#22a;word-break:break-word"
-                                              >
-                                                two
-                                              </span>
-                                            </span>
-                                            ,
-                                            <span>
-                                              <span
-                                                style="color:#22a;word-break:break-word"
-                                              >
-                                                three
-                                              </span>
-                                            </span>
-                                            ]
+                                          </span>
+                                          : 
+                                          <span
+                                            style="color:#22a;word-break:break-word"
+                                          >
+                                            "three"
                                           </span>
                                           }
                                         </span>
+                                        ,
+                                        <span>
+                                          <span
+                                            style="color:#666"
+                                          >
+                                            array
+                                          </span>
+                                        </span>
+                                        : 
+                                        <span
+                                          style="color:#666"
+                                        >
+                                          [
+                                          <span>
+                                            <span
+                                              style="color:#22a;word-break:break-word"
+                                            >
+                                              "one"
+                                            </span>
+                                          </span>
+                                          ,
+                                          <span>
+                                            <span
+                                              style="color:#22a;word-break:break-word"
+                                            >
+                                              "two"
+                                            </span>
+                                          </span>
+                                          ,
+                                          <span>
+                                            <span
+                                              style="color:#22a;word-break:break-word"
+                                            >
+                                              "three"
+                                            </span>
+                                          </span>
+                                          ]
+                                        </span>
                                         }
                                       </span>
+                                      }
                                     </span>
-                                    ]
                                   </span>
-                                  }
+                                  ]
                                 </span>
                                 }
                               </span>
                               }
                             </span>
+                            }
                           </span>
-                          ]
                         </span>
-                        }
+                        ]
                       </span>
+                      }
                     </span>
                   </span>
                   <br />
@@ -6047,15 +6027,13 @@ exports[`Storyshots Addons|Info.React Docgen Comments from Flow declarations 1`]
                     <span>
                       =
                       <span>
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            clicked()
-                          </span>
-                          }
+                        {
+                        <span
+                          style="color:#170"
+                        >
+                          clicked()
                         </span>
+                        }
                       </span>
                     </span>
                   </span>
@@ -6292,27 +6270,31 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                 </span>
                 <span>
                   <span>
-                     
+                    <span>
+                      <br />
+                        
+                    </span>
                     <span>
                       onClick
                     </span>
                     <span>
                       =
                       <span>
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            clicked()
-                          </span>
-                          }
+                        {
+                        <span
+                          style="color:#170"
+                        >
+                          clicked()
                         </span>
+                        }
                       </span>
                     </span>
                   </span>
                   <span>
-                     
+                    <span>
+                      <br />
+                        
+                    </span>
                     <span>
                       label
                     </span>
@@ -6328,7 +6310,202 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                         "
                       </span>
                     </span>
-                     
+                  </span>
+                  <span>
+                    <span>
+                      <br />
+                        
+                    </span>
+                    <span>
+                      one
+                    </span>
+                    <span>
+                      =
+                      <span>
+                        {
+                        <span
+                          style="color:#666"
+                        >
+                          {
+                          <span>
+                            <span
+                              style="color:#666"
+                            >
+                              key
+                            </span>
+                          </span>
+                          : 
+                          <span
+                            style="color:#a11"
+                          >
+                            1
+                          </span>
+                          }
+                        </span>
+                        }
+                      </span>
+                    </span>
+                  </span>
+                  <span>
+                    <span>
+                      <br />
+                        
+                    </span>
+                    <span>
+                      shape
+                    </span>
+                    <span>
+                      =
+                      <span>
+                        {
+                        <span
+                          style="color:#666"
+                        >
+                          {
+                          <span>
+                            <span>
+                              <br />
+                                  
+                            </span>
+                            <span
+                              style="color:#666"
+                            >
+                              id
+                            </span>
+                          </span>
+                          : 
+                          <span
+                            style="color:#a11"
+                          >
+                            3
+                          </span>
+                          ,
+                          <span>
+                            <span>
+                              <br />
+                                  
+                            </span>
+                            <span
+                              style="color:#666"
+                            >
+                              arr
+                            </span>
+                          </span>
+                          : 
+                          <span
+                            style="color:#666"
+                          >
+                            []
+                          </span>
+                          ,
+                          <span>
+                            <span>
+                              <br />
+                                  
+                            </span>
+                            <span
+                              style="color:#666"
+                            >
+                              shape
+                            </span>
+                          </span>
+                          : 
+                          <span
+                            style="color:#666"
+                          >
+                            {
+                            <span>
+                              <span
+                                style="color:#666"
+                              >
+                                shape
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style="color:#666"
+                            >
+                              {
+                              <span>
+                                <span
+                                  style="color:#666"
+                                >
+                                  foo
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style="color:#22a;word-break:break-word"
+                              >
+                                "bar"
+                              </span>
+                              }
+                            </span>
+                            }
+                          </span>
+                          ,
+                          <span>
+                            <span>
+                              <br />
+                                  
+                            </span>
+                            …
+                          </span>
+                          <span>
+                            <br />
+                              
+                          </span>
+                          }
+                        </span>
+                        }
+                      </span>
+                    </span>
+                  </span>
+                  <span>
+                    <span>
+                      <br />
+                        
+                    </span>
+                    <span>
+                      arrayOf
+                    </span>
+                    <span>
+                      =
+                      <span>
+                        {
+                        <span
+                          style="color:#666"
+                        >
+                          [
+                          <span>
+                            <span
+                              style="color:#a11"
+                            >
+                              1
+                            </span>
+                          </span>
+                          ,
+                          <span>
+                            <span
+                              style="color:#a11"
+                            >
+                              2
+                            </span>
+                          </span>
+                          ,
+                          <span>
+                            <span
+                              style="color:#a11"
+                            >
+                              3
+                            </span>
+                          </span>
+                          ]
+                        </span>
+                        }
+                      </span>
+                    </span>
+                    <br />
                   </span>
                 </span>
                 <span
@@ -6646,7 +6823,7 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                       <span
                         style="color:#22a;word-break:break-word"
                       >
-                        value
+                        "value"
                       </span>
                       }
                     </span>
@@ -7036,15 +7213,13 @@ exports[`Storyshots Addons|Info.React Docgen Comments from component declaration
                     <span>
                       =
                       <span>
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            clicked()
-                          </span>
-                          }
+                        {
+                        <span
+                          style="color:#170"
+                        >
+                          clicked()
                         </span>
+                        }
                       </span>
                     </span>
                   </span>
@@ -7340,15 +7515,13 @@ exports[`Storyshots Addons|Info.React Docgen Comments from named export componen
                     <span>
                       =
                       <span>
-                        <span>
-                          {
-                          <span
-                            style="color:#170"
-                          >
-                            clicked()
-                          </span>
-                          }
+                        {
+                        <span
+                          style="color:#170"
+                        >
+                          clicked()
                         </span>
+                        }
                       </span>
                     </span>
                   </span>

--- a/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
@@ -2806,7 +2806,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Object and array properties"
+                          'Object and array properties'
                         </span>
                         ,
                         <span>
@@ -2824,7 +2824,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "will be broken to different lines"
+                          'will be broken to different lines'
                         </span>
                         ,
                         <span>
@@ -2842,7 +2842,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "if greater than \`maxPropsIntoLine\` option threshol…"
+                          'if greater than \`maxPropsIntoLine\` option threshol…'
                         </span>
                         <span>
                           <br />
@@ -2878,7 +2878,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                           <span
                             style="color:#22a;word-break:break-word"
                           >
-                            "one"
+                            'one'
                           </span>
                         </span>
                         ,
@@ -2890,7 +2890,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                           <span
                             style="color:#22a;word-break:break-word"
                           >
-                            "two"
+                            'two'
                           </span>
                         </span>
                         ,
@@ -2902,7 +2902,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                           <span
                             style="color:#22a;word-break:break-word"
                           >
-                            "three"
+                            'three'
                           </span>
                         </span>
                         ,
@@ -2963,7 +2963,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                             <span
                               style="color:#22a;word-break:break-word"
                             >
-                              "Object and array properties will be broken to diff…"
+                              'Object and array properties will be broken to diff…'
                             </span>
                             ,
                             <span>
@@ -2981,7 +2981,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                             <span
                               style="color:#22a;word-break:break-word"
                             >
-                              "if greater than \`maxPropsIntoLine\` option threshol…"
+                              'if greater than \`maxPropsIntoLine\` option threshol…'
                             </span>
                             ,
                             <span>
@@ -3031,7 +3031,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                 <span
                                   style="color:#22a;word-break:break-word"
                                 >
-                                  "one"
+                                  'one'
                                 </span>
                                 ,
                                 <span>
@@ -3049,7 +3049,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                 <span
                                   style="color:#22a;word-break:break-word"
                                 >
-                                  "two"
+                                  'two'
                                 </span>
                                 ,
                                 <span>
@@ -3067,7 +3067,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                 <span
                                   style="color:#22a;word-break:break-word"
                                 >
-                                  "three"
+                                  'three'
                                 </span>
                                 <span>
                                   <br />
@@ -3100,7 +3100,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "one"
+                                    'one'
                                   </span>
                                 </span>
                                 ,
@@ -3112,7 +3112,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "two"
+                                    'two'
                                   </span>
                                 </span>
                                 ,
@@ -3124,7 +3124,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "three"
+                                    'three'
                                   </span>
                                 </span>
                                 <span>
@@ -3181,7 +3181,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "one"
+                                    'one'
                                   </span>
                                   ,
                                   <span>
@@ -3199,7 +3199,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "two"
+                                    'two'
                                   </span>
                                   ,
                                   <span>
@@ -3217,7 +3217,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "three"
+                                    'three'
                                   </span>
                                   <span>
                                     <br />
@@ -3250,7 +3250,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                     <span
                                       style="color:#22a;word-break:break-word"
                                     >
-                                      "one"
+                                      'one'
                                     </span>
                                   </span>
                                   ,
@@ -3262,7 +3262,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                     <span
                                       style="color:#22a;word-break:break-word"
                                     >
-                                      "two"
+                                      'two'
                                     </span>
                                   </span>
                                   ,
@@ -3322,7 +3322,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                           <span
                                             style="color:#22a;word-break:break-word"
                                           >
-                                            "one"
+                                            'one'
                                           </span>
                                           ,
                                           <span>
@@ -3340,7 +3340,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                           <span
                                             style="color:#22a;word-break:break-word"
                                           >
-                                            "two"
+                                            'two'
                                           </span>
                                           ,
                                           <span>
@@ -3358,7 +3358,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                           <span
                                             style="color:#22a;word-break:break-word"
                                           >
-                                            "three"
+                                            'three'
                                           </span>
                                           <span>
                                             <br />
@@ -3391,7 +3391,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span
                                               style="color:#22a;word-break:break-word"
                                             >
-                                              "one"
+                                              'one'
                                             </span>
                                           </span>
                                           ,
@@ -3403,7 +3403,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span
                                               style="color:#22a;word-break:break-word"
                                             >
-                                              "two"
+                                              'two'
                                             </span>
                                           </span>
                                           ,
@@ -3415,7 +3415,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 0 Object and array 
                                             <span
                                               style="color:#22a;word-break:break-word"
                                             >
-                                              "three"
+                                              'three'
                                             </span>
                                           </span>
                                           <span>
@@ -3772,7 +3772,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "Object and array properties"
+                          'Object and array properties'
                         </span>
                         ,
                         <span>
@@ -3786,7 +3786,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "will be broken to different lines"
+                          'will be broken to different lines'
                         </span>
                         ,
                         <span>
@@ -3800,7 +3800,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                         <span
                           style="color:#22a;word-break:break-word"
                         >
-                          "if greater than \`maxPropsIntoLine\` option threshol…"
+                          'if greater than \`maxPropsIntoLine\` option threshol…'
                         </span>
                         }
                       </span>
@@ -3832,7 +3832,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                           <span
                             style="color:#22a;word-break:break-word"
                           >
-                            "one"
+                            'one'
                           </span>
                         </span>
                         ,
@@ -3844,7 +3844,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                           <span
                             style="color:#22a;word-break:break-word"
                           >
-                            "two"
+                            'two'
                           </span>
                         </span>
                         ,
@@ -3856,7 +3856,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                           <span
                             style="color:#22a;word-break:break-word"
                           >
-                            "three"
+                            'three'
                           </span>
                         </span>
                         ,
@@ -3909,7 +3909,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                             <span
                               style="color:#22a;word-break:break-word"
                             >
-                              "Object and array properties will be broken to diff…"
+                              'Object and array properties will be broken to diff…'
                             </span>
                             ,
                             <span>
@@ -3923,7 +3923,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                             <span
                               style="color:#22a;word-break:break-word"
                             >
-                              "if greater than \`maxPropsIntoLine\` option threshol…"
+                              'if greater than \`maxPropsIntoLine\` option threshol…'
                             </span>
                             ,
                             <span>
@@ -3961,7 +3961,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                 <span
                                   style="color:#22a;word-break:break-word"
                                 >
-                                  "one"
+                                  'one'
                                 </span>
                                 ,
                                 <span>
@@ -3975,7 +3975,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                 <span
                                   style="color:#22a;word-break:break-word"
                                 >
-                                  "two"
+                                  'two'
                                 </span>
                                 ,
                                 <span>
@@ -3989,7 +3989,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                 <span
                                   style="color:#22a;word-break:break-word"
                                 >
-                                  "three"
+                                  'three'
                                 </span>
                                 }
                               </span>
@@ -4010,7 +4010,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "one"
+                                    'one'
                                   </span>
                                 </span>
                                 ,
@@ -4018,7 +4018,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "two"
+                                    'two'
                                   </span>
                                 </span>
                                 ,
@@ -4026,7 +4026,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "three"
+                                    'three'
                                   </span>
                                 </span>
                                 ]
@@ -4067,7 +4067,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "one"
+                                    'one'
                                   </span>
                                   ,
                                   <span>
@@ -4081,7 +4081,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "two"
+                                    'two'
                                   </span>
                                   ,
                                   <span>
@@ -4095,7 +4095,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                   <span
                                     style="color:#22a;word-break:break-word"
                                   >
-                                    "three"
+                                    'three'
                                   </span>
                                   }
                                 </span>
@@ -4116,7 +4116,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                     <span
                                       style="color:#22a;word-break:break-word"
                                     >
-                                      "one"
+                                      'one'
                                     </span>
                                   </span>
                                   ,
@@ -4124,7 +4124,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                     <span
                                       style="color:#22a;word-break:break-word"
                                     >
-                                      "two"
+                                      'two'
                                     </span>
                                   </span>
                                   ,
@@ -4168,7 +4168,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                           <span
                                             style="color:#22a;word-break:break-word"
                                           >
-                                            "one"
+                                            'one'
                                           </span>
                                           ,
                                           <span>
@@ -4182,7 +4182,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                           <span
                                             style="color:#22a;word-break:break-word"
                                           >
-                                            "two"
+                                            'two'
                                           </span>
                                           ,
                                           <span>
@@ -4196,7 +4196,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                           <span
                                             style="color:#22a;word-break:break-word"
                                           >
-                                            "three"
+                                            'three'
                                           </span>
                                           }
                                         </span>
@@ -4217,7 +4217,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                             <span
                                               style="color:#22a;word-break:break-word"
                                             >
-                                              "one"
+                                              'one'
                                             </span>
                                           </span>
                                           ,
@@ -4225,7 +4225,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                             <span
                                               style="color:#22a;word-break:break-word"
                                             >
-                                              "two"
+                                              'two'
                                             </span>
                                           </span>
                                           ,
@@ -4233,7 +4233,7 @@ exports[`Storyshots Addons|Info.Options.maxPropsIntoLine === 3 Object and array 
                                             <span
                                               style="color:#22a;word-break:break-word"
                                             >
-                                              "three"
+                                              'three'
                                             </span>
                                           </span>
                                           ]
@@ -6437,7 +6437,7 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                               <span
                                 style="color:#22a;word-break:break-word"
                               >
-                                "bar"
+                                'bar'
                               </span>
                               }
                             </span>
@@ -6823,7 +6823,7 @@ exports[`Storyshots Addons|Info.React Docgen Comments from PropType declarations
                       <span
                         style="color:#22a;word-break:break-word"
                       >
-                        "value"
+                        'value'
                       </span>
                       }
                     </span>

--- a/examples/official-storybook/stories/addon-info.stories.js
+++ b/examples/official-storybook/stories/addon-info.stories.js
@@ -15,7 +15,25 @@ storiesOf('Addons|Info.React Docgen', module)
     'Comments from PropType declarations',
     withInfo(
       'Comments above the PropType declarations should be extracted from the React component file itself and rendered in the Info Addon prop table'
-    )(() => <DocgenButton onClick={action('clicked')} label="Docgen Button" />)
+    )(() => (
+      <DocgenButton
+        onClick={action('clicked')}
+        label="Docgen Button"
+        disabled={false}
+        one={{ key: 1 }}
+        shape={{
+          id: 3,
+          arr: [],
+          shape: {
+            shape: {
+              foo: 'bar',
+            },
+          },
+          func: () => {},
+        }}
+        arrayOf={[1, 2, 3]}
+      />
+    ))
   )
   .add(
     'Comments from Flow declarations',

--- a/lib/cli/test/snapshots/meteor/package.json
+++ b/lib/cli/test/snapshots/meteor/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.26.3",
-    "babel-preset-env": "^1.6.1",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
     "babel-root-slash-import": "^1.1.0",


### PR DESCRIPTION
Issue:
Story Source block has a preview of code used. If preview has objects as properties, then you can not copy-paste it, because it renders redundant braces around nested values.
Preview: http://take.ms/alSVx

## What I did
I've added a prop `braceWrapped` for `PropVal` component, so braces get rendered for a first level entries only. Nested `PropVal` occurrences will no longer wrap themselves into braces.

## How to test
Look at the source of component that has deep object as a property.

Is this testable with Jest or Chromatic screenshots? yes
Does this need a new example in the kitchen sink apps? no
Does this need an update to the documentation? no
