### PR TITLE
Revise the sample in README for ReactNative

### DIFF
--- a/docs/src/pages/basics/guide-react-native/index.md
+++ b/docs/src/pages/basics/guide-react-native/index.md
@@ -103,7 +103,7 @@ const CenteredView = ({ children }) => (
   </View>
 );
 
-storiesOf('CenteredView')
+storiesOf('CenteredView', module)
   .add('default view', () => (
     <CenteredView>
       <Text>Hello Storybook</Text>

--- a/docs/src/pages/basics/guide-react-native/index.md
+++ b/docs/src/pages/basics/guide-react-native/index.md
@@ -73,7 +73,7 @@ import '@storybook/addon-ondevice-notes/register';
  The easiest solution is to replace your app entry with:
  
 ```js
-import './storybook';
+export default from './storybook';
 ```
 
 If you cannot replace your entry point just make sure that the component exported from `./storybook` is displayed
@@ -86,6 +86,7 @@ RN application, e.g. on a tab or within an admin screen.
 Now you can write some stories inside the `storybook/stories/index.js` file, like this:
 
 ```js
+import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { View, Text } from 'react-native';
 


### PR DESCRIPTION
With this change, the sample works without any errors.

## What I did

```js
$ cat package.json
{
  "name": "empty-project-template",
  "main": "node_modules/expo/AppEntry.js",
  "private": true,
  "scripts": {
    "start": "expo start",
    "android": "expo start --android",
    "ios": "expo start --ios",
    "eject": "expo eject"
  },
  "dependencies": {
    "expo": "^31.0.2",
    "react": "16.5.0",
    "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz"
  },
  "devDependencies": {
    "@storybook/react-native": "^4.0.4",
    "babel-preset-expo": "^5.0.0"
  }
}
```

Before change the code of entry point(App.js), I ran into follwing error:

```
[11:44:21] Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s%s, object,  You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check your code at registerRootComponent.js:17.,
    in ExpoRootComponent (at renderApplication.js:34)
    in RCTView (at View.js:44)
    in RCTView (at View.js:44)
    in AppContainer (at renderApplication.js:33)
- node_modules/react/cjs/react.development.js:217:39 in warningWithoutStack
- ... 22 more stack frames from framework internals
```

After change it, I ran into following error:

```
[11:46:38] ReferenceError: Can't find variable: React

This error is located at:
    in StoryView (created by OnDeviceUI)
    in RCTView (at View.js:44)
    in AnimatedComponent (at TouchableOpacity.js:256)
    in TouchableOpacity (created by OnDeviceUI)
    in RCTView (at View.js:44)
    in AnimatedComponent (created by OnDeviceUI)
    in RCTView (at View.js:44)
    in AnimatedComponent (created by OnDeviceUI)
    in RCTView (at View.js:44)
    in RCTView (at View.js:44)
    in AbsolutePositionedKeyboardAwareView (created by OnDeviceUI)
    in RCTSafeAreaView (at SafeAreaView.ios.js:35)
    in SafeAreaView (created by OnDeviceUI)
    in OnDeviceUI (created by StorybookRoot)
    in StorybookRoot (at registerRootComponent.js:17)
    in RootErrorBoundary (at registerRootComponent.js:16)
    in ExpoRootComponent (at renderApplication.js:34)
    in RCTView (at View.js:44)
    in RCTView (at View.js:44)
    in AppContainer (at renderApplication.js:33)
* storybook/stories/index.js:20:4 in <unknown>
- node_modules/@storybook/core/dist/client/preview/client_api.js:58:22 in withSubscriptionTracking
- node_modules/@storybook/react-native/dist/preview/components/StoryView/index.js:122:16 in render
- ... 19 more stack frames from framework internals
```

Then I have added the line to `storybook/stories/index.js`, it works without errors.

EDIT: I add a commit describe below:

I also ran into a warning that described at #4680, So fixing it same way.

```
[13:06:17] Missing 'module' parameter for story with a kind of 'CenteredView'. It will break your HMR
- node_modules/expo/build/environment/logging.js:25:23 in warn
- node_modules/@storybook/core/dist/client/preview/client_api.js:93:32 in <unknown>
* storybook/stories/index.js:18:10 in <unknown>
- node_modules/metro/src/lib/polyfills/require.js:292:12 in loadModuleImplementation
* storybook/index.js:8:9 in <unknown>
- node_modules/@storybook/react-native/dist/preview/index.js:91:17 in configure
* storybook/index.js:7:10 in <unknown>
- node_modules/metro/src/lib/polyfills/require.js:292:12 in loadModuleImplementation
* null:null in <unknown>
- node_modules/metro/src/lib/polyfills/require.js:292:12 in loadModuleImplementation
- node_modules/expo/AppEntry.js:2:0 in <unknown>
- node_modules/metro/src/lib/polyfills/require.js:292:12 in loadModuleImplementation
- node_modules/metro/src/lib/polyfills/require.js:179:45 in guardedLoadModule
* null:null in global code
```