### PR TITLE
fix: @storybook/addon-info table width

### DIFF
--- a/addons/info/src/components/PropTable/style.css
+++ b/addons/info/src/components/PropTable/style.css
@@ -1,3 +1,7 @@
+.info-table {
+  width: 100%;
+}
+
 .info-table, .info-table td, .info-table th {
   border-collapse: collapse;
   border: 1px solid #cccccc;


### PR DESCRIPTION
### Description

Fix width of info-table in `addon-info` addon.

### Scope

`@storybook/addon-info`

### Version

`5.0.0-beta.3`

### Visual Appearance

#### Before

![image](https://user-images.githubusercontent.com/5244986/53292381-c849b400-37c1-11e9-80f7-11db31353aa9.png)


#### After

![image](https://user-images.githubusercontent.com/5244986/53292375-bb2cc500-37c1-11e9-8e99-be173d04e985.png)