### PR TITLE
Fix unkind addon-ondevice-knobs readme.

### DIFF
--- a/addons/ondevice-knobs/README.md
+++ b/addons/ondevice-knobs/README.md
@@ -18,7 +18,7 @@ Refer to its documentation to understand how to use knobs**
 First of all, you need to install knobs into your project.
 
 ```sh
-yarn add @storybook/addon-ondevice-knobs --dev
+yarn add @storybook/addon-ondevice-knobs @storybook/addon-knobs --dev
 ```
 
 Then create a file called `rn-addons.js` in your storybook config.
@@ -26,6 +26,7 @@ Then create a file called `rn-addons.js` in your storybook config.
 ```js
 import '@storybook/addon-ondevice-knobs/register';
 ```
+> `@storybook/addon-ondevice-knobs` use register only.
 
 
 Then import `rn-addons.js` next to your `getStorybookUI` call.
@@ -38,3 +39,10 @@ Now, write your stories with knobs.
 **Refer to [@storybook/addon-knobs](https://github.com/storybooks/storybook/blob/master/addons/knobs) to learn how to write stories.**
 
 **Note:** you'll still have to install `@storybook/addon-knobs` as well and import `withKnobs` and all knob types _(e.g. `select`, `text` etc)_ from that module.
+
+```js
+// Example
+import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
+
+// Write your story...
+```


### PR DESCRIPTION
Issue: #4839

## What I did
Fixed addon-ondevice-knobs's readme.
Instead of importing from `addon-ondevice-knobs`, I explicitly used importing` addon-knobs`.
<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["documentation"]`

-->