### PR TITLE
Replace the term `instance` with `instant` in exporting storybook documentation

### DIFF
--- a/docs/src/pages/basics/exporting-storybook/index.md
+++ b/docs/src/pages/basics/exporting-storybook/index.md
@@ -3,7 +3,7 @@ id: 'exporting-storybook'
 title: 'Exporting Storybook as a Static App'
 ---
 
-Storybook gives a great developer experience with its dev time features, like instance change updates via Webpack's HMR.
+Storybook gives a great developer experience with its dev time features, like instant change updates via Webpack's HMR.
 
 But Storybook is also a tool you can use to showcase your components to others.
 Demos of [React Native Web](http://necolas.github.io/react-native-web/storybook/) and [React Dates](http://airbnb.io/react-dates/) are a good example for that.


### PR DESCRIPTION
As Webpack's Hot Module Replacement does instant module swapping, the term `instant` is more appropriate to describe `change updates` compared to `instance` which refers to single occurrence of something.