### PR TITLE
docs: update html example

### DIFF
--- a/docs/src/pages/basics/guide-html/index.md
+++ b/docs/src/pages/basics/guide-html/index.md
@@ -40,8 +40,7 @@ npm init
 Make sure that you have `babel-runtime`, `babel-core`, and `babel-loader` in your dependencies as well because we list these as a peerDependency:
 
 ```sh
-npm i --save-dev babel-runtime
-npm i --save-dev babel-core
+npm i --save-dev @babel-core
 npm i --save-dev babel-loader
 ```
 


### PR DESCRIPTION
Issue:
The HTML example is out of date, babel has no namespace and `babel-runtime` is not needed to have storybook working

## What I did

Update the docs

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

Thanks for making storybook, it's amazing!

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
