### PR TITLE
Fix tests in node 11 by using `Array#sort` correctly

### DIFF
--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -350,7 +350,7 @@ class Story extends Component {
     extract(children);
 
     const array = Array.from(types.keys());
-    array.sort((a, b) => getName(a) > getName(b));
+    array.sort((a, b) => (getName(a) > getName(b) ? 1 : -1));
 
     propTables = array.map((type, i) => (
       // eslint-disable-next-line react/no-array-index-key


### PR DESCRIPTION
Sorting algorithm has [changed](https://twitter.com/mathias/status/1036626116654637057) in latest V8, and it doesn't work with our improper usage (returning boolean instead of number) anymore

## How to test

```
nvm install 11
yarn test --core
```