### PR TITLE
[BUG FIX] Use fixed version of react-dev-utils

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -54,7 +54,7 @@
     "json5": "^1.0.1",
     "prop-types": "^15.6.2",
     "raw-loader": "^0.5.1",
-    "react-dev-utils": "^6.0.0-next.3e165448",
+    "react-dev-utils": "6.0.0-next.3e165448",
     "react-native-compat": "^1.0.0",
     "react-native-iphone-x-helper": "^1.0.3",
     "shelljs": "^0.8.2",

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -30,7 +30,7 @@
     "global": "^4.3.2",
     "lodash.flattendeep": "^4.4.0",
     "prop-types": "^15.6.2",
-    "react-dev-utils": "^6.0.0-next.3e165448",
+    "react-dev-utils": "6.0.0-next.3e165448",
     "react-emotion": "^9.2.6"
   },
   "peerDependencies": {

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -51,7 +51,7 @@
     "prop-types": "^15.6.2",
     "qs": "^6.5.2",
     "raw-loader": "^0.5.1",
-    "react-dev-utils": "^6.0.0-next.3e165448",
+    "react-dev-utils": "6.0.0-next.3e165448",
     "react-emotion": "^9.2.6",
     "redux": "^4.0.0",
     "serve-favicon": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14477,30 +14477,7 @@ react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
 
-react-dev-utils@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.1.tgz#1f396e161fe44b595db1b186a40067289bf06613"
-  dependencies:
-    address "1.0.3"
-    babel-code-frame "6.26.0"
-    chalk "1.1.3"
-    cross-spawn "5.1.0"
-    detect-port-alt "1.1.6"
-    escape-string-regexp "1.0.5"
-    filesize "3.5.11"
-    global-modules "1.0.0"
-    gzip-size "3.0.0"
-    inquirer "3.3.0"
-    is-root "1.0.0"
-    opn "5.2.0"
-    react-error-overlay "^4.0.0"
-    recursive-readdir "2.2.1"
-    shell-quote "1.6.1"
-    sockjs-client "1.1.4"
-    strip-ansi "3.0.1"
-    text-table "0.2.0"
-
-react-dev-utils@^6.0.0-next.3e165448:
+react-dev-utils@6.0.0-next.3e165448:
   version "6.0.0-next.3e165448"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-6.0.0-next.3e165448.tgz#d573ed0ba692f6cee23166f99204e5761df0897c"
   dependencies:
@@ -14525,6 +14502,29 @@ react-dev-utils@^6.0.0-next.3e165448:
     shell-quote "1.6.1"
     sockjs-client "1.1.4"
     strip-ansi "4.0.0"
+    text-table "0.2.0"
+
+react-dev-utils@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.1.tgz#1f396e161fe44b595db1b186a40067289bf06613"
+  dependencies:
+    address "1.0.3"
+    babel-code-frame "6.26.0"
+    chalk "1.1.3"
+    cross-spawn "5.1.0"
+    detect-port-alt "1.1.6"
+    escape-string-regexp "1.0.5"
+    filesize "3.5.11"
+    global-modules "1.0.0"
+    gzip-size "3.0.0"
+    inquirer "3.3.0"
+    is-root "1.0.0"
+    opn "5.2.0"
+    react-error-overlay "^4.0.0"
+    recursive-readdir "2.2.1"
+    shell-quote "1.6.1"
+    sockjs-client "1.1.4"
+    strip-ansi "3.0.1"
     text-table "0.2.0"
 
 react-devtools-core@3.0.0:


### PR DESCRIPTION
Issue: #3953 #3956

## What I did
Somehow, having a caret in `"react-dev-utils": "^6.0.0-next.3e165448"` is resolved to an older version of `react-dev-utils` - `react-dev-utils@6.0.0-next.b2fd8db8`, which is not compatible with webpack 4.

It worked in our examples because it locked with the right version in the yarn.lock, but a fresh install might change this.