### PR TITLE
Fixed missing iframe.html in output directory

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -37,7 +37,7 @@ export default ({
     devtool: '#cheap-module-source-map',
     entry: entries,
     output: {
-      path: path.join(process.cwd(), outputDir),
+      path: path.resolve(process.cwd(), outputDir),
       filename: '[name].[hash].bundle.js',
       publicPath: '',
     },


### PR DESCRIPTION
path.join is unsafe when using absolute paths after first argument.
For resolving from cwd path.resolve function is safe and makes correct results in both cases, using absolute or relative paths.

Issue:

There is no iframe.html after `build-storybook -o /any/abs/path` is successfully finished.

## What I did

`build-storybook -o /tmp/any/abs/path` 

## How to test

pass any absolute path to `-o` cli argument to `build-storybook` command.

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
