### PR TITLE
fix(knobs): cancel debounced onChange on unmounting

### DIFF
--- a/addons/knobs/src/components/types/Array.js
+++ b/addons/knobs/src/components/types/Array.js
@@ -36,6 +36,10 @@ class ArrayType extends React.Component {
     this.onChange = debounce(this.props.onChange, 200);
   }
 
+  componentWillUnmount() {
+    this.onChange.cancel();
+  }
+
   handleChange = e => {
     const { knob } = this.props;
     const { value } = e.target;

--- a/addons/knobs/src/components/types/Color.js
+++ b/addons/knobs/src/components/types/Color.js
@@ -46,6 +46,7 @@ class ColorType extends React.Component {
   }
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.handleWindowMouseDown);
+    this.onChange.cancel();
   }
 
   handleWindowMouseDown = e => {

--- a/addons/knobs/src/components/types/Number.js
+++ b/addons/knobs/src/components/types/Number.js
@@ -45,6 +45,10 @@ class NumberType extends React.Component {
     this.onChange = debounce(props.onChange, 400);
   }
 
+  componentWillUnmount() {
+    this.onChange.cancel();
+  }
+
   handleChange = event => {
     const { value } = event.target;
 

--- a/addons/knobs/src/components/types/Object.js
+++ b/addons/knobs/src/components/types/Object.js
@@ -37,6 +37,10 @@ class ObjectType extends React.Component {
     this.onChange = debounce(props.onChange, 200);
   }
 
+  componentWillUnmount() {
+    this.onChange.cancel();
+  }
+
   handleChange = e => {
     const { value } = e.target;
 

--- a/addons/knobs/src/components/types/Text.js
+++ b/addons/knobs/src/components/types/Text.js
@@ -28,6 +28,10 @@ class TextType extends React.Component {
     this.onChange = debounce(props.onChange, 200);
   }
 
+  componentWillUnmount() {
+    this.onChange.cancel();
+  }
+
   handleChange = event => {
     const { value } = event.target;
 


### PR DESCRIPTION
Issue: The debounced onChange handlers in the knob components are not cancelled when the components are unmounted, which make cause edge cases where if the component is unmounted while the debounced function is still being called, an unhandled error might be thrown.

## What I did
Cancelled the debounced function on component unmount

## How to test
Too difficult to test reliably, but this is how it'd go:
1. In the kitchen-sink, use knobs to create some inputs which can be manipulated (text or number would be best)
2. In the knob/number component, change the debounce duration to be much bigger - say 2000ms (to demonstrate the edge case).
3. Open the storybook app and change the knob value really fast (press up key, for example)
4. Select some other component within 2 seconds - the issue should manifest itself.

Is this testable with Jest or Chromatic screenshots? No
Does this need a new example in the kitchen sink apps? No
Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
