### PR TITLE
Clear build folder in static build

### DIFF
--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -148,16 +148,13 @@ async function buildPreview(configType, outputDir, packageJson, options) {
 }
 
 function prepareFilesStructure(outputDir, defaultFavIcon) {
+  // clear the output dir
+  logger.info('clean outputDir..');
+  shelljs.rm('-rf', outputDir);
+  
   // create output directory if not exists
   shelljs.mkdir('-p', outputDir);
   shelljs.mkdir('-p', path.join(outputDir, 'sb_dll'));
-
-  // clear the static dir
-  shelljs.rm('-rf', path.join(outputDir, 'static'));
-  shelljs.cp(defaultFavIcon, outputDir);
-
-  logger.info('clean outputDir..');
-  shelljs.rm('-rf', path.join(outputDir, 'static'));
 
   shelljs.cp(defaultFavIcon, outputDir);
 }


### PR DESCRIPTION
Issue:

The static site building did not completely clear the build folder.  This causes issues with additional plugins like CopyWebpackPlugin because once a file was added it was never removed.

## What I did

Changed the logic to completely clear the output dir and cleaned up so that it only copies the defaultFavIcon once.

## How to test

1. Build using build-storybook.  
2. Put a file into the root folder like `test.html`.
3. Now on future build file will be removed
