### PR TITLE
[addon-storysource] Add `parser` for `prettierConfig`

### DIFF
--- a/addons/storysource/README.md
+++ b/addons/storysource/README.md
@@ -75,6 +75,7 @@ The prettier configuration that will be used to format the story source in the a
 Defaults:
 ```js
 {
+  parser: 'babylong'
   printWidth: 120,
   tabWidth: 2,
   bracketSpacing: true,

--- a/addons/storysource/src/loader/default-options.js
+++ b/addons/storysource/src/loader/default-options.js
@@ -1,5 +1,6 @@
 const defaultOptions = {
   prettierConfig: {
+    parser: 'babylon',
     printWidth: 120,
     tabWidth: 2,
     bracketSpacing: true,


### PR DESCRIPTION
Issue: `No parser and no filepath given, using 'babylon' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.`

## What I did

Added `parser: 'babylon'`

## How to test

Specify a `prettierConfig` without a `parser` property
