### PR TITLE
Allow for angular-devkit/core version aligned with Angular v7

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -44,7 +44,7 @@
     "zone.js": "^0.8.26"
   },
   "peerDependencies": {
-    "@angular-devkit/core": "^0.6.1",
+    "@angular-devkit/core": "^0.6.1 || >=7.0.0",
     "@angular/common": ">=6.0.0",
     "@angular/compiler": ">=6.0.0",
     "@angular/core": ">=6.0.0",


### PR DESCRIPTION
Issue:

## What I did

Set @storybook/angular's peer dependency range to allow for Angular ^7.0.0. There's a [test fixture for it](https://github.com/storybooks/storybook/blob/v4.0.0/lib/cli/test/fixtures/angular-cli-v7/package.json#L17) already. Additionally, I was able to successfully run and build Storybook v4 with a Angular CLI v7-generated project.

This change simply removes the peer dependency warning when installing @storybook/angular.

## How to test

There's a [test fixture for it](https://github.com/storybooks/storybook/blob/v4.0.0/lib/cli/test/fixtures/angular-cli-v7/package.json#L17) already. 