### PR TITLE
Make update notifications much less aggressive

### DIFF
--- a/lib/ui/src/core/context.js
+++ b/lib/ui/src/core/context.js
@@ -59,6 +59,7 @@ export class Provider extends Component {
       path,
       viewMode,
       storyId,
+      mode: process.env.NODE_ENV,
     };
 
     this.state = store.getInitialState();

--- a/lib/ui/src/core/versions.js
+++ b/lib/ui/src/core/versions.js
@@ -80,7 +80,11 @@ export default function({ store }) {
     if (versionUpdateAvailable()) {
       const latestVersion = getLatestVersion().version;
 
-      if (latestVersion !== dismissedVersionNotification) {
+      if (
+        latestVersion !== dismissedVersionNotification &&
+        !semver.patch(latestVersion) &&
+        !semver.prerelease(latestVersion)
+      ) {
         addNotification({
           id: 'update',
           link: '/settings/about',

--- a/lib/ui/src/core/versions.js
+++ b/lib/ui/src/core/versions.js
@@ -12,7 +12,7 @@ async function fetchLatestVersion() {
   return fromFetch.json();
 }
 
-export default function({ store }) {
+export default function({ store, mode }) {
   const {
     versions: persistedVersions = {},
     lastVersionCheck,
@@ -83,7 +83,8 @@ export default function({ store }) {
       if (
         latestVersion !== dismissedVersionNotification &&
         !semver.patch(latestVersion) &&
-        !semver.prerelease(latestVersion)
+        !semver.prerelease(latestVersion) &&
+        mode !== 'production'
       ) {
         addNotification({
           id: 'update',

--- a/lib/ui/src/core/versions.test.js
+++ b/lib/ui/src/core/versions.test.js
@@ -173,6 +173,17 @@ describe('versions API', () => {
       await init({ api: { addNotification, ...api } });
       expect(addNotification).not.toHaveBeenCalled();
     });
+
+    it('does not set an update notification in production mode', async () => {
+      const store = createMockStore();
+      const { init, api, state: initialState } = initVersions({ store, mode: 'production' });
+      store.setState(initialState);
+
+      fetch.mockResolvedValueOnce(newResponse);
+      const addNotification = jest.fn();
+      await init({ api: { addNotification, ...api } });
+      expect(addNotification).not.toHaveBeenCalled();
+    });
   });
 
   it('persists a dismissed notification', async () => {

--- a/lib/ui/src/core/versions.test.js
+++ b/lib/ui/src/core/versions.test.js
@@ -38,6 +38,7 @@ const makeResponse = (latest, next) => {
 const newResponse = makeResponse('4.0.0', null);
 const oldResponse = makeResponse('2.0.0', null);
 const prereleaseResponse = makeResponse('3.0.0', '4.0.0-alpha.0');
+const patchResponse = makeResponse('3.0.1', '4.0.0-alpha.0');
 
 jest.mock('@storybook/client-logger');
 
@@ -138,27 +139,40 @@ describe('versions API', () => {
     });
   });
 
-  it('sets an update notification right away in the init function', async () => {
-    const store = createMockStore();
-    const { init, api, state: initialState } = initVersions({ store });
-    store.setState(initialState);
+  describe('notifications', () => {
+    it('sets an update notification right away in the init function', async () => {
+      const store = createMockStore();
+      const { init, api, state: initialState } = initVersions({ store });
+      store.setState(initialState);
 
-    fetch.mockResolvedValueOnce(newResponse);
-    const addNotification = jest.fn();
-    await init({ api: { addNotification, ...api } });
-    expect(addNotification).toHaveBeenCalled();
-  });
+      fetch.mockResolvedValueOnce(newResponse);
+      const addNotification = jest.fn();
+      await init({ api: { addNotification, ...api } });
+      expect(addNotification).toHaveBeenCalled();
+    });
 
-  it('does not set an update notification if it has been dismissed', async () => {
-    const store = createMockStore();
-    store.setState({ dismissedVersionNotification: '4.0.0' });
-    const { init, api, state: initialState } = initVersions({ store });
-    store.setState(initialState);
+    it('does not set an update notification if it has been dismissed', async () => {
+      const store = createMockStore();
+      store.setState({ dismissedVersionNotification: '4.0.0' });
+      const { init, api, state: initialState } = initVersions({ store });
+      store.setState(initialState);
 
-    fetch.mockResolvedValueOnce(newResponse);
-    const addNotification = jest.fn();
-    await init({ api: { addNotification, ...api } });
-    expect(addNotification).not.toHaveBeenCalled();
+      fetch.mockResolvedValueOnce(newResponse);
+      const addNotification = jest.fn();
+      await init({ api: { addNotification, ...api } });
+      expect(addNotification).not.toHaveBeenCalled();
+    });
+
+    it('does not set an update notification if the latest version is a patch', async () => {
+      const store = createMockStore();
+      const { init, api, state: initialState } = initVersions({ store });
+      store.setState(initialState);
+
+      fetch.mockResolvedValueOnce(patchResponse);
+      const addNotification = jest.fn();
+      await init({ api: { addNotification, ...api } });
+      expect(addNotification).not.toHaveBeenCalled();
+    });
   });
 
   it('persists a dismissed notification', async () => {


### PR DESCRIPTION
Issue: N/A, see https://twitter.com/amcdnl/status/1105427759738822656

## What I did

Change update heuristics to not display on patches and prereleases, since we release all the time and it can get annoying.

Also don't display notifications in production mode, since the user can't necessarily do anything about it.

Preserve the rest, so users can see updates if they explicitly navigate to the about page.

## How to test

```
yarn jest --testPathPattern versions.test.js
```