### PR TITLE
Fix non-polyfilled themed UI components

### DIFF
--- a/lib/ui/src/modules/ui/components/search_box.js
+++ b/lib/ui/src/modules/ui/components/search_box.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
+import { polyfill } from 'react-lifecycles-compat';
 
 import ReactModal from 'react-modal';
 import FuzzySearch from 'react-fuzzy';
@@ -62,6 +63,7 @@ const suggestionTemplate = (props, state, styles, clickHandler) =>
   ));
 
 class SearchBox extends React.Component {
+  state = {};
   static getDerivedStateFromProps({ theme }) {
     return {
       modalClass: css({
@@ -154,4 +156,5 @@ SearchBox.propTypes = {
 };
 
 export { SearchBox };
+polyfill(SearchBox);
 export default withTheme(SearchBox);

--- a/lib/ui/src/modules/ui/components/shortcuts_help.js
+++ b/lib/ui/src/modules/ui/components/shortcuts_help.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import styled from 'react-emotion';
 import { css } from 'emotion';
 import { withTheme } from 'emotion-theming';
+import { polyfill } from 'react-lifecycles-compat';
 
 import ReactModal from 'react-modal';
 
@@ -136,6 +137,7 @@ Shortcuts.propTypes = {
 };
 
 class ShortcutsHelp extends Component {
+  state = {};
   static getDerivedStateFromProps({ theme }) {
     return {
       modalClass: css({
@@ -194,4 +196,5 @@ ShortcutsHelp.defaultProps = {
   onClose: () => {},
 };
 
+polyfill(ShortcutsHelp);
 export default withTheme(ShortcutsHelp);


### PR DESCRIPTION
Issue: #3825 

## What I did

There were a couple components that did not use `react-lifecycle-compat` polyfills and broke theming for React v16.3 (?) and below. Added in the needed polyfills.

## How to test

1. Create a CRA with React 16.0.0
2. Add the updated library
3. Storybook should run properly

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
