### PR TITLE
Close tooltips on iframe clicks on keypresses

### DIFF
--- a/lib/components/src/tooltip/WithTooltip.js
+++ b/lib/components/src/tooltip/WithTooltip.js
@@ -97,11 +97,38 @@ WithTooltipPure.defaultProps = {
 const WithTooltip = lifecycle({
   componentDidMount() {
     const { onVisibilityChange } = this.props;
-    this.visibilityHider = () => onVisibilityChange(false);
-    document.addEventListener('keydown', this.visibilityHider, false);
+    const hide = () => onVisibilityChange(false);
+    document.addEventListener('keydown', hide, false);
+
+    // Find all iframes on the screen and bind to clicks inside them (waiting until the iframe is ready)
+    const iframes = Array.from(document.getElementsByTagName('iframe'));
+    const unbinders = [];
+    iframes.forEach(iframe => {
+      const bind = () => {
+        iframe.contentDocument.addEventListener('click', hide);
+        unbinders.push(() => {
+          iframe.contentDocument.removeEventListener('click', hide);
+        });
+      };
+
+      bind(); // I don't know how to find out if it's already loaded so I potentially will bind twice
+      iframe.addEventListener('load', bind);
+      unbinders.push(() => {
+        iframe.removeEventListener('load', bind);
+      });
+    });
+
+    this.unbind = () => {
+      document.removeEventListener('keydown', hide);
+      unbinders.forEach(unbind => {
+        unbind();
+      });
+    };
   },
   componentWillUnmount() {
-    document.removeEventListener('keydown', this.visibilityHider);
+    if (this.unbind) {
+      this.unbind();
+    }
   },
 })(WithTooltipPure);
 

--- a/lib/components/src/tooltip/WithTooltip.js
+++ b/lib/components/src/tooltip/WithTooltip.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
-import { withState } from 'recompose';
+import { withState, lifecycle } from 'recompose';
+import { document } from 'global';
 
 import TooltipTrigger from 'react-popper-tooltip';
 import Tooltip from './Tooltip';
@@ -17,7 +18,8 @@ const TargetSvgContainer = styled.g`
   cursor: ${props => (props.mode === 'hover' ? 'default' : 'pointer')};
 `;
 
-const WithTooltip = ({
+// Pure, does not bind to the body
+const WithTooltipPure = ({
   svg,
   trigger,
   closeOnClick,
@@ -69,7 +71,7 @@ const WithTooltip = ({
   );
 };
 
-WithTooltip.propTypes = {
+WithTooltipPure.propTypes = {
   svg: PropTypes.bool,
   trigger: PropTypes.string,
   closeOnClick: PropTypes.bool,
@@ -82,7 +84,7 @@ WithTooltip.propTypes = {
   onVisibilityChange: PropTypes.func.isRequired,
 };
 
-WithTooltip.defaultProps = {
+WithTooltipPure.defaultProps = {
   svg: false,
   trigger: 'hover',
   closeOnClick: false,
@@ -92,6 +94,17 @@ WithTooltip.defaultProps = {
   tooltipShown: false,
 };
 
+const WithTooltip = lifecycle({
+  componentDidMount() {
+    const { onVisibilityChange } = this.props;
+    this.visibilityHider = () => onVisibilityChange(false);
+    document.addEventListener('keydown', this.visibilityHider, false);
+  },
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.visibilityHider);
+  },
+})(WithTooltipPure);
+
 export default WithTooltip;
 
 const WithToolTipState = withState(
@@ -100,4 +113,4 @@ const WithToolTipState = withState(
   ({ startOpen }) => startOpen
 )(WithTooltip);
 
-export { WithToolTipState };
+export { WithTooltipPure, WithToolTipState };


### PR DESCRIPTION
Issue: #5593

- Added a keydown event handler on tooltip creation
- Find all iframes on the screen and bind on tooltip creation

I'm not sure if this is really robust to changing iframes on the screen 🤷‍♂️ 