### PR TITLE
lib client-api/src/client_api: check type of module.id as fileName

### DIFF
--- a/lib/client-api/src/client_api.js
+++ b/lib/client-api/src/client_api.js
@@ -163,7 +163,7 @@ export default class ClientApi {
         });
       }
 
-      const fileName = m ? m.id : null;
+      const fileName = m && typeof m.id === 'string' ? m.id : undefined;
 
       const { hierarchyRootSeparator, hierarchySeparator } = this.getSeparators();
       const baseOptions = {

--- a/lib/client-api/src/client_api.test.js
+++ b/lib/client-api/src/client_api.test.js
@@ -270,6 +270,29 @@ describe('preview.client_api', () => {
         },
       ]);
     });
+
+    it('should ignore non-string ids from module', () => {
+      const {
+        clientApi: { getStorybook, storiesOf },
+      } = getContext();
+
+      const fn = jest.fn();
+      storiesOf('kind', { id: 1211 }).add('name', fn);
+
+      const storybook = getStorybook();
+
+      expect(storybook).toEqual([
+        {
+          kind: 'kind',
+          stories: [
+            {
+              name: 'name',
+              render: expect.any(Function),
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('hot module loading', () => {


### PR DESCRIPTION
Issue: #5907 

## What I did
Much further downwind when searching through file names, `fuzzy-search`
and `.includes` requires that `parameters.fileName` is a string, and can't handle a
number. This checks to make sure that the fileName is indeed a string,
since webpack may sometimes return the module.id as a number.

https://webpack.js.org/api/module-variables/#moduleid-commonjs

## How to test
- Force a webpack config to `mode = "production"`
- Start typing multiple letters
- See that the search works

<!--
Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
-->
