### PR TITLE
Update syntaxhighlighter.stories.js

### DIFF
--- a/lib/components/src/syntaxhighlighter/__snapshots__/syntaxhighlighter.stories.storyshot
+++ b/lib/components/src/syntaxhighlighter/__snapshots__/syntaxhighlighter.stories.storyshot
@@ -227,7 +227,7 @@ exports[`Storyshots Basics|SyntaxHighlighter bash 1`] = `
                 >
                   &&
                 </span>
-                 yarn
+                 npm install
               </code>
             </pre>
           </div>

--- a/lib/components/src/syntaxhighlighter/__snapshots__/syntaxhighlighter.stories.storyshot
+++ b/lib/components/src/syntaxhighlighter/__snapshots__/syntaxhighlighter.stories.storyshot
@@ -227,7 +227,18 @@ exports[`Storyshots Basics|SyntaxHighlighter bash 1`] = `
                 >
                   &&
                 </span>
-                 npm install
+                 
+                <span
+                  class="token function"
+                >
+                  npm
+                </span>
+                 
+                <span
+                  class="token function"
+                >
+                  install
+                </span>
               </code>
             </pre>
           </div>

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.stories.js
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.stories.js
@@ -5,7 +5,7 @@ import SyntaxHighlighter from './syntaxhighlighter';
 storiesOf('Basics|SyntaxHighlighter', module)
   .add('bash', () => (
     <SyntaxHighlighter language="bash" copyable={false}>
-      npx npm-check-updates '/storybook/' -u && yarn
+      npx npm-check-updates '/storybook/' -u && npm install
     </SyntaxHighlighter>
   ))
   .add('jsx', () => (


### PR DESCRIPTION
In the instructions for updating it calls for using yarn on the npm example

Issue: 

## What I did
Update the example npm update code to use npm only

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
