### PR TITLE
FIX react-scripts-latest-fixture by installing expo globally

### DIFF
--- a/lib/cli/test/test_latest_cra.sh
+++ b/lib/cli/test/test_latest_cra.sh
@@ -3,27 +3,14 @@
 # exit on error
 set -e
 
-# create CR(N)A fixtures using latest versions of creators
-function create_fixture {
-  if [ $2 == "react_native_scripts" ]
-  then
-    echo "create-react-native-app requires node >=6. Checking..."
-    ../../node_modules/.bin/check-node-version --node '>=6' || return 0
-  fi
-
-  # use `npx` rather then `yarn create` to avoid installing global deps
-  ../../node_modules/.bin/npx $1 $2
-}
-
 # remove and recreate `cra-fixtures` directory
 rm -rfd cra-fixtures
 mkdir cra-fixtures
 cd cra-fixtures
 
-create_fixture create-react-app react-scripts-latest-fixture
+../../node_modules/.bin/npx create-react-app react-scripts-latest-fixture
 
-npm install -g expo-cli
-create_fixture create-react-native-app react-native-scripts-latest-fixture
+../../node_modules/.bin/npx expo init react-native-scripts-latest-fixture
 
 cd ..
 ./run_tests.sh -f cra-fixtures

--- a/lib/cli/test/test_latest_cra.sh
+++ b/lib/cli/test/test_latest_cra.sh
@@ -19,7 +19,7 @@ echo ""
 echo "---------------------------------------------"
 echo "expo init react-native-scripts-latest-fixture"
 echo "---------------------------------------------"
-../../node_modules/.bin/npx expo init react-native-scripts-latest-fixture
+../../node_modules/.bin/npx expo init --non-interactive react-native-scripts-latest-fixture
 echo ""
 
 cd ..

--- a/lib/cli/test/test_latest_cra.sh
+++ b/lib/cli/test/test_latest_cra.sh
@@ -21,6 +21,8 @@ mkdir cra-fixtures
 cd cra-fixtures
 
 create_fixture create-react-app react-scripts-latest-fixture
+
+npm install -g expo-cli
 create_fixture create-react-native-app react-native-scripts-latest-fixture
 
 cd ..

--- a/lib/cli/test/test_latest_cra.sh
+++ b/lib/cli/test/test_latest_cra.sh
@@ -10,9 +10,20 @@ cd cra-fixtures
 
 npm install expo-cli -g
 
+echo "---------------------------------------------"
+echo "create-react-app react-scripts-latest-fixture"
+echo "---------------------------------------------"
 ../../node_modules/.bin/npx create-react-app react-scripts-latest-fixture
+echo ""
 
+echo "---------------------------------------------"
+echo "expo init react-native-scripts-latest-fixture"
+echo "---------------------------------------------"
 ../../node_modules/.bin/npx expo init react-native-scripts-latest-fixture
+echo ""
 
 cd ..
+echo "------------------------------"
+echo "./run_tests.sh -f cra-fixtures"
+echo "------------------------------"
 ./run_tests.sh -f cra-fixtures

--- a/lib/cli/test/test_latest_cra.sh
+++ b/lib/cli/test/test_latest_cra.sh
@@ -8,6 +8,8 @@ rm -rfd cra-fixtures
 mkdir cra-fixtures
 cd cra-fixtures
 
+npm install expo-cli -g
+
 ../../node_modules/.bin/npx create-react-app react-scripts-latest-fixture
 
 ../../node_modules/.bin/npx expo init react-native-scripts-latest-fixture


### PR DESCRIPTION
Issue: master build is broken

## What I did

I edited the `cli-latest-cra`-test so they use npx directly and the CRNA one uses expo-cli directly