### PR TITLE
Addon-Knob: Add missing key property in Panel

### DIFF
--- a/addons/knobs/src/components/Panel.js
+++ b/addons/knobs/src/components/Panel.js
@@ -171,7 +171,7 @@ export default class Panel extends PureComponent {
         {groupIds.length > 0 ? (
           <TabsState>
             {Object.entries(groups).map(([k, v]) => (
-              <div id={k} title={v.title}>
+              <div id={k} key={k} title={v.title}>
                 {v.render}
               </div>
             ))}


### PR DESCRIPTION
Issue:
Missing key in iterator for two level knobs. 

## What I did

Added the key, similar to the id.

## How to test

Open Storybook with knob addon and multi level options, should ne throw an error anymore.
