### PR TITLE
Bump version number in live examples page

### DIFF
--- a/docs/src/pages/basics/live-examples/index.md
+++ b/docs/src/pages/basics/live-examples/index.md
@@ -3,7 +3,7 @@ id: 'live-examples'
 title: 'Live Examples'
 ---
 
-### 4.0
+### 5.0
 
 - [React Official](https://storybooks-official.netlify.com)
 - [Vue](https://storybooks-vue.netlify.com/)


### PR DESCRIPTION
Issue:

## What I did
- Bumped the version number to 5.0 for the examples. They all use it.
