### PR TITLE
Fix FAQ markdown page in order to get the link to display

### DIFF
--- a/docs/src/pages/basics/faq/index.md
+++ b/docs/src/pages/basics/faq/index.md
@@ -1,8 +1,7 @@
-* * *
-
+---
 id: 'faq'
-
-## title: 'Frequently Asked Questions'
+title: 'Frequently Asked Questions'
+---
 
 Here are some answers to frequently asked questions. If you have a question, you can ask it by opening an issue on the [Storybook Repository](https://github.com/storybooks/storybook/).
 


### PR DESCRIPTION
## Issue

The link to the `Frequently Asked Questions` isn't being displayed because the title isn't getting pulled in from the frontmatter of the `faq` markdown page. 

![no-faq-link](https://user-images.githubusercontent.com/15054821/47176358-47862300-d2ca-11e8-8aae-bff57b5161cd.png)

## What I did

Moved the title of the page into the frontmatter of `/src/pages/basics/faq/index.md`.

![faq-link](https://user-images.githubusercontent.com/15054821/47176659-fdea0800-d2ca-11e8-97ca-870f8549b37f.png)
