### PR TITLE
allow setting params to storyshot

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -34,7 +34,7 @@ import { imageSnapshot } from '@storybook/addon-storyshots-puppeteer';
 
 initStoryshots({suite: 'Image storyshots', test: imageSnapshot({storybookUrl: 'http://my-specific-domain.com:9010'})});
 ```
-The above config will use _<https://my-specific-domain.com:9010>_ for screenshots.
+The above config will use _<https://my-specific-domain.com:9010>_ for screenshots. You can also use query parameters in your URL (e.g. for setting a different background for your storyshots, if you use `@storybook/addon-backgrounds`).
 
 
 You may also use a local static build of storybook if you do not want to run the webpack dev-server:

--- a/addons/storyshots/storyshots-puppeteer/src/__tests__/url.test.js
+++ b/addons/storyshots/storyshots-puppeteer/src/__tests__/url.test.js
@@ -1,0 +1,49 @@
+import { constructUrl } from '../url';
+
+describe('Construct URL for Storyshots', () => {
+  it('can use a url without path and without query params', () => {
+    expect(constructUrl('http://localhost:9001', 'someKind', 'someStory')).toEqual(
+      'http://localhost:9001/iframe.html?selectedKind=someKind&selectedStory=someStory'
+    );
+  });
+
+  it('can use a url without path (but slash) and without query params', () => {
+    expect(constructUrl('http://localhost:9001/', 'someKind', 'someStory')).toEqual(
+      'http://localhost:9001/iframe.html?selectedKind=someKind&selectedStory=someStory'
+    );
+  });
+
+  it('can use a url without path and with query params', () => {
+    expect(constructUrl('http://localhost:9001?hello=world', 'someKind', 'someStory')).toEqual(
+      'http://localhost:9001/iframe.html?selectedKind=someKind&selectedStory=someStory&hello=world'
+    );
+  });
+
+  it('can use a url without path (buth slash) and with query params', () => {
+    expect(constructUrl('http://localhost:9001/?hello=world', 'someKind', 'someStory')).toEqual(
+      'http://localhost:9001/iframe.html?selectedKind=someKind&selectedStory=someStory&hello=world'
+    );
+  });
+
+  it('can use a url with some path and query params', () => {
+    expect(
+      constructUrl('http://localhost:9001/nice-path?hello=world', 'someKind', 'someStory')
+    ).toEqual(
+      'http://localhost:9001/nice-path/iframe.html?selectedKind=someKind&selectedStory=someStory&hello=world'
+    );
+  });
+
+  it('can use a url with some path (slash) and query params', () => {
+    expect(
+      constructUrl('http://localhost:9001/nice-path/?hello=world', 'someKind', 'someStory')
+    ).toEqual(
+      'http://localhost:9001/nice-path/iframe.html?selectedKind=someKind&selectedStory=someStory&hello=world'
+    );
+  });
+
+  it('can use a url with file protocol', () => {
+    expect(constructUrl('file://users/storybook', 'someKind', 'someStory')).toEqual(
+      'file://users/storybook/iframe.html?selectedKind=someKind&selectedStory=someStory'
+    );
+  });
+});

--- a/addons/storyshots/storyshots-puppeteer/src/index.js
+++ b/addons/storyshots/storyshots-puppeteer/src/index.js
@@ -1,6 +1,7 @@
 import puppeteer from 'puppeteer';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import { logger } from '@storybook/node-logger';
+import { constructUrl } from './url';
 
 expect.extend({ toMatchImageSnapshot });
 
@@ -43,11 +44,7 @@ export const imageSnapshot = (customConfig = {}) => {
 
       return;
     }
-
-    const encodedKind = encodeURIComponent(kind);
-    const encodedStoryName = encodeURIComponent(story);
-    const storyUrl = `/iframe.html?selectedKind=${encodedKind}&selectedStory=${encodedStoryName}`;
-    const url = storybookUrl + storyUrl;
+    const url = constructUrl(storybookUrl, kind, story);
 
     if (!browser || !page) {
       logger.error(

--- a/addons/storyshots/storyshots-puppeteer/src/url.js
+++ b/addons/storyshots/storyshots-puppeteer/src/url.js
@@ -1,0 +1,11 @@
+import { URL } from 'url';
+
+export const constructUrl = (storybookUrl, kind, story) => {
+  const encodedKind = encodeURIComponent(kind);
+  const encodedStoryName = encodeURIComponent(story);
+  const storyUrl = `/iframe.html?selectedKind=${encodedKind}&selectedStory=${encodedStoryName}`;
+  const { protocol, host, pathname, search } = new URL(storybookUrl);
+  const pname = pathname.replace(/\/$/, ''); // removes trailing /
+  const query = search.replace('?', '&'); // convert leading $ to &
+  return `${protocol}//${host}${pname}${storyUrl}${query}`;
+};


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/4119

## What I did

Use `require('url').URL` to parse the `storybookUrl`. Available since Node v6. (Not sure, what you require here?) Construct the new URL.

## How to test

Is this testable with Jest or Chromatic screenshots? Yes
Does this need a new example in the kitchen sink apps? No
Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
