### PR TITLE
Updated documentation

### DIFF
--- a/docs/src/pages/basics/writing-stories/index.md
+++ b/docs/src/pages/basics/writing-stories/index.md
@@ -138,6 +138,9 @@ storiesOf('My App/Buttons/Emoji', module).add('with some emoji', () => (
 ));
 ```
 
+If using the [Storybook Options Addon](https://github.com/storybooks/storybook/tree/master/addons/options), the hierarchySeparator option is set to null by default and must be set in order to use this feature.
+
+
 ## Generating nesting path based on \_\_dirname
 
 Nesting paths can be programmatically generated with template literals because story names are strings.


### PR DESCRIPTION
Updated documentation surrounding the nesting stories feature when also using the Storybook Options Addon

Issue: Nested stories do not work out of the box when also using the Storybook Options Addon. It wasn't until reading [this article](https://medium.com/sears-israel/story-hierarchy-in-storybook-3-2-7506b5a6ceb9) by the feature's developer that I solved why it wasn't happening like the existing documentation stated.

## What I did

Added documentation

## How to test
NA

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
