### PR TITLE
Fix issue where "Tab" => [].

### DIFF
--- a/lib/ui/src/libs/shortcut.test.ts
+++ b/lib/ui/src/libs/shortcut.test.ts
@@ -21,7 +21,11 @@ describe('eventToShortcut', () => {
   });
   test('it handles enter key inputs', () => {
     const output = eventToShortcut(ev({ key: 'Enter' }));
-    expect(output).toEqual([]);
+    expect(output).toEqual(null);
+  });
+  test('it handles tab key inputs', () => {
+    const output = eventToShortcut(ev({ key: 'Tab' }));
+    expect(output).toEqual(null);
   });
   test('it handles space bar inputs', () => {
     const output = eventToShortcut(ev({ key: ' ' }));

--- a/lib/ui/src/libs/shortcut.ts
+++ b/lib/ui/src/libs/shortcut.ts
@@ -54,7 +54,7 @@ export const eventToShortcut = (e: KeyboardEvent): Shortcut | null => {
     keys.push('ArrowLeft');
   }
 
-  return keys;
+  return keys.length > 0 ? keys : null;
 };
 
 export const shortcutMatchesShortcut = (inputShortcut: Shortcut, shortcut: Shortcut): boolean => {


### PR DESCRIPTION
Invalid shortcuts should map to null.

Issue: Tabbing away from shortcuts set them to empty (https://github.com/storybooks/storybook/pull/5373)