### PR TITLE
Use a `/docs` pathPrefix for docs

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  pathPrefix: '/docs',
   siteMetadata: {
     siteTitle: 'Storybook',
     baseColor: '#e64074',

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "main": "n/a",
   "scripts": {
-    "build": "gatsby build && cp static/**/* ./public",
+    "build": "gatsby build --prefix-paths && cp static/**/* ./public",
     "build-storybook": "build-storybook",
     "dev": "gatsby develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
Issue: https://github.com/storybooks/frontpage/issues/26

## What I did

Use Gatsby's `pathPrefix`

## How to test

1. Build docs
2. Create a symlink from `docs` => `public`
3. Serve from the `/docs` directory