### PR TITLE
FIX build-storybook with simplebar esm files

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -81,7 +81,6 @@ export default ({
     resolve: {
       extensions: ['.mjs', '.js', '.jsx', '.json'],
       modules: ['node_modules'].concat(raw.NODE_PATH || []),
-      mainFields: ['browser', 'main', 'module'],
       alias: {
         'core-js': path.dirname(require.resolve('core-js/package.json')),
         ...reactPaths,


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/5788

## What I did
I changed a config for webpack for preview

## Why
So after a bunch of experimentation and debugging, I found that `simplebar` & `simplebar-react` expose `.esm.js` AND `.js` AND `.min.js` files. For the preview configured it so it would load the `.js` file. Turns out that files doesn't work well within a webpack bundle.

Probably due to multiple polyfills.

I don't really have an explanation for why it worked in dev-mode.