### PR TITLE
fix(knobs): color type button z-index

### DIFF
--- a/addons/knobs/src/components/types/Color.js
+++ b/addons/knobs/src/components/types/Color.js
@@ -20,6 +20,10 @@ const Swatch = styled.div(({ theme }) => ({
   borderRadius: '1rem',
 }));
 
+const ColorButton = styled(Button)(({ active }) => ({
+  zIndex: active ? 3 : 'unset',
+}));
+
 const Popover = styled.div({
   position: 'absolute',
   zIndex: '2',
@@ -80,7 +84,13 @@ class ColorType extends React.Component {
     };
 
     return (
-      <Button type="button" name={knob.name} onClick={this.handleClick} size="flex">
+      <ColorButton
+        active={displayColorPicker}
+        type="button"
+        name={knob.name}
+        onClick={this.handleClick}
+        size="flex"
+      >
         {knob.value.toUpperCase()}
         <Swatch style={colorStyle} />
         {displayColorPicker ? (
@@ -92,7 +102,7 @@ class ColorType extends React.Component {
             <SketchPicker color={knob.value} onChange={this.handleChange} />
           </Popover>
         ) : null}
-      </Button>
+      </ColorButton>
     );
   }
 }


### PR DESCRIPTION
Issue: #6184

## What I did
Set knob button zIndex to 3 on color picker is showed
## How to test
Create multiple colors knob
Click not last in the list
Profi!

For more information, see screenshots:
Before (@Zyzle screenshot):
![image](https://user-images.githubusercontent.com/3195714/54713418-9973f300-4b5f-11e9-9184-219860edf08e.png)

After:
<img width="643" alt="Снимок экрана 2019-03-20 в 22 30 00" src="https://user-images.githubusercontent.com/3195714/54713474-be686600-4b5f-11e9-8160-7180898b119c.png">

- Is this testable with Jest or Chromatic screenshots?
no
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
no
