### PR TITLE
Fix duplicate manual mocks in jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -49,6 +49,7 @@ module.exports = {
   setupTestFrameworkScriptFile: './scripts/jest.init.js',
   setupFiles: ['raf/polyfill'],
   testURL: 'http://localhost',
+  modulePathIgnorePatterns: ['/dist/.*/__mocks__/'],
   moduleFileExtensions: [
     'ts',
     'tsx',


### PR DESCRIPTION
Issue: n/a

## What I did

Told jest to ignore compiled mocks (`/dist/.*/__mocks__/`)

## How to test

`yarn test --core` should no longer warn about duplicate manual mocks

```
jest-haste-map: duplicate manual mock found:
  Module name: example
  Duplicate Mock path: /Users/chadfawcett/workspace/contributing/storybook/addons/actions/src/lib/__mocks__/example.js
This warning is caused by two manual mock files with the same file name.
Jest will use the mock file found in:
/Users/chadfawcett/workspace/contributing/storybook/addons/actions/src/lib/__mocks__/example.js
 Please delete one of the following two files:
 /Users/chadfawcett/workspace/contributing/storybook/addons/actions/dist/lib/__mocks__/example.js
/Users/chadfawcett/workspace/contributing/storybook/addons/actions/src/lib/__mocks__/example.js
```