### PR TITLE
Add default style for story source code syntax and add style option for the addon

### DIFF
--- a/addons/storysource/src/StoryPanel.js
+++ b/addons/storysource/src/StoryPanel.js
@@ -5,6 +5,8 @@ import { Link } from '@storybook/router';
 import { SyntaxHighlighter } from '@storybook/components';
 
 import { createElement } from 'react-syntax-highlighter';
+import prism from 'react-syntax-highlighter/dist/styles/prism/prism';
+import { OPTION_KEY } from './constants';
 import { EVENT_ID } from './events';
 
 const StyledStoryLink = styled(Link)(({ theme }) => ({
@@ -159,13 +161,18 @@ export default class StoryPanel extends Component {
   };
 
   render() {
-    const { active } = this.props;
+    const { active, api } = this.props;
     const { source } = this.state;
+    const storyData = api.getCurrentStoryData();
+    const options = storyData && storyData.parameters && storyData.parameters[OPTION_KEY];
+    const finalStyle = options && options.style ? options.style : prism;
 
     return active ? (
       <StyledSyntaxHighlighter
         language="jsx"
         showLineNumbers="true"
+        style={finalStyle}
+        useInlineStyles
         renderer={this.lineRenderer}
         format={false}
         copyable={false}

--- a/addons/storysource/src/constants.js
+++ b/addons/storysource/src/constants.js
@@ -1,0 +1,1 @@
+export const OPTION_KEY = 'storySource';

--- a/examples/official-storybook/stories/__snapshots__/addon-storysource.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-storysource.stories.storyshot
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Addons|Storysource default theme 1`] = `
+<div>
+  <button
+    type="button"
+  >
+    You should be able to see prism themed story source
+  </button>
+</div>
+`;
+
+exports[`Storyshots Addons|Storysource with tomorrow theme 1`] = `
+<div>
+  <button
+    type="button"
+  >
+    You should be able to see tomorrow themed story source
+  </button>
+</div>
+`;

--- a/examples/official-storybook/stories/addon-storysource.stories.js
+++ b/examples/official-storybook/stories/addon-storysource.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import tomorrow from 'react-syntax-highlighter/dist/styles/prism/tomorrow';
+
+import BaseButton from '../components/BaseButton';
+
+storiesOf('Addons|Storysource', module)
+  .add('default theme', () => (
+    <div>
+      <BaseButton label="You should be able to see prism themed story source" />
+    </div>
+  ))
+  .add(
+    'with tomorrow theme',
+    () => (
+      <div>
+        <BaseButton label="You should be able to see tomorrow themed story source" />
+      </div>
+    ),
+    { storySource: { style: tomorrow } }
+  );


### PR DESCRIPTION

Issue: connects #4324

## Summary
I've noticed after V5 the code in story source panel has minimal code syntax highlighting. Where in V4 it had dark theme and was much easier to read the source.

I've created this PR for an initial discussion for story source addon code syntax highlighting.

I'm aware that as part of V5 upgrade, there's bunch of theming variables you can set for code syntax highlighting, however I find it very difficult to implement in consuming applications. Thus the PR so that users can pass in any themes within `react-syntax-highlighter/dist/styles/prism`.

Please feel free with the feedback:
- Is this something you'd consider for the story source addon?
- Any other approaches in mind?

## What I did
- add default prism style for story source plugin
- add storySource option to customise styling
## How to test
- added `Addon | Storysource` stories to `official-storybook` kitchen sink app. Navigate to the stories, and there're two stories, one with default prism theme, another with tomorrow prism theme.

- Is this testable with Jest or Chromatic screenshots?
Yes.
- Does this need a new example in the kitchen sink apps?
Yes.
- Does this need an update to the documentation?
Yes.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
