### PR TITLE
Allow forced renders in @storybook/html  

### DIFF
--- a/app/html/src/client/preview/render.js
+++ b/app/html/src/client/preview/render.js
@@ -4,6 +4,7 @@ import { stripIndents } from 'common-tags';
 const rootElement = document.getElementById('root');
 
 export default function renderMain({
+  parameters = {},
   storyFn,
   selectedKind,
   selectedStory,
@@ -11,13 +12,14 @@ export default function renderMain({
   showError,
   forceRender,
 }) {
+  const { html = {} } = parameters;
   const element = storyFn();
 
   showMain();
   if (typeof element === 'string') {
     rootElement.innerHTML = element;
   } else if (element instanceof Node) {
-    if (forceRender === true) {
+    if (html.preventForcedRender === true && forceRender === true) {
       return;
     }
 

--- a/examples/html-kitchen-sink/.storybook/config.js
+++ b/examples/html-kitchen-sink/.storybook/config.js
@@ -1,6 +1,9 @@
 import { configure, addParameters } from '@storybook/html';
 
 addParameters({
+  html: {
+    preventForcedRender: false, // default
+  },
   options: {
     hierarchyRootSeparator: /\|/,
   },

--- a/examples/html-kitchen-sink/stories/__snapshots__/addon-knobs.stories.storyshot
+++ b/examples/html-kitchen-sink/stories/__snapshots__/addon-knobs.stories.storyshot
@@ -47,6 +47,12 @@ exports[`Storyshots Addons|Knobs All knobs 1`] = `
 </div>
 `;
 
+exports[`Storyshots Addons|Knobs DOM 1`] = `
+<p>
+  John Doe
+</p>
+`;
+
 exports[`Storyshots Addons|Knobs Simple 1`] = `
 <div>
   I am John Doe and I'm 44 years old.

--- a/examples/html-kitchen-sink/stories/addon-knobs.stories.js
+++ b/examples/html-kitchen-sink/stories/addon-knobs.stories.js
@@ -22,6 +22,13 @@ storiesOf('Addons|Knobs', module)
 
     return `<div>${content}</div>`;
   })
+  .add('DOM', () => {
+    const name = text('Name', 'John Doe');
+    // eslint-disable-next-line
+    const container = document.createElement('p');
+    container.textContent = name;
+    return container;
+  })
   .add('All knobs', () => {
     const name = text('Name', 'Jane');
     const stock = number('Stock', 20, {


### PR DESCRIPTION
Issue: #5017

## What I did

This PR adds the ability to setup an `html` object parameter to control whether force re-renders are allowed or not like this:

```js
// .storybook/config.js
import { configure, addParameters } from '@storybook/html';

addParameters({
  html: {
    preventForcedRender: false, // or true
  }
});

// ...
```

This addresses a change introduced in #4822. I understand the rationale around it, but right now it is just preventing @storybook/html to re-render stories returning a DOM node, which looks much more like a bug than a feature on  _normal_ use cases.

## How to test

I added a test story in `examples/html-kitchen-sink/stories/addon-knobs.stories.js` (`Addons > Knobs > DOM`) and the relevant configuration to `examples/html-kitchen-sink/.storybook/config.js`
