### PR TITLE
Restore v4 webpack extend mode behavior AND deprecate it

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,7 @@
 # Migration
 
+- [From version 5.0.1 to 5.0.2](#from-version-501-to-502)
+  - [Deprecate webpack extend mode](#deprecate-webpack-extend-mode)
 - [From version 4.1.x to 5.0.x](#from-version-41x-to-50x)
   - [Webpack config simplification](#webpack-config-simplification)
   - [Theming overhaul](#theming-overhaul)
@@ -49,36 +51,17 @@
   - [Packages renaming](#packages-renaming)
   - [Deprecated embedded addons](#deprecated-embedded-addons)
 
-## From version 4.1.x to 5.0.x
+## From version 5.0.1 to 5.0.2
 
-Storybook 5.0 includes sweeping UI changes as well as changes to the addon API and custom webpack configuration. We've tried to keep backwards compatibility in most cases, but there are some notable exceptions documented below.
+### Deprecate webpack extend mode
 
-## Webpack config simplification
+Exporting an object from your custom webpack config puts storybook in "extend mode".
 
-The API for custom webpack configuration has been simplifed in 5.0, but it's a breaking change.
+There was a bad bug in `v5.0.0` involving webpack "extend mode" that caused webpack issues for users migrating from `4.x`. We've fixed this problem in `v5.0.2` but it means that extend-mode has a different behavior if you're migrating from `5.0.0` or `5.0.1`. In short, `4.x` extended a base config with the custom config, whereas `5.0.0-1` extended the base with a richer config object that could conflict with the custom config in different ways from `4.x`.
 
-- We've simplified "full-control mode"
-- We've deprecated "extend mode"
+We've also deprecated "extend mode" because it doesn't add a lot of value over "full control mode", but adds more code paths, documentation, user confusion etc. Starting in SB6.0 we will only support "full control mode" customization.
 
-We describe each change below and encourage you to refer to the [current custom webpack documentation](https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/custom-webpack-config/index.md) for more information on custom webpack config.
-
-### Simplified full control mode
-
-Storybook's "full control mode" for webpack allows you to override the webpack config with a function that returns a configuration object.
-
-In Storybook 5 there is a single signature for full-control mode that takes a parameters object with the fields `config` and `mode`:
-
-```js
-module.exports = ({ config, mode }) => { config.module.rules.push(...); return config; }
-```
-
-In contrast, the 4.x configuration function accepted either two or three arguments (`(baseConfig, mode)`, or `(baseConfig, mode, defaultConfig)`). The `config` object in the 5.x signature is equivalent to 4.x's `defaultConfig`.
-
-### Deprecated extend mode
-
-Exporting an object from your custom webpack config puts storybook in "extend mode". This is still supported in 5.x but we've deprecated this and encourage users to use full-control mode instead.
-
-If your extend-mode webpack config looks like this:
+To migrate from extend-mode to full-control mode, if your extend-mode webpack config looks like this:
 
 ```js
 module.exports = {
@@ -90,22 +73,7 @@ module.exports = {
 };
 ```
 
-You can replace it with the following full-control equivalent for identical behavior:
-
-```js
-const mergeConfigs = require('@storybook/core/merge-webpack-config');
-
-module.exports = async ({ config }) =>
-  mergeConfigs(config, {
-    module: {
-      rules: [
-        /* ... */
-      ],
-    },
-  });
-```
-
-You can also modify the default config more deliberately:
+In full control mode, you need modify the default config to have the rules of your liking:
 
 ```js
 module.exports = ({ config }) => ({
@@ -113,13 +81,29 @@ module.exports = ({ config }) => ({
   module: {
     ...config.module
     rules: [
-      /* ... some before */
-      ...config.module.rules,
-      /* ... & some after */
+      /* your own rules "..." here and/or some subset of config.module.rules */
     ]
   }
 })
 ```
+
+Please refer to the [current custom webpack documentation](https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/custom-webpack-config/index.md) for more information on custom webpack config and to [Issue #6081](https://github.com/storybooks/storybook/issues/6081) for more information about the change.
+
+## From version 4.1.x to 5.0.x
+
+Storybook 5.0 includes sweeping UI changes as well as changes to the addon API and custom webpack configuration. We've tried to keep backwards compatibility in most cases, but there are some notable exceptions documented below.
+
+## Webpack config simplification
+
+The API for custom webpack configuration has been simplifed in 5.0, but it's a breaking change. Storybook's "full control mode" for webpack allows you to override the webpack config with a function that returns a configuration object.
+
+In Storybook 5 there is a single signature for full-control mode that takes a parameters object with the fields `config` and `mode`:
+
+```js
+module.exports = ({ config, mode }) => { config.module.rules.push(...); return config; }
+```
+
+In contrast, the 4.x configuration function accepted either two or three arguments (`(baseConfig, mode)`, or `(baseConfig, mode, defaultConfig)`). The `config` object in the 5.x signature is equivalent to 4.x's `defaultConfig`.
 
 ## Theming overhaul
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -57,6 +57,13 @@ Storybook 5.0 includes sweeping UI changes as well as changes to the addon API a
 
 The API for custom webpack configuration has been simplifed in 5.0, but it's a breaking change.
 
+- We've simplified "full-control mode"
+- We've deprecated "extend mode"
+
+We describe each change below and encourage you to refer to the [current custom webpack documentation](https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/custom-webpack-config/index.md) for more information on custom webpack config.
+
+### Simplified full control mode
+
 Storybook's "full control mode" for webpack allows you to override the webpack config with a function that returns a configuration object.
 
 In Storybook 5 there is a single signature for full-control mode that takes a parameters object with the fields `config` and `mode`:
@@ -67,7 +74,9 @@ module.exports = ({ config, mode }) => { config.module.rules.push(...); return c
 
 In contrast, the 4.x configuration function accepted either two or three arguments (`(baseConfig, mode)`, or `(baseConfig, mode, defaultConfig)`). The `config` object in the 5.x signature is equivalent to 4.x's `defaultConfig`.
 
-Please see the [current custom webpack documentation](https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/custom-webpack-config/index.md) for more information on custom webpack config.
+### Deprecated extend mode
+
+Exporting an object from your custom webpack config puts storybook in "extend mode". This is still supported in 5.x but we've deprecated this and encourage users to use full-control mode instead.
 
 ## Theming overhaul
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -105,6 +105,8 @@ module.exports = ({ config, mode }) => { config.module.rules.push(...); return c
 
 In contrast, the 4.x configuration function accepted either two or three arguments (`(baseConfig, mode)`, or `(baseConfig, mode, defaultConfig)`). The `config` object in the 5.x signature is equivalent to 4.x's `defaultConfig`.
 
+Please see the [current custom webpack documentation](https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/custom-webpack-config/index.md) for more information on custom webpack config.
+
 ## Theming overhaul
 
 Theming has been rewritten in v5. If you used theming in v4, please consult the [theming docs](https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/theming/index.md) to learn about the new API.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -78,6 +78,49 @@ In contrast, the 4.x configuration function accepted either two or three argumen
 
 Exporting an object from your custom webpack config puts storybook in "extend mode". This is still supported in 5.x but we've deprecated this and encourage users to use full-control mode instead.
 
+If your extend-mode webpack config looks like this:
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      /* ... */
+    ],
+  },
+};
+```
+
+You can replace it with the following full-control equivalent for identical behavior:
+
+```js
+const mergeConfigs = require('@storybook/core/merge-webpack-config');
+
+module.exports = async ({ config }) =>
+  mergeConfigs(config, {
+    module: {
+      rules: [
+        /* ... */
+      ],
+    },
+  });
+```
+
+You can also modify the default config more deliberately:
+
+```js
+module.exports = ({ config }) => ({
+  ...config
+  module: {
+    ...config.module
+    rules: [
+      /* ... some before */
+      ...config.module.rules,
+      /* ... & some after */
+    ]
+  }
+})
+```
+
 ## Theming overhaul
 
 Theming has been rewritten in v5. If you used theming in v4, please consult the [theming docs](https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/theming/index.md) to learn about the new API.

--- a/addons/a11y/src/components/A11YPanel.tsx
+++ b/addons/a11y/src/components/A11YPanel.tsx
@@ -1,5 +1,4 @@
 import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
 
 import { styled } from '@storybook/theming';
 

--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -5,7 +5,7 @@ title: 'Custom Webpack Config'
 
 You can customize Storybook's webpack setup by providing a `webpack.config.js` file exporting a **webpack 4** compatible config exported as a **commonjs module**.
 
-Storybook has its own Webpack setup and a dev server. 
+Storybook has its own Webpack setup and a dev server.
 The webpack config [is configurable](/configurations/webpack), and the default can depend on which framework you're using and whether you've used a generator like [Create React App](https://github.com/facebookincubator/create-react-app) or Angular CLI etc.
 
 > We're trying to make storybook more zero-config over time, **help to hook into the config of generators is very welcome**.
@@ -13,136 +13,137 @@ The webpack config [is configurable](/configurations/webpack), and the default c
 <details>
   <summary>This is what the config for storybook looks like when using CRA in dev-mode:</summary>
 
-  ```js
-  {
-    mode: 'development',
-    bail: false,
-    devtool: '#cheap-module-source-map',
-    entry: [
-      '@storybook/core/dist/server/common/polyfills.js',
-      '@storybook/core/dist/server/preview/globals.js',
-      '<your-storybook-dir>/config.js',
-      'webpack-hot-middleware/client.js?reload=true',
-    ],
-    output: {
-      path: './',
-      filename: '[name].[hash].bundle.js',
-      publicPath: '',
+```js
+{
+  mode: 'development',
+  bail: false,
+  devtool: '#cheap-module-source-map',
+  entry: [
+    '@storybook/core/dist/server/common/polyfills.js',
+    '@storybook/core/dist/server/preview/globals.js',
+    '<your-storybook-dir>/config.js',
+    'webpack-hot-middleware/client.js?reload=true',
+  ],
+  output: {
+    path: './',
+    filename: '[name].[hash].bundle.js',
+    publicPath: '',
+  },
+  plugins: [
+    HtmlWebpackPlugin {
+      options: {
+        template: '@storybook/core/dist/server/templates/index.ejs',
+        templateContent: false,
+        templateParameters: [Function: templateParameters],
+        filename: 'iframe.html',
+        hash: false,
+        inject: false,
+        compile: true,
+        favicon: false,
+        minify: undefined,
+        cache: true,
+        showErrors: true,
+        chunks: 'all',
+        excludeChunks: [],
+        chunksSortMode: 'none',
+        meta: {},
+        title: 'Webpack App',
+        xhtml: false,
+        alwaysWriteToDisk: true,
+      },
     },
-    plugins: [
-      HtmlWebpackPlugin {
-        options: {
-          template: '@storybook/core/dist/server/templates/index.ejs',
-          templateContent: false,
-          templateParameters: [Function: templateParameters],
-          filename: 'iframe.html',
-          hash: false,
-          inject: false,
-          compile: true,
-          favicon: false,
-          minify: undefined,
-          cache: true,
-          showErrors: true,
-          chunks: 'all',
-          excludeChunks: [],
-          chunksSortMode: 'none',
-          meta: {},
-          title: 'Webpack App',
-          xhtml: false,
-          alwaysWriteToDisk: true,
-        },
-      },
-      DefinePlugin {
-        definitions: {
-          'process.env': {
-            NODE_ENV: '"development"',
-            NODE_PATH: '""',
-            PUBLIC_URL: '"."',
-            '<storybook-environment-variables>'
-            '<dotenv-environment-variables>'
-          },
-        },
-      },
-      WatchMissingNodeModulesPlugin {
-        nodeModulesPath: './node_modules',
-      },
-      HotModuleReplacementPlugin {},
-      CaseSensitivePathsPlugin {},
-      ProgressPlugin {},
-      DefinePlugin {
-        definitions: {
+    DefinePlugin {
+      definitions: {
+        'process.env': {
+          NODE_ENV: '"development"',
+          NODE_PATH: '""',
+          PUBLIC_URL: '"."',
           '<storybook-environment-variables>'
           '<dotenv-environment-variables>'
         },
       },
-    ],
-    module: {
-      rules: [
-        { test: /\.(mjs|jsx?)$/, 
-          use: [
-            { loader: 'babel-loader', options:
-              { cacheDirectory: './node_modules/.cache/storybook',
-                presets: [
-                  [ './node_modules/@babel/preset-env/lib/index.js', { shippedProposals: true, useBuiltIns: 'usage' } ],
-                  './node_modules/@babel/preset-react/lib/index.js',
-                  './node_modules/@babel/preset-flow/lib/index.js',
-                ],
-                plugins: [
-                  './node_modules/@babel/plugin-proposal-object-rest-spread/lib/index.js',
-                  './node_modules/@babel/plugin-proposal-class-properties/lib/index.js',
-                  './node_modules/@babel/plugin-syntax-dynamic-import/lib/index.js',
-                  [ './node_modules/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js', { sourceMap: true, autoLabel: true } ],
-                  './node_modules/babel-plugin-macros/dist/index.js',
-                  './node_modules/@babel/plugin-transform-react-constant-elements/lib/index.js',
-                  './node_modules/babel-plugin-add-react-displayname/index.js',
-                  [ './node_modules/babel-plugin-react-docgen/lib/index.js', { DOC_GEN_COLLECTION_NAME: 'STORYBOOK_REACT_CLASSES' } ],
-                ],
-              },
-            },
-          ],
-          include: [ './' ],
-          exclude: [ './node_modules' ],
-        },
-        { test: /\.md$/, 
-          use: [
-            { loader: './node_modules/raw-loader/index.js' },
-          ],
-        },
-        { test: /\.css$/,
-          use: [
-            './node_modules/style-loader/index.js',
-            { loader: './node_modules/css-loader/dist/cjs.js', options: { importLoaders: 1 } },
-            { loader: './node_modules/postcss-loader/src/index.js', options: { ident: 'postcss', postcss: {}, plugins: [Function: plugins] } },
-          ],
-        },
-        { test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/,
-          loader: './node_modules/file-loader/dist/cjs.js',
-          query: { name: 'static/media/[name].[hash:8].[ext]' },
-        },
-        { test: /\.(mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
-          loader: './node_modules/url-loader/dist/cjs.js',
-          query: { limit: 10000, name: 'static/media/[name].[hash:8].[ext]' },
-        },
-      ],
     },
-    resolve: {
-      extensions: [ '.mjs', '.js', '.jsx', '.json' ],
-      modules: [ 'node_modules' ],
-      mainFields: [ 'browser', 'main', 'module' ],
-      alias: {
-        'core-js': './node_modules/core-js',
-        react: './node_modules/react',
-        'react-dom': './node_modules/react-dom',
+    WatchMissingNodeModulesPlugin {
+      nodeModulesPath: './node_modules',
+    },
+    HotModuleReplacementPlugin {},
+    CaseSensitivePathsPlugin {},
+    ProgressPlugin {},
+    DefinePlugin {
+      definitions: {
+        '<storybook-environment-variables>'
+        '<dotenv-environment-variables>'
       },
     },
-    optimization: {
-      splitChunks: { chunks: 'all' },
-      runtimeChunk: true,
-      minimizer: [ [Object] ],
+  ],
+  module: {
+    rules: [
+      { test: /\.(mjs|jsx?)$/,
+        use: [
+          { loader: 'babel-loader', options:
+            { cacheDirectory: './node_modules/.cache/storybook',
+              presets: [
+                [ './node_modules/@babel/preset-env/lib/index.js', { shippedProposals: true, useBuiltIns: 'usage' } ],
+                './node_modules/@babel/preset-react/lib/index.js',
+                './node_modules/@babel/preset-flow/lib/index.js',
+              ],
+              plugins: [
+                './node_modules/@babel/plugin-proposal-object-rest-spread/lib/index.js',
+                './node_modules/@babel/plugin-proposal-class-properties/lib/index.js',
+                './node_modules/@babel/plugin-syntax-dynamic-import/lib/index.js',
+                [ './node_modules/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js', { sourceMap: true, autoLabel: true } ],
+                './node_modules/babel-plugin-macros/dist/index.js',
+                './node_modules/@babel/plugin-transform-react-constant-elements/lib/index.js',
+                './node_modules/babel-plugin-add-react-displayname/index.js',
+                [ './node_modules/babel-plugin-react-docgen/lib/index.js', { DOC_GEN_COLLECTION_NAME: 'STORYBOOK_REACT_CLASSES' } ],
+              ],
+            },
+          },
+        ],
+        include: [ './' ],
+        exclude: [ './node_modules' ],
+      },
+      { test: /\.md$/,
+        use: [
+          { loader: './node_modules/raw-loader/index.js' },
+        ],
+      },
+      { test: /\.css$/,
+        use: [
+          './node_modules/style-loader/index.js',
+          { loader: './node_modules/css-loader/dist/cjs.js', options: { importLoaders: 1 } },
+          { loader: './node_modules/postcss-loader/src/index.js', options: { ident: 'postcss', postcss: {}, plugins: [Function: plugins] } },
+        ],
+      },
+      { test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/,
+        loader: './node_modules/file-loader/dist/cjs.js',
+        query: { name: 'static/media/[name].[hash:8].[ext]' },
+      },
+      { test: /\.(mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
+        loader: './node_modules/url-loader/dist/cjs.js',
+        query: { limit: 10000, name: 'static/media/[name].[hash:8].[ext]' },
+      },
+    ],
+  },
+  resolve: {
+    extensions: [ '.mjs', '.js', '.jsx', '.json' ],
+    modules: [ 'node_modules' ],
+    mainFields: [ 'browser', 'main', 'module' ],
+    alias: {
+      'core-js': './node_modules/core-js',
+      react: './node_modules/react',
+      'react-dom': './node_modules/react-dom',
     },
-    performance: { hints: false },
-  }
-  ```
+  },
+  optimization: {
+    splitChunks: { chunks: 'all' },
+    runtimeChunk: true,
+    minimizer: [ [Object] ],
+  },
+  performance: { hints: false },
+}
+```
+
 </details>
 
 ### Debug the default webpack config
@@ -152,56 +153,23 @@ The webpack config [is configurable](/configurations/webpack), and the default c
   
   <div></div>
 
-  - Create a `.storybook/webpack.config.js` file.
-  - Edit it's contents:
-    ```js
-    module.exports = async ({ config }) => console.dir(config.plugins, { depth: null }) || config;
-    ```
-  - Then run storybook:  
-    ```sh
-    yarn storybook --quiet
-    ```
+- Create a `.storybook/webpack.config.js` file.
+- Edit it's contents:
+  ```js
+  module.exports = async ({ config }) => console.dir(config.plugins, { depth: null }) || config;
+  ```
+- Then run storybook:
+  ```sh
+  yarn storybook --quiet
+  ```
 
-  The console should log the entire config, for you to inspect.
+The console should log the entire config, for you to inspect.
+
 </details>
 
 ## Webpack customisation modes
 
-The file can export an [object](#extend-mode) or a [function](#full-control-mode).
-
-### Extend Mode
-
-If your file exports an **object**, it puts Storybook into **extend-mode**.
-
-Extend-mode _merges_ the exported object with Storybook's [default webpack configuration](../default-config/) which supports a bunch of common file types. The [merge operation](https://github.com/storybooks/storybook/blob/next/lib/core/src/server/utils/merge-webpack-config.js) appends webpack arrays like `rules` and `plugins` and merges objects like `optimization`.
-
-For example, to add [SASS](http://sass-lang.com/) support to Storybook, install `style-loader`, `css-loader`, `sass-loader`, and `node-sass` and add the following snippet to `.storybook/webpack.config.js`:
-
-```js
-const path = require('path');
-
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.scss$/,
-        loaders: ['style-loader', 'css-loader', 'sass-loader'],
-        include: path.resolve(__dirname, '../'),
-      },
-    ],
-  },
-};
-```
-
-If you're using a non-standard Storybook config directory, you should put `webpack.config.js` there instead of `.storybook` and update the `include` path to make sure that it resolves to your project root.
-
-You can add any kind of webpack configuration options with the above config, whether they are plugins, loaders, or aliases.
-But you won't be able to change the following config options:
-
-- entry
-- output
-
-For the advanced usage we strongly recommend [full control mode](#full-control-mode).
+The file should export a [function](#full-control-mode). In older verions of Storybook you were also able to export an [object](#extend-mode), but this behavior is deprecated and will be removed in 5.x.
 
 ### Full Control Mode
 
@@ -239,6 +207,37 @@ Storybook uses the config returned from the above function. So edit `config` wit
 
 > If your custom webpack config uses a loader that does not explicitly include specific file extensions via the `test` property, it is necessary to `exclude` the `.ejs` file extension from that loader.
 
+### Extend Mode
+
+If your file exports an **object**, it puts Storybook into **extend-mode**. This mode is deprecated and will be removed in a future version.
+
+Extend-mode _merges_ the exported object with Storybook's [default webpack configuration](../default-config/) which supports a bunch of common file types. The [merge operation](https://github.com/storybooks/storybook/blob/next/lib/core/src/server/utils/merge-webpack-config.js) appends webpack arrays like `rules` and `plugins` and merges objects like `optimization`.
+
+For example, to add [SASS](http://sass-lang.com/) support to Storybook, install `style-loader`, `css-loader`, `sass-loader`, and `node-sass` and add the following snippet to `.storybook/webpack.config.js`:
+
+```js
+const path = require('path');
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.scss$/,
+        loaders: ['style-loader', 'css-loader', 'sass-loader'],
+        include: path.resolve(__dirname, '../'),
+      },
+    ],
+  },
+};
+```
+
+If you're using a non-standard Storybook config directory, you should put `webpack.config.js` there instead of `.storybook` and update the `include` path to make sure that it resolves to your project root.
+
+You can add any kind of webpack configuration options with the above config, whether they are plugins, loaders, or aliases. But you won't be able to change the following config options:
+
+- entry
+- output
+
 ## Using Your Existing Config
 
 If you have an existing webpack config for your project and want to reuse this app's configuration, you can either:
@@ -247,7 +246,7 @@ If you have an existing webpack config for your project and want to reuse this a
 - Create a new file with common webpack options and use it in both inside the main webpack config and inside Storybook's `webpack.config.js`.
 
 **Example**  
-*merging the loaders from your app's `webpack.config.js` with storybook's*
+_merging the loaders from your app's `webpack.config.js` with storybook's_
 
 ```js
 const path = require('path');
@@ -255,6 +254,6 @@ const path = require('path');
 const custom = require('../webpack.config.js');
 
 module.exports = async ({ config, mode }) => {
-  return {...config, loaders: custom.loaders };
+  return { ...config, loaders: custom.loaders };
 };
 ```

--- a/examples/angular-cli/.storybook/webpack.config.ts
+++ b/examples/angular-cli/.storybook/webpack.config.ts
@@ -1,21 +1,18 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.tsx?$/, /index\.ts$/],
+    loaders: [
       {
-        test: [/\.stories\.tsx?$/, /index\.ts$/],
-        loaders: [
-          {
-            loader: require.resolve('@storybook/addon-storysource/loader'),
-            options: {
-              parser: 'typescript',
-            },
-          },
-        ],
-        include: [path.resolve(__dirname, '../src')],
-        enforce: 'pre',
+        loader: require.resolve('@storybook/addon-storysource/loader'),
+        options: {
+          parser: 'typescript',
+        },
       },
     ],
-  },
+    include: [path.resolve(__dirname, '../src')],
+    enforce: 'pre',
+  });
+  return config;
 };

--- a/examples/cra-ts-kitchen-sink/.storybook/webpack.config.js
+++ b/examples/cra-ts-kitchen-sink/.storybook/webpack.config.js
@@ -1,13 +1,10 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        include: path.resolve(__dirname, '../src'),
-        use: [require.resolve('react-docgen-typescript-loader')],
-      },
-    ],
-  },
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: /\.tsx?$/,
+    include: path.resolve(__dirname, '../src'),
+    use: [require.resolve('react-docgen-typescript-loader')],
+  });
+  return config;
 };

--- a/examples/ember-cli/.storybook/webpack.config.js
+++ b/examples/ember-cli/.storybook/webpack.config.js
@@ -1,14 +1,11 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: [/\.stories\.js$/, /index\.js$/],
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        include: [path.resolve(__dirname, '../')],
-        enforce: 'pre',
-      },
-    ],
-  },
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.js$/, /index\.js$/],
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    include: [path.resolve(__dirname, '../')],
+    enforce: 'pre',
+  });
+  return config;
 };

--- a/examples/html-kitchen-sink/.storybook/webpack.config.js
+++ b/examples/html-kitchen-sink/.storybook/webpack.config.js
@@ -1,14 +1,11 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: [/\.stories\.js$/, /index\.js$/],
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        include: [path.resolve(__dirname, '../stories')],
-        enforce: 'pre',
-      },
-    ],
-  },
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.js$/, /index\.js$/],
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    include: [path.resolve(__dirname, '../stories')],
+    enforce: 'pre',
+  });
+  return config;
 };

--- a/examples/marko-cli/.storybook/webpack.config.js
+++ b/examples/marko-cli/.storybook/webpack.config.js
@@ -1,14 +1,11 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: [/\.stories\.js$/],
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        include: [path.resolve(__dirname, '../src')],
-        enforce: 'pre',
-      },
-    ],
-  },
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.js$/],
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    include: [path.resolve(__dirname, '../src')],
+    enforce: 'pre',
+  });
+  return config;
 };

--- a/examples/mithril-kitchen-sink/.storybook/webpack.config.js
+++ b/examples/mithril-kitchen-sink/.storybook/webpack.config.js
@@ -1,14 +1,11 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: [/\.stories\.js$/],
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        include: [path.resolve(__dirname, '../src')],
-        enforce: 'pre',
-      },
-    ],
-  },
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.js$/],
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    include: [path.resolve(__dirname, '../src')],
+    enforce: 'pre',
+  });
+  return config;
 };

--- a/examples/polymer-cli/.storybook/webpack.config.js
+++ b/examples/polymer-cli/.storybook/webpack.config.js
@@ -8,6 +8,6 @@ module.exports = async ({ config }) => {
     include: [path.resolve(__dirname, '../src')],
     enforce: 'pre',
   });
-  config.module.plugins.push(new webpack.IgnorePlugin(/vertx/));
+  config.plugins.push(new webpack.IgnorePlugin(/vertx/));
   return config;
 };

--- a/examples/polymer-cli/.storybook/webpack.config.js
+++ b/examples/polymer-cli/.storybook/webpack.config.js
@@ -1,16 +1,13 @@
 const path = require('path');
 const webpack = require('webpack');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: [/\.stories\.js$/, /index\.js$/],
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        include: [path.resolve(__dirname, '../src')],
-        enforce: 'pre',
-      },
-    ],
-  },
-  plugins: [new webpack.IgnorePlugin(/vertx/)],
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.js$/, /index\.js$/],
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    include: [path.resolve(__dirname, '../src')],
+    enforce: 'pre',
+  });
+  config.module.plugins.push(new webpack.IgnorePlugin(/vertx/));
+  return config;
 };

--- a/examples/preact-kitchen-sink/.storybook/webpack.config.js
+++ b/examples/preact-kitchen-sink/.storybook/webpack.config.js
@@ -7,6 +7,5 @@ module.exports = ({ config }) => {
     include: [path.resolve(__dirname, '../src')],
     enforce: 'pre',
   });
-
   return config;
 };

--- a/examples/riot-kitchen-sink/.storybook/webpack.config.js
+++ b/examples/riot-kitchen-sink/.storybook/webpack.config.js
@@ -1,18 +1,15 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: [/\.stories\.js$/, /index\.js$/],
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        include: [path.resolve(__dirname, '../src')],
-        enforce: 'pre',
-      },
-      {
-        test: /\.txt$/,
-        use: 'raw-loader',
-      },
-    ],
-  },
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.js$/, /index\.js$/],
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    include: [path.resolve(__dirname, '../src')],
+    enforce: 'pre',
+  });
+  config.module.rules.push({
+    test: /\.txt$/,
+    use: 'raw-loader',
+  });
+  return config;
 };

--- a/examples/svelte-kitchen-sink/.storybook/webpack.config.js
+++ b/examples/svelte-kitchen-sink/.storybook/webpack.config.js
@@ -1,14 +1,11 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: [/\.stories\.js$/, /index\.js$/],
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        include: [path.resolve(__dirname, '../src')],
-        enforce: 'pre',
-      },
-    ],
-  },
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.js$/, /index\.js$/],
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    include: [path.resolve(__dirname, '../src')],
+    enforce: 'pre',
+  });
+  return config;
 };

--- a/examples/vue-kitchen-sink/.storybook/webpack.config.js
+++ b/examples/vue-kitchen-sink/.storybook/webpack.config.js
@@ -1,14 +1,11 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: [/\.stories\.js$/, /index\.js$/],
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        include: [path.resolve(__dirname, '../src')],
-        enforce: 'pre',
-      },
-    ],
-  },
+module.exports = async ({ config }) => {
+  config.module.rules.push({
+    test: [/\.stories\.js$/, /index\.js$/],
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    include: [path.resolve(__dirname, '../src')],
+    enforce: 'pre',
+  });
+  return config;
 };

--- a/lib/core/merge-webpack-config.js
+++ b/lib/core/merge-webpack-config.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/server/utils/merge-webpack-config').default;

--- a/lib/core/merge-webpack-config.js
+++ b/lib/core/merge-webpack-config.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/server/utils/merge-webpack-config').default;

--- a/lib/core/src/server/preview/custom-webpack-preset.js
+++ b/lib/core/src/server/preview/custom-webpack-preset.js
@@ -13,19 +13,18 @@ async function createFinalDefaultConfig(presets, config, options) {
 export async function webpack(config, options) {
   const { configDir, configType, presets } = options;
 
-  const finalDefaultConfig = await createFinalDefaultConfig(presets, config, options);
-
   // Check whether user has a custom webpack config file and
   // return the (extended) base configuration if it's not available.
   const customConfig = loadCustomWebpackConfig(configDir);
 
   if (customConfig === null) {
     logger.info('=> Using default webpack setup.');
-    return finalDefaultConfig;
+    return createFinalDefaultConfig(presets, config, options);
   }
 
   if (typeof customConfig === 'function') {
     logger.info('=> Loading custom webpack config (full-control mode).');
+    const finalDefaultConfig = await createFinalDefaultConfig(presets, config, options);
     return customConfig({ config: finalDefaultConfig, mode: configType });
   }
 

--- a/lib/core/src/server/preview/custom-webpack-preset.js
+++ b/lib/core/src/server/preview/custom-webpack-preset.js
@@ -30,8 +30,11 @@ export async function webpack(config, options) {
   }
 
   logger.info('=> Loading custom webpack config (extending mode).');
+
+  // Restore 4.x behavior, but deprecate this mode of extending webpack
+  const finalConfig = await presets.apply('webpackFinal', config, options);
   return deprecate(
-    () => mergeConfigs(finalDefaultConfig, customConfig),
+    () => mergeConfigs(finalConfig, customConfig),
     stripIndents`
       Extend-mode configuration is deprecated, please use full-control mode instead.
       

--- a/lib/core/src/server/preview/custom-webpack-preset.js
+++ b/lib/core/src/server/preview/custom-webpack-preset.js
@@ -1,3 +1,5 @@
+import deprecate from 'util-deprecate';
+import { stripIndents } from 'common-tags';
 import { logger } from '@storybook/node-logger';
 import loadCustomWebpackConfig from '../utils/load-custom-webpack-config';
 import mergeConfigs from '../utils/merge-webpack-config';
@@ -28,5 +30,12 @@ export async function webpack(config, options) {
   }
 
   logger.info('=> Loading custom webpack config (extending mode).');
-  return mergeConfigs(finalDefaultConfig, customConfig);
+  return deprecate(
+    () => mergeConfigs(finalDefaultConfig, customConfig),
+    stripIndents`
+      Extend-mode configuration is deprecated, please use full-control mode instead.
+      
+      See https://storybook.js.org/docs/configurations/custom-webpack-config/#full-control-mode
+    `
+  )();
 }


### PR DESCRIPTION
Issue: #6081 #5941 #6083 #5708 #6111

## What I did

- In extend-mode, merge with `baseConfig` rather than `defaultConfig`
- Add deprecation message per rationale in #6081

## How to test

1. Update official-storybook's webpack.config.js to export `{}`
2. Observe deprecation message in console
