### PR TITLE
knobs addon Vue.js example

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -55,6 +55,39 @@ stories.add('as dynamic variables', () => {
 });
 ```
 
+### With Vue.js
+```js
+import { storiesOf } from '@storybook/vue';
+import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
+
+import MyButton from './Button.vue';
+
+const stories = storiesOf('Storybook Knobs', module);
+
+// Add the `withKnobs` decorator to add knobs support to your stories.
+// You can also configure `withKnobs` as a global decorator.
+stories.addDecorator(withKnobs);
+
+// Knobs for Vue props
+// Knobs for Vue props
+stories.add('with a button', () => ({
+  components: { MyButton },
+  template:
+    `<button disabled="${boolean('Disabled', false)}" >
+      ${text('Label', 'Hello Storybook')}
+    </button>`
+}));
+
+// Knobs as dynamic variables.
+stories.add('as dynamic variables', () => {
+  const name = text('Name', 'Arunoda Susiripala');
+  const age = number('Age', 89);
+
+  const content = `I am ${name} and I'm ${age} years old.`;
+  return `<div>${content}</div>`;
+});
+```
+
 ### With Angular
 ```js
 import { storiesOf } from '@storybook/angular';


### PR DESCRIPTION
Issue: No Vue.js example for knobs addon

## What I did
Added a code snippet in knobs README to demonstrate Vue.js usage

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? It is a documentation update

If your answer is yes to any of these, please make sure to include it in your PR.
