### PR TITLE
storysource: Add default parser option. Support prettier v0.13.0 ( #3…

### DIFF
--- a/addons/storysource/src/loader/default-options.js
+++ b/addons/storysource/src/loader/default-options.js
@@ -5,6 +5,7 @@ const defaultOptions = {
     bracketSpacing: true,
     trailingComma: 'es5',
     singleQuote: true,
+    parser: 'babylon',
   },
   uglyCommentsRegex: [/^eslint-.*/, /^global.*/],
 };


### PR DESCRIPTION
Issue: #3657 

## What I did

Add default parser option for prettier v0.13 in storysource

## How to test

> Is this testable with Jest or Chromatic screenshots?

Probably can't.

> Does this need a new example in the kitchen sink apps?

No.

> Does this need an update to the documentation?

No.

## Note

> I tried add parser: 'babylon' in default option. And it works.
> But I do not know if this modification alone is enough.

I try to make a PR of this comment on the ticket