### PR TITLE
Exclude story files from angular app build

### DIFF
--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -46,8 +46,8 @@ async function addDependencies(npmOptions) {
 function editAngularAppTsConfig() {
   const tsConfigJson = getAngularAppTsConfigJson();
   if (tsConfigJson) {
-    const { exclude } = tsConfigJson.compilerOptions;
-    tsConfigJson.compilerOptions.exclude = [...exclude, '**/*.stories.ts'];
+    const { exclude } = tsConfigJson;
+    tsConfigJson.exclude = [...exclude, '**/*.stories.ts'];
     writeAngularAppTsConfig(tsConfigJson);
   }
 }

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -1,8 +1,15 @@
 import mergeDirs from 'merge-dirs';
 import path from 'path';
-import { getVersions, getPackageJson, writePackageJson, installBabel } from '../../lib/helpers';
+import {
+  getVersions,
+  getPackageJson,
+  writePackageJson,
+  installBabel,
+  getAngularAppTsConfigJson,
+  writeAngularAppTsConfig,
+} from '../../lib/helpers';
 
-export default async npmOptions => {
+async function addDependencies(npmOptions) {
   const [
     storybookVersion,
     notesVersion,
@@ -17,7 +24,6 @@ export default async npmOptions => {
     '@storybook/addon-links',
     '@storybook/addons'
   );
-  mergeDirs(path.resolve(__dirname, 'template'), '.', 'overwrite');
 
   const packageJson = getPackageJson();
 
@@ -35,4 +41,20 @@ export default async npmOptions => {
   packageJson.scripts['build-storybook'] = 'build-storybook';
 
   writePackageJson(packageJson);
+}
+
+function editAngularAppTsConfig() {
+  const tsConfigJson = getAngularAppTsConfigJson();
+  if (tsConfigJson) {
+    const { exclude } = tsConfigJson.compilerOptions;
+    tsConfigJson.compilerOptions.exclude = [...exclude, '**/*.stories.ts'];
+    writeAngularAppTsConfig(tsConfigJson);
+  }
+}
+
+export default async npmOptions => {
+  mergeDirs(path.resolve(__dirname, 'template'), '.', 'overwrite');
+
+  await addDependencies(npmOptions);
+  editAngularAppTsConfig();
 };

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -50,7 +50,7 @@ function editAngularAppTsConfig() {
     return;
   }
 
-  const { exclude } = tsConfigJson;
+  const { exclude = [] } = tsConfigJson;
   if (exclude.includes(glob)) {
     return;
   }

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -45,11 +45,18 @@ async function addDependencies(npmOptions) {
 
 function editAngularAppTsConfig() {
   const tsConfigJson = getAngularAppTsConfigJson();
-  if (tsConfigJson) {
-    const { exclude } = tsConfigJson;
-    tsConfigJson.exclude = [...exclude, '**/*.stories.ts'];
-    writeAngularAppTsConfig(tsConfigJson);
+  const glob = '**/*.stories.ts';
+  if (!tsConfigJson) {
+    return;
   }
+
+  const { exclude } = tsConfigJson;
+  if (exclude.includes(glob)) {
+    return;
+  }
+
+  tsConfigJson.exclude = [...exclude, glob];
+  writeAngularAppTsConfig(tsConfigJson);
 }
 
 export default async npmOptions => {

--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -62,6 +62,16 @@ export function getBowerJson() {
   return JSON.parse(jsonContent);
 }
 
+export function getAngularJson() {
+  const angularJsonPath = path.resolve('angular.json');
+  if (!fs.existsSync(angularJsonPath)) {
+    return false;
+  }
+
+  const jsonContent = fs.readFileSync(angularJsonPath, 'utf8');
+  return JSON.parse(jsonContent);
+}
+
 export function writePackageJson(packageJson) {
   const content = `${JSON.stringify(packageJson, null, 2)}\n`;
   const packageJsonPath = path.resolve('package.json');

--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -74,7 +74,8 @@ export function getAngularJson() {
 
 export function getAngularAppTsConfigPath() {
   const angularJson = getAngularJson();
-  const tsConfigPath = angularJson.projects['angular-cli'].architect.build.options.tsConfig;
+  const { defaultProject } = angularJson;
+  const tsConfigPath = angularJson.projects[defaultProject].architect.build.options.tsConfig;
 
   if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
     return false;

--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -72,6 +72,35 @@ export function getAngularJson() {
   return JSON.parse(jsonContent);
 }
 
+export function getAngularAppTsConfigPath() {
+  const angularJson = getAngularJson();
+  const tsConfigPath = angularJson.projects['angular-cli'].architect.build.options.tsConfig;
+
+  if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
+    return false;
+  }
+  return tsConfigPath;
+}
+
+export function getAngularAppTsConfigJson() {
+  const tsConfigPath = getAngularAppTsConfigPath();
+
+  if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
+    return false;
+  }
+
+  const jsonContent = fs.readFileSync(tsConfigPath, 'utf8');
+  return JSON.parse(jsonContent);
+}
+
+export function writeAngularAppTsConfig(tsConfigJson) {
+  const content = `${JSON.stringify(tsConfigJson, null, 2)}\n`;
+  const tsConfigPath = getAngularAppTsConfigPath();
+  if (tsConfigPath) {
+    fs.writeFileSync(path.resolve(tsConfigPath), content, 'utf8');
+  }
+}
+
 export function writePackageJson(packageJson) {
   const content = `${JSON.stringify(packageJson, null, 2)}\n`;
   const packageJsonPath = path.resolve('package.json');


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/4481

## What I did

`sb init` adds  `**/*.stories.ts` to `exclude: []` in the `tsconfig.json`, taken from `angular.json` 
```
 "projects": {
    "angular-cli": {
      ...
      "architect": {
        "build": {
          "options": {
            ...
            "tsConfig": "src/tsconfig.app.json",
```

## How to test

```
cd lib/cli
yarn link
ng new my-app
sb init
```