### PR TITLE
bump puppeteer from 1.9.0 to 1.11.0

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -24,7 +24,7 @@
     "@storybook/node-logger": "4.2.0-alpha.8",
     "core-js": "^2.5.7",
     "jest-image-snapshot": "^2.6.0",
-    "puppeteer": "^1.9.0",
+    "puppeteer": "^1.11.0",
     "regenerator-runtime": "^0.12.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16229,9 +16229,10 @@ punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-puppeteer@^1.9.0:
+puppeteer@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
+  integrity sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
Issue:
To be created, but I'll explain here

At GitLab we're having an issue with puppeteer on our CI environment: https://gitlab.com/gitlab-org/csslab/-/jobs/139386734. Puppeteer fails to run the headless instance, updating puppeteer to 1.11.0 and testing locally with a docker image seem to solve the issue.

## What I did

I updated the `package.json` file from addon-storyshots to point to the latest puppeteer version.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
