### PR TITLE
📜[storysource]  📦 [sandpack] The clientApi must be reused when possible

### DIFF
--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -77,9 +77,16 @@ export const getContext = (() => {
         addons.setChannel(channel);
       }
     }
-
-    const storyStore = new StoryStore({ channel });
-    const clientApi = new ClientApi({ storyStore, decorateStory });
+    let storyStore;
+    let clientApi;
+    if (typeof window !== 'undefined' && window.__STORYBOOK_CLIENT_API__) {
+      clientApi = window.__STORYBOOK_CLIENT_API__;
+      // eslint-disable-next-line no-underscore-dangle
+      storyStore = clientApi._storyStore;
+    } else {
+      storyStore = new StoryStore({ channel });
+      clientApi = new ClientApi({ storyStore, decorateStory });
+    }
     const { clearDecorators } = clientApi;
     const configApi = new ConfigApi({ clearDecorators, storyStore, channel, clientApi });
 

--- a/lib/core/src/client/preview/start.test.js
+++ b/lib/core/src/client/preview/start.test.js
@@ -1,4 +1,4 @@
-import { document } from 'global';
+import { document, window } from 'global';
 
 import start from './start';
 
@@ -6,6 +6,7 @@ jest.mock('@storybook/client-logger');
 jest.mock('global', () => ({
   navigator: { userAgent: 'browser', platform: '' },
   window: {
+    __STORYBOOK_CLIENT_API__: undefined,
     addEventListener: jest.fn(),
     location: { search: '' },
     history: { replaceState: jest.fn() },
@@ -18,6 +19,10 @@ jest.mock('global', () => ({
     location: { search: '?id=kind--story' },
   },
 }));
+
+afterEach(() => {
+  window.__STORYBOOK_CLIENT_API__ = undefined;
+});
 
 it('returns apis', () => {
   const render = jest.fn();
@@ -32,6 +37,21 @@ it('returns apis', () => {
       forceReRender: expect.any(Function),
     })
   );
+});
+
+it('reuses the current client api when the lib is reloaded', () => {
+  jest.useFakeTimers();
+  const render = jest.fn();
+
+  const { clientApi } = start(render);
+
+  const valueOfClientApi = window.__STORYBOOK_CLIENT_API__;
+
+  const { clientApi: newClientApi } = start(render);
+  jest.runAllTimers();
+
+  expect(clientApi).toEqual(newClientApi);
+  expect(clientApi).toEqual(valueOfClientApi);
 });
 
 it('calls render when you add a story', () => {


### PR DESCRIPTION
Issue:

## What I did
I am working on a topic : ability to live edit the story when on the screen, and ability to export the component as a project in codesandbox.
This will be done by upgrading the storysource addon, which could become an Integrated Development Environment

Sandpack will re-download storybook. 
Then we must have an idempotent behavior, which means keeping control over code run several times.
In this case, we must prevent the clientApi from being created twice, instead we must reuse the currently existing one.

## How to test

- Is this testable with Jest or Chromatic screenshots?
I added one test to verify that it works.

- Does this need a new example in the kitchen sink apps?
I don't think so.

- Does this need an update to the documentation?
I don't think so.


If your answer is yes to any of these, please make sure to include it in your PR.

