### PR TITLE
riot tag loader missing in cli

### DIFF
--- a/lib/cli/generators/RIOT/index.js
+++ b/lib/cli/generators/RIOT/index.js
@@ -3,12 +3,19 @@ import path from 'path';
 import { getVersions, getPackageJson, writePackageJson, installBabel } from '../../lib/helpers';
 
 export default async npmOptions => {
-  const [storybookVersion, actionsVersion, linksVersion, addonsVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    tagLoaderVersion,
+  ] = await getVersions(
     npmOptions,
     '@storybook/riot',
     '@storybook/addon-actions',
     '@storybook/addon-links',
-    '@storybook/addons'
+    '@storybook/addons',
+    'riot-tag-loader'
   );
 
   mergeDirs(path.resolve(__dirname, 'template'), '.', 'overwrite');
@@ -21,6 +28,11 @@ export default async npmOptions => {
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
   packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+  if (
+    !packageJson.devDependencies['riot-tag-loader'] &&
+    !packageJson.dependencies['riot-tag-loader']
+  )
+    packageJson.devDependencies['riot-tag-loader'] = tagLoaderVersion;
 
   await installBabel(npmOptions, packageJson);
 

--- a/lib/cli/generators/RIOT/template/stories/MyButton.tag
+++ b/lib/cli/generators/RIOT/template/stories/MyButton.tag
@@ -1,17 +1,17 @@
-<MyButton>
+<my-button>
   <button class="buttonStyles" onClick="{ onClick }">
     <yield/>
   </button>
 
   <style>
     .buttonStyles {
-      border: '1px solid #eee';
-      border-radius: 3;
-      background-color: '#FFFFFF';
-      cursor: 'pointer';
-      font-size: 15;
-      padding: '3px 10px';
-      margin: 10;
+      border: solid 1px #eee;
+      border-radius: 3px;
+      background-color: #FFFFFF;
+      cursor: pointer;
+      font-size: 15px;
+      padding: 3px 10px;
+      margin: 10px;
     }
   </style>
 
@@ -21,4 +21,4 @@
         (() => { console.log('clicked') })).bind(this, e)
     }
   </script>
-</MyButton>
+</my-button>

--- a/lib/cli/test/fixtures/riot/package.json
+++ b/lib/cli/test/fixtures/riot/package.json
@@ -25,7 +25,6 @@
     "riot": "latest",
     "webpack": "latest",
     "webpack-cli": "latest",
-    "riot-tag-loader": "latest",
     "uglifyjs-webpack-plugin": "latest",
     "webpack-bundle-analyzer": "latest",
     "packer-webpack-plugin": "latest",

--- a/lib/cli/test/snapshots/riot/package.json
+++ b/lib/cli/test/snapshots/riot/package.json
@@ -27,7 +27,6 @@
     "riot": "latest",
     "webpack": "latest",
     "webpack-cli": "latest",
-    "riot-tag-loader": "latest",
     "uglifyjs-webpack-plugin": "latest",
     "webpack-bundle-analyzer": "latest",
     "packer-webpack-plugin": "latest",
@@ -38,6 +37,7 @@
     "@storybook/addon-actions": "^4.0.0-alpha.20",
     "@storybook/addon-links": "^4.0.0-alpha.20",
     "@storybook/addons": "^4.0.0-alpha.20",
+    "riot-tag-loader": "^2.1.0",
     "@babel/core": "^7.0.0"
   },
   "peerDependencies": {

--- a/lib/cli/test/snapshots/riot/stories/MyButton.tag
+++ b/lib/cli/test/snapshots/riot/stories/MyButton.tag
@@ -1,17 +1,17 @@
-<MyButton>
+<my-button>
   <button class="buttonStyles" onClick="{ onClick }">
     <yield/>
   </button>
 
   <style>
     .buttonStyles {
-      border: '1px solid #eee';
-      border-radius: 3;
-      background-color: '#FFFFFF';
-      cursor: 'pointer';
-      font-size: 15;
-      padding: '3px 10px';
-      margin: 10;
+      border: solid 1px #eee;
+      border-radius: 3px;
+      background-color: #FFFFFF;
+      cursor: pointer;
+      font-size: 15px;
+      padding: 3px 10px;
+      margin: 10px;
     }
   </style>
 
@@ -21,4 +21,4 @@
         (() => { console.log('clicked') })).bind(this, e)
     }
   </script>
-</MyButton>
+</my-button>


### PR DESCRIPTION
Issue:

## What I did
added automatic adding of riot-tag-loader in devDependencies while using `getstorybook --riot`

## How to test

Is this testable with Jest or Chromatic screenshots? no
Does this need a new example in the kitchen sink apps? no
Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

