### PR TITLE
Add aria label to search box

### DIFF
--- a/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
+++ b/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
@@ -9895,6 +9895,7 @@ exports[`Storyshots UI|Sidebar/Sidebar simple 1`] = `
                 class="emotion-14"
               >
                 <input
+                  aria-label="Search stories"
                   class="emotion-8"
                   id="storybook-explorer-searchfield"
                   placeholder="Press \\"/\\" to search..."
@@ -14238,6 +14239,7 @@ exports[`Storyshots UI|Sidebar/SidebarSearch filledIn 1`] = `
     class="emotion-6"
   >
     <input
+      aria-label="Search stories"
       class="emotion-0"
       id="storybook-explorer-searchfield"
       placeholder="Type to search..."
@@ -14528,6 +14530,7 @@ exports[`Storyshots UI|Sidebar/SidebarSearch focussed 1`] = `
     class="emotion-6"
   >
     <input
+      aria-label="Search stories"
       class="emotion-0"
       id="storybook-explorer-searchfield"
       placeholder="Type to search..."
@@ -14817,6 +14820,7 @@ exports[`Storyshots UI|Sidebar/SidebarSearch simple 1`] = `
     class="emotion-6"
   >
     <input
+      aria-label="Search stories"
       class="emotion-0"
       id="storybook-explorer-searchfield"
       placeholder="Press \\"/\\" to search..."
@@ -16507,6 +16511,7 @@ exports[`Storyshots UI|Sidebar/SidebarStories noRoot 1`] = `
       class="emotion-6"
     >
       <input
+        aria-label="Search stories"
         class="emotion-0"
         id="storybook-explorer-searchfield"
         placeholder="Press \\"/\\" to search..."
@@ -17423,6 +17428,7 @@ exports[`Storyshots UI|Sidebar/SidebarStories withRoot 1`] = `
       class="emotion-6"
     >
       <input
+        aria-label="Search stories"
         class="emotion-0"
         id="storybook-explorer-searchfield"
         placeholder="Press \\"/\\" to search..."

--- a/lib/ui/src/components/sidebar/SidebarSearch.js
+++ b/lib/ui/src/components/sidebar/SidebarSearch.js
@@ -114,6 +114,7 @@ export const PureSidebarSearch = ({ focussed, onSetFocussed, className, onChange
       onChange={e => onChange(e.target.value)}
       {...props}
       placeholder={focussed ? 'Type to search...' : 'Press "/" to search...'}
+      aria-label="Search stories"
     />
     <Icons icon="search" />
     <CancelButton type="reset" value="reset" title="Clear search">


### PR DESCRIPTION
Issue: #6130

## What I did

- Added `aria-label` to search box
- Re-generated the Jest snapshots

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No