### PR TITLE
typo fix in the storybook-addon-a11y

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -1,6 +1,6 @@
 # storybook-addon-a11y
 
-This storybook addon can be helpfull to make your UI components more accessibile.
+This storybook addon can be helpful to make your UI components more accessible.
 
 [Framework Support](https://github.com/storybooks/storybook/blob/master/ADDONS_SUPPORT.md)
 


### PR DESCRIPTION
Issue: Typos in the storyshot-addons-a11y
[link](https://github.com/storybooks/storybook/tree/master/addons/a11y)

## What I did

-  Changed the text `carefull` to `careful`

- Changed the text `accessibile` to `accessible`

## How to test

- Does this need an update to the documentation? - YES

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
