### PR TITLE
Add a new Community Addon to addon-gallery

### DIFF
--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -164,3 +164,7 @@ JSS theme selection.
 ### [React live edit](https://github.com/vertexbz/storybook-addon-react-live-edit)
 
 Provides live react story editing and preview.
+
+### [copy-code-block](https://www.npmjs.com/package/@pickra/copy-code-block)
+
+Display code and copy it to the clipboard. It also has options to customize colors and syntax highlighting for any language. There is similar functionality via [@storybook/addon-info](https://www.npmjs.com/package/@storybook/addon-info) but addon-info doesn't currently work when using [@storybook/html](https://www.npmjs.com/package/@storybook/html).


### PR DESCRIPTION
Issue: #4832 

## What I did
At @igor-dv's suggestion I added a link and description for a solution to #4832, in the addon-gallery; Community Addon section.
## How to test

- Is this testable with Jest or Chromatic screenshots?
No
- Does this need a new example in the kitchen sink apps?
No
- Does this need an update to the documentation?
Yes, but just the page that I updated.
