### PR TITLE
Allow collapsing active story and use separate expansion for filtered

### DIFF
--- a/lib/ui/src/components/sidebar/SidebarSearch.js
+++ b/lib/ui/src/components/sidebar/SidebarSearch.js
@@ -99,7 +99,12 @@ const FilterForm = styled.form(({ theme, focussed }) => ({
 }));
 
 export const PureSidebarSearch = ({ focussed, onSetFocussed, className, onChange, ...props }) => (
-  <FilterForm autoComplete="off" focussed={focussed} className={className}>
+  <FilterForm
+    autoComplete="off"
+    focussed={focussed}
+    className={className}
+    onReset={() => onChange('')}
+  >
     <FilterField
       type="text"
       autocomplete="off"
@@ -111,7 +116,7 @@ export const PureSidebarSearch = ({ focussed, onSetFocussed, className, onChange
       placeholder={focussed ? 'Type to search...' : 'Press "/" to search...'}
     />
     <Icons icon="search" />
-    <CancelButton type="reset" value="reset" onClick={() => onChange('')}>
+    <CancelButton type="reset" value="reset">
       <Icons icon="closeAlt" />
     </CancelButton>
   </FilterForm>

--- a/lib/ui/src/components/sidebar/treeview/treeview.js
+++ b/lib/ui/src/components/sidebar/treeview/treeview.js
@@ -138,21 +138,50 @@ const Tree = props => {
   }
 };
 
-const calculateTreeProps = memoize(50)((input, filter, selectedId, extraExpanded) => {
-  const dataset = filter ? toFiltered(input, filter) : input;
+const calculateTreeState = memoize(50)(
+  ({ dataset, selectedId }, { lastSelectedId, unfilteredExpanded }) => {
+    if (selectedId === lastSelectedId) {
+      return null;
+    }
 
+    // If a new selection is made, we need to ensure it is part of the expanded set
+    const selectedAncestorIds = selectedId ? getParents(selectedId, dataset).map(i => i.id) : [];
+
+    const newExpanded = Object.keys(dataset).reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: selectedAncestorIds.includes(key) || unfilteredExpanded[key],
+      }),
+      {}
+    );
+
+    return {
+      lastSelectedId: selectedId,
+      unfilteredExpanded: newExpanded,
+    };
+  }
+);
+
+const getExpanded = ({ unfilteredExpanded, filteredExpanded, filter }) =>
+  filter ? filteredExpanded : unfilteredExpanded;
+
+const getFilteredDataset = memoize(50)(({ dataset, filter }) =>
+  filter ? toFiltered(dataset, filter) : dataset
+);
+
+// Update the set of expansions we are currently working with
+const updateExpanded = fn => ({ unfilteredExpanded, filteredExpanded, filter }) => {
+  if (filter) {
+    return {
+      filteredExpanded: fn(filteredExpanded),
+    };
+  }
+  return { unfilteredExpanded: fn(unfilteredExpanded) };
+};
+
+const getPropsForTree = memoize(50)(({ dataset, selectedId }) => {
   const selected = Object.keys(dataset).reduce(
     (acc, k) => Object.assign(acc, { [k]: k === selectedId }),
-    {}
-  );
-
-  const selectedAncestorIds = selectedId ? getParents(selectedId, dataset).map(i => i.id) : [];
-
-  const expanded = Object.keys(dataset).reduce(
-    (acc, key) => ({
-      ...acc,
-      [key]: selectedAncestorIds.includes(key) || extraExpanded[key],
-    }),
     {}
   );
 
@@ -166,25 +195,50 @@ const calculateTreeProps = memoize(50)((input, filter, selectedId, extraExpanded
     { roots: [], others: [] }
   );
 
-  return { input, dataset, selected, expanded, roots, others };
+  return { selected, roots, others };
 });
 
 // eslint-disable-next-line react/no-multi-comp
 class TreeState extends PureComponent {
+  state = {
+    // We maintain two sets of expanded nodes, so we remember which were expanded if we clear the filter
+    unfilteredExpanded: [],
+    filteredExpanded: [],
+    filter: null,
+    lastSelectedId: null,
+  };
+
+  static getDerivedStateFromProps(props, state) {
+    return calculateTreeState(props, state);
+  }
+
   events = {
     onClick: (e, item) => {
-      const { extraExpanded } = this.state;
+      this.setState(
+        updateExpanded(expanded => ({
+          ...expanded,
+          [item.id]: !expanded[item.id],
+        }))
+      );
+    },
+    onFilter: inputFilter => {
+      const { dataset } = this.props;
+      const filter = inputFilter.length >= 2 ? inputFilter : '';
+      const filteredDataset = getFilteredDataset({ dataset, filter });
+
+      // Whenever we change the filter, we reset the "filtered" expanded set back to all matching stories
       this.setState({
-        extraExpanded: {
-          ...extraExpanded,
-          [item.id]: !extraExpanded[item.id],
-        },
+        filter,
+        filteredExpanded:
+          !!filter &&
+          Object.keys(filteredDataset).reduce((acc, k) => Object.assign(acc, { [k]: true }), {}),
       });
     },
     onKeyUp: (e, item) => {
-      const { dataset: input, selectedId, prefix } = this.props;
-      const { filter, extraExpanded } = this.state;
-      const { dataset, expanded } = calculateTreeProps(input, filter, selectedId, extraExpanded);
+      const { prefix, dataset } = this.props;
+      const { filter } = this.state;
+      const filteredDataset = getFilteredDataset({ dataset, filter });
+      const expanded = getExpanded(this.state);
 
       const action = keyEventToAction(e);
       if (action) {
@@ -192,8 +246,8 @@ class TreeState extends PureComponent {
       }
 
       if (action === 'RIGHT') {
-        const next = getNext({ id: item.id, dataset, expanded });
-        if (!dataset[item.id].children || expanded[item.id]) {
+        const next = getNext({ id: item.id, dataset: filteredDataset, expanded });
+        if (!filteredDataset[item.id].children || expanded[item.id]) {
           if (next) {
             try {
               document.getElementById(createId(next.id, prefix)).focus();
@@ -203,13 +257,13 @@ class TreeState extends PureComponent {
           }
         }
 
-        this.setState({ extraExpanded: { ...extraExpanded, [item.id]: true } });
+        this.setState(updateExpanded(currExpanded => ({ ...currExpanded, [item.id]: true })));
       }
       if (action === 'LEFT') {
-        const prev = getPrevious({ id: item.id, dataset, expanded });
+        const prev = getPrevious({ id: item.id, dataset: filteredDataset, expanded });
 
-        if (!dataset[item.id].children || !expanded[item.id]) {
-          const parent = getParent(item.id, dataset);
+        if (!filteredDataset[item.id].children || !expanded[item.id]) {
+          const parent = getParent(item.id, filteredDataset);
           if (parent && parent.children) {
             try {
               document.getElementById(createId(parent.id, prefix)).focus();
@@ -227,10 +281,10 @@ class TreeState extends PureComponent {
           }
         }
 
-        this.setState({ extraExpanded: { ...extraExpanded, [item.id]: false } });
+        this.setState(updateExpanded(currExpanded => ({ ...currExpanded, [item.id]: false })));
       }
       if (action === 'DOWN') {
-        const next = getNext({ id: item.id, dataset, expanded });
+        const next = getNext({ id: item.id, dataset: filteredDataset, expanded });
         if (next) {
           try {
             document.getElementById(createId(next.id, prefix)).focus();
@@ -240,7 +294,7 @@ class TreeState extends PureComponent {
         }
       }
       if (action === 'UP') {
-        const prev = getPrevious({ id: item.id, dataset, expanded });
+        const prev = getPrevious({ id: item.id, dataset: filteredDataset, expanded });
 
         if (prev) {
           try {
@@ -251,25 +305,15 @@ class TreeState extends PureComponent {
         }
       }
     },
-
-    onFilter: value => {
-      const filter = value.length >= 2 ? value : '';
-      this.setState({ filter });
-    },
-  };
-
-  state = {
-    filter: null,
-    extraExpanded: {},
   };
 
   render() {
     const {
       events,
-      state: { filter, extraExpanded },
+      state: { filter, unfilteredExpanded, filteredExpanded },
       props,
     } = this;
-    const { prefix, dataset: input, selectedId } = props;
+    const { prefix, dataset, selectedId } = props;
 
     const Filter = getFilter(props.Filter);
     const List = getFilter(props.List);
@@ -281,12 +325,9 @@ class TreeState extends PureComponent {
     const Section = getContainer(props.Section);
     const Message = getMessage(props.Message);
 
-    const { dataset, selected, expanded, roots, others } = calculateTreeProps(
-      input,
-      filter,
-      selectedId,
-      extraExpanded
-    );
+    const filteredDataset = getFilteredDataset({ dataset, filter });
+    const expanded = filter ? filteredExpanded : unfilteredExpanded;
+    const { selected, roots, others } = getPropsForTree({ dataset: filteredDataset, selectedId });
 
     return (
       <Fragment>
@@ -302,7 +343,7 @@ class TreeState extends PureComponent {
                   <Branch
                     key={key}
                     depth={0}
-                    dataset={dataset}
+                    dataset={filteredDataset}
                     selected={selected}
                     expanded={expanded}
                     root={key}
@@ -326,7 +367,7 @@ class TreeState extends PureComponent {
                   <Branch
                     key={id}
                     depth={0}
-                    dataset={dataset}
+                    dataset={filteredDataset}
                     selected={selected}
                     expanded={expanded}
                     root={id}
@@ -351,6 +392,8 @@ class TreeState extends PureComponent {
 TreeState.propTypes = {
   prefix: PropTypes.string.isRequired,
   dataset: PropTypes.shape({}).isRequired,
+  // We do use this prop, eslint is confused
+  // eslint-disable-next-line react/no-unused-prop-types
   selectedId: PropTypes.string,
 };
 TreeState.defaultProps = {


### PR DESCRIPTION
Issue: #5594 and #5419 

## What I did

Refactored the expanded set to be more stateful.

Note that the keyboard events don't seem to actually ever get triggered, so I can't really test them properly: https://github.com/storybooks/storybook/issues/5623