### PR TITLE
Ensure @storybook/react can be imported in Node.js without errors

### DIFF
--- a/app/react/src/client/preview/globals.js
+++ b/app/react/src/client/preview/globals.js
@@ -1,6 +1,6 @@
 import { window } from 'global';
 
-if (window.parent !== window) {
+if (window && window.parent !== window) {
   try {
     // eslint-disable-next-line no-underscore-dangle
     window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -8,4 +8,7 @@ if (window.parent !== window) {
     // The above line can throw if we do not have access to the parent frame -- i.e. cross origin
   }
 }
-window.STORYBOOK_ENV = 'react';
+
+if (window) {
+  window.STORYBOOK_ENV = 'react';
+}

--- a/app/react/src/client/preview/index.test.js
+++ b/app/react/src/client/preview/index.test.js
@@ -1,0 +1,24 @@
+/* eslint-disable global-require */
+describe('preview', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  const isFunction = value => typeof value === 'function';
+
+  it('should return the client api in a browser environment', () => {
+    const api = require('.');
+    expect(Object.keys(api).length).toBeGreaterThan(0);
+    expect(Object.values(api).every(isFunction)).toEqual(true);
+  });
+
+  it('should return the client api in a node.js environment', () => {
+    jest.mock('global', () => ({
+      document: undefined,
+      window: undefined,
+    }));
+    const api = require('.');
+    expect(Object.keys(api).length).toBeGreaterThan(0);
+    expect(Object.values(api).every(isFunction)).toEqual(true);
+  });
+});

--- a/app/react/src/client/preview/render.js
+++ b/app/react/src/client/preview/render.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import { stripIndents } from 'common-tags';
 import isReactRenderable from './element_check';
 
-const rootEl = document.getElementById('root');
+const rootEl = document ? document.getElementById('root') : null;
 
 function render(node, el) {
   ReactDOM.render(


### PR DESCRIPTION
Issue: importing `'@storybook/react'` produced the following error in a Node.js Environment:

```
/Users/foldleft/Dev/storybook/app/react/dist/client/preview/globals.js:5
if (_global.window.parent !== _global.window) {
                   ^
TypeError: Cannot read property 'parent' of undefined
    at Object.<anonymous> (/Users/foldleft/Dev/storybook/app/react/dist/client/preview/globals.js:5:20)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/foldleft/Dev/storybook/app/react/dist/client/preview/index.js:12:1)
    at Module._compile (module.js:652:30)
```

## What I did

Added guards in front of global variables not available in Node.js, so you can `require('@storybook/react')` without errors.

## How to test

- Is this testable with Jest or Chromatic screenshots?

Tests have been added and fixed which reproduced the error.

- Does this need a new example in the kitchen sink apps?

No

- Does this need an update to the documentation?

No