### PR TITLE
Add support for SourceCode override in Info Addon

### DIFF
--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -335,6 +335,78 @@ storiesOf('Button', module).add('with text', () => <Button>Hello Button</Button>
 });
 ```
 
+### Rendering a Custom Source View
+
+The `SourceComponent` option allows you to define how the source code view should be rendered. Your component will be rendered with only children defined.
+
+```js
+  {
+    children: React.Children
+  }
+```
+
+Example:
+
+```js
+// button.js
+// @flow
+import React from 'react';
+
+const paddingStyles = {
+  small: '4px 8px',
+  medium: '8px 16px',
+};
+
+const Button = ({
+  size,
+  ...rest
+}: {
+  /** The size of the button */
+  size: 'small' | 'medium',
+}) => {
+  const style = {
+    padding: paddingStyles[size] || '',
+  };
+  return <button style={style} {...rest} />;
+};
+Button.defaultProps = {
+  size: 'medium',
+};
+
+export default Button;
+```
+
+```js
+// stories.js
+import React from 'react';
+import SyntaxHighlighter, { registerLanguage } from "react-syntax-highlighter/prism-light";
+import jsx from 'react-syntax-highlighter/languages/prism/jsx';
+import atomDark from 'react-syntax-highlighter/styles/prism/atom-dark';
+import jsxToString from 'jsx-to-string';
+
+import { storiesOf } from '@storybook/react';
+import Button from './button';
+
+registerLanguage('jsx', jsx);
+
+const SourceComponent = ({ children }) => {
+  return (
+    <SyntaxHighlighter language="jsx" style={atomDark}>
+      {jsxToString(children, {
+        functionNameOnly: true,
+        useFunctionCode: true
+      })}
+    </SyntaxHighlighter>
+  );
+};
+
+storiesOf('Button', module).add('with text', () => <Button>Hello Button</Button>, {
+  info: {
+    SourceComponent,
+  },
+});
+```
+
 ### React Docgen Integration
 
 React Docgen is included as part of the @storybook/react package through the use of `babel-plugin-react-docgen` during babel compile time.

--- a/addons/info/src/components/Code.js
+++ b/addons/info/src/components/Code.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import Node from './Node';
+import { Pre } from './markdown';
+
+export default function Code(props) {
+  return (
+    <Pre>
+      {React.Children.map(props.children, (root, idx) => (
+        <Node
+          key={idx}
+          node={root}
+          depth={0}
+          maxPropsIntoLine={props.maxPropsIntoLine}
+          maxPropObjectKeys={props.maxPropObjectKeys}
+          maxPropArrayLength={props.maxPropArrayLength}
+          maxPropStringLength={props.maxPropStringLength}
+        />
+      ))}
+    </Pre>
+  );
+}
+
+Code.displayName = 'Code';
+
+Code.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  maxPropsIntoLine: PropTypes.number.isRequired,
+  maxPropObjectKeys: PropTypes.number.isRequired,
+  maxPropArrayLength: PropTypes.number.isRequired,
+  maxPropStringLength: PropTypes.number.isRequired
+};
+
+Code.defaultProps = {
+  children: null
+};

--- a/addons/info/src/components/Code.js
+++ b/addons/info/src/components/Code.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Node from './Node';
 import { Pre } from './markdown';
 

--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -8,9 +8,6 @@ import { baseFonts } from '@storybook/components';
 
 import marksy from 'marksy';
 
-import Node from './Node';
-import { Pre } from './markdown';
-
 global.STORYBOOK_REACT_CLASSES = global.STORYBOOK_REACT_CLASSES || [];
 const { STORYBOOK_REACT_CLASSES } = global;
 
@@ -274,22 +271,13 @@ class Story extends Component {
       return null;
     }
 
+    const View = this.props.SourceView;
     return (
       <div>
         <h1 style={stylesheet.source.h1}>Story Source</h1>
-        <Pre>
-          {React.Children.map(children, (root, idx) => (
-            <Node
-              key={idx}
-              node={root}
-              depth={0}
-              maxPropsIntoLine={maxPropsIntoLine}
-              maxPropObjectKeys={maxPropObjectKeys}
-              maxPropArrayLength={maxPropArrayLength}
-              maxPropStringLength={maxPropStringLength}
-            />
-          ))}
-        </Pre>
+        <View>
+          {children}
+        </View>
       </div>
     );
   }

--- a/addons/info/src/index.js
+++ b/addons/info/src/index.js
@@ -7,6 +7,7 @@ import Story from './components/Story';
 import PropTable from './components/PropTable';
 import makeTableComponent from './components/makeTableComponent';
 import { H1, H2, H3, H4, H5, H6, Code, P, UL, A, LI } from './components/markdown';
+import CodeView from './components/Code';
 
 const defaultOptions = {
   inline: false,
@@ -14,6 +15,7 @@ const defaultOptions = {
   source: true,
   propTables: [],
   TableComponent: PropTable,
+  SourceComponent: CodeView,
   maxPropsIntoLine: 3,
   maxPropObjectKeys: 3,
   maxPropArrayLength: 3,
@@ -74,6 +76,7 @@ function addInfo(storyFn, context, infoOptions) {
     propTables: options.propTables,
     propTablesExclude: options.propTablesExclude,
     PropTable: makeTableComponent(options.TableComponent),
+    SourceView: options.SourceComponent,
     components,
     maxPropObjectKeys: options.maxPropObjectKeys,
     maxPropArrayLength: options.maxPropArrayLength,


### PR DESCRIPTION
Issue:
Ability to change how the source code is shown.

## What I did
Add a SourceComponent prop so the source code view can be overwritten.

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
