### PR TITLE
Fixes #4665: set correct cache directory path

### DIFF
--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -8,6 +8,7 @@ import chalk from 'chalk';
 import { logger } from '@storybook/node-logger';
 import fetch from 'node-fetch';
 import Cache from 'file-system-cache';
+import findCacheDir from 'find-cache-dir';
 import opn from 'opn';
 import boxen from 'boxen';
 import semver from 'semver';
@@ -20,6 +21,7 @@ import { getDevCli } from './cli';
 const defaultFavIcon = require.resolve('./public/favicon.ico');
 
 const cache = Cache({
+  basePath: findCacheDir({ name: 'storybook' }),
   ns: 'storybook', // Optional. A grouping namespace for items.
 });
 


### PR DESCRIPTION
Issue: #4665

## What I did

Use `find-cache-dir` (instead of current directory by default) to setup `basePath` for cache file in `build-dev` script.

This allows to store cache file in `node_modules/.cache` instead of the root folder of the project.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
