### PR TITLE
[bug] Enforces corejs v2 for babel

### DIFF
--- a/lib/core/src/server/common/babel.js
+++ b/lib/core/src/server/common/babel.js
@@ -16,7 +16,7 @@ export default ({ configType }) => {
 
   return {
     presets: [
-      [require.resolve('@babel/preset-env'), { shippedProposals: true, useBuiltIns: 'usage' }],
+      [require.resolve('@babel/preset-env'), { shippedProposals: true, useBuiltIns: 'usage', corejs: 2 }],
       ...prodPresets,
     ],
     plugins: [


### PR DESCRIPTION
Issue: #6261 

Corejs 3 got released which adds noisy warning messages. Force storybook
to use corejs 2 instead until proper v3 migration which is breaking change.

