### PR TITLE
Fix addon README.md typo mulitple -> multiple

### DIFF
--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -90,7 +90,7 @@ setOptions({
   /**
    * regex for finding the hierarchy root separator
    * @example:
-   *   null - turn off mulitple hierarchy roots
+   *   null - turn off multiple hierarchy roots
    *   /\|/ - split by `|`
    * @type {Regex}
    */


### PR DESCRIPTION
Issue: 
Typo

## What I did
Fix typo mulitple -> multiple
