### PR TITLE
Pass Jest done callback to testMethod

### DIFF
--- a/addons/storyshots/storyshots-core/src/api/ensureOptionsDefaults.js
+++ b/addons/storyshots/storyshots-core/src/api/ensureOptionsDefaults.js
@@ -23,6 +23,7 @@ function getIntegrityOptions({ integrityOptions }) {
 function ensureOptionsDefaults(options) {
   const {
     suite = 'Storyshots',
+    asyncJest,
     storyNameRegex,
     storyKindRegex,
     renderer,
@@ -34,6 +35,7 @@ function ensureOptionsDefaults(options) {
   const integrityOptions = getIntegrityOptions(options);
 
   return {
+    asyncJest,
     suite,
     storyNameRegex,
     storyKindRegex,

--- a/addons/storyshots/storyshots-core/src/api/index.js
+++ b/addons/storyshots/storyshots-core/src/api/index.js
@@ -32,6 +32,7 @@ function testStorySnapshots(options = {}) {
   }
 
   const {
+    asyncJest,
     suite,
     storyNameRegex,
     storyKindRegex,
@@ -50,6 +51,7 @@ function testStorySnapshots(options = {}) {
 
   snapshotsTests({
     groups: storiesGroups,
+    asyncJest,
     suite,
     framework,
     storyKindRegex,

--- a/addons/storyshots/storyshots-core/src/api/snapshotsTestsTemplate.js
+++ b/addons/storyshots/storyshots-core/src/api/snapshotsTestsTemplate.js
@@ -1,17 +1,35 @@
 import { describe, it } from 'global';
 
-function snapshotTest({ story, kind, fileName, framework, testMethod, testMethodParams }) {
+function snapshotTest({
+  asyncJest,
+  story,
+  kind,
+  fileName,
+  framework,
+  testMethod,
+  testMethodParams,
+}) {
   const { name } = story;
+  const context = { fileName, kind, story: name, framework };
 
-  it(name, () => {
-    const context = { fileName, kind, story: name, framework };
-
-    return testMethod({
-      story,
-      context,
-      ...testMethodParams,
-    });
-  });
+  if (asyncJest === true) {
+    it(name, done =>
+      testMethod({
+        done,
+        story,
+        context,
+        ...testMethodParams,
+      })
+    );
+  } else {
+    it(name, () =>
+      testMethod({
+        story,
+        context,
+        ...testMethodParams,
+      })
+    );
+  }
 }
 
 function snapshotTestSuite({ kind, stories, suite, storyNameRegex, ...restParams }) {

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.enzyme.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.enzyme.test.js.snap
@@ -39,6 +39,12 @@ exports[`Storyshots Another Button with text 1`] = `
 </ForwardRef>
 `;
 
+exports[`Storyshots Async with 5ms timeout simulating async operation 1`] = `
+<AsyncTestComponent>
+  <h1 />
+</AsyncTestComponent>
+`;
+
 exports[`Storyshots Button with some emoji 1`] = `
 <ForwardRef
   onClick={[Function]}

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.shallow.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.shallow.test.js.snap
@@ -21,6 +21,12 @@ exports[`Storyshots Another Button with text 1`] = `
 </Styled(button)>
 `;
 
+exports[`Storyshots Async with 5ms timeout simulating async operation 1`] = `
+<h1>
+  
+</h1>
+`;
+
 exports[`Storyshots Button with some emoji 1`] = `
 <Styled(button)
   onClick={[Function]}

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.shallowWithOptions.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.shallowWithOptions.test.js.snap
@@ -21,6 +21,12 @@ exports[`Storyshots Another Button with text 1`] = `
 </Styled(button)>
 `;
 
+exports[`Storyshots Async with 5ms timeout simulating async operation 1`] = `
+<h1>
+  
+</h1>
+`;
+
 exports[`Storyshots Button with some emoji 1`] = `
 <Styled(button)
   onClick={[Function]}

--- a/addons/storyshots/storyshots-core/stories/required_with_context/Async.stories.js
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/Async.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+export const EXPECTED_VALUE = 'THIS IS SO DONE';
+export const TIMEOUT = 5;
+
+class AsyncTestComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: '',
+    };
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({
+        value: EXPECTED_VALUE,
+      });
+    }, TIMEOUT);
+  }
+
+  render() {
+    const { value } = this.state;
+    return <h1>{value}</h1>;
+  }
+}
+
+storiesOf('Async', module).add(`with ${TIMEOUT}ms timeout simulating async operation`, () => (
+  <AsyncTestComponent />
+));

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Async.stories.async.storyshot
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Async.stories.async.storyshot
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Async with 5ms timeout simulating async operation 1`] = `
+<AsyncTestComponent>
+  <h1>
+    THIS IS SO DONE
+  </h1>
+</AsyncTestComponent>
+`;

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Async.stories.foo
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Async.stories.foo
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Async with 5ms timeout simulating async operation 1`] = `
+<h1>
+  
+</h1>
+`;

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Async.stories.storyshot
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Async.stories.storyshot
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Async with 5ms timeout simulating async operation 1`] = `
+<h1>
+  
+</h1>
+`;

--- a/addons/storyshots/storyshots-core/stories/storyshot.async.test.js
+++ b/addons/storyshots/storyshots-core/stories/storyshot.async.test.js
@@ -1,0 +1,47 @@
+import path from 'path';
+import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import initStoryshots, { Stories2SnapsConverter } from '../src';
+import { TIMEOUT, EXPECTED_VALUE } from './required_with_context/Async.stories';
+
+initStoryshots({
+  asyncJest: true,
+  framework: 'react',
+  integrityOptions: false,
+  configPath: path.join(__dirname, '..', '.storybook'),
+
+  // When async is true we need to provide a test method that
+  // calls done() when at the end of the test method
+  test: ({ story, context, done }) => {
+    expect(done).toBeDefined();
+
+    // This is a storyOf Async (see ./required_with_context/Async.stories)
+    if (context.kind === 'Async') {
+      const converter = new Stories2SnapsConverter({ snapshotExtension: '.async.storyshot' });
+      const snapshotFilename = converter.getSnapshotFileName(context);
+      const storyElement = story.render(context);
+
+      // Mount the component
+      let wrapper = mount(storyElement);
+
+      // The Async component should not contain the expected value
+      expect(wrapper.find('AsyncTestComponent').contains(EXPECTED_VALUE)).toBe(false);
+
+      // wait until the "Async" component is updated
+      setTimeout(() => {
+        // Update the wrapper with the changes in the underlying component
+        wrapper = wrapper.update();
+
+        // Assert the expected value and the corresponding snapshot
+        expect(wrapper.find('AsyncTestComponent').contains(EXPECTED_VALUE)).toBe(true);
+        expect(toJson(wrapper)).toMatchSpecificSnapshot(snapshotFilename);
+
+        // finally mark test as done
+        done();
+      }, TIMEOUT);
+    } else {
+      // If not async just mark the test as done
+      done();
+    }
+  },
+});

--- a/addons/storyshots/storyshots-core/stories/storyshot.test.js
+++ b/addons/storyshots/storyshots-core/stories/storyshot.test.js
@@ -4,7 +4,8 @@ import initStoryshots, { multiSnapshotWithOptions } from '../src';
 // with react-test-renderer
 initStoryshots({
   framework: 'react',
-  integrityOptions: { cwd: __dirname },
+  // Ignore integrityOptions for async.storyshot because only run when asyncJest is true
+  integrityOptions: { cwd: __dirname, ignore: ['**/**.async.storyshot'] },
   configPath: path.join(__dirname, '..', '.storybook'),
   test: multiSnapshotWithOptions(),
 });


### PR DESCRIPTION
Issue: NO ISSUE

## What I did

I added the [Jest done callback](https://jestjs.io/docs/en/asynchronous) to be passed to the testMethod in StoryShot addon. Also updated the addon's README.

## How to test

Is this testable with Jest or Chromatic screenshots?
**I don't think so**

Does this need a new example in the kitchen sink apps?
**I don't think so**

Does this need an update to the documentation?
I updated the StoryShot addon README with usage example.

If your answer is yes to any of these, please make sure to include it in your PR.

