### PR TITLE
Update Addon|Knobs|All knobs story to reflect updated addon-knobs

### DIFF
--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/addon-knobs.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/addon-knobs.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Addon|Knobs All knobs 1`] = `
 <div
-  style="padding: 8px 22px; border-radius: 8px;"
+  style="border: 2px dotted; padding: 8px 22px; border-radius: 8px;"
 >
   <h1>
     My name is Jane,
@@ -13,7 +13,9 @@ exports[`Storyshots Addon|Knobs All knobs 1`] = `
   </h3>
    
   <p>
-    I have a stock of 20 apples, costing $2.25 each.
+    
+              I have a stock of 20 apples, costing $2.25 each.
+            
   </p>
    
   <p>
@@ -22,13 +24,19 @@ exports[`Storyshots Addon|Knobs All knobs 1`] = `
    
   <ul>
     <li>
-      Laptop
+      
+                Laptop
+              
     </li>
     <li>
-      Book
+      
+                Book
+              
     </li>
     <li>
-      Whiskey
+      
+                Whiskey
+              
     </li>
   </ul>
    

--- a/examples/vue-kitchen-sink/src/stories/addon-knobs.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/addon-knobs.stories.js
@@ -81,16 +81,20 @@ storiesOf('Addon|Knobs', module)
         },
         dateOptions: {
           type: Object,
-          default: {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            timeZone: 'UTC',
+          default() {
+            return {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+              timeZone: 'UTC',
+            };
           },
         },
         items: {
           type: Array,
-          default: array('Items', ['Laptop', 'Book', 'Whiskey']),
+          default() {
+            return array('Items', ['Laptop', 'Book', 'Whiskey']);
+          },
         },
         nice: {
           type: Boolean,
@@ -125,10 +129,7 @@ storiesOf('Addon|Knobs', module)
             </p>
             <p>Also, I have:</p>
             <ul>
-              <li
-                v-for="item in items"
-                :key="item"
-              >
+              <li v-for="item in items" :key="item">
                 {{ item }}
               </li>
             </ul>

--- a/examples/vue-kitchen-sink/src/stories/addon-knobs.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/addon-knobs.stories.js
@@ -38,45 +38,102 @@ storiesOf('Addon|Knobs', module)
     },
   }))
   .add('All knobs', () => {
-    const name = text('Name', 'Jane');
-    const stock = number('Stock', 20, {
-      range: true,
-      min: 0,
-      max: 30,
-      step: 5,
-    });
-    const fruits = {
-      Apple: 'apples',
-      Banana: 'bananas',
-      Cherry: 'cherries',
-    };
-    const fruit = select('Fruit', fruits, 'apples');
-    const price = number('Price', 2.25);
-
-    const colour = color('Border', 'deeppink');
-    const today = date('Today', new Date('Jan 20 2017 GMT+0'));
-    const items = array('Items', ['Laptop', 'Book', 'Whiskey']);
-    const nice = boolean('Nice', true);
-
-    const stockMessage = stock
-      ? `I have a stock of ${stock} ${fruit}, costing &dollar;${price} each.`
-      : `I'm out of ${fruit}${nice ? ', Sorry!' : '.'}`;
-    const salutation = nice ? 'Nice to meet you!' : 'Leave me alone!';
-    const dateOptions = { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' };
-
     button('Arbitrary action', action('You clicked it!'));
 
     return {
+      props: {
+        name: {
+          type: String,
+          default: text('Name', 'Jane'),
+        },
+        stock: {
+          type: Number,
+          default: number('Stock', 20, {
+            range: true,
+            min: 0,
+            max: 30,
+            step: 5,
+          }),
+        },
+        fruit: {
+          type: String,
+          default: select(
+            'Fruit',
+            {
+              Apple: 'apples',
+              Banana: 'bananas',
+              Cherry: 'cherries',
+            },
+            'apples'
+          ),
+        },
+        price: {
+          type: Number,
+          default: number('Price', 2.25),
+        },
+        colour: {
+          type: String,
+          default: color('Border', 'deeppink'),
+        },
+        today: {
+          type: Number,
+          default: date('Today', new Date('Jan 20 2017 GMT+0')),
+        },
+        dateOptions: {
+          type: Object,
+          default: {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            timeZone: 'UTC',
+          },
+        },
+        items: {
+          type: Array,
+          default: array('Items', ['Laptop', 'Book', 'Whiskey']),
+        },
+        nice: {
+          type: Boolean,
+          default: boolean('Nice', true),
+        },
+      },
+      computed: {
+        dateString() {
+          const { today, dateOptions } = this;
+
+          return new Date(today).toLocaleDateString('en-US', dateOptions);
+        },
+      },
       template: `
-          <div style="border:2px dotted ${colour}; padding: 8px 22px; border-radius: 8px">
-            <h1>My name is ${name},</h1>
-            <h3>today is ${new Date(today).toLocaleDateString('en-US', dateOptions)}</h3>
-            <p>${stockMessage}</p>
+          <div
+            :style="{
+              border: '2px dotted',
+              borderColor: colour,
+              padding: '8px 22px',
+              borderRadius: '8px'
+            }"
+          >
+            <h1>My name is {{name}},</h1>
+            <h3>today is {{dateString}}</h3>
+            <p v-if="stock">
+              I have a stock of {{stock}} {{fruit}}, costing &dollar;{{price}} each.
+            </p>
+            <p v-else>
+              I'm out of {{fruit}}
+              <span v-if="nice">, Sorry!</span>
+              <span v-else>.</span>
+            </p>
             <p>Also, I have:</p>
             <ul>
-              ${items.map(item => `<li key=${item}>${item}</li>`).join('')}
+              <li
+                v-for="item in items"
+                :key="item"
+              >
+                {{ item }}
+              </li>
             </ul>
-            <p>${salutation}</p>
+            <p v-if="nice">Nice to meet you!</p>
+            <p v-else>Leave me alone!</p>
           </div>
         `,
     };


### PR DESCRIPTION
Issue:

Current [vue-kitchen-sink example](https://storybooks-vue.netlify.com/?selectedKind=Addon%7CKnobs&selectedStory=All%20knobs&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs) knob updates don't update the story.

## What I did

Fixed 'Addon|Knobs|All knobs' story to reflect updated addon-knobs (#4773), as per my suggestion in #4947.

## How to test

- Run `vue-kitchen-sink` example storybook
- Navigate to Addon|Knobs|All knobs
- Knobs now update props of story, unlike the current [vue-kitchen-sink example](https://storybooks-vue.netlify.com/?selectedKind=Addon%7CKnobs&selectedStory=All%20knobs&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)