### PR TITLE
fix: add missing `moment` dependency

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -21,6 +21,7 @@
     "escape-html": "^1.0.3",
     "fast-deep-equal": "^2.0.1",
     "global": "^4.3.2",
+    "moment": "^2.22.2",
     "prop-types": "^15.6.1",
     "qs": "^6.5.2",
     "react-color": "^2.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7862,7 +7862,13 @@ graphql-request@^1.4.0:
   dependencies:
     cross-fetch "1.1.1"
 
-graphql@^0.12.3, graphql@^0.13.2:
+graphql@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
+  dependencies:
+    iterall "1.1.3"
+
+graphql@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
@@ -9306,6 +9312,10 @@ istanbul@^0.4.5:
     supports-color "^3.1.0"
     which "^1.1.1"
     wordwrap "^1.0.0"
+
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 iterall@^1.2.1:
   version "1.2.2"
@@ -11960,6 +11970,10 @@ module-deps@^3.7.0:
     subarg "^1.0.0"
     through2 "^1.0.0"
     xtend "^4.0.0"
+
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 moment@^2.6.0:
   version "2.20.1"


### PR DESCRIPTION
Issue: I noticed that `action-knobs@4.0.0-alpha.12` depended on `react-datetime` which assumes a `moment` peer dependency, but did not provide it. This caused an error when starting Storybook.

## What I did

Add the missing dependency

## How to test

Try starting a Storybook with the `knobs` addon installed before/after this change.

Is this testable with Jest or Chromatic screenshots? No
Does this need a new example in the kitchen sink apps? No
Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
