### PR TITLE
Toggle Dark Mode

### DIFF
--- a/docs/src/pages/addons/using-addons/index.md
+++ b/docs/src/pages/addons/using-addons/index.md
@@ -67,6 +67,7 @@ addParameters({
   options: {
     name: 'CRA Kitchen Sink',
     isFullScreen: false,
+    isDarkMode: true,
     showPanel: true,
     // more configuration here
   },

--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -18,6 +18,11 @@ import { addParameters, configure } from '@storybook/react';
 addParameters({
   options: {
     /**
+     * initially render the storybook in dark mode
+     * @type {Boolean}
+     */
+    isDarkMode: false,
+    /**
      * show story component as full screen
      * @type {Boolean}
      */

--- a/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
+++ b/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
@@ -5856,7 +5856,7 @@ exports[`Storyshots UI|Settings/SettingsFooter basic 1`] = `
 `;
 
 exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
-.emotion-100 {
+.emotion-105 {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
@@ -6003,7 +6003,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   fill: currentColor;
 }
 
-.emotion-99 {
+.emotion-104 {
   display: block;
   position: relative;
   font-size: 13px;
@@ -6016,7 +6016,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   overflow: auto;
 }
 
-.emotion-99 > *:first-child {
+.emotion-104 > *:first-child {
   position: absolute;
   left: 0;
   right: 0;
@@ -6049,7 +6049,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   width: 15px;
 }
 
-.emotion-96 {
+.emotion-101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6060,11 +6060,11 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   font-weight: 700;
 }
 
-.emotion-96 > * + * {
+.emotion-101 > * + * {
   margin-left: 20px;
 }
 
-.emotion-91 {
+.emotion-96 {
   display: inline-block;
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
@@ -6074,30 +6074,30 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   color: #999999;
 }
 
-.emotion-91 svg path {
+.emotion-96 svg path {
   fill: #1EA7FD;
 }
 
-.emotion-91:hover,
-.emotion-91:focus {
+.emotion-96:hover,
+.emotion-96:focus {
   cursor: pointer;
   color: #0297f5;
 }
 
-.emotion-91:hover svg path,
-.emotion-91:focus svg path {
+.emotion-96:hover svg path,
+.emotion-96:focus svg path {
   fill: #0297f5;
 }
 
-.emotion-91:active {
+.emotion-96:active {
   color: #028ee6;
 }
 
-.emotion-91:active svg path {
+.emotion-96:active svg path {
   fill: #028ee6;
 }
 
-.emotion-91 svg {
+.emotion-96 svg {
   display: inline-block;
   height: 1em;
   width: 1em;
@@ -6107,31 +6107,31 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   margin-right: 0.4em;
 }
 
-.emotion-91 svg path {
+.emotion-96 svg path {
   fill: #999999;
 }
 
-.emotion-91:hover {
+.emotion-96:hover {
   color: #666666;
 }
 
-.emotion-91:hover svg path {
+.emotion-96:hover svg path {
   fill: #666666;
 }
 
-.emotion-91:active {
+.emotion-96:active {
   color: #444444;
 }
 
-.emotion-91:active svg path {
+.emotion-96:active svg path {
   fill: #444444;
 }
 
-.emotion-98 {
+.emotion-103 {
   display: block;
 }
 
-.emotion-97 {
+.emotion-102 {
   font-size: 14px;
   padding: 3rem 20px;
   max-width: 600px;
@@ -6152,7 +6152,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   display: flex;
 }
 
-.emotion-88 {
+.emotion-93 {
   display: grid;
   grid-template-columns: 1fr;
   grid-auto-rows: minmax(auto,auto);
@@ -6274,7 +6274,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   width: 14px;
 }
 
-.emotion-89 {
+.emotion-94 {
   border: 0;
   border-radius: 3em;
   cursor: pointer;
@@ -6315,7 +6315,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   z-index: 2;
 }
 
-.emotion-89 svg {
+.emotion-94 svg {
   display: inline-block;
   height: 14px;
   width: 14px;
@@ -6326,29 +6326,29 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   pointer-events: none;
 }
 
-.emotion-89 svg path {
+.emotion-94 svg path {
   fill: currentColor;
 }
 
-.emotion-89:hover {
+.emotion-94:hover {
   background: #f2f2f2;
 }
 
-.emotion-89:active {
+.emotion-94:active {
   background: #FFFFFF;
 }
 
-.emotion-89:focus {
+.emotion-94:focus {
   box-shadow: rgba(30,167,253,0.4) 0 0 0 1px inset;
 }
 
-.emotion-89:hover {
+.emotion-94:hover {
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
 }
 
-.emotion-100 {
+.emotion-105 {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
@@ -6495,7 +6495,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   fill: currentColor;
 }
 
-.emotion-99 {
+.emotion-104 {
   display: block;
   position: relative;
   font-size: 13px;
@@ -6508,7 +6508,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   overflow: auto;
 }
 
-.emotion-99 > *:first-child {
+.emotion-104 > *:first-child {
   position: absolute;
   left: 0;
   right: 0;
@@ -6541,7 +6541,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   width: 15px;
 }
 
-.emotion-96 {
+.emotion-101 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6552,11 +6552,11 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   font-weight: 700;
 }
 
-.emotion-96 > * + * {
+.emotion-101 > * + * {
   margin-left: 20px;
 }
 
-.emotion-91 {
+.emotion-96 {
   display: inline-block;
   -webkit-transition: all 150ms ease-out;
   transition: all 150ms ease-out;
@@ -6566,30 +6566,30 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   color: #999999;
 }
 
-.emotion-91 svg path {
+.emotion-96 svg path {
   fill: #1EA7FD;
 }
 
-.emotion-91:hover,
-.emotion-91:focus {
+.emotion-96:hover,
+.emotion-96:focus {
   cursor: pointer;
   color: #0297f5;
 }
 
-.emotion-91:hover svg path,
-.emotion-91:focus svg path {
+.emotion-96:hover svg path,
+.emotion-96:focus svg path {
   fill: #0297f5;
 }
 
-.emotion-91:active {
+.emotion-96:active {
   color: #028ee6;
 }
 
-.emotion-91:active svg path {
+.emotion-96:active svg path {
   fill: #028ee6;
 }
 
-.emotion-91 svg {
+.emotion-96 svg {
   display: inline-block;
   height: 1em;
   width: 1em;
@@ -6599,31 +6599,31 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   margin-right: 0.4em;
 }
 
-.emotion-91 svg path {
+.emotion-96 svg path {
   fill: #999999;
 }
 
-.emotion-91:hover {
+.emotion-96:hover {
   color: #666666;
 }
 
-.emotion-91:hover svg path {
+.emotion-96:hover svg path {
   fill: #666666;
 }
 
-.emotion-91:active {
+.emotion-96:active {
   color: #444444;
 }
 
-.emotion-91:active svg path {
+.emotion-96:active svg path {
   fill: #444444;
 }
 
-.emotion-98 {
+.emotion-103 {
   display: block;
 }
 
-.emotion-97 {
+.emotion-102 {
   font-size: 14px;
   padding: 3rem 20px;
   max-width: 600px;
@@ -6644,7 +6644,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   display: flex;
 }
 
-.emotion-88 {
+.emotion-93 {
   display: grid;
   grid-template-columns: 1fr;
   grid-auto-rows: minmax(auto,auto);
@@ -6766,7 +6766,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   width: 14px;
 }
 
-.emotion-89 {
+.emotion-94 {
   border: 0;
   border-radius: 3em;
   cursor: pointer;
@@ -6807,7 +6807,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   z-index: 2;
 }
 
-.emotion-89 svg {
+.emotion-94 svg {
   display: inline-block;
   height: 14px;
   width: 14px;
@@ -6818,23 +6818,23 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   pointer-events: none;
 }
 
-.emotion-89 svg path {
+.emotion-94 svg path {
   fill: currentColor;
 }
 
-.emotion-89:hover {
+.emotion-94:hover {
   background: #f2f2f2;
 }
 
-.emotion-89:active {
+.emotion-94:active {
   background: #FFFFFF;
 }
 
-.emotion-89:focus {
+.emotion-94:focus {
   box-shadow: rgba(30,167,253,0.4) 0 0 0 1px inset;
 }
 
-.emotion-89:hover {
+.emotion-94:hover {
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
@@ -6844,7 +6844,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   style="position:relative;height:calc(100vh);width:calc(100vw)"
 >
   <div
-    class="emotion-100"
+    class="emotion-105"
   >
     <div
       class="emotion-8"
@@ -6929,14 +6929,14 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
       </div>
     </div>
     <div
-      class="emotion-99"
+      class="emotion-104"
     >
       <div
-        class="emotion-98"
+        class="emotion-103"
         role="tabpanel"
       >
         <div
-          class="emotion-97"
+          class="emotion-102"
         >
           <header
             class="emotion-9"
@@ -6944,7 +6944,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
             Keyboard shortcuts
           </header>
           <div
-            class="emotion-88"
+            class="emotion-93"
           >
             <div
               class="emotion-12"
@@ -7024,6 +7024,31 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
                 readonly=""
                 spellcheck="false"
                 value="D"
+              />
+              <svg
+                class="emotion-16"
+                viewBox="0 0 1024 1024"
+              >
+                <path
+                  class="emotion-3"
+                  d="M948.598 199.75c-15.622-15.618-40.95-15.618-56.57 0l-535.644 535.644-224.060-224.062c-15.624-15.624-40.954-15.62-56.57 0-15.624 15.62-15.624 40.948 0 56.568l251.574 251.574c0.252 0.266 0.472 0.55 0.734 0.812 7.82 7.82 18.072 11.724 28.322 11.714 10.25 0.010 20.502-3.894 28.322-11.714 0.248-0.248 0.456-0.518 0.698-0.77l563.196-563.202c15.618-15.618 15.618-40.94-0.002-56.564z"
+                />
+              </svg>
+            </div>
+            <div
+              class="emotion-17"
+            >
+              <div
+                class="emotion-13"
+              >
+                Toggle dark mode
+              </div>
+              <input
+                class="modalInput emotion-14"
+                placeholder="Type keys"
+                readonly=""
+                spellcheck="false"
+                value="M"
               />
               <svg
                 class="emotion-16"
@@ -7337,40 +7362,40 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
             </div>
           </div>
           <button
-            class="emotion-89"
+            class="emotion-94"
             id="restoreDefaultsHotkeys"
           >
             Restore defaults
           </button>
           <div
-            class="emotion-96"
+            class="emotion-101"
           >
             <a
-              class="emotion-91"
+              class="emotion-96"
               href="https://storybook.js.org"
             >
               <span
-                class="emotion-90"
+                class="emotion-95"
               >
                 Docs
               </span>
             </a>
             <a
-              class="emotion-91"
+              class="emotion-96"
               href="https://github.com/storybooks/storybook"
             >
               <span
-                class="emotion-90"
+                class="emotion-95"
               >
                 GitHub
               </span>
             </a>
             <a
-              class="emotion-91"
+              class="emotion-96"
               href="https://storybook.js.org/support"
             >
               <span
-                class="emotion-90"
+                class="emotion-95"
               >
                 Support
               </span>

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -9,7 +9,7 @@ import { shortcutToHumanString } from '../libs/shortcut';
 import Sidebar from '../components/sidebar/Sidebar';
 import { Consumer } from '../core/context';
 
-const createMenu = memoize(1)((api, shortcutKeys, isFullscreen, showPanel, showNav) => [
+const createMenu = memoize(1)((api, shortcutKeys, isFullscreen, isDarkMode, showPanel, showNav) => [
   {
     id: 'S',
     title: 'Show sidebar',
@@ -30,6 +30,13 @@ const createMenu = memoize(1)((api, shortcutKeys, isFullscreen, showPanel, showN
     onClick: () => api.togglePanelPosition(),
     right: shortcutToHumanString(shortcutKeys.panelPosition),
     left: <ListItemIcon />,
+  },
+  {
+    id: 'M',
+    title: 'Change dark/light mode',
+    onClick: () => api.toggleDarkMode(),
+    right: shortcutToHumanString(shortcutKeys.toggleDarkMode),
+    left: isDarkMode ? <ListItemIcon icon="check" /> : <ListItemIcon />,
   },
   {
     id: 'F',
@@ -94,7 +101,7 @@ export const mapper = (state, api) => {
     ui: { name, url },
     viewMode,
     storyId,
-    layout: { isFullscreen, showPanel, showNav, panelPosition },
+    layout: { isFullscreen, isDarkMode, showPanel, showNav, panelPosition },
     storiesHash,
     storiesConfigured,
   } = state;
@@ -107,7 +114,15 @@ export const mapper = (state, api) => {
     stories: storiesHash,
     storyId,
     viewMode,
-    menu: createMenu(api, shortcutKeys, isFullscreen, showPanel, showNav, panelPosition),
+    menu: createMenu(
+      api,
+      shortcutKeys,
+      isFullscreen,
+      isDarkMode,
+      showPanel,
+      showNav,
+      panelPosition
+    ),
     menuHighlighted: api.versionUpdateAvailable(),
   };
 };

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -33,7 +33,7 @@ const createMenu = memoize(1)((api, shortcutKeys, isFullscreen, isDarkMode, show
   },
   {
     id: 'M',
-    title: 'Change dark mode',
+    title: 'Toggle dark mode',
     onClick: () => api.toggleDarkMode(),
     right: shortcutToHumanString(shortcutKeys.toggleDarkMode),
     left: isDarkMode ? <ListItemIcon icon="check" /> : <ListItemIcon />,

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -33,7 +33,7 @@ const createMenu = memoize(1)((api, shortcutKeys, isFullscreen, isDarkMode, show
   },
   {
     id: 'M',
-    title: 'Change dark/light mode',
+    title: 'Change dark mode',
     onClick: () => api.toggleDarkMode(),
     right: shortcutToHumanString(shortcutKeys.toggleDarkMode),
     left: isDarkMode ? <ListItemIcon icon="check" /> : <ListItemIcon />,

--- a/lib/ui/src/core/layout.js
+++ b/lib/ui/src/core/layout.js
@@ -77,7 +77,7 @@ export default function({ store }) {
     toggleDarkMode(toggled) {
       return store.setState(state => {
         const isDarkMode = typeof toggled !== 'undefined' ? toggled : !state.layout.isDarkMode;
-        const newTheme = isDarkMode ? themes.dark : themes.light;
+        const newTheme = isDarkMode ? state.ui.darkTheme : state.ui.lightTheme;
 
         const updatedUi = {
           ...state.ui,
@@ -168,7 +168,7 @@ export default function({ store }) {
         };
 
         if (updatedLayout.isDarkMode) {
-          updatedUi.theme = themes.dark;
+          updatedUi.theme = updatedUi.darkTheme;
         }
 
         store.setState(
@@ -191,6 +191,7 @@ export default function({ store }) {
       sortStoriesByKind: false,
       sidebarAnimations: true,
       theme: themes.normal,
+      darkTheme: themes.dark,
     },
     layout: {
       isDarkMode: false,
@@ -203,6 +204,7 @@ export default function({ store }) {
   };
 
   const state = merge(fromState, initial);
+  state.ui.lightTheme = state.ui.theme;
 
   if (state.layout.isDarkMode) {
     state.ui.theme = themes.dark;

--- a/lib/ui/src/core/layout.js
+++ b/lib/ui/src/core/layout.js
@@ -74,6 +74,26 @@ export default function({ store }) {
       });
     },
 
+    toggleDarkMode(toggled) {
+      return store.setState(state => {
+        const isDarkMode = typeof toggled !== 'undefined' ? toggled : !state.layout.isDarkMode;
+        const newTheme = isDarkMode ? themes.dark : themes.light;
+
+        const updatedUi = {
+          ...state.ui,
+          theme: newTheme,
+        };
+
+        return {
+          layout: {
+            ...state.layout,
+            isDarkMode,
+          },
+          ui: updatedUi,
+        };
+      });
+    },
+
     togglePanel(toggled) {
       return store.setState(state => {
         const value = typeof toggled !== 'undefined' ? toggled : !state.layout.showPanel;
@@ -147,6 +167,10 @@ export default function({ store }) {
           ...checkDeprecatedThemeOptions(options),
         };
 
+        if (updatedLayout.isDarkMode) {
+          updatedUi.theme = themes.dark;
+        }
+
         store.setState(
           {
             layout: updatedLayout,
@@ -169,6 +193,7 @@ export default function({ store }) {
       theme: themes.normal,
     },
     layout: {
+      isDarkMode: false,
       isToolshown: true,
       isFullscreen: false,
       showPanel: true,
@@ -178,6 +203,10 @@ export default function({ store }) {
   };
 
   const state = merge(fromState, initial);
+
+  if (state.layout.isDarkMode) {
+    state.ui.theme = themes.dark;
+  }
 
   return { api, state };
 }

--- a/lib/ui/src/core/shortcuts.js
+++ b/lib/ui/src/core/shortcuts.js
@@ -11,6 +11,7 @@ export const defaultShortcuts = Object.freeze({
   fullScreen: ['F'],
   togglePanel: ['A'],
   panelPosition: ['D'],
+  toggleDarkMode: ['M'],
   toggleNav: ['S'],
   toolbar: ['T'],
   search: ['/'],
@@ -163,6 +164,11 @@ export default function initShortcuts({ store }) {
 
         case 'fullScreen': {
           fullApi.toggleFullscreen();
+          break;
+        }
+
+        case 'toggleDarkMode': {
+          fullApi.toggleDarkMode();
           break;
         }
 

--- a/lib/ui/src/settings/shortcuts.js
+++ b/lib/ui/src/settings/shortcuts.js
@@ -107,6 +107,7 @@ const shortcutLabels = {
   fullScreen: 'Go full screen',
   togglePanel: 'Toggle addons',
   panelPosition: 'Toggle addons orientation',
+  toggleDarkMode: 'Toggle dark mode',
   toggleNav: 'Toggle sidebar',
   toolbar: 'Toggle canvas toolbar',
   search: 'Focus search',


### PR DESCRIPTION
Issue:

## What I did

Added a `Toggle dark mode` button to the menu.

- [x] Need to be able to set the UI back to the configured theme. Currently it sets it back to the light them
  - Now during initialization I save the configure theme as the `lightTheme` so it doesn't get overwritten

- [ ] Initial loading UI still renders with light mode. Is there a way to set this so the use doesn't see light mode flash for a second?

@shilman @ndelangen Is this something you would include?

Follow Up PRs to include:

~- configure the dark theme via settings~ Add this to the PR as well. You can configure the `darkTheme`

## How to test

- Is this testable with Jest or Chromatic screenshots? yes
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->


![dark-gif](https://user-images.githubusercontent.com/1192452/53712824-64487080-3dfd-11e9-9afd-c3ba5c015bee.gif)
