### PR TITLE
Fix typo in exporting storybook instructions

### DIFF
--- a/docs/src/pages/basics/exporting-storybook/index.md
+++ b/docs/src/pages/basics/exporting-storybook/index.md
@@ -22,7 +22,7 @@ Simply add the following NPM script:
 
 Then run `npm run storybook`.
 
-This will build the storybook configured in the Storybook directory into a static webpack and place it inside the `.out` directory.
+This will build the storybook configured in the Storybook directory into a static web app and place it inside the `.out` directory.
 Now you can deploy the content in the `.out` directory wherever you want.
 
 To test it locally, simply run the following commands with Python HTTP Server:


### PR DESCRIPTION
Issue:
Documentation typo. The sentence tries to say that storybook can create a static `web app` but it was misspelled as `webpack` 
## What I did
Fix typo

This PR solves #3888 

edit: 

closes: #3888 