### PR TITLE
[bug] Fix for `addon-cssresources` till scrollbars are properly addressed

### DIFF
--- a/addons/cssresources/src/css-resource-panel.test.js
+++ b/addons/cssresources/src/css-resource-panel.test.js
@@ -56,7 +56,7 @@ describe('CSSResourcePanel', () => {
     });
 
     it('should render an empty div', () => {
-      expect(node.matchesElement('<div></div>')).toEqual(true);
+      expect(node.html()).toEqual('<div></div>');
     });
   });
 

--- a/addons/cssresources/src/css-resource-panel.test.js
+++ b/addons/cssresources/src/css-resource-panel.test.js
@@ -55,8 +55,8 @@ describe('CSSResourcePanel', () => {
       expect(node).toHaveState({ list: [], currentStoryId: '' });
     });
 
-    it('should not render anything', () => {
-      expect(node).toBeEmptyRender();
+    it('should render an empty div', () => {
+      expect(node.matchesElement('<div></div>')).toEqual(true);
     });
   });
 

--- a/addons/cssresources/src/css-resource-panel.tsx
+++ b/addons/cssresources/src/css-resource-panel.tsx
@@ -87,7 +87,7 @@ export class CssResourcePanel extends Component<Props, State> {
     }
 
     return (
-      <Fragment>
+      <div>
         {list &&
           list.map(({ id, code, picked }) => (
             <div key={id} style={{ padding: 10 }}>
@@ -98,7 +98,7 @@ export class CssResourcePanel extends Component<Props, State> {
               {code ? <SyntaxHighlighter language="html">{code}</SyntaxHighlighter> : null}
             </div>
           ))}
-      </Fragment>
+      </div>
     );
   }
 }


### PR DESCRIPTION
The absolute positioning caused by https://github.com/storybooks/storybook/commit/79d2cd11d0dadfd1687ca4dd5f449e1d99f95cbe#diff-77ef954da6ec85c57634e9e3c9cc9750 made the css resources tab contain overlapping source files:

![Screen Shot 2019-03-25 at 4 15 42 PM](https://user-images.githubusercontent.com/1943491/54951246-870c0780-4f19-11e9-81c8-5520c265d95d.png)

The solution was to render them into a container instead of a `<Fragment>`