### PR TITLE
Don't change rootElement when received node is the same

### DIFF
--- a/app/html/src/client/preview/render.js
+++ b/app/html/src/client/preview/render.js
@@ -3,13 +3,24 @@ import { stripIndents } from 'common-tags';
 
 const rootElement = document.getElementById('root');
 
-export default function renderMain({ story, selectedKind, selectedStory, showMain, showError }) {
+export default function renderMain({
+  story,
+  selectedKind,
+  selectedStory,
+  showMain,
+  showError,
+  forceRender,
+}) {
   const component = story();
 
   showMain();
   if (typeof component === 'string') {
     rootElement.innerHTML = component;
   } else if (component instanceof Node) {
+    if (forceRender === true) {
+      return;
+    }
+
     rootElement.innerHTML = '';
     rootElement.appendChild(component);
   } else {


### PR DESCRIPTION
Issue:
storybook-html's render is always rewriting the root element's content even when it's not a different component. This appeared to be a problem for dynamic class changes (as in changing a prop in a AngularJS component) as it is removing the dom node and adding it again which kills stuff like animations (since from the browser's perspective this is not a change in the class attribute and it is a new node).

Props to @svipatov for finding the issue and help developing this PR.

## What I did
Checked the reference of the received DOM node, if it is the same then the node was already mutated and there is no need to rewrite the root element.

## How to test

- Is this testable with Jest or Chromatic screenshots?
It could be, but I did not find any test for the changed file (I can add it if it's wanted)
- Does this need a new example in the kitchen sink apps?
No
- Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
