### PR TITLE
Remove deprecated addWithInfo

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,9 @@
 
 ## Table of contents
 
+-   [From version 3.4.x to 4.0.x](#from-version-34x-to-40x)
+    -   [Keyboard shortcuts moved](#keyboard-shortcuts-moved)
+    -   [Removed addWithInfo](#removed-add-with-info)
 -   [From version 3.3.x to 3.4.x](#from-version-33x-to-34x)
 -   [From version 3.2.x to 3.3.x](#from-version-32x-to-33x)
     -   [Refactored Knobs](#refactored-knobs)
@@ -19,11 +22,16 @@
 
 ## From 3.4.x to 4.0
 
-* Keyboard shortcuts have been moved:
+### Keyboard shortcuts moved
+
   - Addon Panel to `Z`
   - Stories Panel to `X`
   - Show Search to `O`
   - Addon Panel right side to `G`
+
+### Removed addWithInfo
+
+`Addon-info`'s `addWithInfo` has been marked deprecated since 3.2. In 4.0 we've removed it completely. See the package [README](https://github.com/storybooks/storybook/blob/master/addons/info/README.md) for the proper usage.
 
 ## From version 3.3.x to 3.4.x
 

--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -36,11 +36,11 @@ storiesOf('Component', module)
   .add('simple info',
     withInfo(`
       description or documentation about my component, supports markdown
-    
+
       ~~~js
       <Button>Click Here</Button>
       ~~~
-    
+
     `)(() =>
       <Component>Click the "?" mark at top-right to view the info.</Component>
     )
@@ -141,39 +141,7 @@ setDefaults({
 }
 ```
 
-## Deprecated usage
-
-There is also a deprecated API that is slated for removal in Storybook 4.0.
-
-```js
-import { configure, setAddon } from '@storybook/react';
-import infoAddon from '@storybook/addon-info';
-
-setAddon(infoAddon);
-
-configure(function () {
-  //...
-}, module);
-```
-
-Then create your stories with the `.addWithInfo` API.
-
-```js
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import Component from './Component';
-
-storiesOf('Component')
-  .addWithInfo(
-    'simple usage',
-    `This is the basic usage with the button with providing a label to show the text.`,
-    () => (
-      <Component>Click the "?" mark at top-right to view the info.</Component>
-    ),
-  );
-```
-
-> Have a look at [this example](example/story.js) stories to learn more about the `addWithInfo` API.
+## Customizing defaults
 
 To customize your defaults:
 

--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -147,7 +147,7 @@ To customize your defaults:
 
 ```js
 // config.js
-import infoAddon, { setDefaults } from '@storybook/addon-info';
+import { setDefaults } from '@storybook/addon-info';
 
 // addon-info
 setDefaults({
@@ -157,7 +157,6 @@ setDefaults({
   maxPropArrayLength: 10,
   maxPropStringLength: 100,
 });
-setAddon(infoAddon);
 ```
 
 ### Rendering a Custom Table

--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -24,8 +24,7 @@
     "prop-types": "^15.6.1",
     "react-addons-create-fragment": "^15.5.3",
     "react-emotion": "^9.1.3",
-    "react-lifecycles-compat": "^3.0.4",
-    "util-deprecate": "^1.0.2"
+    "react-lifecycles-compat": "^3.0.4"
   },
   "devDependencies": {
     "react-test-renderer": "^16.3.2"

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import deprecate from 'util-deprecate';
 import nestedObjectAssign from 'nested-object-assign';
 import { logger } from '@storybook/client-logger';
 import Story from './components/Story';
@@ -89,21 +88,6 @@ export const withInfo = textOrOptions => {
 };
 
 export { Story };
-
-export default {
-  addWithInfo: deprecate(function addWithInfo(storyName, text, storyFn, options) {
-    if (typeof storyFn !== 'function') {
-      if (typeof text === 'function') {
-        options = storyFn; // eslint-disable-line
-        storyFn = text; // eslint-disable-line
-        text = ''; // eslint-disable-line
-      } else {
-        throw new Error('No story defining function has been specified');
-      }
-    }
-    return this.add(storyName, withInfo({ text, ...options })(storyFn));
-  }, '@storybook/addon-info .addWithInfo() addon is deprecated, use withInfo() from the same package instead. \nSee https://github.com/storybooks/storybook/tree/master/addons/info'),
-};
 
 export function setDefaults(newDefaults) {
   return Object.assign(defaultOptions, newDefaults);

--- a/addons/info/src/index.test.js
+++ b/addons/info/src/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import AddonInfo, { withInfo, setDefaults } from './';
+import { withInfo, setDefaults } from './';
 import externalMdDocs from '../README.md';
 
 /* eslint-disable */
@@ -23,7 +23,6 @@ const TestComponent = ({ func, obj, array, number, string, bool, empty }) => (
   </div>);
 /* eslint-enable */
 
-const testContext = { kind: 'addon_info', story: 'jest_test' };
 const testOptions = { propTables: false };
 
 const testMarkdown = `# Test story
@@ -44,10 +43,6 @@ describe('addon Info', () => {
       />
     </div>
   );
-  const api = {
-    add: (name, fn) => fn(testContext),
-  };
-
   it('should render <Info /> and markdown', () => {
     const Info = withInfo(testMarkdown)(story);
 
@@ -66,9 +61,5 @@ describe('addon Info', () => {
     setDefaults(testOptions);
     const Info = withInfo()(story);
     mount(<Info />);
-  });
-  it('should show deprecation warning', () => {
-    const addWithInfo = AddonInfo.addWithInfo.bind(api);
-    addWithInfo('jest', story);
   });
 });

--- a/examples/cra-kitchen-sink/.storybook/config.js
+++ b/examples/cra-kitchen-sink/.storybook/config.js
@@ -1,8 +1,5 @@
-import { configure, setAddon } from '@storybook/react';
+import { configure } from '@storybook/react';
 import { setOptions } from '@storybook/addon-options';
-
-// deprecated usage of infoAddon
-import infoAddon from '@storybook/addon-info';
 
 setOptions({
   name: 'CRA Kitchen Sink',
@@ -16,9 +13,6 @@ setOptions({
   hierarchyRootSeparator: /\|/,
   enableShortcuts: false,
 });
-
-// deprecated usage of infoAddon
-setAddon(infoAddon);
 
 function loadStories() {
   // put welcome screen at the top of the list so it's the first one displayed

--- a/examples/cra-kitchen-sink/src/stories/index.js
+++ b/examples/cra-kitchen-sink/src/stories/index.js
@@ -167,15 +167,6 @@
 //       </div>
 //     );
 //   })
-//   .addWithInfo(
-//     'with some info',
-//     'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its painful API.',
-//     context => (
-//       <Container>
-//         click the <InfoButton /> label in top right for info about "{context.story}"
-//       </Container>
-//     )
-//   )
 //   .add(
 //     'with new info',
 //     withInfo(
@@ -229,22 +220,6 @@
 
 //   return <span>See action logger</span>;
 // });
-
-// storiesOf('AddonInfo.DocgenButton', module).addWithInfo('DocgenButton', 'Some Description', () => (
-//   <DocgenButton onClick={action('clicked')} label="Docgen Button" />
-// ));
-
-// storiesOf('AddonInfo.ImportedPropsButton', module).addWithInfo(
-//   'ImportedPropsButton',
-//   'Button with PropTypes imported from another file. Should fallback to using PropTypes for data.',
-//   () => <ImportedPropsButton onClick={action('clicked')} label="Docgen Button" />
-// );
-
-// storiesOf('AddonInfo.FlowTypeButton', module).addWithInfo(
-//   'FlowTypeButton',
-//   'Some Description',
-//   () => <FlowTypeButton onClick={action('clicked')} label="Flow Typed Button" />
-// );
 
 // storiesOf('App', module).add('full app', () => <App />);
 

--- a/examples/cra-kitchen-sink/src/stories/index.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/index.stories.js
@@ -56,15 +56,6 @@ storiesOf('Button', module)
     ),
     { notes: 'A very simple button' }
   )
-  .addWithInfo(
-    'with some info',
-    'Use the [info addon](https://github.com/storybooks/storybook/tree/master/addons/info) with its painful API.',
-    context => (
-      <Container>
-        click the <InfoButton /> label in top right for info about "{context.story}"
-      </Container>
-    )
-  )
   .add(
     'with new info',
     withInfo(


### PR DESCRIPTION
Issue: #3629

## What I did

Removed all references to `addWithInfo` and documented in MIGRATION.md.

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
