### PR TITLE
fix: Add missing peer dependencies to addon-knobs

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -21,6 +21,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
+    "@emotion/core": "^0.13.1",
     "@emotion/styled": "^0.10.6",
     "@storybook/addons": "4.1.0-alpha.10",
     "@storybook/components": "4.1.0-alpha.10",


### PR DESCRIPTION
Fixes `Uncaught TypeError: Object(...) is not a function` when using `@storybook/addon-knobs` and `@emotion/core@^10.x`

Issue:
- #3999

The combination of the above packages created the following dependency tree:
```
├─ @emotion/core@10.x
├─ @storybook/addon-knobs@4.x
│  └─ @emotion/styled@0.x
```
However `@emotion/styled` has a peer dependency to `@emotion/core@0.x`. I didn't find any method in npm or yarn to add `@emotion/core@0.x` while still being able to use `@emotion/core@10.x`. This is probably the reason missing peer dependencies should be added immediately instead of relying on consuming packages to do this.

## What I did
- Add `@emotion/core@0.x` to dependencies of `@storybook/addon-knobs`.

## How to test

- Is this testable with Jest or Chromatic screenshots? 
  No
- Does this need a new example in the kitchen sink apps?
  No
- Does this need an update to the documentation?
  No

If your answer is yes to any of these, please make sure to include it in your PR.
