### PR TITLE
Fix addon-knobs ObjectType knob react warning #5276

### DIFF
--- a/addons/knobs/src/components/types/Object.js
+++ b/addons/knobs/src/components/types/Object.js
@@ -5,15 +5,11 @@ import { polyfill } from 'react-lifecycles-compat';
 import { Form } from '@storybook/components';
 
 class ObjectType extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      value: null,
-      failed: false,
-      json: props.knob.value,
-    };
-  }
+  state = {
+    value: {},
+    failed: false,
+    json: '',
+  };
 
   static getDerivedStateFromProps(props, state) {
     if (!deepEqual(props.knob.value, state.json)) {

--- a/addons/knobs/src/components/types/Object.js
+++ b/addons/knobs/src/components/types/Object.js
@@ -9,9 +9,9 @@ class ObjectType extends Component {
     super(props);
 
     this.state = {
-      values: null,
+      value: null,
       failed: false,
-      state: '',
+      json: props.knob.value,
     };
   }
 

--- a/addons/knobs/src/components/types/Object.js
+++ b/addons/knobs/src/components/types/Object.js
@@ -5,8 +5,18 @@ import { polyfill } from 'react-lifecycles-compat';
 import { Form } from '@storybook/components';
 
 class ObjectType extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      values: null,
+      failed: false,
+      state: '',
+    };
+  }
+
   static getDerivedStateFromProps(props, state) {
-    if (!state || !deepEqual(props.knob.value, state.json)) {
+    if (!deepEqual(props.knob.value, state.json)) {
       try {
         return {
           value: JSON.stringify(props.knob.value, null, 2),


### PR DESCRIPTION
Issue: #5276 

## What I did

- Fixed the `getDerivedStateFromProps` console warning due to no initial state provided to React.

## How to test

- Is this testable with Jest or Chromatic screenshots?
No

- Does this need a new example in the kitchen sink apps?
No

- Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
