### PR TITLE
fix: Add the raw method to the react-native implementation

### DIFF
--- a/app/react-native/src/index.js
+++ b/app/react-native/src/index.js
@@ -10,3 +10,4 @@ export const clearDecorators = preview.clearDecorators.bind(preview);
 export const configure = preview.configure.bind(preview);
 export const getStorybook = preview.getStorybook.bind(preview);
 export const getStorybookUI = preview.getStorybookUI.bind(preview);
+export const raw = preview.raw.bind(preview);

--- a/app/react-native/src/preview/index.js
+++ b/app/react-native/src/preview/index.js
@@ -28,6 +28,7 @@ export default class Preview {
       'addParameters',
       'clearDecorators',
       'getStorybook',
+      'raw',
     ].forEach(method => {
       this[method] = this._clientApi[method].bind(this._clientApi);
     });


### PR DESCRIPTION
Issue: The new client for `react-native` did not export the `raw` method from `clientApi` as the storyshots addon was expecting

## What I did

Added the `raw` method as an export from the `react-native` client

## How to test

- Run the storyshots addon with the latest alpha version of storybook on a `react-native` project