### PR TITLE
Update CLI options usage

### DIFF
--- a/docs/src/pages/configurations/cli-options/index.md
+++ b/docs/src/pages/configurations/cli-options/index.md
@@ -29,6 +29,8 @@ Options:
 --smoke-test                  Exit after successful start
 --ci                          CI mode (skip interactive prompts, don't open browser)
 --quiet                       Suppress verbose build output
+--no-dll                      Do not use dll reference
+--debug-webpack               Display final webpack configurations for debugging purposes
 ```
 
 ## For build-storybook
@@ -44,4 +46,7 @@ Options:
 -o, --output-dir [dir-name]   Directory where to store built files
 -c, --config-dir [dir-name]   Directory where to load Storybook configurations from
 -w, --watch                   Enable watch mode
+--quiet                       Suppress verbose build output
+--no-dll                      Do not use dll reference
+--debug-webpack               Display final webpack configurations for debugging purposes
 ```


### PR DESCRIPTION
Issue:

## What I did
Update CLI options docs
I'm curios why build has no `--quiet` mode to run on CI with no verbose output and it turns out that this options work. It's just missing from the docs.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
