### PR TITLE
ADD a timeout around the `/` search hotkey, so it doesn't type into the input

### DIFF
--- a/lib/ui/src/core/shortcuts.js
+++ b/lib/ui/src/core/shortcuts.js
@@ -101,11 +101,14 @@ export default function initShortcuts({ store }) {
           if (!showNav) {
             fullApi.toggleNav();
           }
-          const element = document.getElementById('storybook-explorer-searchfield');
 
-          if (element) {
-            element.focus();
-          }
+          setTimeout(() => {
+            const element = document.getElementById('storybook-explorer-searchfield');
+
+            if (element) {
+              element.focus();
+            }
+          }, 16);
           break;
         }
 

--- a/lib/ui/src/core/shortcuts.js
+++ b/lib/ui/src/core/shortcuts.js
@@ -108,7 +108,7 @@ export default function initShortcuts({ store }) {
             if (element) {
               element.focus();
             }
-          }, 16);
+          }, 0);
           break;
         }
 


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/5419

> * If you click anywhere in the Sidebar and press "/", you'll insert a '/' in the search box. This should not happen.

## What I did
I added a 16ms timeout before giving the input-element focus.

I know it may not be the cleanest solution, but in order to cancel the event, I'd need access TO the event, and that would require more refactoring then I'm comfortable doing at this stage of the release.