### PR TITLE
Update README to include registering in addons.js

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -10,16 +10,21 @@ Storybook Viewport Addon allows your stories to be displayed in different sizes 
 
 Install the following npm module:
 
-    npm i --save-dev @storybook/addon-viewport
+```sh
+npm i --save-dev @storybook/addon-viewport
+```
 
 or with yarn:
 
-    yarn add -D @storybook/addon-viewport
-    
+```sh
+yarn add -D @storybook/addon-viewport
+```
+
 Then, add following content to .storybook/addons.js
 
-    import '@storybook/addon-viewport/register';
-
+```js
+import '@storybook/addon-viewport/register';
+```
 
 ## Configuration
 

--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -15,6 +15,10 @@ Install the following npm module:
 or with yarn:
 
     yarn add -D @storybook/addon-viewport
+    
+Then, add following content to .storybook/addons.js
+
+    import '@storybook/addon-viewport/register';
 
 
 ## Configuration


### PR DESCRIPTION
The other addon README files usually contain a line explaining how to register the addon. The viewport addon currently doesn't contain that line so I have added it to avoid potential confusion

Issue:

## What I did

Updated `@storybook/addon-viewport` README to contain addon registration step.

## How to test

Is this testable with Jest or Chromatic screenshots? ⛔️
Does this need a new example in the kitchen sink apps? ⛔️
Does this need an update to the documentation? ⛔️

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
