### PR TITLE
Show active viewport dimensions & button to rotate

### DIFF
--- a/addons/viewport/src/Tool.js
+++ b/addons/viewport/src/Tool.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import memoize from 'memoizerific';
 import deprecate from 'util-deprecate';
 
-import { Global } from '@storybook/theming';
+import { styled, Global } from '@storybook/theming';
 
 import { Icons, IconButton, WithTooltip, TooltipLinkList } from '@storybook/components';
 import { SET_STORIES } from '@storybook/core-events';
@@ -88,6 +88,24 @@ const getState = memoize(10)((props, state, change) => {
   };
 });
 
+const ActiveViewportSize = styled.div(() => ({
+  display: 'inline-flex',
+}));
+
+const ActiveViewportLabel = styled.div(({ theme }) => ({
+  display: 'inline-block',
+  textDecoration: 'none',
+  padding: '10px',
+  fontWeight: theme.typography.weight.bold,
+  fontSize: theme.typography.size.s2 - 1,
+  lineHeight: 1,
+  height: 40,
+  border: 'none',
+  borderTop: '3px solid transparent',
+  borderBottom: '3px solid transparent',
+  background: 'transparent',
+}));
+
 export default class ViewportTool extends Component {
   constructor(props) {
     super(props);
@@ -118,10 +136,23 @@ export default class ViewportTool extends Component {
 
   change = (...args) => this.setState(...args);
 
+  flipViewport = () =>
+    this.setState(({ isRotated }) => ({ isRotated: !isRotated, expanded: false }));
+
   render() {
     const { expanded } = this.state;
     const { items, selected, isRotated } = getState(this.props, this.state, this.change);
     const item = items.find(i => i.id === selected);
+
+    let viewportX = 0;
+    let viewportY = 0;
+    if (item) {
+      const height = item.value.height.replace('px', '');
+      const width = item.value.width.replace('px', '');
+
+      viewportX = isRotated ? height : width;
+      viewportY = isRotated ? width : height;
+    }
 
     return items.length ? (
       <Fragment>
@@ -150,6 +181,15 @@ export default class ViewportTool extends Component {
             <Icons icon="grow" />
           </IconButton>
         </WithTooltip>
+        {item ? (
+          <ActiveViewportSize>
+            <ActiveViewportLabel title="Viewport width">{viewportX}</ActiveViewportLabel>
+            <IconButton key="viewport-rotate" title="Rotate viewport" onClick={this.flipViewport}>
+              <Icons icon="transfer" />
+            </IconButton>
+            <ActiveViewportLabel title="Viewport height">{viewportY}</ActiveViewportLabel>
+          </ActiveViewportSize>
+        ) : null}
       </Fragment>
     ) : null;
   }

--- a/addons/viewport/src/Tool.js
+++ b/addons/viewport/src/Tool.js
@@ -149,6 +149,13 @@ export default class ViewportTool extends Component {
   flipViewport = () =>
     this.setState(({ isRotated }) => ({ isRotated: !isRotated, expanded: false }));
 
+  resetViewport = e => {
+    e.stopPropagation();
+    e.nativeEvent.stopImmediatePropagation();
+
+    this.setState({ selected: undefined, expanded: false });
+  };
+
   render() {
     const { expanded } = this.state;
     const { items, selected, isRotated } = getState(this.props, this.state, this.change);
@@ -194,6 +201,7 @@ export default class ViewportTool extends Component {
             key="viewport"
             title="Change the size of the preview"
             active={!!item}
+            onDoubleClick={e => this.resetViewport(e)}
           >
             <Icons icon="grow" />
             <IconButtonLabel>{viewportTitle}</IconButtonLabel>

--- a/addons/viewport/src/Tool.js
+++ b/addons/viewport/src/Tool.js
@@ -106,6 +106,16 @@ const ActiveViewportLabel = styled.div(({ theme }) => ({
   background: 'transparent',
 }));
 
+const IconButtonWithLabel = styled(IconButton)(() => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+}));
+
+const IconButtonLabel = styled.div(({ theme }) => ({
+  fontSize: theme.typography.size.s2 - 1,
+  marginLeft: '10px',
+}));
+
 export default class ViewportTool extends Component {
   constructor(props) {
     super(props);
@@ -146,12 +156,15 @@ export default class ViewportTool extends Component {
 
     let viewportX = 0;
     let viewportY = 0;
+    let viewportTitle = '';
     if (item) {
       const height = item.value.height.replace('px', '');
       const width = item.value.width.replace('px', '');
 
       viewportX = isRotated ? height : width;
       viewportY = isRotated ? width : height;
+
+      viewportTitle = isRotated ? `${item.title} (L)` : `${item.title} (P)`;
     }
 
     return items.length ? (
@@ -177,9 +190,14 @@ export default class ViewportTool extends Component {
           tooltip={<TooltipLinkList links={items} />}
           closeOnClick
         >
-          <IconButton key="viewport" title="Change the size of the preview" active={!!item}>
+          <IconButtonWithLabel
+            key="viewport"
+            title="Change the size of the preview"
+            active={!!item}
+          >
             <Icons icon="grow" />
-          </IconButton>
+            <IconButtonLabel>{viewportTitle}</IconButtonLabel>
+          </IconButtonWithLabel>
         </WithTooltip>
         {item ? (
           <ActiveViewportSize>


### PR DESCRIPTION
Issue: #5879

## What I did
- Show active pixel dimensions in viewport widget when a viewport is selected
- Added button to flip the viewport
- Show title of active view in button
- Added functionality to reset the viewport by double-clicking the button

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
