### PR TITLE
Change viewport styling to more closely match v4

### DIFF
--- a/addons/viewport/src/Tool.js
+++ b/addons/viewport/src/Tool.js
@@ -129,9 +129,12 @@ export default class ViewportTool extends Component {
           <Global
             styles={{
               [`#${iframeId}`]: {
-                border: '10px solid black',
+                position: 'relative',
+                display: 'block',
+                margin: '10px auto',
+                border: '1px solid #888',
                 borderRadius: 4,
-                margin: 10,
+                boxShadow: '0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08);',
 
                 ...(isRotated ? flip(item.value || {}) : item.value || {}),
               },


### PR DESCRIPTION
Issue: #5965 

## What I did

Styling for addon-viewport iframe was a 10px black border which was a
little intrusive when working on stories. This commit changes the iframe
style to a more familiar style that mimics v4 with horizontal centering
and a subtle box-shadow.

## How to test

The changes are reflected in the `Viewport` stories being tested in Chromatic.

