### PR TITLE
Workaround the dev cli -h shorthand conflict

### DIFF
--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -37,6 +37,15 @@ async function getCLI(packageJson) {
     .option('--no-dll', 'Do not use dll reference')
     .parse(process.argv);
 
+  // Workaround the `-h` shorthand conflict.
+  // Output the help if `-h` is called without any value.
+  // See storybooks/storybook#5360
+  program.on('option:host', value => {
+    if (!value) {
+      program.help();
+    }
+  });
+
   logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}`) + chalk.reset('\n'));
 
   // The key is the field created in `program` variable for


### PR DESCRIPTION
Issue: 

It fixes storybooks/storybook#5360

## What I did

A little workaround so that both `-h` shorthands behave in a more expected manner. 

## How to test

- Is this testable with Jest or Chromatic screenshots? Nope
- Does this need a new example in the kitchen sink apps? Nope
- Does this need an update to the documentation? Nope

