### PR TITLE
update tsconfig docs to contain emitDecoratorMetadata

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -60,7 +60,8 @@ The above example shows a working config with the TSDocgen plugin also integrate
     "noUnusedLocals": true,
     "declaration": true,
     "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build", "scripts"]


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/4035

## What I did
update `tsconfig.json` in docs to contain `emitDecoratorMetadata: true`

## How to test
Navigate to `docs/src/pages/configurations/typescript-config/index.md`

Is this testable with Jest or Chromatic screenshots? No
Does this need a new example in the kitchen sink apps? No
Does this need an update to the documentation? This is a documentation update

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
