### PR TITLE
fix(addon-a11y): move redux to dependencies

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -38,13 +38,13 @@
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
     "react": "^16.8.4",
+    "react-redux": "^6.0.1",
+    "redux": "^4.0.1",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@types/common-tags": "^1.8.0",
-    "@types/react-redux": "^7.0.3",
-    "react-redux": "^6.0.1",
-    "redux": "^4.0.1"
+    "@types/react-redux": "^7.0.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Issue:

## What I did
building storybook was dying over 'redux does not exist'
moving the dependency to `dependencies` should help.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
