### PR TITLE
Spelling correction for markup heading link for Configuration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -53,7 +53,7 @@
 
 Storybook 5.0 includes sweeping UI changes as well as changes to the addon API and custom webpack configuration. We've tried to keep backwards compatibility in most cases, but there are some notable exceptions documented below.
 
-## Webpack config simplifcation
+## Webpack config simplification
 
 The API for custom webpack configuration has been simplifed in 5.0, but it's a breaking change.
 


### PR DESCRIPTION
Issue:

## What I did
Corrected a spelling error in the migration markup document, so that the header would be correctly linked. I hope this isn't too small of a PR.

## How to test
Clicking on the link for "Webpack config simplifcation" should now take a reader to the section of the same name.

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
