### PR TITLE
fixed 4025 - allow setting background via name

### DIFF
--- a/addons/backgrounds/README.md
+++ b/addons/backgrounds/README.md
@@ -81,3 +81,5 @@ storiesOf('Button', module).add('with text', () => <button>Click me</button>, {
   backgrounds: { disable: true },
 });
 ```
+
+You can choose your background in a running storybook instance with the `background` query param and either set the background value or the name as the parameter value. E.g. `?background=twitter` or `?background=#00aced`.

--- a/addons/backgrounds/src/BackgroundPanel.js
+++ b/addons/backgrounds/src/BackgroundPanel.js
@@ -99,8 +99,11 @@ export default class BackgroundPanel extends Component {
 
       // debugger;
 
-      if (current && backgrounds.find(bg => bg.value === current)) {
-        this.updateIframe(current);
+      const foundBackground =
+        current && backgrounds.find(bg => bg.name === decodeURI(current) || bg.value === current);
+
+      if (foundBackground) {
+        this.updateIframe(foundBackground.value);
       } else if (defaultOrFirst) {
         this.updateIframe(defaultOrFirst.value);
         api.setQueryParams({ background: defaultOrFirst.value });


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/4025

## What I did

I updated the backgrounds addon so I can choose my background by name as well and not just by value. 

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation? Yes.

If you run a storybook which includes the backgrounds addon you can set `?background={valueOrName}` to choose the background

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
