### PR TITLE
fix(reactnative): fix accessibility for component preview (iOS+VoiceOver)

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -124,6 +124,7 @@ export default class OnDeviceUI extends PureComponent {
           <Animated.View style={previewWrapperStyles}>
             <Animated.View style={previewStyles}>
               <TouchableOpacity
+                accessible={false}
                 style={style.flex}
                 disabled={tabOpen === PREVIEW}
                 onPress={this.handleOpenPreview}


### PR DESCRIPTION
Issue: N/A

## What I did

On React-Native, `<StoryView>` is wrapped by a `<TouchableOpacity>`, and by default touchable elements on RN has an `accessible={true}` ([docs](https://facebook.github.io/react-native/docs/accessibility#accessible-ios-android)). 

This causes this problem: VoiceOver won't focus on children elements when the parent has `accessible={ true }`, which means it's not possible to fully test the accessibility of components inside Storybook.

So the easiest solution for it is settting `accessible={false}` for the `<TouchableOpacity>`

## How to test

Is this testable with Jest or Chromatic screenshots? N
Does this need a new example in the kitchen sink apps? N
Does this need an update to the documentation? N

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
