### PR TITLE
Updated readme to not instruct use to save-dev

### DIFF
--- a/.teamcity/OpenSourceProjects_Storybook/buildTypes/OpenSourceProjects_Storybook_Bootstrap.kt
+++ b/.teamcity/OpenSourceProjects_Storybook/buildTypes/OpenSourceProjects_Storybook_Bootstrap.kt
@@ -17,7 +17,6 @@ object OpenSourceProjects_Storybook_Bootstrap : BuildType({
         addons/storyshots/*/dist/** => dist.zip/addons/storyshots
         app/*/dist/** => dist.zip/app
         lib/*/dist/** => dist.zip/lib
-        lib/core/dll/** => dll.zip
     """.trimIndent()
 
     vcs {

--- a/.teamcity/OpenSourceProjects_Storybook/buildTypes/StorybookApp.kt
+++ b/.teamcity/OpenSourceProjects_Storybook/buildTypes/StorybookApp.kt
@@ -82,10 +82,7 @@ enum class StorybookApp(val appName: String, val exampleDir: String, val merged:
                 }
 
                 artifacts {
-                    artifactRules = """
-                        dist.zip!**
-                        dll.zip!** => lib/core/dll
-                    """.trimIndent()
+                    artifactRules = "dist.zip!**"
                 }
             }
         }

--- a/addons/centered/README.md
+++ b/addons/centered/README.md
@@ -7,7 +7,7 @@ Storybook Centered Decorator can be used to center components inside the preview
 ### Usage
 
 ```sh
-npm install @storybook/addon-centered --save-dev
+npm install @storybook/addon-centered --save
 ```
 
 #### As a decorator


### PR DESCRIPTION
currently the readme says that this should be saved in dev dependencies, which its shouldn't

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
