### PR TITLE
Update type definition for panelPosition to enum of strings

### DIFF
--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -34,7 +34,7 @@ addParameters({
     showPanel: true,
     /**
      * where to show the addon panel
-     * @type {String}
+     * @type {('bottom'|'right')}
      */
     panelPosition: 'bottom',
     /**


### PR DESCRIPTION
## What I did

Updated the type definition in the docs for the `panelPosition` config. Changed to an enum of strings to show the possible values that can be used ('bottom' & 'right').