### PR TITLE
Remove deprecation of --db-path and --enable-db

### DIFF
--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -35,22 +35,9 @@ export function buildDev({ packageJson, ...loadOptions }) {
     .option('--ssl-key <key>', 'Provide an SSL key. (Required with --https)')
     .option('--smoke-test', 'Exit after successful start')
     .option('--quiet', 'Suppress verbose build output')
-    .option('-d, --db-path [db-file]', 'DEPRECATED!')
-    .option('--enable-db', 'DEPRECATED!')
     .parse(process.argv);
 
   logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}`) + chalk.reset('\n'));
-
-  if (program.enableDb || program.dbPath) {
-    logger.error(
-      [
-        'Error: the experimental local database addon is no longer bundled with',
-        'storybook. Please remove these flags (-d,--db-path,--enable-db)',
-        'from the command or npm script and try again.',
-      ].join(' ')
-    );
-    process.exit(1);
-  }
 
   // The key is the field created in `program` variable for
   // each command line argument. Value is the env variable.

--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -22,22 +22,9 @@ export function buildStatic({ packageJson, ...loadOptions }) {
     .option('-o, --output-dir [dir-name]', 'Directory where to store built files')
     .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
     .option('-w, --watch', 'Enable watch mode')
-    .option('-d, --db-path [db-file]', 'DEPRECATED!')
-    .option('--enable-db', 'DEPRECATED!')
     .parse(process.argv);
 
   logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}\n`));
-
-  if (program.enableDb || program.dbPath) {
-    logger.error(
-      [
-        'Error: the experimental local database addon is no longer bundled with',
-        'storybook. Please remove these flags (-d,--db-path,--enable-db)',
-        'from the command or npm script and try again.',
-      ].join(' ')
-    );
-    process.exit(1);
-  }
 
   // The key is the field created in `program` variable for
   // each command line argument. Value is the env variable.


### PR DESCRIPTION
Issue: There were old `--db-path` and `--enable-db` that we forgot to remove.