### PR TITLE
fix: [core] Respect webpack config stats in static build

### DIFF
--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -23,7 +23,7 @@ async function compileManager(managerConfig, managerStartTime) {
         }
 
         if (stats && (stats.hasErrors() || stats.hasWarnings())) {
-          const { warnings, errors } = stats.toJson();
+          const { warnings, errors } = stats.toJson(managerConfig.stats);
 
           errors.forEach(e => logger.error(e));
           warnings.forEach(e => logger.error(e));
@@ -35,7 +35,7 @@ async function compileManager(managerConfig, managerStartTime) {
       }
 
       logger.trace({ message: '=> manager built', time: process.hrtime(managerStartTime) });
-      stats.toJson().warnings.forEach(e => logger.warn(e));
+      stats.toJson(managerConfig.stats).warnings.forEach(e => logger.warn(e));
 
       resolve(stats);
     });
@@ -52,8 +52,10 @@ async function watchPreview(previewConfig) {
       },
       (error, stats) => {
         if (!error) {
+          const statsConfig = previewConfig.stats ? previewConfig.stats : { colors: true };
+
           // eslint-disable-next-line no-console
-          console.log(stats.toString({ colors: true }));
+          console.log(stats.toString(statsConfig));
         } else {
           logger.error(error.message);
         }
@@ -77,7 +79,7 @@ async function compilePreview(previewConfig, previewStartTime) {
         }
 
         if (stats && (stats.hasErrors() || stats.hasWarnings())) {
-          const { warnings, errors } = stats.toJson();
+          const { warnings, errors } = stats.toJson(previewConfig.stats);
 
           errors.forEach(e => logger.error(e));
           warnings.forEach(e => logger.error(e));
@@ -86,7 +88,7 @@ async function compilePreview(previewConfig, previewStartTime) {
       }
 
       logger.trace({ message: '=> Preview built', time: process.hrtime(previewStartTime) });
-      stats.toJson().warnings.forEach(e => logger.warn(e));
+      stats.toJson(previewConfig.stats).warnings.forEach(e => logger.warn(e));
 
       return resolve(stats);
     });


### PR DESCRIPTION
Issue:

The `stats` webpack config options have no effect on the output.

I think this touches on one part of #5250, though it looks like that issue might not be completely resolved by this PR, as that issue also mentions things about hot module reloading behavior its documentation.

## What I did

I updated `build-static.js` to make sure that we're passing the `stats` config to any method that takes it.

*Note:* I did not update [`dev-server.js`](https://github.com/storybooks/storybook/blob/1c78ccc6323751888695c342a39c4bb026e95b82/lib/core/src/server/dev-server.js#L98-L110) to explicitly pass the `stats` config property. We will instead continue to rely on it being overridden by an optional `config.devServer.stats`.

## How to test

- Is this testable with Jest or Chromatic screenshots? _No_
- Does this need a new example in the kitchen sink apps? _No_
- Does this need an update to the documentation? _I don't think so. This brings the codebase into line with how we'd expect it to work given the current documentation._
