### PR TITLE
Fix addons panel when using preact

### DIFF
--- a/lib/components/src/tabs/tabs.js
+++ b/lib/components/src/tabs/tabs.js
@@ -148,7 +148,8 @@ export const Tabs = ({ children, selected, onSelect, absolute, bordered }) => {
       title,
       id,
       render:
-        typeof React.Children.only(content) === 'function' ? React.Children.only(content)
+        typeof content === 'function' ? content
+          : Array.isArray(content) ? content[0]
           : // eslint-disable-next-line react/prop-types
             ({ active }) => (
               <VisuallyHidden active={active} role="tabpanel">

--- a/lib/components/src/tabs/tabs.js
+++ b/lib/components/src/tabs/tabs.js
@@ -148,8 +148,8 @@ export const Tabs = ({ children, selected, onSelect, absolute, bordered }) => {
       title,
       id,
       render:
-        typeof content === 'function'
-          ? content
+        typeof content === 'function' ? content
+          : Array.isArray(content) ? React.Children.only(content)
           : // eslint-disable-next-line react/prop-types
             ({ active }) => (
               <VisuallyHidden active={active} role="tabpanel">

--- a/lib/components/src/tabs/tabs.js
+++ b/lib/components/src/tabs/tabs.js
@@ -149,7 +149,7 @@ export const Tabs = ({ children, selected, onSelect, absolute, bordered }) => {
       id,
       render:
         typeof content === 'function' ? content
-          : Array.isArray(content) ? content[0]
+          : Array.isArray(content) && typeof content[0] === 'function' ? content[0]
           : // eslint-disable-next-line react/prop-types
             ({ active }) => (
               <VisuallyHidden active={active} role="tabpanel">

--- a/lib/components/src/tabs/tabs.js
+++ b/lib/components/src/tabs/tabs.js
@@ -149,7 +149,7 @@ export const Tabs = ({ children, selected, onSelect, absolute, bordered }) => {
       id,
       render:
         typeof content === 'function' ? content
-          : Array.isArray(content) ? React.Children.only(content)
+          : Array.isArray(content) ? content[0]
           : // eslint-disable-next-line react/prop-types
             ({ active }) => (
               <VisuallyHidden active={active} role="tabpanel">

--- a/lib/components/src/tabs/tabs.js
+++ b/lib/components/src/tabs/tabs.js
@@ -143,20 +143,23 @@ export const panelProps = {
 
 export const Tabs = ({ children, selected, onSelect, absolute, bordered }) => {
   const list = React.Children.toArray(children).map(
-    ({ props: { title, id, children: content } }, index) => ({
-      active: selected ? id === selected : index === 0,
-      title,
-      id,
-      render:
-        typeof content === 'function' ? content
-          : Array.isArray(content) && typeof content[0] === 'function' ? content[0]
-          : // eslint-disable-next-line react/prop-types
-            ({ active }) => (
-              <VisuallyHidden active={active} role="tabpanel">
-                {content}
-              </VisuallyHidden>
-            ),
-    })
+    ({ props: { title, id, children: childrenOfChild } }, index) => {
+      const content = Array.isArray(childrenOfChild) ? childrenOfChild[0] : childrenOfChild;
+      return {
+        active: selected ? id === selected : index === 0,
+        title,
+        id,
+        render:
+          typeof content === 'function'
+            ? content
+            : // eslint-disable-next-line react/prop-types
+              ({ active }) => (
+                <VisuallyHidden active={active} role="tabpanel">
+                  {content}
+                </VisuallyHidden>
+              ),
+      };
+    }
   );
 
   return list.length ? (

--- a/lib/components/src/tabs/tabs.js
+++ b/lib/components/src/tabs/tabs.js
@@ -148,8 +148,7 @@ export const Tabs = ({ children, selected, onSelect, absolute, bordered }) => {
       title,
       id,
       render:
-        typeof content === 'function' ? content
-          : Array.isArray(content) ? content[0]
+        typeof React.Children.only(content) === 'function' ? React.Children.only(content)
           : // eslint-disable-next-line react/prop-types
             ({ active }) => (
               <VisuallyHidden active={active} role="tabpanel">


### PR DESCRIPTION
Issue: 

Addons such as knobs were no longer rendering in the addon panel after installing the latest alpha, stemming from the changes in this merge request: https://github.com/storybooks/storybook/pull/3628. This is due to children in preact always being an Array.

## What I did

use Array.isArray to to check if content is an array, pull out the first value if it is.

## How to test

Is this testable with Jest or Chromatic screenshots?

Nope.

Does this need a new example in the kitchen sink apps?

Nope.

Does this need an update to the documentation?

Nope.