### PR TITLE
Fix Anchor Link to badges section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Storybook comes with a lot of [addons](https://storybook.js.org/addons/introduct
     -   🛠[Supported Frameworks & Examples](#supported-frameworks)
     -   🚇[Sub Projects](#sub-projects)
     -   🔗[Addons](#addons)
--   🏅[Badges & Presentation materials](#badges)
+-   🏅[Badges & Presentation materials](#badges--presentation-materials)
 -   👥[Community](#community)
 -   👏[Contributing](#contributing)
     -   👨‍💻[Development scripts](#development-scripts)


### PR DESCRIPTION
Issue: Anchor link in readme was not working

## What I did 

I updated the anchor link to the badges and presentation materials sections.

## How to test

Click on the link and it will not work work in the current readme
view the file in the PR and click on the link and it will take you to the "Badges & Presentation Materials" Section of the readme

Is this testable with Jest or Chromatic screenshots? N/a
Does this need a new example in the kitchen sink apps? n/a
Does this need an update to the documentation? n/a

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
