### PR TITLE
feat(react-native): Add ability to filter story list from React-Native

### DIFF
--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -22,16 +22,16 @@ The next thing you need to do is make Storybook UI visible in your app.
 The easiest way to use Storybook is to simply replace your App with the Storybook UI, which is possible by replacing `App.js` with a single line of code:
 
 ```js
-export default from "./storybook";
+export default from './storybook';
 ```
 
 This will get you up and running quickly, but then you lose your app!
 There are multiple options here. for example, you can export conditionally:
 
 ```js
-import StorybookUI from "./storybook";
+import StorybookUI from './storybook';
 
-import App from "./app";
+import App from './app';
 
 module.exports = __DEV__ ? StorybookUI : App;
 ```
@@ -125,7 +125,8 @@ You can pass these parameters to getStorybookUI call in your storybook entry poi
         -- initialize storybook with a specific story. In case a valid object is passed, it will take precedence over `shouldPersistSelection. ex: `{ kind: 'Knobs', story: 'with knobs' }`
     shouldPersistSelection: Boolean (true)
         -- initialize storybook with the last selected story.`
-    )
+    shouldDisableKeyboardAvoidingView: Boolean (false)
+        -- Disable KeyboardAvoidingView wrapping Storybook's view
 }
 ```
 

--- a/app/react-native/src/preview/components/OnDeviceUI/addons/wrapper.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/addons/wrapper.js
@@ -1,14 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { View, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, ScrollView } from 'react-native';
 
 import style from '../style';
 
 export default class Wrapper extends PureComponent {
   render() {
     const { panels, addonSelected } = this.props;
-
-    const keyboardVerticalOffset = Platform.OS === 'ios' ? 60 : 0;
 
     const addonKeys = Object.keys(panels);
 
@@ -17,13 +15,7 @@ export default class Wrapper extends PureComponent {
 
       return (
         <View key={id} style={selected ? style.flex : style.invisible}>
-          <KeyboardAvoidingView
-            behavior={Platform.OS === 'android' ? null : 'padding'}
-            keyboardVerticalOffset={keyboardVerticalOffset}
-            style={style.flex}
-          >
-            <ScrollView style={style.flex}>{panels[id].render({ active: selected })}</ScrollView>
-          </KeyboardAvoidingView>
+          <ScrollView style={style.flex}>{panels[id].render({ active: selected })}</ScrollView>
         </View>
       );
     });

--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -105,7 +105,7 @@ export default class OnDeviceUI extends PureComponent {
     });
 
     // close the keyboard opened from a TextInput from story list or knobs
-    if (newTabOpen === 0) {
+    if (newTabOpen === PREVIEW) {
       Keyboard.dismiss();
     }
   };
@@ -135,7 +135,7 @@ export default class OnDeviceUI extends PureComponent {
     return (
       <SafeAreaView style={style.flex}>
         <KeyboardAvoidingView
-          enabled={!shouldDisableKeyboardAvoidingView}
+          enabled={!shouldDisableKeyboardAvoidingView || tabOpen !== PREVIEW}
           behavior={IS_IOS ? 'padding' : null}
           style={style.flex}
         >

--- a/app/react-native/src/preview/components/StoryListView/index.js
+++ b/app/react-native/src/preview/components/StoryListView/index.js
@@ -116,9 +116,10 @@ export default class StoryListView extends Component {
     const { data } = this.state;
 
     return (
-      <React.Fragment>
+      <View style={style.flex}>
         <TextInput
           clearButtonMode="while-editing"
+          disableFullscreenUI
           onChangeText={this.handleChangeSearchText}
           placeholder="Filter"
           returnKeyType="search"
@@ -142,7 +143,7 @@ export default class StoryListView extends Component {
           sections={data}
           stickySectionHeadersEnabled={false}
         />
-      </React.Fragment>
+      </View>
     );
   }
 }

--- a/app/react-native/src/preview/components/StoryListView/index.js
+++ b/app/react-native/src/preview/components/StoryListView/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { SectionList, View, Text, TouchableOpacity } from 'react-native';
+import { SectionList, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import Events from '@storybook/core-events';
 import style from './style';
 
@@ -40,6 +40,7 @@ export default class StoryListView extends Component {
 
     this.state = {
       data: [],
+      originalData: [],
     };
 
     this.storyAddedHandler = this.handleStoryAdded.bind(this);
@@ -71,10 +72,37 @@ export default class StoryListView extends Component {
         }),
         {}
       );
-      this.setState({
-        data,
-      });
+
+      this.setState({ data, originalData: data });
     }
+  };
+
+  handleChangeSearchText = text => {
+    const query = text.trim();
+    const { originalData: data } = this.state;
+
+    if (!query) {
+      this.setState({ data });
+      return;
+    }
+
+    const checkValue = value => value.toLowerCase().includes(query.toLowerCase());
+    const filteredData = data.reduce((acc, story) => {
+      const hasTitle = checkValue(story.title);
+      const hasKind = story.data.some(kind => checkValue(kind.name));
+
+      if (hasTitle || hasKind) {
+        acc.push({
+          ...story,
+          // in case the query matches component's title, all of its stories will be shown
+          data: !hasTitle ? story.data.filter(kind => checkValue(kind.name)) : story.data,
+        });
+      }
+
+      return acc;
+    }, []);
+
+    this.setState({ data: filteredData });
   };
 
   changeStory(kind, story) {
@@ -88,24 +116,33 @@ export default class StoryListView extends Component {
     const { data } = this.state;
 
     return (
-      <SectionList
-        testID="Storybook.ListView"
-        style={[style.list]}
-        renderItem={({ item }) => (
-          <ListItem
-            title={item.name}
-            kind={item.kind}
-            selected={item.kind === selectedKind && item.name === selectedStory}
-            onPress={() => this.changeStory(item.kind, item.name)}
-          />
-        )}
-        renderSectionHeader={({ section: { title } }) => (
-          <SectionHeader title={title} selected={title === selectedKind} />
-        )}
-        keyExtractor={(item, index) => item + index}
-        sections={data}
-        stickySectionHeadersEnabled={false}
-      />
+      <React.Fragment>
+        <TextInput
+          clearButtonMode="while-editing"
+          onChangeText={this.handleChangeSearchText}
+          placeholder="Filter"
+          returnKeyType="search"
+          style={style.searchBar}
+        />
+        <SectionList
+          testID="Storybook.ListView"
+          style={style.flex}
+          renderItem={({ item }) => (
+            <ListItem
+              title={item.name}
+              kind={item.kind}
+              selected={item.kind === selectedKind && item.name === selectedStory}
+              onPress={() => this.changeStory(item.kind, item.name)}
+            />
+          )}
+          renderSectionHeader={({ section: { title } }) => (
+            <SectionHeader title={title} selected={title === selectedKind} />
+          )}
+          keyExtractor={(item, index) => item + index}
+          sections={data}
+          stickySectionHeadersEnabled={false}
+        />
+      </React.Fragment>
     );
   }
 }

--- a/app/react-native/src/preview/components/StoryListView/style.js
+++ b/app/react-native/src/preview/components/StoryListView/style.js
@@ -1,10 +1,17 @@
 export default {
-  list: {
+  searchBar: {
+    backgroundColor: '#eee',
+    borderRadius: 5,
+    fontSize: 16,
+    marginHorizontal: 5,
+    marginVertical: 5,
+    padding: 5,
+  },
+  flex: {
     flex: 1,
   },
   header: {
-    paddingTop: 5,
-    paddingBottom: 5,
+    paddingVertical: 5,
   },
   headerText: {
     fontSize: 20,

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -115,6 +115,7 @@ export default class Preview {
               isUIOpen={params.isUIOpen}
               tabOpen={params.tabOpen}
               initialStory={setInitialStory ? preview._getInitialStory() : null}
+              shouldDisableKeyboardAvoidingView={params.shouldDisableKeyboardAvoidingView}
             />
           );
         }


### PR DESCRIPTION
Issue: N/A

## What I did

1) Add the feature of filtering the story list from React-Native.
2) Wrap storybook view with `KeyboardAvoidingView` to make the story list present the whole list while the filter bar is open. (Basically doing this PR #4710, but adding an option, `shouldDisableKeyboardAvoidingView`, to disable this `KeyboardAvoidingView`, preventing the problem with nested `KeyboardAvoidingView`)
3) Remove `KeyboardAvoidingView` from `OnDeviceUI/addons/wrapper.js`. Looks like it's not working, as expected, and know with `KeyboardAvoidingView` as Storybook wrapper, it's no longer needed;
4) Close keyboard when moves from story list or addons view to the preview.




<br><br><p align="center"><img src="https://user-images.githubusercontent.com/20709038/48685582-07de7f80-eb85-11e8-84f2-87b1c752813e.gif" /></p>








## How to test

- Is this testable with Jest or Chromatic screenshots? N
- Does this need a new example in the kitchen sink apps? N
- Does this need an update to the documentation? Y

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
