### PR TITLE
addon-knobs: Make withKnobs accept story parameters

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -319,23 +319,25 @@ const groupId = 'GROUP-ID1';
 button(label, handler, groupId);
 ```
 
-### withKnobs vs withKnobsOptions
+### withKnobs options
 
-If you feel like this addon is not performing well enough there is an option to use `withKnobsOptions` instead of `withKnobs`.
+withKnobs also accepts two optional options as story parameters.
 Usage:
 
 ```js
 import { storiesOf } from '@storybook/react';
-import { withKnobsOptions } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 
 const stories = storiesOf('Storybook Knobs', module);
 
-stories.addDecorator(withKnobsOptions({
-  timestamps: true, // Doesn't emit events while user is typing.
-  escapeHTML: true // Escapes strings to be safe for inserting as innerHTML. This option is true by default in storybook for Vue, Angular, and Polymer, because those frameworks allow rendering plain HTML.
-                   // You can still set it to false, but it's strongly unrecommendend in cases when you host your storybook on some route of your main site or web app.
-
-}));
+stories.addDecorator(withKnobs)
+stories.add('story name', () => ..., {
+  knobs: {
+    timestamps: true, // Doesn't emit events while user is typing.
+    escapeHTML: true // Escapes strings to be safe for inserting as innerHTML. This option is true by default in storybook for Vue, Angular, and Polymer, because those frameworks allow rendering plain HTML.
+                     // You can still set it to false, but it's strongly unrecommendend in cases when you host your storybook on some route of your main site or web app.  
+  }
+});
 ```
 
 ## Typescript

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -1,4 +1,6 @@
-import addons from '@storybook/addons';
+import deprecate from 'util-deprecate';
+
+import addons, { makeDecorator } from '@storybook/addons';
 
 import { manager, registerKnobs } from './registerKnobs';
 
@@ -71,16 +73,22 @@ const defaultOptions = {
   escapeHTML: true,
 };
 
-export const withKnobsOptions = (options = {}) => storyFn => {
-  const allOptions = { ...defaultOptions, ...options };
+export const withKnobs = makeDecorator({
+  name: 'withKnobs',
+  parameterName: 'knobs',
+  skipIfNoParametersOrOptions: false,
+  wrapper: (getStory, context, { options, parameters }) => {
+    const storyOptions = parameters || options;
+    const allOptions = { ...defaultOptions, ...storyOptions };
 
-  manager.setOptions(allOptions);
-  const channel = addons.getChannel();
-  manager.setChannel(channel);
-  channel.emit('addon:knobs:setOptions', allOptions);
+    manager.setOptions(allOptions);
+    const channel = addons.getChannel();
+    manager.setChannel(channel);
+    channel.emit('addon:knobs:setOptions', allOptions);
 
-  registerKnobs();
-  return storyFn();
-};
+    registerKnobs();
+    return getStory(context);
+  },
+});
 
-export const withKnobs = withKnobsOptions();
+export const withKnobsOptions = deprecate(withKnobs, 'Use withKnobs directly');

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -91,4 +91,7 @@ export const withKnobs = makeDecorator({
   },
 });
 
-export const withKnobsOptions = deprecate(withKnobs, 'Use withKnobs directly');
+export const withKnobsOptions = deprecate(
+  withKnobs,
+  'withKnobsOptions is deprecated. Instead, you can pass options into withKnobs(options) directly, or use the knobs parameter.'
+);

--- a/examples/official-storybook/stories/__snapshots__/addon-knobs.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-knobs.stories.storyshot
@@ -6,6 +6,12 @@ exports[`Storyshots Addons|Knobs.withKnobs XSS safety 1`] = `
 </div>
 `;
 
+exports[`Storyshots Addons|Knobs.withKnobs accepts story parameters 1`] = `
+<div>
+  &lt;h1&gt;Hello&lt;/h1&gt;
+</div>
+`;
+
 exports[`Storyshots Addons|Knobs.withKnobs dynamic knobs 1`] = `
 <div>
   <div>
@@ -121,6 +127,12 @@ exports[`Storyshots Addons|Knobs.withKnobs tweaks static values organized in gro
       Whiskey
     </li>
   </ul>
+</div>
+`;
+
+exports[`Storyshots Addons|Knobs.withKnobs using options accepts options 1`] = `
+<div>
+  &lt;h1&gt;Hello&lt;/h1&gt;
 </div>
 `;
 

--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -181,7 +181,10 @@ storiesOf('Addons|Knobs.withKnobs', module)
         __html: text('Rendered string', '<img src="x" onerror="alert(\'XSS Attack\')" >'),
       }}
     />
-  ));
+  ))
+  .add('accepts story parameters', () => <div>{text('Rendered string', '<h1>Hello</h1>')}</div>, {
+    knobs: { escapeHTML: false },
+  });
 
 storiesOf('Addons|Knobs.withKnobsOptions', module)
   .addDecorator(

--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -186,6 +186,14 @@ storiesOf('Addons|Knobs.withKnobs', module)
     knobs: { escapeHTML: false },
   });
 
+storiesOf('Addons|Knobs.withKnobs using options', module)
+  .addDecorator(
+    withKnobs({
+      escapeHTML: false,
+    })
+  )
+  .add('accepts options', () => <div>{text('Rendered string', '<h1>Hello</h1>')}</div>);
+
 storiesOf('Addons|Knobs.withKnobsOptions', module)
   .addDecorator(
     withKnobsOptions({


### PR DESCRIPTION
Issue: #3625

## What I did

- use makeDectorator to upgrade withKnobs
- deprecate withKnobsOptions
- add a test story to official storybook
- update documentation

## How to test

The knobs stories all work as expected, plus a new story which renders escaped HTML using the story parameters:

https://5b0cab5fdd6a546f7624c1f0--storybooks-official.netlify.com/?knob-Rendered%20string=%3Ch1%3EHello%3C%2Fh1%3E&selectedKind=Addons%7CKnobs.withKnobs&selectedStory=accepts%20story%20parameters&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Fstories%2Fstories-panel



Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
