### PR TITLE
[docs] Update TS config docs

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -145,34 +145,39 @@ Please refer to the [react-docgen-typescript-loader](https://github.com/strothj/
 
 Additional annotation can be achieved by setting a default set of info parameters:
 
-```js
+```ts
+import {addDecorator} from "@storybook/react";
+import {withInfo} from "@storybook/addon-info";
+
 // Globally in your .storybook/config.js, or alternatively, per-chapter
-addDecorator({
-  styles: {
-    header: {
-      h1: {
-        marginRight: '20px',
-        fontSize: '25px',
-        display: 'inline',
+addDecorator(
+  withInfo({
+    styles: {
+      header: {
+        h1: {
+          marginRight: '20px',
+          fontSize: '25px',
+          display: 'inline',
+        },
+        body: {
+          paddingTop: 0,
+          paddingBottom: 0,
+        },
+        h2: {
+          display: 'inline',
+          color: '#999',
+        },
       },
-      body: {
-        paddingTop: 0,
-        paddingBottom: 0,
-      },
-      h2: {
-        display: 'inline',
-        color: '#999',
+      infoBody: {
+        backgroundColor: '#eee',
+        padding: '0px 5px',
+        lineHeight: '2',
       },
     },
-    infoBody: {
-      backgroundColor: '#eee',
-      padding: '0px 5px',
-      lineHeight: '2',
-    },
-  },
-  inline: true,
-  source: false,
-});
+    inline: true,
+    source: false,
+  })
+);
 ```
 
 This can be used like so:


### PR DESCRIPTION
Hi, I updated the example code setting up react-docgen-typescript-loader after having fought with it for quite some time. 

I'm also wondering if recommending react-docgen-typescript-webpack-plugin is really necessary since configuring directly with react-docgen-typescript-loader is the same amount of code... 

```js
const path = require("path");

module.exports = (baseConfig, env, config) => {
    config.module.rules.push({
        test: /\.(ts|tsx)$/,
        include: path.resolve(__dirname, "../"),
        use: [require.resolve("ts-loader"), require.resolve("react-docgen-typescript-loader")],
    });
    config.resolve.extensions.push(".ts", ".tsx");

    return config;
};
```