### PR TITLE
Display functions as variables not invocations

### DIFF
--- a/addons/info/src/components/PropVal.js
+++ b/addons/info/src/components/PropVal.js
@@ -219,7 +219,7 @@ function PropVal(props) {
       />
     );
   } else if (typeof val === 'function') {
-    content = <span style={valueStyles.func}>{val.name ? `${val.name}()` : 'anonymous()'}</span>;
+    content = <span style={valueStyles.func}>{val.name || 'anonymous'}</span>;
   } else if (!val) {
     content = <span style={valueStyles.empty}>{`${val}`}</span>;
   } else if (typeof val !== 'object') {


### PR DESCRIPTION
## Issue
Given this story:

```jsx
import { storiesOf } from '@storybook/react'
import Component from '.'

const logClick = () => console.log('clicked')

storiesOf('Component', module)
  .add('plain', () =>
    <Component onClick={logClick}>Hello Button</Component>
  )
```

the add-on currently displays

```jsx
<Component onClick={logClick()}>Hello Button</Component>
```

which isn't accurate (`logClick()` vs `logClick`) and makes the "copy" feature less useful
## What I did
This PR will output:

```jsx
<Component onClick={logClick}>Hello Button</Component>
```

which matches the story

## How to test

Is this testable with Jest or Chromatic screenshots? yes
Does this need a new example in the kitchen sink apps? I don't think so
Does this need an update to the documentation? I don't think so

If your answer is yes to any of these, please make sure to include it in your PR.