### PR TITLE
feat(react-native): close StoryListView after tap again in the current story

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -63,6 +63,11 @@ export default class OnDeviceUI extends PureComponent {
   };
 
   handleStoryChange = selection => {
+    const { selection: prevSelection } = this.state;
+    if (selection.kind === prevSelection.kind && selection.story === prevSelection.story) {
+      this.handleToggleTab(PREVIEW);
+    }
+
     this.setState({
       selection: {
         kind: selection.kind,


### PR DESCRIPTION
Issue: N/A

## What I did

Close automatically `<StoryListView>` panel after the user tap again in the current story. The idea is to remove some friction to select a story and view it.

## How to test

Is this testable with Jest or Chromatic screenshots?
Does this need a new example in the kitchen sink apps?
Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
