### PR TITLE
horizontal display for addon-knobs radios UI

### DIFF
--- a/addons/knobs/src/components/types/Radio.js
+++ b/addons/knobs/src/components/types/Radio.js
@@ -6,6 +6,11 @@ const styles = {
     fontSize: 11,
     padding: '5px',
   },
+  group: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+  },
 };
 
 class RadiosType extends Component {
@@ -42,7 +47,7 @@ class RadiosType extends Component {
   render() {
     const { knob, onChange } = this.props;
 
-    return <div>{this.renderRadioButtonList(knob, onChange)}</div>;
+    return <div style={styles.group}>{this.renderRadioButtonList(knob, onChange)}</div>;
   }
 }
 


### PR DESCRIPTION
Issue:

Recently merged "radios" knob [(#3894)](https://github.com/storybooks/storybook/pull/3894) is a great new addition from @brycemhammond. The existing implementation, however, displays the radio inputs vertically, and since space can be limited in the addons panel, I propose that the radio inputs be displayed horizontally.

## What I did

Added three lines of CSS to display the `radios` knobs UI horizontally.

**Before**

<img src="http://astronautweb.co/wp-content/uploads/2018/07/radios-vert.png" height="67" alt="before" />

**After**

<img src="http://astronautweb.co/wp-content/uploads/2018/07/radios-horiz.png" height="45" alt="after" />

## How to test

Is this testable with Jest or Chromatic screenshots? 
No.
Does this need a new example in the kitchen sink apps? 
No.
Does this need an update to the documentation?
No.

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
