### PR TITLE
Add-on actions: Specify sort function that compares number-like strings as number

### DIFF
--- a/addons/actions/src/components/ActionLogger/index.js
+++ b/addons/actions/src/components/ActionLogger/index.js
@@ -7,6 +7,18 @@ import { ActionBar, ActionButton } from '@storybook/components';
 
 import { Actions, Action, Wrapper, InspectorContainer, Countwrap, Counter } from './style';
 
+const castIfNumber = subject => {
+  const num = Number(subject);
+  return Number.isNaN(num) ? subject : num;
+};
+
+const sortObjectKeys = (a, b) => {
+  if (a === b) {
+    return 0;
+  }
+  return castIfNumber(a) < castIfNumber(b) ? -1 : 1;
+};
+
 const ActionLogger = withCSSContext(({ actions, onClear }, { theme }) => (
   <Wrapper>
     <Actions>
@@ -16,7 +28,7 @@ const ActionLogger = withCSSContext(({ actions, onClear }, { theme }) => (
           <InspectorContainer>
             <Inspector
               theme={theme.addonActionsTheme || 'chromeLight'}
-              sortObjectKeys
+              sortObjectKeys={sortObjectKeys}
               showNonenumerable={false}
               name={action.data.name}
               data={action.data.args || action.data}

--- a/addons/actions/src/components/ActionLogger/index.js
+++ b/addons/actions/src/components/ActionLogger/index.js
@@ -2,22 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Inspector from 'react-inspector';
 import { withCSSContext } from '@emotion/core';
-
 import { ActionBar, ActionButton } from '@storybook/components';
+import sortObjectKeys from '../../lib/util/sortObjectKeys';
 
 import { Actions, Action, Wrapper, InspectorContainer, Countwrap, Counter } from './style';
-
-const castIfNumber = subject => {
-  const num = Number(subject);
-  return Number.isNaN(num) ? subject : num;
-};
-
-const sortObjectKeys = (a, b) => {
-  if (a === b) {
-    return 0;
-  }
-  return castIfNumber(a) < castIfNumber(b) ? -1 : 1;
-};
 
 const ActionLogger = withCSSContext(({ actions, onClear }, { theme }) => (
   <Wrapper>

--- a/addons/actions/src/lib/util/__tests__/sortObjectKeys.test.js
+++ b/addons/actions/src/lib/util/__tests__/sortObjectKeys.test.js
@@ -1,0 +1,23 @@
+import sortObjectKeys from '../sortObjectKeys';
+
+describe('sortObjectKeys', () => {
+  it('sorts an array in alphabetical order', () => {
+    expect(['c', 'd', 'a', 'c', 'b'].sort(sortObjectKeys)).toEqual(['a', 'b', 'c', 'c', 'd']);
+  });
+
+  it('sorts an array in numerical order', () => {
+    expect(['3', '2', '1', '10', '0'].sort(sortObjectKeys)).toEqual(['0', '1', '2', '3', '10']);
+  });
+
+  it('sorts an array in numerical and alphabetical order', () => {
+    expect(['a', '_', '2', '1', '10', 'b', '0'].sort(sortObjectKeys)).toEqual([
+      '0',
+      '1',
+      '2',
+      '10',
+      '_',
+      'a',
+      'b',
+    ]);
+  });
+});

--- a/addons/actions/src/lib/util/sortObjectKeys.js
+++ b/addons/actions/src/lib/util/sortObjectKeys.js
@@ -1,0 +1,19 @@
+function castIfNumber(subject) {
+  const num = Number(subject);
+  return Number.isNaN(num) ? subject : num;
+}
+
+export default function sortObjectKeys(a, b) {
+  if (a === b) {
+    return 0;
+  }
+  const castedA = castIfNumber(a);
+  const castedB = castIfNumber(b);
+
+  if (typeof castedA === typeof castedB) {
+    return castedA < castedB ? -1 : 1;
+  }
+
+  // If types differ, numerical keys should be ordered before string keys
+  return typeof castedA === 'number' ? -1 : 1;
+}


### PR DESCRIPTION
Issue:

If action logger displays array with 10 or more items, the order of keys is broken because `Array.sort()` 
 sorts an array alphabetical order by default.

(Ex: [0, 1, 2, 3, ..., 10, 11] is displayed as [0, 1, 10, 11, 2, ..., 9])

![image](https://user-images.githubusercontent.com/12454556/48300585-c0704780-e523-11e8-8c5e-beab458c761b.png)

## What I did

Specify a sorting function that tries to parse object key as a number.

## How to test

I added a unit test and can be checked on an official Storybook at.

http://localhost:9011/?selectedKind=Addons%7CActions&selectedStory=All%20types&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

Try `yarn build-packs` and run `yarn start`.

I ran on Chrome dev-console (iframe.html) with following script.

```
window.test = new Array(35).fill(null)
```

and show `window` to log test data.

![image](https://user-images.githubusercontent.com/12454556/48300535-b7cb4180-e522-11e8-831c-7afa81ea57a2.png)
