### PR TITLE
Add types export in lib/theming

### DIFF
--- a/addons/notes/src/typings.d.ts
+++ b/addons/notes/src/typings.d.ts
@@ -1,5 +1,4 @@
 // todo the following packages need definition files or a TS migration
-declare module '@storybook/theming';
 declare module '@storybook/components';
 
 // There are no types for markdown-to-jsx

--- a/lib/theming/package.json
+++ b/lib/theming/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"
   },


### PR DESCRIPTION
## What I did
 
 - Add 'types' attribute in `package.json` of `lib/theming` to reference types entry point  
 - Remove '@storybook/theming' module declaration from 'addons/notes'

