### PR TITLE
chore: bump up Expo version in crna-kitchen-sink example

### DIFF
--- a/examples-native/crna-kitchen-sink/README.md
+++ b/examples-native/crna-kitchen-sink/README.md
@@ -1,3 +1,9 @@
 # CRNA Kitchen Sink
 
-This project was bootstrapped with [Create React Native App](https://github.com/react-community/create-react-native-app) and storybook using [storybook CLI](https://www.npmjs.com/package/@storybook/cli).
+This project was bootstrapped wit [Expo](https://github.com/expo/expo-cli) and storybook using [storybook CLI](https://www.npmjs.com/package/@storybook/cli).
+
+## Getting started
+
+1. Install dependencies: `yarn install`
+2. Run storybook: `yarn storybook`
+3. Run the app: `yarn start`

--- a/examples-native/crna-kitchen-sink/app.json
+++ b/examples-native/crna-kitchen-sink/app.json
@@ -1,10 +1,12 @@
 {
   "expo": {
-    "sdkVersion": "24.0.0",
+    "sdkVersion": "30.0.0",
+    "platforms": ["ios", "android"],
     "androidStatusBarColor": "#C2185B",
     "androidStatusBar": {
       "barStyle": "light-content",
       "backgroundColor": "#C2185B"
-    }
+    },
+    "assetBundlePatterns": ["**/*"]
   }
 }

--- a/examples-native/crna-kitchen-sink/package.json
+++ b/examples-native/crna-kitchen-sink/package.json
@@ -2,12 +2,12 @@
   "name": "crna-kitchen-sink",
   "version": "0.1.0",
   "private": true,
-  "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
+  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "android": "react-native-scripts android",
-    "eject": "react-native-scripts eject",
-    "ios": "react-native-scripts ios",
-    "start": "react-native-scripts start",
+    "android": "expo start --android",
+    "eject": "expo eject",
+    "ios": "expo start --ios",
+    "start": "expo start",
     "storybook": "storybook start",
     "test": "node node_modules/jest/bin/jest.js --watch"
   },
@@ -15,10 +15,11 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "expo": "^24.0.2",
-    "prop-types": "^15.6.0",
+    "expo": "^30.0.1",
+    "prop-types": "^15.6.2",
     "react": "^16.2.0",
-    "react-native": "^0.51.0"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-30.0.0.tar.gz",
+    "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
     "@storybook/addon-actions": "file:../../packs/storybook-addon-actions.tgz",
@@ -40,9 +41,8 @@
     "@storybook/addon-ondevice-knobs": "file:../../packs/storybook-addon-ondevice-knobs.tgz",
     "@storybook/addon-ondevice-notes": "file:../../packs/storybook-addon-ondevice-notes.tgz",
     "@storybook/ui": "file:../../packs/storybook-ui.tgz",
-    "jest-expo": "^24.0.0",
+    "jest-expo": "^30.0.0",
     "react-dom": "^16.2.0",
-    "react-native-scripts": "^1.8.1",
-    "react-test-renderer": "~16.2.0"
+    "react-test-renderer": "^16.6.0"
   }
 }


### PR DESCRIPTION
Issue: N/A

## What I did

Update expo requirement from `^24.0.2` to `^30.0.1` for `crna-kitchen-sink` example. Also remove [`crna`](https://github.com/react-community/create-react-native-app)'s `react-native-scripts` to use `expo`.

Motivation: I tried to use `crna-kitchen-sink`, but [I got stuck in "Starting packager"](https://github.com/react-community/create-react-native-app/issues/203).

PS: `whatwg-fetch` was added to fix this issue: ["Can't Find Variable Self"](https://stackoverflow.com/questions/52269560/react-native-expo-cant-find-variable-self)

## How to test

Is this testable with Jest or Chromatic screenshots? NO
Does this need a new example in the kitchen sink apps? NO
Does this need an update to the documentation? NO

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
