### PR TITLE
[addon-knobs] Allow number knob to be empty

### DIFF
--- a/addons/knobs/src/components/types/Number.js
+++ b/addons/knobs/src/components/types/Number.js
@@ -39,10 +39,11 @@ const RangeWrapper = styled('div')({
 class NumberType extends React.Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      value: props.knob.value,
-    };
+    let { value } = props.knob;
+    if (value === null || value === undefined) {
+      value = '';
+    }
+    this.state = { value };
 
     this.onChange = debounce(props.onChange, 400);
   }
@@ -58,7 +59,7 @@ class NumberType extends React.Component {
 
     let parsedValue = Number(value);
 
-    if (Number.isNaN(parsedValue)) {
+    if (Number.isNaN(parsedValue) || value === '') {
       parsedValue = null;
     }
 
@@ -110,7 +111,7 @@ NumberType.propTypes = {
   onChange: PropTypes.func,
 };
 
-NumberType.serialize = value => String(value);
-NumberType.deserialize = value => parseFloat(value);
+NumberType.serialize = value => (value === null || value === undefined ? '' : String(value));
+NumberType.deserialize = value => (value === '' ? null : parseFloat(value));
 
 export default NumberType;


### PR DESCRIPTION
Issue: When emptying a knob number field, currently the value 0 is returned, due to this [line](https://github.com/storybooks/storybook/blob/master/addons/knobs/src/components/types/Number.js#L59) because:
`Number('') === 0`
which is quite problematic if you want your knob to return nothing if nothing has been input.

## What I did

I checked for the empty string in `handleChange` and returned null in this case as it were a NaN value.
I also handled the case where the value is null or undefined, replacing it in the field with an empty string to avoid the classic _Warning: Input is changing an uncontrolled input of type text to be controlled_ when giving the knob a null or undefined default value.

