### PR TITLE
[bug]Error message when removing value from number knob 

### DIFF
--- a/addons/knobs/src/components/PropForm.js
+++ b/addons/knobs/src/components/PropForm.js
@@ -10,7 +10,7 @@ export default class PropForm extends Component {
   makeChangeHandler(name, type) {
     const { onFieldChange } = this.props;
     return value => {
-      const change = { name, type, value };
+      const change = { name, type, value: value || '' };
 
       onFieldChange(change);
     };


### PR DESCRIPTION
Issue: #5912 

When removing the value from the "number" knob, following error appears in the console:

## What I did
Since number may be null, I assigned '' at that time.

|before|after|
| --- | --- |
|<img width="1440" alt="スクリーンショット 2019-03-12 21 45 31" src="https://user-images.githubusercontent.com/32378535/54201508-2b04b480-4511-11e9-8ae7-06c53885d8a9.png">|<img width="1440" alt="スクリーンショット 2019-03-12 21 46 05" src="https://user-images.githubusercontent.com/32378535/54201519-348e1c80-4511-11e9-9809-7ce5b7a413e7.png">|

## How to test

- Is this testable with Jest or Chromatic screenshots? I'm not sure what is the proper way to do it here.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.