### PR TITLE
Deprecate withA11Y

### DIFF
--- a/addons/a11y/src/index.js
+++ b/addons/a11y/src/index.js
@@ -58,6 +58,12 @@ if (module && module.hot && module.hot.decline) {
 }
 
 // TODO: REMOVE at v6.0.0
+export const withA11Y = deprecate(
+  (...args) => withA11y(...args),
+  'withA11Y has been renamed withA11y'
+);
+
+// TODO: REMOVE at v6.0.0
 export const checkA11y = deprecate(
   (...args) => withA11y(...args),
   'checkA11y has been renamed withA11y'


### PR DESCRIPTION
Issue: #5832 

## What I did

#5833 renames `withA11Y` to `withA11y`. This makes the transition smoother for anybody on the RC

