### PR TITLE
Homepage: Replace ♥️ with ❤

### DIFF
--- a/docs/src/components/Homepage/Heading/index.js
+++ b/docs/src/components/Homepage/Heading/index.js
@@ -10,7 +10,7 @@ const Heading = () => (
       <h3 className="sb-tagline">
         The UI Development Environment
         <br />
-        You'll ♥️ to use
+        You'll ❤ to use
       </h3>
     </div>
   </div>


### PR DESCRIPTION
"Black Heart Suit" is rendered black on some platforms (e.g. Edge, Firefox). "Red Heart Emoji" is always rendered red.

Refs:
- https://emojipedia.org/black-heart-suit/
- https://emojipedia.org/heavy-black-heart/

Issue:

## What I did

Improved the appearance of the homepage on Edge and possibly other platforms.

## How to test

1. Open in Edge.
2. Check that the heart in the heading is red.
