### PR TITLE
Allow extending extensions without a full control mode

### DIFF
--- a/lib/core/src/server/__snapshots__/mergeConfigs.test.js.snap
+++ b/lib/core/src/server/__snapshots__/mergeConfigs.test.js.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mergeConfigs merges partial custom config 1`] = `
+Object {
+  "devtool": "source-maps",
+  "entry": Object {
+    "bundle": "index.js",
+  },
+  "module": Object {
+    "rules": Array [
+      "r1",
+      "r2",
+    ],
+  },
+  "output": Object {
+    "filename": "[name].js",
+  },
+  "plugins": Array [
+    "p1",
+    "p2",
+    "p3",
+  ],
+  "resolve": Object {
+    "alias": Object {
+      "A1": "src/B1",
+      "A2": "src/B2",
+    },
+    "enforceModuleExtension": true,
+    "extensions": Array [
+      ".js",
+      ".json",
+      ".ts",
+      ".tsx",
+    ],
+  },
+}
+`;
+
+exports[`mergeConfigs merges successfully if custom config is empty 1`] = `
+Object {
+  "devtool": "source-maps",
+  "entry": Object {
+    "bundle": "index.js",
+  },
+  "module": Object {
+    "rules": Array [
+      "r1",
+      "r2",
+    ],
+  },
+  "output": Object {
+    "filename": "[name].js",
+  },
+  "plugins": Array [
+    "p1",
+    "p2",
+  ],
+  "resolve": Object {
+    "alias": Object {
+      "A1": "src/B1",
+      "A2": "src/B2",
+    },
+    "enforceModuleExtension": true,
+    "extensions": Array [
+      ".js",
+      ".json",
+    ],
+  },
+}
+`;
+
+exports[`mergeConfigs merges two full configs in one 1`] = `
+Object {
+  "devtool": "source-maps",
+  "entry": Object {
+    "bundle": "index.js",
+  },
+  "module": Object {
+    "noParse": /jquery\\|lodash/,
+    "rules": Array [
+      "r1",
+      "r2",
+      "r3",
+      "r4",
+    ],
+  },
+  "output": Object {
+    "filename": "[name].js",
+  },
+  "plugins": Array [
+    "p1",
+    "p2",
+    "p3",
+    "p4",
+  ],
+  "profile": true,
+  "resolve": Object {
+    "alias": Object {
+      "A1": "src/B1",
+      "A2": "src/B2",
+      "A3": "src/B3",
+      "A4": "src/B4",
+    },
+    "enforceExtension": false,
+    "enforceModuleExtension": true,
+    "extensions": Array [
+      ".js",
+      ".json",
+      ".ts",
+      ".tsx",
+    ],
+  },
+}
+`;

--- a/lib/core/src/server/config.js
+++ b/lib/core/src/server/config.js
@@ -4,6 +4,7 @@ import { createDefaultWebpackConfig } from './config/defaults/webpack.config';
 import devBabelConfig from './config/babel';
 import loadCustomBabelConfig from './loadCustomBabelConfig';
 import loadCustomWebpackConfig from './loadCustomWebpackConfig';
+import mergeConfigs from './mergeConfigs';
 
 const noopWrapper = config => config;
 
@@ -15,36 +16,6 @@ function getBabelConfig({
 }) {
   const defaultConfig = wrapDefaultBabelConfig(defaultBabelConfig);
   return wrapBabelConfig(loadCustomBabelConfig(configDir, defaultConfig));
-}
-
-function mergeConfigs(config, customConfig) {
-  return {
-    ...customConfig,
-    // We'll always load our configurations after the custom config.
-    // So, we'll always load the stuff we need.
-    ...config,
-    // Override with custom devtool if provided
-    devtool: customConfig.devtool || config.devtool,
-    // We need to use our and custom plugins.
-    plugins: [...config.plugins, ...(customConfig.plugins || [])],
-    module: {
-      ...config.module,
-      // We need to use our and custom rules.
-      ...customConfig.module,
-      rules: [
-        ...config.module.rules,
-        ...((customConfig.module && customConfig.module.rules) || []),
-      ],
-    },
-    resolve: {
-      ...config.resolve,
-      ...customConfig.resolve,
-      alias: {
-        ...config.alias,
-        ...(customConfig.resolve && customConfig.resolve.alias),
-      },
-    },
-  };
 }
 
 function informAboutCustomConfig(defaultConfigName) {

--- a/lib/core/src/server/mergeConfigs.js
+++ b/lib/core/src/server/mergeConfigs.js
@@ -1,34 +1,49 @@
+function plugins({ plugins: defaultPlugins = [] }, { plugins: customPlugins = [] }) {
+  return [...defaultPlugins, ...customPlugins];
+}
+
+function rules({ rules: defaultRules = [] }, { rules: customRules = [] }) {
+  return [...defaultRules, ...customRules];
+}
+
+function extensions({ extensions: defaultExtensions = [] }, { extensions: customExtensions = [] }) {
+  return [...defaultExtensions, ...customExtensions];
+}
+
+function alias({ alias: defaultAlias = {} }, { alias: customAlias = {} }) {
+  return {
+    ...defaultAlias,
+    ...customAlias,
+  };
+}
+
+function module({ module: defaultModule = {} }, { module: customModule = {} }) {
+  return {
+    ...defaultModule,
+    ...customModule,
+    rules: rules(defaultModule, customModule),
+  };
+}
+
+function resolve({ resolve: defaultResolve = {} }, { resolve: customResolve = {} }) {
+  return {
+    ...defaultResolve,
+    ...customResolve,
+    alias: alias(defaultResolve, customResolve),
+    extensions: extensions(defaultResolve, customResolve),
+  };
+}
+
 function mergeConfigs(config, customConfig) {
   return {
-    ...customConfig,
     // We'll always load our configurations after the custom config.
     // So, we'll always load the stuff we need.
+    ...customConfig,
     ...config,
-    // Override with custom devtool if provided
     devtool: customConfig.devtool || config.devtool,
-    // We need to use our and custom plugins.
-    plugins: [...config.plugins, ...(customConfig.plugins || [])],
-    module: {
-      ...config.module,
-      // We need to use our and custom rules.
-      ...customConfig.module,
-      rules: [
-        ...config.module.rules,
-        ...((customConfig.module && customConfig.module.rules) || []),
-      ],
-    },
-    resolve: {
-      ...(config.resolve || {}),
-      ...(customConfig.resolve || {}),
-      alias: {
-        ...((config.resolve && config.resolve.alias) || {}),
-        ...((customConfig.resolve && customConfig.resolve.alias) || {}),
-      },
-      extensions: [
-        ...((config.resolve && config.resolve.extensions) || []),
-        ...((customConfig.resolve && customConfig.resolve.extensions) || []),
-      ],
-    },
+    plugins: plugins(config, customConfig),
+    module: module(config, customConfig),
+    resolve: resolve(config, customConfig),
   };
 }
 

--- a/lib/core/src/server/mergeConfigs.js
+++ b/lib/core/src/server/mergeConfigs.js
@@ -18,15 +18,15 @@ function mergeConfigs(config, customConfig) {
       ],
     },
     resolve: {
-      ...config.resolve,
-      ...customConfig.resolve,
+      ...(config.resolve || {}),
+      ...(customConfig.resolve || {}),
       alias: {
-        ...config.resolve.alias,
-        ...(customConfig.resolve && customConfig.resolve.alias),
+        ...((config.resolve && config.resolve.alias) || {}),
+        ...((customConfig.resolve && customConfig.resolve.alias) || {}),
       },
       extensions: [
-        ...config.resolve.extensions,
-        ...(customConfig.resolve && customConfig.resolve.extensions),
+        ...((config.resolve && config.resolve.extensions) || []),
+        ...((customConfig.resolve && customConfig.resolve.extensions) || []),
       ],
     },
   };

--- a/lib/core/src/server/mergeConfigs.js
+++ b/lib/core/src/server/mergeConfigs.js
@@ -1,0 +1,35 @@
+function mergeConfigs(config, customConfig) {
+  return {
+    ...customConfig,
+    // We'll always load our configurations after the custom config.
+    // So, we'll always load the stuff we need.
+    ...config,
+    // Override with custom devtool if provided
+    devtool: customConfig.devtool || config.devtool,
+    // We need to use our and custom plugins.
+    plugins: [...config.plugins, ...(customConfig.plugins || [])],
+    module: {
+      ...config.module,
+      // We need to use our and custom rules.
+      ...customConfig.module,
+      rules: [
+        ...config.module.rules,
+        ...((customConfig.module && customConfig.module.rules) || []),
+      ],
+    },
+    resolve: {
+      ...config.resolve,
+      ...customConfig.resolve,
+      alias: {
+        ...config.resolve.alias,
+        ...(customConfig.resolve && customConfig.resolve.alias),
+      },
+      extensions: [
+        ...config.resolve.extensions,
+        ...(customConfig.resolve && customConfig.resolve.extensions),
+      ],
+    },
+  };
+}
+
+export default mergeConfigs;

--- a/lib/core/src/server/mergeConfigs.test.js
+++ b/lib/core/src/server/mergeConfigs.test.js
@@ -1,0 +1,75 @@
+import mergeConfigs from './mergeConfigs';
+
+const config = {
+  devtool: 'source-maps',
+  entry: {
+    bundle: 'index.js',
+  },
+  output: {
+    filename: '[name].js',
+  },
+  module: {
+    rules: ['r1', 'r2'],
+  },
+  plugins: ['p1', 'p2'],
+  resolve: {
+    enforceModuleExtension: true,
+    extensions: ['.js', '.json'],
+    alias: {
+      A1: 'src/B1',
+      A2: 'src/B2',
+    },
+  },
+};
+
+describe('mergeConfigs', () => {
+  it('merges two full configs in one', () => {
+    const customConfig = {
+      profile: true,
+      entry: {
+        bundle: 'should_not_be_merged.js',
+      },
+      output: {
+        filename: 'should_not_be_merged.js',
+      },
+      module: {
+        noParse: /jquery|lodash/,
+        rules: ['r3', 'r4'],
+      },
+      plugins: ['p3', 'p4'],
+      resolve: {
+        enforceExtension: false,
+        extensions: ['.ts', '.tsx'],
+        alias: {
+          A3: 'src/B3',
+          A4: 'src/B4',
+        },
+      },
+    };
+
+    const result = mergeConfigs(config, customConfig);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('merges partial custom config', () => {
+    const customConfig = {
+      plugins: ['p3'],
+      resolve: {
+        extensions: ['.ts', '.tsx'],
+      },
+    };
+
+    const result = mergeConfigs(config, customConfig);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('merges successfully if custom config is empty', () => {
+    const customConfig = {};
+
+    const result = mergeConfigs(config, customConfig);
+
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Issue: I've played a bit with the code to create a "preset" (for TS) we talked about in slack and found out that it's not possible to extend the `resolve.extensions` without a full control mode (it overrides the existing instead of extending it).

## What I did.
Refactored a bit the `core/config.js` to make it possible to extend the `extensions`. 
