### PR TITLE
Presets - Add "addons" and "config" to preset extensions

### DIFF
--- a/lib/core/src/server/config/entries.js
+++ b/lib/core/src/server/config/entries.js
@@ -1,31 +1,29 @@
-import path from 'path';
-import { logger } from '@storybook/node-logger';
-import { getInterpretedFile } from '../interpret-files';
+export function createPreviewEntry(options) {
+  const { configDir, presets } = options;
+  const preview = [require.resolve('./polyfills'), require.resolve('./globals')];
 
-export function createPreviewEntry({ configDir }) {
-  const iframe = [require.resolve('./polyfills'), require.resolve('./globals')];
+  const configs = presets.apply('config', [], options);
 
-  // Check whether a config.{ext} file exists inside the storybook
-  // config directory and throw an error if it's not.
-  const storybookConfigPath = getInterpretedFile(path.resolve(configDir, 'config'));
-  if (!storybookConfigPath) {
+  if (!configs || !configs.length) {
     throw new Error(`=> Create a storybook config file in "${configDir}/config.{ext}".`);
   }
 
-  iframe.push(require.resolve(storybookConfigPath));
+  preview.push(...configs);
 
-  return iframe;
+  return preview;
 }
 
-export function createManagerEntry({ configDir }) {
-  const manager = [require.resolve('./polyfills'), require.resolve('../../client/manager')];
+export function createManagerEntry(options) {
+  const { presets } = options;
+  const manager = [require.resolve('./polyfills')];
 
-  // Check whether addons.{ext} file exists inside the storybook.
-  const storybookCustomAddonsPath = getInterpretedFile(path.resolve(configDir, 'addons'));
-  if (storybookCustomAddonsPath) {
-    logger.info('=> Loading custom addons config.');
-    manager.unshift(storybookCustomAddonsPath);
+  const addons = presets.apply('addons', [], options);
+
+  if (addons && addons.length) {
+    manager.push(...addons);
   }
+
+  manager.push(require.resolve('../../client/manager'));
 
   return manager;
 }

--- a/lib/core/src/server/core-preset-dev.js
+++ b/lib/core/src/server/core-preset-dev.js
@@ -1,4 +1,6 @@
 import loadCustomBabelConfig from './loadCustomBabelConfig';
+import loadCustomAddons from './loadCustomAddonsFile';
+import loadCustomConfig from './loadCustomConfigFile';
 import createDevConfig from './config/webpack.config.dev';
 import defaultBabelConfig from './config/babel.dev';
 import { createManagerEntry, createPreviewEntry } from './config/entries';
@@ -24,4 +26,12 @@ export function preview(_, options) {
     ...createPreviewEntry(options),
     `${require.resolve('webpack-hot-middleware/client')}?reload=true`,
   ];
+}
+
+export function addons(_, options) {
+  return loadCustomAddons(options);
+}
+
+export function config(_, options) {
+  return loadCustomConfig(options);
 }

--- a/lib/core/src/server/core-preset-prod.js
+++ b/lib/core/src/server/core-preset-prod.js
@@ -1,4 +1,6 @@
 import loadCustomBabelConfig from './loadCustomBabelConfig';
+import loadCustomAddons from './loadCustomAddonsFile';
+import loadCustomConfig from './loadCustomConfigFile';
 import createProdConfig from './config/webpack.config.prod';
 import defaultBabelConfig from './config/babel.prod';
 import { createManagerEntry, createPreviewEntry } from './config/entries';
@@ -21,4 +23,12 @@ export function manager(_, options) {
 
 export function preview(_, options) {
   return createPreviewEntry(options);
+}
+
+export function addons(_, options) {
+  return loadCustomAddons(options);
+}
+
+export function config(_, options) {
+  return loadCustomConfig(options);
 }

--- a/lib/core/src/server/loadCustomAddonsFile.js
+++ b/lib/core/src/server/loadCustomAddonsFile.js
@@ -1,0 +1,16 @@
+import path from 'path';
+import { logger } from '@storybook/node-logger';
+import { getInterpretedFile } from './interpret-files';
+
+function loadCustomAddons({ configDir }) {
+  const storybookCustomAddonsPath = getInterpretedFile(path.resolve(configDir, 'addons'));
+
+  if (storybookCustomAddonsPath) {
+    logger.info('=> Loading custom addons config.');
+    return [storybookCustomAddonsPath];
+  }
+
+  return [];
+}
+
+export default loadCustomAddons;

--- a/lib/core/src/server/loadCustomConfigFile.js
+++ b/lib/core/src/server/loadCustomConfigFile.js
@@ -1,0 +1,14 @@
+import path from 'path';
+import { getInterpretedFile } from './interpret-files';
+
+function loadConfigFiles({ configDir }) {
+  const storybookConfigPath = getInterpretedFile(path.resolve(configDir, 'config'));
+
+  if (storybookConfigPath) {
+    return [storybookConfigPath];
+  }
+
+  return [];
+}
+
+export default loadConfigFiles;


### PR DESCRIPTION
I've played a bit with presets and realized that having more granular extensions for `addons` and `config` will be very helpful for creating presets.

For example, we can expose our addons as presets, i.e. using them like this:

```js
// presets.js (or a future storybook.config.js)
[
  `@storybook/addon-vieports/preset`
]

// or with default params
[
  name: `@storybook/addon-vieports/preset`,
  options: { /* whatever this addon needs */ }
]
```

Same thing with a `config.js` file. Today we enforce people to create `config.js` in order to call the `configure(loadStories, module);`

We can create a preset that does it. One may use `require.context` or some other techniques.
