### PR TITLE
Core: Added suppport for non-latin story names/IDs

### DIFF
--- a/lib/router/package.json
+++ b/lib/router/package.json
@@ -24,7 +24,8 @@
     "@storybook/theming": "5.1.0-alpha.0",
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
-    "qs": "^6.6.0"
+    "qs": "^6.6.0",
+    "slugify": "^1.3.4"
   },
   "peerDependencies": {
     "react": "*",

--- a/lib/router/src/tests/id.test.js
+++ b/lib/router/src/tests/id.test.js
@@ -4,10 +4,11 @@ describe('toId', () => {
   [
     // name, kind, story, output
     ['handles simple cases', 'kind', 'story', 'kind--story'],
-    ['handles basic substitution', 'a b$c?d😀e', '1-2:3', 'a-b-c-d-e--1-2-3'],
+    ['handles basic substitution', 'a b$c?d😀e', '1-2:3', 'a-b-c-de--1-2-3'],
     ['handles runs of non-url chars', 'a?&*b', 'story', 'a-b--story'],
     ['removes non-url chars from start and end', '?ab-', 'story', 'ab--story'],
     ['downcases', 'KIND', 'STORY', 'kind--story'],
+    ['non-latin', 'kind', 'Кнопки', 'kind--knopki'],
   ].forEach(([name, kind, story, output]) => {
     it(name, () => {
       expect(toId(kind, story)).toBe(output);

--- a/lib/router/src/tests/id.test.js
+++ b/lib/router/src/tests/id.test.js
@@ -9,6 +9,7 @@ describe('toId', () => {
     ['removes non-url chars from start and end', '?ab-', 'story', 'ab--story'],
     ['downcases', 'KIND', 'STORY', 'kind--story'],
     ['non-latin', 'kind', 'Кнопки', 'kind--knopki'],
+    ['korean', 'kind', '바보 (babo)', 'kind--babo'],
   ].forEach(([name, kind, story, output]) => {
     it(name, () => {
       expect(toId(kind, story)).toBe(output);

--- a/lib/router/src/utils.ts
+++ b/lib/router/src/utils.ts
@@ -1,5 +1,6 @@
 import qs from 'qs';
 import memoize from 'memoizerific';
+import slugify from 'slugify';
 
 interface StoryData {
   viewMode?: string;
@@ -9,11 +10,9 @@ interface StoryData {
 const knownViewModesRegex = /(story|info)/;
 const splitPath = /\/([^/]+)\/([^/]+)?/;
 
-export const sanitize = (string: string) => {
-  return string
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, '-')
-    .replace(/-+/g, '-')
+export const sanitize = (s: string) => {
+  const clean = s.replace(/[ '`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '-');
+  return slugify(clean, { lower: true })
     .replace(/^-+/, '')
     .replace(/-+$/, '');
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11139,6 +11139,7 @@ graphql-request@^1.5.0:
 graphql@^0.13.2, graphql@^14.1.1:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
+  integrity sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==
   dependencies:
     iterall "^1.2.1"
 
@@ -12822,6 +12823,7 @@ istextorbinary@2.1.0:
 iterall@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 jasmine-core@~2.8.0:
   version "2.8.0"
@@ -21095,6 +21097,11 @@ slide@^1.1.5, slide@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
+
+slugify@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.4.tgz#78d2792d7222b55cd9fc81fa018df99af779efeb"
+  integrity sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw==
 
 smart-buffer@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Issue: #5876 

## What I did

Added back support for non-latin story names/IDs using `slugify`

## How to test
```
yarn jest --testPathPattern id.js
```

