### PR TITLE
Update @storybook/react to include peer dependency @emotion/core

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -28,6 +28,7 @@
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "@emotion/core": "^0.13.1",
     "@emotion/styled": "^0.10.6",
     "@storybook/core": "4.2.0-alpha.8",
     "@storybook/node-logger": "4.2.0-alpha.8",


### PR DESCRIPTION
Issue:

There is a peer dependency warning for `@storybook/react `

```sh
warning "workspace-aggregator-030746e9-6ca4-4790-94de-2380fecfd341 > my-app > @storybook/react > @emotion/styled > @emotion/styled-base@0.10.6" has unmet peer dependency "@emotion/core@0.x.x".
```

## What I did

Update @storybook/react to include peer dependency @emotion/core

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
