### PR TITLE
Fix company name for percy.io

### DIFF
--- a/docs/src/pages/testing/css-style-testing/index.md
+++ b/docs/src/pages/testing/css-style-testing/index.md
@@ -28,7 +28,7 @@ Just like that, you can access all of the stories in your Storybook and use the
 There are several frameworks that have out of the box Storybook integrations:
 - [StoryShots](https://github.com/storybooks/storybook/tree/master/addons/storyshots) with its [seamless integration](https://github.com/storybooks/storybook/tree/master/addons/storyshots#configure-storyshots-for-image-snapshots) with [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot)
 - [Loki](https://loki.js.org/)
-- [Perci](https://percy.io/docs/clients/javascript/react-storybook)
+- [Percy](https://percy.io/docs/clients/javascript/react-storybook)
 - [Screener](https://screener.io/v2/docs) 
 - [Chromatic](https://www.chromaticqa.com)
 

--- a/docs/src/pages/testing/css-style-testing/index.md
+++ b/docs/src/pages/testing/css-style-testing/index.md
@@ -28,7 +28,7 @@ Just like that, you can access all of the stories in your Storybook and use the
 There are several frameworks that have out of the box Storybook integrations:
 - [StoryShots](https://github.com/storybooks/storybook/tree/master/addons/storyshots) with its [seamless integration](https://github.com/storybooks/storybook/tree/master/addons/storyshots#configure-storyshots-for-image-snapshots) with [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot)
 - [Loki](https://loki.js.org/)
-- [Percy](https://percy.io/docs/clients/javascript/react-storybook)
+- [Percy](https://docs.percy.io/docs/storybook-for-react)
 - [Screener](https://screener.io/v2/docs) 
 - [Chromatic](https://www.chromaticqa.com)
 


### PR DESCRIPTION
Change Perci => Percy company name for [Percy.io](https:percy.io)

Issue:

## What I did

Change company name from `Perci` to `Percy`

## How to test

View the markdown and confirm the change is correct.

> Is this testable with Jest or Chromatic screenshots?

I suppose it's possible, but I imagine this has already been covered. Let's run the tests and find out if anything changes.

> Does this need a new example in the kitchen sink apps?

Nope.

> Does this need an update to the documentation?

This is the documentation.