### PR TITLE
Fuzzy search improvement

### DIFF
--- a/lib/ui/src/components/sidebar/treeview/utils.js
+++ b/lib/ui/src/components/sidebar/treeview/utils.js
@@ -3,6 +3,8 @@ import FuzzySearch from 'fuzzy-search';
 
 export const prevent = e => e.preventDefault();
 
+const toList = memoize(1)(dataset => Object.values(dataset));
+
 export const keyEventToAction = ({ keyCode, ctrlKey, shiftKey, altKey, metaKey }) => {
   if (shiftKey || metaKey || ctrlKey || altKey) {
     return false;
@@ -52,7 +54,7 @@ export const getParents = memoize(1000)((id, dataset) => {
 });
 
 export const getMains = memoize(1)(dataset =>
-  Object.values(dataset)
+  toList(dataset)
     .filter(m => m.depth === 0)
     .sort((a, b) => {
       if (a.isRoot && b.isRoot) {
@@ -163,16 +165,24 @@ export const getNext = ({ id, dataset, expanded }) => {
 
 const toHayStack = memoize(2)(
   dataset =>
-    new FuzzySearch(Object.values(dataset), [
-      'kind',
-      'name',
-      'parameters.fileName',
-      'parameters.notes',
-    ])
+    new FuzzySearch(toList(dataset), ['kind', 'name', 'parameters.fileName', 'parameters.notes'])
 );
+
+const exactMatch = memoize(1)(filter => i =>
+  (i.kind && i.kind.includes(filter)) ||
+  (i.name && i.name.includes(filter)) ||
+  (i.parameters && i.parameters.fileName && i.parameters.fileName.includes(filter)) ||
+  (i.parameters && typeof i.parameters.notes === 'string' && i.parameters.notes.includes(filter))
+);
+
 export const toId = (base, addition) => (base === '' ? `${addition}` : `${base}-${addition}`);
 export const toFiltered = (dataset, filter) => {
-  const found = toHayStack(dataset).search(filter);
+  let found;
+  if (filter.length && filter.length > 2) {
+    found = toHayStack(dataset).search(filter);
+  } else {
+    found = toList(dataset).filter(exactMatch(filter));
+  }
 
   // get all parents for all results
   const result = found.reduce((acc, item) => {


### PR DESCRIPTION
Issue: The fuzzy search finds pretty much everything when typing just 2 chars

## What I did
- ADD a memoized fn to get the values of dataset
- CHANGE toFiltered so a 2 char search will only find exact matches

## How to test

- Run the official example
- in the filter input type 'qs'
  expected: no results
- in the filter input type `qss'
  expected: it should find the graphQl stories