### PR TITLE
Clarify Typescript instructions for config.ts

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -78,7 +78,15 @@ Change `config.ts` inside the Storybook config directory (by default, it’s `.s
 ```js
 // automatically import all files ending in *.stories.js
 const req = require.context('../stories', true, /.stories.tsx$/);
+
+function loadStories() {
+  req.keys().forEach(req);
+}
+
+configure(loadStories, module);
 ```
+
+If you have your `/stories` directory in `src`, change the above `../stories` to `../src/stories`.
 
 ## Using Typescript with the TSDocgen addon
 

--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -86,8 +86,6 @@ function loadStories() {
 configure(loadStories, module);
 ```
 
-If you have your `/stories` directory in `src`, change the above `../stories` to `../src/stories`.
-
 ## Using Typescript with the TSDocgen addon
 
 The very handy [Storybook Info addon](https://github.com/storybooks/storybook/tree/master/addons/info) autogenerates prop tables documentation for each component, however it doesn't work with Typescript types. The current solution is to use [react-docgen-typescript-loader](https://github.com/strothj/react-docgen-typescript-loader) to preprocess the Typescript files to give the Info addon what it needs. The webpack config above does this, and so for the rest of your stories you use it as per normal:


### PR DESCRIPTION
After setting up Storybook with Typescript, I got stuck on [this step](https://storybook.js.org/configurations/typescript-config/#import-tsx-stories). I spent an embarrassing amount of time trying to get:

```
const req = require.context('../stories', true, /.stories.tsx$/);
```

to work before finding somewhere that I also needed this:

```javascript
req.keys().forEach(req);
```

Adding that to these docs to hopefully clarify for future readers.