### PR TITLE
fix(addon/a11y): run scan only when addon tab is active

### DIFF
--- a/addons/a11y/src/components/A11YPanel.test.js
+++ b/addons/a11y/src/components/A11YPanel.test.js
@@ -188,7 +188,7 @@ describe('A11YPanel', () => {
     expect(wrapper.find(A11YPanel)).toMatchSnapshot();
   });
 
-  it("should NOT render report when it's running", () => {
+  it("should render loader when it's running", () => {
     // given
     const api = createApi();
     const wrapper = mount(<ThemedA11YPanel api={api} active />);
@@ -200,7 +200,9 @@ describe('A11YPanel', () => {
 
     // then
     expect(wrapper.find('ScrollArea').length).toBe(0);
+    expect(wrapper.find('Loader').length).toBe(1);
     expect(wrapper.find('ActionBar').length).toBe(1);
+    expect(wrapper.find('Loader')).toMatchSnapshot();
   });
 
   it('should NOT anything when tab is not active', () => {

--- a/addons/a11y/src/components/A11YPanel.test.js
+++ b/addons/a11y/src/components/A11YPanel.test.js
@@ -1,0 +1,217 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { ThemeProvider, themes, convert } from '@storybook/theming';
+import { STORY_RENDERED } from '@storybook/core-events';
+import { ScrollArea } from '@storybook/components';
+
+import { A11YPanel } from './A11YPanel.tsx';
+import { EVENTS } from '../constants';
+
+function createApi() {
+  return {
+    emit: jest.fn(),
+    on: jest.fn(),
+    off: jest.fn(),
+  };
+}
+
+const axeResult = {
+  incomplete: [
+    {
+      id: 'color-contrast',
+      impact: 'serious',
+      tags: ['cat.color', 'wcag2aa', 'wcag143'],
+      description:
+        'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
+      help: 'Elements must have sufficient color contrast',
+      helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=axeAPI',
+    },
+  ],
+  passes: [
+    {
+      id: 'aria-allowed-attr',
+      impact: null,
+      tags: ['cat.aria', 'wcag2a', 'wcag412'],
+      description: "Ensures ARIA attributes are allowed for an element's role",
+      help: 'Elements must only use allowed ARIA attributes',
+      helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/aria-allowed-attr?application=axeAPI',
+    },
+  ],
+  violations: [
+    {
+      id: 'color-contrast',
+      impact: 'serious',
+      tags: ['cat.color', 'wcag2aa', 'wcag143'],
+      description:
+        'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
+      help: 'Elements must have sufficient color contrast',
+      helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=axeAPI',
+    },
+  ],
+};
+
+function ThemedA11YPanel(props) {
+  return (
+    <ThemeProvider theme={convert(themes.light)}>
+      <A11YPanel {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe('A11YPanel', () => {
+  it('should register STORY_RENDERED and RESULT updater on mount', () => {
+    // given
+    const api = createApi();
+    expect(api.on).not.toHaveBeenCalled();
+
+    // when
+    mount(<ThemedA11YPanel api={api} />);
+
+    // then
+    expect(api.on.mock.calls.length).toBe(2);
+    expect(api.on.mock.calls[0][0]).toBe(STORY_RENDERED);
+    expect(api.on.mock.calls[1][0]).toBe(EVENTS.RESULT);
+  });
+
+  it('should request a run on tab activation', () => {
+    // given
+    const api = createApi();
+
+    const wrapper = mount(<ThemedA11YPanel api={api} />);
+    expect(api.emit).not.toHaveBeenCalled();
+
+    // when
+    wrapper.setProps({ active: true });
+    wrapper.update();
+
+    // then
+    expect(api.emit).toHaveBeenCalledWith(EVENTS.REQUEST);
+    expect(wrapper.find(ScrollArea).length).toBe(0);
+  });
+
+  it('should deregister STORY_RENDERED and RESULT updater on unmount', () => {
+    // given
+    const api = createApi();
+    const wrapper = mount(<ThemedA11YPanel api={api} />);
+    expect(api.off).not.toHaveBeenCalled();
+
+    // when
+    wrapper.unmount();
+
+    // then
+    expect(api.off.mock.calls.length).toBe(2);
+    expect(api.off.mock.calls[0][0]).toBe(STORY_RENDERED);
+    expect(api.off.mock.calls[1][0]).toBe(EVENTS.RESULT);
+  });
+
+  it('should update run result', () => {
+    // given
+    const api = createApi();
+    const wrapper = mount(<ThemedA11YPanel api={api} active />);
+    const onUpdate = api.on.mock.calls.find(([event]) => event === EVENTS.RESULT)[1];
+
+    expect(
+      wrapper
+        .find('button')
+        .last()
+        .text()
+        .trim()
+    ).toBe('Rerun tests');
+
+    // when
+    onUpdate(axeResult);
+
+    // then
+    expect(
+      wrapper
+        .find('button')
+        .last()
+        .text()
+        .trim()
+    ).toBe('Tests completed');
+  });
+
+  it('should request run', () => {
+    // given
+    const api = createApi();
+    const wrapper = mount(<ThemedA11YPanel api={api} active />);
+    const request = api.on.mock.calls.find(([event]) => event === STORY_RENDERED)[1];
+
+    expect(
+      wrapper
+        .find('button')
+        .last()
+        .text()
+        .trim()
+    ).toBe('Rerun tests');
+    expect(api.emit).not.toHaveBeenCalled();
+
+    // when
+    request();
+
+    // then
+    expect(
+      wrapper
+        .find('button')
+        .last()
+        .text()
+        .trim()
+    ).toBe('Running test');
+    expect(api.emit).toHaveBeenCalledWith(EVENTS.REQUEST);
+  });
+
+  it('should NOT request run on inactive tab', () => {
+    // given
+    const api = createApi();
+    mount(<ThemedA11YPanel api={api} active={false} />);
+    const request = api.on.mock.calls.find(([event]) => event === STORY_RENDERED)[1];
+    expect(api.emit).not.toHaveBeenCalled();
+
+    // when
+    request();
+
+    // then
+    expect(api.emit).not.toHaveBeenCalled();
+  });
+
+  it('should render report', () => {
+    // given
+    const api = createApi();
+    const wrapper = mount(<ThemedA11YPanel api={api} active />);
+    const onUpdate = api.on.mock.calls.find(([event]) => event === EVENTS.RESULT)[1];
+
+    // when
+    onUpdate(axeResult);
+
+    // then
+    expect(wrapper.find(A11YPanel)).toMatchSnapshot();
+  });
+
+  it("should NOT render report when it's running", () => {
+    // given
+    const api = createApi();
+    const wrapper = mount(<ThemedA11YPanel api={api} active />);
+    const request = api.on.mock.calls.find(([event]) => event === STORY_RENDERED)[1];
+
+    // when
+    request();
+    wrapper.update();
+
+    // then
+    expect(wrapper.find('ScrollArea').length).toBe(0);
+    expect(wrapper.find('ActionBar').length).toBe(1);
+  });
+
+  it('should NOT anything when tab is not active', () => {
+    // given
+    const api = createApi();
+
+    // when
+    const wrapper = mount(<ThemedA11YPanel api={api} active={false} />);
+
+    // then
+    expect(wrapper.find('ScrollArea').length).toBe(0);
+    expect(wrapper.find('ActionBar').length).toBe(0);
+  });
+});

--- a/addons/a11y/src/components/A11YPanel.tsx
+++ b/addons/a11y/src/components/A11YPanel.tsx
@@ -142,29 +142,31 @@ export class A11YPanel extends Component<A11YPanelProps, A11YPanelState> {
 
     return active ? (
       <Fragment>
-        <ScrollArea vertical horizontal>
-          <Tabs
-            key="tabs"
-            tabs={[
-              {
-                label: <Violations>{violations.length} Violations</Violations>,
-                panel: (
-                  <Report passes={false} items={violations} empty="No a11y violations found." />
-                ),
-              },
-              {
-                label: <Passes>{passes.length} Passes</Passes>,
-                panel: <Report passes items={passes} empty="No a11y check passed." />,
-              },
-              {
-                label: <Incomplete>{incomplete.length} Incomplete</Incomplete>,
-                panel: (
-                  <Report passes={false} items={incomplete} empty="No a11y incomplete found." />
-                ),
-              },
-            ]}
-          />
-        </ScrollArea>
+        {status === 'running' ? null : (
+          <ScrollArea vertical horizontal>
+            <Tabs
+              key="tabs"
+              tabs={[
+                {
+                  label: <Violations>{violations.length} Violations</Violations>,
+                  panel: (
+                    <Report passes={false} items={violations} empty="No a11y violations found."/>
+                  ),
+                },
+                {
+                  label: <Passes>{passes.length} Passes</Passes>,
+                  panel: <Report passes items={passes} empty="No a11y check passed."/>,
+                },
+                {
+                  label: <Incomplete>{incomplete.length} Incomplete</Incomplete>,
+                  panel: (
+                    <Report passes={false} items={incomplete} empty="No a11y incomplete found."/>
+                  ),
+                },
+              ]}
+            />
+          </ScrollArea>
+        )}
         <ActionBar key="actionbar" actionItems={[{ title: actionTitle, onClick: this.request }]} />
       </Fragment>
     ) : null;

--- a/addons/a11y/src/components/A11YPanel.tsx
+++ b/addons/a11y/src/components/A11YPanel.tsx
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
 
 import { styled } from '@storybook/theming';
 
@@ -35,6 +36,18 @@ const Violations = styled.span(({ theme }) => ({
 const Incomplete = styled.span(({ theme }) => ({
   color: theme.color.warning,
 }));
+
+const Loader = styled(({ className }) => (
+  <div className={className}>
+    <Icon inline icon="sync" status="running" /> Please wait while a11y scan is running ...
+  </div>
+))({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+});
+Loader.displayName = 'Loader';
 
 interface A11YPanelState {
   status: string;
@@ -142,7 +155,9 @@ export class A11YPanel extends Component<A11YPanelProps, A11YPanelState> {
 
     return active ? (
       <Fragment>
-        {status === 'running' ? null : (
+        {status === 'running' ? (
+          <Loader />
+        ) : (
           <ScrollArea vertical horizontal>
             <Tabs
               key="tabs"
@@ -150,17 +165,17 @@ export class A11YPanel extends Component<A11YPanelProps, A11YPanelState> {
                 {
                   label: <Violations>{violations.length} Violations</Violations>,
                   panel: (
-                    <Report passes={false} items={violations} empty="No a11y violations found."/>
+                    <Report passes={false} items={violations} empty="No a11y violations found." />
                   ),
                 },
                 {
                   label: <Passes>{passes.length} Passes</Passes>,
-                  panel: <Report passes items={passes} empty="No a11y check passed."/>,
+                  panel: <Report passes items={passes} empty="No a11y check passed." />,
                 },
                 {
                   label: <Incomplete>{incomplete.length} Incomplete</Incomplete>,
                   panel: (
-                    <Report passes={false} items={incomplete} empty="No a11y incomplete found."/>
+                    <Report passes={false} items={incomplete} empty="No a11y incomplete found." />
                   ),
                 },
               ]}

--- a/addons/a11y/src/components/__snapshots__/A11YPanel.test.js.snap
+++ b/addons/a11y/src/components/__snapshots__/A11YPanel.test.js.snap
@@ -1,5 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`A11YPanel should render loader when it's running 1`] = `
+@keyframes animation-0 {
+  from {
+    -webkit-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  to {
+    -webkit-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.emotion-2 {
+  height: 12px;
+  width: 12px;
+  margin-right: 4px;
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-1 {
+  shape-rendering: inherit;
+  -webkit-transform: translate3d(0,0,0);
+  -ms-transform: translate3d(0,0,0);
+  transform: translate3d(0,0,0);
+  display: inline-block;
+  height: 12px;
+  width: 12px;
+  margin-right: 4px;
+  -webkit-animation: animation-0 1s linear infinite;
+  animation: animation-0 1s linear infinite;
+}
+
+.emotion-0 {
+  fill: currentColor;
+}
+
+<Loader>
+  <Component
+    className="emotion-4"
+  >
+    <div
+      className="emotion-4"
+    >
+      <Styled(Icon)
+        icon="sync"
+        inline={true}
+        status="running"
+      >
+        <Icon
+          className="emotion-2"
+          icon="sync"
+          inline={true}
+          status="running"
+        >
+          <Svg
+            className="emotion-2"
+            inline={true}
+            status="running"
+            viewBox="0 0 1024 1024"
+          >
+            <svg
+              className="emotion-1"
+              viewBox="0 0 1024 1024"
+            >
+              <Styled(path)
+                d="M998.786 474.516l-91 90.988c-8.028 8.036-18.624 11.902-29.152 11.676-10.536 0.234-21.144-3.632-29.184-11.676l-92.3-92.296c-15.624-15.622-15.624-40.95 0-56.57 15.622-15.622 40.95-15.624 56.57 0l26.146 26.148c-13.774-61.416-44.624-117.806-90.216-163.394-63.46-63.464-147.84-98.414-237.586-98.414-89.75 0-174.128 34.95-237.59 98.414-27.012 27.012-48.836 57.824-65.024 91.214l-0.008-0.004c-6.722 12.632-20.008 21.242-35.32 21.242-22.090 0-40-17.906-40-40 0-5.464 1.102-10.668 3.086-15.414l-0.004-0.004c0.016-0.032 0.024-0.058 0.040-0.090 0.036-0.078 0.070-0.156 0.106-0.234 0.73-1.632 0.208-0.718 5.004-9.996 69.18-133.726 208.766-225.128 369.71-225.128 203.224 0 372.374 145.734 408.728 338.392l21.424-21.424c15.618-15.622 40.946-15.622 56.566 0s15.624 40.948 0.004 56.57zM889.992 682.11c0 5.464-1.106 10.672-3.090 15.414l0.008 0.004c-0.016 0.036-0.028 0.058-0.040 0.090-0.036 0.078-0.074 0.156-0.106 0.234-0.73 1.636-0.208 0.718-5.008 10-69.176 133.722-208.762 225.124-369.708 225.124-205.2 0-375.668-148.578-409.76-344.022l-19.478 19.478c-15.622 15.622-40.95 15.622-56.57 0-15.618-15.622-15.622-40.95 0-56.57l90.996-90.992c8.032-8.032 18.628-11.902 29.152-11.672 10.536-0.238 21.144 3.632 29.188 11.672l92.296 92.3c15.624 15.618 15.624 40.946 0 56.566-15.618 15.622-40.946 15.624-56.566 0.004l-29.292-29.292c12.466 65.568 44.214 125.882 92.448 174.116 63.46 63.46 147.84 98.41 237.586 98.41 89.75 0 174.124-34.95 237.59-98.41 27.012-27.012 48.836-57.824 65.020-91.218l0.008 0.004c6.726-12.632 20.012-21.242 35.324-21.242 22.092 0.002 40.002 17.912 40.002 40.002zM145.83 545.416l1.4 0.248-0.824-0.824-0.576 0.576z"
+              >
+                <path
+                  className="emotion-0"
+                  d="M998.786 474.516l-91 90.988c-8.028 8.036-18.624 11.902-29.152 11.676-10.536 0.234-21.144-3.632-29.184-11.676l-92.3-92.296c-15.624-15.622-15.624-40.95 0-56.57 15.622-15.622 40.95-15.624 56.57 0l26.146 26.148c-13.774-61.416-44.624-117.806-90.216-163.394-63.46-63.464-147.84-98.414-237.586-98.414-89.75 0-174.128 34.95-237.59 98.414-27.012 27.012-48.836 57.824-65.024 91.214l-0.008-0.004c-6.722 12.632-20.008 21.242-35.32 21.242-22.090 0-40-17.906-40-40 0-5.464 1.102-10.668 3.086-15.414l-0.004-0.004c0.016-0.032 0.024-0.058 0.040-0.090 0.036-0.078 0.070-0.156 0.106-0.234 0.73-1.632 0.208-0.718 5.004-9.996 69.18-133.726 208.766-225.128 369.71-225.128 203.224 0 372.374 145.734 408.728 338.392l21.424-21.424c15.618-15.622 40.946-15.622 56.566 0s15.624 40.948 0.004 56.57zM889.992 682.11c0 5.464-1.106 10.672-3.090 15.414l0.008 0.004c-0.016 0.036-0.028 0.058-0.040 0.090-0.036 0.078-0.074 0.156-0.106 0.234-0.73 1.636-0.208 0.718-5.008 10-69.176 133.722-208.762 225.124-369.708 225.124-205.2 0-375.668-148.578-409.76-344.022l-19.478 19.478c-15.622 15.622-40.95 15.622-56.57 0-15.618-15.622-15.622-40.95 0-56.57l90.996-90.992c8.032-8.032 18.628-11.902 29.152-11.672 10.536-0.238 21.144 3.632 29.188 11.672l92.296 92.3c15.624 15.618 15.624 40.946 0 56.566-15.618 15.622-40.946 15.624-56.566 0.004l-29.292-29.292c12.466 65.568 44.214 125.882 92.448 174.116 63.46 63.46 147.84 98.41 237.586 98.41 89.75 0 174.124-34.95 237.59-98.41 27.012-27.012 48.836-57.824 65.020-91.218l0.008 0.004c6.726-12.632 20.012-21.242 35.324-21.242 22.092 0.002 40.002 17.912 40.002 40.002zM145.83 545.416l1.4 0.248-0.824-0.824-0.576 0.576z"
+                />
+              </Styled(path)>
+            </svg>
+          </Svg>
+        </Icon>
+      </Styled(Icon)>
+       Please wait while a11y scan is running ...
+    </div>
+  </Component>
+</Loader>
+`;
+
 exports[`A11YPanel should render report 1`] = `
 .emotion-10 {
   overflow-y: auto;
@@ -203,6 +305,7 @@ exports[`A11YPanel should render report 1`] = `
               "qacwg0": true,
               "qb28": true,
               "snh8f7": true,
+              "tkevr6": true,
             },
             "key": "css",
             "nonce": undefined,
@@ -211,6 +314,7 @@ exports[`A11YPanel should render report 1`] = `
               "css-1977chw": "height:10px;width:10px;min-width:10px;color:#999999;margin-right:10px;transition:transform 0.1s ease-in-out;align-self:center;display:inline-flex;",
               "css-1l7fvsg": "height:12px;width:12px;margin-right:4px;",
               "css-jb2puo": "height:12px;width:12px;margin-right:4px;animation:animation-u07e3c 1s linear infinite;;",
+              "css-tkevr6": "display:flex;align-items:center;justify-content:center;height:100%;",
             },
             "sheet": StyleSheet {
               "before": null,
@@ -549,6 +653,12 @@ exports[`A11YPanel should render report 1`] = `
                   data-emotion="css"
                 >
                   
+                  .css-tkevr6{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;height:100%;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
                   .css-jb2puo{height:12px;width:12px;margin-right:4px;-webkit-animation:animation-u07e3c 1s linear infinite;animation:animation-u07e3c 1s linear infinite;}
                 </style>
                 <style
@@ -612,7 +722,7 @@ exports[`A11YPanel should render report 1`] = `
                   .css-6hqipu{shape-rendering:inherit;-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0);display:inline-block;height:12px;width:12px;margin-right:4px;}
                 </style>
               </head>,
-              "ctr": 28,
+              "ctr": 29,
               "isSpeedy": false,
               "key": "css",
               "nonce": undefined,
@@ -718,6 +828,12 @@ exports[`A11YPanel should render report 1`] = `
                 >
                   
                   .emotion-13:focus{box-shadow:#1EA7FD 0 -3px 0 0 inset;outline:0 none;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-tkevr6{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;height:100%;}
                 </style>,
                 <style
                   data-emotion="css"

--- a/addons/a11y/src/components/__snapshots__/A11YPanel.test.js.snap
+++ b/addons/a11y/src/components/__snapshots__/A11YPanel.test.js.snap
@@ -1,0 +1,1024 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`A11YPanel should render report 1`] = `
+.emotion-10 {
+  overflow-y: auto;
+  overflow-x: auto;
+}
+
+.emotion-9 {
+  width: 100%;
+  position: relative;
+  min-height: 100%;
+}
+
+.emotion-6 {
+  box-shadow: rgba(0,0,0,.1) 0 -1px 0 0 inset;
+  background: rgba(0,0,0,.05);
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding: 10px 15px;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 13px;
+  line-height: 1;
+  height: 40px;
+  border: none;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  background: transparent;
+  opacity: 1;
+  border-bottom: 3px solid #1EA7FD;
+}
+
+.emotion-1:focus {
+  outline: 0 none;
+  border-bottom: 3px solid #1EA7FD;
+}
+
+.emotion-0 {
+  color: #FF4400;
+}
+
+.emotion-3 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding: 10px 15px;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 13px;
+  line-height: 1;
+  height: 40px;
+  border: none;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  background: transparent;
+}
+
+.emotion-3:focus {
+  outline: 0 none;
+  border-bottom: 3px solid #1EA7FD;
+}
+
+.emotion-2 {
+  color: #66BF3C;
+}
+
+.emotion-4 {
+  color: #E69D00;
+}
+
+.emotion-8 {
+  padding: 30px;
+  text-align: center;
+  color: #333333;
+  font-size: 13px;
+}
+
+.emotion-7 {
+  font-weight: 700;
+}
+
+.emotion-14 {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  max-width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #FFFFFF;
+}
+
+.emotion-13 {
+  border: 0 none;
+  padding: 4px 10px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #333333;
+  background: #FFFFFF;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 700;
+  border-top: 1px solid rgba(0,0,0,.1);
+  border-left: 1px solid rgba(0,0,0,.1);
+  margin-left: -1px;
+  border-radius: 4px 0 0 0;
+}
+
+.emotion-13:not(:last-child) {
+  border-right: 1px solid rgba(0,0,0,.1);
+}
+
+.emotion-13 + * {
+  border-left: 1px solid rgba(0,0,0,.1);
+  border-radius: 0;
+}
+
+.emotion-13:focus {
+  box-shadow: #1EA7FD 0 -3px 0 0 inset;
+  outline: 0 none;
+}
+
+<A11YPanel
+  active={true}
+  api={
+    Object {
+      "emit": [MockFunction],
+      "off": [MockFunction],
+      "on": [MockFunction] {
+        "calls": Array [
+          Array [
+            "storyRendered",
+            [Function],
+          ],
+          Array [
+            "storybook/a11y/result",
+            [Function],
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    }
+  }
+>
+  <ScrollArea
+    horizontal={true}
+    vertical={true}
+  >
+    <ForwardRef(render)
+      styles={[Function]}
+    >
+      <InnerGlobal
+        cache={
+          Object {
+            "insert": [Function],
+            "inserted": Object {
+              "0": true,
+              "110qmus": true,
+              "1551xjo": true,
+              "176o2y5": true,
+              "18epvrj": true,
+              "1977chw": true,
+              "1l7fvsg": true,
+              "1myfomu": true,
+              "1s6ajii": true,
+              "1vwgrhn": true,
+              "6hqipu": true,
+              "7wurov": true,
+              "animation-u07e3c": true,
+              "fg630j": true,
+              "g90fw7": true,
+              "iau1th": true,
+              "jb2puo": true,
+              "kqzqgg": true,
+              "l0u0ek": true,
+              "qacwg0": true,
+              "qb28": true,
+              "snh8f7": true,
+            },
+            "key": "css",
+            "nonce": undefined,
+            "registered": Object {
+              "emotion-10": "overflow-y:auto;overflow-x:auto;",
+              "css-1977chw": "height:10px;width:10px;min-width:10px;color:#999999;margin-right:10px;transition:transform 0.1s ease-in-out;align-self:center;display:inline-flex;",
+              "css-1l7fvsg": "height:12px;width:12px;margin-right:4px;",
+              "css-jb2puo": "height:12px;width:12px;margin-right:4px;animation:animation-u07e3c 1s linear infinite;;",
+            },
+            "sheet": StyleSheet {
+              "before": null,
+              "container": <head>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  [data-simplebar]{position:relative;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:start;-webkit-justify-content:flex-start;-ms-flex-pack:start;justify-content:flex-start;-webkit-align-content:flex-start;-ms-flex-line-pack:start;align-content:flex-start;-webkit-align-items:flex-start;-webkit-box-align:flex-start;-ms-flex-align:flex-start;align-items:flex-start;width:inherit;height:inherit;max-width:inherit;max-height:inherit;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-wrapper{overflow:hidden;width:inherit;height:inherit;max-width:inherit;max-height:inherit;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-mask{direction:inherit;position:absolute;overflow:hidden;padding:0;margin:0;left:0;top:0;bottom:0;right:0;width:auto !important;height:auto !important;z-index:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-offset{direction:inherit !important;box-sizing:inherit !important;resize:none !important;position:absolute;top:0;left:0;bottom:0;right:0;padding:0;margin:0;-webkit-overflow-scrolling:touch;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-content{direction:inherit;box-sizing:border-box !important;position:relative;display:block;height:100%;width:auto;visibility:visible;overflow:scroll;max-width:100%;max-height:100%;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-placeholder{max-height:100%;max-width:100%;width:100%;pointer-events:none;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-height-auto-observer-wrapper{box-sizing:inherit !important;height:100%;width:inherit;max-width:1px;position:relative;float:left;max-height:1px;overflow:hidden;z-index:-1;padding:0;margin:0;pointer-events:none;-webkit-box-flex:inherit;-webkit-flex-grow:inherit;-ms-flex-positive:inherit;flex-grow:inherit;-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;-webkit-flex-basis:0;-ms-flex-preferred-size:0;flex-basis:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-height-auto-observer{box-sizing:inherit;display:block;opacity:0;position:absolute;top:0;left:0;height:1000%;width:1000%;min-height:1px;min-width:1px;overflow:hidden;pointer-events:none;z-index:-1;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track{z-index:1;position:absolute;right:0;bottom:0;pointer-events:none;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-scrollbar{position:absolute;right:2px;width:6px;min-height:10px;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-scrollbar:before{position:absolute;content:"";border-radius:6px;left:0;right:0;opacity:0;-webkit-transition:opacity 0.2s linear;transition:opacity 0.2s linear;background:#333333;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track .simplebar-scrollbar.simplebar-visible:before{opacity:0.2;-webkit-transition:opacity 0s linear;transition:opacity 0s linear;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-vertical{top:0;width:10px;right:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-vertical .simplebar-scrollbar:before{top:2px;bottom:2px;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-horizontal{left:0;height:10px;bottom:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-horizontal .simplebar-scrollbar:before{height:100%;left:2px;right:2px;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-horizontal .simplebar-scrollbar{right:auto;left:0;top:2px;height:6px;min-height:0;min-width:10px;width:auto;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  [data-simplebar-direction="rtl"] .simplebar-track.simplebar-vertical{right:auto;left:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .hs-dummy-scrollbar-size{direction:rtl;position:fixed;opacity:0;visibility:hidden;height:500px;width:500px;overflow-y:hidden;overflow-x:scroll;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  [data-simplebar]{position:relative;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:start;-webkit-justify-content:flex-start;-ms-flex-pack:start;justify-content:flex-start;-webkit-align-content:flex-start;-ms-flex-line-pack:start;align-content:flex-start;-webkit-align-items:flex-start;-webkit-box-align:flex-start;-ms-flex-align:flex-start;align-items:flex-start;width:inherit;height:inherit;max-width:inherit;max-height:inherit;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-wrapper{overflow:hidden;width:inherit;height:inherit;max-width:inherit;max-height:inherit;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-mask{direction:inherit;position:absolute;overflow:hidden;padding:0;margin:0;left:0;top:0;bottom:0;right:0;width:auto !important;height:auto !important;z-index:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-offset{direction:inherit !important;box-sizing:inherit !important;resize:none !important;position:absolute;top:0;left:0;bottom:0;right:0;padding:0;margin:0;-webkit-overflow-scrolling:touch;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-content{direction:inherit;box-sizing:border-box !important;position:relative;display:block;height:100%;width:auto;visibility:visible;overflow:scroll;max-width:100%;max-height:100%;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-placeholder{max-height:100%;max-width:100%;width:100%;pointer-events:none;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-height-auto-observer-wrapper{box-sizing:inherit !important;height:100%;width:inherit;max-width:1px;position:relative;float:left;max-height:1px;overflow:hidden;z-index:-1;padding:0;margin:0;pointer-events:none;-webkit-box-flex:inherit;-webkit-flex-grow:inherit;-ms-flex-positive:inherit;flex-grow:inherit;-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;-webkit-flex-basis:0;-ms-flex-preferred-size:0;flex-basis:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-height-auto-observer{box-sizing:inherit;display:block;opacity:0;position:absolute;top:0;left:0;height:1000%;width:1000%;min-height:1px;min-width:1px;overflow:hidden;pointer-events:none;z-index:-1;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track{z-index:1;position:absolute;right:0;bottom:0;pointer-events:none;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-scrollbar{position:absolute;right:2px;width:6px;min-height:10px;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-scrollbar:before{position:absolute;content:"";border-radius:6px;left:0;right:0;opacity:0;-webkit-transition:opacity 0.2s linear;transition:opacity 0.2s linear;background:#333333;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track .simplebar-scrollbar.simplebar-visible:before{opacity:0.2;-webkit-transition:opacity 0s linear;transition:opacity 0s linear;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-vertical{top:0;width:10px;right:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-vertical .simplebar-scrollbar:before{top:2px;bottom:2px;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-horizontal{left:0;height:10px;bottom:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-horizontal .simplebar-scrollbar:before{height:100%;left:2px;right:2px;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .simplebar-track.simplebar-horizontal .simplebar-scrollbar{right:auto;left:0;top:2px;height:6px;min-height:0;min-width:10px;width:auto;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  [data-simplebar-direction="rtl"] .simplebar-track.simplebar-vertical{right:auto;left:0;}
+                </style>
+                <style
+                  data-emotion="css-global"
+                >
+                  
+                  .hs-dummy-scrollbar-size{direction:rtl;position:fixed;opacity:0;visibility:hidden;height:500px;width:500px;overflow-y:hidden;overflow-x:scroll;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-10{overflow-y:auto;overflow-x:auto;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-9{width:100%;position:relative;min-height:100%;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-6{box-shadow:rgba(0,0,0,.1) 0 -1px 0 0 inset;background:rgba(0,0,0,.05);-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-1{-webkit-text-decoration:none;text-decoration:none;padding:10px 15px;cursor:pointer;font-weight:700;font-size:13px;line-height:1;height:40px;border:none;border-top:3px solid transparent;border-bottom:3px solid transparent;background:transparent;opacity:1;border-bottom:3px solid #1EA7FD;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-1:focus{outline:0 none;border-bottom:3px solid #1EA7FD;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-0{color:#FF4400;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-3{-webkit-text-decoration:none;text-decoration:none;padding:10px 15px;cursor:pointer;font-weight:700;font-size:13px;line-height:1;height:40px;border:none;border-top:3px solid transparent;border-bottom:3px solid transparent;background:transparent;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-3:focus{outline:0 none;border-bottom:3px solid #1EA7FD;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-2{color:#66BF3C;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-4{color:#E69D00;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-8{padding:30px;text-align:center;color:#333333;font-size:13px;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-7{font-weight:700;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-14{position:absolute;bottom:0;right:0;max-width:100%;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;background:#FFFFFF;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-13{border:0 none;padding:4px 10px;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;color:#333333;background:#FFFFFF;font-size:12px;line-height:16px;font-weight:700;border-top:1px solid rgba(0,0,0,.1);border-left:1px solid rgba(0,0,0,.1);margin-left:-1px;border-radius:4px 0 0 0;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-13:not(:last-child){border-right:1px solid rgba(0,0,0,.1);}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-13 + *{border-left:1px solid rgba(0,0,0,.1);border-radius:0;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-13:focus{box-shadow:#1EA7FD 0 -3px 0 0 inset;outline:0 none;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-jb2puo{height:12px;width:12px;margin-right:4px;-webkit-animation:animation-u07e3c 1s linear infinite;animation:animation-u07e3c 1s linear infinite;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  @-webkit-keyframes animation-u07e3c{from{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  @keyframes animation-u07e3c{from{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-l0u0ek{shape-rendering:inherit;-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0);display:inline-block;height:12px;width:12px;margin-right:4px;-webkit-animation:animation-u07e3c 1s linear infinite;animation:animation-u07e3c 1s linear infinite;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-kqzqgg{fill:currentColor;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-18epvrj{padding:10px;padding-left:7px;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;width:100%;border:0;background:none;color:inherit;text-align:left;border-left:3px solid transparent;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-18epvrj:focus{outline:0 none;border-left:3px solid #1EA7FD;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-1977chw{height:10px;width:10px;min-width:10px;color:#999999;margin-right:10px;-webkit-transition:-webkit-transform 0.1s ease-in-out;-webkit-transition:transform 0.1s ease-in-out;transition:transform 0.1s ease-in-out;-webkit-align-self:center;-ms-flex-item-align:center;align-self:center;display:-webkit-inline-box;display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-1vwgrhn{shape-rendering:inherit;-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0);display:block;height:10px;width:10px;min-width:10px;color:#999999;margin-right:10px;-webkit-transition:-webkit-transform 0.1s ease-in-out;-webkit-transition:transform 0.1s ease-in-out;transition:transform 0.1s ease-in-out;-webkit-align-self:center;-ms-flex-item-align:center;align-self:center;display:-webkit-inline-box;display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-1l7fvsg{height:12px;width:12px;margin-right:4px;}
+                </style>
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-6hqipu{shape-rendering:inherit;-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0);display:inline-block;height:12px;width:12px;margin-right:4px;}
+                </style>
+              </head>,
+              "ctr": 28,
+              "isSpeedy": false,
+              "key": "css",
+              "nonce": undefined,
+              "tags": Array [
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-10{overflow-y:auto;overflow-x:auto;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-9{width:100%;position:relative;min-height:100%;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-6{box-shadow:rgba(0,0,0,.1) 0 -1px 0 0 inset;background:rgba(0,0,0,.05);-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-1{-webkit-text-decoration:none;text-decoration:none;padding:10px 15px;cursor:pointer;font-weight:700;font-size:13px;line-height:1;height:40px;border:none;border-top:3px solid transparent;border-bottom:3px solid transparent;background:transparent;opacity:1;border-bottom:3px solid #1EA7FD;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-1:focus{outline:0 none;border-bottom:3px solid #1EA7FD;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-0{color:#FF4400;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-3{-webkit-text-decoration:none;text-decoration:none;padding:10px 15px;cursor:pointer;font-weight:700;font-size:13px;line-height:1;height:40px;border:none;border-top:3px solid transparent;border-bottom:3px solid transparent;background:transparent;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-3:focus{outline:0 none;border-bottom:3px solid #1EA7FD;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-2{color:#66BF3C;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-4{color:#E69D00;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-8{padding:30px;text-align:center;color:#333333;font-size:13px;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-7{font-weight:700;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-14{position:absolute;bottom:0;right:0;max-width:100%;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;background:#FFFFFF;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-13{border:0 none;padding:4px 10px;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;color:#333333;background:#FFFFFF;font-size:12px;line-height:16px;font-weight:700;border-top:1px solid rgba(0,0,0,.1);border-left:1px solid rgba(0,0,0,.1);margin-left:-1px;border-radius:4px 0 0 0;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-13:not(:last-child){border-right:1px solid rgba(0,0,0,.1);}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-13 + *{border-left:1px solid rgba(0,0,0,.1);border-radius:0;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .emotion-13:focus{box-shadow:#1EA7FD 0 -3px 0 0 inset;outline:0 none;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-jb2puo{height:12px;width:12px;margin-right:4px;-webkit-animation:animation-u07e3c 1s linear infinite;animation:animation-u07e3c 1s linear infinite;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  @-webkit-keyframes animation-u07e3c{from{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  @keyframes animation-u07e3c{from{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-l0u0ek{shape-rendering:inherit;-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0);display:inline-block;height:12px;width:12px;margin-right:4px;-webkit-animation:animation-u07e3c 1s linear infinite;animation:animation-u07e3c 1s linear infinite;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-kqzqgg{fill:currentColor;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-18epvrj{padding:10px;padding-left:7px;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;width:100%;border:0;background:none;color:inherit;text-align:left;border-left:3px solid transparent;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-18epvrj:focus{outline:0 none;border-left:3px solid #1EA7FD;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-1977chw{height:10px;width:10px;min-width:10px;color:#999999;margin-right:10px;-webkit-transition:-webkit-transform 0.1s ease-in-out;-webkit-transition:transform 0.1s ease-in-out;transition:transform 0.1s ease-in-out;-webkit-align-self:center;-ms-flex-item-align:center;align-self:center;display:-webkit-inline-box;display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-1vwgrhn{shape-rendering:inherit;-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0);display:block;height:10px;width:10px;min-width:10px;color:#999999;margin-right:10px;-webkit-transition:-webkit-transform 0.1s ease-in-out;-webkit-transition:transform 0.1s ease-in-out;transition:transform 0.1s ease-in-out;-webkit-align-self:center;-ms-flex-item-align:center;align-self:center;display:-webkit-inline-box;display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-1l7fvsg{height:12px;width:12px;margin-right:4px;}
+                </style>,
+                <style
+                  data-emotion="css"
+                >
+                  
+                  .css-6hqipu{shape-rendering:inherit;-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0);display:inline-block;height:12px;width:12px;margin-right:4px;}
+                </style>,
+              ],
+            },
+          }
+        }
+        serialized={
+          Object {
+            "map": undefined,
+            "name": "6ym4y",
+            "next": undefined,
+            "styles": "[data-simplebar]{position:relative;flex-direction:column;flex-wrap:wrap;justify-content:flex-start;align-content:flex-start;align-items:flex-start;width:inherit;height:inherit;max-width:inherit;max-height:inherit;}.simplebar-wrapper{overflow:hidden;width:inherit;height:inherit;max-width:inherit;max-height:inherit;}.simplebar-mask{direction:inherit;position:absolute;overflow:hidden;padding:0;margin:0;left:0;top:0;bottom:0;right:0;width:auto !important;height:auto !important;z-index:0;}.simplebar-offset{direction:inherit !important;box-sizing:inherit !important;resize:none !important;position:absolute;top:0;left:0;bottom:0;right:0;padding:0;margin:0;-webkit-overflow-scrolling:touch;}.simplebar-content{direction:inherit;box-sizing:border-box !important;position:relative;display:block;height:100% /* Required for horizontal native scrollbar to not appear if parent is taller than natural height */;width:auto;visibility:visible;overflow:scroll;max-width:100% /* Not required for horizontal scroll to trigger */;max-height:100% /* Needed for vertical scroll to trigger */;}.simplebar-placeholder{max-height:100%;max-width:100%;width:100%;pointer-events:none;}.simplebar-height-auto-observer-wrapper{box-sizing:inherit !important;height:100%;width:inherit;max-width:1px;position:relative;float:left;max-height:1px;overflow:hidden;z-index:-1;padding:0;margin:0;pointer-events:none;flex-grow:inherit;flex-shrink:0;flex-basis:0;}.simplebar-height-auto-observer{box-sizing:inherit;display:block;opacity:0;position:absolute;top:0;left:0;height:1000%;width:1000%;min-height:1px;min-width:1px;overflow:hidden;pointer-events:none;z-index:-1;}.simplebar-track{z-index:1;position:absolute;right:0;bottom:0;pointer-events:none;}.simplebar-scrollbar{position:absolute;right:2px;width:6px;min-height:10px;}.simplebar-scrollbar:before{position:absolute;content:\\"\\";border-radius:6px;left:0;right:0;opacity:0;transition:opacity 0.2s linear;background:#333333;}.simplebar-track .simplebar-scrollbar.simplebar-visible:before{opacity:0.2;transition:opacity 0s linear;}.simplebar-track.simplebar-vertical{top:0;width:10px;right:0;}.simplebar-track.simplebar-vertical .simplebar-scrollbar:before{top:2px;bottom:2px;}.simplebar-track.simplebar-horizontal{left:0;height:10px;bottom:0;}.simplebar-track.simplebar-horizontal .simplebar-scrollbar:before{height:100%;left:2px;right:2px;}.simplebar-track.simplebar-horizontal .simplebar-scrollbar{right:auto;left:0;top:2px;height:6px;min-height:0;min-width:10px;width:auto;}[data-simplebar-direction=\\"rtl\\"] .simplebar-track.simplebar-vertical{right:auto;left:0;}.hs-dummy-scrollbar-size{direction:rtl;position:fixed;opacity:0;visibility:hidden;height:500px;width:500px;overflow-y:hidden;overflow-x:scroll;}",
+          }
+        }
+      />
+    </ForwardRef(render)>
+    <Styled(Component)
+      horizontal={true}
+      vertical={true}
+    >
+      <Component
+        className="emotion-10"
+        horizontal={true}
+        vertical={true}
+      >
+        <r
+          className="emotion-10"
+        >
+          <div
+            className="emotion-10"
+            data-simplebar={true}
+          >
+            <div
+              className="simplebar-wrapper"
+            >
+              <div
+                className="simplebar-height-auto-observer-wrapper"
+              >
+                <div
+                  className="simplebar-height-auto-observer"
+                />
+              </div>
+              <div
+                className="simplebar-mask"
+              >
+                <div
+                  className="simplebar-offset"
+                >
+                  <div
+                    className="simplebar-content"
+                  >
+                    <Tabs
+                      key="tabs"
+                      tabs={
+                        Array [
+                          Object {
+                            "label": <ForwardRef(render)>
+                              0
+                               Violations
+                            </ForwardRef(render)>,
+                            "panel": <Unknown
+                              empty="No a11y violations found."
+                              items={Array []}
+                              passes={false}
+                            />,
+                          },
+                          Object {
+                            "label": <ForwardRef(render)>
+                              0
+                               Passes
+                            </ForwardRef(render)>,
+                            "panel": <Unknown
+                              empty="No a11y check passed."
+                              items={Array []}
+                              passes={true}
+                            />,
+                          },
+                          Object {
+                            "label": <ForwardRef(render)>
+                              0
+                               Incomplete
+                            </ForwardRef(render)>,
+                            "panel": <Unknown
+                              empty="No a11y incomplete found."
+                              items={Array []}
+                              passes={false}
+                            />,
+                          },
+                        ]
+                      }
+                    >
+                      <Styled(div)>
+                        <div
+                          className="emotion-9"
+                        >
+                          <Styled(div)>
+                            <div
+                              className="emotion-6"
+                            >
+                              <Styled(button)
+                                active={true}
+                                key="0"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="emotion-1"
+                                  onClick={[Function]}
+                                >
+                                  <Styled(span)>
+                                    <span
+                                      className="emotion-0"
+                                    >
+                                      0
+                                       Violations
+                                    </span>
+                                  </Styled(span)>
+                                </button>
+                              </Styled(button)>
+                              <Styled(button)
+                                key="1"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="emotion-3"
+                                  onClick={[Function]}
+                                >
+                                  <Styled(span)>
+                                    <span
+                                      className="emotion-2"
+                                    >
+                                      0
+                                       Passes
+                                    </span>
+                                  </Styled(span)>
+                                </button>
+                              </Styled(button)>
+                              <Styled(button)
+                                key="2"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="emotion-3"
+                                  onClick={[Function]}
+                                >
+                                  <Styled(span)>
+                                    <span
+                                      className="emotion-4"
+                                    >
+                                      0
+                                       Incomplete
+                                    </span>
+                                  </Styled(span)>
+                                </button>
+                              </Styled(button)>
+                            </div>
+                          </Styled(div)>
+                          <Component
+                            empty="No a11y violations found."
+                            items={Array []}
+                            passes={false}
+                          >
+                            <Placeholder
+                              key="placeholder"
+                            >
+                              <Styled(div)>
+                                <div
+                                  className="emotion-8"
+                                >
+                                  <Styled(div)>
+                                    <div
+                                      className="emotion-7"
+                                    >
+                                      No a11y violations found.
+                                    </div>
+                                  </Styled(div)>
+                                </div>
+                              </Styled(div)>
+                            </Placeholder>
+                          </Component>
+                        </div>
+                      </Styled(div)>
+                    </Tabs>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="simplebar-placeholder"
+              />
+            </div>
+            <div
+              className="simplebar-track simplebar-horizontal"
+            >
+              <div
+                className="simplebar-scrollbar"
+              />
+            </div>
+            <div
+              className="simplebar-track simplebar-vertical"
+            >
+              <div
+                className="simplebar-scrollbar"
+              />
+            </div>
+          </div>
+        </r>
+      </Component>
+    </Styled(Component)>
+  </ScrollArea>
+  <ActionBar
+    actionItems={
+      Array [
+        Object {
+          "onClick": [Function],
+          "title": "Rerun tests",
+        },
+      ]
+    }
+    key="actionbar"
+  >
+    <Styled(div)>
+      <div
+        className="emotion-14"
+      >
+        <ActionButton
+          key="0"
+          onClick={[Function]}
+        >
+          <button
+            className="emotion-13"
+            onClick={[Function]}
+          >
+            Rerun tests
+          </button>
+        </ActionButton>
+      </div>
+    </Styled(div)>
+  </ActionBar>
+</A11YPanel>
+`;

--- a/addons/a11y/src/index.ts
+++ b/addons/a11y/src/index.ts
@@ -4,7 +4,6 @@ import deprecate from 'util-deprecate';
 import { stripIndents } from 'common-tags';
 
 import addons, { StoryWrapper } from '@storybook/addons';
-import { STORY_RENDERED } from '@storybook/core-events';
 import { EVENTS, PARAM_KEY } from './constants';
 
 const channel = addons.getChannel();
@@ -56,7 +55,6 @@ export const withA11y: StoryWrapper = (getStory, context) => {
   return getStory(context);
 };
 
-channel.on(STORY_RENDERED, () => run(setup.element, setup.config, setup.options));
 channel.on(EVENTS.REQUEST, () => run(setup.element, setup.config, setup.options));
 
 if (module && module.hot && module.hot.decline) {


### PR DESCRIPTION
Issue: [#5973 A11y addon freezes the UI](https://github.com/storybooks/storybook/issues/5973)

## What I did
- On a11y addon initialization, there is no listener set on story rendered event to avoid running the scan when the tab is inactive.
- Hide report when a scan is running instead of displaying outdated report.

The resulting behavior : 
- on init, index listen to REQUEST event **only** to perform the a11y scan
- A11y panel listen to RESULT event to update the displayed report
- A11y panel listen to STORY_RENDERED event to emit a REQUEST only if the tab is active

Bonus : Add unit tests on a11y panel component.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps? No 
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
