### PR TITLE
fix(stories): `selectStory` correct behavior on call with one parameter

### DIFF
--- a/lib/ui/src/core/stories.js
+++ b/lib/ui/src/core/stories.js
@@ -195,9 +195,12 @@ const initStoriesApi = ({
   };
 
   const selectStory = (kindOrId, story) => {
-    const { viewMode = 'story', storyId } = store.getState();
+    const { viewMode = 'story', storyId, storiesHash } = store.getState();
     if (!story) {
-      navigate(`/${viewMode}/${kindOrId}`);
+      const s = storiesHash[sanitize(kindOrId)];
+      // eslint-disable-next-line no-nested-ternary
+      const id = s ? (s.children ? s.children[0] : s.id) : kindOrId;
+      navigate(`/${viewMode}/${id}`);
     } else if (!kindOrId) {
       // This is a slugified version of the kind, but that's OK, our toId function is idempotent
       const kind = storyId.split('--', 2)[0];

--- a/lib/ui/src/core/stories.test.js
+++ b/lib/ui/src/core/stories.test.js
@@ -400,5 +400,20 @@ describe('stories API', () => {
       selectStory(null, '2');
       expect(navigate).toHaveBeenCalledWith('/story/a--2');
     });
+
+    it('allows navigating to first story in kind on call by kind', () => {
+      const navigate = jest.fn();
+      const store = createMockStore();
+
+      const {
+        api: { selectStory, setStories },
+        state,
+      } = initStories({ store, navigate });
+      store.setState(state);
+      setStories(storiesHash);
+
+      selectStory('a');
+      expect(navigate).toHaveBeenCalledWith('/story/a--1');
+    });
   });
 });


### PR DESCRIPTION
Issue: #5950

copy from https://github.com/storybooks/storybook/pull/5953

## What I did
Little fix for selectStory function. When in `selectStory` passed kind name will redirect on first story in needed kind.
For more information, read [that](https://github.com/storybooks/storybook/issues/5950) issue.

## How to test
Run jest tests
Add links addon to you storybook, call `linkTo` with kind name and enjoy redirect to first story in kind

- Is this testable with Jest or Chromatic screenshots? 
Yep! I add new jest test (i have doubts on my grammar, i hope  anybody correct me)
- Does this need a new example in the kitchen sink apps?
No
- Does this need an update to the documentation?
No


Sorry for my bad english, i hope you understand me and feel free for correct me. I will not be upset.