### PR TITLE
ADD activity to addon-background and addon-viewport tool

### DIFF
--- a/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -140,7 +140,7 @@ export class BackgroundSelector extends Component<BackgroundToolProps, Backgroun
           tooltip={<TooltipLinkList links={items} />}
           closeOnClick
         >
-          <IconButton key="background" title="Backgrounds">
+          <IconButton key="background" active={selectedBackgroundColor !== 'transparent'} title="Change the background of the preview">
             <Icons icon="photo" />
           </IconButton>
         </WithTooltip>

--- a/addons/viewport/src/Tool.js
+++ b/addons/viewport/src/Tool.js
@@ -123,7 +123,7 @@ export default class ViewportTool extends Component {
           tooltip={<TooltipLinkList links={items} />}
           closeOnClick
         >
-          <IconButton key="viewport" title="Change Viewport">
+          <IconButton key="viewport" title="Change the size of the preview" active={!!item}>
             <Icons icon="grow" />
           </IconButton>
         </WithTooltip>


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/5596

## What I did
ADD active indicators to addon-background tool & addon-viewport tool

## How to test
Toggle the viewport and background tool on an example

expected result:
A blue 3px border should appear when the tool is active