### PR TITLE
Add try, catch for IE11 as it breaks script execution

### DIFF
--- a/lib/ui/src/modules/ui/configs/handle_routing.js
+++ b/lib/ui/src/modules/ui/configs/handle_routing.js
@@ -48,7 +48,11 @@ export function changeUrl(clientStore, usePush) {
   if (!data.selectedKind) return;
 
   const state = getUrlState(data);
-  history[usePush ? 'pushState' : 'replaceState'](state, '', state.url);
+  try {
+    history[usePush ? 'pushState' : 'replaceState'](state, '', state.url);
+  } catch (e) {
+    // do nothing
+  }
 }
 
 export function updateStore(queryParams, actions) {


### PR DESCRIPTION
Issue:
More details - https://github.com/storybooks/storybook/issues/4854, IE11 breaks on change url with security error 
## What I did
Add try/catch for this case
## How to test
Try to load 
- Is this testable with Jest or Chromatic screenshots? - **I think not**
- Does this need a new example in the kitchen sink apps? - **Nope**
- Does this need an update to the documentation? - **I not sure about that**
