### PR TITLE
Update CRA Webpack configuration path

### DIFF
--- a/app/react/src/server/cra-config.js
+++ b/app/react/src/server/cra-config.js
@@ -81,7 +81,14 @@ export const getTypeScriptRules = (webpackConfigRules, configDir) => {
 export function getCraWebpackConfig(mode) {
   const pathToReactScripts = getReactScriptsPath();
 
-  const craWebpackConfig = 'config/webpack.config';
+  let craWebpackConfig = 'config/webpack.config';
+
+  // Needed for backward compatibility.
+  // https://github.com/facebook/create-react-app/pull/5722
+  const isWebpackConfigMerged = isReactScriptsInstalled('2.1.2');
+  if (!isWebpackConfigMerged) {
+    craWebpackConfig += mode === 'production' ? '.prod' : '.dev';
+  }
 
   let pathToWebpackConfig = require.resolve(path.join(pathToReactScripts, craWebpackConfig));
 

--- a/app/react/src/server/cra-config.js
+++ b/app/react/src/server/cra-config.js
@@ -81,8 +81,7 @@ export const getTypeScriptRules = (webpackConfigRules, configDir) => {
 export function getCraWebpackConfig(mode) {
   const pathToReactScripts = getReactScriptsPath();
 
-  const craWebpackConfig =
-    mode === 'production' ? 'config/webpack.config.prod' : 'config/webpack.config.dev';
+  const craWebpackConfig = 'config/webpack.config';
 
   let pathToWebpackConfig = require.resolve(path.join(pathToReactScripts, craWebpackConfig));
 


### PR DESCRIPTION
Issue: #5077

## What I did

I have updated `cra-config.js` to handle the [Webpack configuration merge](https://github.com/facebook/create-react-app/pull/5722) in CRA 2.1.2. This breaks projects running an older version of CRA. Should `cra-kitchen-sink` be updated to reflect this?

Related PR: #5074

## How to test

Run Storybook in a project with version 2.1.2 of `react-scripts` in its dependencies.