### PR TITLE
Use the correct props to start the tooltip open

### DIFF
--- a/lib/components/src/tooltip/TooltipLinkList.stories.js
+++ b/lib/components/src/tooltip/TooltipLinkList.stories.js
@@ -1,23 +1,23 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import WithTooltip from './WithTooltip';
+import WithToolTip from './WithTooltip';
 
 import TooltipLinkList from './TooltipLinkList';
 import StoryLinkWrapper from '../StoryLinkWrapper';
 
 export const links = [
-  { title: 'Link', href: 'http://google.com' },
-  { title: 'Link', href: 'http://google.com' },
-  { title: 'callback', onClick: action('onClick') },
+  { id: '1', title: 'Link', href: 'http://google.com' },
+  { id: '2', title: 'Link', href: 'http://google.com' },
+  { id: '3', title: 'callback', onClick: action('onClick') },
 ];
 
 storiesOf('basics/Tooltip/TooltipLinkList', module)
   .addDecorator(storyFn => (
     <div style={{ height: '300px' }}>
-      <WithTooltip placement="top" trigger="click" startOpen tooltip={storyFn()}>
+      <WithToolTip placement="top" trigger="click" tooltipShown tooltip={storyFn()}>
         <div>Tooltip</div>
-      </WithTooltip>
+      </WithToolTip>
     </div>
   ))
   .add('links', () => <TooltipLinkList links={links.slice(0, 2)} LinkWrapper={StoryLinkWrapper} />)

--- a/lib/components/src/tooltip/TooltipMessage.stories.js
+++ b/lib/components/src/tooltip/TooltipMessage.stories.js
@@ -7,7 +7,7 @@ import TooltipMessage from './TooltipMessage';
 storiesOf('basics/Tooltip/TooltipMessage', module)
   .addDecorator(storyFn => (
     <div style={{ height: '300px' }}>
-      <WithTooltip placement="top" trigger="click" startOpen tooltip={storyFn()}>
+      <WithTooltip placement="top" trigger="click" tooltipShown tooltip={storyFn()}>
         <div>Tooltip</div>
       </WithTooltip>
     </div>

--- a/lib/components/src/tooltip/TooltipNote.stories.js
+++ b/lib/components/src/tooltip/TooltipNote.stories.js
@@ -7,7 +7,13 @@ import TooltipNote from './TooltipNote';
 storiesOf('basics/Tooltip/TooltipNote', module)
   .addDecorator(storyFn => (
     <div style={{ height: '300px' }}>
-      <WithTooltip hasChrome={false} placement="top" trigger="click" startOpen tooltip={storyFn()}>
+      <WithTooltip
+        hasChrome={false}
+        placement="top"
+        trigger="click"
+        tooltipShown
+        tooltip={storyFn()}
+      >
         <div>Tooltip</div>
       </WithTooltip>
     </div>

--- a/lib/components/src/tooltip/__snapshots__/TooltipLinkList.stories.storyshot
+++ b/lib/components/src/tooltip/__snapshots__/TooltipLinkList.stories.storyshot
@@ -1,9 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots basics/Tooltip/TooltipLinkList links 1`] = `
+.emotion-8 {
+  min-width: 180px;
+}
+
+.emotion-4 {
+  font-size: 12px;
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  color: #999999;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  line-height: 18px;
+  padding: 7px 15px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-4 + .emotion-4 {
+  border-top: 1px solid #EEEEEE;
+}
+
+.emotion-4 > * + * {
+  padding-left: 10px;
+}
+
+.emotion-4:hover {
+  background: rgba(0,0,0,.05);
+}
+
+.emotion-4:hover svg {
+  opacity: 1;
+}
+
+.emotion-3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  text-align: left;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.emotion-3 > * + * {
+  padding-left: 10px;
+}
+
+.emotion-2 {
+  color: #444444;
+}
+
 .emotion-0 {
   display: inline-block;
   cursor: pointer;
+}
+
+.emotion-9 {
+  display: inline-block;
+  z-index: 2147483647;
+  margin-bottom: 10px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  background: linear-gradient( -1deg, rgba(248,248,248,0.97) 0%, rgba(255,255,255,0.97) 100% );
+  -webkit-filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  font-size: 12px;
+}
+
+.emotion-1 {
+  position: absolute;
+  border-style: solid;
+  margin-bottom: 0px;
+  margin-top: 8px;
+  margin-right: 8px;
+  margin-left: 8px;
+  bottom: -8px;
+  top: autopx;
+  right: autopx;
+  left: autopx;
+  border-bottom-width: 0px;
+  border-top-width: 8px;
+  border-right-width: 8px;
+  border-left-width: 8px;
+  border-top-color: #FFFFFF;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+  border-right-color: transparent;
 }
 
 <div
@@ -16,13 +113,150 @@ exports[`Storyshots basics/Tooltip/TooltipLinkList links 1`] = `
       Tooltip
     </div>
   </div>
+  <div
+    class="emotion-9"
+    style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+  >
+    <div
+      class="emotion-1"
+    />
+    <div
+      class="emotion-8"
+    >
+      <a
+        class="emotion-4"
+        href="http://google.com"
+      >
+        <span
+          class="emotion-3"
+        >
+          <span
+            class="emotion-2"
+          >
+            Link
+          </span>
+        </span>
+      </a>
+      <a
+        class="emotion-4"
+        href="http://google.com"
+      >
+        <span
+          class="emotion-3"
+        >
+          <span
+            class="emotion-2"
+          >
+            Link
+          </span>
+        </span>
+      </a>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots basics/Tooltip/TooltipLinkList links and callback 1`] = `
+.emotion-11 {
+  min-width: 180px;
+}
+
+.emotion-4 {
+  font-size: 12px;
+  -webkit-transition: all 150ms ease-out;
+  transition: all 150ms ease-out;
+  color: #999999;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  line-height: 18px;
+  padding: 7px 15px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-4 + .emotion-4 {
+  border-top: 1px solid #EEEEEE;
+}
+
+.emotion-4 > * + * {
+  padding-left: 10px;
+}
+
+.emotion-4:hover {
+  background: rgba(0,0,0,.05);
+}
+
+.emotion-4:hover svg {
+  opacity: 1;
+}
+
+.emotion-3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  text-align: left;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.emotion-3 > * + * {
+  padding-left: 10px;
+}
+
+.emotion-2 {
+  color: #444444;
+}
+
 .emotion-0 {
   display: inline-block;
   cursor: pointer;
+}
+
+.emotion-12 {
+  display: inline-block;
+  z-index: 2147483647;
+  margin-bottom: 10px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  background: linear-gradient( -1deg, rgba(248,248,248,0.97) 0%, rgba(255,255,255,0.97) 100% );
+  -webkit-filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  font-size: 12px;
+}
+
+.emotion-1 {
+  position: absolute;
+  border-style: solid;
+  margin-bottom: 0px;
+  margin-top: 8px;
+  margin-right: 8px;
+  margin-left: 8px;
+  bottom: -8px;
+  top: autopx;
+  right: autopx;
+  left: autopx;
+  border-bottom-width: 0px;
+  border-top-width: 8px;
+  border-right-width: 8px;
+  border-left-width: 8px;
+  border-top-color: #FFFFFF;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+  border-right-color: transparent;
 }
 
 <div
@@ -33,6 +267,59 @@ exports[`Storyshots basics/Tooltip/TooltipLinkList links and callback 1`] = `
   >
     <div>
       Tooltip
+    </div>
+  </div>
+  <div
+    class="emotion-12"
+    style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+  >
+    <div
+      class="emotion-1"
+    />
+    <div
+      class="emotion-11"
+    >
+      <a
+        class="emotion-4"
+        href="http://google.com"
+      >
+        <span
+          class="emotion-3"
+        >
+          <span
+            class="emotion-2"
+          >
+            Link
+          </span>
+        </span>
+      </a>
+      <a
+        class="emotion-4"
+        href="http://google.com"
+      >
+        <span
+          class="emotion-3"
+        >
+          <span
+            class="emotion-2"
+          >
+            Link
+          </span>
+        </span>
+      </a>
+      <a
+        class="emotion-4"
+      >
+        <span
+          class="emotion-3"
+        >
+          <span
+            class="emotion-2"
+          >
+            callback
+          </span>
+        </span>
+      </a>
     </div>
   </div>
 </div>

--- a/lib/components/src/tooltip/__snapshots__/TooltipMessage.stories.storyshot
+++ b/lib/components/src/tooltip/__snapshots__/TooltipMessage.stories.storyshot
@@ -6,6 +6,55 @@ exports[`Storyshots basics/Tooltip/TooltipMessage default 1`] = `
   cursor: pointer;
 }
 
+.emotion-6 {
+  display: inline-block;
+  z-index: 2147483647;
+  margin-bottom: 10px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  background: linear-gradient( -1deg, rgba(248,248,248,0.97) 0%, rgba(255,255,255,0.97) 100% );
+  -webkit-filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  font-size: 12px;
+}
+
+.emotion-1 {
+  position: absolute;
+  border-style: solid;
+  margin-bottom: 0px;
+  margin-top: 8px;
+  margin-right: 8px;
+  margin-left: 8px;
+  bottom: -8px;
+  top: autopx;
+  right: autopx;
+  left: autopx;
+  border-bottom-width: 0px;
+  border-top-width: 8px;
+  border-right-width: 8px;
+  border-left-width: 8px;
+  border-top-color: #FFFFFF;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+
+.emotion-5 {
+  padding: 15px;
+  width: 280px;
+  box-sizing: border-box;
+}
+
+.emotion-4 {
+  color: #444444;
+  line-height: 18px;
+}
+
+.emotion-2 {
+  font-weight: 900;
+}
+
 <div
   style="height:300px"
 >
@@ -14,6 +63,32 @@ exports[`Storyshots basics/Tooltip/TooltipMessage default 1`] = `
   >
     <div>
       Tooltip
+    </div>
+  </div>
+  <div
+    class="emotion-6"
+    style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+  >
+    <div
+      class="emotion-1"
+    />
+    <div
+      class="emotion-5"
+    >
+      <div
+        class="emotion-4"
+      >
+        <div
+          class="emotion-2"
+        >
+          Lorem ipsum dolor sit
+        </div>
+        <span
+          class="emotion-3"
+        >
+          Amet consectatur vestibulum concet durum politu coret weirom
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -25,6 +100,51 @@ exports[`Storyshots basics/Tooltip/TooltipMessage minimal message 1`] = `
   cursor: pointer;
 }
 
+.emotion-5 {
+  display: inline-block;
+  z-index: 2147483647;
+  margin-bottom: 10px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  background: linear-gradient( -1deg, rgba(248,248,248,0.97) 0%, rgba(255,255,255,0.97) 100% );
+  -webkit-filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  font-size: 12px;
+}
+
+.emotion-1 {
+  position: absolute;
+  border-style: solid;
+  margin-bottom: 0px;
+  margin-top: 8px;
+  margin-right: 8px;
+  margin-left: 8px;
+  bottom: -8px;
+  top: autopx;
+  right: autopx;
+  left: autopx;
+  border-bottom-width: 0px;
+  border-top-width: 8px;
+  border-right-width: 8px;
+  border-left-width: 8px;
+  border-top-color: #FFFFFF;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+
+.emotion-4 {
+  padding: 15px;
+  width: 280px;
+  box-sizing: border-box;
+}
+
+.emotion-3 {
+  color: #444444;
+  line-height: 18px;
+}
+
 <div
   style="height:300px"
 >
@@ -33,6 +153,27 @@ exports[`Storyshots basics/Tooltip/TooltipMessage minimal message 1`] = `
   >
     <div>
       Tooltip
+    </div>
+  </div>
+  <div
+    class="emotion-5"
+    style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+  >
+    <div
+      class="emotion-1"
+    />
+    <div
+      class="emotion-4"
+    >
+      <div
+        class="emotion-3"
+      >
+        <span
+          class="emotion-2"
+        >
+          Amet consectatur vestibulum concet durum politu coret weirom
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -44,6 +185,65 @@ exports[`Storyshots basics/Tooltip/TooltipMessage with link 1`] = `
   cursor: pointer;
 }
 
+.emotion-8 {
+  display: inline-block;
+  z-index: 2147483647;
+  margin-bottom: 10px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  background: linear-gradient( -1deg, rgba(248,248,248,0.97) 0%, rgba(255,255,255,0.97) 100% );
+  -webkit-filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  font-size: 12px;
+}
+
+.emotion-1 {
+  position: absolute;
+  border-style: solid;
+  margin-bottom: 0px;
+  margin-top: 8px;
+  margin-right: 8px;
+  margin-left: 8px;
+  bottom: -8px;
+  top: autopx;
+  right: autopx;
+  left: autopx;
+  border-bottom-width: 0px;
+  border-top-width: 8px;
+  border-right-width: 8px;
+  border-left-width: 8px;
+  border-top-color: #FFFFFF;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+
+.emotion-7 {
+  padding: 15px;
+  width: 280px;
+  box-sizing: border-box;
+}
+
+.emotion-4 {
+  color: #444444;
+  line-height: 18px;
+}
+
+.emotion-2 {
+  font-weight: 900;
+}
+
+.emotion-6 {
+  margin-top: 8px;
+  text-align: center;
+}
+
+.emotion-6 > * {
+  margin: 0 8px;
+  font-weight: 900;
+}
+
 <div
   style="height:300px"
 >
@@ -52,6 +252,42 @@ exports[`Storyshots basics/Tooltip/TooltipMessage with link 1`] = `
   >
     <div>
       Tooltip
+    </div>
+  </div>
+  <div
+    class="emotion-8"
+    style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+  >
+    <div
+      class="emotion-1"
+    />
+    <div
+      class="emotion-7"
+    >
+      <div
+        class="emotion-4"
+      >
+        <div
+          class="emotion-2"
+        >
+          Lorem ipsum dolor sit
+        </div>
+        <span
+          class="emotion-3"
+        >
+          Amet consectatur vestibulum concet durum politu coret weirom
+        </span>
+      </div>
+      <div
+        class="emotion-6"
+      >
+        <a
+          class="emotion-3"
+          href="test"
+        >
+          Continue
+        </a>
+      </div>
     </div>
   </div>
 </div>
@@ -63,6 +299,65 @@ exports[`Storyshots basics/Tooltip/TooltipMessage with links 1`] = `
   cursor: pointer;
 }
 
+.emotion-9 {
+  display: inline-block;
+  z-index: 2147483647;
+  margin-bottom: 10px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  background: linear-gradient( -1deg, rgba(248,248,248,0.97) 0%, rgba(255,255,255,0.97) 100% );
+  -webkit-filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  filter: drop-shadow(0px 5px 5px rgba(0,0,0,0.05)) drop-shadow(0 1px 3px rgba(0,0,0,0.1));
+  font-size: 12px;
+}
+
+.emotion-1 {
+  position: absolute;
+  border-style: solid;
+  margin-bottom: 0px;
+  margin-top: 8px;
+  margin-right: 8px;
+  margin-left: 8px;
+  bottom: -8px;
+  top: autopx;
+  right: autopx;
+  left: autopx;
+  border-bottom-width: 0px;
+  border-top-width: 8px;
+  border-right-width: 8px;
+  border-left-width: 8px;
+  border-top-color: #FFFFFF;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+
+.emotion-8 {
+  padding: 15px;
+  width: 280px;
+  box-sizing: border-box;
+}
+
+.emotion-4 {
+  color: #444444;
+  line-height: 18px;
+}
+
+.emotion-2 {
+  font-weight: 900;
+}
+
+.emotion-7 {
+  margin-top: 8px;
+  text-align: center;
+}
+
+.emotion-7 > * {
+  margin: 0 8px;
+  font-weight: 900;
+}
+
 <div
   style="height:300px"
 >
@@ -71,6 +366,48 @@ exports[`Storyshots basics/Tooltip/TooltipMessage with links 1`] = `
   >
     <div>
       Tooltip
+    </div>
+  </div>
+  <div
+    class="emotion-9"
+    style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+  >
+    <div
+      class="emotion-1"
+    />
+    <div
+      class="emotion-8"
+    >
+      <div
+        class="emotion-4"
+      >
+        <div
+          class="emotion-2"
+        >
+          Lorem ipsum dolor sit
+        </div>
+        <span
+          class="emotion-3"
+        >
+          Amet consectatur vestibulum concet durum politu coret weirom
+        </span>
+      </div>
+      <div
+        class="emotion-7"
+      >
+        <a
+          class="emotion-3"
+          href="test"
+        >
+          Get more tips
+        </a>
+        <a
+          class="emotion-3"
+          href="test"
+        >
+          Done
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/components/src/tooltip/__snapshots__/TooltipNote.stories.storyshot
+++ b/lib/components/src/tooltip/__snapshots__/TooltipNote.stories.storyshot
@@ -6,6 +6,30 @@ exports[`Storyshots basics/Tooltip/TooltipNote default 1`] = `
   cursor: pointer;
 }
 
+.emotion-2 {
+  display: inline-block;
+  z-index: 2147483647;
+  margin-bottom: 8px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.emotion-1 {
+  padding: 2px 6px;
+  line-height: 16px;
+  font-size: 10px;
+  font-weight: 700;
+  color: #FFFFFF;
+  box-shadow: 0 0 5px 0 rgba(0,0,0,0.3);
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: -1;
+  background: rgba(0,0,0,0.4);
+  margin: 6px;
+}
+
 <div
   style="height:300px"
 >
@@ -14,6 +38,16 @@ exports[`Storyshots basics/Tooltip/TooltipNote default 1`] = `
   >
     <div>
       Tooltip
+    </div>
+  </div>
+  <div
+    class="emotion-2"
+    style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+  >
+    <div
+      class="emotion-1"
+    >
+      Lorem ipsum dolor
     </div>
   </div>
 </div>

--- a/lib/components/src/tooltip/__snapshots__/WithTooltip.stories.storyshot
+++ b/lib/components/src/tooltip/__snapshots__/WithTooltip.stories.storyshot
@@ -159,29 +159,6 @@ exports[`Storyshots basics/Tooltip/WithTooltip simple click start open 1`] = `
   cursor: pointer;
 }
 
-.emotion-12 {
-  height: 300px;
-}
-
-.emotion-11 {
-  width: 500px;
-  height: 500px;
-  overflow-y: scroll;
-  background: #eee;
-  position: relative;
-}
-
-.emotion-0 {
-  height: 100px;
-}
-
-.emotion-1 {
-  width: 200px;
-  height: 100px;
-  background-color: red;
-  color: white;
-}
-
 .emotion-10 {
   display: inline-block;
   z-index: 2147483647;
@@ -239,6 +216,29 @@ exports[`Storyshots basics/Tooltip/WithTooltip simple click start open 1`] = `
 .emotion-8 > * {
   margin: 0 8px;
   font-weight: 900;
+}
+
+.emotion-12 {
+  height: 300px;
+}
+
+.emotion-11 {
+  width: 500px;
+  height: 500px;
+  overflow-y: scroll;
+  background: #eee;
+  position: relative;
+}
+
+.emotion-0 {
+  height: 100px;
+}
+
+.emotion-1 {
+  width: 200px;
+  height: 100px;
+  background-color: red;
+  color: white;
 }
 
 <div


### PR DESCRIPTION
Issue: #5591

The `startOpen` prop is for the stateful `WithTooltipState` (ie. the one that can open and close).

To get an always open one, use `tooltipOpen` on the `WithTooltip`. I assume this is what you wanted @domyen?

PS It seems backwards to export the stateless one as the default @ndelangen. But I guess you are against default exports full stop...