### PR TITLE
ADD a puppeteer test for integration purposes on the cra-kitchen-sink example

### DIFF
--- a/.ci/integration/Dockerfile
+++ b/.ci/integration/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:10
+
+LABEL "com.github.actions.name"="Integration"
+LABEL "com.github.actions.description"="Run an storybook example and assert it's working with puppeteer"
+LABEL "com.github.actions.icon"="mic"
+LABEL "com.github.actions.color"="purple"
+
+LABEL "repository"="http://github.com/storybooks/storybook"
+LABEL "homepage"="http://github.com/storybooks/storybook"
+LABEL "maintainer"="Norbert de Langen <ndelangen@me.com>"
+
+RUN yarn add global puppeteer
+
+RUN yarn install
+RUN yarn bootstrap --core
+
+ENTRYPOINT ["node", "./scripts/integration.js"]

--- a/.ci/integration/Dockerfile
+++ b/.ci/integration/Dockerfile
@@ -8,6 +8,7 @@ LABEL "com.github.actions.color"="purple"
 LABEL "repository"="http://github.com/storybooks/storybook"
 LABEL "homepage"="http://github.com/storybooks/storybook"
 LABEL "maintainer"="Norbert de Langen <ndelangen@me.com>"
-RUN find ./ -type f
+RUN ls -al
+RUN du -sch *
 
 ENTRYPOINT ["node", "./scripts/integration.js"]

--- a/.ci/integration/Dockerfile
+++ b/.ci/integration/Dockerfile
@@ -8,6 +8,6 @@ LABEL "com.github.actions.color"="purple"
 LABEL "repository"="http://github.com/storybooks/storybook"
 LABEL "homepage"="http://github.com/storybooks/storybook"
 LABEL "maintainer"="Norbert de Langen <ndelangen@me.com>"
-RUN ls -al
+RUN find ./ -type f
 
 ENTRYPOINT ["node", "./scripts/integration.js"]

--- a/.ci/integration/Dockerfile
+++ b/.ci/integration/Dockerfile
@@ -8,10 +8,6 @@ LABEL "com.github.actions.color"="purple"
 LABEL "repository"="http://github.com/storybooks/storybook"
 LABEL "homepage"="http://github.com/storybooks/storybook"
 LABEL "maintainer"="Norbert de Langen <ndelangen@me.com>"
-
-RUN yarn add global puppeteer
-
-RUN yarn install
-RUN yarn bootstrap --core
+RUN ls -al
 
 ENTRYPOINT ["node", "./scripts/integration.js"]

--- a/.ci/integration/Dockerfile
+++ b/.ci/integration/Dockerfile
@@ -8,7 +8,9 @@ LABEL "com.github.actions.color"="purple"
 LABEL "repository"="http://github.com/storybooks/storybook"
 LABEL "homepage"="http://github.com/storybooks/storybook"
 LABEL "maintainer"="Norbert de Langen <ndelangen@me.com>"
-RUN ls -al
-RUN du -sch *
+
+RUN ls -al home
+RUN ls -al root
+RUN ls -al opt
 
 ENTRYPOINT ["node", "./scripts/integration.js"]

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,13 +3,20 @@ workflow "Dangerfile JS Pull" {
   resolves = "Danger JS"
 }
 
-workflow "Dangerfile JS Label" {
-  on = "label"
-  resolves = "Danger JS"
-}
-
 action "Danger JS" {
   uses = "danger/danger-js@master"
   secrets = ["GITHUB_TOKEN"]
   args = "--dangerfile .ci/danger/dangerfile.ts"
+}
+
+workflow "Integrations" {
+  on = "push"
+  resolves = [
+    "integration_cra-kitchen-sink",
+  ]
+}
+
+action "integration_cra-kitchen-sink" {
+  uses = "./.ci/integration/"
+  args = "--example cra-kitchen-sink"
 }

--- a/lib/ui/src/components/sidebar/SidebarStories.js
+++ b/lib/ui/src/components/sidebar/SidebarStories.js
@@ -101,7 +101,7 @@ const SidebarStories = React.memo(({ stories, storyId, loading, className, ...re
 
   if (list.length < 1) {
     return (
-      <Wrapper className={className}>
+      <Wrapper className={className} id="storybook-manager-empty">
         <Placeholder key="empty">
           <Fragment key="title">No stories found</Fragment>
           <Fragment>
@@ -116,11 +116,11 @@ const SidebarStories = React.memo(({ stories, storyId, loading, className, ...re
   }
 
   return (
-    <Wrapper className={className}>
+    <Wrapper className={className} id="storybook-manager-explorer">
       <TreeState
         key="treestate"
         dataset={stories}
-        prefix="explorer"
+        prefix="explorer-"
         selectedId={storyId}
         filter=""
         List={List}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "eslint-plugin-html": "^5.0.3",
-    "react-testing-library": "^5.4.4"
+    "puppeteer": "^1.12.2",
+    "react-testing-library": "^5.4.4",
+    "static-server": "^2.2.1"
   },
   "devDependencies": {
     "@angular/common": "^7.2.1",

--- a/scripts/integration.js
+++ b/scripts/integration.js
@@ -1,0 +1,90 @@
+/* eslint-disable no-console */
+/* eslint-disable no-undef */
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const program = require('commander');
+
+program.option('-e, --example [type]', 'which example to test').parse(process.argv);
+
+const StaticServer = require('static-server');
+
+const { example } = program;
+
+if (!fs.existsSync(path.join(__dirname, '..', 'examples', example))) {
+  throw new Error('no example defined or example folder does not exist');
+}
+
+const port = '8081';
+childProcess.execSync(`
+  echo "building ${example}"
+  pushd examples/${example}
+  yarn build-storybook --quiet
+  popd
+`);
+
+const server = new Promise((res, rej) => {
+  const s = new StaticServer({
+    port,
+    rootPath: path.join(__dirname, '..', 'examples', example, 'storybook-static'),
+  });
+  s.start(err => {
+    if (err) {
+      rej(err);
+    } else {
+      res(s);
+    }
+  });
+});
+
+server
+  .then(async () => {
+    // eslint-disable-next-line global-require
+    const puppeteer = require('puppeteer');
+
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    await page.goto(`http://localhost:${port}`, { waitUntil: 'networkidle2' });
+
+    // TEST wether a story was rendered
+    const storyWasRendered = await page.evaluate(
+      () =>
+        !!document
+          .getElementById('storybook-preview-iframe')
+          .contentDocument.querySelector('#root *')
+    );
+    assert.equal(storyWasRendered, true);
+
+    // TEST wether the expected addons are present in the manager
+    // TODO: we want to find all types of addons, not just the panels
+    const foundAddons = await page.evaluate(() =>
+      [
+        ...document
+          .getElementById('storybook-panel-root')
+          .querySelectorAll('[role="tablist"] > button'),
+      ].map(i => i.innerText)
+    );
+    assert.deepEqual(foundAddons, ['Actions', 'Events', 'Knobs', 'Accessibility', 'Tests']);
+
+    // TEST wether stories are present in the manager
+    const foundStories = await page.evaluate(() =>
+      [...document.getElementById('storybook-manager-explorer').querySelectorAll('[id]')].map(
+        i => i.innerText
+      )
+    );
+    assert.equal(foundStories.length > 0, true);
+
+    await browser.close();
+  })
+  .then(() => {
+    server.then(s => {
+      console.log('all good, closing...');
+      s.stop();
+    });
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,6 +2890,11 @@ ansi-red@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
+ansi-regex@^0.2.0, ansi-regex@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
+  integrity sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -2901,6 +2906,11 @@ ansi-regex@^3.0.0:
 ansi-regex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+
+ansi-styles@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.1.0.tgz#eaecbf66cd706882760b2f4691582b8f55d7a7de"
+  integrity sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -5660,6 +5670,17 @@ chalk@2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
+  integrity sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=
+  dependencies:
+    ansi-styles "^1.1.0"
+    escape-string-regexp "^1.0.0"
+    has-ansi "^0.1.0"
+    strip-ansi "^0.3.0"
+    supports-color "^0.2.0"
+
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -6125,7 +6146,7 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.11.0, commander@^2.12.1, commander@^2.14.1, commander@^2.15.1, commander@^2.18.0, commander@^2.19.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0:
+commander@^2.11.0, commander@^2.12.1, commander@^2.14.1, commander@^2.15.1, commander@^2.18.0, commander@^2.19.0, commander@^2.3.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
@@ -8235,7 +8256,7 @@ escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -9136,6 +9157,11 @@ file-loader@^3.0.1:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
+
+file-size@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/file-size/-/file-size-0.0.5.tgz#057d43c3a3ed735da3f90d6052ab380f1e6d5e3b"
+  integrity sha1-BX1Dw6Ptc12j+Q1gUqs4Dx5tXjs=
 
 file-system-cache@^1.0.5:
   version "1.0.5"
@@ -10157,6 +10183,13 @@ har-validator@~5.1.0:
 harmony-reflect@^1.4.6:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
+
+has-ansi@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-0.1.0.tgz#84f265aae8c0e6a88a12d7022894b7568894c62e"
+  integrity sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=
+  dependencies:
+    ansi-regex "^0.2.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -15047,7 +15080,7 @@ opn@5.3.0:
   dependencies:
     is-wsl "^1.1.0"
 
-opn@5.4.0, opn@^5.1.0, opn@^5.3.0, opn@^5.4.0:
+opn@5.4.0, opn@^5.1.0, opn@^5.2.0, opn@^5.3.0, opn@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
   dependencies:
@@ -16630,6 +16663,20 @@ puppeteer@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.12.0.tgz#325b97f42aa6cd66ae4d3d27839278e1f0b8e0e5"
   integrity sha512-+riSxJFPQpwGZvNHFeB7vEefwfdHNSstQmjdzUKZxPp/Qt1Dw9iKRAewl8X0ntdXZz4UR4jODLiM03Iw9HDnyw==
+  dependencies:
+    debug "^4.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
+    mime "^2.0.3"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^6.1.0"
+
+puppeteer@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.12.2.tgz#dbc36afc3ba2d7182b1a37523c0081a0e8507c9a"
+  integrity sha512-xWSyCeD6EazGlfnQweMpM+Hs6X6PhUYhNTHKFj/axNZDq4OmrVERf70isBf7HsnFgB3zOC1+23/8+wCAZYg+Pg==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"
@@ -19361,6 +19408,17 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+static-server@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/static-server/-/static-server-2.2.1.tgz#49e3cae2a001736b0ee9e95d21d3d843fc95efaa"
+  integrity sha512-j5eeW6higxYNmXMIT8iHjsdiViTpQDthg7o+SHsRtqdbxscdHqBHXwrXjHC8hL3F0Tsu34ApUpDkwzMBPBsrLw==
+  dependencies:
+    chalk "^0.5.1"
+    commander "^2.3.0"
+    file-size "0.0.5"
+    mime "^1.2.11"
+    opn "^5.2.0"
+
 stats-webpack-plugin@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/stats-webpack-plugin/-/stats-webpack-plugin-0.7.0.tgz#ccffe9b745de8bbb155571e063f8263fc0e2bc06"
@@ -19600,6 +19658,13 @@ strip-ansi@4.0.0, strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.3.0.tgz#25f48ea22ca79187f3174a4db8759347bb126220"
+  integrity sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=
+  dependencies:
+    ansi-regex "^0.2.1"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -19723,6 +19788,11 @@ sum-up@^1.0.1:
   resolved "https://registry.yarnpkg.com/sum-up/-/sum-up-1.0.3.tgz#1c661f667057f63bcb7875aa1438bc162525156e"
   dependencies:
     chalk "^1.0.0"
+
+supports-color@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
+  integrity sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The current setup with integration tests using storybook's built examples inside the official storybook is flaxy as 🐑.

We want high level integration tests for the UI is a way that we assert things are present when a storybook is build and served.

We (@pksunkara and me) added a github action that takes an example as an argument, then builds and tests the example.