### PR TITLE
update package jest-image-snapshot

### DIFF
--- a/addons/storyshots/package.json
+++ b/addons/storyshots/package.json
@@ -22,7 +22,7 @@
     "babel-runtime": "^6.26.0",
     "glob": "^7.1.2",
     "global": "^4.3.2",
-    "jest-image-snapshot": "^2.4.0",
+    "jest-image-snapshot": "^2.4.3",
     "jest-specific-snapshot": "^0.5.0",
     "puppeteer": "^1.2.0",
     "read-pkg-up": "^3.0.0"


### PR DESCRIPTION
Issue:

## What I did
I updated jest-image-snapshot package to be able to use -u and -i in the jest watch mode. 
https://github.com/americanexpress/jest-image-snapshot/pull/77 - this pr was merged and is on the latest version of jest-image-snapshot. 
