### PR TITLE
FIX the input not sending a onChange to the list when form is cleared

### DIFF
--- a/lib/ui/src/components/sidebar/SidebarSearch.js
+++ b/lib/ui/src/components/sidebar/SidebarSearch.js
@@ -98,7 +98,7 @@ const FilterForm = styled.form(({ theme, focussed }) => ({
   },
 }));
 
-export const PureSidebarSearch = ({ focussed, onSetFocussed, className, ...props }) => (
+export const PureSidebarSearch = ({ focussed, onSetFocussed, className, onChange, ...props }) => (
   <FilterForm autoComplete="off" focussed={focussed} className={className}>
     <FilterField
       type="text"
@@ -106,20 +106,22 @@ export const PureSidebarSearch = ({ focussed, onSetFocussed, className, ...props
       id="storybook-explorer-searchfield"
       onFocus={() => onSetFocussed(true)}
       onBlur={() => onSetFocussed(false)}
+      onChange={e => onChange(e.target.value)}
       {...props}
       placeholder={focussed ? 'Type to search...' : 'Press "/" to search...'}
     />
     <Icons icon="search" />
-    <CancelButton type="reset" value="reset">
+    <CancelButton type="reset" value="reset" onClick={() => onChange('')}>
       <Icons icon="closeAlt" />
     </CancelButton>
   </FilterForm>
 );
 
 PureSidebarSearch.propTypes = {
-  focussed: PropTypes.bool.isRequired,
-  onSetFocussed: PropTypes.func.isRequired,
   className: PropTypes.string,
+  focussed: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onSetFocussed: PropTypes.func.isRequired,
 };
 
 PureSidebarSearch.defaultProps = {

--- a/lib/ui/src/components/sidebar/treeview/treeview.js
+++ b/lib/ui/src/components/sidebar/treeview/treeview.js
@@ -252,8 +252,8 @@ class TreeState extends PureComponent {
       }
     },
 
-    onFilter: e => {
-      const filter = e.target.value.length >= 2 ? e.target.value : '';
+    onFilter: value => {
+      const filter = value.length >= 2 ? value : '';
       this.setState({ filter });
     },
   };


### PR DESCRIPTION
FIX the input not sending a onChange to the list when form is cleared

When clearing a form, the input do not fire a onChange event.
Feels a bit like a react bug to me. The field does change.. Ow well.

Had to change the way onFilter works, but this is cleaner anyway.