### PR TITLE
[bug] Fix "lib/addons" default export for react-native.

### DIFF
--- a/lib/addons/src/public_api.ts
+++ b/lib/addons/src/public_api.ts
@@ -1,5 +1,5 @@
 export * from './make-decorator';
-export * from '.';
+export * from './index';
 export * from './storybook-channel-mock';
 
 // There can only be 1 default export per entry point and it has to be directly from public_api
@@ -7,5 +7,5 @@ export * from './storybook-channel-mock';
 // prefer import { addons } from '@storybook/addons' over import addons from '@storybook/addons'
 //
 // See index.ts
-import { addons } from '.';
+import { addons } from './index';
 export default addons;


### PR DESCRIPTION
Issue:
Broken commonjs import on react-native (metro bundler)

## What I did
Changed require('.') to require('./index')

## How to test
Run @storybook/react-native with the @storybook/addons.

- Is this testable with Jest or Chromatic screenshots?
No. I can make a screenshot of the react-native error we get if required.

- Does this need a new example in the kitchen sink apps?
No - it's an internal API to public API export.

- Does this need an update to the documentation?
No - it's an internal change.