### PR TITLE
Storyshots advanced config options

### DIFF
--- a/addons/storyshots/storyshots-core/.storybook/configTest.js
+++ b/addons/storyshots/storyshots-core/.storybook/configTest.js
@@ -1,0 +1,10 @@
+import { configure } from '@storybook/react';
+
+const req = require.context('../stories/required_with_context', true, /.stories.js$/);
+
+function loadStories() {
+  req.keys().forEach(filename => req(filename));
+  require('../stories/directly_required');
+}
+
+configure(loadStories, module);

--- a/addons/storyshots/storyshots-core/.storybook/configTest.js
+++ b/addons/storyshots/storyshots-core/.storybook/configTest.js
@@ -4,6 +4,7 @@ const req = require.context('../stories/required_with_context', true, /.stories.
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));
+  // eslint-disable-next-line global-require
   require('../stories/directly_required');
 }
 

--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -148,6 +148,22 @@ initStoryshots({
 
 ## Options
 
+### `config`
+
+The `config` parameter must be a function that helps to configure storybook like the `config.js` does.
+If it's not specified, storyshots will try to use [configPath](#configPath) parameter.
+
+```js
+import initStoryshots from '@storybook/addon-storyshots';
+
+initStoryshots({
+  config: ({ configure }) =>
+    configure(() => {
+      require('../stories/Button.story.js');
+    }, module),
+});
+```
+
 ### `configPath`
 
 By default, Storyshots assumes the config directory path for your project as below:
@@ -164,6 +180,21 @@ initStoryshots({
   configPath: '.my-storybook-config-dir'
 });
 ```
+
+`configPath` can also specify path to the `config.js` itself. In this case, config directory will be
+a base directory of the `configPath`. It may be useful when the `config.js` for test should differ from the
+original one. It also may be useful for separating tests to different test configs:
+
+```js
+initStoryshots({
+  configPath: '.my-storybook-config-dir/testConfig1.js'
+});
+
+initStoryshots({
+  configPath: '.my-storybook-config-dir/testConfig2.js'
+});
+```
+
 
 ### `suite`
 
@@ -299,7 +330,7 @@ The value is just a [settings](https://github.com/isaacs/node-glob#options) to a
 ```js
 initStoryshots({
   integrityOptions: { cwd: __dirname }, // it will start searching from the current directory
-  test: multiSnapshotWithOptions({}),
+  test: multiSnapshotWithOptions(),
 });
 ```
 

--- a/addons/storyshots/storyshots-core/src/frameworks/angular/loader.js
+++ b/addons/storyshots/storyshots-core/src/frameworks/angular/loader.js
@@ -1,6 +1,5 @@
-import runWithRequireContext from '../require_context';
 import hasDependency from '../hasDependency';
-import loadConfig from '../config-loader';
+import configure from '../configure';
 
 function setupAngularJestPreset() {
   // Angular + Jest + Storyshots = Crazy Shit:
@@ -20,14 +19,11 @@ function test(options) {
 function load(options) {
   setupAngularJestPreset();
 
-  const appOptions = require.requireActual('@storybook/angular/options').default;
+  const { configPath, config } = options;
+  const frameworkOptions = '@storybook/angular/options';
+  const storybook = require.requireActual('@storybook/angular');
 
-  const { content, contextOpts } = loadConfig({
-    configDirPath: options.configPath,
-    appOptions,
-  });
-
-  runWithRequireContext(content, contextOpts);
+  configure({ configPath, config, frameworkOptions, storybook });
 
   return {
     framework: 'angular',
@@ -35,7 +31,7 @@ function load(options) {
     renderShallowTree: () => {
       throw new Error('Shallow renderer is not supported for angular');
     },
-    storybook: require.requireActual('@storybook/angular'),
+    storybook,
   };
 }
 

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.js
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.js
@@ -1,0 +1,22 @@
+import loadConfig from './config-loader';
+import runWithRequireContext from './require_context';
+
+function configure(options) {
+  const { configPath = '.storybook', config, frameworkOptions, storybook } = options;
+
+  if (config && typeof config === 'function') {
+    config(storybook);
+    return;
+  }
+
+  const appOptions = require.requireActual(frameworkOptions).default;
+
+  const { content, contextOpts } = loadConfig({
+    configPath,
+    appOptions,
+  });
+
+  runWithRequireContext(content, contextOpts);
+}
+
+export default configure;

--- a/addons/storyshots/storyshots-core/src/frameworks/html/loader.js
+++ b/addons/storyshots/storyshots-core/src/frameworks/html/loader.js
@@ -1,6 +1,5 @@
 import global from 'global';
-import runWithRequireContext from '../require_context';
-import loadConfig from '../config-loader';
+import configure from '../configure';
 
 function test(options) {
   return options.framework === 'html';
@@ -9,14 +8,11 @@ function test(options) {
 function load(options) {
   global.STORYBOOK_ENV = 'html';
 
-  const appOptions = require.requireActual('@storybook/html/options').default;
+  const { configPath, config } = options;
+  const frameworkOptions = '@storybook/html/options';
+  const storybook = require.requireActual('@storybook/html');
 
-  const { content, contextOpts } = loadConfig({
-    configDirPath: options.configPath,
-    appOptions,
-  });
-
-  runWithRequireContext(content, contextOpts);
+  configure({ configPath, config, frameworkOptions, storybook });
 
   return {
     framework: 'html',
@@ -24,7 +20,7 @@ function load(options) {
     renderShallowTree: () => {
       throw new Error('Shallow renderer is not supported for HTML');
     },
-    storybook: require.requireActual('@storybook/html'),
+    storybook,
   };
 }
 

--- a/addons/storyshots/storyshots-core/src/frameworks/react/loader.js
+++ b/addons/storyshots/storyshots-core/src/frameworks/react/loader.js
@@ -1,26 +1,22 @@
-import runWithRequireContext from '../require_context';
+import configure from '../configure';
 import hasDependency from '../hasDependency';
-import loadConfig from '../config-loader';
 
 function test(options) {
   return options.framework === 'react' || (!options.framework && hasDependency('@storybook/react'));
 }
 
 function load(options) {
-  const appOptions = require.requireActual('@storybook/react/options').default;
+  const { configPath, config } = options;
+  const frameworkOptions = '@storybook/react/options';
+  const storybook = require.requireActual('@storybook/react');
 
-  const { content, contextOpts } = loadConfig({
-    configDirPath: options.configPath,
-    appOptions,
-  });
-
-  runWithRequireContext(content, contextOpts);
+  configure({ configPath, config, frameworkOptions, storybook });
 
   return {
     framework: 'react',
     renderTree: require.requireActual('./renderTree').default,
     renderShallowTree: require.requireActual('./renderShallowTree').default,
-    storybook: require.requireActual('@storybook/react'),
+    storybook,
   };
 }
 

--- a/addons/storyshots/storyshots-core/src/frameworks/rn/loader.js
+++ b/addons/storyshots/storyshots-core/src/frameworks/rn/loader.js
@@ -9,11 +9,22 @@ function test(options) {
   );
 }
 
+function configure(options, storybook) {
+  const { configPath = 'storybook', config } = options;
+
+  if (config && typeof config === 'function') {
+    config(storybook);
+    return;
+  }
+
+  const resolvedConfigPath = path.resolve(configPath);
+  require.requireActual(resolvedConfigPath);
+}
+
 function load(options) {
   const storybook = require.requireActual('@storybook/react-native');
 
-  const configPath = path.resolve(options.configPath || 'storybook');
-  require.requireActual(configPath);
+  configure(options, storybook);
 
   return {
     renderTree: require('../react/renderTree').default,

--- a/addons/storyshots/storyshots-core/src/frameworks/vue/loader.js
+++ b/addons/storyshots/storyshots-core/src/frameworks/vue/loader.js
@@ -1,7 +1,6 @@
 import global from 'global';
-import runWithRequireContext from '../require_context';
 import hasDependency from '../hasDependency';
-import loadConfig from '../config-loader';
+import configure from '../configure';
 
 function mockVueToIncludeCompiler() {
   jest.mock('vue', () => require.requireActual('vue/dist/vue.common.js'));
@@ -15,14 +14,11 @@ function load(options) {
   global.STORYBOOK_ENV = 'vue';
   mockVueToIncludeCompiler();
 
-  const appOptions = require.requireActual('@storybook/vue/options').default;
+  const { configPath, config } = options;
+  const frameworkOptions = '@storybook/vue/options';
+  const storybook = require.requireActual('@storybook/vue');
 
-  const { content, contextOpts } = loadConfig({
-    configDirPath: options.configPath,
-    appOptions,
-  });
-
-  runWithRequireContext(content, contextOpts);
+  configure({ configPath, config, frameworkOptions, storybook });
 
   return {
     framework: 'vue',
@@ -30,7 +26,7 @@ function load(options) {
     renderShallowTree: () => {
       throw new Error('Shallow renderer is not supported for vue');
     },
-    storybook: require.requireActual('@storybook/vue'),
+    storybook,
   };
 }
 

--- a/addons/storyshots/storyshots-core/src/test-bodies.js
+++ b/addons/storyshots/storyshots-core/src/test-bodies.js
@@ -1,6 +1,6 @@
 import 'jest-specific-snapshot';
 
-export const snapshotWithOptions = options => ({
+export const snapshotWithOptions = (options = {}) => ({
   story,
   context,
   renderTree,
@@ -27,7 +27,7 @@ export const snapshotWithOptions = options => ({
   return match(result);
 };
 
-export const multiSnapshotWithOptions = options => ({
+export const multiSnapshotWithOptions = (options = {}) => ({
   story,
   context,
   renderTree,
@@ -45,7 +45,7 @@ export function shallowSnapshot({ story, context, renderShallowTree, options = {
   expect(result).toMatchSnapshot();
 }
 
-export const renderWithOptions = options => ({ story, context, renderTree }) => {
+export const renderWithOptions = (options = {}) => ({ story, context, renderTree }) => {
   const result = renderTree(story, context, options);
 
   if (typeof result.then === 'function') {
@@ -55,6 +55,6 @@ export const renderWithOptions = options => ({ story, context, renderTree }) => 
   return undefined;
 };
 
-export const renderOnly = renderWithOptions({});
+export const renderOnly = renderWithOptions();
 
-export const snapshot = snapshotWithOptions({});
+export const snapshot = snapshotWithOptions();

--- a/addons/storyshots/storyshots-core/stories/directly_required/__snapshots__/index.foo
+++ b/addons/storyshots/storyshots-core/stories/directly_required/__snapshots__/index.foo
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Another Button with some emoji 1`] = `
+<button
+  className="css-1qwzad5"
+  onClick={[Function]}
+>
+  <span
+    aria-label="so cool"
+    role="img"
+  >
+    😀 😎 👍 💯
+  </span>
+</button>
+`;
+
+exports[`Storyshots Another Button with text 1`] = `
+<button
+  className="css-1qwzad5"
+  onClick={[Function]}
+>
+  Hello Button
+</button>
+`;

--- a/addons/storyshots/storyshots-core/stories/directly_required/__snapshots__/index@Another-_-Button@with-_-some-_-emoji.boo
+++ b/addons/storyshots/storyshots-core/stories/directly_required/__snapshots__/index@Another-_-Button@with-_-some-_-emoji.boo
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Another Button with some emoji 1`] = `
+<button
+  className="css-1qwzad5"
+  onClick={[Function]}
+>
+  <span
+    aria-label="so cool"
+    role="img"
+  >
+    😀 😎 👍 💯
+  </span>
+</button>
+`;

--- a/addons/storyshots/storyshots-core/stories/directly_required/__snapshots__/index@Another-_-Button@with-_-text.boo
+++ b/addons/storyshots/storyshots-core/stories/directly_required/__snapshots__/index@Another-_-Button@with-_-text.boo
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Another Button with text 1`] = `
+<button
+  className="css-1qwzad5"
+  onClick={[Function]}
+>
+  Hello Button
+</button>
+`;

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Button.stories.foo
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Button.stories.foo
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Button with some emoji 1`] = `
+<button
+  className="css-1qwzad5"
+  onClick={[Function]}
+>
+  <span
+    aria-label="so cool"
+    role="img"
+  >
+    😀 😎 👍 💯
+  </span>
+</button>
+`;
+
+exports[`Storyshots Button with text 1`] = `
+<button
+  className="css-1qwzad5"
+  onClick={[Function]}
+>
+  Hello Button
+</button>
+`;

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.foo
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.foo
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Welcome to Storybook 1`] = `
+<article
+  className="css-3qkdq7"
+>
+  <h1
+    className="css-0"
+  >
+    Welcome to storybook
+  </h1>
+  <p>
+    This is a UI component dev environment for your app.
+  </p>
+  <p>
+    We've added some basic stories inside the 
+    <code
+      className="css-1rxzob2"
+    >
+      src/stories
+    </code>
+     directory.
+    <br />
+    A story is a single state of one or more UI components. You can have as many stories as you want.
+    <br />
+    (Basically a story is like a visual test case.)
+  </p>
+  <p>
+    See these sample 
+    <button
+      className="css-1otf2jm"
+      onClick={[Function]}
+    >
+      stories
+    </button>
+     for a component called
+     
+    <code
+      className="css-1rxzob2"
+    >
+      Button
+    </code>
+    .
+  </p>
+  <p>
+    Just like that, you can add your own components as stories.
+    <br />
+    You can also edit those components and see changes right away.
+    <br />
+    (Try editing the 
+    <code
+      className="css-1rxzob2"
+    >
+      Button
+    </code>
+     stories located at
+     
+    <code
+      className="css-1rxzob2"
+    >
+      src/stories/index.js
+    </code>
+    .)
+  </p>
+  <p>
+    Usually we create stories with smaller UI components in the app.
+    <br />
+    Have a look at the
+     
+    <a
+      className="css-4d3lbr"
+      href="https://storybook.js.org/basics/writing-stories"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Writing Stories
+    </a>
+     
+    section in our documentation.
+  </p>
+  <p
+    className="css-1tzeee1"
+  >
+    <b>
+      NOTE:
+    </b>
+    <br />
+    Have a look at the 
+    <code
+      className="css-1rxzob2"
+    >
+      .storybook/webpack.config.js
+    </code>
+     to add webpack loaders and plugins you are using in this project.
+  </p>
+</article>
+`;

--- a/addons/storyshots/storyshots-core/stories/storyshot.configFunc.test.js
+++ b/addons/storyshots/storyshots-core/stories/storyshot.configFunc.test.js
@@ -1,0 +1,44 @@
+import path from 'path';
+import initStoryshots, { multiSnapshotWithOptions, Stories2SnapsConverter } from '../src';
+
+class AnotherStories2SnapsConverter extends Stories2SnapsConverter {
+  getSnapshotFileName(context) {
+    const { fileName, kind, story } = context;
+    const { dir, name } = path.parse(fileName);
+    const uniqueName = `${name}@${kind.replace(/ /g, '-_-')}@${story.replace(/ /g, '-_-')}`;
+    const { snapshotsDirName, snapshotExtension } = this.options;
+
+    return path.format({
+      dir: path.join(dir, snapshotsDirName),
+      name: uniqueName,
+      ext: snapshotExtension,
+    });
+  }
+
+  getPossibleStoriesFiles(storyshotFile) {
+    const { dir, name } = path.parse(storyshotFile);
+    const { storiesExtensions } = this.options;
+
+    const [fileName] = name.split('@');
+
+    return storiesExtensions.map(ext =>
+      path.format({
+        dir: path.dirname(dir),
+        name: fileName,
+        ext,
+      })
+    );
+  }
+}
+
+initStoryshots({
+  framework: 'react',
+  integrityOptions: { cwd: __dirname },
+  stories2snapsConverter: new AnotherStories2SnapsConverter({ snapshotExtension: '.boo' }),
+  config: ({ configure }) =>
+    configure(() => {
+      // eslint-disable-next-line global-require
+      require('../stories/directly_required');
+    }, module),
+  test: multiSnapshotWithOptions(),
+});

--- a/addons/storyshots/storyshots-core/stories/storyshot.specificConfig.test.js
+++ b/addons/storyshots/storyshots-core/stories/storyshot.specificConfig.test.js
@@ -1,0 +1,10 @@
+import path from 'path';
+import initStoryshots, { multiSnapshotWithOptions, Stories2SnapsConverter } from '../src';
+
+initStoryshots({
+  framework: 'react',
+  integrityOptions: { cwd: __dirname },
+  stories2snapsConverter: new Stories2SnapsConverter({ snapshotExtension: '.foo' }),
+  configPath: path.join(__dirname, '..', '.storybook', 'configTest.js'),
+  test: multiSnapshotWithOptions(),
+});

--- a/addons/storyshots/storyshots-core/stories/storyshot.test.js
+++ b/addons/storyshots/storyshots-core/stories/storyshot.test.js
@@ -6,5 +6,5 @@ initStoryshots({
   framework: 'react',
   integrityOptions: { cwd: __dirname },
   configPath: path.join(__dirname, '..', '.storybook'),
-  test: multiSnapshotWithOptions({}),
+  test: multiSnapshotWithOptions(),
 });

--- a/examples/angular-cli/angularshots.test.js
+++ b/examples/angular-cli/angularshots.test.js
@@ -5,5 +5,5 @@ initStoryshots({
   framework: 'angular',
   integrityOptions: { cwd: path.join(__dirname, 'src', 'stories') },
   configPath: path.join(__dirname, '.storybook'),
-  test: multiSnapshotWithOptions({}),
+  test: multiSnapshotWithOptions(),
 });

--- a/examples/html-kitchen-sink/tests/htmlshots.test.js
+++ b/examples/html-kitchen-sink/tests/htmlshots.test.js
@@ -5,5 +5,5 @@ initStoryshots({
   framework: 'html',
   integrityOptions: { cwd: path.resolve(__dirname, '../stories') },
   configPath: path.resolve(__dirname, '../.storybook'),
-  test: multiSnapshotWithOptions({}),
+  test: multiSnapshotWithOptions(),
 });

--- a/examples/vue-kitchen-sink/vueshots.test.js
+++ b/examples/vue-kitchen-sink/vueshots.test.js
@@ -5,5 +5,5 @@ initStoryshots({
   framework: 'vue',
   configPath: path.join(__dirname, '.storybook'),
   integrityOptions: { cwd: path.join(__dirname, 'src', 'stories') },
-  test: multiSnapshotWithOptions({}),
+  test: multiSnapshotWithOptions(),
 });


### PR DESCRIPTION
Issue: #3260

This PR is rebased on "storyshots-refactoring" branch because I didn't want to wait for the #3745 to be merged.

## What I did
1. Added an option to configure storybook inside the storyshot test.
2. `configPath` were only able to point on config dir, now it can also point on `config.js`
3. Added an optional parameter for the test functions to prevent using them like this : `multiSnapshotWithOptions({})`