### PR TITLE
Bump svelte to 2.15.3, addresses !4478

### DIFF
--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^16.6.0"
   },
   "devDependencies": {
-    "svelte": "^2.15.2",
+    "svelte": "^2.15.3",
     "svelte-loader": "^2.11.0"
   },
   "peerDependencies": {

--- a/examples/svelte-kitchen-sink/src/stories/__snapshots__/index.storyshot
+++ b/examples/svelte-kitchen-sink/src/stories/__snapshots__/index.storyshot
@@ -185,9 +185,7 @@ exports[`Storyshots Welcome Welcome 1`] = `
         href="https://storybook.js.org/basics/writing-stories"
         target="_blank"
       >
-        
-			      Writing Stories
-			    
+        Writing Stories
       </a>
       
 			    section in our documentation.

--- a/examples/svelte-kitchen-sink/src/stories/views/WelcomeView.svelte
+++ b/examples/svelte-kitchen-sink/src/stories/views/WelcomeView.svelte
@@ -26,9 +26,7 @@
       class="link"
       href="https://storybook.js.org/basics/writing-stories"
       target="_blank"
-    >
-      Writing Stories
-    </a>
+    >Writing Stories</a>
     section in our documentation.
   </p>
   <p class="note">

--- a/yarn.lock
+++ b/yarn.lock
@@ -21213,10 +21213,10 @@ svelte-loader@^2.11.0:
     require-relative "^0.8.7"
     svelte-dev-helper "^1.1.9"
 
-svelte@^2.15.2:
-  version "2.15.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-2.15.2.tgz#6aaf4a10307409099ec30dd7c73f746fef32c949"
-  integrity sha512-l/YAQQ/ArmUTlEdspyLS7viFtKX0ZRKVmYeizAlvFoJ4vKos+7/aBD8xWxQTUd8EPh1JD95DVy7NK3h8+ITlxw==
+svelte@^2.15.3:
+  version "2.15.3"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-2.15.3.tgz#d9ba5b48eae30f5501b3266c563add2399c67b40"
+  integrity sha512-0bKpXppM/YlPZ8F0mREaUYpE8Te11RvG62ttFr+n1U3G2qdr3cZzuXCnQMcVZukwAUJAjRM55OSH7FLmXnPGRA==
 
 svg-tags@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Issue:
At 2.14.0, the svelte renderer changed the way it output html, so
snapshot tests failed and a link had incorrect whitespace.

## What I did
- Updated the example welcome template to address the link whitespace.
- Updated the example snapshots since the rendered output from svelte has now very different whitespacing.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
