### PR TITLE
Reject webpack-related issues

### DIFF
--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -38,7 +38,9 @@ export async function buildStaticStandalone(options) {
       const managerTotalTime = process.hrtime(managerStartTime);
       logger.trace({ message: 'manager built', time: managerTotalTime });
 
-      if (stats.hasErrors()) {
+      if (err) {
+        rej(err);
+      } else if (stats.hasErrors()) {
         rej(stats);
       } else {
         res(stats);


### PR DESCRIPTION
## The Problem

If there is a webpack-related issue, you won't be able to see it, and instead, you'll see the following error:

![image](https://user-images.githubusercontent.com/11733036/49189818-805cf180-f378-11e8-80cf-a262706500ba.png)

Which does not help with finding the solution to the problem.

__________

> The err object will not include compilation errors and those must be handled separately using stats.hasErrors() which will be covered in detail in Error Handling section of this guide. The err object will only contain webpack-related issues, such as misconfiguration, etc.

[From webpack docs](https://webpack.js.org/api/node/#webpack-)

______

## The Solution

When there is an error, reject it instead of the stats.