### PR TITLE
(bug) Fix Select array values showing k (fixes #4560)

### DIFF
--- a/addons/knobs/src/components/__tests__/Select.js
+++ b/addons/knobs/src/components/__tests__/Select.js
@@ -17,14 +17,12 @@ describe('Select', () => {
       };
     });
 
-    describe('displays value', () => {
-      it('correctly maps option keys and values', () => {
-        const wrapper = shallow(<SelectType knob={knob} />);
+    it('correctly maps option keys and values', () => {
+      const wrapper = shallow(<SelectType knob={knob} />);
 
-        const green = wrapper.find('option').first();
-        expect(green.text()).toEqual('Green');
-        expect(green.prop('value')).toEqual('Green');
-      });
+      const green = wrapper.find('option').first();
+      expect(green.text()).toEqual('Green');
+      expect(green.prop('value')).toEqual('Green');
     });
   });
 
@@ -37,14 +35,12 @@ describe('Select', () => {
       };
     });
 
-    describe('displays value', () => {
-      it('correctly maps option keys and values', () => {
-        const wrapper = shallow(<SelectType knob={knob} />);
+    it('correctly maps option keys and values', () => {
+      const wrapper = shallow(<SelectType knob={knob} />);
 
-        const green = wrapper.find('option').first();
-        expect(green.text()).toEqual('green');
-        expect(green.prop('value')).toEqual('green');
-      });
+      const green = wrapper.find('option').first();
+      expect(green.text()).toEqual('green');
+      expect(green.prop('value')).toEqual('green');
     });
   });
 });

--- a/addons/knobs/src/components/__tests__/Select.js
+++ b/addons/knobs/src/components/__tests__/Select.js
@@ -5,24 +5,46 @@ import SelectType from '../types/Select';
 describe('Select', () => {
   let knob;
 
-  beforeEach(() => {
-    knob = {
-      name: 'Colors',
-      value: '#00ff00',
-      options: {
-        Green: '#00ff00',
-        Red: '#ff0000',
-      },
-    };
+  describe('Object values', () => {
+    beforeEach(() => {
+      knob = {
+        name: 'Colors',
+        value: '#00ff00',
+        options: {
+          Green: '#00ff00',
+          Red: '#ff0000',
+        },
+      };
+    });
+
+    describe('displays value', () => {
+      it('correctly maps option keys and values', () => {
+        const wrapper = shallow(<SelectType knob={knob} />);
+
+        const green = wrapper.find('option').first();
+        expect(green.text()).toEqual('Green');
+        expect(green.prop('value')).toEqual('Green');
+      });
+    });
   });
 
-  describe('displays value', () => {
-    it('correctly maps option keys and values', () => {
-      const wrapper = shallow(<SelectType knob={knob} />);
+  describe('Array values', () => {
+    beforeEach(() => {
+      knob = {
+        name: 'Colors',
+        value: 'green',
+        options: ['green', 'red'],
+      };
+    });
 
-      const green = wrapper.find('option').first();
-      expect(green.text()).toEqual('Green');
-      expect(green.prop('value')).toEqual('Green');
+    describe('displays value', () => {
+      it('correctly maps option keys and values', () => {
+        const wrapper = shallow(<SelectType knob={knob} />);
+
+        const green = wrapper.find('option').first();
+        expect(green.text()).toEqual('green');
+        expect(green.prop('value')).toEqual('green');
+      });
     });
   });
 });

--- a/addons/knobs/src/components/types/Select.js
+++ b/addons/knobs/src/components/types/Select.js
@@ -6,7 +6,7 @@ import { Select } from '@storybook/components';
 const SelectType = ({ knob, onChange }) => {
   const { options } = knob;
   const entries = Array.isArray(options)
-    ? options.reduce((acc, k) => Object.assign(acc, { k }), {})
+    ? options.reduce((acc, k) => Object.assign(acc, { [k]: k }), {})
     : options;
 
   const selectedKey = Object.keys(entries).find(k => entries[k] === knob.value);


### PR DESCRIPTION
Issue: #4560


Turns out the assignment of `k` in a shorthand notation of an object was
wrong. Using `k` instead of `[k]: k` makes it assign to parameter key
`'k'` as opposed to what `k` as a variable contains.


This is testable with Jest. The added test covers this bug.