### PR TITLE
FIX blurring an empty field restores default

### DIFF
--- a/lib/ui/src/settings/shortcuts.js
+++ b/lib/ui/src/settings/shortcuts.js
@@ -101,16 +101,15 @@ class ShortcutsScreen extends Component {
 
     this.setState({
       activeFeature: focusedInput,
-      shortcutKeys: { ...shortcutKeys, [focusedInput]: { shortcut: null, error: false } },
+      shortcutKeys: { ...shortcutKeys, [focusedInput]: { shortcut: [], error: false } },
     });
   };
 
-  onBlur = async () => {
+  onBlur = () => {
     const { shortcutKeys, activeFeature } = this.state;
-
     if (shortcutKeys[activeFeature]) {
       const { shortcut, error } = shortcutKeys[activeFeature];
-      if (!shortcut || error) {
+      if (!shortcut.length || error) {
         return this.restoreDefault();
       }
       return this.saveShortcut();


### PR DESCRIPTION
Issue:
Focusing an element nullifies input but it is never restored when tabbing out of element
## What I did
- restore teh default shortcut if shortcut field is empty on blur
## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
