### PR TITLE
Fix type of function `makeDecorator` from `lib/addons`

### DIFF
--- a/addons/cssresources/src/index.ts
+++ b/addons/cssresources/src/index.ts
@@ -67,7 +67,7 @@ export const withCssResources = makeDecorator({
   skipIfNoParametersOrOptions: true,
   allowDeprecatedUsage: false,
 
-  wrapper: (getStory: any, context: any, { options, parameters }: any) => {
+  wrapper: (getStory, context, { options, parameters }) => {
     const storyOptions = parameters || options;
     addons.getChannel().on(EVENTS.SET, setResources);
 

--- a/lib/addons/src/make-decorator.ts
+++ b/lib/addons/src/make-decorator.ts
@@ -26,18 +26,18 @@ type MakeDecoratorResult = (...args: any) => any;
 interface MakeDecoratorOptions {
   name: string;
   parameterName: string;
-  allowDeprecatedUsage: boolean;
-  skipIfNoParametersOrOptions: boolean;
+  allowDeprecatedUsage?: boolean;
+  skipIfNoParametersOrOptions?: boolean;
   wrapper: StoryWrapper;
 }
 
-export const makeDecorator: MakeDecoratorResult = ({
+export const makeDecorator = ({
   name,
   parameterName,
   wrapper,
   skipIfNoParametersOrOptions = false,
   allowDeprecatedUsage = false,
-}: MakeDecoratorOptions) => {
+}: MakeDecoratorOptions): MakeDecoratorResult => {
   const decorator: any = (options: object) => (getStory: StoryGetter, context: StoryContext) => {
     const parameters = context.parameters && context.parameters[parameterName];
 


### PR DESCRIPTION
## What I did

Fix type of function `makeDecorator` from `lib/addons`.

`MakeDecoratorResult` is type of object returned by `makeDecorator` and not `makeDecorator` itself.
This fix also helps a lot in addons TS migration because correct types are now inferred 😃.

Also remove some `any` typings linked to `makeDecorator` in `addon/cssresources`