### PR TITLE
fix(client-api): add core-js as a dep

### DIFF
--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -25,6 +25,7 @@
     "@storybook/core-events": "5.1.0-alpha.11",
     "@storybook/router": "5.1.0-alpha.11",
     "common-tags": "^1.8.0",
+    "core-js": "^2.6.5",
     "eventemitter3": "^3.1.0",
     "global": "^4.3.2",
     "is-plain-object": "^2.0.4",


### PR DESCRIPTION
client-api requires core-js in the dist files but it is not listed as a dependency. This causes it to use whatever package npm/yarn/whatev thinks it should use, in my case, ver3 since that's the top most version.

See https://github.com/storybooks/storybook/issues/6204#issuecomment-475073128 for more info on the problem