### PR TITLE
Presets - API generalization 

### DIFF
--- a/lib/core/src/server/config.js
+++ b/lib/core/src/server/config.js
@@ -3,6 +3,15 @@ import { logger } from '@storybook/node-logger';
 import loadPresets from './presets';
 import serverRequire from './serverRequire';
 
+function wrapCorePresets(presets) {
+  return {
+    babel: (config, args) => presets.apply('babel', config, args),
+    webpack: (config, args) => presets.apply('webpack', config, args),
+    preview: (config, args) => presets.apply('preview', config, args),
+    manager: (config, args) => presets.apply('manager', config, args),
+  };
+}
+
 function customPreset({ configDir }) {
   const presets = serverRequire(path.resolve(configDir, 'presets'));
 
@@ -41,5 +50,5 @@ export default options => {
 
   const presets = loadPresets(presetsConfig);
 
-  return getWebpackConfig({ ...restOptions, presets }, presets);
+  return getWebpackConfig({ ...restOptions, presets }, wrapCorePresets(presets));
 };

--- a/lib/core/src/server/core-preset-dev.js
+++ b/lib/core/src/server/core-preset-dev.js
@@ -9,7 +9,10 @@ export function webpack(_, options) {
 
 export function babel(_, options) {
   const { configDir, presets } = options;
-  return loadCustomBabelConfig(configDir, () => presets.babelDefault(defaultBabelConfig, options));
+
+  return loadCustomBabelConfig(configDir, () =>
+    presets.apply('babelDefault', defaultBabelConfig, options)
+  );
 }
 
 export function manager(_, options) {

--- a/lib/core/src/server/core-preset-prod.js
+++ b/lib/core/src/server/core-preset-prod.js
@@ -9,7 +9,10 @@ export function webpack(_, options) {
 
 export function babel(_, options) {
   const { configDir, presets } = options;
-  return loadCustomBabelConfig(configDir, () => presets.babelDefault(defaultBabelConfig, options));
+
+  return loadCustomBabelConfig(configDir, () =>
+    presets.apply('babelDefault', defaultBabelConfig, options)
+  );
 }
 
 export function manager(_, options) {

--- a/lib/core/src/server/presets.js
+++ b/lib/core/src/server/presets.js
@@ -66,11 +66,7 @@ function getPresets(presets) {
   const loadedPresets = loadPresets(presets);
 
   return {
-    babel: (config, args) => applyPresets(loadedPresets, config, args, 'babel'),
-    babelDefault: (config, args) => applyPresets(loadedPresets, config, args, 'babelDefault'),
-    webpack: (config, args) => applyPresets(loadedPresets, config, args, 'webpack'),
-    preview: (config, args) => applyPresets(loadedPresets, config, args, 'preview'),
-    manager: (config, args) => applyPresets(loadedPresets, config, args, 'manager'),
+    apply: (extension, config, args) => applyPresets(loadedPresets, config, args, extension),
   };
 }
 

--- a/lib/core/src/server/presets.test.js
+++ b/lib/core/src/server/presets.test.js
@@ -1,3 +1,10 @@
+function wrapPreset(basePresets) {
+  return {
+    babel: (config, args) => basePresets.apply('babel', config, args),
+    webpack: (config, args) => basePresets.apply('webpack', config, args),
+  };
+}
+
 function mockPreset(name, mockPresetObject) {
   jest.mock(name, () => mockPresetObject, { virtual: true });
 }
@@ -8,11 +15,9 @@ describe('presets', () => {
     let presets;
 
     expect(() => {
-      presets = loadPresets();
+      presets = wrapPreset(loadPresets());
       presets.webpack();
       presets.babel();
-      presets.preview();
-      presets.manager();
     }).not.toThrow();
 
     expect(presets).toBeDefined();
@@ -20,24 +25,20 @@ describe('presets', () => {
 
   it('does not throw when presets are empty', () => {
     const loadPresets = require.requireActual('./presets').default;
-    const presets = loadPresets([]);
+    const presets = wrapPreset(loadPresets([]));
 
     expect(() => {
       presets.webpack();
       presets.babel();
-      presets.preview();
-      presets.manager();
     }).not.toThrow();
   });
 
   it('does not throw when preset can not be loaded', () => {
     const loadPresets = require.requireActual('./presets').default;
-    const presets = loadPresets(['preset-foo']);
+    const presets = wrapPreset(loadPresets(['preset-foo']));
 
     expect(() => {
       presets.webpack({});
-      presets.preview();
-      presets.manager();
       presets.babel();
     }).not.toThrow();
   });
@@ -55,12 +56,10 @@ describe('presets', () => {
     });
 
     const loadPresets = require.requireActual('./presets').default;
-    const presets = loadPresets(['preset-foo', 'preset-bar']);
+    const presets = wrapPreset(loadPresets(['preset-foo', 'preset-bar']));
 
     expect(() => {
       presets.webpack();
-      presets.preview();
-      presets.manager();
       presets.babel();
     }).not.toThrow();
 
@@ -81,12 +80,10 @@ describe('presets', () => {
     });
 
     const loadPresets = require.requireActual('./presets').default;
-    const presets = loadPresets([{ name: 'preset-foo' }, { name: 'preset-bar' }]);
+    const presets = wrapPreset(loadPresets([{ name: 'preset-foo' }, { name: 'preset-bar' }]));
 
     expect(() => {
       presets.webpack();
-      presets.preview();
-      presets.manager();
       presets.babel();
     }).not.toThrow();
 
@@ -107,15 +104,15 @@ describe('presets', () => {
     });
 
     const loadPresets = require.requireActual('./presets').default;
-    const presets = loadPresets([
-      { name: 'preset-foo', options: { foo: 1 } },
-      { name: 'preset-bar', options: { bar: 'a' } },
-    ]);
+    const presets = wrapPreset(
+      loadPresets([
+        { name: 'preset-foo', options: { foo: 1 } },
+        { name: 'preset-bar', options: { bar: 'a' } },
+      ])
+    );
 
     expect(() => {
       presets.webpack({});
-      presets.preview();
-      presets.manager();
       presets.babel({});
     }).not.toThrow();
 
@@ -136,12 +133,12 @@ describe('presets', () => {
     });
 
     const loadPresets = require.requireActual('./presets').default;
-    const presets = loadPresets(['preset-foo', { name: 'preset-bar', options: { bar: 'a' } }]);
+    const presets = wrapPreset(
+      loadPresets(['preset-foo', { name: 'preset-bar', options: { bar: 'a' } }])
+    );
 
     expect(() => {
       presets.webpack({});
-      presets.preview();
-      presets.manager();
       presets.babel({});
     }).not.toThrow();
 
@@ -162,12 +159,12 @@ describe('presets', () => {
     });
 
     const loadPresets = require.requireActual('./presets').default;
-    const presets = loadPresets(['preset-foo', { name: 'preset-bar', options: { bar: 'a' } }]);
+    const presets = wrapPreset(
+      loadPresets(['preset-foo', { name: 'preset-bar', options: { bar: 'a' } }])
+    );
 
     expect(() => {
       presets.webpack({});
-      presets.preview();
-      presets.manager();
       presets.babel();
     }).not.toThrow();
 


### PR DESCRIPTION
Issue: 
The presets API, in the beginning, was to expose these methods: babel, webpack, preview & manager. Each one is about to extend a relevant part in the SB configuration.

After that, `babelDefault` was added to solve the babel 6 compatibility problems and remove the complexity of `babel-merge`. 

## What I did
From now, the core will expose presets loader that only knows to do the `apply`. Then core will wrap the `apply` with `babel`, `webpack`, `preview` & `manager`. Since presets object is passed deeper to the presets chain, any other preset will be able to extend it with the new functionality.