### PR TITLE
REFACTOR dev-serve to output less noise

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -68,6 +68,7 @@
     "opn": "^5.4.0",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",
+    "pretty-hrtime": "^1.0.3",
     "prop-types": "^15.6.2",
     "qs": "^6.5.2",
     "raw-loader": "^0.5.1",

--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -5,7 +5,7 @@ import favicon from 'serve-favicon';
 import path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
-import { logger } from '@storybook/node-logger';
+import { logger, colors } from '@storybook/node-logger';
 import fetch from 'node-fetch';
 import Cache from 'file-system-cache';
 import opn from 'opn';
@@ -13,6 +13,7 @@ import boxen from 'boxen';
 import semver from 'semver';
 import { stripIndents } from 'common-tags';
 import Table from 'cli-table3';
+import prettyTime from 'pretty-hrtime';
 
 import storybook, { webpackValid } from './dev-server';
 import { getDevCli } from './cli';
@@ -144,7 +145,10 @@ export async function buildDevStandalone(options) {
 
     const serverListening = listenToServer(server, listenAddr);
 
-    const [stats, updateInfo] = await Promise.all([
+    const [
+      { iframeStats, managerStats, managerTotalTime, iframeTotalTime },
+      updateInfo,
+    ] = await Promise.all([
       webpackValid,
       updateCheck(options.packageJson.version),
       serverListening,
@@ -159,7 +163,7 @@ export async function buildDevStandalone(options) {
       updateMessage =
         updateInfo.success && semver.lt(options.packageJson.version, updateInfo.data.latest.version)
           ? stripIndents`
-          ${chalk.hex('#F3AD38')(
+          ${colors.orange(
             `A new version (${chalk.bold(updateInfo.data.latest.version)}) is available!`
           )}
           ${chalk.gray(updateInfo.data.latest.info.plain)}
@@ -205,7 +209,11 @@ export async function buildDevStandalone(options) {
     console.log(
       boxen(
         stripIndents`
-          ${chalk.hex('#A2E05E')(`Storybook ${chalk.bold(options.packageJson.version)} started`)}
+          ${colors.green(`Storybook ${chalk.bold(options.packageJson.version)} started`)}
+          ${chalk.gray(stripIndents`
+          ${chalk.underline(prettyTime(managerTotalTime))} for manager and ${chalk.underline(
+            prettyTime(iframeTotalTime)
+          )} for preview`)}
 
           ${serveMessage.toString()}${updateMessage ? `\n\n${updateMessage}` : ''}
         `,
@@ -214,7 +222,8 @@ export async function buildDevStandalone(options) {
     );
 
     if (options.smokeTest) {
-      process.exit(stats.toJson().warnings.length ? 1 : 0);
+      process.exit(iframeStats.toJson().warnings.length ? 1 : 0);
+      process.exit(managerStats.toJson().warnings.length ? 1 : 0);
     } else if (!options.ci) {
       opn(address).catch(() => {
         logger.error(stripIndents`

--- a/lib/core/src/server/dev-server.js
+++ b/lib/core/src/server/dev-server.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import { Router } from 'express';
 import webpack from 'webpack';
-import { logger } from '@storybook/node-logger';
 
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
@@ -25,6 +24,7 @@ export default async function(options) {
   const configType = 'DEVELOPMENT';
 
   const managerStartTime = process.hrtime();
+  let managerTotalTime;
 
   const managerConfig = await loadManagerConfig({
     configType,
@@ -42,16 +42,21 @@ export default async function(options) {
   });
 
   const managerPromise = new Promise((res, rej) => {
-    webpack(managerConfig).watch({}, (err, stats) => {
-      const managerTotalTime = process.hrtime(managerStartTime);
-      logger.trace({ message: 'manager built', time: managerTotalTime });
+    webpack(managerConfig).watch(
+      {
+        aggregateTimeout: 1,
+        ignored: /node_modules/,
+      },
+      (err, stats) => {
+        managerTotalTime = process.hrtime(managerStartTime);
 
-      if (stats.hasErrors()) {
-        rej(stats);
-      } else {
-        res(stats);
+        if (err || stats.hasErrors()) {
+          rej(stats);
+        } else {
+          res(stats);
+        }
       }
-    });
+    );
   });
 
   const middlewareFn = getMiddleware(configDir);
@@ -63,11 +68,19 @@ export default async function(options) {
   }
 
   const iframeStartTime = process.hrtime();
+  let iframeTotalTime;
   const iframeCompiler = webpack(iframeConfig);
   const devMiddlewareOptions = {
-    noInfo: true,
     publicPath: iframeConfig.output.publicPath,
-    watchOptions: iframeConfig.watchOptions || {},
+    watchOptions: {
+      aggregateTimeout: 1,
+      ignored: /node_modules/,
+      ...(iframeConfig.watchOptions || {}),
+    },
+    // this actually causes 0 (regular) output from wdm & webpack
+    logLevel: 'warn',
+    clientLogLevel: 'warning',
+    noInfo: true,
     ...iframeConfig.devServer,
   };
 
@@ -81,8 +94,7 @@ export default async function(options) {
 
   const iframePromise = new Promise((res, rej) => {
     webpackDevMiddlewareInstance.waitUntilValid(stats => {
-      const iframeTotalTime = process.hrtime(iframeStartTime);
-      logger.trace({ message: 'iframe built', time: iframeTotalTime });
+      iframeTotalTime = process.hrtime(iframeStartTime);
 
       if (stats.hasErrors()) {
         rej(stats);
@@ -93,7 +105,7 @@ export default async function(options) {
   });
 
   Promise.all([managerPromise, iframePromise])
-    .then(([, iframeStats]) => {
+    .then(([managerStats, iframeStats]) => {
       router.get('/', (request, response) => {
         response.set('Content-Type', 'text/html');
         response.sendFile(path.join(`${outputDir}/index.html`));
@@ -103,7 +115,7 @@ export default async function(options) {
         response.sendFile(path.join(`${outputDir}/${request.params[0]}`));
       });
 
-      webpackResolve(iframeStats);
+      webpackResolve({ iframeStats, managerStats, managerTotalTime, iframeTotalTime });
     })
     .catch(e => webpackReject(e));
 


### PR DESCRIPTION
This moves the logging of the computation-time to build-dev.

This also removed the webpack stats output on build, if all is good there is 0 output.
If there are errors, they are logged.