### PR TITLE
Update `addon-jest` to new propType

### DIFF
--- a/addons/jest/src/register.js
+++ b/addons/jest/src/register.js
@@ -7,7 +7,8 @@ import Panel from './components/Panel';
 addons.register('storybook/tests', api => {
   const channel = addons.getChannel();
   addons.addPanel('storybook/tests/panel', {
-    title: <PanelTitle channel={addons.getChannel()} api={api} />,
+    // eslint-disable-next-line react/prop-types
+    title: () => <PanelTitle channel={addons.getChannel()} api={api} />,
     // eslint-disable-next-line react/prop-types
     render: ({ active }) => <Panel channel={channel} api={api} active={active} />,
   });


### PR DESCRIPTION
Fixes #4251.

## What I did
Changed title from React element to function returning React element, as per propType requirements.

## How to test
Run this add-on as described in issue #4251. I've tested this locally and it works as expected.