### PR TITLE
Theme docs fix

### DIFF
--- a/docs/src/pages/configurations/theming/index.md
+++ b/docs/src/pages/configurations/theming/index.md
@@ -96,7 +96,7 @@ export default create({
 Finally, import your theme into `.storybook/config` and add it to your Storybook parameters.
 
 ```
-import {yourTheme} from './yourTheme';
+import yourTheme from './yourTheme';
 
 addParameters({
   options: {


### PR DESCRIPTION
The doc says `export default create({...` for the theme, which gives an error when you do `import { ... } from ...`