### PR TITLE
using disableWebsockets instead of useWebsockets

### DIFF
--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -149,6 +149,28 @@ The following parameters can be passed to the start command:
     Override the root(s) to be used by the packager
 ```
 
+## getStorybookUI Options
+
+You can pass these parameters to getStorybookUI call in your storybook entry point:
+
+```
+{
+    onDeviceUI: Boolean (false) 
+        -- display stories list on the device
+    disableWebsockets: Boolean (false) 
+        -- allows to display stories without running storybook server. Should be used with onDeviceUI
+    secured: Boolean (false) 
+        -- use wss/https instead of ws/http
+    host: String (NativeModules.SourceCode.scriptURL) 
+        -- host to use
+    port: Number (7007)
+        -- port to use
+    query: String ("") 
+        -- additional query string to pass to websockets
+}
+```
+
+
 ## Learn More
 
 Check the `docs` directory in this repo for more advanced setup guides and other info.

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -51,7 +51,7 @@ export default class Preview {
       }
 
       if (!channel || params.resetStorybook) {
-        if (params.onDeviceUI && !params.useWebsockets) {
+        if (params.onDeviceUI && params.disableWebsockets) {
           channel = new EventEmitter();
         } else {
           const host = params.host || parse(NativeModules.SourceCode.scriptURL).hostname;


### PR DESCRIPTION
Additional PR for #3636. As discussed with @shilman it would be better to maintain backwards compatibility with using both onDeviceUI and storybook server at the same time. So I swapped useWebsockets with disableWebsockets. So now if somebody will want to use storybook without server in the app he will have to pass in the disableWebsockets option. This will be described in some documentation when we start separating RN storybook into two parts.