### PR TITLE
CLI: Add missing @babel/core dependency

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -25,6 +25,7 @@
     "test-latest-cra": "cd test && ./test_latest_cra.sh"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/4071#issuecomment-418430669

`@babel/core` is now a peer dependency of `@babel/register`: https://github.com/babel/babel/pull/6655