### PR TITLE
Fix: Avoid false-negative checks for port

### DIFF
--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -57,6 +57,10 @@ async function getCLI(packageJson) {
     configDir: 'SBCONFIG_CONFIG_DIR',
   });
 
+  if (typeof program.port === 'string' && program.port.length > 0) {
+    program.port = parseInt(program.port, 10);
+  }
+
   const port = await getFreePort(program.port);
 
   if (!program.ci && !program.smokeTest && program.port != null && port !== program.port) {


### PR DESCRIPTION
Issue:

When a port is provided via env vars, we're usually told by the CLI that it's unavailable, only to be suggested the same port next.

The usage of these `SBCONFIG_CONFIG_<NAME>` env vars is only intended for internals, as far as I'm aware. Nevertheless, when using the `SBCONFIG_CONFIG_PORT` we're left with an unexpected behaviour.

## What I did

Make sure the `SBCONFIG_CONFIG_PORT` is cast to a number, so as not to trip on any explicit (`===`) equality tests further down the code.

## How to test

- Is this testable with Jest or Chromatic screenshots?  
  **Not sure, I haven't looked at the test suit in the repo sorry :(**
- Does this need a new example in the kitchen sink apps?  
  **No, as it resembles expected behaviour and was rarely encountered.**
- Does this need an update to the documentation?  
  **No, as it resembles expected behaviour and was rarely encountered.**

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
