### PR TITLE
chore(deps): use alpha minify dependency to upgrade transitive lodash dependencies

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
-    "babel-preset-minify": "^0.5.0",
+    "babel-preset-minify": "^0.5.0 || 0.6.0-alpha.5",
     "babel-preset-react": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -39,7 +39,7 @@
     "airbnb-js-shims": "^1 || ^2",
     "autoprefixer": "^9.3.1",
     "babel-plugin-macros": "^2.4.2",
-    "babel-preset-minify": "^0.5.0",
+    "babel-preset-minify": "^0.5.0 || 0.6.0-alpha.5",
     "boxen": "^2.0.0",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4318,7 +4318,7 @@ babel-preset-jest@^23.2.0:
     babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-preset-minify@^0.5.0:
+"babel-preset-minify@^0.5.0 || 0.6.0-alpha.5":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz#e25bb8d3590087af02b650967159a77c19bfb96b"
   integrity sha512-xj1s9Mon+RFubH569vrGCayA9Fm2GMsCgDRm1Jb8SgctOB7KFcrVc2o8K3YHUyMz+SWP8aea75BoS8YfsXXuiA==


### PR DESCRIPTION
What:
Add babel-preset-minify 0.6.0-alpha.5 dependency (parallel to ^0.5.0) to benefit from forthcoming updates in minify

Updated the dependency in core and react-native

Why:
Minify team is running slow in releasing their next patch release

Testing:
yarn test --core