### PR TITLE
Add missing button titles

### DIFF
--- a/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
+++ b/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
@@ -8446,6 +8446,7 @@ exports[`Storyshots UI|Sidebar/Sidebar loading 1`] = `
               >
                 <button
                   class="emotion-5"
+                  title="Shortcuts"
                 >
                   <svg
                     class="emotion-4"
@@ -9872,6 +9873,7 @@ exports[`Storyshots UI|Sidebar/Sidebar simple 1`] = `
               >
                 <button
                   class="emotion-5"
+                  title="Shortcuts"
                 >
                   <svg
                     class="emotion-4"
@@ -9909,6 +9911,7 @@ exports[`Storyshots UI|Sidebar/Sidebar simple 1`] = `
                 </svg>
                 <button
                   class="emotion-13"
+                  title="Clear search"
                   type="reset"
                   value="reset"
                 >
@@ -10412,6 +10415,7 @@ exports[`Storyshots UI|Sidebar/SidebarHeading customBrandImage 1`] = `
     >
       <button
         class="emotion-5"
+        title="Shortcuts"
       >
         <svg
           class="emotion-4"
@@ -10709,6 +10713,7 @@ exports[`Storyshots UI|Sidebar/SidebarHeading linkAndText 1`] = `
     >
       <button
         class="emotion-4"
+        title="Shortcuts"
       >
         <svg
           class="emotion-3"
@@ -10986,6 +10991,7 @@ exports[`Storyshots UI|Sidebar/SidebarHeading longText 1`] = `
     >
       <button
         class="emotion-3"
+        title="Shortcuts"
       >
         <svg
           class="emotion-2"
@@ -11362,6 +11368,7 @@ exports[`Storyshots UI|Sidebar/SidebarHeading menuHighlighted 1`] = `
     >
       <button
         class="emotion-5"
+        title="Shortcuts"
       >
         <svg
           class="emotion-4"
@@ -11639,6 +11646,7 @@ exports[`Storyshots UI|Sidebar/SidebarHeading onlyText 1`] = `
     >
       <button
         class="emotion-3"
+        title="Shortcuts"
       >
         <svg
           class="emotion-2"
@@ -11993,6 +12001,7 @@ exports[`Storyshots UI|Sidebar/SidebarHeading standard 1`] = `
     >
       <button
         class="emotion-5"
+        title="Shortcuts"
       >
         <svg
           class="emotion-4"
@@ -12327,6 +12336,7 @@ exports[`Storyshots UI|Sidebar/SidebarHeading standardNoLink 1`] = `
     >
       <button
         class="emotion-4"
+        title="Shortcuts"
       >
         <svg
           class="emotion-3"
@@ -14245,6 +14255,7 @@ exports[`Storyshots UI|Sidebar/SidebarSearch filledIn 1`] = `
     </svg>
     <button
       class="emotion-5"
+      title="Clear search"
       type="reset"
       value="reset"
     >
@@ -14533,6 +14544,7 @@ exports[`Storyshots UI|Sidebar/SidebarSearch focussed 1`] = `
     </svg>
     <button
       class="emotion-5"
+      title="Clear search"
       type="reset"
       value="reset"
     >
@@ -14821,6 +14833,7 @@ exports[`Storyshots UI|Sidebar/SidebarSearch simple 1`] = `
     </svg>
     <button
       class="emotion-5"
+      title="Clear search"
       type="reset"
       value="reset"
     >
@@ -16510,6 +16523,7 @@ exports[`Storyshots UI|Sidebar/SidebarStories noRoot 1`] = `
       </svg>
       <button
         class="emotion-5"
+        title="Clear search"
         type="reset"
         value="reset"
       >
@@ -17425,6 +17439,7 @@ exports[`Storyshots UI|Sidebar/SidebarStories withRoot 1`] = `
       </svg>
       <button
         class="emotion-5"
+        title="Clear search"
         type="reset"
         value="reset"
       >

--- a/lib/ui/src/components/preview/__snapshots__/preview.stories.storyshot
+++ b/lib/ui/src/components/preview/__snapshots__/preview.stories.storyshot
@@ -244,6 +244,7 @@ Array [
                 </span>
                 <button
                   class="emotion-2"
+                  title="Open canvas in new tab"
                 >
                   <svg
                     class="emotion-1"
@@ -731,6 +732,7 @@ Array [
                 </span>
                 <button
                   class="emotion-8"
+                  title="Open canvas in new tab"
                 >
                   <svg
                     class="emotion-7"

--- a/lib/ui/src/components/preview/preview.js
+++ b/lib/ui/src/components/preview/preview.js
@@ -150,7 +150,11 @@ const getTools = memoize(10)(
       {
         match: p => p.viewMode === 'story',
         render: () => (
-          <IconButton key="opener" onClick={() => window.open(`${baseUrl}?id=${storyId}`)}>
+          <IconButton
+            key="opener"
+            onClick={() => window.open(`${baseUrl}?id=${storyId}`)}
+            title="Open canvas in new tab"
+          >
             <Icons icon="share" />
           </IconButton>
         ),

--- a/lib/ui/src/components/sidebar/SidebarHeading.js
+++ b/lib/ui/src/components/sidebar/SidebarHeading.js
@@ -121,7 +121,7 @@ const SidebarHeading = withState('tooltipShown', 'onVisibilityChange', false)(
         }
         closeOnClick
       >
-        <MenuButton outline small containsIcon highlighted={menuHighlighted}>
+        <MenuButton outline small containsIcon highlighted={menuHighlighted} title="Shortcuts">
           <Icons icon="ellipsis" />
         </MenuButton>
       </WithTooltip>

--- a/lib/ui/src/components/sidebar/SidebarSearch.js
+++ b/lib/ui/src/components/sidebar/SidebarSearch.js
@@ -116,7 +116,7 @@ export const PureSidebarSearch = ({ focussed, onSetFocussed, className, onChange
       placeholder={focussed ? 'Type to search...' : 'Press "/" to search...'}
     />
     <Icons icon="search" />
-    <CancelButton type="reset" value="reset">
+    <CancelButton type="reset" value="reset" title="Clear search">
       <Icons icon="closeAlt" />
     </CancelButton>
   </FilterForm>


### PR DESCRIPTION
Issue: #6123

## What I did

- Added titles to some of the image buttons that were missing them. This helps to meet WCAG 2.1 (Level A) for accessibility.
  - WCAG 2.1 [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
  - Deque University's guidance on [buttons having discernible text](https://dequeuniversity.com/rules/axe/3.1/button-name)

## How to test

Run any of the examples and inspect the adjusted buttons to see that they now have a `title` attribute specified. These issues can also be picked up by [Lighthouse](https://developers.google.com/web/tools/lighthouse/) in the Accessibility audit in the Chrome Developer Tools.