### PR TITLE
bug fix (addons/viewport): viewport iframe dimensions

### DIFF
--- a/addons/viewport/src/Tool.js
+++ b/addons/viewport/src/Tool.js
@@ -135,6 +135,7 @@ export default class ViewportTool extends Component {
                 border: '1px solid #888',
                 borderRadius: 4,
                 boxShadow: '0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08);',
+                boxSizing: 'content-box',
 
                 ...(isRotated ? flip(item.value || {}) : item.value || {}),
               },


### PR DESCRIPTION
Issue:

## What I did

Use `boxSizing: 'content-box'` to override the global box-sizing rule
and allow the storybook preview iframe to have the specified dimensions
from the viewport addon config.

Fixes #5927

## How to test

Before. Incorrect viewport iframe size:
<img width="600" alt="Incorrect viewport iframe size" src="https://user-images.githubusercontent.com/660368/54078462-4a58d300-42c0-11e9-91ac-ed7bd801d129.png">

After. Corrected viewport iframe size:
<img width="600" alt="Corrected viewport iframe size" src="https://user-images.githubusercontent.com/660368/54078463-53e23b00-42c0-11e9-9c71-752fa84c363d.png">

- Is this testable with Jest or Chromatic screenshots?
No (but I don't actually know).
- Does this need a new example in the kitchen sink apps?
No.
- Does this need an update to the documentation?
No.
