### PR TITLE
Add directory attribute to repositories in package.json files

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/storybooks/storybook.git"
+    "url": "git+https://github.com/storybooks/storybook.git",
+    "directory": "addons/a11y"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/actions"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/backgrounds"
   },
   "license": "MIT",
   "author": "jbaxleyiii",

--- a/addons/centered/package.json
+++ b/addons/centered/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/centered"
   },
   "license": "MIT",
   "author": "Muhammed Thanish <mnmtanish@gmail.com>",

--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/cssresources"
   },
   "license": "MIT",
   "author": "nm123github",

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/events"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/google-analytics/package.json
+++ b/addons/google-analytics/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/google-analytics"
   },
   "license": "MIT",
   "scripts": {

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/graphql"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/info"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/jest/package.json
+++ b/addons/jest/package.json
@@ -17,7 +17,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/jest"
   },
   "license": "MIT",
   "author": "Renaud Tertrais <renaud.tertrais@gmail.com> (https://github.com/renaudtertrais)",

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/knobs"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/links"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/notes/package.json
+++ b/addons/notes/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/notes"
   },
   "license": "MIT",
   "main": "dist/public_api.js",

--- a/addons/ondevice-backgrounds/package.json
+++ b/addons/ondevice-backgrounds/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/ondevice-backgrounds"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/ondevice-knobs/package.json
+++ b/addons/ondevice-knobs/package.json
@@ -11,7 +11,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/ondevice-knobs"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/ondevice-notes/package.json
+++ b/addons/ondevice-notes/package.json
@@ -9,7 +9,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/ondevice-notes"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/options/package.json
+++ b/addons/options/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/options"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/storyshots/storyshots-core"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/storyshots/storyshots-puppeteer"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/storysource"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "addons/viewport"
   },
   "license": "MIT",
   "main": "preview.js",

--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/angular"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/ember/package.json
+++ b/app/ember/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/ember"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/html/package.json
+++ b/app/html/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/html"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/marko/package.json
+++ b/app/marko/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/marko"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/mithril/package.json
+++ b/app/mithril/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/mithril"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/polymer/package.json
+++ b/app/polymer/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/polymer"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/preact"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/react-native"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/react"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/riot/package.json
+++ b/app/riot/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/riot"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/svelte"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "app/vue"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/examples/marko-cli/package.json
+++ b/examples/marko-cli/package.json
@@ -5,7 +5,8 @@
   "description": "Demo of how to build an app using marko-starter",
   "repository": {
     "type": "git",
-    "url": "https://github.com/marko-js-samples/marko-starter-demo"
+    "url": "https://github.com/marko-js-samples/marko-starter-demo",
+    "directory": "examples/marko-cli"
   },
   "license": "MIT",
   "scripts": {

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/addons"
   },
   "license": "MIT",
   "main": "dist/public_api.js",

--- a/lib/channel-postmessage/package.json
+++ b/lib/channel-postmessage/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/channel-postmessage"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/channel-websocket/package.json
+++ b/lib/channel-websocket/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/channel-websocket"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/channels/package.json
+++ b/lib/channels/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/channels"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/cli"
   },
   "license": "MIT",
   "author": "Storybook Team",

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/client-api"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/client-logger/package.json
+++ b/lib/client-logger/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/client-logger"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/codemod"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/components"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/core-events/package.json
+++ b/lib/core-events/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/core-events"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/core"
   },
   "license": "MIT",
   "main": "dist/client/index.js",

--- a/lib/node-logger/package.json
+++ b/lib/node-logger/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/node-logger"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/router/package.json
+++ b/lib/router/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/router"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/theming/package.json
+++ b/lib/theming/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/theming"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybooks/storybook.git"
+    "url": "https://github.com/storybooks/storybook.git",
+    "directory": "lib/ui"
   },
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Issue: it's hard for automated tools (or humans) to find the relevant packages within a monorepo.

## What I did

I worked with the npm team to add a standard for declaring the directory within a repository that a package lives in. The accepted RFC is [here](https://github.com/npm/rfcs/pull/19), and the new guidance was accepted into npm's docs [here](https://github.com/npm/cli/pull/140).

This PR adds the recommended `directory` attribute to the repository specification for each of storybook's packages. It will allow tools like Dependabot to show only the commits that are relevant to a particular packages when creating PRs.

## How to test

Not required.