### PR TITLE
fix(tooltip): event bindings, logger import

### DIFF
--- a/lib/components/src/tooltip/WithTooltip.js
+++ b/lib/components/src/tooltip/WithTooltip.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
-import logger from '@storybook/client-logger';
+import { logger } from '@storybook/client-logger';
 import { withState, lifecycle } from 'recompose';
 import { document } from 'global';
 
@@ -107,16 +107,18 @@ const WithTooltip = lifecycle({
     iframes.forEach(iframe => {
       const bind = () => {
         try {
-          iframe.contentDocument.addEventListener('click', hide);
-          unbinders.push(() => {
-            try {
-              iframe.contentDocument.removeEventListener('click', hide);
-            } catch (e) {
-              logger.log('tried to remove listeners from iframe, but failed. whatever');
-            }
-          });
+          if (iframe.contentWindow.document) {
+            iframe.contentWindow.document.addEventListener('click', hide);
+            unbinders.push(() => {
+              try {
+                iframe.contentWindow.document.removeEventListener('click', hide);
+              } catch (e) {
+                logger.warn('Removing a click listener from iframe failed: ', e);
+              }
+            });
+          }
         } catch (e) {
-          logger.log('tried to remove listeners from iframe, but failed. whatever');
+          logger.warn('Adding a click listener to iframe failed: ', e);
         }
       };
 


### PR DESCRIPTION
Issue: #6211

Actually, the problem was in incorrect logger import because as any sensitive code wrapped in try/catch block. I fixed import and change catch block for more clear.

## What I did
Fix logger import
Catch error bindings

## How to test
Install https://github.com/wolfmanstout/vimium in FF
Open any sample
...
Profit!

- Is this testable with Jest or Chromatic screenshots?
no
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
no