### PR TITLE
docs(addons): add hint about addon tab order

### DIFF
--- a/docs/src/pages/addons/using-addons/index.md
+++ b/docs/src/pages/addons/using-addons/index.md
@@ -29,7 +29,19 @@ This will register all the addons and you'll be able to see the actions and note
 
 ![Stories without notes](../static/stories-without-notes.png)
 
-Now when you are writing a story, import it and add some notes:
+## Addons tab order
+
+The tab order is created by the import order in the `addons.js` file. In the example, the actions addon is the first and thus active tab. Resorting the imports results in the notes addon tab being placed before the actions tab:
+
+```js
+import '@storybook/addon-notes/register';
+import '@storybook/addon-actions/register';
+import '@storybook/addon-links/register';
+```
+
+## Using the addon
+
+Now when you are writing a story, you can import the actions addon to log actions. Also, you can add notes:
 
 ```js
 import { storiesOf } from '@storybook/react';

--- a/docs/src/pages/addons/using-addons/index.md
+++ b/docs/src/pages/addons/using-addons/index.md
@@ -12,31 +12,30 @@ We are going to use an addon called [Notes](https://github.com/storybooks/storyb
 First, we need to install the addons:
 
 ```sh
-yarn add -D @storybook/addons @storybook/addon-actions @storybook/addon-links @storybook/addon-notes
+yarn add -D @storybook/addons @storybook/addon-actions @storybook/addon-knobs @storybook/addon-notes
 ```
 
 Then, we need to create a file called `addons.js` inside the storybook config directory and add the following content:
 
 ```js
 import '@storybook/addon-actions/register';
-import '@storybook/addon-links/register';
+import '@storybook/addon-knobs/register';
 import '@storybook/addon-notes/register';
 ```
 
 Once created, you'll have to restart storybook to make the underlying webpack aware of the addons file.
 
-This will register all the addons and you'll be able to see the actions and notes panels (in that order) when you are viewing the story. (Links do not register a tab--check individual addon docs to see which Storybook features they use!)
+This will register all the addons and you'll be able to see the actions and knobs panels (in that order) when you are viewing the story. (Links do not register a tab--check individual addon docs to see which Storybook features they use!)
 
 ![Stories without notes](../static/stories-without-notes.png)
 
 ## Addons tab order
 
-The tab order is created by the import order in the `addons.js` file. In the example, the actions addon is the first and thus active tab. Resorting the imports results in the notes addon tab being placed before the actions tab:
+The tab order is created by the import order in the `addons.js` file. In the example, the actions addon is the first and thus active tab. Resorting the imports results in the knobs addon tab being placed before the actions tab:
 
 ```js
-import '@storybook/addon-notes/register';
 import '@storybook/addon-actions/register';
-import '@storybook/addon-links/register';
+import '@storybook/addon-knobs/register';
 ```
 
 ## Using the addon


### PR DESCRIPTION
Issue: #6019 

which I missed and I guess would be rather helpful for others searching for this.

## What I did

Added a short paragraph about how to change the tab order. I also inserted some headlines to structure the page a bit more. Also, because of the injected paragraph, I changed the sentence about the usage since it now lacked context.

## How to test

1. Start the docs subfolder as described in its readme.
1. Navigate to "Using addons".
1. Read the sentence 😆 
