### PR TITLE
Fix typo in example, use MyPanel component

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -102,7 +102,7 @@ class MyPanel extends React.Component {
 }
 
 addons.register(ADDON_ID, api => {
-  const render = ({ active }) => <Panel api={api} active={active} />;
+  const render = ({ active }) => <MyPanel api={api} active={active} />;
   const title = 'My Addon';
 
   addons.add(PANEL_ID, {


### PR DESCRIPTION
Issue:
`render` function used undeclared `Panel` component. Seems like it should use `MyPanel` instead.

## What I did
Fixed small typo in example in "Writing Addons" article.
