### PR TITLE
Document `makeDecorators` for addons authors

### DIFF
--- a/addons/backgrounds/src/index.js
+++ b/addons/backgrounds/src/index.js
@@ -15,6 +15,7 @@ export const withBackgrounds = makeDecorator({
   name: 'backgrounds',
   parameterName: 'backgrounds',
   skipIfNoParametersOrOptions: true,
+  allowDeprecatedUsage: true,
   wrapper: (getStory, context, { options, parameters }) => {
     const backgrounds = parameters || options;
 

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -87,6 +87,7 @@ function addInfo(storyFn, context, infoOptions) {
 export const withInfo = makeDecorator({
   name: 'withInfo',
   parameterName: 'info',
+  allowDeprecatedUsage: true,
   wrapper: (getStory, context, { options, parameters }) => {
     const storyOptions = parameters || options;
     const infoOptions = typeof storyOptions === 'string' ? { text: storyOptions } : storyOptions;

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -77,6 +77,7 @@ export const withKnobs = makeDecorator({
   name: 'withKnobs',
   parameterName: 'knobs',
   skipIfNoParametersOrOptions: false,
+  allowDeprecatedUsage: true,
   wrapper: (getStory, context, { options, parameters }) => {
     const storyOptions = parameters || options;
     const allOptions = { ...defaultOptions, ...storyOptions };

--- a/addons/notes/src/index.js
+++ b/addons/notes/src/index.js
@@ -10,6 +10,7 @@ export const withNotes = makeDecorator({
   name: 'withNotes',
   parameterName: 'notes',
   skipIfNoParametersOrOptions: true,
+  allowDeprecatedUsage: true,
   wrapper: (getStory, context, { options, parameters }) => {
     const channel = addons.getChannel();
 

--- a/addons/viewport/src/preview/withViewport.js
+++ b/addons/viewport/src/preview/withViewport.js
@@ -33,6 +33,7 @@ const applyViewportOptions = (options = {}) => {
 const withViewport = makeDecorator({
   name: 'withViewport',
   parameterName: 'viewport',
+  allowDeprecatedUsage: true,
   wrapper: (getStory, context, { options, parameters }) => {
     const storyOptions = parameters || options;
     const viewportOptions =

--- a/docs/src/pages/addons/api/index.md
+++ b/docs/src/pages/addons/api/index.md
@@ -28,9 +28,7 @@ See how we can use this:
 import addonAPI from '@storybook/addons';
 
 // Register the addon with a unique name.
-addonAPI.register('my-organisation/my-addon', storybookAPI => {
-
-});
+addonAPI.register('my-organisation/my-addon', storybookAPI => {});
 ```
 
 Now you'll get an instance to our StorybookAPI. See the [api docs](/addons/api#storybook-api) for Storybook API regarding using that.
@@ -43,18 +41,12 @@ See how you can use this method:
 ```js
 import addonAPI from '@storybook/addons';
 
-const MyPanel = () => (
-  <div>
-    This is a panel.
-  </div>
-);
+const MyPanel = () => <div>This is a panel.</div>;
 
 // give a unique name for the panel
 addonAPI.addPanel('my-organisation/my-addon/panel', {
   title: 'My Addon',
-  render: () => (
-    <MyPanel />
-  ),
+  render: () => <MyPanel />,
 });
 ```
 
@@ -71,11 +63,9 @@ addonAPI.register('my-organisation/my-addon', storybookAPI => {
   // Also need to set a unique name to the panel.
   addonAPI.addPanel('my-organisation/my-addon/panel', {
     title: 'Notes',
-    render: () => (
-      <Notes channel={addonAPI.getChannel()} api={storybookAPI}/>
-    ),
-  })
-})
+    render: () => <Notes channel={addonAPI.getChannel()} api={storybookAPI} />,
+  });
+});
 ```
 
 ## Storybook API
@@ -96,10 +86,7 @@ Let's say you've got a story like this:
 ```js
 import { storiesOf } from '@storybook/react';
 
-storiesOf('heading', module)
-  .add('with text', () => (
-    <h1>Hello world</h1>
-  ));
+storiesOf('heading', module).add('with text', () => <h1>Hello world</h1>);
 ```
 
 This is how you can select the above story:
@@ -107,7 +94,7 @@ This is how you can select the above story:
 ```js
 addonAPI.register('my-organisation/my-addon', storybookAPI => {
   storybookAPI.selectStory('heading', 'with text');
-})
+});
 ```
 
 ### storybookAPI.selectInCurrentKind()
@@ -161,7 +148,7 @@ This method allows you to get application url state with some changed params. Fo
 addonAPI.register('my-organisation/my-addon', storybookAPI => {
   const href = storybookAPI.getUrlState({
     selectedKind: 'kind',
-    selectedStory: 'story'
+    selectedStory: 'story',
   }).url;
 });
 ```
@@ -175,3 +162,33 @@ addonAPI.register('my-organisation/my-addon', storybookAPI => {
   storybookAPI.onStory((kind, story) => console.log(kind, story));
 });
 ```
+
+## `makeDecorator` API
+
+The `makeDecorator` API can be used to create decorators in the style of the official addons easily. Use it like so:
+
+```js
+import { makeDecorator } from '@storybook/addons';
+
+export makeDecorator({
+  name: 'withSomething',
+  parameterName: 'something',
+  wrapper: (storyFn, context, { parameters }) => {
+    // Do something with `parameters`, which are set via { something: ... }
+
+    // Note you may alter the story output if you like, although generally that's
+    // not advised
+    return storyFn(context);
+  }
+})
+```
+
+The options to `makeDecorator` are:
+
+- `name`: The name of the export (e.g. `withNotes`)
+- `parameterName`: The name of the parameter your addon uses. This should be unique.
+- `skipIfNoParametersOrOptions`: Don't run your decorator if the user hasn't set options (via `.addDecorator(withFoo(options)))`) or parameters (`.add('story', () => <Story/>, { foo: 'param' })`, or `.addParameters({foo: 'param'})`).
+- `allowDeprecatedUsage`: support the deprecated "wrapper" usage (`.add('story', () => withFoo(options)(() => <Story/>))`).
+- `wrapper`: your decorator function. Takes the `storyFn`, `context`, and both the `options` and `parameters` (as defined in `skipIfNoParametersOrOptions` above).
+
+Note if the parameters to a story include `{ foo: {disable: true } }` (where `foo` is the `parameterName` of your addon), your decorator will note be called.

--- a/lib/addons/src/make-decorator.js
+++ b/lib/addons/src/make-decorator.js
@@ -15,6 +15,7 @@ export const makeDecorator = ({
   parameterName,
   wrapper,
   skipIfNoParametersOrOptions = false,
+  allowDeprecatedUsage = false,
 }) => {
   const decorator = options => (getStory, context) => {
     const parameters = context.parameters && context.parameters[parameterName];
@@ -44,11 +45,17 @@ export const makeDecorator = ({
         return decorator(...args)(...innerArgs);
       }
 
-      // Used to wrap a story directly .add('story', decorator(options)(() => <Story />))
-      //   This is now deprecated:
-      return deprecate(
-        context => decorator(...args)(innerArgs[0], context),
-        `Passing stories directly into ${name}() is deprecated, instead use addDecorator(${name}) and pass options with the '${parameterName}' parameter`
+      if (allowDeprecatedUsage) {
+        // Used to wrap a story directly .add('story', decorator(options)(() => <Story />))
+        //   This is now deprecated:
+        return deprecate(
+          context => decorator(...args)(innerArgs[0], context),
+          `Passing stories directly into ${name}() is deprecated, instead use addDecorator(${name}) and pass options with the '${parameterName}' parameter`
+        );
+      }
+
+      throw new Error(
+        `Passing stories directly into ${name}() is not allowed, instead use addDecorator(${name}) and pass options with the '${parameterName}' parameter`
       );
     };
   };

--- a/lib/addons/src/make-decorator.test.js
+++ b/lib/addons/src/make-decorator.test.js
@@ -103,10 +103,15 @@ describe('makeDecorator', () => {
     expect(story).toHaveBeenCalled();
   });
 
-  it('passes options added at story time, but with a deprecation warning', () => {
+  it('passes options added at story time, but with a deprecation warning, if allowed', () => {
     deprecatedFns = [];
     const wrapper = jest.fn();
-    const decorator = makeDecorator({ wrapper, name: 'test', parameterName: 'test' });
+    const decorator = makeDecorator({
+      wrapper,
+      name: 'test',
+      parameterName: 'test',
+      allowDeprecatedUsage: true,
+    });
     const options = 'test-val';
     const story = jest.fn();
     const decoratedStory = decorator(options)(story);
@@ -120,5 +125,18 @@ describe('makeDecorator', () => {
       options: 'test-val',
     });
     expect(deprecatedFns[0].deprecatedFn).toHaveBeenCalled();
+  });
+
+  it('throws if options are added at storytime, if not allowed', () => {
+    const wrapper = jest.fn();
+    const decorator = makeDecorator({
+      wrapper,
+      name: 'test',
+      parameterName: 'test',
+      allowDeprecatedUsage: false,
+    });
+    const options = 'test-val';
+    const story = jest.fn();
+    expect(() => decorator(options)(story)).toThrow(/not allowed/);
   });
 });


### PR DESCRIPTION
Issue:

We added a `makeDecorators` API and use it everywhere but it is not documented.

## What I did

Added a `allowDeprecatedUsage` (defaults to `false`) option to `makeDecorator` and set it to `true` for our addons.

Updated the writing addons documentation to reflect the above.

## How to test

Added tests for the API change. Please read the docs.
