### PR TITLE
[docs] add doc to highlight active attribute before rendering addon

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -69,6 +69,12 @@ Then it will appear in the Notes panel like this:
 
 ![With notes](../static/stories-with-notes.png)
 
+> To avoid having addons show up at the same time as each other, each addon should be aware of the active prop sent by Storybook and only render addon when active is true.
+
+```js
+render: ({ active }) => <Notes channel={channel} api={api} active={active} />,
+```
+
 ## Setup
 
 First, create an `addons.js` inside the Storybook config directory and add the following content to it.


### PR DESCRIPTION
Issue: #4200 

## What I did

add a doc to highlight this behavior if active is not used when rendering
