### PR TITLE
[RFC] addon-knobs options

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -282,19 +282,19 @@ Configurable UI for selecting a value from a set of options.
 import { optionsKnob as options } from '@storybook/addon-knobs';
 
 const label = 'Fruits';
-const options = {
+const valuesObj = {
   Kiwi: 'kiwi',
   Guava: 'guava',
   Watermelon: 'watermelon',
 };
 const defaultValue = 'kiwi';
-const config = {
+const optionsObj = {
   display: 'inline-radio'
 };
 
-const value = options(label, options, defaultValue, config);
+const value = options(label, valuesObj, defaultValue, optionsObj);
 ```
-> The display property for `config` accepts:
+> The display property for `optionsObj` accepts:
 > - `radio`
 > - `inline-radio`
 > - `select`

--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -274,6 +274,32 @@ const defaultValue = 'kiwi';
 const value = radios(label, options, defaultValue);
 ```
 
+### options
+
+Configurable UI for selecting a value from a set of options. 
+
+```js
+import { optionsKnob as options } from '@storybook/addon-knobs';
+
+const label = 'Fruits';
+const options = {
+  Kiwi: 'kiwi',
+  Guava: 'guava',
+  Watermelon: 'watermelon',
+};
+const defaultValue = 'kiwi';
+const config = {
+  display: 'inline-radio'
+};
+
+const value = options(label, options, defaultValue, config);
+```
+> The display property for `config` accepts:
+> - `radio`
+> - `inline-radio`
+> - `select`
+> - `check`
+
 ### files
 
 Allows you to get a value from a file input from the user.

--- a/addons/knobs/src/components/types/Options.js
+++ b/addons/knobs/src/components/types/Options.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import RadiosType from './Radio';
+import SelectType from './Select';
+import BooleanType from './Boolean';
+
+const OptionsType = props => {
+  const { knob } = props;
+  const { display } = knob.displayType;
+
+  if (display === 'radio') {
+    return <RadiosType {...props} />;
+  }
+  if (display === 'inline-radio') {
+    return <RadiosType {...props} inline />;
+  }
+  if (display === 'check') {
+    return <BooleanType name={knob.name} value={knob.value} />;
+  }
+
+  return <SelectType {...props} />;
+};
+
+OptionsType.defaultProps = {
+  knob: {},
+  onChange: value => value,
+};
+
+OptionsType.propTypes = {
+  knob: PropTypes.shape({
+    name: PropTypes.string,
+    value: PropTypes.string,
+    options: PropTypes.object,
+  }),
+  onChange: PropTypes.func,
+};
+
+OptionsType.serialize = value => value;
+OptionsType.deserialize = value => value;
+
+export default OptionsType;

--- a/addons/knobs/src/components/types/Radio.js
+++ b/addons/knobs/src/components/types/Radio.js
@@ -46,8 +46,9 @@ class RadiosType extends Component {
 
   render() {
     const { knob, inline } = this.props;
+    const displayStyle = inline ? styles.group : {};
 
-    return <div style={inline && styles.group}>{this.renderRadioButtonList(knob)}</div>;
+    return <div style={displayStyle}>{this.renderRadioButtonList(knob)}</div>;
   }
 }
 

--- a/addons/knobs/src/components/types/Radio.js
+++ b/addons/knobs/src/components/types/Radio.js
@@ -45,15 +45,16 @@ class RadiosType extends Component {
   }
 
   render() {
-    const { knob } = this.props;
+    const { knob, inline } = this.props;
 
-    return <div style={styles.group}>{this.renderRadioButtonList(knob)}</div>;
+    return <div style={inline && styles.group}>{this.renderRadioButtonList(knob)}</div>;
   }
 }
 
 RadiosType.defaultProps = {
   knob: {},
   onChange: value => value,
+  inline: false,
 };
 
 RadiosType.propTypes = {
@@ -63,6 +64,7 @@ RadiosType.propTypes = {
     options: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   }),
   onChange: PropTypes.func,
+  inline: PropTypes.bool,
 };
 
 RadiosType.serialize = value => value;

--- a/addons/knobs/src/components/types/index.js
+++ b/addons/knobs/src/components/types/index.js
@@ -9,6 +9,7 @@ import ArrayType from './Array';
 import DateType from './Date';
 import ButtonType from './Button';
 import FilesType from './Files';
+import OptionsType from './Options';
 
 export default {
   text: TextType,
@@ -22,4 +23,5 @@ export default {
   date: DateType,
   button: ButtonType,
   files: FilesType,
+  options: OptionsType,
 };

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -4,8 +4,8 @@ import addons, { makeDecorator } from '@storybook/addons';
 
 import { manager, registerKnobs } from './registerKnobs';
 
-export function knob(name, options) {
-  return manager.knob(name, options);
+export function knob(name, optionsParam) {
+  return manager.knob(name, optionsParam);
 }
 
 export function text(name, value, groupId) {
@@ -71,6 +71,10 @@ export function button(name, callback, groupId) {
 
 export function files(name, accept, value = []) {
   return manager.knob(name, { type: 'files', accept, value });
+}
+
+export function optionsKnob(name, options, value, displayType, groupId) {
+  return manager.knob(name, { type: 'options', options, value, displayType, groupId });
 }
 
 const defaultOptions = {

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -73,8 +73,8 @@ export function files(name, accept, value = []) {
   return manager.knob(name, { type: 'files', accept, value });
 }
 
-export function optionsKnob(name, options, value, displayType, groupId) {
-  return manager.knob(name, { type: 'options', options, value, displayType, groupId });
+export function optionsKnob(name, options, value, config, groupId) {
+  return manager.knob(name, { type: 'options', options, value, config, groupId });
 }
 
 const defaultOptions = {

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -73,8 +73,8 @@ export function files(name, accept, value = []) {
   return manager.knob(name, { type: 'files', accept, value });
 }
 
-export function optionsKnob(name, options, value, config, groupId) {
-  return manager.knob(name, { type: 'options', options, value, config, groupId });
+export function optionsKnob(name, valuesObj, value, optionsObj, groupId) {
+  return manager.knob(name, { type: 'options', valuesObj, value, optionsObj, groupId });
 }
 
 const defaultOptions = {


### PR DESCRIPTION
*Request for comments* proposed approach to creating a new `options` knob which combines the similar knobs under the hood.

Issue: see https://github.com/storybooks/storybook/issues/3972#issuecomment-411343776

## What I did

Added `optionsKnob` knob (was getting lint errors due to `options` variable already existing in namespace) which composes `SelectType`, `RadiosType` and `BooleanType` under the hood.

## Not yet done

Make it work with multiple select and multiple checkboxes.

## How to test

No tests yet. Just looking for feedback on the approach.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
