### PR TITLE
[docs] Fix syntax of `makeDecorator` example.

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -141,7 +141,7 @@ The `@storybook/addons` package contains a `makeDecorator` function which we can
 import React from 'react';
 import addons, { makeDecorator } from '@storybook/addons';
 
-export withFoo = makeDecorator({
+export default makeDecorator({
   name: 'withFoo',
   parameterName: 'foo',
   // This means don't run this decorator if the notes decorator is not set


### PR DESCRIPTION
Issue:

makeDecorator example code for creating a new addon is not valid to copy + paste.

Line 101: ```export withNotes = makeDecorator({``` should either be ```export default makeDecorator({``` or ```const withNotes = makeDecorator({``` with a further ```export default withNotes;``` line after line 115, to be valid example for copy + paste.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
