### PR TITLE
Only check versions for dev/local builds

### DIFF
--- a/lib/ui/src/core/context.js
+++ b/lib/ui/src/core/context.js
@@ -71,8 +71,10 @@ export class Provider extends Component {
       initShortcuts,
       initStories,
       initURL,
-      initVersions,
-    ].map(initModule => initModule(apiData));
+      process.env.NODE_ENV !== 'production' && initVersions,
+    ]
+      .filter(Boolean)
+      .map(initModule => initModule(apiData));
 
     // Create our initial state by combining the initial state of all modules, then overlaying any saved state
     const state = getInitialState(...this.modules.map(m => m.state));


### PR DESCRIPTION
Might be a tad controversial, but with this PR I aim to only enable the version checking things on local/dev builds. IMO production, deployed versions shouldn't really echo their outdated.

_Or_ am I completely wrong, and the intent here is to tell them to upgrade wherever they are?