### PR TITLE
Add missing babel-preset-env dependency

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -37,6 +37,7 @@
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-emotion": "^10.0.7",
     "babel-plugin-macros": "^2.4.5",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-minify": "^0.5.0 || 0.6.0-alpha.5",
     "boxen": "^2.1.0",
     "case-sensitive-paths-webpack-plugin": "^2.2.0",


### PR DESCRIPTION
Issue: #5498 broke the apps that doesn't have a dependency on `babel-preset-env`. We didn't catch that issue on CI because we have `babel-preset-env` hoisted from `@storybook/react-native` and `ember-cli`

Note that both this and #5498 can be reverted, if `telejson` gets rid of `safe-eval` dependency, see https://github.com/storybooks/telejson/issues/4