### PR TITLE
Fix centered addon for IE11

### DIFF
--- a/addons/centered/src/styles.js
+++ b/addons/centered/src/styles.js
@@ -7,11 +7,11 @@ const styles = {
     right: 0,
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
     overflow: 'auto',
   },
   innerStyle: {
     margin: 'auto',
+    maxHeight: '100%', // Hack for centering correctly in IE11
   },
 };
 

--- a/examples/angular-cli/src/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/angular-cli/src/stories/__snapshots__/addon-centered.stories.storyshot
@@ -13,7 +13,7 @@ exports[`Storyshots Addon|Centered centered component 1`] = `
     >
       <div
         ng-reflect-ng-style="[object Object]"
-        style="margin: auto;"
+        style="margin: auto; max-height: 100%;"
       >
         <storybook-app-root>
           <div
@@ -89,7 +89,7 @@ exports[`Storyshots Addon|Centered centered template 1`] = `
     >
       <div
         ng-reflect-ng-style="[object Object]"
-        style="margin: auto;"
+        style="margin: auto; max-height: 100%;"
       >
         <storybook-button-component
           _nghost-c6=""

--- a/examples/cra-kitchen-sink/src/stories/__snapshots__/index.stories.storyshot
+++ b/examples/cra-kitchen-sink/src/stories/__snapshots__/index.stories.storyshot
@@ -644,10 +644,10 @@ exports[`Storyshots Lifecycle logging 1`] = `
 
 exports[`Storyshots Some really long story kind description with text 1`] = `
 <div
-  style="position:fixed;top:0;left:0;bottom:0;right:0;display:flex;align-items:center;justify-content:center;overflow:auto"
+  style="position:fixed;top:0;left:0;bottom:0;right:0;display:flex;align-items:center;overflow:auto"
 >
   <div
-    style="margin:auto"
+    style="margin:auto;max-height:100%"
   >
     <button
       class="css-1qwzad5"

--- a/examples/html-kitchen-sink/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/html-kitchen-sink/stories/__snapshots__/addon-centered.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Addons|Centered button in center 1`] = `
 >
   <div
     id="sb-addon-centered-inner"
-    style="margin: auto;"
+    style="margin: auto; max-height: 100%;"
   >
     <button>
       I am a Button !

--- a/examples/official-storybook/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-centered.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`Storyshots Addons|Centered story 1 1`] = `
 <div
-  style="position:fixed;top:0;left:0;bottom:0;right:0;display:flex;align-items:center;justify-content:center;overflow:auto"
+  style="position:fixed;top:0;left:0;bottom:0;right:0;display:flex;align-items:center;overflow:auto"
 >
   <div
-    style="margin:auto"
+    style="margin:auto;max-height:100%"
   >
     <button>
       This story should be centered

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
@@ -5,13 +5,13 @@ exports[`Storyshots Addon|Centered rounded 1`] = `
   style="position: fixed; top: 0px; left: 0px; bottom: 0px; right: 0px; display: flex; overflow: auto;"
 >
   <div
-    style="margin: auto;"
+    style="margin: auto; max-height: 100%;"
   >
     <div
       style="position: fixed; top: 0px; left: 0px; bottom: 0px; right: 0px; display: flex; overflow: auto;"
     >
       <div
-        style="margin: auto;"
+        style="margin: auto; max-height: 100%;"
       >
         <button
           class="button rounded"


### PR DESCRIPTION
Issue:
https://github.com/storybooks/storybook/issues/2525

## What I did
Fix the style rules for centered add on so that it works correctly in IE11

## How to test

Look at centered add on in IE 11. Components will now be correctly centered

