### PR TITLE
Update guide for Vue to match current requirements

### DIFF
--- a/docs/src/pages/basics/guide-vue/index.md
+++ b/docs/src/pages/basics/guide-vue/index.md
@@ -37,8 +37,8 @@ Make sure that you have `vue`, `babel-core`, `babel-loader` in your dependencies
 
 ```sh
 npm i --save vue
-npm i --save-dev babel-core
-npm i --save-dev babel-loader
+npm i --save-dev babel-loader vue-loader vue-template-compiler
+npm i --save-dev @babel/core babel-preset-vue
 ```
 
 ## Create the NPM script


### PR DESCRIPTION
Issue:

docs is not up to date regarding Guide for Vue.

## What I did

Fixing the doc, added dependencies as they should be. It is separated in 2 parts to highlight dev and peer dependencies.

It will answer to #4505 #4475 and #4821 

### Side note

As @igor-dv mentioned on Discord, `babel-preset-vue` is probably not necessary. As seen in this package's homepage, it's a preset to transform JSX in Vue projects, but Vue.js team advices to use template instead for the majority of cases (see [here](https://vuejs.org/v2/guide/render-function.html#Basics)). As we can extend webpack configuration to add loaders easily, it would make more sense to remove `babel-preset-vue` from the dependencies and advice advanced users of Vue.js to add it themselves following [existing SB documentation](https://storybook.js.org/configurations/custom-webpack-config/).