### PR TITLE
FIX the layout issue where panels still sort-of appear on non story viewmodes

### DIFF
--- a/lib/ui/src/components/layout/container.js
+++ b/lib/ui/src/components/layout/container.js
@@ -383,7 +383,7 @@ class Layout extends Component {
 
     const margin = theme.layoutMargin;
     const isNavHidden = options.isFullscreen || !options.showNav;
-    const isPanelHidden = options.isFullscreen || !options.showPanel || !viewMode;
+    const isPanelHidden = options.isFullscreen || !options.showPanel || viewMode !== 'story';
     const isFullscreen = options.isFullscreen || (isNavHidden && isPanelHidden);
     const { isToolshown } = options;
 


### PR DESCRIPTION
Desktop layout had panels still semi-showing when in info viewmode