### PR TITLE
ADD a `no-dll` option to CLI to disable DllReferencePlugin, fix polyfills missing in manager

### DIFF
--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -34,6 +34,7 @@ async function getCLI(packageJson) {
     .option('--smoke-test', 'Exit after successful start')
     .option('--ci', "CI mode (skip interactive prompts, don't open browser")
     .option('--quiet', 'Suppress verbose build output')
+    .option('--no-dll', 'Do not use dll reference')
     .parse(process.argv);
 
   logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}`) + chalk.reset('\n'));

--- a/lib/core/src/server/cli/prod.js
+++ b/lib/core/src/server/cli/prod.js
@@ -13,6 +13,7 @@ function getCLI(packageJson) {
     .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
     .option('-w, --watch', 'Enable watch mode')
     .option('--quiet', 'Suppress verbose build output')
+    .option('--no-dll', 'Do not use dll reference')
     .parse(process.argv);
 
   logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}\n`));

--- a/lib/core/src/server/dev-server.js
+++ b/lib/core/src/server/dev-server.js
@@ -37,6 +37,7 @@ export default async function(options) {
     configDir,
     cache,
     corePresets: [require.resolve('./manager/manager-preset.js')],
+    ...options,
   }).then(
     config =>
       new Promise((resolve, reject) => {

--- a/lib/core/src/server/manager/manager-preset.js
+++ b/lib/core/src/server/manager/manager-preset.js
@@ -7,7 +7,7 @@ export async function managerWebpack(_, options) {
 
 export async function managerEntries(_, options) {
   const { presets } = options;
-  const entries = [];
+  const entries = [require.resolve('../common/polyfills')];
 
   const installedAddons = await presets.apply('addons', [], options);
 

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -12,11 +12,11 @@ import { getManagerHeadHtml } from '../utils/template';
 import { loadEnv } from '../config/utils';
 import babelLoader from '../common/babel-loader';
 
-// const coreDirName = path.dirname(require.resolve('@storybook/core/package.json'));
-// const context = path.join(coreDirName, '../../node_modules');
+const coreDirName = path.dirname(require.resolve('@storybook/core/package.json'));
+const context = path.join(coreDirName, '../../node_modules');
 const cacheDir = findCacheDir({ name: 'storybook' });
 
-export default ({ configDir, configType, entries, outputDir, cache, babelOptions }) => {
+export default ({ configDir, configType, entries, dll, outputDir, cache, babelOptions }) => {
   const { raw, stringified } = loadEnv();
   const isProd = configType === 'PRODUCTION';
 
@@ -33,10 +33,12 @@ export default ({ configDir, configType, entries, outputDir, cache, babelOptions
     },
     cache,
     plugins: [
-      // new webpack.DllReferencePlugin({
-      //   context,
-      //   manifest: path.join(__dirname, '../../../dll/storybook_ui-manifest.json'),
-      // }),
+      dll
+        ? new webpack.DllReferencePlugin({
+            context,
+            manifest: path.join(__dirname, '../../../dll/storybook_ui-manifest.json'),
+          })
+        : null,
       new HtmlWebpackPlugin({
         filename: `index.html`,
         chunksSortMode: 'none',
@@ -47,7 +49,7 @@ export default ({ configDir, configType, entries, outputDir, cache, babelOptions
           files,
           options,
           version,
-          dlls: ['/sb_dll/storybook_ui_dll.js'],
+          dlls: dll ? ['/sb_dll/storybook_ui_dll.js'] : [],
           headHtmlSnippet: getManagerHeadHtml(configDir, process.env),
         }),
         template: require.resolve(`../templates/index.ejs`),
@@ -55,7 +57,7 @@ export default ({ configDir, configType, entries, outputDir, cache, babelOptions
       new webpack.DefinePlugin({ 'process.env': stringified }),
       new CaseSensitivePathsPlugin(),
       new Dotenv({ silent: true }),
-    ],
+    ].filter(Boolean),
     module: {
       rules: [babelLoader(babelOptions)],
     },

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -49,7 +49,7 @@ export default ({ configDir, configType, entries, dll, outputDir, cache, babelOp
           files,
           options,
           version,
-          dlls: dll ? ['/sb_dll/storybook_ui_dll.js'] : [],
+          dlls: dll ? ['./sb_dll/storybook_ui_dll.js'] : [],
           headHtmlSnippet: getManagerHeadHtml(configDir, process.env),
         }),
         template: require.resolve(`../templates/index.ejs`),


### PR DESCRIPTION
Fixes: https://github.com/storybooks/storybook/issues/5055

## What I did
- ADD a `no-dll` option to CLI to disable DllReferencePlugin
- FIX polyfills missing in manager
- DISABLE dll for official example
- ENABLE dll for all other examples

## How to test
run the examples