### PR TITLE
Documentation for setting up Ember has a syntax error.

### DIFF
--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -46,7 +46,7 @@ Storyshots is a way to automatically jest-snapshot all your stories. [More info 
 
 Redirects console output (logs, errors, warnings) into Action Logger Panel. `withConsole` decorator notifies from what stories logs are coming.
 
-### [Backgrounds](https://github.com/storybooks/storybook/tree/master/addons/background)
+### [Backgrounds](https://github.com/storybooks/storybook/tree/master/addons/backgrounds)
 
 With this addon, you can switch between background colors and background images for your preview components. It is really helpful for styleguides.
 

--- a/docs/src/pages/basics/guide-ember/index.md
+++ b/docs/src/pages/basics/guide-ember/index.md
@@ -90,10 +90,10 @@ storiesOf('Demo', module)
     return {
       template: hbs`<button {{action onClick}}>
         Hello Button
-      </button>`
-    },
-    context: {
-      onClick: (e) => console.log(e)
+      </button>`,
+      context: {
+        onClick: (e) => console.log(e)
+      }
     }
   })
   .add('component', () => {


### PR DESCRIPTION
Issue: Documentation for setting up Ember has a syntax error.

## What I did

moved the `context` property, into the returned object (instead of after).

## How to test

This is a documentation fix.
