### PR TITLE
Fix a11y build by adding hoist-non-react-statics

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -39,12 +39,13 @@
     "memoizerific": "^1.11.3",
     "react": "^16.8.4",
     "react-redux": "^6.0.1",
+    "hoist-non-react-statics": "^3.3.0",
     "redux": "^4.0.1",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@types/common-tags": "^1.8.0",
-    "@types/react-redux": "^7.0.3"
+    "@types/react-redux": "^7.0.6"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3171,10 +3171,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-redux@^7.0.3":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.5.tgz#4d284f8565cd9f7316086cce50e87f3d201d0880"
-  integrity sha512-O0WyoSbrMofJRxtSDe8qYhnmr2SSlTnshlQdnpgpD763L8BzlhXuEseksV7LSoCUwZ7vN4YqpQThl3jp02sceQ==
+"@types/react-redux@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.6.tgz#992271450e0d3bf61130ad9e356ad018841c7f78"
+  integrity sha512-Nlofk/xq8oVWpylvrFayezNb/HONsYJfjlSmTmZ7xoMDe+Muf6c1qHMVRZ7C5S2W1+iVcY21ggZwlUgLv+66hQ==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"


### PR DESCRIPTION
## What I did
I encountered a build error in addon-a11y: https://circleci.com/gh/storybooks/storybook/114635?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link

After reading https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33919 I thought raising `@types/react-redux` would fix it. It did not and the suggested way to fix this is to add `"hoist-non-react-statics": "^3.3.0",`

We should remove this as soon as it is fixed - I will create a separate issue for that task.