### PR TITLE
docs(configurations): fix markdown for react-typescript

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -109,7 +109,7 @@ module.exports = ({ config, mode }) => {
 
 ### `tsconfig.json`
 
-The default `tsconfig.json` that comes with CRA works great. If your stories are outside the `src` folder, for example the `stories` folder in root, then `rootDirs": ["src", "stories"]` needs to be added to be added to `compilerOptions` so it knows what folders to compile. Make sure `jsx` is set to preserve. Should be unchanged.
+The default `tsconfig.json` that comes with CRA works great. If your stories are outside the `src` folder, for example the `stories` folder in root, then `"rootDirs": ["src", "stories"]` needs to be added to be added to `compilerOptions` so it knows what folders to compile. Make sure `jsx` is set to preserve. Should be unchanged.
 
 ## Import tsx stories
 


### PR DESCRIPTION
## What I did
Add missing `"` to the tsconfig.json example
