### PR TITLE
Expose webpackFinal extension

### DIFF
--- a/app/angular/src/server/framework-preset-angular-cli.js
+++ b/app/angular/src/server/framework-preset-angular-cli.js
@@ -5,7 +5,7 @@ import {
   applyAngularCliWebpackConfig,
 } from './angular-cli_config';
 
-export function webpack(config) {
+export function webpackFinal(config) {
   const cwd = process.cwd();
   const cliWebpackConfigOptions = getAngularCliWebpackConfigOptions(cwd);
 

--- a/lib/core/src/server/config.js
+++ b/lib/core/src/server/config.js
@@ -7,6 +7,7 @@ function wrapCorePresets(presets) {
   return {
     babel: (config, args) => presets.apply('babel', config, args),
     webpack: (config, args) => presets.apply('webpack', config, args),
+    webpackFinal: (config, args) => presets.apply('webpackFinal', config, args),
     preview: (config, args) => presets.apply('preview', config, args),
     manager: (config, args) => presets.apply('manager', config, args),
   };
@@ -34,7 +35,9 @@ function getWebpackConfig(options, presets) {
     manager: presets.manager([], options),
   };
 
-  return presets.webpack({}, { ...options, babelOptions, entries });
+  const webpackConfig = presets.webpack({}, { ...options, babelOptions, entries });
+
+  return presets.webpackFinal(webpackConfig, options);
 }
 
 export default options => {


### PR DESCRIPTION
Issue: 
`angular-cli` preset should filter out all the styling rules in order to integrate its rules instead. 
Currently, angular-cli preset is kicked-in in the middle of the presets chain because it's a framework preset.

The last preset in the chain adds default rules or execute the custom webpack config. We need the ability for other presets to clean the webpack config after all the manipulations.

![image](https://user-images.githubusercontent.com/7867954/46958116-bd5b7600-d0a1-11e8-8a84-da94f7d73759.png)

Related #4296

## What I did
I've added the `webpackFinal` step.