### PR TITLE
[onDeviceUI] Updated channel to support async option

### DIFF
--- a/lib/channel-websocket/src/index.js
+++ b/lib/channel-websocket/src/index.js
@@ -3,15 +3,13 @@
 import { WebSocket } from 'global';
 import Channel from '@storybook/channels';
 
-const logger = console;
-
 export class WebsocketTransport {
-  constructor({ url }) {
+  constructor({ url, onError }) {
     this._socket = null;
     this._buffer = [];
     this._handler = null;
     this._isReady = false;
-    this._connect(url);
+    this._connect(url, onError);
   }
 
   setHandler(handler) {
@@ -41,7 +39,7 @@ export class WebsocketTransport {
     buffer.forEach(event => this.send(event));
   }
 
-  _connect(url) {
+  _connect(url, onError) {
     this._socket = new WebSocket(url);
     this._socket.onopen = () => {
       this._isReady = true;
@@ -52,15 +50,14 @@ export class WebsocketTransport {
       this._handler(event);
     };
     this._socket.onerror = e => {
-      logger.error('websocket: connection error', e.message);
-    };
-    this._socket.onclose = e => {
-      logger.error('websocket: connection closed', e.code, e.reason);
+      if (onError) {
+        onError(e);
+      }
     };
   }
 }
 
-export default function createChannel({ url }) {
-  const transport = new WebsocketTransport({ url });
-  return new Channel({ transport });
+export default function createChannel({ url, async, onError }) {
+  const transport = new WebsocketTransport({ url, onError });
+  return new Channel({ transport, async });
 }

--- a/lib/channels/src/index.js
+++ b/lib/channels/src/index.js
@@ -1,10 +1,13 @@
 /* eslint no-underscore-dangle: 0 */
 
 export default class Channel {
-  constructor({ transport }) {
+  constructor({ transport, async } = {}) {
     this._sender = this._randomId();
-    this._transport = transport;
-    this._transport.setHandler(event => this._handleEvent(event));
+    this._async = async;
+    if (transport) {
+      this._transport = transport;
+      this._transport.setHandler(event => this._handleEvent(event));
+    }
     this._listeners = {};
   }
 
@@ -20,8 +23,19 @@ export default class Channel {
 
   emit(type, ...args) {
     const event = { type, args, from: this._sender };
-    this._transport.send(event);
-    this._handleEvent(event, true);
+
+    const handler = () => {
+      if (this._transport) {
+        this._transport.send(event);
+      }
+      this._handleEvent(event, true);
+    };
+
+    if (this._async) {
+      setImmediate(handler);
+    } else {
+      handler();
+    }
   }
 
   eventNames() {

--- a/lib/channels/src/index.test.js
+++ b/lib/channels/src/index.test.js
@@ -1,6 +1,7 @@
 /* eslint no-underscore-dangle: 0 */
-
 import Channel from '.';
+
+jest.useFakeTimers();
 
 describe('Channel', () => {
   let transport = null;
@@ -12,8 +13,14 @@ describe('Channel', () => {
   });
 
   describe('constructor', () => {
-    it('should set the handler', () => {
+    it('should set the handler if handler is preset', () => {
+      channel = new Channel({ transport });
       expect(transport.setHandler).toHaveBeenCalled();
+    });
+
+    it('should not try to set handler if handler is missing', () => {
+      channel = new Channel();
+      expect(channel._transport).not.toBeDefined();
     });
   });
 
@@ -41,6 +48,20 @@ describe('Channel', () => {
 
       delete event.from;
       expect(event).toEqual(expected);
+    });
+
+    it('should call handle async option', () => {
+      transport.send = jest.fn();
+      const type = 'test-type';
+      const args = [1, 2, 3];
+
+      channel = new Channel({ async: true, transport });
+
+      channel.emit(type, ...args);
+      expect(transport.send).not.toHaveBeenCalled();
+
+      jest.runAllImmediates();
+      expect(transport.send).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This is a part of PR #3903.

* Async option for the channels. If set to true emit is called in setImmediate.

Current storybook architecture works in two parts. Manager and preview. Adding addons to onDeviceUI removes this separation.

This separation was necessary to support emitting events inside decorators.
Without it now we get warning that renders are not "pure" (they are calling setState while setState is already happening).

By using async channel we avoid this issue since events are emitted only after render has finished.


* Websockets channel does not crash RN if connection fails. Added optional onError argument to call on connection fail.

