### PR TITLE
angular-cli 6 assets as a glob-object compatibility fix

### DIFF
--- a/app/angular/src/server/angular-cli_utils.js
+++ b/app/angular/src/server/angular-cli_utils.js
@@ -38,6 +38,10 @@ export function normalizeAssetPatterns(assetPatterns, dirToSearch, sourceRoot) {
   }
 
   return assetPatterns.map(assetPattern => {
+    if (typeof assetPattern === 'object') {
+      return assetPattern;
+    }
+
     const assetPath = normalize(assetPattern);
     const resolvedSourceRoot = resolve(dirToSearch, sourceRoot);
     const resolvedAssetPath = resolve(dirToSearch, assetPath);


### PR DESCRIPTION
Issue: #3750

## What I did
Added a check if the asset is already an object