### PR TITLE
fix(a11y): remove bg color from reports

### DIFF
--- a/addons/a11y/src/components/Report/Info.tsx
+++ b/addons/a11y/src/components/Report/Info.tsx
@@ -3,11 +3,10 @@ import React, { FunctionComponent } from 'react';
 import { styled } from '@storybook/theming';
 import { Result } from 'axe-core';
 
-const Wrapper = styled.div(({ theme }) => ({
-  backgroundColor: theme.background.bar,
+const Wrapper = styled.div({
   padding: '12px',
   marginBottom: '10px',
-}));
+});
 const Help = styled.p({
   margin: '0 0 12px',
 });


### PR DESCRIPTION
Issue: #6025 

## What I did
Remove bg from reports

## How to test
Open cra-kitchen-sink with dark theme
Open a11y addon
Show reports

- Is this testable with Jest or Chromatic screenshots?
no
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
no

Before:
<img width="648" src="https://user-images.githubusercontent.com/3195714/54157599-b3c01980-4459-11e9-8e3d-9208583c4fe9.png">
After:
<img width="648" src="https://user-images.githubusercontent.com/3195714/54157604-b753a080-4459-11e9-9ee5-7ae6aaf2dc34.png">
