### PR TITLE
Addon-actions: safe render for cyclic obj

### DIFF
--- a/addons/actions/src/containers/ActionLogger/index.tsx
+++ b/addons/actions/src/containers/ActionLogger/index.tsx
@@ -17,6 +17,14 @@ interface ActionLoggerState {
   actions: ActionDisplay[];
 }
 
+const safeDeepEqual = (a: any, b: any): boolean => {
+  try {
+    return deepEqual(a, b);
+  } catch (e) {
+    return false;
+  }
+};
+
 export default class ActionLogger extends Component<ActionLoggerProps, ActionLoggerState> {
   private mounted: boolean;
 
@@ -50,18 +58,17 @@ export default class ActionLogger extends Component<ActionLoggerProps, ActionLog
   };
 
   addAction = (action: ActionDisplay) => {
-    let { actions = [] } = this.state;
-    actions = [...actions];
-
-    const previous = actions.length && actions[0];
-
-    if (previous && deepEqual(previous.data, action.data)) {
-      previous.count++; // eslint-disable-line
-    } else {
-      action.count = 1; // eslint-disable-line
-      actions.unshift(action);
-    }
-    this.setState({ actions: actions.slice(0, action.options.limit) });
+    this.setState((prevState: ActionLoggerState) => {
+      const actions = [...prevState.actions];
+      const previous = actions.length && actions[0];
+      if (previous && safeDeepEqual(previous.data, action.data)) {
+        previous.count++; // eslint-disable-line
+      } else {
+        action.count = 1; // eslint-disable-line
+        actions.unshift(action);
+      }
+      return { actions: actions.slice(0, action.options.limit) };
+    });
   };
 
   clearActions = () => {


### PR DESCRIPTION
Issue: #6004

## What I did
Wrap deepEqual function call in try/catch.
I spend much time finding an elegant solution, but...
I analyzed comparing objects and they have cyclic react instance ('__reactInternalInstance...' has an element, an element has __reactblabla, and etc ). I don't know its bug or feature.

More information: 'fast-deep-equal' issue and author reply [here](https://github.com/epoberezkin/fast-deep-equal/issues/8)

And I rewrite 'addAction' method: if new state based on the previous state you must use a callback in 'setState' function. React [docs](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous) for more information.

## How to test
Start cra-kitchen-app
Open button sample
Double click to button

- Is this testable with Jest or Chromatic screenshots?
no
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
no