### PR TITLE
feat(react-native): add option to set keyboarVerticalOffset to KeyboardAvoidingView

### DIFF
--- a/app/react-native/readme.md
+++ b/app/react-native/readme.md
@@ -124,9 +124,11 @@ You can pass these parameters to getStorybookUI call in your storybook entry poi
     initialSelection: Object (null)
         -- initialize storybook with a specific story. In case a valid object is passed, it will take precedence over `shouldPersistSelection. ex: `{ kind: 'Knobs', story: 'with knobs' }`
     shouldPersistSelection: Boolean (true)
-        -- initialize storybook with the last selected story.`
+        -- initialize storybook with the last selected story.
     shouldDisableKeyboardAvoidingView: Boolean (false)
         -- Disable KeyboardAvoidingView wrapping Storybook's view
+    keyboardAvoidingViewVerticalOffset: Number (0)
+        -- With shouldDisableKeyboardAvoidingView=true, this will set the keyboardverticaloffset (https://facebook.github.io/react-native/docs/keyboardavoidingview#keyboardverticaloffset) value for KeyboardAvoidingView wrapping Storybook's view
 }
 ```
 

--- a/app/react-native/src/preview/components/OnDeviceUI/index.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.js
@@ -111,7 +111,14 @@ export default class OnDeviceUI extends PureComponent {
   };
 
   render() {
-    const { stories, events, url, isUIHidden, shouldDisableKeyboardAvoidingView } = this.props;
+    const {
+      stories,
+      events,
+      url,
+      isUIHidden,
+      shouldDisableKeyboardAvoidingView,
+      keyboardAvoidingViewVerticalOffset,
+    } = this.props;
     const {
       tabOpen,
       slideBetweenAnimation,
@@ -137,6 +144,7 @@ export default class OnDeviceUI extends PureComponent {
         <KeyboardAvoidingView
           enabled={!shouldDisableKeyboardAvoidingView || tabOpen !== PREVIEW}
           behavior={IS_IOS ? 'padding' : null}
+          keyboardVerticalOffset={keyboardAvoidingViewVerticalOffset}
           style={style.flex}
         >
           <AbsolutePositionedKeyboardAwareView
@@ -200,6 +208,7 @@ OnDeviceUI.propTypes = {
     storyFn: PropTypes.func.isRequired,
   }),
   shouldDisableKeyboardAvoidingView: PropTypes.bool,
+  keyboardAvoidingViewVerticalOffset: PropTypes.number,
 };
 
 OnDeviceUI.defaultProps = {
@@ -208,4 +217,5 @@ OnDeviceUI.defaultProps = {
   isUIHidden: false,
   initialStory: null,
   shouldDisableKeyboardAvoidingView: false,
+  keyboardAvoidingViewVerticalOffset: 0,
 };

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -116,6 +116,7 @@ export default class Preview {
               tabOpen={params.tabOpen}
               initialStory={setInitialStory ? preview._getInitialStory() : null}
               shouldDisableKeyboardAvoidingView={params.shouldDisableKeyboardAvoidingView}
+              keyboardAvoidingViewVerticalOffset={params.keyboardAvoidingViewVerticalOffset}
             />
           );
         }


### PR DESCRIPTION
Issue: N/A

## What I did

Add option to set `keyboarVerticalOffset` to `<KeyboardAvoidingView>` wrapping Storybook's view.

It's needed to avoid the Storybook's navigation bar (`<Navigation>`) to stay underneath the keyboard when `getStorybookUI` doesn't render in a 100% height viewport, for instance: 

```jsx
<View>
  <CustomNavigationBar style={{ height: 100 }} />
  {getStorybookUI({
    keyboardAvoidingViewVerticalOffset: 100,
  })}
</View>
```


## How to test

- Is this testable with Jest or Chromatic screenshots? N
- Does this need a new example in the kitchen sink apps? N
- Does this need an update to the documentation? Y

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
