### PR TITLE
FIX react native by adding an empty array named dlls to the templateParameters

### DIFF
--- a/app/react-native/src/server/config/webpack.config.js
+++ b/app/react-native/src/server/config/webpack.config.js
@@ -40,6 +40,7 @@ const getConfig = options => {
           files,
           options: o,
           version,
+          dlls: [],
           ...entriesMeta.manager,
         }),
         template: require.resolve(`@storybook/core/src/server/templates/index.ejs`),


### PR DESCRIPTION
ReactNative currently fails because of dlls missing.

Adding an empty array named dlls to the templateParameters fices this.