### PR TITLE
documentation: fix debug flag; highlight deprecation and debug info

### DIFF
--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -148,7 +148,6 @@ The webpack config [is configurable](/configurations/webpack), and the default c
 
 ### Debug the default webpack config
 
-<details>
   <summary>To effectively customise the webpack config, you might need to get the full default config it's using.</summary>
   
   <div></div>
@@ -160,12 +159,10 @@ The webpack config [is configurable](/configurations/webpack), and the default c
   ```
 - Then run storybook:
   ```sh
-  yarn storybook --quiet
+  yarn storybook --debug-webpack
   ```
 
 The console should log the entire config, for you to inspect.
-
-</details>
 
 ## Webpack customisation modes
 
@@ -207,7 +204,7 @@ Storybook uses the config returned from the above function. So edit `config` wit
 
 > If your custom webpack config uses a loader that does not explicitly include specific file extensions via the `test` property, it is necessary to `exclude` the `.ejs` file extension from that loader.
 
-### Extend Mode
+### Extend Mode (**Deprecated**)
 
 If your file exports an **object**, it puts Storybook into **extend-mode**. This mode is deprecated and will be removed in a future version.
 


### PR DESCRIPTION
Issue: Documentation changes

## What I did
- removed `<details>` wrapper around "Debug the default webpack config" so that the section would be harder to overlook
- fixed bad flag command in the debugging section (`yarn storybook` `--quiet` --> `--debug-webpack`
- added prominent `(**Deprecated**)` to the "Extend Mode" section so that it's harder to overlook

## How to test

All changes to documentation markdown, i.e. no testable changes

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
