### PR TITLE
Compare component name to story name, not story fn

### DIFF
--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -2608,7 +2608,7 @@ exports[`addon Info should render component description if story kind matches co
     context={
       Object {
         "kind": "TestComponent",
-        "story": "Basic test",
+        "name": "Basic test",
       }
     }
     excludedPropTypes={Array []}
@@ -2670,7 +2670,9 @@ exports[`addon Info should render component description if story kind matches co
                   "padding": 0,
                 }
               }
-            />
+            >
+              Basic test
+            </h2>
           </div>
         </div>
       </div>
@@ -2823,7 +2825,6 @@ exports[`addon Info should render component description if story kind matches co
                 >
                   cursive
                 </em>
-                 
               </div>
             </P>
           </div>
@@ -3822,7 +3823,7 @@ exports[`addon Info should render component description if story name matches co
     context={
       Object {
         "kind": "Test Components",
-        "story": "TestComponent",
+        "name": "TestComponent",
       }
     }
     excludedPropTypes={Array []}
@@ -3884,7 +3885,9 @@ exports[`addon Info should render component description if story name matches co
                   "padding": 0,
                 }
               }
-            />
+            >
+              TestComponent
+            </h2>
           </div>
         </div>
       </div>
@@ -4037,7 +4040,6 @@ exports[`addon Info should render component description if story name matches co
                 >
                   cursive
                 </em>
-                 
               </div>
             </P>
           </div>

--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -264,11 +264,11 @@ class Story extends Component {
 
   _getComponentDescription() {
     const {
-      context: { kind, story },
+      context: { kind, name },
     } = this.props;
     let retDiv = null;
 
-    const validMatches = [kind, story];
+    const validMatches = [kind, name];
 
     if (Object.keys(STORYBOOK_REACT_CLASSES).length) {
       Object.keys(STORYBOOK_REACT_CLASSES).forEach(key => {

--- a/addons/info/src/index.test.js
+++ b/addons/info/src/index.test.js
@@ -20,7 +20,8 @@ const TestComponent = ({ func, obj, array, number, string, bool, empty }) => (
       <li>1</li>
       <li>2</li>
     </ul>
-  </div>);
+  </div>
+);
 /* eslint-enable */
 
 const reactClassPath = 'some/path/TestComponent.jsx';
@@ -31,7 +32,7 @@ const storybookReactClassMock = {
     description: `
 # Awesome test component description
 ## with markdown support
-**bold** *cursive* 
+**bold** *cursive*
     `,
     name: 'TestComponent',
   },
@@ -45,9 +46,9 @@ containing **bold**, *cursive* text, \`code\` and [a link](https://github.com)`;
 
 describe('addon Info', () => {
   // eslint-disable-next-line react/prop-types
-  const storyFn = ({ story }) => (
+  const storyFn = ({ name }) => (
     <div>
-      It's a {story} story:
+      It's a {name} story:
       <TestComponent
         func={x => x + 1}
         obj={{ a: 'a', b: 'b' }}
@@ -85,7 +86,7 @@ describe('addon Info', () => {
     const Info = () =>
       withInfo({ inline: true, propTables: false })(storyFn, {
         kind: 'TestComponent',
-        story: 'Basic test',
+        name: 'Basic test',
       });
 
     expect(mount(<Info />)).toMatchSnapshot();
@@ -100,7 +101,7 @@ describe('addon Info', () => {
     const Info = () =>
       withInfo({ inline: true, propTables: false })(storyFn, {
         kind: 'Test Components',
-        story: 'TestComponent',
+        name: 'TestComponent',
       });
 
     expect(mount(<Info />)).toMatchSnapshot();


### PR DESCRIPTION
It seems like the `story` context property used to be the story name, but now contains the story function instead. The story name is now found in `context.name`.

The context PropTypes was correctly adjusted for this here https://github.com/storybooks/storybook/commit/751b847fa93712b7c46eaf484f70a44b3d00edf6#diff-36f288162c3cc9bd518d680f366bbe54, but the code in `_getComponentDescription` was not updated to reflect this.