### PR TITLE
Make all licenses consistent to MIT

### DIFF
--- a/examples/html-kitchen-sink/package.json
+++ b/examples/html-kitchen-sink/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "",
   "keywords": [],
-  "license": "ISC",
+  "license": "MIT",
   "author": "",
   "main": "index.js",
   "scripts": {

--- a/lib/ui/example/package.json
+++ b/lib/ui/example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.2",


### PR DESCRIPTION
Issue: All but 2 subprojects were licensed with `MIT`, while the remaining 2 were licensed under `ISC`. As I said in https://github.com/storybooks/storybook/pull/3572#discussion_r189438353:

> From what I could find, [there doesn't seem to be a major difference with MIT](https://gist.github.com/indexzero/10602128)

Maybe someone else knows whether there's a significant difference. Otherwise, this is a trivial change to keep the licensing consistent throughout the project.