### PR TITLE
Add custom grid size

### DIFF
--- a/examples/cra-kitchen-sink/.storybook/config.js
+++ b/examples/cra-kitchen-sink/.storybook/config.js
@@ -1,12 +1,11 @@
 import { configure, addParameters, addDecorator } from '@storybook/react';
+import { create } from '@storybook/theming';
 
 import { withA11y } from '@storybook/addon-a11y';
 
 addDecorator(withA11y);
 addParameters({
   options: {
-    brandTitle: 'CRA Kitchen Sink',
-    brandUrl: 'https://github.com/storybooks/storybook/tree/master/examples/cra-kitchen-sink',
     isFullscreen: false,
     showAddonsPanel: true,
     showSearchBox: false,
@@ -15,7 +14,12 @@ addParameters({
     hierarchySeparator: /\./,
     hierarchyRootSeparator: /\|/,
     enableShortcuts: true,
-    gridCellSize: 12,
+    theme: create({
+      base: 'light',
+      brandTitle: 'CRA Kitchen Sink',
+      brandUrl: 'https://github.com/storybooks/storybook/tree/master/examples/cra-kitchen-sink',
+      gridCellSize: 12,
+    }),
   },
 });
 

--- a/examples/cra-kitchen-sink/.storybook/config.js
+++ b/examples/cra-kitchen-sink/.storybook/config.js
@@ -15,6 +15,7 @@ addParameters({
     hierarchySeparator: /\./,
     hierarchyRootSeparator: /\|/,
     enableShortcuts: true,
+    gridCellSize: 12,
   },
 });
 

--- a/examples/cra-kitchen-sink/package.json
+++ b/examples/cra-kitchen-sink/package.json
@@ -34,6 +34,7 @@
     "@storybook/addons": "5.1.0-alpha.13",
     "@storybook/client-logger": "5.1.0-alpha.13",
     "@storybook/react": "5.1.0-alpha.13",
+    "@storybook/theming": "5.1.0-alpha.13",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.3.5",

--- a/lib/theming/src/base.ts
+++ b/lib/theming/src/base.ts
@@ -42,6 +42,7 @@ export const background = {
   app: '#F6F9FC',
   bar: '#FFFFFF',
   content: color.lightest,
+  gridCellSize: 10,
   hoverable: 'rgba(0,0,0,.05)', // hover state for items in a list
 
   // Notification, error, and warning backgrounds
@@ -129,6 +130,8 @@ export interface ThemeVars {
   brandTitle?: string;
   brandUrl?: string;
   brandImage?: string;
+
+  gridCellSize?: number;
 }
 
 export type Color = typeof color;

--- a/lib/theming/src/create.ts
+++ b/lib/theming/src/create.ts
@@ -119,6 +119,7 @@ export const convert = (inherit: ThemeVars = lightThemeVars): Theme => {
     brandTitle,
     brandUrl,
     brandImage,
+    gridCellSize,
     ...rest
   } = inherit;
 
@@ -131,6 +132,7 @@ export const convert = (inherit: ThemeVars = lightThemeVars): Theme => {
       app: appBg,
       bar: background.bar,
       content: appContentBg,
+      gridCellSize: gridCellSize || background.gridCellSize,
       hoverable:
         base === 'light' ? 'rgba(0,0,0,.05)' : 'rgba(250,250,252,.1)' || background.hoverable,
 

--- a/lib/theming/src/tests/create.test.js
+++ b/lib/theming/src/tests/create.test.js
@@ -167,4 +167,22 @@ describe('convert', () => {
       }),
     });
   });
+  it('should map optional vars', () => {
+    const customVars = create({
+      base: 'light',
+      brandTitle: 'my custom storybook',
+      gridCellSize: 12,
+    });
+
+    const result = convert(customVars);
+    expect(result.base).toEqual('light');
+    expect(result).toMatchObject({
+      background: expect.objectContaining({
+        gridCellSize: 12,
+      }),
+      brand: expect.objectContaining({
+        title: 'my custom storybook',
+      }),
+    });
+  });
 });

--- a/lib/theming/src/tests/create.test.js
+++ b/lib/theming/src/tests/create.test.js
@@ -81,6 +81,31 @@ describe('create brand', () => {
   });
 });
 
+describe('create grid', () => {
+  it('should have default', () => {
+    const result = create({ base: 'light' });
+
+    expect(result.gridCellSize).not.toBeDefined();
+  });
+  it('should accept null', () => {
+    const result = create({ base: 'light', gridCellSize: null });
+
+    expect(result).toMatchObject({
+      gridCellSize: null,
+    });
+  });
+  it('should accept values', () => {
+    const result = create({
+      base: 'light',
+      gridCellSize: 12,
+    });
+
+    expect(result).toMatchObject({
+      gridCellSize: 12,
+    });
+  });
+});
+
 describe('create extend', () => {
   it('should allow custom props', () => {
     const result = create(

--- a/lib/ui/src/components/preview/background.js
+++ b/lib/ui/src/components/preview/background.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
 
@@ -31,14 +32,49 @@ class Provider extends Component {
 
 const { Consumer } = Context;
 
-const defaults = {
-  grid: {
-    backgroundImage: `url("data:image/svg+xml,%3Csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3E%3Cdefs%3E%3Cpattern id='smallGrid' width='10' height='10' patternUnits='userSpaceOnUse'%3E%3Cpath d='M 10 0 L 0 0 0 10' fill='none' stroke='gray' stroke-width='0.5'/%3E%3C/pattern%3E%3Cpattern id='grid' width='100' height='100' patternUnits='userSpaceOnUse'%3E%3Crect width='100' height='100' fill='url(%23smallGrid)'/%3E%3Cpath d='M 100 0 L 0 0 0 100' fill='none' stroke='gray' stroke-width='1'/%3E%3C/pattern%3E%3C/defs%3E%3Crect width='100%25' height='100%25' fill='url(%23grid)' /%3E%3C/svg%3E")`,
-    backgroundSize: '100px 100px, 100px 100px, 20px 20px, 20px 20px',
+function createGridStyles(cellSize) {
+  const cellSizeDoubled = cellSize * 2;
+  const cellSizeSquared = cellSize ** 2;
+
+  const gridSVGEncoded = encodeURIComponent(
+    renderToStaticMarkup(
+      <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <pattern id="smallGrid" width={cellSize} height={cellSize} patternUnits="userSpaceOnUse">
+            <path
+              d={`M ${cellSize} 0 L 0 0 0 ${cellSize}`}
+              fill="none"
+              stroke="gray"
+              strokeWidth="0.5"
+            />
+          </pattern>
+          <pattern
+            id="grid"
+            width={cellSizeSquared}
+            height={cellSizeSquared}
+            patternUnits="userSpaceOnUse"
+          >
+            <rect width={cellSizeSquared} height={cellSizeSquared} fill="url(#smallGrid)" />
+            <path
+              d={`M ${cellSizeSquared} 0 L 0 0 0 ${cellSizeSquared}`}
+              fill="none"
+              stroke="gray"
+              strokeWidth="1"
+            />
+          </pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#grid)" />
+      </svg>
+    )
+  );
+
+  return {
+    backgroundImage: `url("data:image/svg+xml,${gridSVGEncoded}")`,
+    backgroundSize: `${cellSizeSquared}px ${cellSizeSquared}px, ${cellSizeSquared}px ${cellSizeSquared}px, ${cellSizeDoubled}px ${cellSizeDoubled}px, ${cellSizeDoubled}px ${cellSizeDoubled}px`,
     backgroundPosition: '-2px -2px',
     mixBlendMode: 'difference',
-  },
-};
+  };
+}
 
 const Grid = styled.div(
   {
@@ -48,7 +84,7 @@ const Grid = styled.div(
     width: '100%',
     height: '100%',
   },
-  defaults.grid
+  ({ theme }) => createGridStyles(theme.background.gridCellSize)
 );
 
 const Background = styled.div(


### PR DESCRIPTION
Issue: #5853 `Make grid cell size customizeable`

## What I did

- Made grid background SVG dynamically generated based on custom cell size
- Update grid SVG to be more human readable (and editable)
- Grid cell size defined by `Theme`
- Pick up `gridCellSize` from Theme configuration options

## How to test

- Added Jest tests
