### PR TITLE
fix 'read full changelog' link on about page

### DIFF
--- a/lib/ui/src/settings/about.js
+++ b/lib/ui/src/settings/about.js
@@ -152,6 +152,7 @@ const AboutScreen = ({ latest, current, onClose }) => {
                     secondary
                     href="https://github.com/storybooks/storybook/blob/next/CHANGELOG.md"
                     withArrow
+                    cancel={false}
                     target="_blank"
                   >
                     Read full changelog


### PR DESCRIPTION
Issue:

Clicking it didn't do anything because the `Link` component cancels by default.

## What I did

Made the link actually work.

## How to test

Click the link on the about page and make sure the full changelog opens.