### PR TITLE
DOCUMENTATION add import for configure to config.js

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -112,6 +112,7 @@ The default `tsconfig.json` that comes with CRA works great. If your stories are
 Change `config.ts` inside the Storybook config directory (by default, it’s `.storybook`) to import stories made with TypeScript:
 
 ```js
+import { configure } from '@storybook/react';
 // automatically import all files ending in *.stories.tsx
 const req = require.context('../stories', true, /.stories.tsx$/);
 


### PR DESCRIPTION
Issue:

TypeScript config.js example was missing the import for `configure`

When I tried to get up and running, it took me a bit of time to realize what I was doing wrong
