### PR TITLE
Fixed Colorblindness Emulation

### DIFF
--- a/addons/a11y/src/components/ColorBlindness.tsx
+++ b/addons/a11y/src/components/ColorBlindness.tsx
@@ -8,6 +8,16 @@ import { Icons, IconButton, WithTooltip, TooltipLinkList } from '@storybook/comp
 
 const getIframe = memoize(1)(() => document.getElementById('storybook-preview-iframe'));
 
+const getFilter = (filter: string | null) => {
+  if (filter === null) {
+    return 'none';
+  }
+  if (filter === 'mono') {
+    return 'grayscale(100%)';
+  }
+  return `url('#${filter}')`;
+};
+
 const ColorIcon = styled.span(
   {
     background: 'linear-gradient(to right, #F44336, #FF9800, #FFEB3B, #8BC34A, #2196F3, #9C27B0)',
@@ -17,7 +27,7 @@ const ColorIcon = styled.span(
     width: '1rem',
   },
   ({ filter }: { filter: string | null }) => ({
-    filter: filter === 'mono' ? 'grayscale(100%)' : `url('#${filter}')`,
+    filter: getFilter(filter),
   }),
   ({ theme }) => ({
     boxShadow: `${theme.appBorderColor} 0 0 0 1px inset`,
@@ -42,7 +52,7 @@ export class ColorBlindness extends Component<ColorBlindnessProps, ColorBlindnes
     const iframe = getIframe();
 
     if (iframe) {
-      iframe.style.filter = filter === 'mono' ? 'grayscale(100%)' : `url('#${filter}')`;
+      iframe.style.filter = getFilter(filter);
       this.setState({
         expanded: false,
         filter,
@@ -78,6 +88,7 @@ export class ColorBlindness extends Component<ColorBlindnessProps, ColorBlindnes
         this.setFilter(i);
       },
       right: <ColorIcon filter={i} />,
+      active: filter === i,
     }));
 
     if (filter !== null) {
@@ -89,6 +100,7 @@ export class ColorBlindness extends Component<ColorBlindnessProps, ColorBlindnes
             this.setFilter(null);
           },
           right: undefined,
+          active: false,
         },
         ...colorList,
       ];

--- a/addons/a11y/src/register.tsx
+++ b/addons/a11y/src/register.tsx
@@ -7,7 +7,11 @@ import { A11YPanel } from './components/A11YPanel';
 import { addons, types } from '@storybook/addons';
 
 const Hidden = styled.div(() => ({
-  display: 'none',
+  '&, & svg': {
+    position: 'absolute',
+    width: 0,
+    height: 0,
+  },
 }));
 
 const PreviewWrapper: FunctionComponent<{}> = p => (


### PR DESCRIPTION
Issue: #5959 

## What I did

- Fixed the issue in Firefox where the filters where not showing. The problem was that the div containing the svg was set to `display: none`, but Firefox won't render filters that are set to `display: none` (see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/display and https://benfrain.com/applying-multiple-svg-filter-effects-defined-in-css-or-html/), so I've used the position absolute no sizes technique.
- Fixed the css property used to reset the filter, from `filter: url("#null")` to `filter: none`, since Firefox doesn't render filters that are not found (and the code doesn't have a filter with id `null`) while the correct property in css is `none` (see https://developer.mozilla.org/en-US/docs/Web/CSS/filter)
- While at it, I added the `active` property to the selection list, to show the selected filter
![Screenshot 2019-03-26 10 01 24](https://user-images.githubusercontent.com/458523/55018291-bec58e80-4faf-11e9-993e-c09c01e6e551.png)


## How to test

Run storybook in Firefox and use the Colorblindness selection list
