### PR TITLE
add forwardRef support to addon-info

### DIFF
--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -30,6 +30,7 @@
     "nested-object-assign": "^1.0.1",
     "prop-types": "^15.6.2",
     "react-addons-create-fragment": "^15.5.3",
+    "react-is": "^16.6.1",
     "react-lifecycles-compat": "^3.0.4",
     "util-deprecate": "^1.0.2"
   },

--- a/addons/info/src/components/Node.js
+++ b/addons/info/src/components/Node.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isForwardRef } from 'react-is';
 import PropTypes from 'prop-types';
 import Props from './Props';
 
@@ -68,6 +69,43 @@ export default function Node(props) {
     return (
       <div style={containerStyleCopy}>
         <span style={tagStyle}>{text}</span>
+      </div>
+    );
+  }
+
+  if (isForwardRef(node)) {
+    const childElement = node.type.render(node.props);
+    return (
+      <div>
+        <div style={containerStyleCopy}>
+          <span style={tagStyle}>
+            &lt;
+            {`ForwardRef`}
+          </span>
+          <Props
+            node={node}
+            maxPropsIntoLine={maxPropsIntoLine}
+            maxPropObjectKeys={maxPropObjectKeys}
+            maxPropArrayLength={maxPropArrayLength}
+            maxPropStringLength={maxPropStringLength}
+          />
+          <span style={tagStyle}>&gt;</span>
+        </div>
+        <Node
+          node={childElement}
+          depth={depth + 1}
+          maxPropsIntoLine={maxPropsIntoLine}
+          maxPropObjectKeys={maxPropObjectKeys}
+          maxPropArrayLength={maxPropArrayLength}
+          maxPropStringLength={maxPropStringLength}
+        />
+        <div style={containerStyleCopy}>
+          <span style={tagStyle}>
+            &lt;/
+            {`ForwardRef`}
+            &gt;
+          </span>
+        </div>
       </div>
     );
   }

--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -1,6 +1,7 @@
 /* eslint no-underscore-dangle: 0 */
 
 import React, { Component, createElement } from 'react';
+import { isForwardRef } from 'react-is';
 import { polyfill } from 'react-lifecycles-compat';
 import PropTypes from 'prop-types';
 import global from 'global';
@@ -337,9 +338,13 @@ class Story extends Component {
       if (innerChildren.props && innerChildren.props.children) {
         extract(innerChildren.props.children);
       }
+      if (isForwardRef(innerChildren)) {
+        extract(innerChildren.type.render(innerChildren.props));
+      }
       if (
         typeof innerChildren === 'string' ||
         typeof innerChildren.type === 'string' ||
+        isForwardRef(innerChildren) ||
         (Array.isArray(propTablesExclude) && // also ignore excluded types
           ~propTablesExclude.indexOf(innerChildren.type)) // eslint-disable-line no-bitwise
       ) {

--- a/examples/official-storybook/components/ForwardedRefButton.js
+++ b/examples/official-storybook/components/ForwardedRefButton.js
@@ -1,0 +1,24 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import BaseButton from './BaseButton';
+
+const ForwardedRefButton = forwardRef((props, ref) => <BaseButton {...props} forwardedRef={ref} />);
+
+ForwardedRefButton.defaultProps = {
+  disabled: false,
+  onClick: () => {},
+  style: {},
+};
+
+ForwardedRefButton.propTypes = {
+  /** Boolean indicating whether the button should render as disabled */
+  disabled: PropTypes.bool,
+  /** button label. */
+  label: PropTypes.string.isRequired,
+  /** onClick handler */
+  onClick: PropTypes.func,
+  /** Custom styles */
+  style: PropTypes.shape({}),
+};
+
+export default ForwardedRefButton;

--- a/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
@@ -357,6 +357,435 @@ exports[`Storyshots Addons|Info.Decorator Use Info as story decorator 1`] = `
 </div>
 `;
 
+exports[`Storyshots Addons|Info.ForwardRef Displays forwarded ref components correctly 1`] = `
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: .88em;
+  font-family: Menlo,Monaco,"Courier New",monospace;
+  background-color: #fafafa;
+  padding: .5rem;
+  line-height: 1.5;
+  overflow-x: scroll;
+}
+
+.emotion-2 {
+  overflow: hidden;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  background-color: #FFFFFF;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 3px 10px;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-2:hover {
+  background-color: #f4f7fa;
+  border-color: #ddd;
+}
+
+.emotion-2:active {
+  background-color: #e9ecef;
+  border-color: #ccc;
+}
+
+.emotion-0 {
+  -webkit-transition: -webkit-transform .2s ease;
+  -webkit-transition: transform .2s ease;
+  transition: transform .2s ease;
+  height: 16px;
+  -webkit-transform: translateY(-100%) translateY(-6px);
+  -ms-transform: translateY(-100%) translateY(-6px);
+  transform: translateY(-100%) translateY(-6px);
+}
+
+.emotion-56 {
+  border-collapse: collapse;
+}
+
+.emotion-6 {
+  padding: 2px 6px;
+  border: 1px solid #ccc;
+}
+
+.emotion-16 {
+  padding: 2px 6px;
+  border: 1px solid #ccc;
+  white-space: nowrap;
+  font-family: Monaco,Consolas,"Courier New",monospace;
+}
+
+<div>
+  <div
+    style="position:relative;z-index:0"
+  >
+    <button
+      type="button"
+    >
+      Forwarded Ref Button
+    </button>
+  </div>
+  <button
+    style="font-family:sans-serif;font-size:12px;display:block;position:fixed;border:none;background:#28c;color:#fff;padding:5px 15px;cursor:pointer;top:0;right:0;border-radius:0 0 0 5px"
+    type="button"
+  >
+    Show Info
+  </button>
+  <div
+    style="position:fixed;background:white;top:0;bottom:0;left:0;right:0;padding:0 40px;overflow:auto;z-index:99999;display:none"
+  >
+    <button
+      style="font-family:sans-serif;font-size:12px;display:block;position:fixed;border:none;background:#28c;color:#fff;padding:5px 15px;cursor:pointer;top:0;right:0;border-radius:0 0 0 5px"
+      type="button"
+    >
+      ×
+    </button>
+    <div>
+      <div
+        style="font-family:-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif;color:#444;-webkit-font-smoothing:antialiased;font-weight:300;line-height:1.45;font-size:15px;border:1px solid #eee;padding:20px 40px 40px;border-radius:2px;background-color:#fff;margin-top:20px;margin-bottom:20px"
+      >
+        <div
+          style="border-bottom:1px solid #eee;padding-top:10px;margin-bottom:10px"
+        >
+          <h1
+            style="margin:0;padding:0;font-size:35px"
+          >
+            Addons|Info.ForwardRef
+          </h1>
+          <h2
+            style="margin:0 0 10px 0;padding:0;font-weight:400;font-size:22px"
+          >
+            Displays forwarded ref components correctly
+          </h2>
+        </div>
+        <div>
+          <h1
+            style="margin:20px 0 0 0;padding:0 0 5px 0;font-size:25px;border-bottom:1px solid #EEE"
+          >
+            Story Source
+          </h1>
+          <pre
+            class="emotion-4 emotion-5"
+          >
+            <div>
+              <div>
+                <div
+                  style="padding-left:18px;padding-right:3px"
+                >
+                  <span
+                    style="color:#444"
+                  >
+                    &lt;ForwardRef
+                  </span>
+                  <span>
+                    <span>
+                       
+                      <span>
+                        label
+                      </span>
+                      <span>
+                        =
+                        <span>
+                          "
+                          <span
+                            style="color:#22a;word-break:break-word"
+                          >
+                            Forwarded Ref Button
+                          </span>
+                          "
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span
+                    style="color:#444"
+                  >
+                    &gt;
+                  </span>
+                </div>
+                <div
+                  style="padding-left:33px;padding-right:3px"
+                >
+                  <span
+                    style="color:#444"
+                  >
+                    &lt;BaseButton
+                  </span>
+                  <span>
+                    <span>
+                       
+                      <span>
+                        label
+                      </span>
+                      <span>
+                        =
+                        <span>
+                          "
+                          <span
+                            style="color:#22a;word-break:break-word"
+                          >
+                            Forwarded Ref Button
+                          </span>
+                          "
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                       
+                      <span>
+                        onClick
+                      </span>
+                      <span>
+                        =
+                        <span>
+                          {
+                          <span
+                            style="color:#170"
+                          >
+                            onClick
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                       
+                      <span>
+                        style
+                      </span>
+                      <span>
+                        =
+                        <span>
+                          {
+                          <span
+                            style="color:#666"
+                          >
+                            {}
+                          </span>
+                          }
+                        </span>
+                      </span>
+                       
+                    </span>
+                  </span>
+                  <span
+                    style="color:#444"
+                  >
+                    /&gt;
+                  </span>
+                </div>
+                <div
+                  style="padding-left:18px;padding-right:3px"
+                >
+                  <span
+                    style="color:#444"
+                  >
+                    &lt;/ForwardRef&gt;
+                  </span>
+                </div>
+              </div>
+            </div>
+            <button
+              class="emotion-2 emotion-3"
+            >
+              <div
+                class="emotion-0 emotion-1"
+              >
+                <div
+                  style="margin-bottom:6px"
+                >
+                  Copied!
+                </div>
+                <div>
+                  Copy
+                </div>
+              </div>
+            </button>
+          </pre>
+        </div>
+        <div>
+          <h1
+            style="margin:20px 0 0 0;padding:0 0 5px 0;font-size:25px;border-bottom:1px solid #EEE"
+          >
+            Prop Types
+          </h1>
+          <div>
+            <h2
+              style="margin:20px 0 0 0"
+            >
+              "BaseButton" Component
+            </h2>
+            <table
+              class="emotion-56 emotion-57"
+            >
+              <thead>
+                <tr>
+                  <th
+                    class="emotion-6 emotion-7"
+                  >
+                    property
+                  </th>
+                  <th
+                    class="emotion-6 emotion-7"
+                  >
+                    propType
+                  </th>
+                  <th
+                    class="emotion-6 emotion-7"
+                  >
+                    required
+                  </th>
+                  <th
+                    class="emotion-6 emotion-7"
+                  >
+                    default
+                  </th>
+                  <th
+                    class="emotion-6 emotion-7"
+                  >
+                    description
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td
+                    class="emotion-16 emotion-17"
+                  >
+                    disabled
+                  </td>
+                  <td
+                    class="emotion-16 emotion-17"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  >
+                    -
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  >
+                    <span
+                      style="color:#a11"
+                    >
+                      false
+                    </span>
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  />
+                </tr>
+                <tr>
+                  <td
+                    class="emotion-16 emotion-17"
+                  >
+                    label
+                  </td>
+                  <td
+                    class="emotion-16 emotion-17"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  >
+                    yes
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  >
+                    -
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  />
+                </tr>
+                <tr>
+                  <td
+                    class="emotion-16 emotion-17"
+                  >
+                    onClick
+                  </td>
+                  <td
+                    class="emotion-16 emotion-17"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  >
+                    -
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  >
+                    <span
+                      style="color:#170"
+                    >
+                      onClick
+                    </span>
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  />
+                </tr>
+                <tr>
+                  <td
+                    class="emotion-16 emotion-17"
+                  >
+                    style
+                  </td>
+                  <td
+                    class="emotion-16 emotion-17"
+                  >
+                    <span />
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  >
+                    -
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  >
+                    <span
+                      style="color:#666"
+                    >
+                      {}
+                    </span>
+                  </td>
+                  <td
+                    class="emotion-6 emotion-17"
+                  />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Addons|Info.GitHub issues #1814 1`] = `
 .emotion-4 {
   display: -webkit-box;

--- a/examples/official-storybook/stories/addon-info.stories.js
+++ b/examples/official-storybook/stories/addon-info.stories.js
@@ -6,6 +6,7 @@ import { action } from '@storybook/addon-actions';
 import DocgenButton from '../components/DocgenButton';
 import FlowTypeButton from '../components/FlowTypeButton';
 import BaseButton from '../components/BaseButton';
+import ForwardedRefButton from '../components/ForwardedRefButton';
 import { NamedExportButton } from '../components/NamedExportButton';
 import TableComponent from '../components/TableComponent';
 import externalMdDocs from './addon-info-resources/EXAMPLE.md';
@@ -431,6 +432,12 @@ storiesOf('Addons|Info.Parameters', module)
     () => <BaseButton onClick={action('clicked')} label="Button" />,
     { info: { disable: true } }
   );
+
+storiesOf('Addons|Info.ForwardRef', module)
+  .addDecorator(withInfo)
+  .add('Displays forwarded ref components correctly', () => (
+    <ForwardedRefButton label="Forwarded Ref Button" />
+  ));
 
 storiesOf('Addons|Info.deprecated', module).add(
   'Displays Markdown in description',


### PR DESCRIPTION
Issue: closes #4787

## What I did
- added `react-is` to dependencies in `addon-info`.
- in both `Node` and `Story` checks if the element is `forwardRef` element and parses accordingly.
- add new example of `forwardRef` component in kitchen sink app.

## How to test

- Is this testable with Jest or Chromatic screenshots?
Yes.
- Does this need a new example in the kitchen sink apps?
Yes.
- Does this need an update to the documentation?
Don't think so.

If your answer is yes to any of these, please make sure to include it in your PR.

