### PR TITLE
Fix {name, url} options deprecation message

### DIFF
--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -64,11 +64,11 @@ interface OptionsMap {
 }
 
 const deprecatedThemeOptions: {
-  name: 'brandTitle';
-  url: 'brandUrl';
+  name: 'theme.brandTitle';
+  url: 'theme.brandUrl';
 } = {
-  name: 'brandTitle',
-  url: 'brandUrl',
+  name: 'theme.brandTitle',
+  url: 'theme.brandUrl',
 };
 
 const deprecatedLayoutOptions: {


### PR DESCRIPTION
Right now it's misleading
