### PR TITLE
Add customizePage method to imageSnapshot

### DIFF
--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -34,7 +34,7 @@ If you still need to configure jest you can use the resources mentioned below:
 -   [Javascript Testing with Jest - Egghead](https://egghead.io/lessons/javascript-test-javascript-with-jest). ***paid content***
 
 > Note: If you use React 16, you'll need to follow [these additional instructions](https://github.com/facebook/react/issues/9102#issuecomment-283873039).
-
+>
 > Note: Make sure you have added the ```json``` extention to ```moduleFileExtensions``` in ```jest.config.json```. If this is missing it leads to the [following error](https://github.com/storybooks/storybook/issues/3728): ```Cannot find module 'spdx-license-ids' from 'scan.js'```.
 
 

--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -84,6 +84,7 @@ const getGotoOptions = ({context, url}) => {
 }
 initStoryshots({suite: 'Image storyshots', test: imageSnapshot({storybookUrl: 'http://localhost:6006', getGotoOptions})});
 ```
+
 ### Specifying options to _screenshot()_ (puppeteer API)
 
 You might use `getScreenshotOptions` to specify options for screenshot. Will be passed to [Puppeteer .screenshot() fn](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagescreenshotoptions)
@@ -112,6 +113,32 @@ import { imageSnapshot } from '@storybook/addon-storyshots-puppeteer';
 const chromeExecutablePath = '/usr/local/bin/chrome';
 
 initStoryshots({suite: 'Image storyshots', test: imageSnapshot({storybookUrl: 'http://localhost:6006', chromeExecutablePath})});
+```
+
+### Customizing a `page` instance
+
+Sometimes, there is a need to customize a page before it  calls to the `goto` api. 
+
+Here is an example for a device emulation: 
+
+```js
+import initStoryshots from '@storybook/addon-storyshots';
+import { imageSnapshot } from '@storybook/addon-storyshots-puppeteer';
+const devices = require('puppeteer/DeviceDescriptors');
+
+const iPhone = devices['iPhone 6'];
+
+function customizePage(page) {
+  return page.emulate(iPhone);
+}
+
+initStoryshots({
+  suite: 'Image storyshots', 
+  test: imageSnapshot({
+      storybookUrl: 'http://localhost:6006', 
+      customizePage,
+  })
+});
 ```
 
 ### Integrate image storyshots with regular app

--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -117,7 +117,7 @@ initStoryshots({suite: 'Image storyshots', test: imageSnapshot({storybookUrl: 'h
 
 ### Customizing a `page` instance
 
-Sometimes, there is a need to customize a page before it  calls to the `goto` api. 
+Sometimes, there is a need to customize a page before it calls to the `goto` api. 
 
 Here is an example for a device emulation: 
 

--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -117,9 +117,9 @@ initStoryshots({suite: 'Image storyshots', test: imageSnapshot({storybookUrl: 'h
 
 ### Customizing a `page` instance
 
-Sometimes, there is a need to customize a page before it calls to the `goto` api. 
+Sometimes, there is a need to customize a page before it calls the `goto` api. 
 
-Here is an example for a device emulation: 
+An example of device emulation: 
 
 ```js
 import initStoryshots from '@storybook/addon-storyshots';
@@ -178,4 +178,4 @@ If you run your test without either the static build or a running instance, this
 
 To make sure your screenshots are taken from latest changes of your Storybook, you must keep your static build or running Storybook up-to-date.
 This can be achieved by adding a step before running the test ie: `yarn run build-storybook && yarn run image-snapshots`.
-If you run the image snapshots against a running Storybook in dev mode, you don't have to care about being up-to-date because the dev-server is watching changes and rebuilds automatically.
+If you run the image snapshots against a running Storybook in dev mode, you don't have to worry about the snapshots being up-to-date because the dev-server is watching changes and rebuilds automatically.

--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@storybook/node-logger": "4.0.0-alpha.14",
+    "babel-runtime": "^6.26.0",
     "jest-image-snapshot": "^2.4.2",
     "puppeteer": "^1.4.0"
   },

--- a/addons/storyshots/storyshots-puppeteer/src/index.js
+++ b/addons/storyshots/storyshots-puppeteer/src/index.js
@@ -8,6 +8,7 @@ expect.extend({ toMatchImageSnapshot });
 const defaultScreenshotOptions = () => ({ fullPage: true });
 
 const noop = () => {};
+const asyncNoop = async () => {};
 
 const defaultConfig = {
   storybookUrl: 'http://localhost:6006',
@@ -16,6 +17,7 @@ const defaultConfig = {
   getScreenshotOptions: defaultScreenshotOptions,
   beforeScreenshot: noop,
   getGotoOptions: noop,
+  customizePage: asyncNoop,
 };
 
 export const imageSnapshot = (customConfig = {}) => {
@@ -26,65 +28,65 @@ export const imageSnapshot = (customConfig = {}) => {
     getScreenshotOptions,
     beforeScreenshot,
     getGotoOptions,
+    customizePage,
   } = { ...defaultConfig, ...customConfig };
   let browser; // holds ref to browser. (ie. Chrome)
   let page; // Hold ref to the page to screenshot.
 
-  const testFn = ({ context }) => {
+  const testFn = async ({ context }) => {
     if (context.framework === 'rn') {
       // Skip tests since we de not support RN image snapshots.
       logger.error(
         "It seems you are running imageSnapshot on RN app and it's not supported. Skipping test."
       );
-      return Promise.resolve();
+
+      return;
     }
 
     const encodedKind = encodeURIComponent(context.kind);
     const encodedStoryName = encodeURIComponent(context.story);
     const storyUrl = `/iframe.html?selectedKind=${encodedKind}&selectedStory=${encodedStoryName}`;
     const url = storybookUrl + storyUrl;
+
     if (!browser || !page) {
       logger.error(
         `Error when generating image snapshot for test ${context.kind} - ${
           context.story
         } : It seems the headless browser is not running.`
       );
-      return Promise.reject(new Error('no-headless-browser-running'));
+
+      throw new Error('no-headless-browser-running');
     }
 
     expect.assertions(1);
-    return page
-      .goto(url, getGotoOptions({ context, url }))
-      .catch(e => {
-        logger.error(
-          `ERROR WHILE CONNECTING TO ${url}, did you start or build the storybook first ? A storybook instance should be running or a static version should be built when using image snapshot feature.`,
-          e
-        );
-        throw e;
-      })
-      .then(() => beforeScreenshot(page, { context, url }))
-      .then(() => page.screenshot(getScreenshotOptions({ context, url })))
-      .then(image => {
-        expect(image).toMatchImageSnapshot(getMatchOptions({ context, url }));
-      });
+
+    try {
+      await customizePage(page);
+      await page.goto(url, getGotoOptions({ context, url }));
+      await beforeScreenshot(page, { context, url });
+      const image = await page.screenshot(getScreenshotOptions({ context, url }));
+
+      expect(image).toMatchImageSnapshot(getMatchOptions({ context, url }));
+    } catch (e) {
+      logger.error(
+        `ERROR WHILE CONNECTING TO ${url}, did you start or build the storybook first ? A storybook instance should be running or a static version should be built when using image snapshot feature.`,
+        e
+      );
+      throw e;
+    }
   };
 
-  testFn.beforeAll = () =>
-    puppeteer
-      // add some options "no-sandbox" to make it work properly on some Linux systems as proposed here: https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322851507
-      .launch({
-        args: ['--no-sandbox ', '--disable-setuid-sandbox'],
-        executablePath: chromeExecutablePath,
-      })
-      .then(b => {
-        browser = b;
-      })
-      .then(() => browser.newPage())
-      .then(p => {
-        page = p;
-      });
-
   testFn.afterAll = () => browser.close();
+
+  testFn.beforeAll = async () => {
+    // add some options "no-sandbox" to make it work properly on some Linux systems as proposed here: https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322851507
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox ', '--disable-setuid-sandbox'],
+      executablePath: chromeExecutablePath,
+    });
+
+    page = await browser.newPage();
+  };
 
   return testFn;
 };

--- a/lib/cli/test/snapshots/polymer/package.json
+++ b/lib/cli/test/snapshots/polymer/package.json
@@ -15,6 +15,6 @@
     "@storybook/polymer": "^4.0.0-alpha.14",
     "babel-core": "^6.26.3",
     "babel-runtime": "^6.26.0",
-    "polymer-webpack-loader": "^2.0.2"
+    "polymer-webpack-loader": "^2.0.3"
   }
 }


### PR DESCRIPTION
Issue: There is no ability to customize the `page` instance before it goes to a page.

## What I did
I've added a `customizePage` method that will be invoked before page calls to `goto`. 
