### PR TITLE
[v3.4] Accept babel-loader 8, to support babel 7

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -32,7 +32,6 @@
     "@storybook/node-logger": "3.4.11",
     "@storybook/ui": "3.4.11",
     "airbnb-js-shims": "^1 || ^2",
-    "babel-loader": "^7.1.4",
     "babel-plugin-macros": "^2.2.0",
     "babel-plugin-react-docgen": "^1.9.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
@@ -64,10 +63,12 @@
     "webpack-hot-middleware": "^2.22.1"
   },
   "devDependencies": {
+    "babel-loader": "^7.1.4",
     "nodemon": "^1.17.2"
   },
   "peerDependencies": {
     "babel-core": "^6.26.0 || ^7.0.0-0",
+    "babel-loader": "^7.1.4 || ^8.0.0",
     "babel-runtime": ">=6.0.0",
     "react": ">=15.0.0 || ^16.0.0",
     "react-dom": ">=15.0.0 || ^16.0.0"


### PR DESCRIPTION
**This PR is based on the release/3.4 branch and is intended to be a v3 release**

Issue:

`@storybook/react` accepts `"babel-core": "^7.0.0-0"`
https://github.com/storybooks/storybook/blob/01731dfe6f4158d8be4fd9bf3a26952654662fe7/app/react/package.json#L70

But, `"babel-loader": "^7.1.4"` has a peer dep on `"babel-core": "6"`
https://github.com/babel/babel-loader/blob/8fe5da3fb923096c98af31cb66fc1a3a22b44992/package.json#L18

So, in order to use `babel-core@7.0.0-bridge.0` (and `@babel/core@^7.0.0`) at the root, we need to use `babel-loader@^8.0.0`.
https://github.com/babel/babel-loader/blob/d1a3dd57e5f934fe509b9aeab78e5e3d66af8b49/package.json#L19

We are not yet on Storybook 4 (which doesn't have this issue) because we are on React 16.2 and Webpack 3 at the moment. Excited to upgrade soon! Thanks for your great work on Storybook!

## What I did

- Moved babel-loader to a peer dep
- Add babel-loader 8 as an accepted version
- Add babel-loader 7 as a dev dep

Happy to make this change in other packages too, if we feel it's the right solution.

This approach is similar to how v4 is versioning babel-loader
https://github.com/storybooks/storybook/blob/80ec5726b68aea0dff1245642a888e43c07daaf3/app/react/package.json#L44

## How to test

We ran a large `v3.4.11 + this patch` react storybook app through babel-loader loader and saw no errors. Happy to add tests/apps to the repo as you see best - would just need a bit of guidance on what you think the best way to test this would be. 

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
