### PR TITLE
Workaround broken treebeard animations

### DIFF
--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -93,7 +93,7 @@ addDecorator(
      * sidebar tree animations
      * @type {Boolean}
      */
-    sidebarAnimations: true,
+    sidebarAnimations: false,
     /**
      * id to select an addon panel
      * @type {String}

--- a/lib/ui/src/modules/api/defaultState.js
+++ b/lib/ui/src/modules/api/defaultState.js
@@ -5,7 +5,7 @@ export default {
     sortStoriesByKind: false,
     hierarchySeparator: '/',
     hierarchyRootSeparator: null,
-    sidebarAnimations: true,
+    sidebarAnimations: false,
     theme: null,
   },
 };

--- a/lib/ui/src/modules/ui/components/stories_panel/__snapshots__/index.stories.storyshot
+++ b/lib/ui/src/modules/ui/components/stories_panel/__snapshots__/index.stories.storyshot
@@ -538,83 +538,78 @@ exports[`Storyshots UI|stories/StoriesPanel with storiesHierarchies prop 1`] = `
       <li
         class="emotion-8"
       >
-        <div>
-          <ul
-            class="emotion-17"
+        <ul
+          class="emotion-17"
+        >
+          <li
+            class="emotion-8"
           >
-            <li
-              class="emotion-8"
+            <div
+              data-name="kk"
+              role="menuitem"
+              style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+              tabindex="0"
             >
-              <div
-                data-name="kk"
-                role="menuitem"
-                style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-                tabindex="0"
-              >
-                <div>
+              <div>
+                <div
+                  style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+                >
                   <div
-                    style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+                    style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
                   >
-                    <div
-                      style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
+                    <svg
+                      fill="currentColor"
+                      height="10"
+                      preserveAspectRatio="xMidYMid meet"
+                      style="vertical-align:top;fill:currentColor"
+                      viewBox="0 0 40 40"
+                      width="10"
                     >
-                      <svg
-                        fill="currentColor"
-                        height="10"
-                        preserveAspectRatio="xMidYMid meet"
-                        style="vertical-align:top;fill:currentColor"
-                        viewBox="0 0 40 40"
-                        width="10"
-                      >
-                        <g>
-                          <path
-                            d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                      <g>
+                        <path
+                          d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                        />
+                      </g>
+                    </svg>
                   </div>
+                </div>
+                <div
+                  class="emotion-11"
+                >
                   <div
-                    class="emotion-11"
+                    class="emotion-10"
                   >
-                    <div
-                      class="emotion-10"
-                    >
-                      kk
-                    </div>
+                    kk
                   </div>
                 </div>
               </div>
-              <div>
-                <ul
-                  class="emotion-17"
+            </div>
+            <ul
+              class="emotion-17"
+            >
+              <li
+                class="emotion-8"
+              >
+                <a
+                  class="emotion-14 emotion-15"
+                  href="?selectedKind=kk&selectedStory=bb&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
                 >
-                  <li
-                    class="emotion-8"
-                  >
-                    <a
-                      class="emotion-14 emotion-15"
-                      href="?selectedKind=kk&selectedStory=bb&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+                  <div>
+                    <div
+                      class="emotion-11"
                     >
-                      <div>
-                        <div
-                          class="emotion-11"
-                        >
-                          <div
-                            class="emotion-12"
-                          >
-                            bb
-                          </div>
-                        </div>
+                      <div
+                        class="emotion-12"
+                      >
+                        bb
                       </div>
-                    </a>
-                    <div />
-                  </li>
-                </ul>
-              </div>
-            </li>
-          </ul>
-        </div>
+                    </div>
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </li>
+        </ul>
       </li>
     </ul>
   </div>

--- a/lib/ui/src/modules/ui/components/stories_panel/stories_tree/__snapshots__/index.stories.storyshot
+++ b/lib/ui/src/modules/ui/components/stories_panel/stories_tree/__snapshots__/index.stories.storyshot
@@ -34,11 +34,9 @@ exports[`Storyshots UI|stories/Stories empty 1`] = `
     <li
       class="emotion-1"
     >
-      <div>
-        <ul
-          class="emotion-0"
-        />
-      </div>
+      <ul
+        class="emotion-0"
+      />
     </li>
   </ul>
 </div>
@@ -119,149 +117,142 @@ exports[`Storyshots UI|stories/Stories simple 1`] = `
     <li
       class="emotion-2"
     >
-      <div>
-        <ul
-          class="emotion-15"
+      <ul
+        class="emotion-15"
+      >
+        <li
+          class="emotion-2"
         >
-          <li
-            class="emotion-2"
+          <div
+            data-name="a"
+            role="menuitem"
+            style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+            tabindex="0"
           >
-            <div
-              data-name="a"
-              role="menuitem"
-              style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-              tabindex="0"
-            >
-              <div>
-                <div
-                  style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
-                >
-                  <div
-                    style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
-                  >
-                    <svg
-                      fill="currentColor"
-                      height="10"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="vertical-align:top;fill:currentColor"
-                      viewBox="0 0 40 40"
-                      width="10"
-                    >
-                      <g>
-                        <path
-                          d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                        />
-                      </g>
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="emotion-1"
-                >
-                  <div
-                    class="emotion-0"
-                  >
-                    a
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div />
-          </li>
-          <li
-            class="emotion-2"
-          >
-            <div
-              data-name="b"
-              role="menuitem"
-              style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-              tabindex="0"
-            >
-              <div>
-                <div
-                  style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
-                >
-                  <div
-                    style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
-                  >
-                    <svg
-                      fill="currentColor"
-                      height="10"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="vertical-align:top;fill:currentColor"
-                      viewBox="0 0 40 40"
-                      width="10"
-                    >
-                      <g>
-                        <path
-                          d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                        />
-                      </g>
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="emotion-1"
-                >
-                  <div
-                    class="emotion-0"
-                  >
-                    b
-                  </div>
-                </div>
-              </div>
-            </div>
             <div>
-              <ul
-                class="emotion-15"
+              <div
+                style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
               >
-                <li
-                  class="emotion-2"
+                <div
+                  style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
                 >
-                  <a
-                    class="emotion-7 emotion-8"
-                    href="?selectedKind=b&selectedStory=b1&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+                  <svg
+                    fill="currentColor"
+                    height="10"
+                    preserveAspectRatio="xMidYMid meet"
+                    style="vertical-align:top;fill:currentColor"
+                    viewBox="0 0 40 40"
+                    width="10"
                   >
-                    <div>
-                      <div
-                        class="emotion-1"
-                      >
-                        <div
-                          class="emotion-5"
-                        >
-                          b1
-                        </div>
-                      </div>
-                    </div>
-                  </a>
-                  <div />
-                </li>
-                <li
-                  class="emotion-2"
+                    <g>
+                      <path
+                        d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <div
+                  class="emotion-0"
                 >
-                  <a
-                    class="emotion-12 emotion-8"
-                    href="?selectedKind=b&selectedStory=b2&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
-                  >
-                    <div>
-                      <div
-                        class="emotion-1"
-                      >
-                        <div
-                          class="emotion-5"
-                        >
-                          b2
-                        </div>
-                      </div>
-                    </div>
-                  </a>
-                  <div />
-                </li>
-              </ul>
+                  a
+                </div>
+              </div>
             </div>
-          </li>
-        </ul>
-      </div>
+          </div>
+        </li>
+        <li
+          class="emotion-2"
+        >
+          <div
+            data-name="b"
+            role="menuitem"
+            style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+            tabindex="0"
+          >
+            <div>
+              <div
+                style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+              >
+                <div
+                  style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="10"
+                    preserveAspectRatio="xMidYMid meet"
+                    style="vertical-align:top;fill:currentColor"
+                    viewBox="0 0 40 40"
+                    width="10"
+                  >
+                    <g>
+                      <path
+                        d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <div
+                  class="emotion-0"
+                >
+                  b
+                </div>
+              </div>
+            </div>
+          </div>
+          <ul
+            class="emotion-15"
+          >
+            <li
+              class="emotion-2"
+            >
+              <a
+                class="emotion-7 emotion-8"
+                href="?selectedKind=b&selectedStory=b1&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+              >
+                <div>
+                  <div
+                    class="emotion-1"
+                  >
+                    <div
+                      class="emotion-5"
+                    >
+                      b1
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+            <li
+              class="emotion-2"
+            >
+              <a
+                class="emotion-12 emotion-8"
+                href="?selectedKind=b&selectedStory=b2&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+              >
+                <div>
+                  <div
+                    class="emotion-1"
+                  >
+                    <div
+                      class="emotion-5"
+                    >
+                      b2
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
     </li>
   </ul>
 </div>
@@ -342,99 +333,142 @@ exports[`Storyshots UI|stories/Stories with hierarchy - hierarchySeparator is de
     <li
       class="emotion-2"
     >
-      <div>
-        <ul
-          class="emotion-19"
+      <ul
+        class="emotion-19"
+      >
+        <li
+          class="emotion-2"
         >
-          <li
-            class="emotion-2"
+          <div
+            data-name="some"
+            role="menuitem"
+            style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+            tabindex="0"
           >
-            <div
-              data-name="some"
-              role="menuitem"
-              style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-              tabindex="0"
-            >
-              <div>
-                <div
-                  style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
-                >
-                  <div
-                    style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
-                  >
-                    <svg
-                      fill="currentColor"
-                      height="10"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="vertical-align:top;fill:currentColor"
-                      viewBox="0 0 40 40"
-                      width="10"
-                    >
-                      <g>
-                        <path
-                          d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                        />
-                      </g>
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="emotion-1"
-                >
-                  <div
-                    class="emotion-0"
-                  >
-                    some
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div />
-          </li>
-          <li
-            class="emotion-2"
-          >
-            <div
-              data-name="another"
-              role="menuitem"
-              style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-              tabindex="0"
-            >
-              <div>
-                <div
-                  style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
-                >
-                  <div
-                    style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
-                  >
-                    <svg
-                      fill="currentColor"
-                      height="10"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="vertical-align:top;fill:currentColor"
-                      viewBox="0 0 40 40"
-                      width="10"
-                    >
-                      <g>
-                        <path
-                          d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                        />
-                      </g>
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="emotion-1"
-                >
-                  <div
-                    class="emotion-0"
-                  >
-                    another
-                  </div>
-                </div>
-              </div>
-            </div>
             <div>
+              <div
+                style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+              >
+                <div
+                  style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="10"
+                    preserveAspectRatio="xMidYMid meet"
+                    style="vertical-align:top;fill:currentColor"
+                    viewBox="0 0 40 40"
+                    width="10"
+                  >
+                    <g>
+                      <path
+                        d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <div
+                  class="emotion-0"
+                >
+                  some
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-2"
+        >
+          <div
+            data-name="another"
+            role="menuitem"
+            style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+            tabindex="0"
+          >
+            <div>
+              <div
+                style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+              >
+                <div
+                  style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="10"
+                    preserveAspectRatio="xMidYMid meet"
+                    style="vertical-align:top;fill:currentColor"
+                    viewBox="0 0 40 40"
+                    width="10"
+                  >
+                    <g>
+                      <path
+                        d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <div
+                  class="emotion-0"
+                >
+                  another
+                </div>
+              </div>
+            </div>
+          </div>
+          <ul
+            class="emotion-19"
+          >
+            <li
+              class="emotion-2"
+            >
+              <div
+                data-name="space"
+                role="menuitem"
+                style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+                tabindex="0"
+              >
+                <div>
+                  <div
+                    style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+                  >
+                    <div
+                      style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
+                    >
+                      <svg
+                        fill="currentColor"
+                        height="10"
+                        preserveAspectRatio="xMidYMid meet"
+                        style="vertical-align:top;fill:currentColor"
+                        viewBox="0 0 40 40"
+                        width="10"
+                      >
+                        <g>
+                          <path
+                            d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    class="emotion-1"
+                  >
+                    <div
+                      class="emotion-0"
+                    >
+                      space
+                    </div>
+                  </div>
+                </div>
+              </div>
               <ul
                 class="emotion-19"
               >
@@ -442,7 +476,7 @@ exports[`Storyshots UI|stories/Stories with hierarchy - hierarchySeparator is de
                   class="emotion-2"
                 >
                   <div
-                    data-name="space"
+                    data-name="20"
                     role="menuitem"
                     style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
                     tabindex="0"
@@ -476,115 +510,61 @@ exports[`Storyshots UI|stories/Stories with hierarchy - hierarchySeparator is de
                         <div
                           class="emotion-0"
                         >
-                          space
+                          20
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div>
-                    <ul
-                      class="emotion-19"
+                  <ul
+                    class="emotion-19"
+                  >
+                    <li
+                      class="emotion-2"
                     >
-                      <li
-                        class="emotion-2"
+                      <a
+                        class="emotion-11 emotion-12"
+                        href="?selectedKind=another.space.20&selectedStory=b1&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
                       >
-                        <div
-                          data-name="20"
-                          role="menuitem"
-                          style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-                          tabindex="0"
-                        >
-                          <div>
+                        <div>
+                          <div
+                            class="emotion-1"
+                          >
                             <div
-                              style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+                              class="emotion-9"
                             >
-                              <div
-                                style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
-                              >
-                                <svg
-                                  fill="currentColor"
-                                  height="10"
-                                  preserveAspectRatio="xMidYMid meet"
-                                  style="vertical-align:top;fill:currentColor"
-                                  viewBox="0 0 40 40"
-                                  width="10"
-                                >
-                                  <g>
-                                    <path
-                                      d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                                    />
-                                  </g>
-                                </svg>
-                              </div>
-                            </div>
-                            <div
-                              class="emotion-1"
-                            >
-                              <div
-                                class="emotion-0"
-                              >
-                                20
-                              </div>
+                              b1
                             </div>
                           </div>
                         </div>
+                      </a>
+                    </li>
+                    <li
+                      class="emotion-2"
+                    >
+                      <a
+                        class="emotion-16 emotion-12"
+                        href="?selectedKind=another.space.20&selectedStory=b2&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+                      >
                         <div>
-                          <ul
-                            class="emotion-19"
+                          <div
+                            class="emotion-1"
                           >
-                            <li
-                              class="emotion-2"
+                            <div
+                              class="emotion-9"
                             >
-                              <a
-                                class="emotion-11 emotion-12"
-                                href="?selectedKind=another.space.20&selectedStory=b1&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
-                              >
-                                <div>
-                                  <div
-                                    class="emotion-1"
-                                  >
-                                    <div
-                                      class="emotion-9"
-                                    >
-                                      b1
-                                    </div>
-                                  </div>
-                                </div>
-                              </a>
-                              <div />
-                            </li>
-                            <li
-                              class="emotion-2"
-                            >
-                              <a
-                                class="emotion-16 emotion-12"
-                                href="?selectedKind=another.space.20&selectedStory=b2&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
-                              >
-                                <div>
-                                  <div
-                                    class="emotion-1"
-                                  >
-                                    <div
-                                      class="emotion-9"
-                                    >
-                                      b2
-                                    </div>
-                                  </div>
-                                </div>
-                              </a>
-                              <div />
-                            </li>
-                          </ul>
+                              b2
+                            </div>
+                          </div>
                         </div>
-                      </li>
-                    </ul>
-                  </div>
+                      </a>
+                    </li>
+                  </ul>
                 </li>
               </ul>
-            </div>
-          </li>
-        </ul>
-      </div>
+            </li>
+          </ul>
+        </li>
+      </ul>
     </li>
   </ul>
 </div>
@@ -665,64 +645,108 @@ exports[`Storyshots UI|stories/Stories with highlighting when storiesFilter is p
     <li
       class="emotion-10"
     >
-      <div>
-        <ul
-          class="emotion-16"
+      <ul
+        class="emotion-16"
+      >
+        <li
+          class="emotion-10"
         >
-          <li
-            class="emotion-10"
+          <div
+            data-name="another"
+            role="menuitem"
+            style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+            tabindex="0"
           >
-            <div
-              data-name="another"
-              role="menuitem"
-              style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-              tabindex="0"
-            >
-              <div>
+            <div>
+              <div
+                style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+              >
                 <div
-                  style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+                  style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
                 >
-                  <div
-                    style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
+                  <svg
+                    fill="currentColor"
+                    height="10"
+                    preserveAspectRatio="xMidYMid meet"
+                    style="vertical-align:top;fill:currentColor"
+                    viewBox="0 0 40 40"
+                    width="10"
                   >
-                    <svg
-                      fill="currentColor"
-                      height="10"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="vertical-align:top;fill:currentColor"
-                      viewBox="0 0 40 40"
-                      width="10"
-                    >
-                      <g>
-                        <path
-                          d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                        />
-                      </g>
-                    </svg>
-                  </div>
+                    <g>
+                      <path
+                        d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                      />
+                    </g>
+                  </svg>
                 </div>
+              </div>
+              <div
+                class="emotion-1"
+              >
                 <div
-                  class="emotion-1"
+                  class="emotion-0"
                 >
-                  <div
-                    class="emotion-0"
+                  <span>
+                    ano
+                  </span>
+                  <strong
+                    style="background-color:#FFFEAA;font-weight:inherit;background:#9fdaff;color:black"
                   >
-                    <span>
-                      ano
-                    </span>
-                    <strong
-                      style="background-color:#FFFEAA;font-weight:inherit;background:#9fdaff;color:black"
-                    >
-                      th
-                    </strong>
-                    <span>
-                      er
-                    </span>
-                  </div>
+                    th
+                  </strong>
+                  <span>
+                    er
+                  </span>
                 </div>
               </div>
             </div>
-            <div>
+          </div>
+          <ul
+            class="emotion-16"
+          >
+            <li
+              class="emotion-10"
+            >
+              <div
+                data-name="space"
+                role="menuitem"
+                style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+                tabindex="0"
+              >
+                <div>
+                  <div
+                    style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+                  >
+                    <div
+                      style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
+                    >
+                      <svg
+                        fill="currentColor"
+                        height="10"
+                        preserveAspectRatio="xMidYMid meet"
+                        style="vertical-align:top;fill:currentColor"
+                        viewBox="0 0 40 40"
+                        width="10"
+                      >
+                        <g>
+                          <path
+                            d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    class="emotion-1"
+                  >
+                    <div
+                      class="emotion-0"
+                    >
+                      space
+                    </div>
+                  </div>
+                </div>
+              </div>
               <ul
                 class="emotion-16"
               >
@@ -730,7 +754,7 @@ exports[`Storyshots UI|stories/Stories with highlighting when storiesFilter is p
                   class="emotion-10"
                 >
                   <div
-                    data-name="space"
+                    data-name="20"
                     role="menuitem"
                     style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
                     tabindex="0"
@@ -764,115 +788,61 @@ exports[`Storyshots UI|stories/Stories with highlighting when storiesFilter is p
                         <div
                           class="emotion-0"
                         >
-                          space
+                          20
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div>
-                    <ul
-                      class="emotion-16"
+                  <ul
+                    class="emotion-16"
+                  >
+                    <li
+                      class="emotion-10"
                     >
-                      <li
-                        class="emotion-10"
+                      <a
+                        class="emotion-8 emotion-9"
+                        href="?selectedKind=another.space.20&selectedStory=b1&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
                       >
-                        <div
-                          data-name="20"
-                          role="menuitem"
-                          style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-                          tabindex="0"
-                        >
-                          <div>
+                        <div>
+                          <div
+                            class="emotion-1"
+                          >
                             <div
-                              style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+                              class="emotion-6"
                             >
-                              <div
-                                style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
-                              >
-                                <svg
-                                  fill="currentColor"
-                                  height="10"
-                                  preserveAspectRatio="xMidYMid meet"
-                                  style="vertical-align:top;fill:currentColor"
-                                  viewBox="0 0 40 40"
-                                  width="10"
-                                >
-                                  <g>
-                                    <path
-                                      d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                                    />
-                                  </g>
-                                </svg>
-                              </div>
-                            </div>
-                            <div
-                              class="emotion-1"
-                            >
-                              <div
-                                class="emotion-0"
-                              >
-                                20
-                              </div>
+                              b1
                             </div>
                           </div>
                         </div>
+                      </a>
+                    </li>
+                    <li
+                      class="emotion-10"
+                    >
+                      <a
+                        class="emotion-13 emotion-9"
+                        href="?selectedKind=another.space.20&selectedStory=b2&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+                      >
                         <div>
-                          <ul
-                            class="emotion-16"
+                          <div
+                            class="emotion-1"
                           >
-                            <li
-                              class="emotion-10"
+                            <div
+                              class="emotion-6"
                             >
-                              <a
-                                class="emotion-8 emotion-9"
-                                href="?selectedKind=another.space.20&selectedStory=b1&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
-                              >
-                                <div>
-                                  <div
-                                    class="emotion-1"
-                                  >
-                                    <div
-                                      class="emotion-6"
-                                    >
-                                      b1
-                                    </div>
-                                  </div>
-                                </div>
-                              </a>
-                              <div />
-                            </li>
-                            <li
-                              class="emotion-10"
-                            >
-                              <a
-                                class="emotion-13 emotion-9"
-                                href="?selectedKind=another.space.20&selectedStory=b2&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
-                              >
-                                <div>
-                                  <div
-                                    class="emotion-1"
-                                  >
-                                    <div
-                                      class="emotion-6"
-                                    >
-                                      b2
-                                    </div>
-                                  </div>
-                                </div>
-                              </a>
-                              <div />
-                            </li>
-                          </ul>
+                              b2
+                            </div>
+                          </div>
                         </div>
-                      </li>
-                    </ul>
-                  </div>
+                      </a>
+                    </li>
+                  </ul>
                 </li>
               </ul>
-            </div>
-          </li>
-        </ul>
-      </div>
+            </li>
+          </ul>
+        </li>
+      </ul>
     </li>
   </ul>
 </div>
@@ -953,149 +923,142 @@ exports[`Storyshots UI|stories/Stories without hierarchy - hierarchySeparator is
     <li
       class="emotion-2"
     >
-      <div>
-        <ul
-          class="emotion-15"
+      <ul
+        class="emotion-15"
+      >
+        <li
+          class="emotion-2"
         >
-          <li
-            class="emotion-2"
+          <div
+            data-name="some.name.item1"
+            role="menuitem"
+            style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+            tabindex="0"
           >
-            <div
-              data-name="some.name.item1"
-              role="menuitem"
-              style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-              tabindex="0"
-            >
-              <div>
-                <div
-                  style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
-                >
-                  <div
-                    style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
-                  >
-                    <svg
-                      fill="currentColor"
-                      height="10"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="vertical-align:top;fill:currentColor"
-                      viewBox="0 0 40 40"
-                      width="10"
-                    >
-                      <g>
-                        <path
-                          d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                        />
-                      </g>
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="emotion-1"
-                >
-                  <div
-                    class="emotion-0"
-                  >
-                    some.name.item1
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div />
-          </li>
-          <li
-            class="emotion-2"
-          >
-            <div
-              data-name="another.space.20"
-              role="menuitem"
-              style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
-              tabindex="0"
-            >
-              <div>
-                <div
-                  style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
-                >
-                  <div
-                    style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
-                  >
-                    <svg
-                      fill="currentColor"
-                      height="10"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="vertical-align:top;fill:currentColor"
-                      viewBox="0 0 40 40"
-                      width="10"
-                    >
-                      <g>
-                        <path
-                          d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
-                        />
-                      </g>
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="emotion-1"
-                >
-                  <div
-                    class="emotion-0"
-                  >
-                    another.space.20
-                  </div>
-                </div>
-              </div>
-            </div>
             <div>
-              <ul
-                class="emotion-15"
+              <div
+                style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
               >
-                <li
-                  class="emotion-2"
+                <div
+                  style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
                 >
-                  <a
-                    class="emotion-7 emotion-8"
-                    href="?selectedKind=another.space.20&selectedStory=b1&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+                  <svg
+                    fill="currentColor"
+                    height="10"
+                    preserveAspectRatio="xMidYMid meet"
+                    style="vertical-align:top;fill:currentColor"
+                    viewBox="0 0 40 40"
+                    width="10"
                   >
-                    <div>
-                      <div
-                        class="emotion-1"
-                      >
-                        <div
-                          class="emotion-5"
-                        >
-                          b1
-                        </div>
-                      </div>
-                    </div>
-                  </a>
-                  <div />
-                </li>
-                <li
-                  class="emotion-2"
+                    <g>
+                      <path
+                        d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <div
+                  class="emotion-0"
                 >
-                  <a
-                    class="emotion-12 emotion-8"
-                    href="?selectedKind=another.space.20&selectedStory=b2&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
-                  >
-                    <div>
-                      <div
-                        class="emotion-1"
-                      >
-                        <div
-                          class="emotion-5"
-                        >
-                          b2
-                        </div>
-                      </div>
-                    </div>
-                  </a>
-                  <div />
-                </li>
-              </ul>
+                  some.name.item1
+                </div>
+              </div>
             </div>
-          </li>
-        </ul>
-      </div>
+          </div>
+        </li>
+        <li
+          class="emotion-2"
+        >
+          <div
+            data-name="another.space.20"
+            role="menuitem"
+            style="cursor:pointer;position:relative;overflow:hidden;padding:0px 5px;display:block;z-index:1"
+            tabindex="0"
+          >
+            <div>
+              <div
+                style="position:relative;display:inline-block;vertical-align:top;margin-left:-5px;height:24px;width:24px;transform-origin:50% 11px"
+              >
+                <div
+                  style="position:absolute;top:50%;left:50%;margin:-6px 0 0 -5px"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="10"
+                    preserveAspectRatio="xMidYMid meet"
+                    style="vertical-align:top;fill:currentColor"
+                    viewBox="0 0 40 40"
+                    width="10"
+                  >
+                    <g>
+                      <path
+                        d="m23.3 20l-13.1-13.6c-0.3-0.3-0.3-0.9 0-1.2l2.4-2.4c0.3-0.3 0.9-0.4 1.2-0.1l16 16.7c0.1 0.1 0.2 0.4 0.2 0.6s-0.1 0.5-0.2 0.6l-16 16.7c-0.3 0.3-0.9 0.3-1.2 0l-2.4-2.5c-0.3-0.3-0.3-0.9 0-1.2z"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="emotion-1"
+              >
+                <div
+                  class="emotion-0"
+                >
+                  another.space.20
+                </div>
+              </div>
+            </div>
+          </div>
+          <ul
+            class="emotion-15"
+          >
+            <li
+              class="emotion-2"
+            >
+              <a
+                class="emotion-7 emotion-8"
+                href="?selectedKind=another.space.20&selectedStory=b1&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+              >
+                <div>
+                  <div
+                    class="emotion-1"
+                  >
+                    <div
+                      class="emotion-5"
+                    >
+                      b1
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+            <li
+              class="emotion-2"
+            >
+              <a
+                class="emotion-12 emotion-8"
+                href="?selectedKind=another.space.20&selectedStory=b2&full=NaN&addons=NaN&stories=NaN&panelRight=NaN"
+              >
+                <div>
+                  <div
+                    class="emotion-1"
+                  >
+                    <div
+                      class="emotion-5"
+                    >
+                      b2
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
     </li>
   </ul>
 </div>

--- a/lib/ui/src/modules/ui/components/stories_panel/stories_tree/index.js
+++ b/lib/ui/src/modules/ui/components/stories_panel/stories_tree/index.js
@@ -183,7 +183,7 @@ Stories.defaultProps = {
   onSelectStory: null,
   storiesHierarchy: null,
   storyFilter: null,
-  sidebarAnimations: true,
+  sidebarAnimations: false,
 };
 
 Stories.propTypes = {


### PR DESCRIPTION
Issue: #6248

## What I did

Disable sidebar animations by default

This means that treebeard won't create `velocity-react` transition elements, which are apparently broken for reasons I don't understand.

## How to test

UI will break per #6248 before this change, and be fixed after this change:

```
rm yarn.lock # forces the latest version of react?
yarn bootstrap --reset --core
cd examples/official-storybook
yarn storybook
```



