### PR TITLE
Fixed a typo in the react native example

### DIFF
--- a/docs/src/pages/guides/guide-react-native/index.md
+++ b/docs/src/pages/guides/guide-react-native/index.md
@@ -11,7 +11,7 @@ You may have tried to use our quick start guide to setup your project for Storyb
 If it failed because it couldn't detect you're using react-native, you could try forcing it to use react-native:
 
 ```sh
-npx -p @storybook/cli sb init --type react-native
+npx -p @storybook/cli sb init --type react_native
 ```
 
 ## Manual setup


### PR DESCRIPTION
`npx -p @storybook/cli sb init --type react-native`

would  output:

```
The provided project type was not recognized by Storybook.

The project types currently supported by Storybook are:

    - angular
    - ember
    - html
    - marko
    - meteor
    - mithril
    - polymer
    - preact
    - react
    - react_native
    - react_project
    - react_scripts
    - riot
    - sfc_vue
    - vue
    - webpack_react
```