### PR TITLE
Fix: Don't mangle function names for production builds

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -100,6 +100,7 @@ export default ({
           sourceMap: true,
           terserOptions: {
             mangle: false,
+            keep_fnames: true,
           },
         }),
       ],


### PR DESCRIPTION
Issue:

this fixes #5546 

## What I did

Added the `keep_fnames: true` option to the Terser webpack plugin.   
This basically restore #2705 for version 5, and hopefully will be backported to 4.  

## How to test

- Is this testable with Jest or Chromatic screenshots? Nope
- Does this need a new example in the kitchen sink apps? Nope
- Does this need an update to the documentation? Nope
