### PR TITLE
[Docs] Vue guide typo

### DIFF
--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -140,7 +140,7 @@ storiesOf('Button', module)
   }));
 ```
 
-Each story is a single state of your component. In the above case, there are two stories for the demo button component:
+Each story is a single state of your component. In the above case, there are three stories for the demo button component:
 
 ```plaintext
 Button


### PR DESCRIPTION
The example shows 3 stories but the text refers to just 2 stories which might be a bit confusing for newcomers.