### PR TITLE
added code example to addon docs

### DIFF
--- a/docs/src/pages/addons/using-addons/index.md
+++ b/docs/src/pages/addons/using-addons/index.md
@@ -56,4 +56,24 @@ Then you'll be able to see those notes when you are viewing the story.
 
 ![Stories with notes](../static/stories-with-notes.png)
 
+## Global Configuration
+Sometimes you might want to configure an addon globally, as in the case of collocating stories with components, or just simply to keep your stories file cleaner. To do that, you can add your decorators to a config file, typically in `.storybook/config.js`. Here's an example of how you might do that.
+
+```js
+import { configure, addDecorator } from '@storybook/react';
+import { withOptions } from '@storybook/addon-options';
+
+addDecorator(
+  withOptions({
+    name: 'CRA Kitchen Sink',
+    goFullScreen: false,
+    showAddonsPanel: true,
+    showSearchBox: false
+    // more configuration here
+  })
+);
+```
+
+Here's an example of a [production-ready config file](https://github.com/storybooks/storybook/blob/next/examples/cra-kitchen-sink/.storybook/config.js) from the cra-kitchen example.
+
 Just like this, you can install any other addon and use it. Have a look at our [addon gallery](/addons/addon-gallery) to discover more addons.


### PR DESCRIPTION
Issue:

## What I did
I added documentation to the addon docs to show a code example of global configuration.

This is a change to the documentation.

