### PR TITLE
FIX brandImage staying storybook's logo when theme is created with brandTitle

### DIFF
--- a/lib/theming/src/create.ts
+++ b/lib/theming/src/create.ts
@@ -170,7 +170,7 @@ export const convert = (inherit: ThemeVars = lightThemeVars): Theme => {
     brand: {
       title: brandTitle,
       url: brandUrl,
-      image: brandImage,
+      image: brandImage || brandTitle ? null : undefined,
     },
 
     code: createSyntax({


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/5866

## What I did
CHANGE theme creation so when setting brandTitle, it sets brandImage to null if not supplied also.
