### PR TITLE
Migrate addon google analytics to TS

### DIFF
--- a/addons/google-analytics/package.json
+++ b/addons/google-analytics/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/storybooks/storybook.git"
   },
   "license": "MIT",
-  "jsnext:main": "src/index.js",
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"
   },

--- a/addons/google-analytics/src/register.ts
+++ b/addons/google-analytics/src/register.ts
@@ -1,5 +1,5 @@
 import { window } from 'global';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { STORY_CHANGED, STORY_ERRORED, STORY_MISSING } from '@storybook/core-events';
 
 import ReactGA from 'react-ga';
@@ -11,13 +11,13 @@ addons.register('storybook/google-analytics', api => {
     const { url } = api.getUrlState();
     ReactGA.pageview(url);
   });
-  api.on(STORY_ERRORED, ({ description }) => {
+  api.on(STORY_ERRORED, ({ description }: { description: string }) => {
     ReactGA.exception({
       description,
       fatal: true,
     });
   });
-  api.on(STORY_MISSING, ({ id }) => {
+  api.on(STORY_MISSING, ({ id }: { id: string }) => {
     ReactGA.exception({
       description: `attempted to render ${id}, but it is missing`,
       fatal: false,

--- a/addons/google-analytics/src/typings.d.ts
+++ b/addons/google-analytics/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'global';

--- a/addons/google-analytics/tsconfig.json
+++ b/addons/google-analytics/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "types": ["webpack-env"]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/__tests__/**/*"
+  ]
+}


### PR DESCRIPTION
Issue:

https://github.com/storybooks/storybook/issues/5030

(@kroeder I have preferred to start with a super simple addon)

## What I did

Migrated `@storybook/addon-google-analytics` to TypeScript. 

