### PR TITLE
Add storybook-addon-angularjs to addon-gallery

### DIFF
--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -143,3 +143,6 @@ Convert stories into Sketch 💎 symbols.
 
 ### [styled components theme](https://github.com/echoulen/storybook-addon-styled-component-theme)
 styled components theme selection.
+
+### [AngularJS](https://github.com/titonobre/storybook-addon-angularjs)
+Create stories with AngularJS(1.x) components.


### PR DESCRIPTION
Issue: N/A

## What I did
I Added [storybook-addon-angularjs](https://github.com/titonobre/storybook-addon-angularjs) to the Addon Gallery.

## How to test
Docs only. Just check https://storybook.js.org/addons/addon-gallery/

Is this testable with Jest or Chromatic screenshots? No
Does this need a new example in the kitchen sink apps? No
Does this need an update to the documentation? Yes (this is the update)

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
