### PR TITLE
Added missing option documentation

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -196,6 +196,7 @@ addParameters({
     }),
     isFullscreen: false,
     panelPosition: 'right',
+    isToolshown: true,
   },
 });
 ```
@@ -211,8 +212,11 @@ Here is the mapping from old options to new:
 | showAddonPanel    | showPanel        |
 | addonPanelInRight | panelPosition    |
 | showSearchBox     |                  |
+|                   | isToolshown      |
 
 Storybook v5 removes the search dialog box in favor of a quick search in the navigation view, so `showSearchBox` has been removed.
+
+Storybook v5 introduce a new tool bar above the story view and you can show\hide it with the new `isToolshown` option. 
 
 ## Individual story decorators
 

--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -112,6 +112,11 @@ addParameters({
      * @type {Boolean}
      */
     enableShortcuts: false, // true by default
+    /**
+     * show/hide tool bar
+     * @type {Boolean}
+     */
+    isToolshown: false, // true by default
   },
 });
 

--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -71,6 +71,11 @@ addParameters({
      */
     enableShortcuts: true,
     /**
+     * show/hide tool bar
+     * @type {Boolean}
+     */
+    isToolshown: true,
+    /**
      * theme storybook, see link below
      */
     theme: undefined,


### PR DESCRIPTION
### What I did
isToolshown was missing from documentation so i've added it.
It allows to control if to show or hide the toolbar above the story.