### PR TITLE
update modal manager for rn 0.58 support

### DIFF
--- a/addons/ondevice-knobs/package.json
+++ b/addons/ondevice-knobs/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.6.2",
     "react-native-color-picker": "^0.4.0",
     "react-native-modal-datetime-picker": "^5.1.0",
-    "react-native-modal-selector": "^0.0.29",
+    "react-native-modal-selector": "^1.0.2",
     "react-native-switch": "^1.5.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17111,9 +17111,10 @@ react-native-modal-datetime-picker@^5.1.0:
     prop-types "^15.6.1"
     react-native-modal "^5.4.0"
 
-react-native-modal-selector@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/react-native-modal-selector/-/react-native-modal-selector-0.0.29.tgz#e33326a9191ce6a6ed07c222366eb13ba5e03e21"
+react-native-modal-selector@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-modal-selector/-/react-native-modal-selector-1.0.2.tgz#d6ec94ea9d280162be6c439fea72455479bc5c73"
+  integrity sha512-nMHwYj5f6brhGC6f+AjZY2BqU3p3TDoqzJJEIMRn7/o27NAvJGE3XS+2J+wfLJstCcYdaDrfYWRWE854KfSHBA==
   dependencies:
     prop-types "^15.5.10"
 


### PR DESCRIPTION
Issue:

## What I did

Update the dependency.

## How to test

I simply added a select and then updated to see if it still works. And it does. A major version bump was included in this somewhere, but I can't see any breaking changes. Regardless, this works.

