### PR TITLE
Using only single channel for react native

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -50,7 +50,7 @@ export default class OnDeviceUI extends Component {
     });
   };
 
-  handleStoryChange = (storyFn, selection) => {
+  handleStoryChange = selection => {
     const { kind, story } = selection;
     this.setState({
       selectedKind: kind,

--- a/app/react-native/src/preview/components/StoryView/index.js
+++ b/app/react-native/src/preview/components/StoryView/index.js
@@ -21,7 +21,7 @@ export default class StoryView extends Component {
     this.props.events.removeListener(Events.FORCE_RE_RENDER, this.forceRender);
   }
 
-  selectStory(storyFn, selection) {
+  selectStory(selection, storyFn) {
     this.setState({ storyFn, selection });
   }
 

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -15,7 +15,6 @@ export default class Preview {
   constructor() {
     this._addons = {};
     this._decorators = [];
-    this._events = new EventEmitter();
     this._stories = new StoryStore();
     this._clientApi = new ClientApi({ storyStore: this._stories });
 
@@ -51,34 +50,38 @@ export default class Preview {
         // which is fine in this case (we will define it below)
       }
 
-      if (params.resetStorybook || !channel) {
-        const host = params.host || parse(NativeModules.SourceCode.scriptURL).hostname;
-        const port = params.port !== false ? `:${params.port || 7007}` : '';
+      if (!channel || params.resetStorybook) {
+        if (params.onDeviceUI && !params.useWebsockets) {
+          channel = new EventEmitter();
+        } else {
+          const host = params.host || parse(NativeModules.SourceCode.scriptURL).hostname;
+          const port = params.port !== false ? `:${params.port || 7007}` : '';
 
-        const query = params.query || '';
-        const { secured } = params;
-        const websocketType = secured ? 'wss' : 'ws';
-        const httpType = secured ? 'https' : 'http';
+          const query = params.query || '';
+          const { secured } = params;
+          const websocketType = secured ? 'wss' : 'ws';
+          const httpType = secured ? 'https' : 'http';
 
-        const url = `${websocketType}://${host}${port}/${query}`;
-        webUrl = `${httpType}://${host}${port}`;
-        channel = createChannel({ url });
+          const url = `${websocketType}://${host}${port}/${query}`;
+          webUrl = `${httpType}://${host}${port}`;
+          channel = createChannel({ url });
+        }
+
         addons.setChannel(channel);
 
         channel.emit(Events.CHANNEL_CREATED);
       }
+
       channel.on(Events.GET_STORIES, () => this._sendSetStories());
       channel.on(Events.SET_CURRENT_STORY, d => this._selectStory(d));
-      channel.on(Events.FORCE_RE_RENDER, () => this._forceRender());
-      this._events.on(Events.SET_CURRENT_STORY, d => this._selectStory(d, true));
       this._sendSetStories();
       this._sendGetCurrentStory();
 
       // finally return the preview component
       return params.onDeviceUI ? (
-        <OnDeviceUI stories={this._stories} events={this._events} url={webUrl} />
+        <OnDeviceUI stories={this._stories} events={channel} url={webUrl} />
       ) : (
-        <StoryView url={webUrl} events={this._events} />
+        <StoryView url={webUrl} events={channel} />
       );
     };
   }
@@ -94,17 +97,10 @@ export default class Preview {
     channel.emit(Events.GET_CURRENT_STORY);
   }
 
-  _selectStory(selection, fromPreview) {
+  _selectStory(selection) {
     const { kind, story } = selection;
     const storyFn = this._stories.getStoryWithContext(kind, story);
-    if (fromPreview) {
-      const channel = addons.getChannel();
-      channel.emit(Events.SELECT_STORY, selection);
-    }
-    this._events.emit(Events.SELECT_STORY, storyFn, selection);
-  }
-
-  _forceRender() {
-    this._events.emit(Events.FORCE_RE_RENDER);
+    const channel = addons.getChannel();
+    channel.emit(Events.SELECT_STORY, selection, storyFn);
   }
 }


### PR DESCRIPTION
Issue:

Made sure that only one channel is used when working with React Native, so we can reach all events everywhere. If running without storybook server the channel is set to event emitter, otherwise it is websockets. This PR extends PR #3278. So it also solves websockets error.

I am not sure if this is a breaking change or not, I guess it is not common for user to use both websockets and on device ui at the same time. I don't want to mark this as a breaking change.