### PR TITLE
[addon-a11y] improve documentation

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -67,6 +67,24 @@ storiesOf('button', module)
   ));
 ```
 
+If you want to add a11y globally to your stories, you can use the global Storybook decorator in your *.storybook/config.js* file:
+
+```
+import { configure, addDecorator } from '@storybook/react';
+import { checkA11y } from '@storybook/addon-a11y';
+
+// pick all stories.js files within the src/ folder
+const req = require.context('../src', true, /stories\.js$/);
+
+addDecorator(checkA11y);
+
+function loadStories() {
+  req.keys().forEach(filename => req(filename));
+}
+
+configure(loadStories, module);
+```
+
 ## Roadmap
 
 * Make UI accessibile

--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -69,7 +69,7 @@ storiesOf('button', module)
 
 If you want to add a11y globally to your stories, you can use the global Storybook decorator in your *.storybook/config.js* file:
 
-```
+```js
 import { configure, addDecorator } from '@storybook/react';
 import { checkA11y } from '@storybook/addon-a11y';
 


### PR DESCRIPTION
Adds documentation about the global Storybook decorator for making a11y available for all stories without adding individual decorators to each story.