### PR TITLE
Add missing semicolon to knobs addon readme

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -31,7 +31,7 @@ npm install @storybook/addon-knobs --save-dev
 Then, configure it as an addon by adding it to your `addons.js` file (located in the Storybook config directory).
 
 ```js
-import '@storybook/addon-knobs/register'
+import '@storybook/addon-knobs/register';
 ```
 
 Now, write your stories with knobs.


### PR DESCRIPTION

## What I did
Fix missing semicolon in knobs addon readme