### PR TITLE
Knob changed debounce performance fix

### DIFF
--- a/addons/knobs/src/registerKnobs.js
+++ b/addons/knobs/src/registerKnobs.js
@@ -6,6 +6,8 @@ import { CHANGE, CLICK, RESET, SET } from './shared';
 
 export const manager = new KnobManager();
 const { knobStore } = manager;
+const KNOB_CHANGED_DEBOUNCE_DELAY_MS = 155; // approximatly the average time between keypresses
+let timeoutId = null;
 
 function forceReRender() {
   addons.getChannel().emit(FORCE_RE_RENDER);
@@ -17,15 +19,19 @@ function setPaneKnobs(timestamp = +new Date()) {
 }
 
 function knobChanged(change) {
-  const { name, value } = change;
+  clearTimeout(timeoutId);
+  timeoutId = setTimeout(() => {
+    // debouncing occurs here to increase performance
+    const { name, value } = change;
 
-  // Update the related knob and it's value.
-  const knobOptions = knobStore.get(name);
+    // Update the related knob and it's value.
+    const knobOptions = knobStore.get(name);
 
-  knobOptions.value = value;
-  knobStore.markAllUnused();
+    knobOptions.value = value;
+    knobStore.markAllUnused();
 
-  forceReRender();
+    forceReRender();
+  }, DEBOUNCE_DELAY_MS); // this is an arbitrary amount of time used to ensure that the user has time to type before re-rendering
 }
 
 function knobClicked(clicked) {

--- a/addons/knobs/src/registerKnobs.js
+++ b/addons/knobs/src/registerKnobs.js
@@ -31,7 +31,7 @@ function knobChanged(change) {
     knobStore.markAllUnused();
 
     forceReRender();
-  }, DEBOUNCE_DELAY_MS); // this is an arbitrary amount of time used to ensure that the user has time to type before re-rendering
+  }, DEBOUNCE_DELAY_MS); // Amount of time used to ensure that the user has time to type before re-rendering
 }
 
 function knobClicked(clicked) {


### PR DESCRIPTION
Issue: #5376

## What I did
I added debouncing within the knob changed function to reduce the number of times that a component is rendered when the user is typing. The knob changed functionality will only be called if there is a delay of 155ms during user typing. The previous version re-rendered the component upon each keypress. This will help increase performance and is seen mostly when running large components within storybook.

For more information about this PR, please refer to #5376

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
