### PR TITLE
Fix deprecated url/name options

### DIFF
--- a/lib/ui/src/core/init-provider-api.js
+++ b/lib/ui/src/core/init-provider-api.js
@@ -8,6 +8,7 @@ const applyDeprecatedUiOptions = deprecate(({ name, url, theme }) => {
   const vars = {
     brandTitle: name,
     brandUrl: url,
+    brandImage: null,
   };
 
   return { theme: create(vars, theme) };


### PR DESCRIPTION
Issue: #5665 

## What I did

#5733 does not appear to work as advertised. When I modify `official-storybook` in the `next` branch as follows:

```js
addParameters({
  options: {
    name: 'Foo',
    url: 'https://github.com',
  }
});
```

It uses the URL and uses `Foo` as the alt text. However I expect to see the text "Foo" instead of Storybook.

This fix forces the `brandImage` theme var to `null` when using the deprecated options, which shows `Foo` but hides the image entirely. Not sure this is the behavior we want, but it's an improvement.

## How to test

See above
