### PR TITLE
Added missing background color for left panel

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/panel.js
+++ b/app/react-native/src/preview/components/OnDeviceUI/panel.js
@@ -9,6 +9,7 @@ const style = StyleSheet.create({
     borderTopWidth: 1,
     borderBottomWidth: 0,
     borderColor: '#e6e6e6',
+    backgroundColor: '#ffffff',
   },
 });
 


### PR DESCRIPTION
This is a problem when working on an app with darker background. It might only be a problem for react-native-navigation apps, which uses different rootView structure.

Issue: Discord conversation

## What I did
Added white background to the left panel

## How to test
Open DeviceUI on React Native, work a view with black background, other panels should be white.

- Is this testable with Jest or Chromatic screenshots?
Maybe with screenshots, not sure. Just not necessary in my opinion.
- Does this need a new example in the kitchen sink apps?
No.
- Does this need an update to the documentation?
No.