### PR TITLE
RFC/Propposal: Rendering with enzyme to allow e2e tests

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -31,7 +31,9 @@
     "global": "^4.3.2",
     "lodash.flattendeep": "^4.4.0",
     "prop-types": "^15.6.1",
-    "react-emotion": "^9.1.3"
+    "react-emotion": "^9.1.3",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "npm:enzyme-react-adapter-future"
   },
   "peerDependencies": {
     "react": ">=15.0.0",

--- a/app/react/src/client/preview/render.js
+++ b/app/react/src/client/preview/render.js
@@ -1,15 +1,19 @@
-import { document } from 'global';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { document, window } from 'global';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { stripIndents } from 'common-tags';
 import isReactRenderable from './element_check';
 
+Enzyme.configure({ adapter: new Adapter() });
+
 const rootEl = document.getElementById('root');
 
 function render(node, el) {
-  ReactDOM.render(
+  window.storyEl = Enzyme.mount(
     process.env.STORYBOOK_EXAMPLE_APP ? <React.StrictMode>{node}</React.StrictMode> : node,
-    el
+    { attachTo: el }
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,6 +5921,18 @@ enzyme-adapter-react-16@^1.1.0, enzyme-adapter-react-16@^1.1.1:
     react-reconciler "^0.7.0"
     react-test-renderer "^16.0.0-0"
 
+"enzyme-adapter-react-16@npm:enzyme-react-adapter-future":
+  version "1.1.3"
+  resolved "https://unpm.uberinternal.com/enzyme-react-adapter-future/-/enzyme-react-adapter-future-1.1.3.tgz#f0c102f098086a0ad0270bbdaf9da5113297dc05"
+  dependencies:
+    enzyme-adapter-utils "^1.3.0"
+    lodash "^4.17.4"
+    object.assign "^4.1.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.0"
+    react-reconciler "^0.7.0"
+    react-test-renderer "^16.0.0-0"
+
 enzyme-adapter-utils@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz#d6c85756826c257a8544d362cc7a67e97ea698c7"


### PR DESCRIPTION
## Issue:
We want to use storybook to run our e2e/(selenium) tests. We don't want to introduce any data attributes in our DOM for test-only purposes (we  also don't use traditional css classes in our React codebase so getting elements by xpath or css is not feasible either). Enzyme provide [elements query API](http://airbnb.io/enzyme/docs/api/ReactWrapper/findWhere.html) where one can look up elements by Component name for instance. Which makes looking up and testing real DOM elements really easy.
I have written in details about `enzyme` for e2e idea for `create-react-app` [here](https://github.com/DianaSuvorova/e2e). Same idea applies to storybook.

## What I did

Instead of rendering stories with `ReactDOM.render` I did it with `Enzyme.Mount` which in turn will call `ReactDOM.render` after wrapping it in its API. I also created a global `storyEl` variable selenium would be able to read. So example of selenium script is something like below.

```js
const enzymeEl = await driver.executeScript('return window.storyEl;');
const componentEl = enzymeEl.findWhere(c => c.name() === 'MyComponent');
componentEl. getDOMNode().click()
expect(...)
```

Alternatively there can be additional `e2e-storybook` build where it is rendered with enzyme while default one is unchanged and rendered with ReactDOM.

Let me know your thoughts

## How to test
> Is this testable with Jest or Chromatic screenshots? 

Yes
> Does this need a new example in the kitchen sink apps? 

Yes
> Does this need an update to the documentation? 

Yes

> If your answer is yes to any of these, please make sure to include it in your PR.

I have hacked it around to make sure it works as expected. I am going to create comprehensive PR once I get an initial feedback on the proposal above.



For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
