### PR TITLE
Document generic addons and knobs select migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,9 +347,12 @@ NOTE: `3.4.9` publish failed
 
 2018-May-17
 
+NOTE: As part of the generic addon decorators, we've reversed the order of addon-knob's `select` knob keys/values, which had been called `selectV2` prior to this breaking change.
+
 #### Breaking Changes
 
 -   Support webpack4 modules format [#3576](https://github.com/storybooks/storybook/pull/3576)
+-   Generic addon decorators [#3555](https://github.com/storybooks/storybook/pull/3555)
 
 #### Features
 
@@ -357,7 +360,6 @@ NOTE: `3.4.9` publish failed
 
 #### Maintenance
 
--   Generic addon decorators [#3555](https://github.com/storybooks/storybook/pull/3555)
 -   Refactor transitional decorator from addon-notes [#3559](https://github.com/storybooks/storybook/pull/3559)
 
 # 3.4.5

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,36 +2,54 @@
 
 ## Table of contents
 
--   [From version 3.4.x to 4.0.x](#from-version-34x-to-40x)
-    -   [Keyboard shortcuts moved](#keyboard-shortcuts-moved)
-    -   [Removed addWithInfo](#removed-add-with-info)
-    -   [Removed RN addons](#removed-rn-addons)
-    -   [Storyshots changes](#storyshots-changes)
--   [From version 3.3.x to 3.4.x](#from-version-33x-to-34x)
--   [From version 3.2.x to 3.3.x](#from-version-32x-to-33x)
-    -   [Refactored Knobs](#refactored-knobs)
-    -   [Storyshots Jest configuration](#storyshots-jest-configuration)
--   [From version 3.1.x to 3.2.x](#from-version-31x-to-32x)
-    -   [Moved TypeScript addons definitions](#moved-typescript-addons-definitions)
-    -   [Updated Addons API](#updated-addons-api)
--   [From version 3.0.x to 3.1.x](#from-version-30x-to-31x)
-    -   [Moved TypeScript definitions](#moved-typescript-definitions)
-    -   [Deprecated head.html](#deprecated-headhtml)
--   [From version 2.x.x to 3.x.x](#from-version-2xx-to-3xx)
-    -   [Webpack upgrade](#webpack-upgrade)
-    -   [Packages renaming](#packages-renaming)
-    -   [Deprecated embedded addons](#deprecated-embedded-addons)
+- [From version 3.4.x to 4.0.x](#from-version-34x-to-40x)
+  - [Keyboard shortcuts moved](#keyboard-shortcuts-moved)
+  - [Removed addWithInfo](#removed-add-with-info)
+  - [Removed RN addons](#removed-rn-addons)
+  - [Storyshots changes](#storyshots-changes)
+- [From version 3.3.x to 3.4.x](#from-version-33x-to-34x)
+- [From version 3.2.x to 3.3.x](#from-version-32x-to-33x)
+  - [Refactored Knobs](#refactored-knobs)
+  - [Storyshots Jest configuration](#storyshots-jest-configuration)
+- [From version 3.1.x to 3.2.x](#from-version-31x-to-32x)
+  - [Moved TypeScript addons definitions](#moved-typescript-addons-definitions)
+  - [Updated Addons API](#updated-addons-api)
+- [From version 3.0.x to 3.1.x](#from-version-30x-to-31x)
+  - [Moved TypeScript definitions](#moved-typescript-definitions)
+  - [Deprecated head.html](#deprecated-headhtml)
+- [From version 2.x.x to 3.x.x](#from-version-2xx-to-3xx)
+  - [Webpack upgrade](#webpack-upgrade)
+  - [Packages renaming](#packages-renaming)
+  - [Deprecated embedded addons](#deprecated-embedded-addons)
 
 ## From 3.4.x to 4.0
 
 With 4.0 as our first major release in over a year, we've collected a lot of cleanup tasks. All deprecations have been marked for months, so we hope that there will be no significant impact on your project.
 
+### Generic addons
+
+4.x introduces generic addon decorators that are not tied to specific view layers [#3555](https://github.com/storybooks/storybook/pull/3555). So for example:
+
+```js
+import { number } from "@storybook/addon-knobs/react";
+```
+
+Becomes:
+
+```js
+import { number } from "@storybook/addon-knobs";
+```
+
+### Knobs select ordering
+
+4.0 also reversed the order of addon-knob's `select` knob keys/values, which had been called `selectV2` prior to this breaking change. See the knobs [package README](https://github.com/storybooks/storybook/blob/master/addons/knobs/README.md#select) for usage.
+
 ### Keyboard shortcuts moved
 
-  - Addon Panel to `Z`
-  - Stories Panel to `X`
-  - Show Search to `O`
-  - Addon Panel right side to `G`
+- Addon Panel to `Z`
+- Stories Panel to `X`
+- Show Search to `O`
+- Addon Panel right side to `G`
 
 ### Removed addWithInfo
 
@@ -43,16 +61,16 @@ The `@storybook/react-native` had built-in addons (`addon-actions` and `addon-li
 
 ### Storyshots Changes
 
-1. `imageSnapshot` test function was extracted from `addon-storyshots` 
-and moved to a new package - `addon-storyshots-puppeteer` that now will 
-be dependant on puppeteer. [README](https://github.com/storybooks/storybook/tree/master/addons/storyshots/storyshots-puppeteer)
-2. `getSnapshotFileName` export was replaced with the `Stories2SnapsConverter` 
-class that now can be overridden for a custom implementation of the 
-snapshot-name generation. [README](https://github.com/storybooks/storybook/tree/master/addons/storyshots/storyshots-core#stories2snapsconverter)
-3. Storybook that was configured with Webpack's `require.context()` feature 
-will need to add a babel plugin to polyfill this functionality. 
-A possible plugin might be [babel-plugin-require-context-hook](https://github.com/smrq/babel-plugin-require-context-hook).
-[README](https://github.com/storybooks/storybook/tree/master/addons/storyshots/storyshots-core#configure-jest-to-work-with-webpacks-requirecontext)
+1.  `imageSnapshot` test function was extracted from `addon-storyshots`
+    and moved to a new package - `addon-storyshots-puppeteer` that now will
+    be dependant on puppeteer. [README](https://github.com/storybooks/storybook/tree/master/addons/storyshots/storyshots-puppeteer)
+2.  `getSnapshotFileName` export was replaced with the `Stories2SnapsConverter`
+    class that now can be overridden for a custom implementation of the
+    snapshot-name generation. [README](https://github.com/storybooks/storybook/tree/master/addons/storyshots/storyshots-core#stories2snapsconverter)
+3.  Storybook that was configured with Webpack's `require.context()` feature
+    will need to add a babel plugin to polyfill this functionality.
+    A possible plugin might be [babel-plugin-require-context-hook](https://github.com/smrq/babel-plugin-require-context-hook).
+    [README](https://github.com/storybooks/storybook/tree/master/addons/storyshots/storyshots-core#configure-jest-to-work-with-webpacks-requirecontext)
 
 ## From version 3.3.x to 3.4.x
 
@@ -66,9 +84,11 @@ Also read on if you're using `addon-knobs`: we advise an update to your code for
 ### `babel-core` is now a peer dependency ([#2494](https://github.com/storybooks/storybook/pull/2494))
 
 This affects you if you don't use babel in your project. You may need to add `babel-core` as dev dependency:
+
 ```
 npm install --save-dev babel-core
 ```
+
 This was done to support different major versions of babel.
 
 ### Base webpack config now contains vital plugins ([#1775](https://github.com/storybooks/storybook/pull/1775))
@@ -82,7 +102,7 @@ Knobs users: there was a bug in 3.2.x where using the knobs addon imported all f
 In the case of React or React-Native, import knobs like this:
 
 ```js
-import { withKnobs, text, boolean, number } from '@storybook/addon-knobs/react';
+import { withKnobs, text, boolean, number } from "@storybook/addon-knobs/react";
 ```
 
 In the case of Vue: `import { ... } from '@storybook/addon-knobs/vue';`
@@ -110,14 +130,14 @@ We're in the process of upgrading our addons APIs. As a first step, we've upgrad
 Here's an example of using Notes and Info in 3.2 with the new API.
 
 ```js
-storiesOf('composition', module)
-  .add('new addons api',
-    withInfo('see Notes panel for composition info')(
-      withNotes({ text: 'Composition: Info(Notes())' })(context =>
-        <MyComponent name={context.story} />
-      )
-    )
-  );
+storiesOf("composition", module).add(
+  "new addons api",
+  withInfo("see Notes panel for composition info")(
+    withNotes({ text: "Composition: Info(Notes())" })(context => (
+      <MyComponent name={context.story} />
+    ))
+  )
+);
 ```
 
 It's not beautiful, but we'll be adding a more convenient/idiomatic way of using these [withX primitives](https://gist.github.com/shilman/792dc25550daa9c2bf37238f4ef7a398) in Storybook 3.3.
@@ -140,8 +160,8 @@ We have deprecated the use of `head.html` for including scripts/styles/etc. into
 
 Now we use:
 
--   `preview-head.html` for including extra content into the preview pane.
--   `manager-head.html` for including extra content into the manager window.
+- `preview-head.html` for including extra content into the preview pane.
+- `manager-head.html` for including extra content into the manager window.
 
 [Read our docs](https://storybook.js.org/configurations/add-custom-head-tags/) for more details.
 
@@ -223,17 +243,17 @@ We used to ship 2 addons with every single installation of storybook: `actions` 
 
 If you **are** using these addons, migrating is simple:
 
--   add the addons you use to your `package.json`.
--   update your code:
-    change `addons.js` like so:
-    ```js
-    import '@storybook/addon-actions/register';
-    import '@storybook/addon-links/register';
-    ```
-    change `x.story.js` like so:
-    ```js
-    import React from 'react';
-    import { storiesOf } from '@storybook/react';
-    import { action } from '@storybook/addon-actions';
-    import { linkTo } from '@storybook/addon-links';
-    ```
+- add the addons you use to your `package.json`.
+- update your code:
+  change `addons.js` like so:
+  ```js
+  import "@storybook/addon-actions/register";
+  import "@storybook/addon-links/register";
+  ```
+  change `x.story.js` like so:
+  ```js
+  import React from "react";
+  import { storiesOf } from "@storybook/react";
+  import { action } from "@storybook/addon-actions";
+  import { linkTo } from "@storybook/addon-links";
+  ```


### PR DESCRIPTION
Issue: N/A

## What I did

Added documentation of breaking changes around:
- generic addons
- knobs select key/value reorder

## How to test
N/A

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
