### PR TITLE
Update ember docs for ember-cli-storybook@0.1.0

### DIFF
--- a/docs/src/pages/basics/guide-ember/index.md
+++ b/docs/src/pages/basics/guide-ember/index.md
@@ -15,24 +15,18 @@ In this guide, we will set up Storybook for your Ember project.
 
 ## Table of contents
 
--   [Add @storybook/ember](#add-storybookember)
+-   [Add ember-cli-storybook](#add-storybookember)
 -   [Setup environment](#setup-environment)
 -   [Create the config file](#create-the-config-file)
 -   [Write your stories](#write-your-stories)
 -   [Run your Storybook](#run-your-storybook)
 
-## Add @storybook/ember
+## Add ember-cli-storybook
 
-First of all, you need to add `@storybook/ember` to your project. To do that, simply run:
-
-```sh
-npm i --save-dev @storybook/ember
-```
-
-If you don't have `package.json` in your project, you'll need to init it first:
+First of all, you need to add `ember-cli-storybook` to your project. To do that, simply run:
 
 ```sh
-npm init
+ember install ember-cli-storybook
 ```
 
 Then add the following NPM script to your package json in order to start the storybook later in this guide:


### PR DESCRIPTION
Issue: Ember docs have unnecessary steps

## What I did

In ember-cli-storybook@0.1.0 the addon installs the necessary `@storybook/ember` dependencies and creates files needed to start using Storybook. Also removed section about creating a `package.json` file via `npm init` since ember applications & addons should already be configured via ember-cli.

## How to test

Create an ember app via ember-cli & `ember install ember-cli-storybook`

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
