### PR TITLE
Docs: Typescript Configuration Examples for v5

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -25,21 +25,25 @@ We first have to use the [custom Webpack config in full control mode, extending 
 
 ```js
 const path = require('path');
-module.exports = (baseConfig, env, config) => {
+module.exports = ({ config, mode }) => {
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
-    use: [{
-      loader: require.resolve('awesome-typescript-loader')
-    }, {
-      loader: require.resolve('react-docgen-typescript-loader')
-    }]
+    use: [
+      {
+        loader: require.resolve('awesome-typescript-loader')
+      },
+      // Optional
+      {
+        loader: require.resolve('react-docgen-typescript-loader')
+      }
+    ]
   });
   config.resolve.extensions.push('.ts', '.tsx');
   return config;
 };
 ```
 
-The above example shows a working Webpack config with the TSDocgen plugin also integrated; remove the optional sections if you don't plan on using them.
+The above example shows a working Webpack config with the [TSDocgen plugin](https://github.com/strothj/react-docgen-typescript-loader) integrated.  This plugin is not necessary to use Storybook and the section marked `// optional` can be safely removed if the features of TSDocgen are not required.
 
 ### `tsconfig.json`
 
@@ -91,13 +95,13 @@ yarn add -D @types/storybook__react # typings
 We first have to use the [custom Webpack config in full control mode, extending default configs](/configurations/custom-webpack-config/#full-control-mode--default) by creating a `webpack.config.js` file in our Storybook configuration directory (by default, it’s `.storybook`):
 
 ```js
-module.exports = (baseConfig, env, config) => {
+module.exports = ({ config, mode }) => {
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
     loader: require.resolve('babel-loader'),
     options: {
-      presets: [['react-app', { flow: false, typescript: true }]],
-    },
+      presets: [['react-app', { flow: false, typescript: true }]]
+    }
   });
   config.resolve.extensions.push('.ts', '.tsx');
   return config;


### PR DESCRIPTION
[The documentation for "full control" Webpack configuration](https://storybook.js.org/docs/configurations/custom-webpack-config/#full-control-mode) has already been updated to reflect the changes made with version 5, however the [Typescript sample code](https://storybook.js.org/configurations/typescript-config/) reflected version 4's configuration method prior to this PR. 

These changes resolve the confusion of #5877.

Apologies if this should be submitted to `master` -- if so, let me know and I will gladly re-submit!