### PR TITLE
fix: Set custom options on first load

### DIFF
--- a/lib/api/src/index.tsx
+++ b/lib/api/src/index.tsx
@@ -142,6 +142,10 @@ class ManagerProvider extends Component<Props, State> {
 
     api.on(SET_STORIES, (data: { stories: StoriesRaw }) => {
       api.setStories(data.stories);
+      const options = storyId
+        ? api.getParameters(storyId, 'options')
+        : api.getParameters(Object.keys(data.stories)[0], 'options');
+      api.setOptions(options);
     });
     api.on(
       SELECT_STORY,


### PR DESCRIPTION
Issue:
`V5.1.0-alpha.20`: Custom options were not loaded on storybook first load, only when selecting a story (changing story)

## What I did
Saw that in v5.0.6 the above issue does not happen, so i've check what have changed and saw when moving the "Provider" from `v5.0.x` to `typescript` in `v5.1.x` in SET_STORIES event there was missing setting the first options, so i've added it back.

## How to test
1. change some options and load them with addParameters.
2. clear localStorage and referesh storybook and see that on first load it'll apply the custom options.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
