### PR TITLE
[docs] add maintainers guide to help define process

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,54 @@
+This document will document some of the processes that members of the documentation team should adhere to.
+
+# PR Process
+
+1. Triage with the correct [label](#labels)
+2. If there a change related to it ensure it has been published and tested before closing
+
+# Labels
+
+| label name  | purpose |
+|:--------------:|:------------|
+| accessibility | |
+| addon:(name) | |
+| app:(name) | |
+| api:(name) | |
+| cleanup | Minor cleanup style change that won't show up in release changelog |
+| bug | |
+| cli | |
+| good first review | |
+| compatibility with other tools | |
+| patch | Bugfix & documentation PR that need to be picked to release branch |
+| picked | Patch PRs cherry-picked to master |
+| compatibility with other tools | |
+| components | |
+| core | |
+| decorators | |
+| dependencies:update | |
+| dependencies | |
+| discussion | |
+| do not merge | |
+| documentation | |
+| feature request | |
+| good first issue | |
+| has workaround | |
+| help wanted | |
+| high priority | |
+| in progress | |
+| inactive | |
+| maintenance | |
+| merged | |
+| needs example | |
+| needs more info | |
+| needs rebase | |
+| needs reproduction | |
+| needs review | |
+| performance issue | |
+| presets | |
+| question / support | |
+| ready | |
+| security | |
+| todo | |
+| typescript | |
+| ui | |
+| won't fix | |


### PR DESCRIPTION
Issue: Just joined the project as a maintainer and closed an issue by accident

## What I did

Started a conversation for what the maintainers guide should look like and have
