### PR TITLE
Fix variable reference in docs: story → getStory

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -110,7 +110,7 @@ export withNotes = makeDecorator({
     // which we send to the channel
     channel.emit('MYADDON/add_notes', parameters);
 
-    return story(context);
+    return getStory(context);
   }
 })
 ```


### PR DESCRIPTION
## What I did

A variable reference in the docs was incorrect – it used `story` when it meant `getStory`.

## How to test

Documentation: no tests needed.