### PR TITLE
Fix iframe url params

### DIFF
--- a/lib/components/src/preview/__snapshots__/preview.stories.storyshot
+++ b/lib/components/src/preview/__snapshots__/preview.stories.storyshot
@@ -116,7 +116,6 @@ Array [
       <button
         class="css-1iy95j7"
       >
-        ,
         <svg
           class="css-13o7eu2"
           height="14px"

--- a/lib/components/src/preview/__snapshots__/preview.stories.storyshot
+++ b/lib/components/src/preview/__snapshots__/preview.stories.storyshot
@@ -116,6 +116,7 @@ Array [
       <button
         class="css-1iy95j7"
       >
+        ,
         <svg
           class="css-13o7eu2"
           height="14px"

--- a/lib/components/src/preview/preview.js
+++ b/lib/components/src/preview/preview.js
@@ -130,7 +130,6 @@ class Preview extends Component {
             </IconButton>,
             <Separator key="2" />,
             <IconButton key="opener" onClick={() => window.open(`iframe.html?id=${storyId}`)}>
-              ,
               <Icons icon="share" />
             </IconButton>,
           ]}

--- a/lib/components/src/preview/preview.js
+++ b/lib/components/src/preview/preview.js
@@ -129,7 +129,8 @@ class Preview extends Component {
               <Icons icon={options.isFullscreen ? 'cross' : 'expand'} />
             </IconButton>,
             <Separator key="2" />,
-            <IconButton key="opener" onClick={() => window.open(`iframe.html?path=${path}`)}>
+            <IconButton key="opener" onClick={() => window.open(`iframe.html?id=${storyId}`)}>
+              ,
               <Icons icon="share" />
             </IconButton>,
           ]}

--- a/lib/core/src/client/preview/pathToId.js
+++ b/lib/core/src/client/preview/pathToId.js
@@ -1,0 +1,7 @@
+export default function pathToId(path) {
+  const match = (path || '').match(/^\/components\/(.+)/);
+  if (!match) {
+    throw new Error(`Invalid path '${path}',  must start with '/components/'`);
+  }
+  return match[1];
+}

--- a/lib/core/src/client/preview/pathToid.test.js
+++ b/lib/core/src/client/preview/pathToid.test.js
@@ -1,0 +1,15 @@
+import pathToId from './pathToId';
+
+describe('pathToId', () => {
+  describe('pathToId', () => {
+    it('errors on invalid path', () => {
+      expect(() => pathToId('/something/random')).toThrow(/Invalid/);
+    });
+    it('errors empty path', () => {
+      expect(() => pathToId(null)).toThrow(/Invalid/);
+    });
+    it('succeeds on a valid path', () => {
+      expect(pathToId('/components/some--id')).toBe('some--id');
+    });
+  });
+});

--- a/lib/core/src/client/preview/story_store.js
+++ b/lib/core/src/client/preview/story_store.js
@@ -6,6 +6,8 @@ import Events from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 import debounce from 'lodash.debounce';
 import { stripIndents } from 'common-tags';
+import toId from './id';
+import pathToId from './pathToId';
 
 // TODO: these are copies from components/nav/lib
 // refactor to DRY
@@ -44,6 +46,9 @@ const toExtracted = obj =>
     return Object.assign(acc, { [key]: value });
   }, {});
 
+const getIdFromLegacyQuery = ({ path, selectedKind, selectedStory }) =>
+  (path && pathToId(path)) || (selectedKind && selectedStory && toId(selectedKind, selectedStory));
+
 export default class StoryStore extends EventEmitter {
   constructor({ channel }) {
     super();
@@ -55,7 +60,15 @@ export default class StoryStore extends EventEmitter {
     this._channel = channel;
 
     this.on(Events.STORY_INIT, () => {
-      this.setSelection(this.fromId(this.getIdOnPath()));
+      let storyId = this.getIdOnPath();
+      if (!storyId) {
+        const params = qs.parse(document.location.search, { ignoreQueryPrefix: true });
+        storyId = getIdFromLegacyQuery(params);
+        if (storyId) {
+          this.setPath(storyId);
+        }
+      }
+      this.setSelection(this.fromId(storyId));
     });
   }
 


### PR DESCRIPTION
Issue: #5263 

## What I did
- updated preview button to link to id rather than path
- updated iframe.html to support both path and selectedStory/Kind params

## How to test

See #5263 for repro. Testing:

1. Undo the `preview.js` change
2. Click on the iframe opener, it should redirect to `id=...`
3. Manually navigate to a `iframe.html&selectedKind=xxx&selectedStory=yyy` legacy URL
4. It should redirect to `id=...`
5. Redo the `preview.js` change and undo the `story_store.js` change
6. Click on the iframe opener and see that it takes you to the `id=...` URL

Also there are unit tests for the `pathToId` helper (which probably belongs in the new router package)
