### PR TITLE
Remove status bar hiding

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ifIphoneX } from 'react-native-iphone-x-helper';
 
-import { Dimensions, View, TouchableWithoutFeedback, Image, Text, StatusBar } from 'react-native';
+import { Dimensions, View, TouchableWithoutFeedback, Image, Text } from 'react-native';
 import Events from '@storybook/core-events';
 import style from './style';
 import StoryListView from '../StoryListView';
@@ -36,7 +36,6 @@ export default class OnDeviceUI extends Component {
   componentDidMount() {
     Dimensions.addEventListener('change', this.handleDeviceRotation);
     this.props.events.on(Events.SELECT_STORY, this.handleStoryChange);
-    StatusBar.setHidden(true);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Issue: Hiding status bar throws errors on apps that don't support it.  Users can still manually hide status bar in react-native, but for users that cannot hide it this was simply breaking the app.

## What I did
Removed status bar hiding.
## How to test
N/A