### PR TITLE
Fix links in v5

### DIFF
--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@storybook/addons": "5.0.0-debug.1",
-    "@storybook/components": "5.0.0-debug.1",
     "@storybook/core-events": "5.0.0-debug.1",
     "common-tags": "^1.8.0",
     "core-js": "^2.6.1",

--- a/addons/links/src/react/components/__snapshots__/link.test.js.snap
+++ b/addons/links/src/react/components/__snapshots__/link.test.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LinkTo render should render a link 1`] = `
-<Link
-  cancel={true}
+<a
   href="http://localhost/?id=foo-bar"
   onClick={[Function]}
 />

--- a/addons/links/src/react/components/link.js
+++ b/addons/links/src/react/components/link.js
@@ -64,7 +64,7 @@ export default class LinkTo extends PureComponent {
 LinkTo.defaultProps = {
   kind: null,
   story: null,
-  children: null,
+  children: undefined,
 };
 
 LinkTo.propTypes = {

--- a/addons/links/src/react/components/link.js
+++ b/addons/links/src/react/components/link.js
@@ -1,8 +1,23 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import { Typography } from '@storybook/components';
 import { navigate, hrefTo } from '../../preview';
+
+// FIXME: copied from Typography.Link. Code is duplicated to
+// avoid emotion dependency which breaks React 15.x back-compat
+
+// Cmd/Ctrl/Shift/Alt + Click should trigger default browser behaviour. Same applies to non-left clicks
+const LEFT_BUTTON = 0;
+
+const isPlainLeftClick = e =>
+  e.button === LEFT_BUTTON && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+
+const cancelled = (e, cb = () => {}) => {
+  if (isPlainLeftClick(e)) {
+    e.preventDefault();
+    cb(e);
+  }
+};
 
 export default class LinkTo extends PureComponent {
   state = {
@@ -35,19 +50,25 @@ export default class LinkTo extends PureComponent {
   }
 
   render() {
-    const { kind, story, ...rest } = this.props;
+    const { kind, story, children, ...rest } = this.props;
     const { href } = this.state;
 
-    return <Typography.Link cancel href={href} onClick={this.handleClick} {...rest} />;
+    return (
+      <a href={href} onClick={e => cancelled(e, this.handleClick)} {...rest}>
+        {children}
+      </a>
+    );
   }
 }
 
 LinkTo.defaultProps = {
   kind: null,
   story: null,
+  children: null,
 };
 
 LinkTo.propTypes = {
   kind: PropTypes.string,
   story: PropTypes.string,
+  children: PropTypes.node,
 };

--- a/addons/links/src/react/components/link.test.js
+++ b/addons/links/src/react/components/link.test.js
@@ -30,7 +30,7 @@ describe('LinkTo', () => {
       addons.getChannel.mockReturnValue(channel);
 
       const wrapper = shallow(<LinkTo kind="foo" story="bar" />);
-      wrapper.simulate('click');
+      wrapper.simulate('click', { button: 0, preventDefault: () => {} });
       expect(channel.emit.mock.calls).toContainEqual([
         SELECT_STORY,
         {

--- a/lib/components/src/typography/link/link.js
+++ b/lib/components/src/typography/link/link.js
@@ -20,33 +20,28 @@ const A = styled.a({
 });
 A.propTypes = {
   children: PropTypes.node.isRequired,
-  href: PropTypes.string.isRequired,
+  href: PropTypes.string,
 };
 
-const CancelledLink = ({ children, onClick, ...rest }) => (
-  <A {...rest} onClick={e => cancelled(e, onClick)}>
+const Link = ({ cancel, children, onClick, ...rest }) => (
+  <A {...rest} onClick={cancel ? e => cancelled(e, onClick) : onClick}>
     {children}
   </A>
 );
-CancelledLink.propTypes = {
-  children: PropTypes.node.isRequired,
-  onClick: PropTypes.func,
-};
-CancelledLink.defaultProps = {
-  onClick: () => {},
-};
 
-const Link = ({ cancel, children, ...rest }) =>
-  cancel ? <CancelledLink {...rest}>{children}</CancelledLink> : <A {...rest}>{children}</A>;
 Link.propTypes = {
   cancel: PropTypes.bool,
   className: PropTypes.string,
   style: PropTypes.shape({}),
+  children: PropTypes.node,
+  onClick: PropTypes.func,
 };
 Link.defaultProps = {
   cancel: true,
   className: undefined,
   style: undefined,
+  children: null,
+  onClick: () => {},
 };
 
 export default Link;

--- a/lib/components/src/typography/link/link.test.js
+++ b/lib/components/src/typography/link/link.test.js
@@ -11,17 +11,17 @@ const createEvent = options => ({
   preventDefault: jest.fn(),
   ...options,
 });
-const render = props => shallow(<Link {...{ children: 'Content', ...props }} />);
+const renderLink = props => shallow(<Link {...{ children: 'Content', ...props }} />);
 
 const setup = ({ props, event }) => ({
   e: createEvent(event),
-  result: render(props),
+  result: renderLink(props),
   onClick: props.onClick || jest.fn(),
 });
 
 describe('Link', () => {
   describe('events', () => {
-    test('should call onClick on a plain left click', () => {
+    it('should call onClick on a plain left click', () => {
       const { result, onClick, e } = setup({
         props: { onClick: jest.fn() },
         event: { button: LEFT_BUTTON },
@@ -33,7 +33,7 @@ describe('Link', () => {
       expect(e.preventDefault).toHaveBeenCalled();
     });
 
-    test("shouldn't call onClick on a middle click", () => {
+    it("shouldn't call onClick on a middle click", () => {
       const { result, onClick, e } = setup({
         props: { onClick: jest.fn() },
         event: { button: MIDDLE_BUTTON },
@@ -45,7 +45,7 @@ describe('Link', () => {
       expect(e.preventDefault).not.toHaveBeenCalled();
     });
 
-    test("shouldn't call onClick on a right click", () => {
+    it("shouldn't call onClick on a right click", () => {
       const { result, onClick, e } = setup({
         props: { onClick: jest.fn() },
         event: { button: RIGHT_BUTTON },
@@ -57,7 +57,7 @@ describe('Link', () => {
       expect(e.preventDefault).not.toHaveBeenCalled();
     });
 
-    test("shouldn't call onClick on alt+click", () => {
+    it("shouldn't call onClick on alt+click", () => {
       const { result, onClick, e } = setup({
         props: { onClick: jest.fn() },
         event: { altKey: true },
@@ -69,7 +69,7 @@ describe('Link', () => {
       expect(e.preventDefault).not.toHaveBeenCalled();
     });
 
-    test("shouldn't call onClick on ctrl+click", () => {
+    it("shouldn't call onClick on ctrl+click", () => {
       const { result, onClick, e } = setup({
         props: { onClick: jest.fn() },
         event: { ctrlKey: true },
@@ -81,7 +81,7 @@ describe('Link', () => {
       expect(e.preventDefault).not.toHaveBeenCalled();
     });
 
-    test("shouldn't call onClick on cmd+click / win+click", () => {
+    it("shouldn't call onClick on cmd+click / win+click", () => {
       const { result, onClick, e } = setup({
         props: { onClick: jest.fn() },
         event: { metaKey: true },
@@ -93,7 +93,7 @@ describe('Link', () => {
       expect(e.preventDefault).not.toHaveBeenCalled();
     });
 
-    test("shouldn't call onClick on shift+click", () => {
+    it("shouldn't call onClick on shift+click", () => {
       const { result, onClick, e } = setup({
         props: { onClick: jest.fn() },
         event: { shiftKey: true },


### PR DESCRIPTION
Issue: #5198 #5200 

## What I did

Addon-links was working for me when I tested `official-storybook`, so this PR:
- Fixes broken test cases
- Decouples addon-links from emotion for react back-compat

## How to test

```
yarn jest --testPathPattern link.test.js
cd examples/official-storybook
yarn storybook
```
