### PR TITLE
Don't scroll story on knob change

### DIFF
--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -17,11 +17,7 @@ setOptions({
   hierarchyRootSeparator: /\|/,
 });
 
-addDecorator(Story => (
-  <ThemeProvider theme={themes.normal}>
-    <Story />
-  </ThemeProvider>
-));
+addDecorator(story => <ThemeProvider theme={themes.normal}>{story()}</ThemeProvider>);
 
 configureViewport({
   viewports: {

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -139,8 +139,10 @@ export default function start(render, { decorateStory } = {}) {
       return;
     }
 
-    // Scroll to top of the page when changing story
-    document.documentElement.scrollTop = 0;
+    if (!forceRender) {
+      // Scroll to top of the page when changing story
+      document.documentElement.scrollTop = 0;
+    }
     previousRevision = revision;
     previousKind = selectedKind;
     previousStory = selectedStory;


### PR DESCRIPTION
Issue: When changing knobs, example is scrolled to top
