### PR TITLE
Add missing `register.js` file in GA addon base directory

### DIFF
--- a/addons/google-analytics/register.js
+++ b/addons/google-analytics/register.js
@@ -1,0 +1,1 @@
+require('./dist/register.js');


### PR DESCRIPTION
## What I did

Add missing `register.js` file in addon-google-analytics base directory.

This file is missing since addon beginning and is needed to be able to make import as describe in README work:

```js
import '@storybook/addon-google-analytics/register';
```

--

For now only `import '@storybook/addon-google-analytics/dist/register';` is working.
