### PR TITLE
Fix #4217, exit build when successful

### DIFF
--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -76,6 +76,7 @@ export function buildStatic({ packageJson, ...loadOptions }) {
       process.exitCode = 1;
     }
     logger.info('Building storybook completed.');
+    process.exit();
   };
   const compiler = webpack(config);
   if (program.watch) {


### PR DESCRIPTION
Issue:
#4217 
## What I did
Added the `process.exit()` line so that the process will exit after a build

## How to test

Is this testable with Jest or Chromatic screenshots? no
Does this need a new example in the kitchen sink apps? no
Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
