### PR TITLE
Upgrade react-komposer to 2.0.5

### DIFF
--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -32,7 +32,7 @@
     "@storybook/core-events": "4.0.0-rc.5",
     "@storybook/mantra-core": "^1.7.2",
     "@storybook/podda": "^1.2.3",
-    "@storybook/react-komposer": "^2.0.4",
+    "@storybook/react-komposer": "^2.0.5",
     "deep-equal": "^1.0.1",
     "events": "^3.0.0",
     "fuse.js": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,7 +1893,7 @@
     babel-runtime "^6.11.6"
     immutable "^3.8.1"
 
-"@storybook/react-komposer@^2.0.1", "@storybook/react-komposer@^2.0.4":
+"@storybook/react-komposer@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@storybook/react-komposer/-/react-komposer-2.0.4.tgz#c2c0d4a75d9b4a9c0c6b46f14ab050f458ad4bb0"
   integrity sha1-wsDUp12bSpwMa0bxSrBQ9FitS7A=
@@ -1903,6 +1903,17 @@
     hoist-non-react-statics "^1.2.0"
     lodash.pick "^4.4.0"
     shallowequal "^0.2.2"
+
+"@storybook/react-komposer@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@storybook/react-komposer/-/react-komposer-2.0.5.tgz#0c23163f28b2e1bd2aeeb4421fed382bb512de0e"
+  integrity sha512-zX5UITgAh37tmD0MWnUFR29S5YM8URMHc/9iwczX/P1f3tM4nPn8VAzxG/UWQecg1xZVphmqkZoux+SDrtTZOQ==
+  dependencies:
+    "@storybook/react-stubber" "^1.0.0"
+    babel-runtime "^6.11.6"
+    hoist-non-react-statics "^1.2.0"
+    lodash "^4.17.11"
+    shallowequal "^1.1.0"
 
 "@storybook/react-simple-di@^1.2.1":
   version "1.3.0"


### PR DESCRIPTION
Issue: N/A

## What I did

Released `react-komposer@2.0.5` which removes some old versions of lodash etc. that have vulnerabilities. Courtesy of @Stephanemw 	
