### PR TITLE
Storyshots: Fix async issue with obtaining custom Puppeteer instance …

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -148,7 +148,7 @@ initStoryshots({
 
 ### Specifying a custom puppeteer `browser` instance
 
-You might use `customBrowser` to specify a custom instance of a puppeteer `browser` object. This will prevent `storyshots-puppeteer` from creating its own `browser`. It will create and close pages within the `browser`, and it is your responsibility to manage the lifecycle of the `browser` itself.
+You might use the async `getCustomBrowser` function to obtain a custom instance of a puppeteer `browser` object. This will prevent `storyshots-puppeteer` from creating its own `browser`. It will create and close pages within the `browser`, and it is your responsibility to manage the lifecycle of the `browser` itself.
 
 ```js
 import initStoryshots from '@storybook/addon-storyshots';
@@ -156,11 +156,12 @@ import { imageSnapshot } from '@storybook/addon-storyshots-puppeteer';
 import puppeteer from 'puppeteer';
 
 (async function() {
-    const customBrowser = await puppeteer.connect('ws://yourUrl');
-
     initStoryshots({
       suite: 'Image storyshots',
-      test: imageSnapshot({ storybookUrl: 'http://localhost:6006', customBrowser }),
+      test: imageSnapshot({ 
+        storybookUrl: 'http://localhost:6006', 
+        getCustomBrowser: async () => puppeteer.connect('ws://yourUrl')
+      }),
     });
 })();
 ```

--- a/addons/storyshots/storyshots-puppeteer/src/index.js
+++ b/addons/storyshots/storyshots-puppeteer/src/index.js
@@ -19,7 +19,7 @@ const defaultConfig = {
   beforeScreenshot: noop,
   getGotoOptions: noop,
   customizePage: asyncNoop,
-  customBrowser: undefined,
+  getCustomBrowser: undefined,
 };
 
 export const imageSnapshot = (customConfig = {}) => {
@@ -31,15 +31,11 @@ export const imageSnapshot = (customConfig = {}) => {
     beforeScreenshot,
     getGotoOptions,
     customizePage,
-    customBrowser,
+    getCustomBrowser,
   } = { ...defaultConfig, ...customConfig };
 
   let browser; // holds ref to browser. (ie. Chrome)
   let page; // Hold ref to the page to screenshot.
-
-  if (customBrowser) {
-    browser = customBrowser;
-  }
 
   const testFn = async ({ context }) => {
     const { kind, framework, story } = context;
@@ -81,7 +77,7 @@ export const imageSnapshot = (customConfig = {}) => {
   };
 
   testFn.afterAll = () => {
-    if (customBrowser) {
+    if (getCustomBrowser && page) {
       return page.close();
     }
 
@@ -89,7 +85,9 @@ export const imageSnapshot = (customConfig = {}) => {
   };
 
   testFn.beforeAll = async () => {
-    if (!browser) {
+    if (getCustomBrowser) {
+      browser = await getCustomBrowser();
+    } else {
       // add some options "no-sandbox" to make it work properly on some Linux systems as proposed here: https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322851507
       browser = await puppeteer.launch({
         args: ['--no-sandbox ', '--disable-setuid-sandbox'],


### PR DESCRIPTION
…(#5069#)

Issue: The `customBrowser` config option for storyshots-puppeteer doesn't work because Jest doesn't wait for async functions to complete in test files that aren't part of the actual test function. You will get a `Your test suite must contain at least one test.` error because it doesn't find the tests in the current stack.

## What I did
Instead of trying to do the async operation outside of the test function, we can pass the function to `initStoryshots` to later be called inside the `beforeAll` hook, where Jest will happily wait.

I changed `customBrowser` to `getCustomBrowser`, which is an async function that returns the `browser` instance. If that function isn't provided in config, the normal launch behaviour remains.