### PR TITLE
fixing documentation for correct src location in angular guide

### DIFF
--- a/docs/src/pages/guides/guide-angular/index.md
+++ b/docs/src/pages/guides/guide-angular/index.md
@@ -74,7 +74,7 @@ That'll load stories in `../stories/index.js`. You can choose where to place sto
 > import { configure } from '@storybook/angular';
 > 
 > function loadStories() {
->   const req = require.context('../stories', true, /\.stories\.ts$/);
+>   const req = require.context('../src/stories', true, /\.stories\.ts$/);
 >   req.keys().forEach(filename => req(filename));
 > }
 > 


### PR DESCRIPTION
Issue:

## What I did

I changed the code in the angular guide
from:
const req = require.context('../stories', true, /.stories.ts$/);

to be:
const req = require.context('../src/stories', true, /.stories.ts$/);

This is to match what is automatically generated when you do the initial install of the CLI into your angular project.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
