### PR TITLE
Added property name into form fields on addon knobs

### DIFF
--- a/addons/knobs/src/components/types/Array.js
+++ b/addons/knobs/src/components/types/Array.js
@@ -29,7 +29,15 @@ class ArrayType extends React.Component {
     const { knob } = this.props;
     const value = knob.value.join(knob.separator);
 
-    return <Form.Textarea id={knob.name} value={value} onChange={this.handleChange} size="flex" />;
+    return (
+      <Form.Textarea
+        id={knob.name}
+        name={knob.name}
+        value={value}
+        onChange={this.handleChange}
+        size="flex"
+      />
+    );
   }
 }
 

--- a/addons/knobs/src/components/types/Boolean.js
+++ b/addons/knobs/src/components/types/Boolean.js
@@ -17,6 +17,7 @@ const Input = styled.input({
 const BooleanType = ({ knob, onChange }) => (
   <Input
     id={knob.name}
+    name={knob.name}
     type="checkbox"
     onChange={e => onChange(e.target.checked)}
     checked={knob.value}

--- a/addons/knobs/src/components/types/Button.js
+++ b/addons/knobs/src/components/types/Button.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { Form } from '@storybook/components';
 
 const ButtonType = ({ knob, onClick }) => (
-  <Form.Button type="button" onClick={() => onClick(knob)}>
+  <Form.Button type="button" name={knob.name} onClick={() => onClick(knob)}>
     {knob.name}
   </Form.Button>
 );

--- a/addons/knobs/src/components/types/Color.js
+++ b/addons/knobs/src/components/types/Color.js
@@ -74,7 +74,7 @@ class ColorType extends React.Component {
     };
 
     return (
-      <Button type="button" onClick={this.handleClick} size="flex">
+      <Button type="button" name={knob.name} onClick={this.handleClick} size="flex">
         {knob.value}
         <Swatch style={colorStyle} />
         {displayColorPicker ? (

--- a/addons/knobs/src/components/types/Date.js
+++ b/addons/knobs/src/components/types/Date.js
@@ -104,11 +104,13 @@ class DateType extends Component {
             this.dateInput = el;
           }}
           id={`${name}date`}
+          name={`${name}date`}
           onChange={this.onDateChange}
         />
         <FlexInput
           type="time"
           id={`${name}time`}
+          name={`${name}time`}
           ref={el => {
             this.timeInput = el;
           }}

--- a/addons/knobs/src/components/types/Files.js
+++ b/addons/knobs/src/components/types/Files.js
@@ -20,6 +20,7 @@ function fileReaderPromise(file) {
 const FilesType = ({ knob, onChange }) => (
   <FileInput
     type="file"
+    name={knob.name}
     multiple
     onChange={e => Promise.all(Array.from(e.target.files).map(fileReaderPromise)).then(onChange)}
     accept={knob.accept}

--- a/addons/knobs/src/components/types/Number.js
+++ b/addons/knobs/src/components/types/Number.js
@@ -61,6 +61,7 @@ class NumberType extends React.Component {
         <RangeInput
           value={knob.value}
           type="range"
+          name={knob.name}
           min={knob.min}
           max={knob.max}
           step={knob.step}
@@ -72,6 +73,7 @@ class NumberType extends React.Component {
       <Form.Input
         value={knob.value}
         type="number"
+        name={knob.name}
         min={knob.min}
         max={knob.max}
         step={knob.step}

--- a/addons/knobs/src/components/types/Object.js
+++ b/addons/knobs/src/components/types/Object.js
@@ -45,9 +45,11 @@ class ObjectType extends Component {
 
   render() {
     const { value, failed } = this.state;
+    const { knob } = this.props;
 
     return (
       <Form.Textarea
+        name={knob.name}
         valid={failed ? 'error' : null}
         value={value}
         onChange={this.handleChange}

--- a/addons/knobs/src/components/types/Select.js
+++ b/addons/knobs/src/components/types/Select.js
@@ -14,6 +14,7 @@ const SelectType = ({ knob, onChange }) => {
   return (
     <Form.Select
       value={selectedKey}
+      name={knob.name}
       onChange={e => {
         onChange(entries[e.target.value]);
       }}

--- a/addons/knobs/src/components/types/Text.js
+++ b/addons/knobs/src/components/types/Text.js
@@ -21,7 +21,13 @@ class TextType extends React.Component {
     const { knob } = this.props;
 
     return (
-      <Form.Textarea id={knob.name} value={knob.value} onChange={this.handleChange} size="flex" />
+      <Form.Textarea
+        id={knob.name}
+        name={knob.name}
+        value={knob.value}
+        onChange={this.handleChange}
+        size="flex"
+      />
     );
   }
 }


### PR DESCRIPTION
## What I did
Added HTML attribute `name` to form fields into addon knobs. 

The value that is going to be set as the name it's the same defined in the knob name.

The motivation for this work is to allow access to the element directly throught `form.elements` in JS.

e.g.:
```js
let form = document.querySelector("form");
let guestName = form.elements.guest;
let hatSize = form.elements["hat-size"];
```
## How to test
- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
