### PR TITLE
Fixes to cli ember support (followup on #4309)

### DIFF
--- a/lib/cli/lib/detect.js
+++ b/lib/cli/lib/detect.js
@@ -122,6 +122,7 @@ function isStorybookInstalled(dependencies, force) {
       'polymer',
       'mithril',
       'riot',
+      'ember',
     ];
     if (
       supportedFrameworks.reduce(

--- a/lib/cli/lib/detect.js
+++ b/lib/cli/lib/detect.js
@@ -24,6 +24,13 @@ function detectFramework(dependencies) {
   }
 
   if (
+    (dependencies.dependencies && dependencies.dependencies['ember-cli']) ||
+    (dependencies.devDependencies && dependencies.devDependencies['ember-cli'])
+  ) {
+    return types.EMBER;
+  }
+
+  if (
     (dependencies.dependencies && dependencies.dependencies['react-scripts']) ||
     (dependencies.devDependencies && dependencies.devDependencies['react-scripts'])
   ) {
@@ -66,13 +73,6 @@ function detectFramework(dependencies) {
     (dependencies.devDependencies && dependencies.devDependencies['@angular/core'])
   ) {
     return types.ANGULAR;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies['ember-cli']) ||
-    (dependencies.devDependencies && dependencies.devDependencies['ember-cli'])
-  ) {
-    return types.EMBER;
   }
 
   if (


### PR DESCRIPTION
In reference to comment: https://github.com/storybooks/storybook/pull/4309#issuecomment-427808091

This PR corrects app detection when 'react' has also been added to package.json and fixes detection of storybook configuration.