### PR TITLE
Fix a11y addon, add ability to change context

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -50,11 +50,13 @@ import { storiesOf } from '@storybook/react';
 
 import { checkA11y, configureA11y } from '@storybook/addon-a11y';
 
-const whateverOptionsYouWant = {
-  axeOptions : {},
-  contextElementId: ''
-};
-configureA11y(whateverOptionsYouWant);
+// axe options
+const whateverOptionsYouWant = {};
+
+// optional element id for axe context 
+const contextElementId = '';
+
+configureA11y(whateverOptionsYouWant, contextElementId);
 
 storiesOf('button', module)
   .addDecorator(checkA11y)

--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -50,7 +50,10 @@ import { storiesOf } from '@storybook/react';
 
 import { checkA11y, configureA11y } from '@storybook/addon-a11y';
 
-const whateverOptionsYouWant = {};
+const whateverOptionsYouWant = {
+  axeOptions : {},
+  contextElementId: ''
+};
 configureA11y(whateverOptionsYouWant);
 
 storiesOf('button', module)

--- a/addons/a11y/src/index.js
+++ b/addons/a11y/src/index.js
@@ -6,22 +6,28 @@ import { logger } from '@storybook/client-logger';
 
 import { CHECK_EVENT_ID, REQUEST_CHECK_EVENT_ID } from './shared';
 
-let axeOptions = {};
+const config = {
+  axeOptions: {},
+  contextElementId: '',
+};
 
 export const configureA11y = (options = {}) => {
-  axeOptions = options;
+  Object.assign(config, options);
 };
 
 const runA11yCheck = () => {
   const channel = addons.getChannel();
-  const infoWrapper = document.getElementById('story-root').children;
-  const wrapper = document.getElementById('root');
+
+  let axeContext = config.contextElementId;
+  if (!axeContext) {
+    const infoWrapper = document.getElementById('story-root');
+    const wrapper = document.getElementById('root');
+    axeContext = (infoWrapper && infoWrapper.children) || wrapper;
+  }
 
   axe.reset();
-  axe.configure(axeOptions);
-  axe
-    .run(infoWrapper || wrapper)
-    .then(results => channel.emit(CHECK_EVENT_ID, results), logger.error);
+  axe.configure(config.axeOptions);
+  axe.run(axeContext).then(results => channel.emit(CHECK_EVENT_ID, results), logger.error);
 };
 
 const a11ySubscription = () => {

--- a/addons/a11y/src/index.js
+++ b/addons/a11y/src/index.js
@@ -11,8 +11,9 @@ const config = {
   contextElementId: '',
 };
 
-export const configureA11y = (options = {}) => {
-  Object.assign(config, options);
+export const configureA11y = (axeOptions = {}, contextElementId = '') => {
+  config.axeOptions = axeOptions;
+  config.contextElementId = contextElementId;
 };
 
 const runA11yCheck = () => {

--- a/addons/a11y/src/index.js
+++ b/addons/a11y/src/index.js
@@ -8,23 +8,25 @@ import { CHECK_EVENT_ID, REQUEST_CHECK_EVENT_ID } from './shared';
 
 const config = {
   axeOptions: {},
-  contextElementId: '',
+  axeContext: '',
 };
 
-export const configureA11y = (axeOptions = {}, contextElementId = '') => {
+export const configureA11y = (axeOptions = {}, axeContext = '') => {
   config.axeOptions = axeOptions;
-  config.contextElementId = contextElementId;
+  config.axeContext = axeContext;
+};
+
+const getDefaultAxeContext = () => {
+  const infoWrapper = document.getElementById('story-root');
+  const wrapper = document.getElementById('root');
+
+  return (infoWrapper && infoWrapper.children) || wrapper;
 };
 
 const runA11yCheck = () => {
   const channel = addons.getChannel();
 
-  let axeContext = config.contextElementId;
-  if (!axeContext) {
-    const infoWrapper = document.getElementById('story-root');
-    const wrapper = document.getElementById('root');
-    axeContext = (infoWrapper && infoWrapper.children) || wrapper;
-  }
+  const axeContext = config.axeContext || getDefaultAxeContext();
 
   axe.reset();
   axe.configure(config.axeOptions);


### PR DESCRIPTION
Issue:#4889

A11y addon requires to have Info addon and also info add-on must have settings 

```
// info addon settings
{
        inline: true, // where the components are inlined
        source: false,
}
``` 

## What I did
So I removed this requirement and also add ability to configure context for a11y checking.