### PR TITLE
added `optionsKnob` to addon-knobs

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -274,6 +274,34 @@ const defaultValue = 'kiwi';
 const value = radios(label, options, defaultValue);
 ```
 
+### options
+
+Configurable UI for selecting a value from a set of options. 
+
+```js
+import { optionsKnob as options } from '@storybook/addon-knobs';
+
+const label = 'Fruits';
+const valuesObj = {
+  Kiwi: 'kiwi',
+  Guava: 'guava',
+  Watermelon: 'watermelon',
+};
+const defaultValue = 'kiwi';
+const optionsObj = {
+  display: 'inline-radio'
+};
+
+const value = options(label, valuesObj, defaultValue, optionsObj);
+```
+> The display property for `optionsObj` accepts:
+> - `radio`
+> - `inline-radio`
+> - `check`
+> - `inline-check`
+> - `select`
+> - `multi-select`
+
 ### files
 
 Allows you to get a value from a file input from the user.

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -36,6 +36,7 @@
     "qs": "^6.5.2",
     "react-color": "^2.14.1",
     "react-lifecycles-compat": "^3.0.4",
+    "react-select": "^2.1.0",
     "util-deprecate": "^1.0.2"
   },
   "peerDependencies": {

--- a/addons/knobs/src/components/__tests__/Options.js
+++ b/addons/knobs/src/components/__tests__/Options.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ReactSelect from 'react-select';
+import OptionsType from '../types/Options';
+
+const mockOn = jest.fn();
+
+describe('Options', () => {
+  let knob;
+  let wrapper;
+  let firstLabel;
+  let firstInput;
+  let lastInput;
+
+  describe('renders checkbox input', () => {
+    beforeEach(() => {
+      knob = {
+        name: 'Color',
+        defaultValue: ['#0ff'],
+        options: {
+          Red: '#f00',
+          Green: '#090',
+          Blue: '#0ff',
+        },
+        optionsObj: {
+          display: 'check',
+        },
+      };
+
+      wrapper = mount(<OptionsType knob={knob} onChange={mockOn} />);
+      firstLabel = wrapper.find('label').first();
+      firstInput = wrapper.find('input').first();
+      lastInput = wrapper.find('input').last();
+    });
+
+    it('correctly renders label', () => {
+      expect(firstLabel.text()).toEqual('Red');
+    });
+
+    it('correctly sets checkbox value', () => {
+      expect(firstInput.prop('value')).toEqual('#f00');
+    });
+
+    it('marks the correct default checkbox as checked', () => {
+      expect(firstInput.prop('checked')).toEqual(false);
+      expect(lastInput.prop('checked')).toEqual(true);
+    });
+
+    it('updates on change event', () => {
+      expect(wrapper.props().knob.defaultValue).toEqual(['#0ff']);
+
+      firstInput.simulate('change');
+
+      expect(mockOn).toBeCalled();
+      expect(wrapper.props().knob.defaultValue).toEqual(['#0ff', '#f00']);
+    });
+  });
+
+  describe('renders radio input', () => {
+    beforeEach(() => {
+      knob = {
+        name: 'Color',
+        value: '#0ff',
+        options: {
+          Red: '#f00',
+          Green: '#090',
+          Blue: '#0ff',
+        },
+        optionsObj: {
+          display: 'radio',
+        },
+      };
+
+      wrapper = mount(<OptionsType knob={knob} onChange={mockOn} />);
+      firstLabel = wrapper.find('label').first();
+      firstInput = wrapper.find('input').first();
+      lastInput = wrapper.find('input').last();
+    });
+
+    it('correctly renders label', () => {
+      expect(firstLabel.text()).toEqual('Red');
+    });
+
+    it('correctly sets radio input value', () => {
+      expect(firstInput.prop('value')).toEqual('#f00');
+    });
+
+    it('marks the correct default radio input as checked', () => {
+      expect(firstInput.prop('checked')).toEqual(false);
+      expect(lastInput.prop('checked')).toEqual(true);
+    });
+
+    it('updates on change event', () => {
+      firstInput.simulate('change');
+      expect(mockOn).toBeCalled();
+    });
+  });
+
+  describe('renders select input', () => {
+    let selectInput;
+    beforeEach(() => {
+      knob = {
+        name: 'Color',
+        value: '#0ff',
+        options: {
+          Red: '#f00',
+          Green: '#090',
+          Blue: '#0ff',
+        },
+        optionsObj: {
+          display: 'select',
+        },
+      };
+
+      wrapper = mount(<OptionsType knob={knob} onChange={mockOn} />);
+      selectInput = wrapper.find(ReactSelect).find('input');
+    });
+
+    it('updates when dropdown is opened and first option selected', () => {
+      // Simulate the arrow down event to open the dropdown menu.
+      selectInput.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+
+      // Simulate the enter key to select the first option.
+      selectInput.simulate('keyDown', { key: 'Enter', keyCode: 13 });
+
+      // selectInput.simulate('change');
+      expect(mockOn).toBeCalled();
+    });
+  });
+});

--- a/addons/knobs/src/components/__tests__/RadioButtons.js
+++ b/addons/knobs/src/components/__tests__/RadioButtons.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import RadioType from '../types/Radio';
 
 describe('Radio', () => {
@@ -18,21 +18,21 @@ describe('Radio', () => {
 
   describe('displays value of button input', () => {
     it('correctly renders labels', () => {
-      const wrapper = shallow(<RadioType knob={knob} />);
+      const wrapper = mount(<RadioType knob={knob} />);
 
       const greenLabel = wrapper.find('label').first();
       expect(greenLabel.text()).toEqual('Green');
     });
 
     it('sets value on the radio buttons', () => {
-      const wrapper = shallow(<RadioType knob={knob} />);
+      const wrapper = mount(<RadioType knob={knob} />);
 
       const greenInput = wrapper.find('input').first();
       expect(greenInput.prop('value')).toEqual('#319C16');
     });
 
     it('marks the correct checkbox as checked', () => {
-      const wrapper = shallow(<RadioType knob={knob} />);
+      const wrapper = mount(<RadioType knob={knob} />);
 
       const greenInput = wrapper.find('input').first();
       const redInput = wrapper.find('input').last();

--- a/addons/knobs/src/components/types/Checkboxes.js
+++ b/addons/knobs/src/components/types/Checkboxes.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+const CheckboxFieldset = styled.fieldset({
+  border: 0,
+  padding: 0,
+  margin: 0,
+});
+
+const CheckboxLabel = styled.label({
+  fontSize: 11,
+  padding: '5px',
+});
+
+const flex = ({ isInline }) => {
+  if (isInline) {
+    return {
+      display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      height: '100%',
+    };
+  }
+  return null;
+};
+
+const FlexWrapper = styled.div(flex);
+
+class CheckboxesType extends Component {
+  constructor(props) {
+    super(props);
+    const { knob } = props;
+
+    this.state = {
+      values: knob.defaultValue || [],
+    };
+  }
+
+  handleChange = e => {
+    const { onChange } = this.props;
+    const currentValue = e.target.value;
+    const { values } = this.state;
+
+    if (values.includes(currentValue)) {
+      values.splice(values.indexOf(currentValue), 1);
+    } else {
+      values.push(currentValue);
+    }
+
+    this.setState({ values });
+
+    onChange(values);
+  };
+
+  renderCheckboxList = ({ options }) =>
+    Object.keys(options).map(key => this.renderCheckbox(key, options[key]));
+
+  renderCheckbox = (label, value) => {
+    const { knob } = this.props;
+    const { name } = knob;
+    const id = `${name}-${value}`;
+    const { values } = this.state;
+
+    return (
+      <div key={id}>
+        <input
+          type="checkbox"
+          id={id}
+          name={name}
+          value={value}
+          onChange={this.handleChange}
+          checked={values.includes(value)}
+        />
+        <CheckboxLabel htmlFor={id}>{label}</CheckboxLabel>
+      </div>
+    );
+  };
+
+  render() {
+    const { knob, isInline } = this.props;
+
+    return (
+      <CheckboxFieldset>
+        <FlexWrapper isInline={isInline}>{this.renderCheckboxList(knob)}</FlexWrapper>
+      </CheckboxFieldset>
+    );
+  }
+}
+
+CheckboxesType.defaultProps = {
+  knob: {},
+  onChange: value => value,
+  isInline: false,
+};
+
+CheckboxesType.propTypes = {
+  knob: PropTypes.shape({
+    name: PropTypes.string,
+    value: PropTypes.array,
+    options: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  }),
+  onChange: PropTypes.func,
+  isInline: PropTypes.bool,
+};
+
+CheckboxesType.serialize = value => value;
+CheckboxesType.deserialize = value => value;
+
+export default CheckboxesType;

--- a/addons/knobs/src/components/types/Options.js
+++ b/addons/knobs/src/components/types/Options.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactSelect from 'react-select';
+import styled from '@emotion/styled';
+
+import RadiosType from './Radio';
+import CheckboxesType from './Checkboxes';
+
+const OptionsSelect = styled(ReactSelect)({
+  width: '100%',
+  maxWidth: '300px',
+});
+
+const OptionsType = props => {
+  const { knob, onChange } = props;
+  const { display } = knob.optionsObj;
+
+  if (display === 'check' || display === 'inline-check') {
+    const isInline = display === 'inline-check';
+    return <CheckboxesType {...props} isInline={isInline} />;
+  }
+
+  if (display === 'radio' || display === 'inline-radio') {
+    const isInline = display === 'inline-radio';
+    return <RadiosType {...props} isInline={isInline} />;
+  }
+
+  if (display === 'select' || display === 'multi-select') {
+    const options = Object.keys(knob.options).map(key => ({
+      value: knob.options[key],
+      label: key,
+    }));
+
+    const isMulti = display === 'multi-select';
+    const optionsIndex = options.findIndex(i => i.value === knob.value);
+    let defaultValue = options[optionsIndex];
+    let handleChange = e => onChange(e.value);
+
+    if (isMulti) {
+      defaultValue = options.filter(i => knob.value.includes(i.value));
+      handleChange = values => onChange(values.map(item => item.value));
+    }
+
+    return (
+      <OptionsSelect
+        value={defaultValue}
+        options={options}
+        isMulti={isMulti}
+        onChange={handleChange}
+      />
+    );
+  }
+  return null;
+};
+
+OptionsType.defaultProps = {
+  knob: {},
+  display: 'select',
+  onChange: value => value,
+};
+
+OptionsType.propTypes = {
+  knob: PropTypes.shape({
+    name: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+    options: PropTypes.object,
+  }),
+  display: PropTypes.oneOf([
+    'check',
+    'inline-check',
+    'radio',
+    'inline-radio',
+    'select',
+    'multi-select',
+  ]),
+  onChange: PropTypes.func,
+};
+
+OptionsType.serialize = value => value;
+OptionsType.deserialize = value => value;
+
+export default OptionsType;

--- a/addons/knobs/src/components/types/Options.js
+++ b/addons/knobs/src/components/types/Options.js
@@ -9,6 +9,7 @@ import CheckboxesType from './Checkboxes';
 const OptionsSelect = styled(ReactSelect)({
   width: '100%',
   maxWidth: '300px',
+  color: 'black',
 });
 
 const OptionsType = props => {

--- a/addons/knobs/src/components/types/Radio.js
+++ b/addons/knobs/src/components/types/Radio.js
@@ -1,17 +1,24 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 
-const styles = {
-  label: {
-    fontSize: 11,
-    padding: '5px',
-  },
-  group: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-  },
+const flex = ({ isInline }) => {
+  if (isInline) {
+    return {
+      display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+    };
+  }
+  return null;
 };
+
+const RadiosWrapper = styled.div(flex);
+
+const RadioLabel = styled.label({
+  fontSize: 11,
+  padding: '5px',
+});
 
 class RadiosType extends Component {
   renderRadioButtonList({ options }) {
@@ -37,23 +44,22 @@ class RadiosType extends Component {
           onChange={e => onChange(e.target.value)}
           checked={value === knob.value}
         />
-        <label style={styles.label} htmlFor={id}>
-          {label}
-        </label>
+        <RadioLabel htmlFor={id}>{label}</RadioLabel>
       </div>
     );
   }
 
   render() {
-    const { knob } = this.props;
+    const { knob, isInline } = this.props;
 
-    return <div style={styles.group}>{this.renderRadioButtonList(knob)}</div>;
+    return <RadiosWrapper isInline={isInline}>{this.renderRadioButtonList(knob)}</RadiosWrapper>;
   }
 }
 
 RadiosType.defaultProps = {
   knob: {},
   onChange: value => value,
+  isInline: false,
 };
 
 RadiosType.propTypes = {
@@ -63,6 +69,7 @@ RadiosType.propTypes = {
     options: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   }),
   onChange: PropTypes.func,
+  isInline: PropTypes.bool,
 };
 
 RadiosType.serialize = value => value;

--- a/addons/knobs/src/components/types/index.js
+++ b/addons/knobs/src/components/types/index.js
@@ -9,6 +9,7 @@ import ArrayType from './Array';
 import DateType from './Date';
 import ButtonType from './Button';
 import FilesType from './Files';
+import OptionsType from './Options';
 
 export default {
   text: TextType,
@@ -22,4 +23,5 @@ export default {
   date: DateType,
   button: ButtonType,
   files: FilesType,
+  options: OptionsType,
 };

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -4,8 +4,8 @@ import addons, { makeDecorator } from '@storybook/addons';
 
 import { manager, registerKnobs } from './registerKnobs';
 
-export function knob(name, options) {
-  return manager.knob(name, options);
+export function knob(name, optionsParam) {
+  return manager.knob(name, optionsParam);
 }
 
 export function text(name, value, groupId) {
@@ -71,6 +71,10 @@ export function button(name, callback, groupId) {
 
 export function files(name, accept, value = []) {
   return manager.knob(name, { type: 'files', accept, value });
+}
+
+export function optionsKnob(name, valuesObj, value, optionsObj, groupId) {
+  return manager.knob(name, { type: 'options', options: valuesObj, value, optionsObj, groupId });
 }
 
 const defaultOptions = {

--- a/examples/official-storybook/stories/__snapshots__/addon-knobs.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-knobs.stories.storyshot
@@ -29,6 +29,46 @@ exports[`Storyshots Addons|Knobs.withKnobs dynamic knobs 1`] = `
 </div>
 `;
 
+exports[`Storyshots Addons|Knobs.withKnobs optionsKnob 1`] = `
+<div
+  style="color:white"
+>
+  <p>
+    Weekday: Tuesday
+  </p>
+  <p>
+    Weekend: Saturday
+  </p>
+  <p>
+    Month: January
+  </p>
+  <p>
+    Fruit:
+  </p>
+  <ul>
+    <li>
+      apple
+    </li>
+  </ul>
+  <p>
+    Vegetables:
+  </p>
+  <ul>
+    <li>
+      carrot
+    </li>
+  </ul>
+  <p>
+    Dairy:
+  </p>
+  <ul>
+    <li>
+      milk
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`Storyshots Addons|Knobs.withKnobs triggers actions via button 1`] = `
 <div>
   <p>

--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -16,6 +16,7 @@ import {
   button,
   object,
   files,
+  optionsKnob as options,
 } from '@storybook/addon-knobs';
 
 const ItemLoader = ({ isLoading, items }) => {
@@ -206,6 +207,80 @@ storiesOf('Addons|Knobs.withKnobs', module)
       <pre>
         the type of {value} = {typeof m}
       </pre>
+    );
+  })
+  .add('optionsKnob', () => {
+    const valuesRadio = {
+      Monday: 'Monday',
+      Tuesday: 'Tuesday',
+      Wednesday: 'Wednesday',
+    };
+    const optionRadio = options('Radio', valuesRadio, 'Tuesday', { display: 'radio' });
+
+    const valuesInlineRadio = {
+      Saturday: 'Saturday',
+      Sunday: 'Sunday',
+    };
+    const optionInlineRadio = options('Inline Radio', valuesInlineRadio, 'Saturday', {
+      display: 'inline-radio',
+    });
+
+    const valuesSelect = {
+      January: 'January',
+      February: 'February',
+      March: 'March',
+    };
+    const optionSelect = options('Select', valuesSelect, 'January', { display: 'select' });
+
+    const valuesMultiSelect = {
+      Apple: 'apple',
+      Banana: 'banana',
+      Cherry: 'cherry',
+    };
+    const optionsMultiSelect = options('Multi Select', valuesMultiSelect, ['apple'], {
+      display: 'multi-select',
+    });
+
+    const valuesCheck = {
+      Corn: 'corn',
+      Carrot: 'carrot',
+      Cucumber: 'cucumber',
+    };
+    const optionsCheck = options('Check', valuesCheck, ['carrot'], { display: 'check' });
+
+    const valuesInlineCheck = {
+      Milk: 'milk',
+      Cheese: 'cheese',
+      Butter: 'butter',
+    };
+    const optionsInlineCheck = options('Inline Check', valuesInlineCheck, ['milk'], {
+      display: 'inline-check',
+    });
+
+    return (
+      <div style={{ color: 'white' }}>
+        <p>Weekday: {optionRadio}</p>
+        <p>Weekend: {optionInlineRadio}</p>
+        <p>Month: {optionSelect}</p>
+        <p>Fruit:</p>
+        <ul>
+          {optionsMultiSelect.map(item => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <p>Vegetables:</p>
+        <ul>
+          {optionsCheck.map(item => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <p>Dairy:</p>
+        <ul>
+          {optionsInlineCheck.map(item => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </div>
     );
   })
   .add('triggers actions via button', () => {

--- a/lib/components/src/form/input.js
+++ b/lib/components/src/form/input.js
@@ -72,12 +72,14 @@ Input.styles = styles;
 Input.sizes = sizes;
 Input.alignment = alignment;
 Input.displayName = 'Input';
+
 export const Select = styled.select(styles, sizes, alignment, validation, {
   height: 32,
   userSelect: 'none',
   paddingRight: 20,
 });
 Select.displayName = 'Select';
+
 export const Textarea = styled(TextareaAutoResize)(styles, sizes, alignment, validation, {
   minHeight: 32,
   paddingTop: 5,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,7 +1213,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.1.tgz#50f63225e712d99e2b2b39c19c70fff023793ca5"
   integrity sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==
 
-"@emotion/unitless@^0.6.7":
+"@emotion/unitless@^0.6.2", "@emotion/unitless@^0.6.7":
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
   integrity sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==
@@ -6951,6 +6951,19 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
+create-emotion@^9.2.12:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.12.tgz#0fc8e7f92c4f8bb924b0fef6781f66b1d07cb26f"
+  integrity sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==
+  dependencies:
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.7.0"
+    "@emotion/unitless" "^0.6.2"
+    csstype "^2.5.2"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -7325,6 +7338,11 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   integrity sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.5.2:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
+  integrity sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==
 
 csurf@~1.8.3:
   version "1.8.3"
@@ -8447,6 +8465,14 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
+
+emotion@^9.1.2:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.12.tgz#53925aaa005614e65c6e43db8243c843574d1ea9"
+  integrity sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==
+  dependencies:
+    babel-plugin-emotion "^9.2.11"
+    create-emotion "^9.2.12"
 
 encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
@@ -14753,6 +14779,11 @@ memoize-id@^0.2.0:
   resolved "https://registry.yarnpkg.com/memoize-id/-/memoize-id-0.2.0.tgz#19f018135f7607278639a23667683cbf3cf171cf"
   integrity sha1-GfAYE192ByeGOaI2Z2g8vzzxcc8=
 
+memoize-one@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
+  integrity sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg==
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -18171,6 +18202,13 @@ react-ga@^2.5.3:
     prop-types "^15.6.0"
     react "^15.6.2 || ^16.0"
 
+react-input-autosize@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
+  integrity sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-inspector@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.3.0.tgz#fc9c1d38ab687fc0d190dcaf133ae40158968fc8"
@@ -18385,6 +18423,19 @@ react-scripts@^2.1.0:
   optionalDependencies:
     fsevents "1.2.4"
 
+react-select@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.1.1.tgz#762d0babd8c7c46a944db51cbb72e4ee117253f9"
+  integrity sha512-ukie2LJStNfJEJ7wtqA+crAfzYpkpPr86urvmJGisECwsWJob9boCM4zjmKCi5QR7G8uY9+v7ZoliJpeCz/4xw==
+  dependencies:
+    classnames "^2.2.5"
+    emotion "^9.1.2"
+    memoize-one "^4.0.0"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-input-autosize "^2.2.1"
+    react-transition-group "^2.2.1"
+
 react-split-pane@^0.1.84:
   version "0.1.84"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.84.tgz#b9c1499cbc40b09cf29953ee6f5ff1039d31906e"
@@ -18443,7 +18494,7 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react-transition-group@^2.0.0:
+react-transition-group@^2.0.0, react-transition-group@^2.2.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
   integrity sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==
@@ -21109,6 +21160,16 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
+  integrity sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ==
 
 stylus-loader@3.0.2:
   version "3.0.2"


### PR DESCRIPTION
## What I did

Added `optionsKnob`* to addon-knobs which composes SelectType, RadiosType and BooleanType under the hood. This PR is for issue #3972 

This knobs has six display types:

- select
- multi-select
- radio
- inline-radio
- checkbox
- inline-checkbox

`radio` and `inline-radio` re-use the existing RadiosType.

`checkbox` and `inline-checkbox` introduces a new `CheckboxesType`.

`select` and `multi-select` use the [react-select](https://github.com/JedWatson/react-select) package.

*using the name `options` was causing lint errors due to options variable already existing in namespace, so I used the name `optionsKnob` to workaround. I'm open to suggestions for how to optimize this.

See: https://deploy-preview-4723--storybooks-official.netlify.com/?selectedKind=Addons%7CKnobs.withKnobs&selectedStory=optionsKnob&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

![screenshot](https://i.imgur.com/iIpjfDD.png)

## How to test

Is this testable with Jest or Chromatic screenshots?

Yes, with Jest. I have added `__tests__/Options.js` with unit tests.

Does this need a new example in the kitchen sink apps?

Yes. I have added the new story at Knobs/withKnobs/optionsKnob which demonstrates the six display variants.

**Note** I have noticed a UI issue with the `select` and `multi-select` variants used in the dark theme. It looks like I need to contextually pass a text color style to the React Select component. If anyone can help me do this, that would be greatly appreciated.

Does this need an update to the documentation?

Yes. I have updated addons/knobs/README.md

If your answer is yes to any of these, please make sure to include it in your PR.

For maintainers only: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
