### PR TITLE
sorting by kind and nested stories

### DIFF
--- a/lib/ui/src/modules/ui/libs/filters.js
+++ b/lib/ui/src/modules/ui/libs/filters.js
@@ -19,7 +19,11 @@ const searchOptions = {
 function sort(stories, sortStoriesByKind) {
   if (!sortStoriesByKind) return stories;
 
-  return sortBy(stories, ['kind']);
+  const sortedStories = sortBy(stories, ['kind']);
+  return sortedStories.map(item => ({
+    ...item,
+    stories: item.stories.sort(),
+  }));
 }
 
 function flattenStories(items) {

--- a/lib/ui/src/modules/ui/libs/filters.js
+++ b/lib/ui/src/modules/ui/libs/filters.js
@@ -22,7 +22,7 @@ function sort(stories, sortStoriesByKind) {
   const sortedStories = sortBy(stories, ['kind']);
   return sortedStories.map(item => ({
     ...item,
-    stories: item.stories.sort(),
+    stories: item.stories.concat().sort(),
   }));
 }
 

--- a/lib/ui/src/modules/ui/libs/filters.test.js
+++ b/lib/ui/src/modules/ui/libs/filters.test.js
@@ -74,7 +74,7 @@ describe('manager.ui.libs.filters', () => {
       expect(res).toEqual([stories[1], stories[2], stories[0]]);
     });
 
-    test('should sort nested stories by kind', () => {
+    test('should sort nested stories', () => {
       const unsorted = ['bb', 'aa'];
       const stories = [
         { kind: 'ss', namespaces: ['ss'], stories: unsorted, rootName: '' },

--- a/lib/ui/src/modules/ui/libs/filters.test.js
+++ b/lib/ui/src/modules/ui/libs/filters.test.js
@@ -52,7 +52,7 @@ describe('manager.ui.libs.filters', () => {
       expect(res).toMatchObject([stories[0], stories[1]]);
     });
 
-    test('should not sort stories by kind', () => {
+    test('should sort nested stories', () => {
       const stories = [
         { kind: 'ss', namespaces: ['ss'], stories: ['bb'], rootName: '' },
         { kind: 'aa', namespaces: ['aa'], stories: ['bb'], rootName: '' },

--- a/lib/ui/src/modules/ui/libs/filters.test.js
+++ b/lib/ui/src/modules/ui/libs/filters.test.js
@@ -74,6 +74,20 @@ describe('manager.ui.libs.filters', () => {
       expect(res).toEqual([stories[1], stories[2], stories[0]]);
     });
 
+    test('should sort nested stories by kind', () => {
+      const unsorted = ['bb', 'aa'];
+      const stories = [
+        { kind: 'ss', namespaces: ['ss'], stories: unsorted, rootName: '' },
+        { kind: 'aa', namespaces: ['aa'], stories: ['bb'], rootName: '' },
+        { kind: 'bb', namespaces: ['bb'], stories: ['bb'], rootName: '' },
+      ];
+
+      const res = storyFilter(stories, null, null, null, true);
+
+      expect(res[2].stories).not.toEqual(unsorted);
+      expect(res[2].stories).toEqual(unsorted.concat().sort());
+    });
+
     test('should filter on story level', () => {
       const stories = [
         { kind: 'aa', namespaces: ['aa'], stories: ['bb'], rootName: '' },

--- a/lib/ui/src/modules/ui/libs/filters.test.js
+++ b/lib/ui/src/modules/ui/libs/filters.test.js
@@ -52,7 +52,7 @@ describe('manager.ui.libs.filters', () => {
       expect(res).toMatchObject([stories[0], stories[1]]);
     });
 
-    test('should sort nested stories', () => {
+    test('should not sort stories by kind', () => {
       const stories = [
         { kind: 'ss', namespaces: ['ss'], stories: ['bb'], rootName: '' },
         { kind: 'aa', namespaces: ['aa'], stories: ['bb'], rootName: '' },


### PR DESCRIPTION
Issue:

## What I did
sorting nested stories when activating: `sortStoriesByKind: false`

## How to test

```import { setOptions } from '@storybook/addon-options';
setOptions({sortStoriesByKind: false});
```

make sure that now both the root list of stories and the nested ones are ordered. At the moment just the root stories where sorted.

["bug", "maintenance"]
#3963 

