### PR TITLE
Add missing props in stories

### DIFF
--- a/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
+++ b/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
@@ -244,6 +244,7 @@ exports[`Storyshots Basics|Brand/StorybookLogo normal 1`] = `
 <svg
   height="40px"
   role="img"
+  title="Storybook"
   viewBox="0 0 200 40"
   width="200px"
 >
@@ -1254,15 +1255,15 @@ exports[`Storyshots Basics|DocumentFormatting withDOM 1`] = `
     </p>
     <ul>
       <li>
-        Create a list by starting a line with 
+        Create a list by starting a line with
         <code>
           +
         </code>
-        , 
+        ,
         <code>
           -
         </code>
-        , or 
+        , or
         <code>
           *
         </code>
@@ -1320,7 +1321,7 @@ exports[`Storyshots Basics|DocumentFormatting withDOM 1`] = `
       </li>
       <li>
         <p>
-          …or keep all the numbers as 
+          …or keep all the numbers as
           <code>
             1.
           </code>
@@ -1457,7 +1458,7 @@ exports[`Storyshots Basics|DocumentFormatting withDOM 1`] = `
       </a>
     </p>
     <p>
-      Autoconverted link 
+      Autoconverted link
       <a
         href="https://github.com/nodeca/pica"
       >
@@ -2519,7 +2520,7 @@ exports[`Storyshots Basics|Placeholder twoChildren 1`] = `
   <div
     class="emotion-3"
   >
-    The second normal weight. Here's a 
+    The second normal weight. Here's a
     <a
       class="emotion-2"
       href="https://storybook.js.org"
@@ -14018,7 +14019,7 @@ exports[`Storyshots UI|Sidebar/SidebarItem with long name 1`] = `
       />
     </svg>
     <span>
-      Story with a long and windy name that is descriptive, precise, and readable. 
+      Story with a long and windy name that is descriptive, precise, and readable.
     </span>
   </div>
 </div>
@@ -15035,7 +15036,7 @@ exports[`Storyshots UI|Sidebar/SidebarStories empty 1`] = `
       <div
         class="emotion-3"
       >
-        Learn how to 
+        Learn how to
         <a
           class="emotion-2"
           href="https://storybook.js.org/basics/writing-stories/"

--- a/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
+++ b/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
@@ -244,7 +244,6 @@ exports[`Storyshots Basics|Brand/StorybookLogo normal 1`] = `
 <svg
   height="40px"
   role="img"
-  title="Storybook"
   viewBox="0 0 200 40"
   width="200px"
 >
@@ -1255,15 +1254,15 @@ exports[`Storyshots Basics|DocumentFormatting withDOM 1`] = `
     </p>
     <ul>
       <li>
-        Create a list by starting a line with
+        Create a list by starting a line with 
         <code>
           +
         </code>
-        ,
+        , 
         <code>
           -
         </code>
-        , or
+        , or 
         <code>
           *
         </code>
@@ -1321,7 +1320,7 @@ exports[`Storyshots Basics|DocumentFormatting withDOM 1`] = `
       </li>
       <li>
         <p>
-          …or keep all the numbers as
+          …or keep all the numbers as 
           <code>
             1.
           </code>
@@ -1458,7 +1457,7 @@ exports[`Storyshots Basics|DocumentFormatting withDOM 1`] = `
       </a>
     </p>
     <p>
-      Autoconverted link
+      Autoconverted link 
       <a
         href="https://github.com/nodeca/pica"
       >
@@ -2520,7 +2519,7 @@ exports[`Storyshots Basics|Placeholder twoChildren 1`] = `
   <div
     class="emotion-3"
   >
-    The second normal weight. Here's a
+    The second normal weight. Here's a 
     <a
       class="emotion-2"
       href="https://storybook.js.org"
@@ -14019,7 +14018,7 @@ exports[`Storyshots UI|Sidebar/SidebarItem with long name 1`] = `
       />
     </svg>
     <span>
-      Story with a long and windy name that is descriptive, precise, and readable.
+      Story with a long and windy name that is descriptive, precise, and readable. 
     </span>
   </div>
 </div>
@@ -15036,7 +15035,7 @@ exports[`Storyshots UI|Sidebar/SidebarStories empty 1`] = `
       <div
         class="emotion-3"
       >
-        Learn how to
+        Learn how to 
         <a
           class="emotion-2"
           href="https://storybook.js.org/basics/writing-stories/"

--- a/lib/ui/src/components/preview/iframe.stories.js
+++ b/lib/ui/src/components/preview/iframe.stories.js
@@ -16,11 +16,19 @@ export const workingStory = () => (
     src="/iframe.html?id=ui-panel--default"
     allowFullScreen
     style={style}
+    scale={1.0}
   />
 );
 
 export const missingStory = () => (
-  <IFrame id="iframe" title="Missing" src="/iframe.html?id=missing" allowFullScreen style={style} />
+  <IFrame
+    id="iframe"
+    title="Missing"
+    src="/iframe.html?id=missing"
+    allowFullScreen
+    style={style}
+    scale={1.0}
+  />
 );
 
 export const errorStory = () => (
@@ -30,6 +38,7 @@ export const errorStory = () => (
     src="/iframe.html?id=core-errors--story-throws-exception"
     allowFullScreen
     style={style}
+    scale={1.0}
   />
 );
 // We need to disable this one in Chromatic because the screenshot includes the uploaded URL sadly:


### PR DESCRIPTION
## What I did

- A couple of the stories were throwing errors in the console when running the Official Storybook example as they were missing some required props. I've added them in.

## How to test

- Run the Official Storybook example and open the console. You should see no more missing prop errors.