### PR TITLE
Updated list of peerDependencies for mithriljs.

### DIFF
--- a/docs/src/pages/basics/guide-mithril/index.md
+++ b/docs/src/pages/basics/guide-mithril/index.md
@@ -31,11 +31,11 @@ npm i --save-dev @storybook/mithril
 
 ## Add mithril and babel-core
 
-Make sure that you have `mithril` and `babel-core` in your dependencies as well because we list these as a peerDependency:
+Make sure that you have `mithril`, `@babel/core`, and `babel-loader` in your dependencies as well because we list these as a peerDependency:
 
 ```sh
 npm i --save mithril
-npm i --save-dev babel-core
+npm i --save-dev @babel/core babel-loader
 ```
 
 Then add the following NPM script to your package json in order to start the storybook later in this guide:


### PR DESCRIPTION
Issue:

## What I did

Updated list of peerDependencies in the documentation to get up and running with storybook and mithriljs.

## How to test

Install according to documentation. I found out that babel-core was not required peerDependency so updated it to get up and running.