### PR TITLE
Fix a broken link in the Default Config page

### DIFF
--- a/docs/src/pages/configurations/default-config/index.md
+++ b/docs/src/pages/configurations/default-config/index.md
@@ -28,7 +28,7 @@ Here are some key features of Storybook's Babel configurations.
 
 We have added ES2016 support with Babel for transpiling your JS code.
 In addition to that, we've added a few experimental features, like object spreading and async await.
-Check out our [source](https://github.com/storybooks/storybook/blob/master/app/react/src/server/config/babel.js#L19) to learn more about these plugins.
+Check out our [source](https://github.com/storybooks/storybook/blob/master/lib/core/src/server/config/babel.js#L4) to learn more about these plugins.
 
 ### .babelrc support
 


### PR DESCRIPTION
The source link in the ES2016+ Support section is currently broken. This PR will replace the link source with https://github.com/storybooks/storybook/blob/master/lib/core/src/server/config/babel.js#L4