### PR TITLE
4694 fix color picker display

### DIFF
--- a/lib/components/src/addon_panel/__snapshots__/index.stories.storyshot
+++ b/lib/components/src/addon_panel/__snapshots__/index.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Components|AddonPanel default 1`] = `
   style="height:calc(100vh - 20px)"
 >
   <div
-    class="css-d7g4da e1lzzkxx0"
+    class="css-1ils9jj e1lzzkxx0"
   >
     <div
       class="css-1whcqvw e1lzzkxx1"

--- a/lib/components/src/addon_panel/__snapshots__/index.stories.storyshot
+++ b/lib/components/src/addon_panel/__snapshots__/index.stories.storyshot
@@ -1,50 +1,1129 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Components|AddonPanel default 1`] = `
+exports[`Storyshots Components|Tabs stateful - dynamic 1`] = `
+.emotion-12 {
+  background: rgba(255,255,255,1);
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  overflow: auto;
+  padding: 0 8px;
+  white-space: nowrap;
+  height: 40px;
+}
+
+.emotion-0 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: rgba(0,0,0,0.4);
+  border-bottom-color: transparent;
+}
+
+.emotion-0:empty {
+  display: none;
+}
+
+.emotion-0:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-4 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: #444;
+  border-bottom-color: rgba(0,0,0,0.1);
+}
+
+.emotion-4:empty {
+  display: none;
+}
+
+.emotion-4:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-14 {
+  display: none;
+}
+
+.emotion-18 {
+  overflow: hidden;
+  background: rgba(255,255,255,0.89);
+  border-radius: 4px;
+  border: 1px solid rgba(0,0,0,0.1);
+  display: block;
+}
+
+.emotion-16 {
+  display: block;
+  position: relative;
+}
+
 <div
   style="height:calc(100vh - 20px)"
 >
   <div
-    class="css-1ils9jj e1lzzkxx0"
+    class="emotion-18 emotion-19"
   >
     <div
-      class="css-1whcqvw e1lzzkxx1"
+      class="emotion-12 emotion-13"
       role="tablist"
     >
       <button
-        class="css-xcko46 e1lzzkxx2"
+        class="emotion-0 emotion-1"
         role="tab"
         type="button"
       >
-        Test 1
+        Tab title #1
       </button>
       <button
-        class="css-1hf831j e1lzzkxx2"
+        class="emotion-0 emotion-1"
         role="tab"
         type="button"
       >
-        Test 2
+        Tab title #2
+      </button>
+      <button
+        class="emotion-4 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab with scroll
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #4
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #5
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #6
       </button>
     </div>
     <div
-      class="css-18lpvrh e1lzzkxx3"
+      class="emotion-16 emotion-17"
     >
       <div
         id="test2"
+        style="background:hotpink;min-height:100%;display:none"
       >
-        TEST 2
+        CONTENT 2
+      </div>
+      <div
+        id="test3"
+      >
+        <div
+          style="background:#000000;height:30.8px"
+        />
+        <div
+          style="background:#111111;height:31.3px"
+        />
+        <div
+          style="background:#222222;height:32.1px"
+        />
+        <div
+          style="background:#333333;height:33.4px"
+        />
+        <div
+          style="background:#444444;height:35.5px"
+        />
+        <div
+          style="background:#555555;height:38.9px"
+        />
+        <div
+          style="background:#666666;height:44.4px"
+        />
+        <div
+          style="background:#777777;height:53.3px"
+        />
+        <div
+          style="background:#888888;height:67.7px"
+        />
+        <div
+          style="background:#999999;height:91px"
+        />
+        <div
+          style="background:#aaaaaa;height:128.7px"
+        />
+        <div
+          style="background:#bbbbbb;height:189.7px"
+        />
+        <div
+          style="background:#cccccc;height:288.4px"
+        />
+        <div
+          style="background:#dddddd;height:448.1px"
+        />
+        <div
+          style="background:#eeeeee;height:706.5px"
+        />
+      </div>
+      <div
+        class="emotion-14 emotion-15"
+      >
+        <div>
+          CONTENT 6
+        </div>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`Storyshots Components|AddonPanel no panels 1`] = `
+exports[`Storyshots Components|Tabs stateful - no initial 1`] = `
+.emotion-12 {
+  background: rgba(255,255,255,1);
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  overflow: auto;
+  padding: 0 8px;
+  white-space: nowrap;
+  height: 40px;
+}
+
+.emotion-2 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: rgba(0,0,0,0.4);
+  border-bottom-color: transparent;
+}
+
+.emotion-2:empty {
+  display: none;
+}
+
+.emotion-2:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-0 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: #444;
+  border-bottom-color: rgba(0,0,0,0.1);
+}
+
+.emotion-0:empty {
+  display: none;
+}
+
+.emotion-0:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-14 {
+  display: none;
+}
+
+.emotion-18 {
+  overflow: hidden;
+  background: rgba(255,255,255,0.89);
+  border-radius: 4px;
+  border: 1px solid rgba(0,0,0,0.1);
+  display: block;
+}
+
+.emotion-16 {
+  display: block;
+  position: relative;
+}
+
+<div
+  style="height:calc(100vh - 20px)"
+>
+  <div
+    class="emotion-18 emotion-19"
+  >
+    <div
+      class="emotion-12 emotion-13"
+      role="tablist"
+    >
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #1
+      </button>
+      <button
+        class="emotion-2 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #2
+      </button>
+      <button
+        class="emotion-2 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab with scroll
+      </button>
+      <button
+        class="emotion-2 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #4
+      </button>
+      <button
+        class="emotion-2 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #5
+      </button>
+      <button
+        class="emotion-2 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #6
+      </button>
+    </div>
+    <div
+      class="emotion-16 emotion-17"
+    >
+      <div
+        id="test1"
+      >
+        CONTENT 1
+      </div>
+      <div
+        id="test2"
+        style="background:hotpink;min-height:100%;display:none"
+      >
+        CONTENT 2
+      </div>
+      <div
+        class="emotion-14 emotion-15"
+      >
+        <div>
+          CONTENT 6
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components|Tabs stateful - static 1`] = `
+.emotion-4 {
+  background: rgba(255,255,255,1);
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  overflow: auto;
+  padding: 0 8px;
+  white-space: nowrap;
+  height: 40px;
+}
+
+.emotion-0 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: rgba(0,0,0,0.4);
+  border-bottom-color: transparent;
+}
+
+.emotion-0:empty {
+  display: none;
+}
+
+.emotion-0:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-2 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: #444;
+  border-bottom-color: rgba(0,0,0,0.1);
+}
+
+.emotion-2:empty {
+  display: none;
+}
+
+.emotion-2:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-10 {
+  overflow: hidden;
+  background: rgba(255,255,255,0.89);
+  border-radius: 4px;
+  border: 1px solid rgba(0,0,0,0.1);
+  display: block;
+}
+
+.emotion-8 {
+  display: block;
+  position: relative;
+}
+
+.emotion-6 {
+  display: block;
+}
+
+<div
+  style="height:calc(100vh - 20px)"
+>
+  <div
+    class="emotion-10 emotion-11"
+  >
+    <div
+      class="emotion-4 emotion-5"
+      role="tablist"
+    >
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        With a function
+      </button>
+      <button
+        class="emotion-2 emotion-1"
+        role="tab"
+        type="button"
+      >
+        With markup
+      </button>
+    </div>
+    <div
+      class="emotion-8 emotion-9"
+    >
+      <div
+        class="emotion-6 emotion-7"
+        role="tabpanel"
+      >
+        <div>
+          test2 is always active (but visually hidden)
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components|Tabs stateless - absolute 1`] = `
+.emotion-18 {
+  overflow: hidden;
+  background: rgba(255,255,255,0.89);
+  border-radius: 4px;
+  border: 1px solid rgba(0,0,0,0.1);
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-12 {
+  background: rgba(255,255,255,1);
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  overflow: auto;
+  padding: 0 8px;
+  white-space: nowrap;
+  height: 40px;
+}
+
+.emotion-0 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: rgba(0,0,0,0.4);
+  border-bottom-color: transparent;
+}
+
+.emotion-0:empty {
+  display: none;
+}
+
+.emotion-0:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-4 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: #444;
+  border-bottom-color: rgba(0,0,0,0.1);
+}
+
+.emotion-4:empty {
+  display: none;
+}
+
+.emotion-4:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-16 {
+  display: block;
+  position: relative;
+  position: relative;
+  overflow: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  width: 100%;
+}
+
+.emotion-14 {
+  display: none;
+}
+
+<div
+  style="height:calc(100vh - 20px)"
+>
+  <div
+    class="emotion-18 emotion-19"
+  >
+    <div
+      class="emotion-12 emotion-13"
+      role="tablist"
+    >
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #1
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #2
+      </button>
+      <button
+        class="emotion-4 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab with scroll
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #4
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #5
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #6
+      </button>
+    </div>
+    <div
+      class="emotion-16 emotion-17"
+    >
+      <div
+        id="test2"
+        style="background:hotpink;min-height:100%;display:none"
+      >
+        CONTENT 2
+      </div>
+      <div
+        id="test3"
+      >
+        <div
+          style="background:#000000;height:30.8px"
+        />
+        <div
+          style="background:#111111;height:31.3px"
+        />
+        <div
+          style="background:#222222;height:32.1px"
+        />
+        <div
+          style="background:#333333;height:33.4px"
+        />
+        <div
+          style="background:#444444;height:35.5px"
+        />
+        <div
+          style="background:#555555;height:38.9px"
+        />
+        <div
+          style="background:#666666;height:44.4px"
+        />
+        <div
+          style="background:#777777;height:53.3px"
+        />
+        <div
+          style="background:#888888;height:67.7px"
+        />
+        <div
+          style="background:#999999;height:91px"
+        />
+        <div
+          style="background:#aaaaaa;height:128.7px"
+        />
+        <div
+          style="background:#bbbbbb;height:189.7px"
+        />
+        <div
+          style="background:#cccccc;height:288.4px"
+        />
+        <div
+          style="background:#dddddd;height:448.1px"
+        />
+        <div
+          style="background:#eeeeee;height:706.5px"
+        />
+      </div>
+      <div
+        class="emotion-14 emotion-15"
+      >
+        <div>
+          CONTENT 6
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components|Tabs stateless - bordered 1`] = `
+.emotion-12 {
+  background: rgba(255,255,255,1);
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  overflow: auto;
+  padding: 0 8px;
+  white-space: nowrap;
+  height: 40px;
+}
+
+.emotion-0 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: rgba(0,0,0,0.4);
+  border-bottom-color: transparent;
+}
+
+.emotion-0:empty {
+  display: none;
+}
+
+.emotion-0:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-4 {
+  white-space: normal;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  font-size: 11px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0 8px;
+  text-transform: uppercase;
+  -webkit-transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  transition: color 0.2s linear,border-bottom-color 0.2s linear;
+  height: 40px;
+  line-height: 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: transparent;
+  border: 0 solid transparent;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  color: #444;
+  border-bottom-color: rgba(0,0,0,0.1);
+}
+
+.emotion-4:empty {
+  display: none;
+}
+
+.emotion-4:focus {
+  outline: 0 none;
+  border-bottom-color: #9fdaff;
+}
+
+.emotion-14 {
+  display: none;
+}
+
+.emotion-18 {
+  overflow: hidden;
+  background: rgba(255,255,255,0.89);
+  border-radius: 4px;
+  border: 1px solid rgba(0,0,0,0.1);
+  display: block;
+}
+
+.emotion-16 {
+  display: block;
+  position: relative;
+}
+
+<div
+  style="height:calc(100vh - 20px)"
+>
+  <div
+    class="emotion-18 emotion-19"
+  >
+    <div
+      class="emotion-12 emotion-13"
+      role="tablist"
+    >
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #1
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #2
+      </button>
+      <button
+        class="emotion-4 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab with scroll
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #4
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #5
+      </button>
+      <button
+        class="emotion-0 emotion-1"
+        role="tab"
+        type="button"
+      >
+        Tab title #6
+      </button>
+    </div>
+    <div
+      class="emotion-16 emotion-17"
+    >
+      <div
+        id="test2"
+        style="background:hotpink;min-height:100%;display:none"
+      >
+        CONTENT 2
+      </div>
+      <div
+        id="test3"
+      >
+        <div
+          style="background:#000000;height:30.8px"
+        />
+        <div
+          style="background:#111111;height:31.3px"
+        />
+        <div
+          style="background:#222222;height:32.1px"
+        />
+        <div
+          style="background:#333333;height:33.4px"
+        />
+        <div
+          style="background:#444444;height:35.5px"
+        />
+        <div
+          style="background:#555555;height:38.9px"
+        />
+        <div
+          style="background:#666666;height:44.4px"
+        />
+        <div
+          style="background:#777777;height:53.3px"
+        />
+        <div
+          style="background:#888888;height:67.7px"
+        />
+        <div
+          style="background:#999999;height:91px"
+        />
+        <div
+          style="background:#aaaaaa;height:128.7px"
+        />
+        <div
+          style="background:#bbbbbb;height:189.7px"
+        />
+        <div
+          style="background:#cccccc;height:288.4px"
+        />
+        <div
+          style="background:#dddddd;height:448.1px"
+        />
+        <div
+          style="background:#eeeeee;height:706.5px"
+        />
+      </div>
+      <div
+        class="emotion-14 emotion-15"
+      >
+        <div>
+          CONTENT 6
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components|Tabs stateless - empty 1`] = `
+.emotion-0 {
+  font-size: 11px;
+  display: block;
+  text-align: center;
+  text-transform: uppercase;
+  margin: 0;
+  padding: 20px;
+}
+
 <div
   style="height:calc(100vh - 20px)"
 >
   <p
-    class="css-hftiue ejh6i270"
+    class="emotion-0 emotion-1"
   >
     no panels available
   </p>

--- a/lib/components/src/tabs/__snapshots__/tabs.stories.storyshot
+++ b/lib/components/src/tabs/__snapshots__/tabs.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Components|Tabs stateful - dynamic 1`] = `
   style="height:calc(100vh - 20px)"
 >
   <div
-    class="css-8a9ncn e1lzzkxx0"
+    class="css-1ms7tx7 e1lzzkxx0"
   >
     <div
       class="css-1whcqvw e1lzzkxx1"
@@ -129,7 +129,7 @@ exports[`Storyshots Components|Tabs stateful - no initial 1`] = `
   style="height:calc(100vh - 20px)"
 >
   <div
-    class="css-8a9ncn e1lzzkxx0"
+    class="css-1ms7tx7 e1lzzkxx0"
   >
     <div
       class="css-1whcqvw e1lzzkxx1"
@@ -209,7 +209,7 @@ exports[`Storyshots Components|Tabs stateful - static 1`] = `
   style="height:calc(100vh - 20px)"
 >
   <div
-    class="css-8a9ncn e1lzzkxx0"
+    class="css-1ms7tx7 e1lzzkxx0"
   >
     <div
       class="css-1whcqvw e1lzzkxx1"
@@ -251,7 +251,7 @@ exports[`Storyshots Components|Tabs stateless - absolute 1`] = `
   style="height:calc(100vh - 20px)"
 >
   <div
-    class="css-d7g4da e1lzzkxx0"
+    class="css-1ils9jj e1lzzkxx0"
   >
     <div
       class="css-1whcqvw e1lzzkxx1"
@@ -375,7 +375,7 @@ exports[`Storyshots Components|Tabs stateless - bordered 1`] = `
   style="height:calc(100vh - 20px)"
 >
   <div
-    class="css-8a9ncn e1lzzkxx0"
+    class="css-1ms7tx7 e1lzzkxx0"
   >
     <div
       class="css-1whcqvw e1lzzkxx1"

--- a/lib/components/src/tabs/tabs.js
+++ b/lib/components/src/tabs/tabs.js
@@ -10,7 +10,6 @@ const Wrapper = styled.div(
   ({ theme, bordered }) =>
     bordered
       ? {
-          overflow: 'hidden',
           background: theme.mainFill,
           borderRadius: theme.mainBorderRadius,
           border: theme.mainBorder,


### PR DESCRIPTION
Issue: #4694 Storybook 4 color knob not rendering properly 

## What I did
The `overflow` property was removed from `Tab`'s `Wrapper` component to enable using absolutely positioned elements in the knob panel. 

This might not be the best solution, since the `overflow: hidden` property seems to have been added for a reason. However, given the way the other knobs are represented in the panel, hiding the overflow would most probably require a more thorough rewrite. To fix the color picker's behavior - which seems to be a pain for some users - I'm therefore proposing the following change.