### PR TITLE
Update getStorybook to return story parameters

### DIFF
--- a/lib/client-api/src/client_api.js
+++ b/lib/client-api/src/client_api.js
@@ -226,9 +226,9 @@ export default class ClientApi {
     this._storyStore.getStoryKinds().map(kind => {
       const fileName = this._storyStore.getStoryFileName(kind);
 
-      const stories = this._storyStore.getStories(kind).map(name => {
-        const render = this._storyStore.getStoryWithContext(kind, name);
-        return { name, render };
+      const stories = this._storyStore.getStories(kind).map(story => {
+        const render = this._storyStore.getStoryWithContext(kind, story.name);
+        return { name: story.name, render, parameters: story.parameters };
       });
 
       return { kind, fileName, stories };

--- a/lib/client-api/src/client_api.js
+++ b/lib/client-api/src/client_api.js
@@ -226,9 +226,9 @@ export default class ClientApi {
     this._storyStore.getStoryKinds().map(kind => {
       const fileName = this._storyStore.getStoryFileName(kind);
 
-      const stories = this._storyStore.getStories(kind).map(story => {
-        const render = this._storyStore.getStoryWithContext(kind, story.name);
-        return { name: story.name, render, parameters: story.parameters };
+      const stories = this._storyStore.getStories(kind).map(({ name, parameters }) => {
+        const render = this._storyStore.getStoryWithContext(kind, name);
+        return { name, render, parameters };
       });
 
       return { kind, fileName, stories };

--- a/lib/client-api/src/client_api.js
+++ b/lib/client-api/src/client_api.js
@@ -226,10 +226,12 @@ export default class ClientApi {
     this._storyStore.getStoryKinds().map(kind => {
       const fileName = this._storyStore.getStoryFileName(kind);
 
-      const stories = this._storyStore.getStories(kind).map(({ name, parameters }) => {
-        const render = this._storyStore.getStoryWithContext(kind, name);
-        return { name, render, parameters };
-      });
+      const stories = this._storyStore
+        .getStoriesWithParameters(kind)
+        .map(({ name, parameters }) => {
+          const render = this._storyStore.getStoryWithContext(kind, name);
+          return { name, render, parameters };
+        });
 
       return { kind, fileName, stories };
     });

--- a/lib/client-api/src/client_api.test.js
+++ b/lib/client-api/src/client_api.test.js
@@ -223,10 +223,12 @@ describe('preview.client_api', () => {
             {
               name: 'name 1',
               render: expect.any(Function),
+              parameters: expect.any(Object),
             },
             {
               name: 'name 2',
               render: expect.any(Function),
+              parameters: expect.any(Object),
             },
           ],
         }),
@@ -237,10 +239,12 @@ describe('preview.client_api', () => {
             {
               name: 'name 1',
               render: expect.any(Function),
+              parameters: expect.any(Object),
             },
             {
               name: 'name 2',
               render: expect.any(Function),
+              parameters: expect.any(Object),
             },
           ],
         }),
@@ -265,6 +269,7 @@ describe('preview.client_api', () => {
             {
               name: 'name',
               render: expect.any(Function),
+              parameters: expect.any(Object),
             },
           ],
         },
@@ -317,7 +322,7 @@ describe('preview.client_api', () => {
       expect(firstStorybook).toEqual([
         {
           kind: 'kind',
-          stories: [{ name: 'story', render: expect.anything() }],
+          stories: [{ name: 'story', render: expect.anything(), parameters: expect.any(Object) }],
         },
       ]);
 
@@ -333,7 +338,7 @@ describe('preview.client_api', () => {
       expect(secondStorybook).toEqual([
         {
           kind: 'kind',
-          stories: [{ name: 'story', render: expect.anything() }],
+          stories: [{ name: 'story', render: expect.anything(), parameters: expect.any(Object) }],
         },
       ]);
       secondStorybook[0].stories[0].render();

--- a/lib/client-api/src/story_store.js
+++ b/lib/client-api/src/story_store.js
@@ -214,8 +214,7 @@ export default class StoryStore extends EventEmitter {
 
     return Object.keys(this._legacydata[key].stories)
       .map(name => this._legacydata[key].stories[name])
-      .sort((info1, info2) => info1.index - info2.index)
-      .map(info => ({ name: info.name, parameters: info.parameters }));
+      .sort((info1, info2) => info1.index - info2.index);
   }
 
   getStoryFileName(kind) {

--- a/lib/client-api/src/story_store.js
+++ b/lib/client-api/src/story_store.js
@@ -206,7 +206,7 @@ export default class StoryStore extends EventEmitter {
       .map(info => info.kind);
   }
 
-  getStories(kind) {
+  getStoriesWithParameters(kind) {
     const key = toKey(kind);
     if (!this._legacydata[key]) {
       return [];
@@ -215,6 +215,10 @@ export default class StoryStore extends EventEmitter {
     return Object.keys(this._legacydata[key].stories)
       .map(name => this._legacydata[key].stories[name])
       .sort((info1, info2) => info1.index - info2.index);
+  }
+
+  getStories(kind) {
+    return this.getStoriesWithParameters(kind).map(story => story.name);
   }
 
   getStoryFileName(kind) {
@@ -286,7 +290,7 @@ export default class StoryStore extends EventEmitter {
   dumpStoryBook() {
     const data = this.getStoryKinds().map(kind => ({
       kind,
-      stories: this.getStories(kind).map(story => story.name),
+      stories: this.getStories(kind),
     }));
 
     return data;

--- a/lib/client-api/src/story_store.js
+++ b/lib/client-api/src/story_store.js
@@ -215,7 +215,7 @@ export default class StoryStore extends EventEmitter {
     return Object.keys(this._legacydata[key].stories)
       .map(name => this._legacydata[key].stories[name])
       .sort((info1, info2) => info1.index - info2.index)
-      .map(info => info.name);
+      .map(info => ({ name: info.name, parameters: info.parameters }));
   }
 
   getStoryFileName(kind) {
@@ -287,7 +287,7 @@ export default class StoryStore extends EventEmitter {
   dumpStoryBook() {
     const data = this.getStoryKinds().map(kind => ({
       kind,
-      stories: this.getStories(kind),
+      stories: this.getStories(kind).map(story => story.name),
     }));
 
     return data;


### PR DESCRIPTION
Issue:
v4 of Storybook [introduced story parameters](https://github.com/storybooks/storybook/pull/2679), but getStorybook doesn't return them.  This PR updates getStorybook so it does return parameters.

This allows in-browser consumers to access story parameters with a more supportable `window['__STORYBOOK_CLIENT_API__'].getStorybook()` instead of `window['__STORYBOOK_CLIENT_API__']['_storyStore']['_data']`

## What I did
Updated the getStorybook function to return parameters

## How to test
Unit tests
