### PR TITLE
[other] help: allow webpack.config.babel.js

### DIFF
--- a/lib/core/src/server/config.js
+++ b/lib/core/src/server/config.js
@@ -92,6 +92,7 @@ export default options => (configType, baseConfig, configDir) => {
     wrapInitialConfig = noopWrapper,
     wrapBasicConfig = noopWrapper,
     wrapDefaultConfig = noopWrapper,
+    webpackBabel = false,
   } = options;
 
   const config = wrapInitialConfig(baseConfig, configDir);
@@ -104,7 +105,7 @@ export default options => (configType, baseConfig, configDir) => {
 
   // Check whether user has a custom webpack config file and
   // return the (extended) base configuration if it's not available.
-  const customConfigPath = path.resolve(configDir, 'webpack.config.js');
+  const customConfigPath = path.resolve(configDir, webpackBabel ? 'webpack.config.babel.js' : 'webpack.config.js');
 
   if (!fs.existsSync(customConfigPath)) {
     informAboutCustomConfig(defaultConfigName);


### PR DESCRIPTION
## Issue:
I want to configure my custom webpack config with the latest syntax and have it transpile through babel, as webpack is fully capable of doing. 

The problem is that to import from my custom config, I already have `webpackBase.config.babel.js` files in my project.

## What I did
This PR is just the result of my digging through the codebase and trying to find where I would enable this manually. I would love if this was allowed though since webpack natively handles `.babel.js` files.

## How to test
Likely testable with Jest. This PR is just a POC / WIP /not mergeable atm but with help could get there.

Thanks!