### PR TITLE
Fix Seamless Typescript Integration section in readme

### DIFF
--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -89,7 +89,7 @@ module.exports = ({ platform }) => ({
 
 ## Seamless Typescript Integration
 
-*Note: These instructions are for react-native >= 0.45 and the (default) [metro](https://github.com/facebook/metro) bundler*
+*Note: These instructions are for react-native >= 0.45, @storybook/react-native >= 4.0.0-alpha.2 and the (default) [metro](https://github.com/facebook/metro) bundler*
 
 For seamless type integration (no intermediate build step) we use the custom rn cli config feature and the [react-native-typescript-transformer](https://github.com/ds300/react-native-typescript-transformer) project 
 

--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -89,7 +89,7 @@ module.exports = ({ platform }) => ({
 
 ## Seamless Typescript Integration
 
-*Note: These instructions are for react-native >= 0.45, @storybook/react-native >= 4.0.0-alpha.2 and the (default) [metro](https://github.com/facebook/metro) bundler*
+*Note: These instructions are for react-native >= 0.45, @storybook/react-native >= 4.0.0-alpha.2 or higher and the (default) [metro](https://github.com/facebook/metro) bundler*
 
 For seamless type integration (no intermediate build step) we use the custom rn cli config feature and the [react-native-typescript-transformer](https://github.com/ds300/react-native-typescript-transformer) project 
 


### PR DESCRIPTION
The readme specifies using the ```--metro-config``` option which according to https://github.com/storybooks/storybook/issues/3700#issuecomment-394093968 was only added in ```4.0.0.alpha.2```

Issue:

## What I did

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
