### PR TITLE
Remove use of const

### DIFF
--- a/addons/a11y/manager.js
+++ b/addons/a11y/manager.js
@@ -1,3 +1,1 @@
-const manager = require('./dist/register');
-
-manager.init();
+require('./dist/register').init();


### PR DESCRIPTION
Issue:

Usage of `const` is causing runtime errors in older browsers

## What I did

Removed use of `const`

## How to test

- Is this testable with Jest or Chromatic screenshots?
no
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
