### PR TITLE
Fix knobs story so array type is array

### DIFF
--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -197,15 +197,16 @@ storiesOf('Addons|Knobs.withKnobs', module)
         number: 1,
         string: 'string',
         object: {},
-        array: [],
+        array: [1, 2, 3],
         function: () => {},
       },
       'string'
     );
     const value = m.toString();
+    const type = Array.isArray(m) ? 'array' : typeof m;
     return (
       <pre>
-        the type of {JSON.stringify(value, null, 2)} = {typeof m}
+        the type of {JSON.stringify(value, null, 2)} = {type}
       </pre>
     );
   })


### PR DESCRIPTION
Issue: N/A

## What I did

Current story makes it look like knobs is not working properly (typeof [] => `object`).
Improved the story to make the results more legible.

## How to test

```
yarn bootstrap --core
cd examples/official-storybook
yarn storybook
```

Or check out the preview online (linked below?)