### PR TITLE
Set expanded stores to objects instead of arrays

### DIFF
--- a/lib/ui/src/components/sidebar/treeview/treeview.js
+++ b/lib/ui/src/components/sidebar/treeview/treeview.js
@@ -202,8 +202,8 @@ const getPropsForTree = memoize(50)(({ dataset, selectedId }) => {
 class TreeState extends PureComponent {
   state = {
     // We maintain two sets of expanded nodes, so we remember which were expanded if we clear the filter
-    unfilteredExpanded: [],
-    filteredExpanded: [],
+    unfilteredExpanded: {},
+    filteredExpanded: {},
     filter: null,
     lastSelectedId: null,
   };


### PR DESCRIPTION
Issue: #6210 

## What I did

Fixed the setting of `unfilteredExpanded` & `filteredExpanded` to objects instead of arrays (I'm assuming these were meant to be objects).

The bug was happening on `treeview.js:153`. `unfilteredExpanded[key]` was being stored as the value. This usually returns a bool if the key exists in the array, but when you run this with an array function name it returns the function itself 😮 😆 
![image](https://user-images.githubusercontent.com/1811583/54978853-96608300-4ff5-11e9-97ae-08b5178dac27.png)

## How to test

* Change line 5 in `examples/cra-kitchen-sink/src/stories/Lifecycle.stories.js` to 

```js
storiesOf('Map', module).add('logging', () => <LifecycleLogger />);`
```

```bash
cd examples/cra-kitchen-sink
yarn storybook --no-dll
````

* Open console in your browser.

------

Alternatively I also coded a solution which refactored these stores of expanded items into arrays of sidebar item id's and checked `indexOf()`, instead of using a key-value relationship. This was before I realised these were probably just meant to be objects. If you'd prefer that solution I can push that up.
