### PR TITLE
Updated React reference to Vue

### DIFF
--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -14,7 +14,7 @@ npx -p @storybook/cli sb init --type vue
 
 ## Manual setup
 
-If you want to set up Storybook manually for your React project, this is the guide for you.
+If you want to set up Storybook manually for your Vue project, this is the guide for you.
 
 ## Step 1: Add dependencies
 


### PR DESCRIPTION
Issue: Small reference to `React` instead of `Vue` in Vue guide

## What I did
Updated the reference

## How to test
No testing needed, just a copy update.
