### PR TITLE
Remove styling of elements after re-running the the accessibility rules

### DIFF
--- a/addons/a11y/src/components/A11YPanel.tsx
+++ b/addons/a11y/src/components/A11YPanel.tsx
@@ -133,6 +133,8 @@ export class A11YPanel extends Component<A11YPanelProps, A11YPanelState> {
         },
         () => {
           api.emit(EVENTS.REQUEST);
+          // removes all elements from the redux map in store from the previous panel
+          store.dispatch(clearElements(null));
         }
       );
     }


### PR DESCRIPTION
Issue: (No formal issue - If we would like to track it with an issue, I can create one) When tests are re-run after a11y rules are fixed, the elements that are highlighted remain highlighted until the next time the redux state is changed. This is not expected behavior.

## What I did
I added a line of code to remove the elements from the redux store(In the same way I did on tab switch) when the tests are re-run.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
