### PR TITLE
ADD a STORY_UNCHANGED event

### DIFF
--- a/lib/core-events/src/index.ts
+++ b/lib/core-events/src/index.ts
@@ -8,6 +8,7 @@ enum events {
   APPLY_SHORTCUT = 'applyShortcut',
   STORY_ADDED = 'storyAdded',
   STORY_CHANGED = 'storyChanged',
+  STORY_UNCHANGED = 'storyUnchanged',
   FORCE_RE_RENDER = 'forceReRender',
   REGISTER_SUBSCRIPTION = 'registerSubscription',
   STORY_INIT = 'storyInit',

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -123,6 +123,7 @@ export default function start(render, { decorateStory } = {}) {
         kind === previousKind &&
         previousStory === name
       ) {
+        addons.getChannel().emit(Events.STORY_UNCHANGED, id);
         return;
       }
 


### PR DESCRIPTION
Emit when the STORY_RENDER event is received but nothing has changed, so we aren't re-rendering.

This helps tools like Chromatic detect with certainty when a story has finished rendering