### PR TITLE
addons-jest : bug with the jest parameter

### DIFF
--- a/addons/jest/src/index.js
+++ b/addons/jest/src/index.js
@@ -2,7 +2,7 @@ import addons from '@storybook/addons';
 import deprecate from 'util-deprecate';
 
 const findTestResults = (testFiles, jestTestResults, jestTestFilesExt) =>
-  Array.slice({...testFiles, length: Object.keys(testFiles).length}).map(name => {
+  Array.prototype.slice.call({...testFiles, length: Object.keys(testFiles).length}).map(name => {
     if (jestTestResults && jestTestResults.testResults) {
       return {
         name,

--- a/addons/jest/src/index.js
+++ b/addons/jest/src/index.js
@@ -2,7 +2,7 @@ import addons from '@storybook/addons';
 import deprecate from 'util-deprecate';
 
 const findTestResults = (testFiles, jestTestResults, jestTestFilesExt) =>
-  Array.prototype.slice.call({...testFiles, length: Object.keys(testFiles).length}).map(name => {
+  Object.values(testFiles).map(name => {
     if (jestTestResults && jestTestResults.testResults) {
       return {
         name,

--- a/addons/jest/src/index.js
+++ b/addons/jest/src/index.js
@@ -2,7 +2,7 @@ import addons from '@storybook/addons';
 import deprecate from 'util-deprecate';
 
 const findTestResults = (testFiles, jestTestResults, jestTestFilesExt) =>
-  Array.from(testFiles).map(name => {
+  Array.slice({...testFiles, length: Object.keys(testFiles).length}).map(name => {
     if (jestTestResults && jestTestResults.testResults) {
       return {
         name,


### PR DESCRIPTION
The jest param is not working on my machine. Array.from({0: 'zero', 1: 'one'}) does not work on my nodejs.

Instead, Array.prototype.slice works pretty well.

Issue:

## What I did
1°) Made a storybook with the jest addon included, version 4.0.0.alpha-14
2°) tried to invoke the jest addon decorator : 
   2°a) in the config.js : withTests({results: require('../.jest-test-results.json'),  filesExt: '(\\-specs)?(\\.js)?$'}))
   2°b) in the story file :  storiesOf('One card preview', module).addParameters({ jest: ['creditCardPreview'] })

## How to test
Is this testable with Jest or Chromatic screenshots? I don't know
Does this need a new example in the kitchen sink apps? I am not sure
Does this need an update to the documentation? I think not, it looks like a regression.

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
