### PR TITLE
FIX broken error reporting

### DIFF
--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -322,7 +322,7 @@ export async function buildDevStandalone(options) {
       } else if (error.stats && error.stats.compilation.errors) {
         error.stats.compilation.errors.forEach(e => logger.plain(e));
       } else {
-        logger.error(Object.keys(error.stats.compilation));
+        logger.error(error);
       }
 
       if (error.close) {


### PR DESCRIPTION
Issue: error in error reporting causes error to never be shown, or process to exit

## What I did
Fixed it