### PR TITLE
CLI: add --preview-url cli argument for custom preview

### DIFF
--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -341,5 +341,6 @@ export async function buildDev({ packageJson, ...loadOptions }) {
     ...loadOptions,
     packageJson,
     configDir: loadOptions.configDir || cliOptions.configDir || './.storybook',
+    ignorePreview: loadOptions.ignorePreview || cliOptions.ignorePreview,
   });
 }

--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -335,12 +335,13 @@ export async function buildDevStandalone(options) {
 
 export async function buildDev({ packageJson, ...loadOptions }) {
   const cliOptions = await getDevCli(packageJson);
+  process.env.PREVIEW_URL = cliOptions.previewUrl;
 
   await buildDevStandalone({
     ...cliOptions,
     ...loadOptions,
     packageJson,
     configDir: loadOptions.configDir || cliOptions.configDir || './.storybook',
-    ignorePreview: loadOptions.ignorePreview || cliOptions.ignorePreview,
+    ignorePreview: !!cliOptions.previewUrl,
   });
 }

--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -193,6 +193,7 @@ export async function buildStaticStandalone(options) {
 
 export function buildStatic({ packageJson, ...loadOptions }) {
   const cliOptions = getProdCli(packageJson);
+  process.env.PREVIEW_URL = cliOptions.previewUrl;
 
   return buildStaticStandalone({
     ...cliOptions,
@@ -200,6 +201,6 @@ export function buildStatic({ packageJson, ...loadOptions }) {
     packageJson,
     configDir: loadOptions.configDir || cliOptions.configDir || './.storybook',
     outputDir: loadOptions.outputDir || cliOptions.outputDir || './storybook-static',
-    ignorePreview: loadOptions.ignorePreview || cliOptions.ignorePreview,
+    ignorePreview: !!cliOptions.previewUrl,
   });
 }

--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -200,5 +200,6 @@ export function buildStatic({ packageJson, ...loadOptions }) {
     packageJson,
     configDir: loadOptions.configDir || cliOptions.configDir || './.storybook',
     outputDir: loadOptions.outputDir || cliOptions.outputDir || './storybook-static',
+    ignorePreview: loadOptions.ignorePreview || cliOptions.ignorePreview,
   });
 }

--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -36,6 +36,10 @@ async function getCLI(packageJson) {
     .option('--quiet', 'Suppress verbose build output')
     .option('--no-dll', 'Do not use dll reference')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
+    .option(
+      '--ignore-preview',
+      'Ignore the storybook default preview implementation so that you can rollout your own'
+    )
     .parse(process.argv);
 
   // Workaround the `-h` shorthand conflict.

--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -37,8 +37,8 @@ async function getCLI(packageJson) {
     .option('--no-dll', 'Do not use dll reference')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(
-      '--ignore-preview',
-      'Ignore the storybook default preview implementation so that you can rollout your own'
+      '--preview-url [string]',
+      'Disables the default storybook preview and lets your use your own'
     )
     .parse(process.argv);
 

--- a/lib/core/src/server/cli/prod.js
+++ b/lib/core/src/server/cli/prod.js
@@ -16,8 +16,8 @@ function getCLI(packageJson) {
     .option('--no-dll', 'Do not use dll reference')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(
-      '--ignore-preview',
-      'Ignore the storybook default preview implementation so that you can rollout your own'
+      '--preview-url [string]',
+      'Disables the default storybook preview and lets your use your own'
     )
     .parse(process.argv);
 

--- a/lib/core/src/server/cli/prod.js
+++ b/lib/core/src/server/cli/prod.js
@@ -15,6 +15,10 @@ function getCLI(packageJson) {
     .option('--quiet', 'Suppress verbose build output')
     .option('--no-dll', 'Do not use dll reference')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
+    .option(
+      '--ignore-preview',
+      'Ignore the storybook default preview implementation so that you can rollout your own'
+    )
     .parse(process.argv);
 
   logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}\n`));

--- a/lib/core/src/server/config/utils.js
+++ b/lib/core/src/server/config/utils.js
@@ -23,6 +23,7 @@ export function loadEnv(options = {}) {
     // even when deployed inside a subpath. (like in GitHub pages)
     // In development this is just empty as we always serves from the root.
     PUBLIC_URL: options.production ? '.' : '',
+    PREVIEW_URL: process.env.PREVIEW_URL,
   };
 
   Object.keys(process.env)

--- a/lib/core/src/server/config/utils.js
+++ b/lib/core/src/server/config/utils.js
@@ -23,7 +23,7 @@ export function loadEnv(options = {}) {
     // even when deployed inside a subpath. (like in GitHub pages)
     // In development this is just empty as we always serves from the root.
     PUBLIC_URL: options.production ? '.' : '',
-    PREVIEW_URL: process.env.PREVIEW_URL,
+    PREVIEW_URL: process.env.PREVIEW_URL || '',
   };
 
   Object.keys(process.env)

--- a/lib/ui/src/components/preview/preview.js
+++ b/lib/ui/src/components/preview/preview.js
@@ -299,7 +299,7 @@ Preview.defaultProps = {
   storyId: undefined,
   path: undefined,
   description: undefined,
-  baseUrl: 'iframe.html',
+  baseUrl: process.env.PREVIEW_URL || 'iframe.html',
 };
 
 export { Preview };

--- a/lib/ui/src/components/preview/preview.js
+++ b/lib/ui/src/components/preview/preview.js
@@ -294,12 +294,20 @@ Preview.propTypes = {
   actions: PropTypes.shape({}).isRequired,
   baseUrl: PropTypes.string,
 };
+
+function getBaseUrl() {
+  if (!process.env.PREVIEW_URL || process.env.PREVIEW_URL === 'undefined') {
+    return 'iframe.html';
+  }
+  return process.env.PREVIEW_URL;
+}
+
 Preview.defaultProps = {
   viewMode: undefined,
   storyId: undefined,
   path: undefined,
   description: undefined,
-  baseUrl: process.env.PREVIEW_URL || 'iframe.html',
+  baseUrl: getBaseUrl(),
 };
 
 export { Preview };


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/5975

## What I did

- I added a new env variable called `PREVIEW_URL` that the manager can use to override the url of the iframe to laod
- I added a new CLI option called `--ignore-preview` that triggers an already available flag called `ignorePreview`
- I updated the `preview.js` component to use the `process.env.PREVIEW_URL` variable if available, otherwise falling back to `iframe.html`

## How to test

- Is this testable with Jest or Chromatic screenshots?

We could create a new repo I guess to test this feature ?
To test locally, I've been updating (temporarly) the `package.json` script called `storybook` from `official-storybook`

```
 "storybook": "cross-env PREVIEW_URL=http://localhost:1337 STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./ -s built-storybooks --no-dll --ignore-preview"
```

Then I execute a little parcel example I run locally as well

```tsx
//storybook.tsx
import { configure, storiesOf } from "@storybook/react";
import React from "react";

configure(() => {
  storiesOf("Category 1").add("Test 1", () => <div>Category 1 - Test 1</div>);
  storiesOf("Category 2")
    .add("Test 1", () => <div>Category 2 - Test 1</div>)
    .add("Test 2", () => <div>Category 2 - Test 2</div>);
}, {});
```

```html
<!-- storybook.html -->
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
    <title></title>
  </head>
  <body>
    <div id="root"></div>
    <script src="./storybook.tsx"></script>
  </body>
</html>
```

```bash
# parcel command
parcel ./lib/storybook.html --port 1337
```

- Does this need a new example in the kitchen sink apps?

Maybe ? I'm not sure @tmeasday ?

- Does this need an update to the documentation?

Yes, but where @tmeasday?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

If you can't run it locally, here's my entire `package.json` for my parcel test

```json
{
  "name": "",
  "version": "0.0.0",
  "description": "",
  "license": "UNLICENSED",
  "main": "dist/storybook.html",
  "scripts": {
    "watch": "parcel ./lib/storybook.html --port 1337"
  },
  "dependencies": {
    "@storybook/react": "^5.0.5",
    "react": "^16.8.5",
    "react-dom": "^16.8.5"
  },
  "devDependencies": {
    "@babel/core": "^7.4.0"
  }
}
```
