### PR TITLE
Fix storyshots by compiling JS modules

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', { shippedProposals: true, useBuiltIns: 'usage', modules: false }],
+    ['@babel/preset-env', { shippedProposals: true, useBuiltIns: 'usage' }],
     '@babel/preset-react',
     '@babel/preset-flow',
   ],

--- a/examples/official-storybook/webpack.config.js
+++ b/examples/official-storybook/webpack.config.js
@@ -21,7 +21,6 @@ module.exports = async (baseConfig, env, defaultConfig) => ({
         test: /\.js/,
         use: defaultConfig.module.rules[0].use,
         include: [
-          path.resolve(__dirname, '../../app/react'),
           path.resolve(__dirname, '../../lib/ui/src'),
           path.resolve(__dirname, '../../lib/components/src'),
         ],


### PR DESCRIPTION
Issue: #4964

## What I did

Reverts a change that I believe breaks 4.1 storyshots in exchange for being able to tree-shake. I believe we should wait until 5.0 for this change.

As I understand it, this line means that we are shipping es6 with import in our builds, which breaks jest. Users can configure jest to support import and we can make that required, but it's a breaking change that got introduced recently for reasons I don't quite understand (something to do with tree-shaking) so I'd like to revert it for now.