### PR TITLE
ADD support for all versions of react

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -40,13 +40,13 @@
     "lodash": "^4.17.11",
     "mini-css-extract-plugin": "^0.4.4",
     "prop-types": "^15.6.2",
+    "react": "^16.6.0",
     "react-dev-utils": "^6.1.0",
+    "react-dom": "^16.6.0",
     "semver": "^5.6.0",
     "webpack": "^4.23.1"
   },
   "peerDependencies": {
-    "babel-loader": "^7.0.0 || ^8.0.0",
-    "react": ">=15.0.0",
-    "react-dom": ">=15.0.0"
+    "babel-loader": "^7.0.0 || ^8.0.0"
   }
 }

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -70,6 +70,8 @@ export default ({ configDir, entries, outputDir }) => {
       modules: ['node_modules'].concat(raw.NODE_PATH || []),
       alias: {
         '@babel/runtime': getBabelRuntimePath(),
+        react: require.resolve('react'),
+        'react-dom': require.resolve('react-dom'),
       },
     },
     optimization: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,11 +1824,11 @@
   integrity sha512-55Mo2b5WtIT0l653y6ocu7C6QzznbasEnlixGzA26WK8Fj81wuEY3xf5N5bNAvDVfrwTLIPTXdEUGgPdrPLszw==
   dependencies:
     mkdirp "^0.5.1"
+
 "@ngrx/store@^6.1.2":
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/@ngrx/store/-/store-6.1.2.tgz#20fb5ab4d79571b804a348093aa11a167fe2946f"
   integrity sha512-W9MbXrwhIRmN1BlINF9BT+rHR046e1HNk7GqykcDJrK9wW74PJW3aE5iuPb2sTPipBMjPHsXzc73E4U/+OTAyw==
-
 
 "@ngtools/webpack@7.0.3":
   version "7.0.3"
@@ -13674,7 +13674,6 @@ listr-silent-renderer@^1.1.1:
 
 listr-update-renderer@^0.4.0, "listr-update-renderer@https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update":
   version "0.4.0"
-  uid "06073fa93166277607a7814f4e1f83960081414c"
   resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
   dependencies:
     chalk "^1.1.3"


### PR DESCRIPTION
- manager will always use 1 version we control
- users can not install any version of react
- users can now specify a react alternative inmodule.resolve webpack config