### PR TITLE
fixed mistype in returning parameter

### DIFF
--- a/addons/storysource/README.md
+++ b/addons/storysource/README.md
@@ -30,7 +30,7 @@ module.exports = function({ config }) {
     enforce: 'pre',
   });
 
-  return defaultConfig;
+  return config;
 };
 ```
 


### PR DESCRIPTION
should be `config` instead of `defaultConfig`

Issue:

## What I did
fixed mistype in returning parameter

## How to test
Look into readme.md file

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
