### PR TITLE
docs: use npm command for npm example

### DIFF
--- a/lib/ui/src/settings/__snapshots__/about.stories.storyshot
+++ b/lib/ui/src/settings/__snapshots__/about.stories.storyshot
@@ -1903,7 +1903,18 @@ exports[`Storyshots UI|Settings/AboutScreen new version required 1`] = `
                               >
                                 &&
                               </span>
-                               yarn
+                               
+                              <span
+                                class="token function"
+                              >
+                                npm
+                              </span>
+                               
+                              <span
+                                class="token function"
+                              >
+                                install
+                              </span>
                             </code>
                           </pre>
                         </div>

--- a/lib/ui/src/settings/about.js
+++ b/lib/ui/src/settings/about.js
@@ -180,7 +180,7 @@ const AboutScreen = ({ latest, current, onClose }) => {
                     <b>Upgrade all Storybook packages to latest:</b>
                   </p>
                   <SyntaxHighlighter language="bash" copyable padded bordered>
-                    npx npm-check-updates '/storybook/' -u && yarn
+                    npx npm-check-updates '/storybook/' -u && npm install
                   </SyntaxHighlighter>
                   <p>
                     Alternatively, if you're using yarn run the following command, and check all


### PR DESCRIPTION
Upgrade notice screen shows an NPM and a Yarn example. However, the npm example uses `yarn`. This merely asks the user to run `npm install` rather than `yarn` if that is their flavour. 