### PR TITLE
Fix issue with `sb init` on the Vue CLI

### DIFF
--- a/lib/cli/generators/VUE/index.js
+++ b/lib/cli/generators/VUE/index.js
@@ -1,14 +1,27 @@
 import mergeDirs from 'merge-dirs';
 import path from 'path';
-import { getVersions, getPackageJson, writePackageJson, installBabel } from '../../lib/helpers';
+import {
+  getVersions,
+  getPackageJson,
+  writePackageJson,
+  installBabel,
+  addToDevDependenciesIfNotPresent,
+} from '../../lib/helpers';
 
 export default async npmOptions => {
-  const [storybookVersion, actionsVersion, linksVersion, addonsVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    addonsVersion,
+    babelPresetVersion,
+  ] = await getVersions(
     npmOptions,
     '@storybook/vue',
     '@storybook/addon-actions',
     '@storybook/addon-links',
-    '@storybook/addons'
+    '@storybook/addons',
+    'babel-preset-vue'
   );
 
   mergeDirs(path.resolve(__dirname, 'template'), '.', 'overwrite');
@@ -21,6 +34,9 @@ export default async npmOptions => {
   packageJson.devDependencies['@storybook/addon-actions'] = actionsVersion;
   packageJson.devDependencies['@storybook/addon-links'] = linksVersion;
   packageJson.devDependencies['@storybook/addons'] = addonsVersion;
+
+  // We should probably just not even be using this directly, see: https://github.com/storybooks/storybook/issues/4475#issuecomment-432141296
+  addToDevDependenciesIfNotPresent(packageJson, 'babel-preset-vue', babelPresetVersion);
 
   await installBabel(npmOptions, packageJson);
 

--- a/lib/cli/generators/VUE/index.js
+++ b/lib/cli/generators/VUE/index.js
@@ -15,13 +15,15 @@ export default async npmOptions => {
     linksVersion,
     addonsVersion,
     babelPresetVersion,
+    babelCoreVersion,
   ] = await getVersions(
     npmOptions,
     '@storybook/vue',
     '@storybook/addon-actions',
     '@storybook/addon-links',
     '@storybook/addons',
-    'babel-preset-vue'
+    'babel-preset-vue',
+    '@babel/core'
   );
 
   mergeDirs(path.resolve(__dirname, 'template'), '.', 'overwrite');
@@ -38,6 +40,15 @@ export default async npmOptions => {
   // We should probably just not even be using this directly, see: https://github.com/storybooks/storybook/issues/4475#issuecomment-432141296
   addToDevDependenciesIfNotPresent(packageJson, 'babel-preset-vue', babelPresetVersion);
 
+  const packageBabelCoreVersion =
+    packageJson.dependencies['babel-core'] || packageJson.devDependencies['babel-core'];
+
+  // This seems to be the version installed by the Vue CLI, and it is not handled by
+  // installBabel below. For some reason it leads to the wrong version of @babel/core (a beta)
+  // being installed
+  if (packageBabelCoreVersion === '7.0.0-bridge.0') {
+    addToDevDependenciesIfNotPresent(packageJson, '@babel/core', babelCoreVersion);
+  }
   await installBabel(npmOptions, packageJson);
 
   packageJson.scripts = packageJson.scripts || {};

--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -150,7 +150,7 @@ export function paddedLog(message) {
 
 export function getChars(char, amount) {
   let line = '';
-  for (let lc = 0; lc < amount; lc++) { // eslint-disable-line
+  for (let lc = 0; lc < amount; lc += 1) {
     line += char;
   }
 
@@ -225,5 +225,11 @@ export async function installBabel(npmOptions, packageJson) {
       'babel-loader',
       babelLoaderVersion
     );
+  }
+}
+
+export function addToDevDependenciesIfNotPresent(packageJson, name, packageVersion) {
+  if (!packageJson.dependencies[name] && !packageJson.devDependencies[name]) {
+    packageJson.devDependencies[name] = packageVersion;
   }
 }


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/4475

## What I did

Re add `babel-preset-vue` to vue init script.

Also install a manual dep on `@babel/core`, to fix yarn problems.

## How to test

```
cd lib/cli
yarn link

cd /tmp
npx -p @vue/cli vue create new-app

cd new-app
sb init

yarn storybook
```