### PR TITLE
Add additional device options to addon-viewport

### DIFF
--- a/addons/viewport/src/manager/components/tests/Panel.test.js
+++ b/addons/viewport/src/manager/components/tests/Panel.test.js
@@ -360,7 +360,7 @@ describe('Viewport/Panel', () => {
     });
 
     it('passes the children', () => {
-      expect(select.props().children).toHaveLength(8);
+      expect(select.props().children).toHaveLength(15);
     });
 
     it('onChange it updates the viewport', () => {

--- a/addons/viewport/src/shared/index.js
+++ b/addons/viewport/src/shared/index.js
@@ -40,11 +40,41 @@ export const INITIAL_VIEWPORTS = {
     },
     type: 'mobile',
   },
+  iphone8p: {
+    name: 'iPhone 7 Plus',
+    styles: {
+      height: '960px',
+      width: '540px',
+    },
+  },
+  iphonex: {
+    name: 'iPhone X',
+    styles: {
+      height: '1218px',
+      width: '563px',
+    },
+  },
   ipad: {
     name: 'iPad',
     styles: {
       height: '1024px',
       width: '768px',
+    },
+    type: 'tablet',
+  },
+  ipad10p: {
+    name: 'iPad Pro 10.5-in',
+    styles: {
+      height: '1112px',
+      width: '834px',
+    },
+    type: 'tablet',
+  },
+  ipad12p: {
+    name: 'iPad Pro 12.9-in',
+    styles: {
+      height: '1366px',
+      width: '1024px',
     },
     type: 'tablet',
   },
@@ -55,6 +85,13 @@ export const INITIAL_VIEWPORTS = {
       width: '360px',
     },
     type: 'mobile',
+  },
+  galaxys9: {
+    name: 'Galaxy S9',
+    styles: {
+      height: '1480px',
+      width: '720px',
+    },
   },
   nexus5x: {
     name: 'Nexus 5X',
@@ -71,6 +108,20 @@ export const INITIAL_VIEWPORTS = {
       width: '412px',
     },
     type: 'mobile',
+  },
+  pixel: {
+    name: 'Pixel',
+    styles: {
+      height: '960px',
+      width: '540px',
+    },
+  },
+  pixelxl: {
+    name: 'Pixel XL',
+    styles: {
+      height: '1280px',
+      width: '720px',
+    },
   },
 };
 export const DEFAULT_VIEWPORT = 'responsive';

--- a/addons/viewport/src/shared/index.js
+++ b/addons/viewport/src/shared/index.js
@@ -46,6 +46,7 @@ export const INITIAL_VIEWPORTS = {
       height: '960px',
       width: '540px',
     },
+    type: 'mobile',
   },
   iphonex: {
     name: 'iPhone X',
@@ -53,6 +54,7 @@ export const INITIAL_VIEWPORTS = {
       height: '1218px',
       width: '563px',
     },
+    type: 'mobile',
   },
   ipad: {
     name: 'iPad',
@@ -92,6 +94,7 @@ export const INITIAL_VIEWPORTS = {
       height: '1480px',
       width: '720px',
     },
+    type: 'mobile',
   },
   nexus5x: {
     name: 'Nexus 5X',
@@ -115,6 +118,7 @@ export const INITIAL_VIEWPORTS = {
       height: '960px',
       width: '540px',
     },
+    type: 'mobile',
   },
   pixelxl: {
     name: 'Pixel XL',
@@ -122,6 +126,7 @@ export const INITIAL_VIEWPORTS = {
       height: '1280px',
       width: '720px',
     },
+    type: 'mobile',
   },
 };
 export const DEFAULT_VIEWPORT = 'responsive';


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/3915

## What I did
Added iPhone, iPad, Samsung Galaxy and Google Pixel models to the list of devices in `addon-viewport`

## How to test
I spun up the `html-kitchen-sink` example and was able to see the new devices and sizes.