### PR TITLE
Fix: SidebarItem feels "laggy" when clicked

### DIFF
--- a/lib/ui/src/components/sidebar/SidebarItem.js
+++ b/lib/ui/src/components/sidebar/SidebarItem.js
@@ -60,7 +60,6 @@ export const Item = styled.div(
     alignItems: 'center',
     flex: 1,
     background: 'transparent',
-    transition: 'background 75ms ease-out',
   },
   ({ depth }) => ({
     paddingLeft: depth * 15 + 9,


### PR DESCRIPTION
**Issue:**
SidebarItem feels laggy when clicked. Reported by @hypnosphi in Discord
![image](https://cdn.discordapp.com/attachments/489892645087215636/552203554568404993/Kapture_2019-03-04_at_19.26.18.gif)

## What I did
- Eliminate transition 75ms css transition

## How to test
- Click a story in the Sidebar. It should now visually change state instantly.

