### PR TITLE
ADD special entry-points for vue and react for addon-centered.

### DIFF
--- a/addons/centered/README.md
+++ b/addons/centered/README.md
@@ -10,15 +10,13 @@ Storybook Centered Decorator can be used to center components inside the preview
 yarn add @storybook/addon-centered --dev
 ```
 
-#### As a decorator
-
 You can set the decorator locally.
 
 example for React:
 
 ```js
 import { storiesOf } from '@storybook/react';
-import centered from '@storybook/addon-centered';
+import centered from '@storybook/addon-centered/react';
 
 import MyComponent from '../Component';
 
@@ -32,7 +30,7 @@ example for Vue:
 
 ```js
 import { storiesOf } from '@storybook/vue';
-import centered from '@storybook/addon-centered';
+import centered from '@storybook/addon-centered/vue';
 
 import MyComponent from '../Component.vue';
 storiesOf('MyComponent', module)
@@ -101,8 +99,9 @@ storiesOf('MyComponent', module)
 example for Angular with component:
 
 ```ts
-import { centered } from '@storybook/addon-centered/angular';
 import { storiesOf } from '@storybook/angular';
+import { centered } from '@storybook/addon-centered/angular';
+
 import { AppComponent } from '../app/app.component';
 
 storiesOf('Addon|Centered', module)
@@ -117,8 +116,9 @@ storiesOf('Addon|Centered', module)
 example for Angular with template:
 
 ```ts
-import { centered } from '@storybook/addon-centered/angular';
 import { moduleMetadata, storiesOf } from '@storybook/angular';
+import { centered } from '@storybook/addon-centered/angular';
+
 import { AppComponent } from '../app/app.component';
 
 storiesOf('Addon|Centered', module)
@@ -148,7 +148,7 @@ example for React:
 
 ```js
 import { configure, addDecorator } from '@storybook/react';
-import centered from '@storybook/addon-centered';
+import centered from '@storybook/addon-centered/react';
 
 addDecorator(centered);
 
@@ -161,7 +161,7 @@ example for Vue:
 
 ```js
 import { configure, addDecorator } from '@storybook/vue';
-import centered from '@storybook/addon-centered';
+import centered from '@storybook/addon-centered/vue';
 
 addDecorator(centered);
 
@@ -194,36 +194,4 @@ addDecorator(centered);
 configure(function () {
   //...
 }, module);
-```
-
-#### As an extension
-
-##### 1 - Configure the extension
-
-```js
-import { configure, setAddon } from '@storybook/react';
-import centered from '@storybook/addon-centered';
-
-setAddon({
-  addCentered(storyName, storyFn) {
-    this.add(storyName, (context) => (
-      centered.call(context, storyFn)
-    ));
-  },
-});
-
-configure(function () {
-  //...
-}, module);
-```
-
-##### 2 - Use it in your story
-
-```js
-import { storiesOf } from '@storybook/react';
-
-import Component from '../Component';
-
-storiesOf('Component', module)
-  .addCentered('without props', () => (<Component />))
 ```

--- a/addons/centered/package.json
+++ b/addons/centered/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "core-js": "^2.6.2",
-    "global": "^4.3.2"
+    "global": "^4.3.2",
+    "util-deprecate": "^1.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/centered/react.js
+++ b/addons/centered/react.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/react');

--- a/addons/centered/src/index.js
+++ b/addons/centered/src/index.js
@@ -4,6 +4,8 @@ import deprecate from 'util-deprecate';
 import ReactCentered from './react';
 import VueCentered from './vue';
 
+// TODO: REMOVE this entire file in V6.0.0
+
 const Centered = deprecate(
   () => (window.STORYBOOK_ENV === 'vue' ? VueCentered : ReactCentered),
   `

--- a/addons/centered/src/index.js
+++ b/addons/centered/src/index.js
@@ -1,8 +1,20 @@
 import { window } from 'global';
+import deprecate from 'util-deprecate';
+
 import ReactCentered from './react';
 import VueCentered from './vue';
 
-const Centered = window.STORYBOOK_ENV === 'vue' ? VueCentered : ReactCentered;
+const Centered = deprecate(
+  () => (window.STORYBOOK_ENV === 'vue' ? VueCentered : ReactCentered),
+  `
+  Using "import centered from '@storybook/addon-centered'" is deprecated.
+  Please use either:
+  "import centered from '@storybook/addon-centered/react'"
+  or
+  "import centered from '@storybook/addon-centered/vue'"
+`
+)();
+
 export default Centered;
 
 if (module && module.hot && module.hot.decline) {

--- a/addons/centered/vue.js
+++ b/addons/centered/vue.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/vue');

--- a/examples/cra-kitchen-sink/src/stories/long-description.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/long-description.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import centered from '@storybook/addon-centered';
+import centered from '@storybook/addon-centered/react';
 import { Button } from '@storybook/react/demo';
 
 storiesOf('Some really long story kind description', module)

--- a/examples/official-storybook/stories/addon-centered.stories.js
+++ b/examples/official-storybook/stories/addon-centered.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import centered from '@storybook/addon-centered';
+import centered from '@storybook/addon-centered/react';
 
 import BaseButton from '../components/BaseButton';
 

--- a/examples/vue-kitchen-sink/src/stories/addon-centered.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/addon-centered.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import Centered from '@storybook/addon-centered';
+import Centered from '@storybook/addon-centered/vue';
 
 import MyButton from './Button.vue';
 


### PR DESCRIPTION
Related issue: https://github.com/storybooks/storybook/issues/5292

Vue & React had some special case for addon-centered.

This was because when adding in vue support we didn't really think much about it, and just shoe-horned it in.

Later we realised we need a separate entry point for each framework so the bundle doesn't get blow up.

This PR makes it equal for all frameworks.

The old method still works but is deprecated. Should be removed after V6.