### PR TITLE
Make addon-options work with story parameters

### DIFF
--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -105,4 +105,29 @@ setOptions({
 
 storybook.configure(() => require('./stories'), module);
 ```
+
+### using withOptions options or parameters
+
+The options-addon accepts story paramters to set options (as shown below).
+
+```js
+import { storiesOf } from '@storybook/marko';
+import { withKnobs, text, number } from '@storybook/addon-knobs';
+import { withOptions } from '@storybook/addon-options';
+import Hello from '../components/hello/index.marko';
+
+storiesOf('Addons|Knobs/Hello', module)
+  .addDecorator(withOptions)
+  .addDecorator(withKnobs)
+  .addParameters({ options: { addonPanelInRight: true } })
+  .add('Simple', () => {
+    const name = text('Name', 'John Doe');
+    const age = number('Age', 44);
+    return Hello.renderSync({
+      name,
+      age,
+    });
+  });
+```
+
 It is also possible to call `setOptions()` inside individual stories. Note that this will bring impact story render performance significantly.

--- a/addons/options/preview.js
+++ b/addons/options/preview.js
@@ -1,4 +1,6 @@
 const preview = require('./dist/preview');
 
 exports.setOptions = preview.setOptions;
+exports.withOptions = preview.withOptions;
+
 preview.init();

--- a/examples/marko-cli/src/stories/addon-knobs.stories.js
+++ b/examples/marko-cli/src/stories/addon-knobs.stories.js
@@ -1,11 +1,14 @@
 import { storiesOf } from '@storybook/marko';
 import { withKnobs, boolean, text, number } from '@storybook/addon-knobs';
+import { withOptions } from '@storybook/addon-options';
 import Hello from '../components/hello/index.marko';
 import MarkoWidgetHello from '../components/marko-widgets/hello';
 import MarkoWidgetButton from '../components/marko-widgets/button';
 
 storiesOf('Addons|Knobs/Hello', module)
+  .addDecorator(withOptions)
   .addDecorator(withKnobs)
+  .addParameters({ options: { addonPanelInRight: true } })
   .add('Simple', () => {
     const name = text('Name', 'John Doe');
     const age = number('Age', 44);
@@ -16,7 +19,9 @@ storiesOf('Addons|Knobs/Hello', module)
   });
 
 storiesOf('Addons|Knobs/Hello (Marko Widget)', module)
+  .addDecorator(withOptions)
   .addDecorator(withKnobs)
+  .addParameters({ options: { addonPanelInRight: false } })
   .add('Simple', () => {
     const name = text('Name', 'John Doe');
     return MarkoWidgetHello.renderSync({

--- a/examples/marko-cli/src/stories/index.stories.js
+++ b/examples/marko-cli/src/stories/index.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/marko';
-
+import { withOptions } from '@storybook/addon-options';
 import Hello from '../components/hello/index.marko';
 import ClickCount from '../components/click-count/index.marko';
 import StopWatch from '../components/stop-watch/index.marko';
@@ -8,9 +8,17 @@ import Welcome from '../components/welcome/index.marko';
 storiesOf('Welcome', module).add('welcome', () => Welcome.renderSync({}));
 
 storiesOf('Hello', module)
+  .addDecorator(withOptions)
+  .addParameters({ options: { addonPanelInRight: false } })
   .add('Simple', () => Hello.renderSync({ name: 'abc', age: 20 }))
   .add('with ERROR!', () => 'NOT A MARKO RENDER_RESULT');
 
-storiesOf('ClickCount', module).add('Simple', () => ClickCount.renderSync({}));
+storiesOf('ClickCount', module)
+  .addDecorator(withOptions)
+  .addParameters({ options: { addonPanelInRight: true } })
+  .add('Simple', () => ClickCount.renderSync({}), { hierarchyRootSeparator: /\|/ });
 
-storiesOf('StopWatch', module).add('Simple', () => StopWatch.renderSync({}));
+storiesOf('StopWatch', module)
+  .addDecorator(withOptions)
+  .addParameters({ options: { addonPanelInRight: false } })
+  .add('Simple', () => StopWatch.renderSync({}));


### PR DESCRIPTION
## What I did
- use makeDectorator to upgrade withOptions
- update documentation

## How to test
I've added usage to some stories in the marko-cli

![addon-options-eg](https://user-images.githubusercontent.com/8527474/43681118-af56df0c-97ff-11e8-8919-e03632449451.gif)

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
