### PR TITLE
Fix React Native async storage. Added missing return

### DIFF
--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -165,7 +165,7 @@ export default class Preview {
     }
 
     if (story) {
-      this._getStory(story);
+      return this._getStory(story);
     }
 
     const dump = this._stories.dumpStoryBook();


### PR DESCRIPTION
Issue: Added missing return in my previous pull request.

I managed to lose the return statement while moving my changes from node_modules to storybook monorepo.