### PR TITLE
feat(react-native): persist last displayed story

### DIFF
--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -121,6 +121,8 @@ You can pass these parameters to getStorybookUI call in your storybook entry poi
         -- should the ui be closed initialy.
     tabOpen: Number (0)
         -- which tab should be open. -1 Navigator, 0 Preview, 1 Addons
+    shouldPersistSelection: Boolean (true)
+        -- initialize storybook with the last selected story.
 }
 ```
 

--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -121,8 +121,11 @@ You can pass these parameters to getStorybookUI call in your storybook entry poi
         -- should the ui be closed initialy.
     tabOpen: Number (0)
         -- which tab should be open. -1 Navigator, 0 Preview, 1 Addons
+    initialSelection: Object (null)
+        -- initialize storybook with a specific story. In case a valid object is passed, it will take precedence over `shouldPersistSelection. ex: `{ kind: 'Knobs', story: 'with knobs' }`
     shouldPersistSelection: Boolean (true)
-        -- initialize storybook with the last selected story.
+        -- initialize storybook with the last selected story.`
+    )
 }
 ```
 


### PR DESCRIPTION
Issue: N/A

## What I did

I've implemented this feature from the [react-native roadmap](https://medium.com/storybookjs/whats-new-in-storybook-4-0-react-native-741c7f481bbb
):
> Easily select initial story: We could use async storage to remember last selected story. It would help users who cannot use Hot Reload to have similiar functionality just by using Live Reload.

The last displayed store will be persisted just in case storybook is not running.

## How to test

Is this testable with Jest or Chromatic screenshots? N
Does this need a new example in the kitchen sink apps? N
Does this need an update to the documentation? N

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
