### PR TITLE
riot wrong-readme

### DIFF
--- a/app/riot/README.md
+++ b/app/riot/README.md
@@ -15,7 +15,7 @@ So you can develop UI components in isolation without worrying about app specifi
 ```sh
 npm i -g @storybook/cli
 cd my-app
-getstorybook --riot
+getstorybook
 ```
 
 For more information visit: [storybook.js.org](https://storybook.js.org)


### PR DESCRIPTION
There is no such --riot parameter.
Therefore it should be deleted from the README.md

Issue:

## What I did

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
