### PR TITLE
Emit messages when stories fail to render

### DIFF
--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -18,7 +18,14 @@ setOptions({
   theme: themes.dark,
 });
 
-addDecorator(story => <ThemeProvider theme={themes.normal}>{story()}</ThemeProvider>);
+addDecorator(
+  (story, { kind }) =>
+    kind === 'Core|Errors' ? (
+      story()
+    ) : (
+      <ThemeProvider theme={themes.normal}>{story()}</ThemeProvider>
+    )
+);
 
 configureViewport({
   viewports: {

--- a/examples/official-storybook/stories/core.stories.js
+++ b/examples/official-storybook/stories/core.stories.js
@@ -3,6 +3,7 @@ import { storiesOf, addParameters } from '@storybook/react';
 import addons from '@storybook/addons';
 import Events from '@storybook/core-events';
 import { Button } from '@storybook/components';
+import { navigator } from 'global';
 
 const globalParameter = 'globalParameter';
 const chapterParameter = 'chapterParameter';
@@ -32,9 +33,13 @@ storiesOf('Core|Events', module).add('Force re-render', () => (
   <Button onClick={increment}>Clicked: {timesClicked}</Button>
 ));
 
-storiesOf('Core|Errors', module)
-  .add('story throws exception', () => {
-    throw new Error('error');
-  })
-  // Story does not return something react can render
-  .add('story errors', () => null);
+// Skip these stories in storyshots, they will throw -- NOTE: would rather do this
+// via a params API, see https://github.com/storybooks/storybook/pull/3967#issuecomment-411616023
+if (navigator && navigator.userAgent && !(navigator.userAgent.indexOf('jsdom') > -1)) {
+  storiesOf('Core|Errors', module)
+    .add('story throws exception', () => {
+      throw new Error('error');
+    })
+    // Story does not return something react can render
+    .add('story errors', () => null);
+}

--- a/examples/official-storybook/stories/core.stories.js
+++ b/examples/official-storybook/stories/core.stories.js
@@ -35,7 +35,12 @@ storiesOf('Core|Events', module).add('Force re-render', () => (
 
 // Skip these stories in storyshots, they will throw -- NOTE: would rather do this
 // via a params API, see https://github.com/storybooks/storybook/pull/3967#issuecomment-411616023
-if (navigator && navigator.userAgent && !(navigator.userAgent.indexOf('jsdom') > -1)) {
+if (
+  navigator &&
+  navigator.userAgent &&
+  !(navigator.userAgent.indexOf('jsdom') > -1) &&
+  !(navigator.userAgent.indexOf('Chromatic') > -1)
+) {
   storiesOf('Core|Errors', module)
     .add('story throws exception', () => {
       throw new Error('error');

--- a/examples/official-storybook/stories/core.stories.js
+++ b/examples/official-storybook/stories/core.stories.js
@@ -31,3 +31,10 @@ const increment = () => {
 storiesOf('Core|Events', module).add('Force re-render', () => (
   <Button onClick={increment}>Clicked: {timesClicked}</Button>
 ));
+
+storiesOf('Core|Errors', module)
+  .add('story throws exception', () => {
+    throw new Error('error');
+  })
+  // Story does not return something react can render
+  .add('story errors', () => null);

--- a/lib/core-events/index.js
+++ b/lib/core-events/index.js
@@ -10,4 +10,6 @@ module.exports = {
   FORCE_RE_RENDER: 'forceReRender',
   REGISTER_SUBSCRIPTION: 'registerSubscription',
   STORY_RENDERED: 'storyRendered',
+  STORY_ERRORED: 'storyErrored',
+  STORY_THREW_EXCEPTION: 'storyThrewException',
 };

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -43,14 +43,19 @@ function showErrorDisplay({ message, stack }) {
   document.body.classList.add(classes.ERROR);
 }
 
+// showError is used by the various app layers to inform the user they have done something
+// wrong -- for instance returned the wrong thing from a story
 function showError({ title, description }) {
+  addons.getChannel().emit(Events.STORY_ERRORED, { title, description });
   showErrorDisplay({
     message: title,
     stack: description,
   });
 }
 
+// showException is used if we fail to render the story and it is uncaught by the app layer
 function showException(exception) {
+  addons.getChannel().emit(Events.STORY_THREW_EXCEPTION, exception);
   showErrorDisplay(exception);
 
   // Log the stack to the console. So, user could check the source code.

--- a/lib/core/src/client/preview/start.test.js
+++ b/lib/core/src/client/preview/start.test.js
@@ -1,0 +1,101 @@
+import addons from '@storybook/addons';
+import Events from '@storybook/core-events';
+import { document } from 'global';
+
+import start from './start';
+
+jest.mock('@storybook/client-logger');
+jest.mock('@storybook/addons');
+jest.mock('global', () => ({
+  navigator: { userAgent: 'browser' },
+  window: {
+    addEventListener: jest.fn(),
+    location: { search: '' },
+    history: { replaceState: jest.fn() },
+  },
+  document: {
+    addEventListener: jest.fn(),
+    getElementById: jest.fn().mockReturnValue({}),
+    body: { classList: { add: jest.fn(), remove: jest.fn() } },
+    documentElement: {},
+  },
+}));
+
+function mockEmit() {
+  const emit = jest.fn();
+  addons.getChannel.mockReturnValue({ emit });
+
+  return emit;
+}
+
+it('renders nopreview when you have no stories', () => {
+  const emit = mockEmit();
+
+  const render = jest.fn();
+
+  start(render);
+
+  expect(render).not.toHaveBeenCalled();
+  expect(document.body.classList.add).toHaveBeenCalledWith('sb-show-nopreview');
+  expect(emit).toHaveBeenCalledWith(Events.STORY_RENDERED);
+});
+
+it('calls render when you add a story', () => {
+  const emit = mockEmit();
+
+  const render = jest.fn();
+
+  const { clientApi, configApi } = start(render);
+
+  emit.mockReset();
+  configApi.configure(() => {
+    clientApi.storiesOf('kind', {}).add('story', () => {});
+  }, {});
+
+  expect(render).toHaveBeenCalled();
+  expect(emit).toHaveBeenCalledWith(Events.STORY_RENDERED);
+});
+
+it('emits an exception and shows error when your story throws', () => {
+  const emit = mockEmit();
+
+  const render = jest.fn().mockImplementation(() => {
+    throw new Error('Some exception');
+  });
+
+  const { clientApi, configApi } = start(render);
+
+  emit.mockReset();
+  document.body.classList.add.mockReset();
+  configApi.configure(() => {
+    clientApi.storiesOf('kind', {}).add('story', () => {});
+  }, {});
+
+  expect(render).toHaveBeenCalled();
+  expect(document.body.classList.add).toHaveBeenCalledWith('sb-show-errordisplay');
+  expect(emit).toHaveBeenCalledWith(Events.STORY_THREW_EXCEPTION, expect.any(Error));
+});
+
+it('emits an error and shows error when your framework calls showError', () => {
+  const emit = mockEmit();
+
+  const error = {
+    title: 'Some error',
+    description: 'description',
+  };
+  const render = jest.fn().mockImplementation(({ showError }) => {
+    showError(error);
+  });
+
+  const { clientApi, configApi } = start(render);
+
+  emit.mockReset();
+  document.body.classList.add.mockReset();
+  configApi.configure(() => {
+    clientApi.storiesOf('kind', {}).add('story', () => {});
+  }, {});
+
+  expect(render).toHaveBeenCalled();
+  expect(document.body.classList.add).toHaveBeenCalledWith('sb-show-errordisplay');
+  expect(emit).toHaveBeenCalledWith(Events.STORY_ERRORED, error);
+});


### PR DESCRIPTION
Issue:

There is no way for external tools or the manager context to know when a story fails to render

## What I did

Emitted two events when the story errors or throws.

## How to test

I added stories for the two cases, however there are a couple of problems/questions:

1. The current use of emotion's `ThemeProvider` in official storybook means that my "error" story ends up throwing rather than triggering the react layer's error code. Any ideas on how to work around this @ndelangen? -- I don't want this decorator to apply for this story -- Perhaps we need to do something hacky like `addDecorator(story, ({kind})) => kind === 'Errors' ? story() : <ThemeProvider>...)`

2. I'd like to also throw the error if the story *throws sometime after the initial render*. Is this out of scope? It would be useful for Chromatic to know that a component has errored even if it does it async. This would require work from all the view layers so perhaps is a separate PR. Could be out of scope for storybook in any case.

3. Is there a way to test the event is emitted correctly?