### PR TITLE
[react-native] Fix Typescript Integration documentation

### DIFF
--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -107,7 +107,7 @@ First follow the instructions [here](https://github.com/ds300/react-native-types
 Now update your storybook `package.json` script to the following
 
     "scripts": {
-       "storybook": "storybook --metro-config $PWD/rn-cli.config.js"
+       "storybook": "storybook start -p 7007 --metro-config $PWD/rn-cli.config.js"
     }
 
 The metro bundler requires an absolute path to the config. The above setup assumes the `rn-cli.config.js` is in the root of your project or next to your `package.json`


### PR DESCRIPTION
Issue: `--metro-config` options is for `storybook-start`, so `storybook --metro-config $PWD/rn-cli.config.js` will be an error.

## What I did

Fix `## Seamless Typescript Integration` section in the react-native's README by adding `start` subcommand.

## How to test

This is just a documentation error.

Is this testable with Jest or Chromatic screenshots? No
Does this need a new example in the kitchen sink apps? No
Does this need an update to the documentation? Yes (Updated)