### PR TITLE
Fix wrong heading format

### DIFF
--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -20,7 +20,7 @@ Add this line to your `addons.js` file (create this file inside your storybook c
 import '@storybook/addon-options/register';
 ```
 
-###Set options globally
+### Set options globally
 
 Import and use the `withOptions` decorator in your `config.js` file.
 


### PR DESCRIPTION
Issue: Formatting

## What I did

Add a space between heading syntax and subtitle to get the right Markdown format
