### PR TITLE
Addon-a11y: fix design icons

### DIFF
--- a/addons/a11y/src/components/Report/Item.tsx
+++ b/addons/a11y/src/components/Report/Item.tsx
@@ -13,6 +13,7 @@ const Wrapper = styled.div();
 const Icon = styled<any, any>(Icons)(({ theme }) => ({
   height: 10,
   width: 10,
+  minWidth: 10,
   color: theme.color.mediumdark,
   marginRight: '10px',
   transition: 'transform 0.1s ease-in-out',
@@ -28,6 +29,7 @@ const HeaderBar = styled.button(({ theme }) => ({
   border: 0,
   background: 'none',
   color: 'inherit',
+  textAlign: 'left',
 
   borderLeft: '3px solid transparent',
 

--- a/addons/a11y/src/components/Report/Rules.tsx
+++ b/addons/a11y/src/components/Report/Rules.tsx
@@ -30,16 +30,14 @@ const Message = styled.div({
 });
 
 const Status = styled.div(({ passes, impact }: { passes: boolean; impact: string }) => ({
-  height: '16px',
-  width: '16px',
-  borderRadius: '8px',
-  fontSize: '10px',
   display: 'inline-flex',
   justifyContent: 'center',
   alignItems: 'center',
-  textAlign: 'center',
-  flex: '0 0 16px',
   color: passes ? impactColors.success : (impactColors as any)[impact],
+  '& > svg': {
+    height: '16px',
+    width: '16px',
+  },
 }));
 
 interface RuleProps {


### PR DESCRIPTION
Issue:
I notice what in a11y tab in 'rules' list icons not visible. It's not good. Fix it!

## What I did
Mini clean css in 'rules'
Fix 'rules' text position

## How to test
1. Open [official example](https://storybooks-official.netlify.com/?path=/story/ui-panel--default)
2. Click 'Accessibility' tab
3. Expand any rule
4. You don't see icons

For more information please look at screenshots:
Before:
<img width="499" alt="Снимок экрана 2019-03-10 в 1 28 46" src="https://user-images.githubusercontent.com/3195714/54078163-99106800-42d4-11e9-82b9-e417ba65ac5f.png">
After:
<img width="362" alt="Снимок экрана 2019-03-10 в 1 29 28" src="https://user-images.githubusercontent.com/3195714/54078164-9f064900-42d4-11e9-9531-db2d41249566.png">

I work in macbook 17' without fullscreen monitor, open devtool panel broken a11y rules list. I fix icon width and rules text align. Look at screenshots:
Before:
<img width="233" alt="Снимок экрана 2019-03-10 в 1 37 45" src="https://user-images.githubusercontent.com/3195714/54078201-3f5c6d80-42d5-11e9-894c-8a01cf630881.png">

After:
<img width="190" alt="Снимок экрана 2019-03-10 в 1 38 23" src="https://user-images.githubusercontent.com/3195714/54078203-42eff480-42d5-11e9-934f-79d367338d12.png">

- Is this testable with Jest or Chromatic screenshots?
no
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
no
