### PR TITLE
Fix code example in "writing-addons" docs

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -61,7 +61,7 @@ We write an addon that responds to a change in story selection like so:
 // register.js
 
 import React from 'react';
-import { STORY_CHANGED } from '@storybook/core-events';
+import { STORY_RENDERED } from '@storybook/core-events';
 import addons, { types } from '@storybook/addons';
 
 const ADDON_ID = 'myaddon';

--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -184,7 +184,7 @@ class MyPanel extends React.Component {
   componentDidMount() {
     const { api } = this.props;
     api.on('foo/doSomeAction', this.onSomeAction);
-    api.on(STORY_RENDERED this.onStoryChange);
+    api.on(STORY_RENDERED, this.onStoryChange);
   }
   componentWillUnmount() {
     const { api } = this.props;


### PR DESCRIPTION
Issue: Missing comma in docs.

## What I did

Added a comma to the docs.
