### PR TITLE
Allow component class in Angular storiesOf

### DIFF
--- a/app/angular/index.d.ts
+++ b/app/angular/index.d.ts
@@ -1,4 +1,5 @@
 import { NgModuleMetadata, ICollection } from './dist/client/preview/angular/types';
+import { Type } from '@angular/core';
 export { moduleMetadata } from './dist/client/preview/angular/decorators';
 
 export interface IStorybookStory {
@@ -35,7 +36,8 @@ export interface IApi {
 }
 
 declare module '@storybook/angular' {
-  export function storiesOf(kind: string, module: NodeModule): IApi;
+  export function storiesOf(kind: string | Type<any>, module: NodeModule): IApi;
+  export function storiesOf(kind: string, componentClass: Type<any>, module: NodeModule): IApi;
   export function setAddon(addon: any): void;
   export function addDecorator(decorator: any): IApi;
   export function addParameters(parameters: any): IApi;

--- a/app/angular/src/client/preview/index.js
+++ b/app/angular/src/client/preview/index.js
@@ -1,12 +1,11 @@
 import { start } from '@storybook/core/client';
-
+import { moduleMetadata } from './angular/decorators';
 import './globals';
 import render from './render';
 
 const { clientApi, configApi, forceReRender } = start(render);
 
 export const {
-  storiesOf,
   setAddon,
   addDecorator,
   addParameters,
@@ -14,6 +13,40 @@ export const {
   getStorybook,
   raw,
 } = clientApi;
+
+const coreStoriesOf = clientApi.storiesOf;
+
+const classToStoryName = cmpClass => cmpClass.name.replace(/Component$/, '');
+
+export const storiesOf = (a1, a2, a3) => {
+  let kind;
+  let m;
+  let cmpClass;
+
+  if (typeof a1 === 'function') {
+    cmpClass = a1;
+    kind = classToStoryName(a1);
+    m = a2;
+  } else if (typeof a1 === 'string') {
+    if (typeof a2 === 'function') {
+      cmpClass = a2;
+      kind = `${a1}/${classToStoryName(a2)}`;
+      m = a3;
+    } else {
+      kind = a1;
+      m = a2;
+    }
+  }
+
+  if (cmpClass) {
+    return coreStoriesOf(kind, m).addDecorator(
+      moduleMetadata({
+        declarations: [cmpClass],
+      })
+    );
+  }
+  return coreStoriesOf(kind, m);
+};
 
 export const { configure } = configApi;
 export { forceReRender };


### PR DESCRIPTION
## What I did

The need to use the `moduleMetadata` decorator when scaffolding a basic story is something of a pain when using Angular:

```ts
import { storiesOf, moduleMetadata } from '@storybook/angular';
import { MyAwesomeButtonComponent } from './my-awesome-button.component.ts';

storiesOf('MyAwesomeButton', module)
  .addDecorator(moduleMetadata({
    declarations: [MyAwesomeButtonComponent]
  }))
  .add('Default', () => ({
    template: `<my-awesome-button>Hello there</my-awesome-button>`
  });
```

This PR adds a small but, I feel, significant improvement. It allows the user to pass the component class in place of the story name to `storiesOf()`:

```ts
import { storiesOf } from '@storybook/angular';
import { MyAwesomeButtonComponent } from './my-awesome-button.component.ts';

storiesOf(MyAwesomeButtonComponent, module)
  .add('Default', () => ({
    template: `<my-awesome-button>Hello there</my-awesome-button>`
  });
```

When passed a class, the `storiesOf` function will strip out any trailing "Component" from the name and use the rest as the name of story. It also automatically adds a `moduleMetadata` decorator declaring the component in the story module.

You can still nest stories by passing a string as well a component class:

```ts
storiesOf('My App/Buttons', MyAwesomeButtonComponent, module)
```

## How to test

I haven't written tests or docs yet. I want to get feedback on whether this is something we are willing to go for?

If it is, I think there are a number of ways the Angular API could be more helpful. E.g. allowing the story to return a string and automatically wrap it in a `{ template: ... }`. But that's for the future.