### PR TITLE
Corrected import path for `themes`

### DIFF
--- a/docs/src/pages/configurations/theming/index.md
+++ b/docs/src/pages/configurations/theming/index.md
@@ -33,7 +33,7 @@ You can get these themes like so:
 
 ```js
 import { addParameters, configure } from '@storybook/react';
-import { themes } from '@storybook/components';
+import { themes } from '@storybook/theming';
 
 // Option defaults.
 addParameters({


### PR DESCRIPTION
Issue:

Incorrect import path for `themes` in example.

## What I did

Corrected import path for `themes`.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.