### PR TITLE
Removed deprecated react-native built-in addons

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,7 @@
 -   [From version 3.4.x to 4.0.x](#from-version-34x-to-40x)
     -   [Keyboard shortcuts moved](#keyboard-shortcuts-moved)
     -   [Removed addWithInfo](#removed-add-with-info)
+    -   [Removed RN addons](#removed-rn-addons)
 -   [From version 3.3.x to 3.4.x](#from-version-33x-to-34x)
 -   [From version 3.2.x to 3.3.x](#from-version-32x-to-33x)
     -   [Refactored Knobs](#refactored-knobs)
@@ -22,6 +23,8 @@
 
 ## From 3.4.x to 4.0
 
+With 4.0 as our first major release in over a year, we've collected a lot of cleanup tasks. All deprecations have been marked for months, so we hope that there will be no significant impact on your project.
+
 ### Keyboard shortcuts moved
 
   - Addon Panel to `Z`
@@ -32,6 +35,10 @@
 ### Removed addWithInfo
 
 `Addon-info`'s `addWithInfo` has been marked deprecated since 3.2. In 4.0 we've removed it completely. See the package [README](https://github.com/storybooks/storybook/blob/master/addons/info/README.md) for the proper usage.
+
+### Removed RN addons
+
+The `@storybook/react-native` had built-in addons (`addon-actions` and `addon-links`) that have been marked as deprecated since 3.x. They have been fully removed in 4.x. If your project still uses the built-ins, you'll need to add explicit dependencies on `@storybook/addon-actions` and/or `@storybook/addon-links` and import directly from those packages.
 
 ## From version 3.3.x to 3.4.x
 

--- a/app/react-native/addons.js
+++ b/app/react-native/addons.js
@@ -1,4 +1,0 @@
-// We are not using this file inside this project.
-// But, this will be useful when a user is configuring it's own addons.
-// Then he can import this file to add default set of addons.
-require('./dist/server/addons');

--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -61,7 +61,6 @@
     "react-native-iphone-x-helper": "^1.0.3",
     "shelljs": "^0.8.2",
     "url-parse": "^1.4.0",
-    "util-deprecate": "^1.0.2",
     "uuid": "^3.2.1",
     "webpack": "^4.8.3",
     "webpack-dev-middleware": "^3.1.3",

--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -25,8 +25,6 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
-    "@storybook/addon-actions": "4.0.0-alpha.7",
-    "@storybook/addon-links": "4.0.0-alpha.7",
     "@storybook/addons": "4.0.0-alpha.7",
     "@storybook/channel-websocket": "4.0.0-alpha.7",
     "@storybook/core": "4.0.0-alpha.7",

--- a/app/react-native/src/index.js
+++ b/app/react-native/src/index.js
@@ -1,9 +1,3 @@
-import deprecate from 'util-deprecate';
-
-// NOTE export these to keep backwards compatibility
-import { action as deprecatedAction } from '@storybook/addon-actions';
-import { linkTo as deprecatedLinkTo } from '@storybook/addon-links';
-
 import Preview from './preview';
 
 const preview = new Preview();
@@ -16,13 +10,3 @@ export const clearDecorators = preview.clearDecorators.bind(preview);
 export const configure = preview.configure.bind(preview);
 export const getStorybook = preview.getStorybook.bind(preview);
 export const getStorybookUI = preview.getStorybookUI.bind(preview);
-
-export const action = deprecate(
-  deprecatedAction,
-  '@storybook/react action is deprecated. See: https://github.com/storybooks/storybook/tree/master/addons/actions'
-);
-
-export const linkTo = deprecate(
-  deprecatedLinkTo,
-  '@storybook/react linkTo is deprecated. See: https://github.com/storybooks/storybook/tree/master/addons/links'
-);

--- a/app/react-native/src/server/addons.js
+++ b/app/react-native/src/server/addons.js
@@ -1,6 +1,0 @@
-import deprecate from 'util-deprecate';
-import '@storybook/addon-actions/register';
-import '@storybook/addon-links/register';
-
-deprecate(() => {},
-'@storybook/react-native/addons is deprecated. See https://storybook.js.org/addons/using-addons/')();


### PR DESCRIPTION
Issue: #3629

## What I did

- Remove deprecated react-native/addons
- Will finish this after #3630 is merged

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
