### PR TITLE
CHANGE index.html.ejs to use files over chunks && UPGRADE generate-page-webpack-plugin

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -50,7 +50,7 @@
     "ejs": "^2.6.1",
     "express": "^4.16.3",
     "find-cache-dir": "^2.0.0",
-    "generate-page-webpack-plugin": "^1.0.0",
+    "generate-page-webpack-plugin": "^1.1.0",
     "global": "^4.3.2",
     "json5": "^2.0.1",
     "prop-types": "^15.6.2",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -45,7 +45,7 @@
     "express": "^4.16.3",
     "file-loader": "^2.0.0",
     "find-cache-dir": "^2.0.0",
-    "generate-page-webpack-plugin": "^1.0.0",
+    "generate-page-webpack-plugin": "^1.1.0",
     "global": "^4.3.2",
     "interpret": "^1.1.0",
     "json5": "^2.0.1",

--- a/lib/core/src/server/templates/index.html.ejs
+++ b/lib/core/src/server/templates/index.html.ejs
@@ -7,17 +7,23 @@
     <title>Storybook</title>
     <link rel="shortcut icon" href="favicon.ico?v=1" />
 
+    <% if (options.headHtmlSnippet) { %>
+      <%- options.headHtmlSnippet %>
+    <% } %>
+      
     <% if (options.links) { %>
       <% for (item of options.links) { %>
       <% if (typeof item === 'string' || item instanceof String) { item = { href: item, rel: 'stylesheet' } } %>
         <link<% for (key in item) { %> <%= key %>="<%= item[key] %>"<% } %>>
       <% } %>
     <% } %>
-  
-    <% if (options.headHtmlSnippet) { %>
-      <%- options.headHtmlSnippet %>
+
+    <% for (item of files) { %>
+      <% if (item.match(/.css$/)) { %>
+        <link href="<%- item %>" rel="stylesheet" />
+      <% } %>
     <% } %>
-  
+    
 </head>
 <body>
     
@@ -45,10 +51,10 @@
     <% for (key in dlls) { %>
       <script src="<%= compilation.outputOptions.publicPath %><%= dlls[key] %>" defer></script>
     <% } %>
-  
-    <% for (index in chunks) { %>
-      <% for (key in chunks[index].files) { %>
-        <script src="<%= compilation.outputOptions.publicPath %><%= chunks[index].files[key] %>" defer></script>
+
+    <% for (item of files) { %>
+      <% if (item.match(/.js$/)) { %>
+        <script src="<%- item %>" defer></script>
       <% } %>
     <% } %>
   

--- a/yarn.lock
+++ b/yarn.lock
@@ -7796,9 +7796,9 @@ gaze@^1.0.0:
   dependencies:
     globule "^1.0.0"
 
-generate-page-webpack-plugin@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/generate-page-webpack-plugin/-/generate-page-webpack-plugin-1.0.0.tgz#e6261efb7e6b9ef8a8136126b14fa26aedfb7f33"
+generate-page-webpack-plugin@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/generate-page-webpack-plugin/-/generate-page-webpack-plugin-1.1.0.tgz#5940c9c6bdbfa03b1a4ef8f909875d5ebafbd3af"
 
 genfun@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Issue: generate-page-webpack-plugin was using object spread & it now exposes a more reliable entrypoint.getFiles() as `files`.

This PR upgrades to the latest version & changes the html.ejs template to use the `files` property.

This implements compatibility with https://github.com/webpack-contrib/mini-css-extract-plugin, possibly other css extraction plugins as well.
