### PR TITLE
Load Symbol polyfill before any other code

### DIFF
--- a/lib/core/src/server/common/polyfills.js
+++ b/lib/core/src/server/common/polyfills.js
@@ -1,2 +1,3 @@
 import 'regenerator-runtime/runtime';
 import 'airbnb-js-shims';
+import 'core-js/fn/symbol';


### PR DESCRIPTION
Issue: second part of #5080 (invariant violation)

After introducing `useBuiltIns: usage`, polyfills get injected at the place of the feature usage. This is good most of the times, but breaks something in React and related packages. Basically, the problem is that `Symbol` polyfill is loaded somewhere between loading React and React DOM. So React thinks that symbols aren't supported and uses numbers instead, while React DOM expects symbols because it sees that they're supported (thanks to polyfill)

This PR adds symbol polyfill to the first webpack entry to ensure that it's loaded before all other packages
