### PR TITLE
ADD parameters to compile-js to no longer copy .ts files into dist

### DIFF
--- a/scripts/compile-js.js
+++ b/scripts/compile-js.js
@@ -10,6 +10,7 @@ function getCommand(watch) {
     '--ignore **/__mocks__/,**/tests/*,**/__tests__/,**/**.test.js,**/stories/,**/**.story.js,**/**.stories.js,**/__snapshots__',
     './src --out-dir ./dist',
     '--copy-files',
+    '--ignore *.ts',
     `--config-file ${path.resolve(__dirname, '../.babelrc.js')}`,
   ];
 


### PR DESCRIPTION
Issue: in our dist there are typescript source files

## What I did
I added a cli parameter to babel to NOT copy these files into dist