### PR TITLE
fix #3933: Duplicated keys in PropTypes table 

### DIFF
--- a/addons/info/src/components/PropTable.js
+++ b/addons/info/src/components/PropTable.js
@@ -6,9 +6,6 @@ import { Table, Td, Th } from '@storybook/components';
 import PropVal from './PropVal';
 import PrettyPropType from './types/PrettyPropType';
 
-const willItOccurAgain = (collection, item, itemIndex = 0) =>
-  collection.indexOf(item, itemIndex + 1) !== -1;
-
 export const multiLineText = input => {
   if (!input) {
     return input;
@@ -18,13 +15,9 @@ export const multiLineText = input => {
   const isSingleLine = arrayOfText.length < 2;
   return isSingleLine
     ? text
-    : arrayOfText.map((
-        lineOfText,
-        i // note: lineOfText is the closest we will get to a unique key
-      ) => (
-        <span
-          key={willItOccurAgain(arrayOfText, lineOfText, i) ? `${lineOfText}.${i}` : lineOfText}
-        >
+    : arrayOfText.map((lineOfText, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <span key={`${lineOfText}.${i}`}>
           {i > 0 && <br />} {lineOfText}
         </span>
       ));

--- a/addons/info/src/components/PropTable.js
+++ b/addons/info/src/components/PropTable.js
@@ -6,6 +6,9 @@ import { Table, Td, Th } from '@storybook/components';
 import PropVal from './PropVal';
 import PrettyPropType from './types/PrettyPropType';
 
+const willItOccurAgain = (collection, item, itemIndex = 0) =>
+  collection.indexOf(item, itemIndex + 1) !== -1;
+
 export const multiLineText = input => {
   if (!input) {
     return input;
@@ -19,7 +22,9 @@ export const multiLineText = input => {
         lineOfText,
         i // note: lineOfText is the closest we will get to a unique key
       ) => (
-        <span key={lineOfText}>
+        <span
+          key={willItOccurAgain(arrayOfText, lineOfText, i) ? `${lineOfText}.${i}` : lineOfText}
+        >
           {i > 0 && <br />} {lineOfText}
         </span>
       ));

--- a/addons/info/src/components/PropTable.test.js
+++ b/addons/info/src/components/PropTable.test.js
@@ -9,6 +9,7 @@ describe('PropTable', () => {
     const singleLine = 'Foo bar baz';
     const unixMultiLineText = 'foo \n bar \n baz';
     const windowsMultiLineText = 'foo \r bar \r baz';
+    const duplicatedMultiLine = 'foo\nfoo\nfoo';
     const propDefinitions = [
       {
         defaultValue: undefined,
@@ -55,6 +56,12 @@ describe('PropTable', () => {
     });
     it('should return an array for windows multiline text', () => {
       expect(multiLineText(windowsMultiLineText)).toHaveLength(3);
+    });
+    it('should return an array with unique keys for duplicated multiline text', () => {
+      const wrappers = multiLineText(duplicatedMultiLine).map(tag => shallow(tag));
+      const keys = wrappers.map(wrapper => wrapper.key());
+      const deDup = new Set(keys);
+      expect(keys).toHaveLength(deDup.size);
     });
     it('should have 2 br tags for 3 lines of text', () => {
       const tree = renderer.create(multiLineText(unixMultiLineText)).toJSON();

--- a/examples/official-storybook/components/DocgenButton.js
+++ b/examples/official-storybook/components/DocgenButton.js
@@ -139,7 +139,9 @@ DocgenButton.propTypes = {
    */
   union: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Set)]),
   /**
-   * test string
+   * test string with a comment that has
+   * two identical lines
+   * two identical lines
    */
   optionalString: PropTypes.string,
 };


### PR DESCRIPTION
Issue: #3933 

## What I did
I've added check for duplicated lines, if line of text occur multiple times, index value will be added (as postfix) to the key.

## How to test

Appropriate test is included in this PR.

