### PR TITLE
Add @emotion/core dependency to addon-a11y

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -25,6 +25,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
+    "@emotion/core": "^0.13.1",
     "@emotion/styled": "^0.10.6",
     "@storybook/addons": "4.2.0-alpha.11",
     "@storybook/client-logger": "4.2.0-alpha.11",


### PR DESCRIPTION
## What I did

Fix yarn complaining about a missing peer dependency 

`warning "@storybook/addon-a11y > @emotion/styled > @emotion/styled-base@0.10.6"
has unmet peer dependency "@emotion/core@0.x.x".`

The same sort of problem as #5135 but for a different package.

## How to test

N/A
