### PR TITLE
Continue to support `{name, kind}` on the `SET_CURRENT_STORY` event

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -88,6 +88,7 @@
     "svg-url-loader": "^2.3.2",
     "terser-webpack-plugin": "^1.2.1",
     "url-loader": "^1.1.2",
+    "util-deprecate": "^1.0.2",
     "webpack": "^4.28.3",
     "webpack-dev-middleware": "^3.4.0",
     "webpack-hot-middleware": "^2.24.3"

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -4,6 +4,7 @@ import createChannel from '@storybook/channel-postmessage';
 import { handleKeyboardShortcuts } from '@storybook/ui/dist/libs/key_events';
 import { logger } from '@storybook/client-logger';
 import Events from '@storybook/core-events';
+import deprecate from 'util-deprecate';
 
 import StoryStore from './story_store';
 import ClientApi from './client_api';
@@ -166,6 +167,11 @@ export default function start(render, { decorateStory } = {}) {
 
   // channel can be null in NodeJS
   if (isBrowser) {
+    const deprecatedToId = deprecate(
+      toId,
+      `Passing name+kind to the SET_CURRENT_STORY event is deprecated, use a storyId instead`
+    );
+
     channel.on(Events.FORCE_RE_RENDER, forceReRender);
     channel.on(Events.SET_CURRENT_STORY, ({ storyId: inputStoryId, name, kind }) => {
       let storyId = inputStoryId;
@@ -174,7 +180,7 @@ export default function start(render, { decorateStory } = {}) {
         if (!name || !kind) {
           throw new Error('You should pass `storyId` into SET_CURRENT_STORY');
         }
-        storyId = toId(kind, name);
+        storyId = deprecatedToId(kind, name);
       }
 
       const data = storyStore.fromId(storyId);

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -174,7 +174,7 @@ export default function start(render, { decorateStory } = {}) {
         if (!name || !kind) {
           throw new Error('You should pass `storyId` into SET_CURRENT_STORY');
         }
-        storyId = toId(name, kind);
+        storyId = toId(kind, name);
       }
 
       const data = storyStore.fromId(storyId);

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -8,6 +8,7 @@ import Events from '@storybook/core-events';
 import StoryStore from './story_store';
 import ClientApi from './client_api';
 import ConfigApi from './config_api';
+import toId from './id';
 
 const classes = {
   MAIN: 'sb-show-main',
@@ -166,10 +167,16 @@ export default function start(render, { decorateStory } = {}) {
   // channel can be null in NodeJS
   if (isBrowser) {
     channel.on(Events.FORCE_RE_RENDER, forceReRender);
-    channel.on(Events.SET_CURRENT_STORY, ({ storyId }) => {
+    channel.on(Events.SET_CURRENT_STORY, ({ storyId: inputStoryId, name, kind }) => {
+      let storyId = inputStoryId;
+      // For backwards compatibility
       if (!storyId) {
-        throw new Error('should have storyId');
+        if (!name || !kind) {
+          throw new Error('You should pass `storyId` into SET_CURRENT_STORY');
+        }
+        storyId = toId(name, kind);
       }
+
       const data = storyStore.fromId(storyId);
 
       storyStore.setSelection(data);


### PR DESCRIPTION
Tools like Chromatic use this to change the story programmatically

Issue: We switched from APIs based on name/kind to storyId.

Although we export `toId` from `@storybook/core` and we can expect callers to use this, for the sake of backwards compatibility, we may as well continue to support the old API, at least until v6
