### PR TITLE
CLI-less api for node

### DIFF
--- a/app/angular/src/server/index.js
+++ b/app/angular/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/angular/standalone.js
+++ b/app/angular/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/ember/src/server/index.js
+++ b/app/ember/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/ember/standalone.js
+++ b/app/ember/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/html/src/server/index.js
+++ b/app/html/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/html/standalone.js
+++ b/app/html/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/marko/src/server/index.js
+++ b/app/marko/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/marko/standalone.js
+++ b/app/marko/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/mithril/src/server/index.js
+++ b/app/mithril/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/mithril/standalone.js
+++ b/app/mithril/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/polymer/src/server/index.js
+++ b/app/polymer/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/polymer/standalone.js
+++ b/app/polymer/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/react/src/server/index.js
+++ b/app/react/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/react/standalone.js
+++ b/app/react/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/riot/src/server/index.js
+++ b/app/riot/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/riot/standalone.js
+++ b/app/riot/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/svelte/src/server/build.js
+++ b/app/svelte/src/server/build.js
@@ -1,5 +1,4 @@
 import { buildStatic } from '@storybook/core/server';
-
 import options from './options';
 
 buildStatic(options);

--- a/app/svelte/src/server/index.js
+++ b/app/svelte/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/svelte/standalone.js
+++ b/app/svelte/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/vue/src/server/index.js
+++ b/app/vue/src/server/index.js
@@ -1,5 +1,4 @@
 import { buildDev } from '@storybook/core/server';
-
 import options from './options';
 
 buildDev(options);

--- a/app/vue/standalone.js
+++ b/app/vue/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -2,121 +2,59 @@ import express from 'express';
 import https from 'https';
 import ip from 'ip';
 import favicon from 'serve-favicon';
-import program from 'commander';
 import path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
-import detectFreePort from 'detect-port';
-import inquirer from 'inquirer';
 import { logger } from '@storybook/node-logger';
 import opn from 'opn';
-
 import storybook, { webpackValid } from './middleware';
-import { parseList, getEnvConfig } from './utils';
+import { getDevCli } from './cli';
 import './config/env';
 
 const defaultFavIcon = require.resolve('./public/favicon.ico');
 
-const getFreePort = port =>
-  detectFreePort(port).catch(error => {
-    logger.error(error);
+function getServer(app, options) {
+  if (!options.https) {
+    return app;
+  }
+
+  if (!options.sslCert) {
+    logger.error('Error: --ssl-cert is required with --https');
     process.exit(-1);
-  });
-
-export async function buildDev({ packageJson, ...loadOptions }) {
-  process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-
-  program
-    .version(packageJson.version)
-    .option('-p, --port [number]', 'Port to run Storybook', str => parseInt(str, 10))
-    .option('-h, --host [string]', 'Host to run Storybook')
-    .option('-s, --static-dir <dir-names>', 'Directory where to load static files from')
-    .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
-    .option(
-      '--https',
-      'Serve Storybook over HTTPS. Note: You must provide your own certificate information.'
-    )
-    .option(
-      '--ssl-ca <ca>',
-      'Provide an SSL certificate authority. (Optional with --https, required if using a self-signed certificate)',
-      parseList
-    )
-    .option('--ssl-cert <cert>', 'Provide an SSL certificate. (Required with --https)')
-    .option('--ssl-key <key>', 'Provide an SSL key. (Required with --https)')
-    .option('--smoke-test', 'Exit after successful start')
-    .option('--ci', "CI mode (skip interactive prompts, don't open browser")
-    .option('--quiet', 'Suppress verbose build output')
-    .parse(process.argv);
-
-  logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}`) + chalk.reset('\n'));
-
-  // The key is the field created in `program` variable for
-  // each command line argument. Value is the env variable.
-  getEnvConfig(program, {
-    port: 'SBCONFIG_PORT',
-    host: 'SBCONFIG_HOSTNAME',
-    staticDir: 'SBCONFIG_STATIC_DIR',
-    configDir: 'SBCONFIG_CONFIG_DIR',
-  });
-
-  const port = await getFreePort(program.port);
-
-  if (!program.ci && !program.smokeTest && program.port != null && port !== program.port) {
-    const { shouldChangePort } = await inquirer.prompt({
-      type: 'confirm',
-      default: true,
-      name: 'shouldChangePort',
-      message: `Port ${program.port} is not available.
-Would you like to run Storybook on port ${port} instead?`,
-    });
-    if (!shouldChangePort) {
-      process.exit(1);
-    }
   }
 
-  // Used with `app.listen` below
-  const listenAddr = [port];
-
-  if (program.host) {
-    listenAddr.push(program.host);
+  if (!options.sslKey) {
+    logger.error('Error: --ssl-key is required with --https');
+    process.exit(-1);
   }
 
-  const app = express();
-  let server = app;
+  const sslOptions = {
+    ca: (options.sslCa || []).map(ca => fs.readFileSync(ca, 'utf-8')),
+    cert: fs.readFileSync(options.sslCert, 'utf-8'),
+    key: fs.readFileSync(options.sslKey, 'utf-8'),
+  };
 
-  if (program.https) {
-    if (!program.sslCert) {
-      logger.error('Error: --ssl-cert is required with --https');
-      process.exit(-1);
-    }
-    if (!program.sslKey) {
-      logger.error('Error: --ssl-key is required with --https');
-      process.exit(-1);
-    }
+  return https.createServer(sslOptions, app);
+}
 
-    const sslOptions = {
-      ca: (program.sslCa || []).map(ca => fs.readFileSync(ca, 'utf-8')),
-      cert: fs.readFileSync(program.sslCert, 'utf-8'),
-      key: fs.readFileSync(program.sslKey, 'utf-8'),
-    };
-
-    server = https.createServer(sslOptions, app);
-  }
-
+function applyStatic(app, options) {
+  const { staticDir } = options;
   let hasCustomFavicon = false;
 
-  if (program.staticDir) {
-    program.staticDir = parseList(program.staticDir);
-    program.staticDir.forEach(dir => {
+  if (staticDir) {
+    staticDir.forEach(dir => {
       const staticPath = path.resolve(dir);
+
       if (!fs.existsSync(staticPath)) {
         logger.error(`Error: no such directory to load static files: ${staticPath}`);
         process.exit(-1);
       }
+
       logger.info(`=> Loading static files from: ${staticPath} .`);
       app.use(express.static(staticPath, { index: false }));
 
       const faviconPath = path.resolve(staticPath, 'favicon.ico');
+
       if (fs.existsSync(faviconPath)) {
         hasCustomFavicon = true;
         app.use(favicon(faviconPath));
@@ -127,21 +65,17 @@ Would you like to run Storybook on port ${port} instead?`,
   if (!hasCustomFavicon) {
     app.use(favicon(defaultFavIcon));
   }
+}
 
-  // Build the webpack configuration using the `baseConfig`
-  // custom `.babelrc` file and `webpack.config.js` files
-  const configDir = program.configDir || './.storybook';
-
-  // NOTE changes to env should be done before calling `getBaseConfig`
-  // `getBaseConfig` function which is called inside the middleware
-  app.use(storybook(configDir, loadOptions, program.quiet));
-
+function listenToServer(server, listenAddr) {
   let serverResolve = () => {};
   let serverReject = () => {};
+
   const serverListening = new Promise((resolve, reject) => {
     serverResolve = resolve;
     serverReject = reject;
   });
+
   server.listen(...listenAddr, error => {
     if (error) {
       serverReject(error);
@@ -150,24 +84,57 @@ Would you like to run Storybook on port ${port} instead?`,
     }
   });
 
+  return serverListening;
+}
+
+export async function buildDevStandalone(options) {
+  const { port, host } = options;
+
+  // Used with `app.listen` below
+  const listenAddr = [port];
+
+  if (host) {
+    listenAddr.push(host);
+  }
+
+  const app = express();
+  const server = getServer(app, options);
+
+  applyStatic(app, options);
+
+  app.use(storybook(options));
+
+  const serverListening = listenToServer(server, listenAddr);
+
   try {
     const [stats] = await Promise.all([webpackValid, serverListening]);
-    const proto = program.https ? 'https' : 'http';
-    const address = `${proto}://${program.host || 'localhost'}:${port}/`;
+    const proto = options.https ? 'https' : 'http';
+    const address = `${proto}://${host || 'localhost'}:${port}/`;
     const networkAddress = `${proto}://${ip.address()}:${port}/`;
     logger.info(`Storybook started on => ${chalk.cyan(address)}`);
     logger.info(`Available on the network at => ${chalk.cyan(networkAddress)}\n`);
-    if (program.smokeTest) {
+
+    if (options.smokeTest) {
       process.exit(stats.toJson().warnings.length ? 1 : 0);
-    } else if (!program.ci) {
+    } else if (!options.ci) {
       opn(address);
     }
   } catch (error) {
     if (error instanceof Error) {
       logger.error(error);
     }
-    if (program.smokeTest) {
+    if (options.smokeTest) {
       process.exit(1);
     }
   }
+}
+
+export async function buildDev({ packageJson, ...loadOptions }) {
+  const cliOptions = await getDevCli(packageJson);
+
+  await buildDevStandalone({
+    ...cliOptions,
+    ...loadOptions,
+    configDir: cliOptions.configDir || './.storybook',
+  });
 }

--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -1,39 +1,16 @@
 import webpack from 'webpack';
-import program from 'commander';
 import path from 'path';
 import fs from 'fs';
-import chalk from 'chalk';
 import shelljs from 'shelljs';
 import { logger } from '@storybook/node-logger';
-import { parseList, getEnvConfig } from './utils';
+import { getProdCli } from './cli';
 import './config/env';
 import loadConfig from './config';
 
 const defaultFavIcon = require.resolve('./public/favicon.ico');
 
-export function buildStatic({ packageJson, ...loadOptions }) {
-  process.env.NODE_ENV = process.env.NODE_ENV || 'production';
-
-  program
-    .version(packageJson.version)
-    .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
-    .option('-o, --output-dir [dir-name]', 'Directory where to store built files')
-    .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
-    .option('-w, --watch', 'Enable watch mode')
-    .parse(process.argv);
-
-  logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}\n`));
-
-  // The key is the field created in `program` variable for
-  // each command line argument. Value is the env variable.
-  getEnvConfig(program, {
-    staticDir: 'SBCONFIG_STATIC_DIR',
-    outputDir: 'SBCONFIG_OUTPUT_DIR',
-    configDir: 'SBCONFIG_CONFIG_DIR',
-  });
-
-  const configDir = program.configDir || './.storybook';
-  const outputDir = program.outputDir || './storybook-static';
+export function buildStaticStandalone(options) {
+  const { outputDir, staticDir, watch } = options;
 
   // create output directory if not exists
   shelljs.mkdir('-p', path.resolve(outputDir));
@@ -47,14 +24,14 @@ export function buildStatic({ packageJson, ...loadOptions }) {
   const config = loadConfig({
     configType: 'PRODUCTION',
     corePresets: [require.resolve('./core-preset-prod.js')],
-    configDir,
-    ...loadOptions,
+    ...options,
   });
+
   config.output.path = path.resolve(outputDir);
 
   // copy all static files
-  if (program.staticDir) {
-    program.staticDir.forEach(dir => {
+  if (staticDir) {
+    staticDir.forEach(dir => {
       if (!fs.existsSync(dir)) {
         logger.error(`Error: no such directory to load static files: ${dir}`);
         process.exit(-1);
@@ -77,10 +54,23 @@ export function buildStatic({ packageJson, ...loadOptions }) {
     }
     logger.info('Building storybook completed.');
   };
+
   const compiler = webpack(config);
-  if (program.watch) {
+
+  if (watch) {
     compiler.watch({}, webpackCb);
   } else {
     compiler.run(webpackCb);
   }
+}
+
+export function buildStatic({ packageJson, ...loadOptions }) {
+  const cliOptions = getProdCli(packageJson);
+
+  buildStaticStandalone({
+    ...cliOptions,
+    ...loadOptions,
+    configDir: cliOptions.configDir || './.storybook',
+    outputDir: cliOptions.outputDir || './storybook-static',
+  });
 }

--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -1,0 +1,68 @@
+import program from 'commander';
+import chalk from 'chalk';
+import detectFreePort from 'detect-port';
+import inquirer from 'inquirer';
+import { logger } from '@storybook/node-logger';
+import { parseList, getEnvConfig } from './utils';
+
+const getFreePort = port =>
+  detectFreePort(port).catch(error => {
+    logger.error(error);
+    process.exit(-1);
+  });
+
+async function getCLI(packageJson) {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
+  program
+    .version(packageJson.version)
+    .option('-p, --port [number]', 'Port to run Storybook', str => parseInt(str, 10))
+    .option('-h, --host [string]', 'Host to run Storybook')
+    .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
+    .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
+    .option(
+      '--https',
+      'Serve Storybook over HTTPS. Note: You must provide your own certificate information.'
+    )
+    .option(
+      '--ssl-ca <ca>',
+      'Provide an SSL certificate authority. (Optional with --https, required if using a self-signed certificate)',
+      parseList
+    )
+    .option('--ssl-cert <cert>', 'Provide an SSL certificate. (Required with --https)')
+    .option('--ssl-key <key>', 'Provide an SSL key. (Required with --https)')
+    .option('--smoke-test', 'Exit after successful start')
+    .option('--ci', "CI mode (skip interactive prompts, don't open browser")
+    .option('--quiet', 'Suppress verbose build output')
+    .parse(process.argv);
+
+  logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}`) + chalk.reset('\n'));
+
+  // The key is the field created in `program` variable for
+  // each command line argument. Value is the env variable.
+  getEnvConfig(program, {
+    port: 'SBCONFIG_PORT',
+    host: 'SBCONFIG_HOSTNAME',
+    staticDir: 'SBCONFIG_STATIC_DIR',
+    configDir: 'SBCONFIG_CONFIG_DIR',
+  });
+
+  const port = await getFreePort(program.port);
+
+  if (!program.ci && !program.smokeTest && program.port != null && port !== program.port) {
+    const { shouldChangePort } = await inquirer.prompt({
+      type: 'confirm',
+      default: true,
+      name: 'shouldChangePort',
+      message: `Port ${program.port} is not available.
+Would you like to run Storybook on port ${port} instead?`,
+    });
+    if (!shouldChangePort) {
+      process.exit(1);
+    }
+  }
+
+  return { ...program, port };
+}
+
+export default getCLI;

--- a/lib/core/src/server/cli/index.js
+++ b/lib/core/src/server/cli/index.js
@@ -1,0 +1,4 @@
+import getDevCli from './dev';
+import getProdCli from './prod';
+
+export { getDevCli, getProdCli };

--- a/lib/core/src/server/cli/prod.js
+++ b/lib/core/src/server/cli/prod.js
@@ -1,0 +1,30 @@
+import program from 'commander';
+import chalk from 'chalk';
+import { logger } from '@storybook/node-logger';
+import { parseList, getEnvConfig } from './utils';
+
+function getCLI(packageJson) {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+
+  program
+    .version(packageJson.version)
+    .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
+    .option('-o, --output-dir [dir-name]', 'Directory where to store built files')
+    .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
+    .option('-w, --watch', 'Enable watch mode')
+    .parse(process.argv);
+
+  logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}\n`));
+
+  // The key is the field created in `program` variable for
+  // each command line argument. Value is the env variable.
+  getEnvConfig(program, {
+    staticDir: 'SBCONFIG_STATIC_DIR',
+    outputDir: 'SBCONFIG_OUTPUT_DIR',
+    configDir: 'SBCONFIG_CONFIG_DIR',
+  });
+
+  return { ...program };
+}
+
+export default getCLI;

--- a/lib/core/src/server/cli/utils.js
+++ b/lib/core/src/server/cli/utils.js
@@ -1,0 +1,13 @@
+export function parseList(str) {
+  return str.split(',');
+}
+
+export function getEnvConfig(program, configEnv) {
+  Object.keys(configEnv).forEach(fieldName => {
+    const envVarName = configEnv[fieldName];
+    const envVarValue = process.env[envVarName];
+    if (envVarValue) {
+      program[fieldName] = envVarValue; // eslint-disable-line
+    }
+  });
+}

--- a/lib/core/src/server/middleware.js
+++ b/lib/core/src/server/middleware.js
@@ -14,15 +14,15 @@ export const webpackValid = new Promise((resolve, reject) => {
   webpackReject = reject;
 });
 
-export default function(configDir, loadOptions, quiet) {
+export default function(options) {
+  const { configDir } = options;
+
   // Build the webpack configuration using the `getBaseConfig`
   // custom `.babelrc` file and `webpack.config.js` files
   const config = loadConfig({
     configType: 'DEVELOPMENT',
     corePresets: [require.resolve('./core-preset-dev.js')],
-    configDir,
-    quiet,
-    ...loadOptions,
+    ...options,
   });
   const middlewareFn = getMiddleware(configDir);
 

--- a/lib/core/src/server/standalone.js
+++ b/lib/core/src/server/standalone.js
@@ -1,0 +1,24 @@
+import { buildStaticStandalone } from './build-static';
+import { buildDevStandalone } from './build-dev';
+
+async function build(options = {}, frameworkOptions = {}) {
+  const { mode = 'dev' } = options;
+
+  const commonOptions = {
+    ...options,
+    ...frameworkOptions,
+    frameworkPresets: [...options.frameworkPresets, ...(frameworkOptions.frameworkPresets || [])],
+  };
+
+  if (mode === 'dev') {
+    return buildDevStandalone(commonOptions);
+  }
+
+  if (mode === 'static') {
+    return buildStaticStandalone(commonOptions);
+  }
+
+  throw new Error(`'mode' parameter should be either 'dev' or 'static'`);
+}
+
+export default build;

--- a/lib/core/src/server/utils.js
+++ b/lib/core/src/server/utils.js
@@ -1,20 +1,6 @@
 import path from 'path';
 import fs from 'fs';
 
-export function parseList(str) {
-  return str.split(',');
-}
-
-export function getEnvConfig(program, configEnv) {
-  Object.keys(configEnv).forEach(fieldName => {
-    const envVarName = configEnv[fieldName];
-    const envVarValue = process.env[envVarName];
-    if (envVarValue) {
-      program[fieldName] = envVarValue; // eslint-disable-line
-    }
-  });
-}
-
 export function getMiddleware(configDir) {
   const middlewarePath = path.resolve(configDir, 'middleware.js');
   if (fs.existsSync(middlewarePath)) {

--- a/lib/core/standalone.js
+++ b/lib/core/standalone.js
@@ -1,0 +1,3 @@
+const build = require('./dist/server/standalone').default;
+
+module.exports = build;


### PR DESCRIPTION
Issue: #4249

## What I did

There are cases when people want to run storybook from their code. 
I've exposed the "standalone" api, so now it will be possible to do something like this:

```js
import build from '@storybook/react/standalone';

build({
  mode: 'dev',
  port: 9009,
  configDir: './storybook',
  frameworkPresets: [],
});
```

