### PR TITLE
[documentation] Update URL to babel config in default-config

### DIFF
--- a/docs/src/pages/configurations/default-config/index.md
+++ b/docs/src/pages/configurations/default-config/index.md
@@ -28,7 +28,7 @@ Here are some key features of Storybook's Babel configurations.
 
 We have added ES2016 support with Babel for transpiling your JS code.
 In addition to that, we've added a few experimental features, like object spreading and async await.
-Check out our [source](https://github.com/storybooks/storybook/blob/master/lib/core/src/server/config/babel.js#L4) to learn more about these plugins.
+Check out our [source](https://github.com/storybooks/storybook/blob/master/lib/core/src/server/config/babel.dev.js) to learn more about these plugins.
 
 ### .babelrc support
 


### PR DESCRIPTION
Issue: Documentation refers to a file which no longer exists

## What I did
- Update documents to refer to similar dev config file. I am open to recommendations on how to revise this in a different way. But for now linking to a 404 is not helpful in this documentation and this is a potential fix.
## How to test
- Evaluate the documentation update update