### PR TITLE
Addon-a11y: Run analysis on demand

### DIFF
--- a/addons/a11y/src/components/Panel.js
+++ b/addons/a11y/src/components/Panel.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 
 import styled from 'react-emotion';
 
-import { CHECK_EVENT_ID } from '../shared';
+import Events from '@storybook/core-events';
+
+import { CHECK_EVENT_ID, RERUN_EVENT_ID, REQUEST_CHECK_EVENT_ID } from '../shared';
 
 import Tabs from './Tabs';
 import Report from './Report';
@@ -33,10 +35,20 @@ class Panel extends Component {
 
   componentDidMount() {
     this.props.channel.on(CHECK_EVENT_ID, this.onUpdate);
+    this.props.channel.on(Events.STORY_RENDERED, this.requestCheck);
+    this.props.channel.on(RERUN_EVENT_ID, this.requestCheck);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.active && this.props.active) {
+      this.requestCheck();
+    }
   }
 
   componentWillUnmount() {
     this.props.channel.removeListener(CHECK_EVENT_ID, this.onUpdate);
+    this.props.channel.removeListener(Events.STORY_RENDERED, this.requestCheck);
+    this.props.channel.removeListener(RERUN_EVENT_ID, this.requestCheck);
   }
 
   onUpdate = ({ passes, violations }) => {
@@ -44,6 +56,12 @@ class Panel extends Component {
       passes,
       violations,
     });
+  };
+
+  requestCheck = () => {
+    if (this.props.active) {
+      this.props.channel.emit(REQUEST_CHECK_EVENT_ID);
+    }
   };
 
   render() {

--- a/addons/a11y/src/components/Panel.js
+++ b/addons/a11y/src/components/Panel.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import styled from 'react-emotion';
 
-import Events from '@storybook/core-events';
+import { STORY_RENDERED } from '@storybook/core-events';
 
 import { CHECK_EVENT_ID, RERUN_EVENT_ID, REQUEST_CHECK_EVENT_ID } from '../shared';
 
@@ -35,7 +35,7 @@ class Panel extends Component {
 
   componentDidMount() {
     this.props.channel.on(CHECK_EVENT_ID, this.onUpdate);
-    this.props.channel.on(Events.STORY_RENDERED, this.requestCheck);
+    this.props.channel.on(STORY_RENDERED, this.requestCheck);
     this.props.channel.on(RERUN_EVENT_ID, this.requestCheck);
   }
 
@@ -47,7 +47,7 @@ class Panel extends Component {
 
   componentWillUnmount() {
     this.props.channel.removeListener(CHECK_EVENT_ID, this.onUpdate);
-    this.props.channel.removeListener(Events.STORY_RENDERED, this.requestCheck);
+    this.props.channel.removeListener(STORY_RENDERED, this.requestCheck);
     this.props.channel.removeListener(RERUN_EVENT_ID, this.requestCheck);
   }
 

--- a/addons/a11y/src/index.js
+++ b/addons/a11y/src/index.js
@@ -4,7 +4,7 @@ import addons from '@storybook/addons';
 import Events from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 
-import { CHECK_EVENT_ID, RERUN_EVENT_ID } from './shared';
+import { CHECK_EVENT_ID, REQUEST_CHECK_EVENT_ID } from './shared';
 
 let axeOptions = {};
 
@@ -23,11 +23,10 @@ const runA11yCheck = () => {
 
 const a11ySubscription = () => {
   const channel = addons.getChannel();
-  channel.on(Events.STORY_RENDERED, runA11yCheck);
-  channel.on(RERUN_EVENT_ID, runA11yCheck);
+  channel.on(REQUEST_CHECK_EVENT_ID, runA11yCheck);
+
   return () => {
-    channel.removeListener(Events.STORY_RENDERED, runA11yCheck);
-    channel.removeListener(RERUN_EVENT_ID, runA11yCheck);
+    channel.removeListener(REQUEST_CHECK_EVENT_ID, runA11yCheck);
   };
 };
 

--- a/addons/a11y/src/shared/index.js
+++ b/addons/a11y/src/shared/index.js
@@ -3,5 +3,6 @@ const ADDON_ID = '@storybook/addon-a11y';
 const PANEL_ID = `${ADDON_ID}/panel`;
 const CHECK_EVENT_ID = `${ADDON_ID}/check`;
 const RERUN_EVENT_ID = `${ADDON_ID}/rerun`;
+const REQUEST_CHECK_EVENT_ID = `${ADDON_ID}/request-check`;
 
-export { ADDON_ID, PANEL_ID, CHECK_EVENT_ID, RERUN_EVENT_ID };
+export { ADDON_ID, PANEL_ID, CHECK_EVENT_ID, RERUN_EVENT_ID, REQUEST_CHECK_EVENT_ID };


### PR DESCRIPTION
Issue: [3683 - a11y accessibility plugin slow on larger components
](https://github.com/storybooks/storybook/issues/3683)

## What I did
I moved around some event emitters, so that the a11y analysis is now run only if the accessibility addon is currently active. The test is also run whenever the addon _becomes_ active.

## How to test
In the UI, everything should work exactly the same.