### PR TITLE
Update index.md

### DIFF
--- a/docs/src/pages/basics/guide-react/index.md
+++ b/docs/src/pages/basics/guide-react/index.md
@@ -81,7 +81,7 @@ Now you can write some stories inside the `../stories/index.js` file, like this:
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import Button from '../components/Button';
+import { Button } from '@storybook/react/demo';
 
 storiesOf('Button', module)
   .add('with text', () => (


### PR DESCRIPTION
Issue:
The react starter guide docs point to a `<Button>` component that doesn't exist. 

## What I did
This PR corrects that `@import` so future doc readers won't have to troubleshoot their setup.