### PR TITLE
Updating react-split-pane to version 0.1.84

### DIFF
--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -23,7 +23,7 @@
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.6.2",
     "react-inspector": "^2.3.0",
-    "react-split-pane": "^0.1.82",
+    "react-split-pane": "^0.1.84",
     "react-textarea-autosize": "^7.0.4",
     "render-fragment": "^0.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15146,9 +15146,9 @@ react-scripts@^1.1.5:
   optionalDependencies:
     fsevents "^1.1.3"
 
-react-split-pane@^0.1.82:
-  version "0.1.82"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.82.tgz#42fbb9fd4823f05e037de0dab3cd6cf9bf0cf4ea"
+react-split-pane@^0.1.84:
+  version "0.1.84"
+  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.84.tgz#b9c1499cbc40b09cf29953ee6f5ff1039d31906e"
   dependencies:
     inline-style-prefixer "^3.0.6"
     prop-types "^15.5.10"


### PR DESCRIPTION
Issue:

closes: #4147 

see https://github.com/storybooks/storybook/pull/3965#issuecomment-411602308 for context

cc: @tmeasday 

## What I did

Updated `react-split-pane` to release `v0.1.84` https://github.com/tomkp/react-split-pane/releases/tag/v0.1.84

## How to test

load the official storybook and check that dragging windows resizes correctly. In the options section, check that clicking the hide panel story works as intended.

Is this testable with Jest or Chromatic screenshots? NA
Does this need a new example in the kitchen sink apps? NA
Does this need an update to the documentation? NA

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
