### PR TITLE
fix: move `react-select` dependency to 2.2

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -35,7 +35,7 @@
     "qs": "^6.5.2",
     "react-color": "^2.17.0",
     "react-lifecycles-compat": "^3.0.4",
-    "react-select": "^2.3.0"
+    "react-select": "^2.2.0"
   },
   "peerDependencies": {
     "react": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18872,7 +18872,7 @@ react-scripts@^2.1.3:
   optionalDependencies:
     fsevents "1.2.4"
 
-react-select@^2.3.0:
+react-select@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.3.0.tgz#990429622445eb2b4a6e985b8069fe7d498cae91"
   integrity sha512-CD3jyZs5lwy/CHW3SdYU1d1FtmJxgvVPdKMwEE8dD6MyNANFtvW95P/V20StPsPppFY7oePv/i2Mun2C2+WgTA==


### PR DESCRIPTION
Issue:

Version 2.3 went from emotion 10 to emotion 9, causing issues with code dedupe for us (since yarn decided to hoist differently).

2.3 is still en semver range here, but this allows us to lock down the older version.

We're stuck on `alpha.5` due to the upgrade that landed in alpha 6

See https://github.com/JedWatson/react-select/pull/3346

## What I did

Lowered the version in package.json.

An alternative plan is to not use a lib that's larger than react-dom just to render a dropdown in an addon 😛 

## How to test

Not much to test