### PR TITLE
fix: remove call to `forceReRender()` on STORY_CHANGED in addon knobs

### DIFF
--- a/addons/knobs/src/registerKnobs.js
+++ b/addons/knobs/src/registerKnobs.js
@@ -37,6 +37,12 @@ function knobClicked(clicked) {
 function resetKnobs() {
   knobStore.reset();
 
+  setPaneKnobs(false);
+}
+
+function resetKnobsAndForceReRender() {
+  knobStore.reset();
+
   forceReRender();
 
   setPaneKnobs(false);
@@ -47,7 +53,7 @@ function disconnectCallbacks() {
   channel.removeListener(CHANGE, knobChanged);
   channel.removeListener(CLICK, knobClicked);
   channel.removeListener(STORY_CHANGED, resetKnobs);
-  channel.removeListener(RESET, resetKnobs);
+  channel.removeListener(RESET, resetKnobsAndForceReRender);
   knobStore.unsubscribe(setPaneKnobs);
 }
 
@@ -56,7 +62,7 @@ function connectCallbacks() {
   channel.on(CHANGE, knobChanged);
   channel.on(CLICK, knobClicked);
   channel.on(STORY_CHANGED, resetKnobs);
-  channel.on(RESET, resetKnobs);
+  channel.on(RESET, resetKnobsAndForceReRender);
   knobStore.subscribe(setPaneKnobs);
 
   return disconnectCallbacks;


### PR DESCRIPTION
Issue: #5382

## What I did

Fix issue https://github.com/storybooks/storybook/issues/5382

I removed call to `forceReRender()` on STORY_CHANGED in addon knobs as this call is no necessary because it's already done by SB core and was causing an error in SB Angular.

## How to test

Open Angular CLI example and check that there is no error in browser console when switching between stories using addon knobs.
