### PR TITLE
Update Extend Mode webpack.config docu for Vuejs

### DIFF
--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -30,6 +30,12 @@ module.exports = {
         include: path.resolve(__dirname, "../")
       }
     ]
+  },
+  // This relevant only for Vuejs projects:
+  resolve: {
+    alias: {
+      vue: 'vue/dist/vue.js'
+    }
   }
 };
 ```


### PR DESCRIPTION
After long struggle with adding storybook on my Vuejs project with sass support I have found that additional resolve section must be added to the webpack.config.js file - I think that this can spare some time to others.

Issue:

## What I did

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
