### PR TITLE
fix: horizontal scrolling overflow

### DIFF
--- a/addons/centered/src/styles.js
+++ b/addons/centered/src/styles.js
@@ -7,11 +7,12 @@ const styles = {
     right: 0,
     display: 'flex',
     alignItems: 'center',
-    overflow: 'auto',
+    overflow: 'auto'
   },
   innerStyle: {
     margin: 'auto',
     maxHeight: '100%', // Hack for centering correctly in IE11
+    overflow: 'auto'
   },
 };
 

--- a/examples/angular-cli/src/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/angular-cli/src/stories/__snapshots__/addon-centered.stories.storyshot
@@ -13,7 +13,7 @@ exports[`Storyshots Addon|Centered centered component 1`] = `
     >
       <div
         ng-reflect-ng-style="[object Object]"
-        style="margin: auto; max-height: 100%;"
+        style="margin: auto; max-height: 100%; overflow: auto;"
       >
         <storybook-app-root>
           <div
@@ -89,7 +89,7 @@ exports[`Storyshots Addon|Centered centered template 1`] = `
     >
       <div
         ng-reflect-ng-style="[object Object]"
-        style="margin: auto; max-height: 100%;"
+        style="margin: auto; max-height: 100%; overflow: auto;"
       >
         <storybook-button-component
           _nghost-c6=""

--- a/examples/cra-kitchen-sink/src/stories/__snapshots__/long-description.stories.storyshot
+++ b/examples/cra-kitchen-sink/src/stories/__snapshots__/long-description.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Some really long story kind description with text 1`] = `
   style="position:fixed;top:0;left:0;bottom:0;right:0;display:flex;align-items:center;overflow:auto"
 >
   <div
-    style="margin:auto;max-height:100%"
+    style="margin:auto;max-height:100%;overflow:auto"
   >
     <button
       style="border:1px solid #eee;border-radius:3px;background-color:#FFFFFF;cursor:pointer;font-size:15px;padding:3px 10px;margin:10px"

--- a/examples/html-kitchen-sink/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/html-kitchen-sink/stories/__snapshots__/addon-centered.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Addons|Centered button in center 1`] = `
 >
   <div
     id="sb-addon-centered-inner"
-    style="margin: auto; max-height: 100%;"
+    style="margin: auto; max-height: 100%; overflow: auto;"
   >
     <button>
       I am a Button !

--- a/examples/official-storybook/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-centered.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Addons|Centered story 1 1`] = `
   style="position:fixed;top:0;left:0;bottom:0;right:0;display:flex;align-items:center;overflow:auto"
 >
   <div
-    style="margin:auto;max-height:100%"
+    style="margin:auto;max-height:100%;overflow:auto"
   >
     <button
       type="button"

--- a/examples/preact-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/preact-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
@@ -20,6 +20,7 @@ exports[`Storyshots Addons|Centered Button 1`] = `
       Object {
         "margin": "auto",
         "maxHeight": "100%",
+        "overflow": "auto",
       }
     }
   >

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Addon|Centered rounded 1`] = `
   style="position: fixed; top: 0px; left: 0px; bottom: 0px; right: 0px; display: flex; align-items: center; overflow: auto;"
 >
   <div
-    style="margin: auto; max-height: 100%;"
+    style="margin: auto; max-height: 100%; overflow: auto;"
   >
     <button
       class="button rounded"


### PR DESCRIPTION
Issue: A component (In my use case a table with fixed th, td widths) does not overflow when the content of the storybook does not fit de viewport.

## What I did
I added the property `overflow: auto` to the inner div of the centered add-on.

## How to test
This should be tested by setting a viewport width smaller than the width of the component being rendered. 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
