### PR TITLE
Support webpack4 modules format

### DIFF
--- a/lib/core/src/client/preview/client_api.js
+++ b/lib/core/src/client/preview/client_api.js
@@ -85,7 +85,7 @@ export default class ClientApi {
       // wrap the first decorator and so on.
       const decorators = [...localDecorators, ...this._globalDecorators];
 
-      const fileName = m ? m.filename : null;
+      const fileName = m ? m.id : null;
 
       // Add the fully decorated getStory function.
       this._storyStore.addStory(kind, storyName, this._decorateStory(getStory, decorators), {

--- a/lib/core/src/client/preview/client_api.test.js
+++ b/lib/core/src/client/preview/client_api.test.js
@@ -214,10 +214,27 @@ describe('preview.client_api', () => {
   describe('reads filename from module', () => {
     const api = new ClientAPI();
     const story = jest.fn();
-    api.storiesOf('kind', { filename: 'foo.js' }).add('story', story);
+    api.storiesOf('kind', { id: 'foo.js' }).add('story', story);
     const storybook = api.getStorybook();
     expect(storybook).toEqual([
       { kind: 'kind', fileName: 'foo.js', stories: [{ name: 'story', render: expect.anything() }] },
+    ]);
+
+    storybook[0].stories[0].render();
+    expect(story).toHaveBeenCalled();
+  });
+
+  describe('reads filename from nodejs module', () => {
+    const api = new ClientAPI();
+    const story = jest.fn();
+    api.storiesOf('kind', module).add('story', story);
+    const storybook = api.getStorybook();
+    expect(storybook).toEqual([
+      {
+        kind: 'kind',
+        fileName: module.filename,
+        stories: [{ name: 'story', render: expect.anything() }],
+      },
     ]);
 
     storybook[0].stories[0].render();


### PR DESCRIPTION
Issue: storybook 4.0.0 does not pass `filename` to story context, as long module.filename is not defined.

## What I did

I've changed module.filename to module.name, and added one test, to test `storyOf` function agains real `module` variable. (double checked in browser)

## How to test

As usual. But you might need run storybook to test integration with webpack in real.

Not sure about keeping old way for accessing fileName, but, look like, it's obsolete.