### PR TITLE
FIX keybindings were pointing to null events

### DIFF
--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -200,9 +200,9 @@ export default function start(render, { decorateStory } = {}) {
     window.onkeydown = event => {
       if (!focusInInput(event)) {
         // We have to pick off the keys of the event that we need on the other side
-        const { altKey, ctrlKey, metaKey, shiftKey, key } = event;
+        const { altKey, ctrlKey, metaKey, shiftKey, key, code, keyCode } = event;
         channel.emit(Events.PREVIEW_KEYDOWN, {
-          event: { altKey, ctrlKey, metaKey, shiftKey, key },
+          event: { altKey, ctrlKey, metaKey, shiftKey, key, code, keyCode },
         });
       }
     };

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -49,7 +49,7 @@ const createMenu = memoize(1)(
       id: 'A',
       title: 'Toggle Navigation',
       action: () => api.toggleNav(),
-      detail: shortcutToHumanString(shortcutKeys.navigation),
+      detail: shortcutToHumanString(shortcutKeys.toggleNav),
       icon: showNav ? 'check' : '',
     },
     {

--- a/lib/ui/src/core/shortcuts.js
+++ b/lib/ui/src/core/shortcuts.js
@@ -11,7 +11,7 @@ export const defaultShortcuts = Object.freeze({
   fullScreen: ['F'],
   togglePanel: ['S'], // Panel visibiliy
   panelPosition: ['D'],
-  navigation: ['A'],
+  toggleNav: ['A'],
   toolbar: ['T'],
   search: ['/'],
   focusNav: ['1'],
@@ -94,7 +94,7 @@ export default function initShortcuts({ store }) {
           break;
         }
 
-        case 'focusSearch': {
+        case 'search': {
           if (isFullscreen) {
             fullApi.toggleFullscreen();
           }
@@ -181,7 +181,7 @@ export default function initShortcuts({ store }) {
           break;
         }
 
-        case 'toggleToolbar': {
+        case 'toolbar': {
           fullApi.toggleToolbar();
           break;
         }

--- a/lib/ui/src/settings/shortcuts.js
+++ b/lib/ui/src/settings/shortcuts.js
@@ -31,7 +31,7 @@ const shortcutLabels = {
   fullScreen: 'Go full screen',
   togglePanel: 'Toggle panel',
   panelPosition: 'Toggle panel position',
-  navigation: 'Toggle navigation',
+  toggleNav: 'Toggle navigation',
   toolbar: 'Toggle toolbar',
   search: 'Focus search',
   focusNav: 'Focus navigation',

--- a/lib/ui/src/settings/shortcuts.test.js
+++ b/lib/ui/src/settings/shortcuts.test.js
@@ -6,7 +6,7 @@ import ShortcutsScreen from './shortcuts';
 const shortcutKeys = {
   fullScreen: ['F'],
   togglePanel: ['S'],
-  navigation: ['A'],
+  toggleNav: ['A'],
   toolbar: ['T'],
   search: ['/'],
   focusNav: ['1'],


### PR DESCRIPTION
Issue:

## What I did
Some of the storybook keybindings were mapped to mistyped shortcuts, I fixed the incorrect mapping and also passed additonal keyboard event properties in the event object that I will need.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
