### PR TITLE
Core: support unicode chars in story IDs

### DIFF
--- a/examples/official-storybook/stories/core/__snapshots__/unicode.stories.storyshot
+++ b/examples/official-storybook/stories/core/__snapshots__/unicode.stories.storyshot
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Core|Unicode Кнопки 1`] = `
+<p>
+  нормальный
+</p>
+`;
+
+exports[`Storyshots Core|Unicode 바보 1`] = `
+<p>
+  🤷🏻‍♂️
+</p>
+`;
+
+exports[`Storyshots Core|Unicode 😀 1`] = `
+<p>
+  ❤️
+</p>
+`;

--- a/examples/official-storybook/stories/core/unicode.stories.js
+++ b/examples/official-storybook/stories/core/unicode.stories.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+storiesOf('Core|Unicode', module)
+  .add('😀', () => <p>❤️</p>)
+  .add('Кнопки', () => <p>нормальный</p>)
+  .add('바보', () => <p>🤷🏻‍♂️</p>);

--- a/lib/router/src/tests/id.test.js
+++ b/lib/router/src/tests/id.test.js
@@ -10,6 +10,7 @@ describe('toId', () => {
     ['downcases', 'KIND', 'STORY', 'kind--story'],
     ['non-latin', 'Кнопки', 'нормальный', 'кнопки--нормальный'],
     ['korean', 'kind', '바보 (babo)', 'kind--바보-babo'],
+    ['all punctuation', 'kind', 'unicorns,’–—―′¿`"<>()!.!!!{}[]%^&$*#&', 'kind--unicorns'],
   ].forEach(([name, kind, story, output]) => {
     it(name, () => {
       expect(toId(kind, story)).toBe(output);

--- a/lib/router/src/tests/id.test.js
+++ b/lib/router/src/tests/id.test.js
@@ -4,10 +4,12 @@ describe('toId', () => {
   [
     // name, kind, story, output
     ['handles simple cases', 'kind', 'story', 'kind--story'],
-    ['handles basic substitution', 'a b$c?d😀e', '1-2:3', 'a-b-c-d-e--1-2-3'],
+    ['handles basic substitution', 'a b$c?d😀e', '1-2:3', 'a-b-c-d😀e--1-2-3'],
     ['handles runs of non-url chars', 'a?&*b', 'story', 'a-b--story'],
     ['removes non-url chars from start and end', '?ab-', 'story', 'ab--story'],
     ['downcases', 'KIND', 'STORY', 'kind--story'],
+    ['non-latin', 'Кнопки', 'нормальный', 'кнопки--нормальный'],
+    ['korean', 'kind', '바보 (babo)', 'kind--바보-babo'],
   ].forEach(([name, kind, story, output]) => {
     it(name, () => {
       expect(toId(kind, story)).toBe(output);

--- a/lib/router/src/utils.ts
+++ b/lib/router/src/utils.ts
@@ -9,10 +9,11 @@ interface StoryData {
 const knownViewModesRegex = /(story|info)/;
 const splitPath = /\/([^/]+)\/([^/]+)?/;
 
+// Remove punctuation https://gist.github.com/davidjrice/9d2af51100e41c6c4b4a
 export const sanitize = (string: string) => {
   return string
     .toLowerCase()
-    .replace(/[ '`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '-')
+    .replace(/[ ’–—―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '-')
     .replace(/-+/g, '-')
     .replace(/^-+/, '')
     .replace(/-+$/, '');

--- a/lib/router/src/utils.ts
+++ b/lib/router/src/utils.ts
@@ -12,7 +12,7 @@ const splitPath = /\/([^/]+)\/([^/]+)?/;
 export const sanitize = (string: string) => {
   return string
     .toLowerCase()
-    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/[ '`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '-')
     .replace(/-+/g, '-')
     .replace(/^-+/, '')
     .replace(/-+$/, '');


### PR DESCRIPTION
Issue: #5876 

## What I did

- Support unicode chars in story names
- Remove punctuation only

From what I can tell on the Chinese/Korean internet, URLs typically contain unicode chars. They are escaped into long ugly strings when transcoded to ASCII, but people are used to it.

Technically this is a breaking change, but let's sneak it in since v5 has just been released and it's still kind of an edge case (since unicode chars are getting stripped currently)

## How to test

```
yarn jest --testPathPattern id.test.js
```
Also:
```
cd examples/official-storybook
yarn storybook
open http://localhost:9011/?path=/story/core-unicode--%EB%B0%94%EB%B3%B4
```