### PR TITLE
Added storybook-addon-jss-theme to Community Addons

### DIFF
--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -147,5 +147,5 @@ styled components theme selection.
 ### [AngularJS](https://github.com/titonobre/storybook-addon-angularjs)
 Create stories with AngularJS(1.x) components.
 
-### [jss theme](https://github.com/vertexbz/storybook-addon-jss-theme)
-jss theme selection.
+### [JSS theme](https://github.com/vertexbz/storybook-addon-jss-theme)
+JSS theme selection.

--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -146,3 +146,6 @@ styled components theme selection.
 
 ### [AngularJS](https://github.com/titonobre/storybook-addon-angularjs)
 Create stories with AngularJS(1.x) components.
+
+### [jss theme](https://github.com/vertexbz/storybook-addon-jss-theme)
+jss theme selection.


### PR DESCRIPTION
Issue: Please update the addon list with new community addon for jss component theming

## What I did
I created a storybook addon and added it to list of community addons

## How to test
- clone https://github.com/vertexbz/storybook-addon-jss-theme
- run "lint", "flow", "test" scripts of the package in case you want check code style, static typing, unit tests
- run "example" script to see an example of the addon

For maintainers only: Please tag your pull request with at least one of the following:
`["documentation"]`
