### PR TITLE
Fix imported package for "dark" theme

### DIFF
--- a/docs/src/pages/configurations/theming/index.md
+++ b/docs/src/pages/configurations/theming/index.md
@@ -33,7 +33,7 @@ You can get these themes like so:
 
 ```js
 import { addParameters, configure } from '@storybook/react';
-import { themes } from '@storybook/components';
+import { themes } from '@storybook/theming';
 
 // Option defaults.
 addParameters({


### PR DESCRIPTION
Issue:

Could not import themes from `@storybook/components`.

![image](https://user-images.githubusercontent.com/22530815/53831661-f14d1000-3f4a-11e9-9c7c-cd85faed75d5.png)

## What I did

Changed the imported example for theming to use `@storybook/theming` instead of `@storybook/components`.

I followed the documentation, but it looks like `themes` was moved to the `@storybook/theming` package or this was a typo.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
