### PR TITLE
addon-notes: register as a panel or tab

### DIFF
--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -19,7 +19,10 @@ Then create a file called `addons.js` in your storybook config.
 Add following content to it:
 
 ```js
+// register the notes addon as a tab
 import '@storybook/addon-notes/register';
+// register the notes addon as a panel
+import '@storybook/addon-notes/register-panel';
 ```
 
 You can use the `notes` parameter to add a note to each story:
@@ -29,10 +32,9 @@ import { storiesOf } from '@storybook/react';
 
 import Component from './Component';
 
-storiesOf('Component', module)
-  .add('with some emoji', () => <Component />, {
-    notes: 'A very simple example of addon notes',
-  });
+storiesOf('Component', module).add('with some emoji', () => <Component />, {
+  notes: 'A very simple example of addon notes',
+});
 ```
 
 #### Using Markdown
@@ -44,8 +46,7 @@ import { storiesOf } from '@storybook/react';
 import Component from './Component';
 import notes from './someMarkdownText.md';
 
-storiesOf('Component', module)
-  .add('With Markdown', () => <Component />, { notes });
+storiesOf('Component', module).add('With Markdown', () => <Component />, { notes });
 ```
 
 ### Giphy
@@ -57,4 +58,3 @@ When using markdown, you can also embed gifs from Giphy into your markdown. Curr
 
 <Giphy gif='cheese' />
 ```
-

--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -21,7 +21,7 @@ Add following content to it:
 ```js
 // register the notes addon as a tab
 import '@storybook/addon-notes/register';
-// register the notes addon as a panel
+// or register the notes addon as a panel. Only one can be used!
 import '@storybook/addon-notes/register-panel';
 ```
 

--- a/addons/notes/register-panel.js
+++ b/addons/notes/register-panel.js
@@ -1,1 +1,1 @@
-require('./dist/register.js')('panel');
+require('./dist/register.js').default('panel');

--- a/addons/notes/register-panel.js
+++ b/addons/notes/register-panel.js
@@ -1,0 +1,1 @@
+require('./dist/register.js')('panel');

--- a/addons/notes/register.js
+++ b/addons/notes/register.js
@@ -1,1 +1,1 @@
-require('./dist/register.js');
+require('./dist/register.js')('tab');

--- a/addons/notes/register.js
+++ b/addons/notes/register.js
@@ -1,1 +1,1 @@
-require('./dist/register.js')('tab');
+require('./dist/register.js').default('tab');

--- a/addons/notes/src/register.tsx
+++ b/addons/notes/src/register.tsx
@@ -6,12 +6,14 @@ import { ADDON_ID, PANEL_ID } from './shared';
 // TODO: fix eslint in tslint (igor said he fixed it, should ask him)
 import Panel from './Panel';
 
-addons.register(ADDON_ID, api => {
-  addons.add(PANEL_ID, {
-    type: types.TAB,
-    title: 'Notes',
-    route: ({ storyId }) => `/info/${storyId}`, // todo add type
-    match: ({ viewMode }) => viewMode === 'info', // todo add type
-    render: ({ active }) => <Panel api={api} active={active} />,
+export default function register(type: types) {
+  addons.register(ADDON_ID, api => {
+    addons.add(PANEL_ID, {
+      type,
+      title: 'Notes',
+      route: ({ storyId }) => `/info/${storyId}`, // todo add type
+      match: ({ viewMode }) => viewMode === 'info', // todo add type
+      render: ({ active }) => <Panel api={api} active={active} />,
+    });
   });
-});
+}


### PR DESCRIPTION
Issue: People in my organization prefer having the notes tab in the addon panel, but in v5 it only renders as a tab.

## What I did

Expose a `register-panel` script from addon-notes. This allows the user register the notes as a panel.

## How to test

- Is this testable with Jest or Chromatic screenshots? yes, but addons seem untested
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? maybe

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

I have verified that this works in my storybook. If a user tries to use both of the registers then storybook breaks, but this is expected because you are registering the same addon twice