### PR TITLE
Update addons options readme

### DIFF
--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -137,3 +137,14 @@ storiesOf('Addons|Knobs/Hello', module)
 ```
 
 _NOTE_ that you must attach `withOptions` as a decorator (at the top-level) for this to work.
+
+## Typescript
+
+To install type definitions: `npm install -D @types/storybook__addon-options`
+
+Make sure you also have the type definitions installed for the following libs:
+
+ - node
+ - react
+ 
+You can install them using `npm install -D @types/node @types/react`, assuming you are using Typescript >2.0.

--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -20,7 +20,9 @@ Add this line to your `addons.js` file (create this file inside your storybook c
 import '@storybook/addon-options/register';
 ```
 
-Import and use the `withOptions` decorator in your config.js file.
+###Set options globally
+
+Import and use the `withOptions` decorator in your `config.js` file.
 
 ```js
 import { addDecorator, configure } from '@storybook/react';
@@ -113,24 +115,15 @@ configure(() => require('./stories'), module);
 The options-addon accepts story parameters on the `options` key:
 
 ```js
-import { storiesOf } from '@storybook/marko';
-import { withKnobs, text, number } from '@storybook/addon-knobs';
-import Hello from '../components/hello/index.marko';
+import { storiesOf } from '@storybook/react';
+import MyComponent from './my-component';
 
-storiesOf('Addons|Knobs/Hello', module)
+storiesOf('Addons|Custom options', module)
   // If you want to set the option for all stories in of this kind
   .addParameters({ options: { addonPanelInRight: true } })
-  .addDecorator(withKnobs)
   .add(
-    'Simple',
-    () => {
-      const name = text('Name', 'John Doe');
-      const age = number('Age', 44);
-      return Hello.renderSync({
-        name,
-        age,
-      });
-    },
+    'Story for MyComponent',
+    () => <MyComponent />,
     // If you want to set the options for a specific story
     { options: { addonPanelInRight: false } }
   );


### PR DESCRIPTION
## What I did

 - Add a section about typescript, I updated types for version 4.0+ and they will be merged/available soon: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30609
 - Move example to `storybook/react`, much more used than `@storybook/marko`
 - Remove all references to `@storybook/addon-knobs` from example as it's irrelevant in this addon-options doc

## How to test

- Just take a look at README.md

