### PR TITLE
Storyshots puppeteer images do not match

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/src/index.js
+++ b/addons/storyshots/storyshots-puppeteer/src/index.js
@@ -59,20 +59,21 @@ export const imageSnapshot = (customConfig = {}) => {
 
     expect.assertions(1);
 
+    let image;
     try {
       await customizePage(page);
       await page.goto(url, getGotoOptions({ context, url }));
       await beforeScreenshot(page, { context, url });
-      const image = await page.screenshot(getScreenshotOptions({ context, url }));
-
-      expect(image).toMatchImageSnapshot(getMatchOptions({ context, url }));
+      image = await page.screenshot(getScreenshotOptions({ context, url }));
     } catch (e) {
       logger.error(
-        `ERROR WHILE CONNECTING TO ${url}, did you start or build the storybook first ? A storybook instance should be running or a static version should be built when using image snapshot feature.`,
+        `Error when connecting to ${url}, did you start or build the storybook first? A storybook instance should be running or a static version should be built when using image snapshot feature.`,
         e
       );
       throw e;
     }
+
+    expect(image).toMatchImageSnapshot(getMatchOptions({ context, url }));
   };
 
   testFn.afterAll = () => browser.close();


### PR DESCRIPTION
When current screenshots do not much with previous ones,
we show connection error since `expect` method also throws.

Workaround that and also lowercase the error message so it would look
like more then other errors

Fixes #4036