### PR TITLE
Fix the output of the boolean knob

### DIFF
--- a/addons/knobs/src/components/PropField.js
+++ b/addons/knobs/src/components/PropField.js
@@ -23,23 +23,14 @@ const Label = styled('label')({
   fontWeight: 600,
 });
 
-export default class PropField extends React.Component {
-  onChange = e => {
-    this.props.onChange(e.target.value);
-  };
-
-  render() {
-    const { onChange, onClick, knob } = this.props;
-
-    const InputType = TypeMap[knob.type] || InvalidType;
-
-    return (
-      <Field>
-        <Label htmlFor={knob.name}>{!knob.hideLabel && `${knob.name}`}</Label>
-        <InputType knob={knob} onChange={onChange} onClick={onClick} />
-      </Field>
-    );
-  }
+export default function PropField({ onChange, onClick, knob }) {
+  const InputType = TypeMap[knob.type] || InvalidType;
+  return (
+    <Field>
+      <Label htmlFor={knob.name}>{!knob.hideLabel && `${knob.name}`}</Label>
+      <InputType knob={knob} onChange={onChange} onClick={onClick} />
+    </Field>
+  );
 }
 
 PropField.propTypes = {

--- a/addons/knobs/src/components/types/Boolean.js
+++ b/addons/knobs/src/components/types/Boolean.js
@@ -14,23 +14,16 @@ const Input = styled('input')({
   color: '#555',
 });
 
-class BooleanType extends React.Component {
-  render() {
-    const { knob, onChange } = this.props;
-
-    return (
-      <Input
-        id={knob.name}
-        ref={c => {
-          this.input = c;
-        }}
-        type="checkbox"
-        onChange={() => onChange(this.input.checked)}
-        checked={knob.value}
-      />
-    );
-  }
-}
+const BooleanType = ({ knob, onChange }) => (
+  <Input
+    id={knob.name}
+    type="checkbox"
+    onChange={e => {
+      onChange(e.target.checked);
+    }}
+    checked={knob.value}
+  />
+);
 
 BooleanType.defaultProps = {
   knob: {},

--- a/addons/knobs/src/components/types/Boolean.js
+++ b/addons/knobs/src/components/types/Boolean.js
@@ -18,9 +18,7 @@ const BooleanType = ({ knob, onChange }) => (
   <Input
     id={knob.name}
     type="checkbox"
-    onChange={e => {
-      onChange(e.target.checked);
-    }}
+    onChange={e => onChange(e.target.checked)}
     checked={knob.value}
   />
 );

--- a/addons/knobs/src/registerKnobs.js
+++ b/addons/knobs/src/registerKnobs.js
@@ -15,16 +15,12 @@ function setPaneKnobs(timestamp = +new Date()) {
 }
 
 function knobChanged(change) {
-  const { name, type, value } = change;
+  const { name, value } = change;
 
   // Update the related knob and it's value.
   const knobOptions = knobStore.get(name);
 
-  if (type === 'boolean') {
-    knobOptions.value = !knobOptions.value;
-  } else {
-    knobOptions.value = value;
-  }
+  knobOptions.value = value;
   knobStore.markAllUnused();
 
   forceReRender();

--- a/addons/knobs/src/registerKnobs.js
+++ b/addons/knobs/src/registerKnobs.js
@@ -15,12 +15,16 @@ function setPaneKnobs(timestamp = +new Date()) {
 }
 
 function knobChanged(change) {
-  const { name, value } = change;
+  const { name, type, value } = change;
 
   // Update the related knob and it's value.
   const knobOptions = knobStore.get(name);
 
-  knobOptions.value = value;
+  if (type === 'boolean') {
+    knobOptions.value = !knobOptions.value;
+  } else {
+    knobOptions.value = value;
+  }
   knobStore.markAllUnused();
 
   forceReRender();


### PR DESCRIPTION
Issue: While doing some work on fixing [an issue with the button knob discussed on Slack](https://storybooks.slack.com/archives/C55DBHZL0/p1526589520000555), I found out that the `boolean` knob's behaviour was also kind of broken: after the initial toggle the value of the knob would always return `undefined`. This was due to the incoming `change` object at https://github.com/storybooks/storybook/blob/master/addons/knobs/src/registerKnobs.js#L18 always being of the form: `{name: "name-of-knob", type: "boolean"}`, without a value. Easiest reproducible by adding a story with a boolean knob and just printing out its direct value.

## What I did
Change the behaviour when the incoming `change` object is of type `boolean`, to flip the current value.
