### PR TITLE
FIX addon-centered README to refer to /dist files

### DIFF
--- a/addons/centered/README.md
+++ b/addons/centered/README.md
@@ -16,7 +16,7 @@ example for React:
 
 ```js
 import { storiesOf } from '@storybook/react';
-import centered from '@storybook/addon-centered/react';
+import centered from '@storybook/addon-centered/dist/react';
 
 import MyComponent from '../Component';
 
@@ -30,7 +30,7 @@ example for Vue:
 
 ```js
 import { storiesOf } from '@storybook/vue';
-import centered from '@storybook/addon-centered/vue';
+import centered from '@storybook/addon-centered/dist/vue';
 
 import MyComponent from '../Component.vue';
 storiesOf('MyComponent', module)
@@ -49,7 +49,7 @@ example for Preact:
 
 ```js
 import { storiesOf } from '@storybook/preact';
-import centered from '@storybook/addon-centered/preact';
+import centered from '@storybook/addon-centered/dist/preact';
 
 import MyComponent from '../Component';
 
@@ -63,7 +63,7 @@ example for Svelte:
 
 ```js
 import { storiesOf } from '@storybook/svelte';
-import Centered from '@storybook/addon-centered/svelte';
+import Centered from '@storybook/addon-centered/dist/svelte';
 
 import Component from '../Component.svelte';
 
@@ -82,7 +82,7 @@ example for Mithril:
 
 ```js
 import { storiesOf } from '@storybook/mithril';
-import centered from '@storybook/addon-centered/mithril';
+import centered from '@storybook/addon-centered/dist/mithril';
 
 import MyComponent from '../Component';
 
@@ -100,7 +100,7 @@ example for Angular with component:
 
 ```ts
 import { storiesOf } from '@storybook/angular';
-import { centered } from '@storybook/addon-centered/angular';
+import { centered } from '@storybook/addon-centered/dist/angular';
 
 import { AppComponent } from '../app/app.component';
 
@@ -117,7 +117,7 @@ example for Angular with template:
 
 ```ts
 import { moduleMetadata, storiesOf } from '@storybook/angular';
-import { centered } from '@storybook/addon-centered/angular';
+import { centered } from '@storybook/addon-centered/dist/angular';
 
 import { AppComponent } from '../app/app.component';
 
@@ -148,7 +148,7 @@ example for React:
 
 ```js
 import { configure, addDecorator } from '@storybook/react';
-import centered from '@storybook/addon-centered/react';
+import centered from '@storybook/addon-centered/dist/react';
 
 addDecorator(centered);
 
@@ -161,7 +161,7 @@ example for Vue:
 
 ```js
 import { configure, addDecorator } from '@storybook/vue';
-import centered from '@storybook/addon-centered/vue';
+import centered from '@storybook/addon-centered/dist/vue';
 
 addDecorator(centered);
 
@@ -174,7 +174,7 @@ example for Svelte:
 
 ```js
 import { configure, addDecorator } from '@storybook/svelte';
-import Centered from '@storybook/addon-centered/svelte';
+import Centered from '@storybook/addon-centered/dist/svelte';
 
 addDecorator(Centered);
 
@@ -187,7 +187,7 @@ example for Mithril:
 
 ```js
 import { configure, addDecorator } from '@storybook/mithril';
-import centered from '@storybook/addon-centered/mithril';
+import centered from '@storybook/addon-centered/dist/mithril';
 
 addDecorator(centered);
 


### PR DESCRIPTION
Issue:
Currently `import centered from '@storybook/addon-centered/react'` results in file not found.

## What I did
Using files under `/dist` instead.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
