### PR TITLE
Fix: markdown typo

### DIFF
--- a/app/react-native/docs/addons.md
+++ b/app/react-native/docs/addons.md
@@ -25,6 +25,7 @@ configure(() => {
 
 const StorybookUI = getStorybookUI();
 export default StorybookUI;
+```
 
 **storybook/rn-addons.js**
 ```


### PR DESCRIPTION
I believe the documentation would read as intended with the fix.

Issue: The documentation was not correctly formatted as one code block was not closed.

<img width="912" alt="screen shot 2018-10-30 at 09 04 41" src="https://user-images.githubusercontent.com/22741774/47704158-fad40d80-dc22-11e8-9911-7fd32754207e.png">


## What I did
Closed the code block to obtain the following:

<img width="898" alt="screen shot 2018-10-30 at 09 05 10" src="https://user-images.githubusercontent.com/22741774/47704177-06bfcf80-dc23-11e8-9ee5-369d7e582bec.png">


## How to test
Preview markdown result.

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
