### PR TITLE
Fix knobs for React < 16.3

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -26,6 +26,7 @@
     "react-color": "^2.14.1",
     "react-datetime": "^2.14.0",
     "react-emotion": "^9.1.3",
+    "react-lifecycles-compat": "^3.0.4",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {

--- a/addons/knobs/src/components/types/Array.js
+++ b/addons/knobs/src/components/types/Array.js
@@ -10,28 +10,18 @@ function formatArray(value, separator) {
   return value.split(separator);
 }
 
-class ArrayType extends React.Component {
-  static getDerivedStateFromProps(props, state) {
-    if (!state || props.knob.value !== state.value) {
-      return { value: props.knob.value };
-    }
-    return null;
-  }
-
+class ArrayType extends React.PureComponent {
   handleChange = e => {
     const { knob } = this.props;
     const { value } = e.target;
     const newVal = formatArray(value, knob.separator);
-
-    this.setState({ value });
     this.props.onChange(newVal);
   };
 
   render() {
     const { knob } = this.props;
-    const { value } = this.state;
 
-    return <Textarea id={knob.name} value={value} onChange={this.handleChange} size="flex" />;
+    return <Textarea id={knob.name} value={knob.value} onChange={this.handleChange} size="flex" />;
   }
 }
 

--- a/addons/knobs/src/components/types/Array.js
+++ b/addons/knobs/src/components/types/Array.js
@@ -10,7 +10,11 @@ function formatArray(value, separator) {
   return value.split(separator);
 }
 
-class ArrayType extends React.PureComponent {
+class ArrayType extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return nextProps.knob.value !== this.props.knob.value;
+  }
+
   handleChange = e => {
     const { knob } = this.props;
     const { value } = e.target;

--- a/addons/knobs/src/components/types/Color.js
+++ b/addons/knobs/src/components/types/Color.js
@@ -19,17 +19,10 @@ const Popover = styled('div')({
   zIndex: '2',
 });
 
-class ColorType extends React.Component {
+class ColorType extends React.PureComponent {
   state = {
     displayColorPicker: false,
   };
-
-  static getDerivedStateFromProps(props, state) {
-    if (!state || props.knob.value !== state.value) {
-      return { value: props.knob.value };
-    }
-    return null;
-  }
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleWindowMouseDown);
@@ -54,16 +47,12 @@ class ColorType extends React.Component {
   };
 
   handleChange = color => {
-    this.setState({
-      value: color,
-    });
-
     this.props.onChange(`rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`);
   };
 
   render() {
     const { knob } = this.props;
-    const { displayColorPicker, value } = this.state;
+    const { displayColorPicker } = this.state;
     const colorStyle = {
       background: knob.value,
     };
@@ -78,7 +67,7 @@ class ColorType extends React.Component {
               this.popover = e;
             }}
           >
-            <SketchPicker color={value} onChange={this.handleChange} />
+            <SketchPicker color={knob.value} onChange={this.handleChange} />
           </Popover>
         ) : null}
       </Button>

--- a/addons/knobs/src/components/types/Color.js
+++ b/addons/knobs/src/components/types/Color.js
@@ -19,13 +19,16 @@ const Popover = styled('div')({
   zIndex: '2',
 });
 
-class ColorType extends React.PureComponent {
+class ColorType extends React.Component {
   state = {
     displayColorPicker: false,
   };
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleWindowMouseDown);
+  }
+  shouldComponentUpdate(nextProps) {
+    return nextProps.knob.value !== this.props.knob.value;
   }
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.handleWindowMouseDown);

--- a/addons/knobs/src/components/types/Date/index.js
+++ b/addons/knobs/src/components/types/Date/index.js
@@ -8,7 +8,11 @@ import style from './styles';
 
 const DateInput = styled(Datetime)(style);
 
-class DateType extends React.PureComponent {
+class DateType extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return nextProps.knob.value !== this.props.knob.value;
+  }
+
   handleChange = date => {
     const value = date.valueOf();
     this.props.onChange(value);

--- a/addons/knobs/src/components/types/Date/index.js
+++ b/addons/knobs/src/components/types/Date/index.js
@@ -8,27 +8,18 @@ import style from './styles';
 
 const DateInput = styled(Datetime)(style);
 
-class DateType extends React.Component {
-  static getDerivedStateFromProps(props, state) {
-    if (!state || props.knob.value !== state.value) {
-      return { value: props.knob.value };
-    }
-    return null;
-  }
-
+class DateType extends React.PureComponent {
   handleChange = date => {
     const value = date.valueOf();
-    this.setState({ value });
-
     this.props.onChange(value);
   };
 
   render() {
-    const { value } = this.state;
+    const { knob } = this.props;
 
     return (
       <DateInput
-        value={value ? new Date(value) : null}
+        value={knob.value ? new Date(knob.value) : null}
         type="date"
         onChange={this.handleChange}
         size="flex"
@@ -38,7 +29,6 @@ class DateType extends React.Component {
 }
 
 DateType.propTypes = {
-  // eslint-disable-next-line react/no-unused-prop-types
   knob: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.number,

--- a/addons/knobs/src/components/types/Number.js
+++ b/addons/knobs/src/components/types/Number.js
@@ -32,18 +32,9 @@ const RangeWrapper = styled('div')({
   width: '100%',
 });
 
-class NumberType extends React.Component {
-  static getDerivedStateFromProps(props, state) {
-    if (!state || props.knob.value !== state.value) {
-      return { value: props.knob.value };
-    }
-    return null;
-  }
-
+class NumberType extends React.PureComponent {
   handleChange = event => {
     const { value } = event.target;
-
-    this.setState({ value });
 
     let parsedValue = Number(value);
 
@@ -56,24 +47,23 @@ class NumberType extends React.Component {
 
   render() {
     const { knob } = this.props;
-    const { value } = this.state;
 
     return knob.range ? (
       <RangeWrapper>
         <RangeLabel>{knob.min}</RangeLabel>
         <RangeInput
-          value={value}
+          value={knob.value}
           type="range"
           min={knob.min}
           max={knob.max}
           step={knob.step}
           onChange={this.handleChange}
         />
-        <RangeLabel>{`${value} / ${knob.max}`}</RangeLabel>
+        <RangeLabel>{`${knob.value} / ${knob.max}`}</RangeLabel>
       </RangeWrapper>
     ) : (
       <Input
-        value={value}
+        value={knob.value}
         type="number"
         min={knob.min}
         max={knob.max}

--- a/addons/knobs/src/components/types/Number.js
+++ b/addons/knobs/src/components/types/Number.js
@@ -79,6 +79,10 @@ NumberType.propTypes = {
   knob: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.number,
+    range: PropTypes.bool,
+    min: PropTypes.number,
+    max: PropTypes.number,
+    step: PropTypes.number,
   }).isRequired,
   onChange: PropTypes.func.isRequired,
 };

--- a/addons/knobs/src/components/types/Number.js
+++ b/addons/knobs/src/components/types/Number.js
@@ -32,7 +32,11 @@ const RangeWrapper = styled('div')({
   width: '100%',
 });
 
-class NumberType extends React.PureComponent {
+class NumberType extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return nextProps.knob.value !== this.props.knob.value;
+  }
+
   handleChange = event => {
     const { value } = event.target;
 

--- a/addons/knobs/src/components/types/Object.js
+++ b/addons/knobs/src/components/types/Object.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import deepEqual from 'fast-deep-equal';
+import { polyfill } from 'react-lifecycles-compat';
 import { Textarea } from '@storybook/components';
 
 class ObjectType extends Component {
@@ -23,7 +24,7 @@ class ObjectType extends Component {
     const { value } = e.target;
 
     try {
-      const json = JSON.parse(e.target.value.trim());
+      const json = JSON.parse(value.trim());
       this.setState({
         value,
         json,
@@ -64,5 +65,7 @@ ObjectType.propTypes = {
 
 ObjectType.serialize = object => JSON.stringify(object);
 ObjectType.deserialize = value => (value ? JSON.parse(value) : {});
+
+polyfill(ObjectType);
 
 export default ObjectType;

--- a/addons/knobs/src/components/types/Text.js
+++ b/addons/knobs/src/components/types/Text.js
@@ -3,7 +3,11 @@ import React from 'react';
 
 import { Textarea } from '@storybook/components';
 
-class TextType extends React.PureComponent {
+class TextType extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return nextProps.knob.value !== this.props.knob.value;
+  }
+
   handleChange = event => {
     const { value } = event.target;
     this.props.onChange(value);

--- a/addons/knobs/src/components/types/Text.js
+++ b/addons/knobs/src/components/types/Text.js
@@ -3,27 +3,16 @@ import React from 'react';
 
 import { Textarea } from '@storybook/components';
 
-class TextType extends React.Component {
-  static getDerivedStateFromProps(props, state) {
-    if (!state || props.knob.value !== state.value) {
-      return { value: props.knob.value };
-    }
-    return null;
-  }
-
+class TextType extends React.PureComponent {
   handleChange = event => {
     const { value } = event.target;
-
-    this.setState({ value });
-
     this.props.onChange(value);
   };
 
   render() {
     const { knob } = this.props;
-    const { value } = this.state;
 
-    return <Textarea id={knob.name} value={value} onChange={this.handleChange} size="flex" />;
+    return <Textarea id={knob.name} value={knob.value} onChange={this.handleChange} size="flex" />;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7869,7 +7869,13 @@ graphql-request@^1.4.0:
   dependencies:
     cross-fetch "1.1.1"
 
-graphql@^0.12.3, graphql@^0.13.2:
+graphql@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
+  dependencies:
+    iterall "1.1.3"
+
+graphql@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
@@ -9313,6 +9319,10 @@ istanbul@^0.4.5:
     supports-color "^3.1.0"
     which "^1.1.1"
     wordwrap "^1.0.0"
+
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 iterall@^1.2.1:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7869,13 +7869,7 @@ graphql-request@^1.4.0:
   dependencies:
     cross-fetch "1.1.1"
 
-graphql@^0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
-  dependencies:
-    iterall "1.1.3"
-
-graphql@^0.13.2:
+graphql@^0.12.3, graphql@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
@@ -9319,10 +9313,6 @@ istanbul@^0.4.5:
     supports-color "^3.1.0"
     which "^1.1.1"
     wordwrap "^1.0.0"
-
-iterall@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 iterall@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
Issue:

The `getDerivedStateFromProps` lifecycle method was added in React 16.3,
and older versions of react won’t execute it.  Many of the knob components
were relying on this function to initialize component state, and so in
older versions of react state was undefined, and grabbing `value` would
blow up.

## What I did

Most of the usages in these components were to memoize props, but that
can be handled more cleanly through the use of `PureComponent`, as 
mentioned in:
https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization

I wasn't sure quite how to avoid derived state in the `object` knob, so instead I followed the same approach as https://github.com/storybooks/storybook/pull/3829 and polyfilled it.

## How to test

The only thing I can think of is to test with a version of react prior to the introduction of `getDerivedStateFromProps`.  I'm unfamiliar with your testing setup though, so I don't know how to accomplish this in an automated method.  Do you already have any smoke tests for older react versions?  If so, perhaps it's just a matter of a simple UI test of these components to ensure they don't go up in flames?

Is this testable with Jest or Chromatic screenshots? I don't know.  :(
Does this need a new example in the kitchen sink apps? No
Does this need an update to the documentation? No
