### PR TITLE
Fix broken SVGs -  issue #4066 / #4180

### DIFF
--- a/lib/core/src/server/config/webpack.config.default.js
+++ b/lib/core/src/server/config/webpack.config.default.js
@@ -33,15 +33,11 @@ export function createDefaultWebpackConfig(storybookBaseConfig) {
           ],
         },
         {
-          test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2)(\?.*)?$/,
+          test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2)(\?.*)?$/,
           loader: require.resolve('file-loader'),
           query: {
             name: 'static/media/[name].[hash:8].[ext]',
           },
-        },
-        {
-          test: /\.svg$/,
-          loader: require.resolve('svg-url-loader'),
         },
         {
           test: /\.(mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,


### PR DESCRIPTION
The webpack currently uses both file-loader and svg-url-loader.

file-loader will handle .svg files just fine. svg-url-loader is causing images to not load properly. This might be identified by @cainlevy in issue 4180:
> svg-url-loader is not drop-in compatible with url-loader.

Unless there is a compelling reason to use svg-url-loader instead of just leveraging the currently utilized url-loader, this change seems to fix the issues and can result in removing the dependency on svg-url-loader from the repo completely.

Issue:

## What I did

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
