### PR TITLE
dependencies: update lit-html to 1.0.0

### DIFF
--- a/app/polymer/package.json
+++ b/app/polymer/package.json
@@ -35,12 +35,12 @@
     "webpack": "^4.29.0"
   },
   "devDependencies": {
-    "lit-html": "^0.14.0",
+    "lit-html": "^1.0.0",
     "polymer-webpack-loader": "^2.0.3"
   },
   "peerDependencies": {
     "babel-loader": "^7.0.0 || ^8.0.0",
-    "lit-html": "0.10.0",
+    "lit-html": "^1.0.0",
     "polymer-webpack-loader": "^2.0.2"
   },
   "publishConfig": {

--- a/examples/polymer-cli/package.json
+++ b/examples/polymer-cli/package.json
@@ -20,7 +20,7 @@
     "@storybook/polymer": "5.0.0-beta.1",
     "@webcomponents/webcomponentsjs": "^1.2.0",
     "global": "^4.3.2",
-    "lit-html": "^0.14.0",
+    "lit-html": "^1.0.0",
     "polymer-webpack-loader": "^2.0.3",
     "webpack": "^4.29.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12959,9 +12959,10 @@ listr@^0.14.2:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-lit-html@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-0.14.0.tgz#d6830e8f55fb923b0f5824decf7da082a1d22997"
+lit-html@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.0.0.tgz#3dc3781a8ca68a9b5c2ff2a61e263662b9b2267b"
+  integrity sha512-oeWlpLmBW3gFl7979Wol2LKITpmKTUFNn7PnFbh6YNynF61W74l6x5WhwItAwPRSATpexaX1egNnRzlN4GOtfQ==
 
 livereload-js@^2.3.0:
   version "2.4.0"


### PR DESCRIPTION
Issue: Prerequisite for #4958

## What I did
I have updated lit-html dependency to 1.0.0

## How to test

- Is this testable with Jest or Chromatic screenshots? **No tests needed**
- Does this need a new example in the kitchen sink apps? **Existing examples are valid**
- Does this need an update to the documentation? **Maybe changelog entry?**