### PR TITLE
Fix #4829: render non-grouped knobs in the ALL tab

### DIFF
--- a/addons/knobs/src/components/Panel.js
+++ b/addons/knobs/src/components/Panel.js
@@ -20,26 +20,9 @@ const PanelWrapper = styled.div({
   width: '100%',
 });
 
-/** @typedef {{[knob: string]: { name: string; defaultValue: unknown; used: boolean; groupId?: string }}} Knobs */
-/**
- * @typedef {Object} Props
- * @prop {boolean} active
- * @prop {object=} onReset
- * @prop {Partial<Record<'emit'|'on'|'removeListener', Function>>} channel
- * @prop {Partial<Record<'onStory'|'getQueryParam'|'setQueryParams', Function>>} api
- */
-/**
- * @typedef {Object} State
- * @prop {Knobs} knobs
- */
-
 export default class Panel extends PureComponent {
-  /**
-   * @param {Props} props
-   */
   constructor(props) {
     super(props);
-    /** @type {State} */
     this.state = {
       knobs: {},
     };
@@ -71,7 +54,6 @@ export default class Panel extends PureComponent {
     this.options = options;
   };
 
-  /** @param {{ knobs: Knobs; timestamp?: number }} param0 */
   setKnobs = ({ knobs, timestamp }) => {
     const queryParams = {};
     const { api, channel } = this.props;
@@ -153,9 +135,7 @@ export default class Panel extends PureComponent {
       return null;
     }
 
-    /** @type {Record<string, { render(props: { active: boolean; selected: string }): JSX.Element|null; title: string }} */
     const groups = {};
-    /** @type {string[]} */
     const groupIds = [];
 
     const knobKeysArray = Object.keys(knobs).filter(key => knobs[key].used);
@@ -163,7 +143,7 @@ export default class Panel extends PureComponent {
     knobKeysArray
       .filter(key => knobs[key].groupId)
       .forEach(key => {
-        const knobKeyGroupId = /** @type {string} */ (knobs[key].groupId);
+        const knobKeyGroupId = knobs[key].groupId;
         groupIds.push(knobKeyGroupId);
         groups[knobKeyGroupId] = {
           render: ({ active: groupActive, selected }) => (

--- a/addons/knobs/src/components/__tests__/Panel.js
+++ b/addons/knobs/src/components/__tests__/Panel.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
+import { TabsState } from '@storybook/components';
 import Panel from '../Panel';
+import PropForm from '../PropForm';
 
 describe('Panel', () => {
   it('should subscribe to setKnobs event of channel', () => {
@@ -142,6 +144,126 @@ describe('Panel', () => {
 
       // const paramsChange = { 'knob-foo': 'changed text' };
       // expect(testApi.setQueryParams).toHaveBeenCalledWith(paramsChange);
+    });
+  });
+
+  describe('groups', () => {
+    /** @type {Required<import('../Panel').Props['channel']>} */
+    const testChannel = {
+      on: jest.fn(),
+      emit: jest.fn(),
+      removeListener: jest.fn(),
+    };
+    /** @type {Required<import('../Panel').Props['api']>} */
+    const testApi = {
+      getQueryParam: jest.fn(),
+      setQueryParams: jest.fn(),
+      onStory: jest.fn(() => () => {}),
+    };
+
+    it('should have no tabs when there are no groupIds', () => {
+      // Unfortunately, a shallow render will not invoke the render() function of the groups --
+      // it thinks they are unnamed function components (what they effectively are anyway).
+      //
+      // We have to do a full mount.
+
+      /** @type {import('enzyme').ShallowWrapper<import('../Panel').Props, import('../Panel').State, Panel>} */
+      const wrapper = mount(<Panel channel={testChannel} api={testApi} active />);
+      try {
+        wrapper.setState({
+          knobs: {
+            foo: {
+              name: 'foo',
+              defaultValue: 'test',
+              used: true,
+              // no groupId
+            },
+          },
+        });
+
+        expect(wrapper.find(TabsState).exists()).toBeFalsy();
+
+        const formWrapper = wrapper.find(PropForm);
+        const knobs = formWrapper.map(formInstanceWrapper => formInstanceWrapper.prop('knobs'));
+        expect(knobs).toMatchSnapshot();
+      } finally {
+        wrapper.unmount();
+      }
+    });
+
+    it('should have one tab per groupId and an empty ALL tab when all are defined', () => {
+      /** @type {import('enzyme').ShallowWrapper<import('../Panel').Props, import('../Panel').State, Panel>} */
+      const wrapper = mount(<Panel channel={testChannel} api={testApi} active />);
+      try {
+        wrapper.setState({
+          knobs: {
+            foo: {
+              name: 'foo',
+              defaultValue: 'test',
+              used: true,
+              groupId: 'foo',
+            },
+            bar: {
+              name: 'bar',
+              defaultValue: 'test2',
+              used: true,
+              groupId: 'bar',
+            },
+          },
+        });
+
+        const titles = wrapper
+          .find(TabsState)
+          // TabsState will replace the <div/> that Panel actually makes with a <Tab/>
+          .find('Tab')
+          .map(child => child.prop('name'));
+        // the "ALL" tab is always defined
+        expect(titles).toEqual(['foo', 'bar', 'ALL']);
+
+        const knobs = wrapper.find(PropForm).map(propForm => propForm.prop('knobs'));
+        // but it should not have its own PropForm in this case
+        expect(knobs).toHaveLength(titles.length - 1);
+        expect(knobs).toMatchSnapshot();
+      } finally {
+        wrapper.unmount();
+      }
+    });
+
+    it('the ALL tab should have its own additional content when there are knobs both with and without a groupId', () => {
+      /** @type {import('enzyme').ShallowWrapper<import('../Panel').Props, import('../Panel').State, Panel>} */
+      const wrapper = mount(<Panel channel={testChannel} api={testApi} active />);
+      try {
+        wrapper.setState({
+          knobs: {
+            foo: {
+              name: 'foo',
+              defaultValue: 'test',
+              used: true,
+              groupId: 'foo',
+            },
+            bar: {
+              name: 'bar',
+              defaultValue: 'test2',
+              used: true,
+              // no groupId
+            },
+          },
+        });
+
+        const titles = wrapper
+          .find(TabsState)
+          // TabsState will replace the <div/> that Panel actually makes with a <Tab/>
+          .find('Tab')
+          .map(child => child.prop('name'));
+        expect(titles).toEqual(['foo', 'ALL']);
+
+        const knobs = wrapper.find(PropForm).map(propForm => propForm.prop('knobs'));
+        // there are props with no groupId so ALL should also have its own PropForm
+        expect(knobs).toHaveLength(titles.length);
+        expect(knobs).toMatchSnapshot();
+      } finally {
+        wrapper.unmount();
+      }
     });
   });
 });

--- a/addons/knobs/src/components/__tests__/Panel.js
+++ b/addons/knobs/src/components/__tests__/Panel.js
@@ -148,13 +148,11 @@ describe('Panel', () => {
   });
 
   describe('groups', () => {
-    /** @type {Required<import('../Panel').Props['channel']>} */
     const testChannel = {
       on: jest.fn(),
       emit: jest.fn(),
       removeListener: jest.fn(),
     };
-    /** @type {Required<import('../Panel').Props['api']>} */
     const testApi = {
       getQueryParam: jest.fn(),
       setQueryParams: jest.fn(),
@@ -167,7 +165,6 @@ describe('Panel', () => {
       //
       // We have to do a full mount.
 
-      /** @type {import('enzyme').ShallowWrapper<import('../Panel').Props, import('../Panel').State, Panel>} */
       const wrapper = mount(<Panel channel={testChannel} api={testApi} active />);
       try {
         wrapper.setState({
@@ -192,7 +189,6 @@ describe('Panel', () => {
     });
 
     it('should have one tab per groupId and an empty ALL tab when all are defined', () => {
-      /** @type {import('enzyme').ShallowWrapper<import('../Panel').Props, import('../Panel').State, Panel>} */
       const wrapper = mount(<Panel channel={testChannel} api={testApi} active />);
       try {
         wrapper.setState({
@@ -230,7 +226,6 @@ describe('Panel', () => {
     });
 
     it('the ALL tab should have its own additional content when there are knobs both with and without a groupId', () => {
-      /** @type {import('enzyme').ShallowWrapper<import('../Panel').Props, import('../Panel').State, Panel>} */
       const wrapper = mount(<Panel channel={testChannel} api={testApi} active />);
       try {
         wrapper.setState({

--- a/addons/knobs/src/components/__tests__/__snapshots__/Panel.js.snap
+++ b/addons/knobs/src/components/__tests__/__snapshots__/Panel.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Panel groups should have no tabs when there are no groupIds 1`] = `
+Array [
+  Array [
+    Object {
+      "defaultValue": "test",
+      "name": "foo",
+      "used": true,
+    },
+  ],
+]
+`;
+
+exports[`Panel groups should have one tab per groupId and an empty ALL tab when all are defined 1`] = `
+Array [
+  Array [
+    Object {
+      "defaultValue": "test",
+      "groupId": "foo",
+      "name": "foo",
+      "used": true,
+    },
+  ],
+  Array [
+    Object {
+      "defaultValue": "test2",
+      "groupId": "bar",
+      "name": "bar",
+      "used": true,
+    },
+  ],
+]
+`;
+
+exports[`Panel groups the ALL tab should have its own additional content when there are knobs both with and without a groupId 1`] = `
+Array [
+  Array [
+    Object {
+      "defaultValue": "test",
+      "groupId": "foo",
+      "name": "foo",
+      "used": true,
+    },
+  ],
+  Array [
+    Object {
+      "defaultValue": "test2",
+      "name": "bar",
+      "used": true,
+    },
+  ],
+]
+`;


### PR DESCRIPTION
Issue: #4829 

## What I did

When there are knobs both with and without a `groupId`, the knobs without a `groupId` were not getting rendered at all.

I made them be rendered as part of the content of the (normally contentless) `ALL` tab.

## How to test

- Is this testable with Jest or Chromatic screenshots?
  - I don't know about screenshots but I wrote Jest tests.
- Does this need an update to the documentation?
  - No, this fixes something that is documented to work but doesn't

---

PS: Oops, I only saw the notice about which branch to use as base after I wrote this. I need this to be in `master` FWIW. What do?