### PR TITLE
Upgrade `@babel/preset-env`

### DIFF
--- a/app/riot/package.json
+++ b/app/riot/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
-    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-env": "^7.4.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0"
   },

--- a/app/riot/package.json
+++ b/app/riot/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
-    "@babel/preset-env": "^7.4.0",
+    "@babel/preset-env": "^7.4.1",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0"
   },

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.3.4",
-    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-env": "^7.4.0",
     "@babel/register": "^7.0.0",
     "@storybook/codemod": "5.1.0-alpha.15",
     "chalk": "^2.4.1",

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.3.4",
-    "@babel/preset-env": "^7.4.0",
+    "@babel/preset-env": "^7.4.1",
     "@babel/register": "^7.0.0",
     "@storybook/codemod": "5.1.0-alpha.15",
     "chalk": "^2.4.1",

--- a/lib/cli/test/fixtures/react_project/package.json
+++ b/lib/cli/test/fixtures/react_project/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
-    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-env": "^7.4.0",
     "@babel/preset-react": "7.0.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3"

--- a/lib/cli/test/fixtures/react_project/package.json
+++ b/lib/cli/test/fixtures/react_project/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
-    "@babel/preset-env": "^7.4.0",
+    "@babel/preset-env": "^7.4.1",
     "@babel/preset-react": "7.0.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3"

--- a/lib/cli/test/fixtures/sfc_vue/package.json
+++ b/lib/cli/test/fixtures/sfc_vue/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/plugin-transform-runtime": "^7.1.0",
-    "@babel/preset-env": "^7.4.0",
+    "@babel/preset-env": "^7.4.1",
     "@babel/preset-stage-2": "^7.0.0",
     "@babel/register": "^7.0.0",
     "autoprefixer": "^9.4.9",

--- a/lib/cli/test/fixtures/sfc_vue/package.json
+++ b/lib/cli/test/fixtures/sfc_vue/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/plugin-transform-runtime": "^7.1.0",
-    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-env": "^7.4.0",
     "@babel/preset-stage-2": "^7.0.0",
     "@babel/register": "^7.0.0",
     "autoprefixer": "^9.4.9",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -24,7 +24,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
-    "@babel/preset-env": "^7.4.0",
+    "@babel/preset-env": "^7.4.1",
     "@storybook/addons": "5.1.0-alpha.15",
     "@storybook/channel-postmessage": "5.1.0-alpha.15",
     "@storybook/client-api": "5.1.0-alpha.15",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -24,7 +24,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
-    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-env": "^7.4.0",
     "@storybook/addons": "5.1.0-alpha.15",
     "@storybook/channel-postmessage": "5.1.0-alpha.15",
     "@storybook/client-api": "5.1.0-alpha.15",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@babel/plugin-proposal-class-properties": "^7.3.3",
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
-    "@babel/preset-env": "^7.4.0",
+    "@babel/preset-env": "^7.4.1",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@types/common-tags": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@babel/plugin-proposal-class-properties": "^7.3.3",
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
-    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-env": "^7.4.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@types/common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,6 +986,13 @@
   dependencies:
     regexp-tree "^0.1.0"
 
+"@babel/plugin-transform-named-capturing-groups-regex@^7.4.2":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz#800391136d6cbcc80728dbdba3c1c6e46f86c12e"
+  integrity sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==
+  dependencies:
+    regexp-tree "^0.1.0"
+
 "@babel/plugin-transform-new-target@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz#ae8fbd89517fa7892d20e6564e641e8770c3aa4a"
@@ -1225,7 +1232,7 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
-"@babel/preset-env@^7.0.0", "@babel/preset-env@^7.1.6", "@babel/preset-env@^7.3.1", "@babel/preset-env@^7.3.4":
+"@babel/preset-env@^7.0.0", "@babel/preset-env@^7.1.6", "@babel/preset-env@^7.3.1":
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.1.tgz#80e19ad76f62fb136d57ee4b963db3e8a6840bad"
   integrity sha512-uC2DeVb6ljdjBGhJCyHxNZfSJEVgPdUm2R5cX85GCl1Qreo5sMM5g85ntqtzRF7XRYGgnRmV5we9cdlvo1wJvg==
@@ -1259,6 +1266,57 @@
     "@babel/plugin-transform-modules-systemjs" "^7.4.0"
     "@babel/plugin-transform-modules-umd" "^7.2.0"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.3.0"
+    "@babel/plugin-transform-new-target" "^7.4.0"
+    "@babel/plugin-transform-object-super" "^7.2.0"
+    "@babel/plugin-transform-parameters" "^7.4.0"
+    "@babel/plugin-transform-regenerator" "^7.4.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.2.0"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.2.0"
+    "@babel/types" "^7.4.0"
+    browserslist "^4.4.2"
+    core-js-compat "^3.0.0"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.3.0"
+
+"@babel/preset-env@^7.4.0":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.2.tgz#2f5ba1de2daefa9dcca653848f96c7ce2e406676"
+  integrity sha512-OEz6VOZaI9LW08CWVS3d9g/0jZA6YCn1gsKIy/fut7yZCJti5Lm1/Hi+uo/U+ODm7g4I6gULrCP+/+laT8xAsA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.4.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.0"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.4.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.4.0"
+    "@babel/plugin-transform-classes" "^7.4.0"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.4.0"
+    "@babel/plugin-transform-dotall-regex" "^7.2.0"
+    "@babel/plugin-transform-duplicate-keys" "^7.2.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.4.0"
+    "@babel/plugin-transform-function-name" "^7.2.0"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.2.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.4.0"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.4.2"
     "@babel/plugin-transform-new-target" "^7.4.0"
     "@babel/plugin-transform-object-super" "^7.2.0"
     "@babel/plugin-transform-parameters" "^7.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,7 +1283,7 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
-"@babel/preset-env@^7.4.0":
+"@babel/preset-env@^7.4.1":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.2.tgz#2f5ba1de2daefa9dcca653848f96c7ce2e406676"
   integrity sha512-OEz6VOZaI9LW08CWVS3d9g/0jZA6YCn1gsKIy/fut7yZCJti5Lm1/Hi+uo/U+ODm7g4I6gULrCP+/+laT8xAsA==


### PR DESCRIPTION
Issue:

## What I did

Force us to use latest version of preset-env which supports `corejs` option needed by https://github.com/storybooks/storybook/pull/6267

## How to test

Not sure the best way to test. Saw the problem on `master` with `official-storybook` after trying to patch in #6267 and upgraded there to fix the problem. This PR is a more comprehensive upgrade of all `preset-env` instances.