### PR TITLE
Updated addon docs, removed deprecated Viewport component

### DIFF
--- a/addons/actions/README.md
+++ b/addons/actions/README.md
@@ -134,11 +134,11 @@ import { storiesOf } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions';
 
 storiesOf('button', module)
-  // Log mousovers on entire story and clicks on .btn
+  // Log mouseovers on entire story and clicks on .btn
   .addDecorator(withActions('mouseover', 'click .btn'))
   .add('with actions', () => `
     <div>
-      Clicks on this button will be logged: <button class="btn" type="button">Button</button>
+      Clicks on this button will be logged: <button className="btn" type="button">Button</button>
     </div>
   `);
 ```

--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -179,6 +179,10 @@ In order, all of them will be combined together, with a later call overriding th
 ```js
 {
   /**
+   * Text to display with storybook component
+   */
+  text?: string;
+  /**
    * Displays info inline vs click button to view
    * @default false
    */

--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -212,23 +212,3 @@ storiesOf('Decorator with object', module)
   .add('onViewportChange', () => <MobileFirstComponent />);
 
 ```
-
-## Viewport Component
-
-You can also change the default viewport for a single story using `Viewport` component
-
-```js
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { Viewport } from '@storybook/addon-viewport';
-
-// Collection
-storiesOf('Custom Default', module)
-  .add('iphone6p', () => (
-    <Viewport name="iphone6p">
-      <h1>
-        Do I look good on <b>iPhone 6 Plus</b>?
-      </h1>
-    </Viewport>
-  ));
-```


### PR DESCRIPTION
## What I did
I went through most of the `@storybook/addon-*` libs to update/add DefinitelyTyped/TypeScript definition files. Along the way I noticed a few typos or items being deprecated and still mentioned in the 4.0 docs.

## How to test
Check out my PR :)