### PR TITLE
adds closing tag in component state example

### DIFF
--- a/docs/src/pages/basics/faq/index.md
+++ b/docs/src/pages/basics/faq/index.md
@@ -59,5 +59,5 @@ class MyComponent extends Component {
 
 storiesOf('MyComponent', module)
   .add('default', () => <MyComponent />)
-  .add('other', () => <MyComponent initialState={{ someVar: 'otherVal' }});
+  .add('other', () => <MyComponent initialState={{ someVar: 'otherVal' }} />);
 ```


### PR DESCRIPTION
Issue:
[Can I modify React component state in stories?](https://storybook.js.org/basics/faq/#can-i-modify-react-component-state-in-stories) example is missing a closing tag and causes a SyntaxError.
## What I did
Added the missing closing tag
## How to test
Copy example code and execute, no SyntaxError should be thrown.
Is this testable with Jest or Chromatic screenshots? **NO**
Does this need a new example in the kitchen sink apps? **NO**
Does this need an update to the documentation? **NO**

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
