### PR TITLE
Remove unnecessary dependencies, fix aliasing

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -41,15 +41,15 @@
     "lodash": "^4.17.11",
     "mini-css-extract-plugin": "^0.4.4",
     "prop-types": "^15.6.2",
-    "react": "^16.6.0",
     "react-dev-utils": "^6.1.0",
-    "react-dom": "^16.6.0",
     "regenerator-runtime": "^0.12.1",
     "semver": "^5.6.0",
     "webpack": "^4.23.1"
   },
   "peerDependencies": {
-    "babel-loader": "^7.0.0 || ^8.0.0"
+    "babel-loader": "^7.0.0 || ^8.0.0",
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -87,7 +87,9 @@
     "mock-fs": "^4.7.0"
   },
   "peerDependencies": {
-    "babel-loader": "^7.0.0 || ^8.0.0"
+    "babel-loader": "^7.0.0 || ^8.0.0",
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -87,9 +87,7 @@
     "mock-fs": "^4.7.0"
   },
   "peerDependencies": {
-    "babel-loader": "^7.0.0 || ^8.0.0",
-    "react": ">=16.3.0",
-    "react-dom": ">=16.3.0"
+    "babel-loader": "^7.0.0 || ^8.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -71,7 +71,6 @@
     "redux": "^4.0.1",
     "regenerator-runtime": "^0.12.1",
     "resolve": "^1.8.1",
-    "resolve-cwd": "^2.0.0",
     "semver": "^5.6.0",
     "serve-favicon": "^2.5.0",
     "shelljs": "^0.8.2",

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -3,7 +3,7 @@ import webpack from 'webpack';
 import Dotenv from 'dotenv-webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
-import * as uiPaths from '@storybook/ui/paths';
+import uiPaths from '@storybook/ui/paths';
 
 import findCacheDir from 'find-cache-dir';
 

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -3,6 +3,7 @@ import webpack from 'webpack';
 import Dotenv from 'dotenv-webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
+import * as uiPaths from '@storybook/ui/paths';
 
 import findCacheDir from 'find-cache-dir';
 
@@ -59,8 +60,7 @@ export default ({ configDir, configType, entries, outputDir, cache }) => {
       modules: ['node_modules'].concat(raw.NODE_PATH || []),
       alias: {
         'core-js': path.dirname(require.resolve('core-js/package.json')),
-        react: require.resolve('react'),
-        'react-dom': require.resolve('react-dom'),
+        ...uiPaths,
       },
     },
     recordsPath: path.join(cacheDir, 'records.json'),

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -5,7 +5,6 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import WatchMissingNodeModulesPlugin from 'react-dev-utils/WatchMissingNodeModulesPlugin';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
-import resolveCwd from 'resolve-cwd';
 
 import { includePaths, excludePaths, nodeModulesPaths, loadEnv } from '../config/utils';
 import { getPreviewHeadHtml, getPreviewBodyHtml } from '../utils/template';
@@ -84,10 +83,7 @@ export default ({
       modules: ['node_modules'].concat(raw.NODE_PATH || []),
       mainFields: ['browser', 'main', 'module'],
       alias: {
-        // We want to alias core-js to the version *we* install, but react(-dom) to the version the *user* installed
         'core-js': path.dirname(require.resolve('core-js/package.json')),
-        react: path.dirname(resolveCwd('react/package.json')),
-        'react-dom': path.dirname(resolveCwd('react-dom/package.json')),
       },
     },
     optimization: {

--- a/lib/ui/paths.js
+++ b/lib/ui/paths.js
@@ -1,0 +1,8 @@
+const { dirname } = require('path');
+
+// These paths need to be aliased in the manager webpack config to ensure that all
+// code running inside the manager uses the *same* version of react[-dom] that we use.
+module.exports = {
+  react: dirname(require.resolve('react/package.json')),
+  'react-dom': dirname(require.resolve('react-dom/package.json')),
+};


### PR DESCRIPTION
Issue: 

 - We had an unnecessary direct dependency on react in `@storybook/react` that led to a convoluted solution for aliasing react in the preview context
 - We had an unnecessary peer dependency on react in `@storybook/core` that wasn't guaranteed to resolve properly (for aliasing the manager), instead, we should resolve via asking `@storybook/ui` for it's `react` path

## What I did

Fixed the above

## How to test

Release and test in some apps