### PR TITLE
Fix Array.js value to string

### DIFF
--- a/addons/knobs/src/components/types/Array.js
+++ b/addons/knobs/src/components/types/Array.js
@@ -28,7 +28,9 @@ class ArrayType extends React.Component {
   render() {
     const { knob } = this.props;
 
-    return <Textarea id={knob.name} value={knob.value} onChange={this.handleChange} size="flex" />;
+    const value = knob.value.join(knob.separator);
+
+    return <Textarea id={knob.name} value={value} onChange={this.handleChange} size="flex" />;
   }
 }
 


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/4299

## What I did

I fixed Array.js `value` types for `react-text-area-autosize`

https://github.com/andreypopp/react-textarea-autosize/blob/master/src/index.js#L21

## How to test

I did only test on browser. I didn't find that error.