### PR TITLE
Fix theming doc typo

### DIFF
--- a/docs/src/pages/configurations/theming/index.md
+++ b/docs/src/pages/configurations/theming/index.md
@@ -106,7 +106,7 @@ addParameters({
 });
 ```
 
-Many them variables are optional, the `base` property is NOT. This is a perfectly valid theme:
+Many theme variables are optional, the `base` property is NOT. This is a perfectly valid theme:
 
 ```ts
 import { create } from '@storybook/theming';


### PR DESCRIPTION
Issue:
There's a small typo on the theming documentation page.

## What I did
Replaced the word `them` with `theme`