### PR TITLE
[Documentation] Fix inline documentation on info plugin readme

### DIFF
--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -72,7 +72,7 @@ storiesOf('Component', module)
   .add(
     'with some emoji',
     () => <Component emoji />,
-    { info: { inline: false, header: false } } // Make your component render inline with the additional info
+    { info: { inline: true, header: false } } // Make your component render inline with the additional info
   )
   .add(
     'with no emoji',


### PR DESCRIPTION
Issue:

## What I did
Updated the documentation on the info plugin to be correct in regards to the `inline` option.

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
