### PR TITLE
Fix how markdownOptions are passed to marked

### DIFF
--- a/addons/notes/src/index.js
+++ b/addons/notes/src/index.js
@@ -2,8 +2,7 @@ import addons, { makeDecorator } from '@storybook/addons';
 import marked from 'marked';
 
 function renderMarkdown(text, options) {
-  marked.setOptions({ ...marked.defaults, options });
-  return marked(text);
+  return marked(text, { ...marked.defaults, ...options });
 }
 
 export const withNotes = makeDecorator({


### PR DESCRIPTION
Previously, the options have been passed as property "options" within the actual options object, which is ignored by marked.

Also, using the parameter of marked instead of setOptions to avoid global state.