### PR TITLE
Fix typo in install instructions for @storybook/html

### DIFF
--- a/docs/src/pages/basics/guide-html/index.md
+++ b/docs/src/pages/basics/guide-html/index.md
@@ -40,7 +40,7 @@ npm init
 Make sure that you have `@babel/core`, and `babel-loader` in your dependencies as well because we list these as a peerDependency:
 
 ```sh
-npm i --save-dev @babel-core
+npm i --save-dev @babel/core
 npm i --save-dev babel-loader
 ```
 


### PR DESCRIPTION
Issue:

## What I did

There is a small typo in the install instructions for HTML: https://storybook.js.org/basics/guide-html/

## How to test

Update documentation

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
