### PR TITLE
[addon: A11Y] use 'indeterminate' checkbox state for partial selected group

### DIFF
--- a/addons/a11y/src/components/A11YPanel.test.js
+++ b/addons/a11y/src/components/A11YPanel.test.js
@@ -26,6 +26,7 @@ const axeResult = {
         'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
       help: 'Elements must have sufficient color contrast',
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=axeAPI',
+      nodes: [],
     },
   ],
   passes: [
@@ -36,6 +37,7 @@ const axeResult = {
       description: "Ensures ARIA attributes are allowed for an element's role",
       help: 'Elements must only use allowed ARIA attributes',
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/aria-allowed-attr?application=axeAPI',
+      nodes: [],
     },
   ],
   violations: [
@@ -47,6 +49,7 @@ const axeResult = {
         'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
       help: 'Elements must have sufficient color contrast',
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=axeAPI',
+      nodes: [],
     },
   ],
 };

--- a/addons/a11y/src/components/A11YPanel.tsx
+++ b/addons/a11y/src/components/A11YPanel.tsx
@@ -91,7 +91,7 @@ export class A11YPanel extends Component<A11YPanelProps, A11YPanelState> {
 
     if (!prevProps.active && active) {
       // removes all elements from the redux map in store from the previous panel
-      store.dispatch(clearElements(null));
+      store.dispatch(clearElements());
       this.request();
     }
   }
@@ -134,7 +134,7 @@ export class A11YPanel extends Component<A11YPanelProps, A11YPanelState> {
         () => {
           api.emit(EVENTS.REQUEST);
           // removes all elements from the redux map in store from the previous panel
-          store.dispatch(clearElements(null));
+          store.dispatch(clearElements());
         }
       );
     }

--- a/addons/a11y/src/components/Report/Elements.tsx
+++ b/addons/a11y/src/components/Report/Elements.tsx
@@ -23,7 +23,7 @@ const HighlightToggleElement = styled.span({
   fontWeight: 'normal',
   float: 'right',
   paddingRight: '15px',
-  input: { margin: 0, },
+  input: { margin: 0 },
 });
 
 interface ElementProps {
@@ -43,7 +43,12 @@ const Element: FunctionComponent<ElementProps> = ({ element, passes, type }) => 
       <ItemTitle>
         {element.target[0]}
         <HighlightToggleElement>
-          <HighlightToggle toggleId={highlightToggleId} type={type} elementsToHighlight={[element]} label={highlightLabel} />
+          <HighlightToggle
+            toggleId={highlightToggleId}
+            type={type}
+            elementsToHighlight={[element]}
+            label={highlightLabel}
+          />
         </HighlightToggleElement>
       </ItemTitle>
       <Rules rules={rules} passes={passes} />

--- a/addons/a11y/src/components/Report/HighlightToggle.tsx
+++ b/addons/a11y/src/components/Report/HighlightToggle.tsx
@@ -53,10 +53,6 @@ function setElementOutlineStyle(targetElement: HTMLElement, outlineStyle: string
   targetElement.style.outline = outlineStyle;
 }
 
-function highlightElement(targetElement: HTMLElement, type: RuleType) {
-  return setElementOutlineStyle(targetElement, `${colorsByType[type]} dotted 1px`);
-}
-
 function areAllRequiredElementsHighlighted(
   elementsToHighlight: NodeResult[],
   highlightedElementsMap: Map<HTMLElement, HighlightedElementData>
@@ -123,7 +119,7 @@ class HighlightToggle extends Component<ToggleProps> {
     }
 
     if (addHighlight) {
-      highlightElement(targetElement, this.props.type);
+      setElementOutlineStyle(targetElement, `${colorsByType[this.props.type]} dotted 1px`);
       return;
     }
 

--- a/addons/a11y/src/components/Report/HighlightToggle.tsx
+++ b/addons/a11y/src/components/Report/HighlightToggle.tsx
@@ -1,22 +1,43 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { styled, themes, convert } from '@storybook/theming';
 import memoize from 'memoizerific';
 
 import { NodeResult } from 'axe-core';
-import { Rules } from './Rules';
 import { RuleType } from '../A11YPanel';
 import { addElement } from '../../redux-config';
 import { IFRAME } from '../../constants';
-
-const Checkbox = styled.input({
-  cursor: 'pointer',
-});
 
 export class HighlightedElementData {
   originalOutline: string;
   isHighlighted: boolean;
 }
+
+interface ToggleProps {
+  elementsToHighlight: NodeResult[];
+  type: RuleType;
+  addElement?: (data: any) => void;
+  highlightedElementsMap?: Map<HTMLElement, HighlightedElementData>;
+  isToggledOn?: boolean;
+  toggleId?: string;
+  indeterminate?: boolean;
+}
+
+enum CheckBoxStates {
+  CHECKED,
+  UNCHECKED,
+  INDETERMINATE,
+}
+
+const Checkbox = styled.input(({ disabled }) => ({
+  cursor: disabled ? 'not-allowed' : 'pointer',
+}));
+
+const colorsByType = [
+  convert(themes.normal).color.negative, // VIOLATION,
+  convert(themes.normal).color.positive, // PASS,
+  convert(themes.normal).color.warning, // INCOMPLETION,
+];
 
 const getIframe = memoize(1)(() => document.getElementsByTagName(IFRAME)[0]);
 
@@ -28,106 +49,96 @@ function getElementBySelectorPath(elementPath: string): HTMLElement {
   return null;
 }
 
-function areAllRequiredElementsHiglighted(
-  elementsToHighlight: NodeResult[],
-  highlightedElementsMap: Map<HTMLElement, HighlightedElementData>
-): boolean {
-  let elementsInMapExist = false;
-  if (elementsToHighlight) {
-    for (let element of elementsToHighlight) {
-      if (element) {
-        const targetElement = getElementBySelectorPath(element.target[0]);
-        if (highlightedElementsMap.get(targetElement)) {
-          elementsInMapExist = true;
-          if (!highlightedElementsMap.get(targetElement).isHighlighted) {
-            return false;
-          }
-        }
-      }
-    }
-  }
-  return elementsInMapExist;
+function setElementOutlineStyle(targetElement: HTMLElement, outlineStyle: string): void {
+  targetElement.style.outline = outlineStyle;
 }
 
-interface ToggleProps {
-  elementsToHighlight: NodeResult[];
-  type: RuleType;
-  addElement?: (data: any) => void;
-  highlightedElementsMap?: Map<HTMLElement, HighlightedElementData>;
-  isToggledOn?: boolean;
-  toggleId?: string;
+function highlightElement(targetElement: HTMLElement, type: RuleType) {
+  return setElementOutlineStyle(targetElement, `${colorsByType[type]} dotted 1px`);
+}
+
+function areAllRequiredElementsHighlighted(
+  elementsToHighlight: NodeResult[],
+  highlightedElementsMap: Map<HTMLElement, HighlightedElementData>
+): CheckBoxStates {
+  const highlightedCount = elementsToHighlight.filter(item => {
+    const targetElement = getElementBySelectorPath(item.target[0]);
+    return (
+      highlightedElementsMap.has(targetElement) &&
+      highlightedElementsMap.get(targetElement).isHighlighted
+    );
+  }).length;
+
+  return highlightedCount === 0
+    ? CheckBoxStates.UNCHECKED
+    : highlightedCount === elementsToHighlight.length
+    ? CheckBoxStates.CHECKED
+    : CheckBoxStates.INDETERMINATE;
 }
 
 function mapDispatchToProps(dispatch: any) {
   return {
-    addElement: (data: any) => dispatch(addElement(data)),
+    addElement: (data: { element: HTMLElement; data: HighlightedElementData }) =>
+      dispatch(addElement(data)),
   };
 }
 
 const mapStateToProps = (state: any, ownProps: any) => {
-  const isToggledOn = areAllRequiredElementsHiglighted(
-    ownProps.elementsToHighlight,
+  const checkBoxState = areAllRequiredElementsHighlighted(
+    ownProps.elementsToHighlight || [],
     state.highlightedElementsMap
   );
   return {
     highlightedElementsMap: state.highlightedElementsMap,
-    isToggledOn,
+    isToggledOn: checkBoxState === CheckBoxStates.CHECKED,
+    indeterminate: checkBoxState === CheckBoxStates.INDETERMINATE,
   };
 };
 
-class HighlightToggle extends Component<ToggleProps, {}> {
+class HighlightToggle extends Component<ToggleProps> {
   static defaultProps: Partial<ToggleProps> = {
     elementsToHighlight: [],
   };
 
+  private checkBoxRef = React.createRef<HTMLInputElement>();
+
   componentDidMount() {
-    for (let element of this.props.elementsToHighlight) {
-      if (element) {
-        const targetElement = getElementBySelectorPath(element.target[0]);
-        if (targetElement && !this.props.highlightedElementsMap.get(targetElement)) {
-          this.saveElementDataToMap(
-            targetElement,
-            false,
-            targetElement.style.outline,
-            this.props.type
-          );
-        }
+    this.props.elementsToHighlight.forEach(element => {
+      const targetElement = getElementBySelectorPath(element.target[0]);
+      if (targetElement && !this.props.highlightedElementsMap.has(targetElement)) {
+        this.saveElementDataToMap(targetElement, false, targetElement.style.outline);
       }
+    });
+  }
+
+  componentDidUpdate(prevProps: Readonly<ToggleProps>): void {
+    if (this.checkBoxRef.current) {
+      this.checkBoxRef.current.indeterminate = this.props.indeterminate;
     }
   }
 
-  higlightRuleLocation(targetElement: HTMLElement, addHighlight: boolean): void {
-    const OUTLINE_STYLE = `dotted`;
-    const OUTLINE_WIDTH = `1px`;
-    if (targetElement) {
-      if (addHighlight) {
-        switch (this.props.type) {
-          case RuleType.PASS:
-            this.setTargetElementOutlineStyle(targetElement, `${convert(themes.normal).color.positive} ${OUTLINE_STYLE} ${OUTLINE_WIDTH}`);
-            break;
-          case RuleType.VIOLATION:
-            this.setTargetElementOutlineStyle(targetElement, `${convert(themes.normal).color.negative} ${OUTLINE_STYLE} ${OUTLINE_WIDTH}`);
-            break;
-          case RuleType.INCOMPLETION:
-            this.setTargetElementOutlineStyle(targetElement, `${convert(themes.normal).color.warning} ${OUTLINE_STYLE} ${OUTLINE_WIDTH}`);
-            break;
-        }
-      } else {
-        if (this.props.highlightedElementsMap.get(targetElement)) {
-          this.setTargetElementOutlineStyle(
-            targetElement,
-            this.props.highlightedElementsMap.get(targetElement).originalOutline
-          );
-        }
-      }
+  highlightRuleLocation(targetElement: HTMLElement, addHighlight: boolean): void {
+    if (!targetElement) {
+      return;
+    }
+
+    if (addHighlight) {
+      highlightElement(targetElement, this.props.type);
+      return;
+    }
+
+    if (this.props.highlightedElementsMap.has(targetElement)) {
+      setElementOutlineStyle(
+        targetElement,
+        this.props.highlightedElementsMap.get(targetElement).originalOutline
+      );
     }
   }
 
   saveElementDataToMap(
     targetElement: HTMLElement,
     isHighlighted: boolean,
-    originalOutline: string,
-    ruleTypeState: RuleType
+    originalOutline: string
   ): void {
     const data: HighlightedElementData = new HighlightedElementData();
     data.isHighlighted = isHighlighted;
@@ -136,42 +147,32 @@ class HighlightToggle extends Component<ToggleProps, {}> {
     this.props.addElement(payload);
   }
 
-  setTargetElementOutlineStyle(targetElement: HTMLElement, outlineStyle: string): void {
-    targetElement.style.outline = outlineStyle;
-  }
-
-  onToggle(): void {
-    for (let element of this.props.elementsToHighlight) {
-      if (element) {
-        const targetElement = getElementBySelectorPath(element.target[0]);
-        if (this.props.highlightedElementsMap.get(targetElement)) {
-          let originalOutline = this.props.highlightedElementsMap.get(targetElement).originalOutline;
-          if (
-            this.props.isToggledOn &&
-            this.props.highlightedElementsMap.get(targetElement).isHighlighted
-          ) {
-            this.higlightRuleLocation(targetElement, false);
-            this.saveElementDataToMap(targetElement, false, originalOutline, this.props.type);
-          } else if (
-            !this.props.isToggledOn &&
-            !this.props.highlightedElementsMap.get(targetElement).isHighlighted
-          ) {
-            this.higlightRuleLocation(targetElement, true);
-            this.saveElementDataToMap(targetElement, true, originalOutline, this.props.type);
-          }
-        }
+  onToggle = (): void => {
+    this.props.elementsToHighlight.forEach(element => {
+      const targetElement = getElementBySelectorPath(element.target[0]);
+      if (!this.props.highlightedElementsMap.has(targetElement)) {
+        return;
       }
-    }
-  }
+      const originalOutline = this.props.highlightedElementsMap.get(targetElement).originalOutline;
+      const { isHighlighted } = this.props.highlightedElementsMap.get(targetElement);
+      const { isToggledOn } = this.props;
+      if ((isToggledOn && isHighlighted) || (!isToggledOn && !isHighlighted)) {
+        const addHighlight = !isToggledOn && !isHighlighted;
+        this.highlightRuleLocation(targetElement, addHighlight);
+        this.saveElementDataToMap(targetElement, addHighlight, originalOutline);
+      }
+    });
+  };
 
   render() {
     return (
       <Checkbox
+        ref={this.checkBoxRef}
         id={this.props.toggleId}
         type="checkbox"
         aria-label="Highlight result"
-        disabled={this.props.elementsToHighlight && this.props.elementsToHighlight.length === 0 ? true : false}
-        onChange={() => this.onToggle()}
+        disabled={!this.props.elementsToHighlight.length}
+        onChange={this.onToggle}
         checked={this.props.isToggledOn}
       />
     );

--- a/addons/a11y/src/components/Report/Item.tsx
+++ b/addons/a11y/src/components/Report/Item.tsx
@@ -51,7 +51,7 @@ const HighlightToggleElement = styled.span({
   marginRight: '15px',
   marginTop: '10px',
 
-  input: { margin: 0, },
+  input: { margin: 0 },
 });
 
 interface ItemProps {
@@ -94,7 +94,11 @@ export class Item extends Component<ItemProps, ItemState> {
             {item.description}
           </HeaderBar>
           <HighlightToggleElement>
-            <HighlightToggle toggleId={highlightToggleId} type={type} elementsToHighlight={item ? item.nodes : null} />
+            <HighlightToggle
+              toggleId={highlightToggleId}
+              type={type}
+              elementsToHighlight={item ? item.nodes : null}
+            />
           </HighlightToggleElement>
         </Wrapper>
         {open ? (

--- a/addons/a11y/src/components/Report/__snapshots__/HighlightToggle.test.js.snap
+++ b/addons/a11y/src/components/Report/__snapshots__/HighlightToggle.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`HighlightToggle component should match snapshot 1`] = `
 .emotion-0 {
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 <Provider
@@ -338,6 +338,7 @@ exports[`HighlightToggle component should match snapshot 1`] = `
           addElement={[Function]}
           elementsToHighlight={Array []}
           highlightedElementsMap={Map {}}
+          indeterminate={false}
           isToggledOn={false}
         >
           <Styled(input)

--- a/addons/a11y/src/components/Report/index.tsx
+++ b/addons/a11y/src/components/Report/index.tsx
@@ -1,10 +1,8 @@
 import React, { Fragment, FunctionComponent } from 'react';
 import { Placeholder } from '@storybook/components';
-import { styled } from '@storybook/theming';
-import { Result, NodeResult } from 'axe-core';
+import { Result } from 'axe-core';
 import { Item } from './Item';
 import { RuleType } from '../A11YPanel';
-import HighlightToggle from './HighlightToggle';
 
 export interface ReportProps {
   items: Result[];

--- a/addons/a11y/src/components/Tabs.tsx
+++ b/addons/a11y/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, SyntheticEvent } from 'react';
 
 import { styled } from '@storybook/theming';
 import store, { clearElements } from '../redux-config';
@@ -71,7 +71,7 @@ const TabsWrapper = styled.div({});
 
 const List = styled.div(({ theme }) => ({
   boxShadow: `${theme.appBorderColor} 0 -1px 0 0 inset`,
-  background: 'rgba(0,0,0,.05)',
+  background: 'rgba(0, 0, 0, .05)',
   display: 'flex',
   justifyContent: 'space-between',
   whiteSpace: 'nowrap',
@@ -90,26 +90,22 @@ interface TabsState {
   active: number;
 }
 
+function retrieveAllNodesFromResults(items: Result[]): NodeResult[] {
+  return items.reduce((acc, item) => acc.concat(item.nodes), []);
+}
+
 export class Tabs extends Component<TabsProps, TabsState> {
   state: TabsState = {
     active: 0,
   };
 
-  onToggle = (index: number) => {
+  onToggle = (event: SyntheticEvent) => {
     this.setState({
-      active: index,
+      active: parseInt(event.currentTarget.getAttribute('data-index'), 10),
     });
     // removes all elements from the redux map in store from the previous panel
-    store.dispatch(clearElements(null));
+    store.dispatch(clearElements());
   };
-
-  retrieveAllNodeResults(items: Result[]): NodeResult[] {
-    let nodeArray: NodeResult[] = [];
-    for (const item of items) {
-      nodeArray = nodeArray.concat(item.nodes);
-    }
-    return nodeArray;
-  }
 
   render() {
     const { tabs } = this.props;
@@ -120,21 +116,25 @@ export class Tabs extends Component<TabsProps, TabsState> {
       <Container>
         <List>
           <TabsWrapper>
-          {tabs.map((tab, index) => (
-            <Item
-              key={index}
-              active={active === index ? true : undefined}
-              onClick={() => this.onToggle(index)}>
-              {tab.label}
-            </Item>
-          ))}
+            {tabs.map((tab, index) => (
+              <Item
+                key={index}
+                data-index={index}
+                active={active === index}
+                onClick={this.onToggle}
+              >
+                {tab.label}
+              </Item>
+            ))}
           </TabsWrapper>
           <GlobalToggleWrapper>
-            <HighlightToggleLabel htmlFor={highlightToggleId}>{highlightLabel}</HighlightToggleLabel>
+            <HighlightToggleLabel htmlFor={highlightToggleId}>
+              {highlightLabel}
+            </HighlightToggleLabel>
             <HighlightToggle
               toggleId={highlightToggleId}
               type={tabs[active].type}
-              elementsToHighlight={this.retrieveAllNodeResults(tabs[active].items)}
+              elementsToHighlight={retrieveAllNodesFromResults(tabs[active].items)}
               label={highlightLabel}
             />
           </GlobalToggleWrapper>

--- a/addons/a11y/src/components/__snapshots__/A11YPanel.test.js.snap
+++ b/addons/a11y/src/components/__snapshots__/A11YPanel.test.js.snap
@@ -215,7 +215,7 @@ exports[`A11YPanel should render report 1`] = `
 }
 
 .emotion-8 {
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .emotion-12 {
@@ -336,16 +336,15 @@ exports[`A11YPanel should render report 1`] = `
                 "110qmus": true,
                 "152wg9i": true,
                 "1551xjo": true,
+                "15paq49": true,
                 "176o2y5": true,
                 "1977chw": true,
                 "1cwfnw4": true,
                 "1fp6daz": true,
-                "1kjdm0k": true,
                 "1l7fvsg": true,
                 "1myfomu": true,
                 "1s6ajii": true,
                 "1vwgrhn": true,
-                "4g6ai3": true,
                 "4ryd4s": true,
                 "6hqipu": true,
                 "animation-u07e3c": true,
@@ -360,6 +359,7 @@ exports[`A11YPanel should render report 1`] = `
                 "qb28": true,
                 "snh8f7": true,
                 "tkevr6": true,
+                "vdhlfv": true,
               },
               "key": "css",
               "nonce": undefined,
@@ -683,7 +683,7 @@ exports[`A11YPanel should render report 1`] = `
                     data-emotion="css"
                   >
                     
-                    .emotion-8{cursor:pointer;}
+                    .emotion-8{cursor:not-allowed;}
                   </style>
                   <style
                     data-emotion="css"
@@ -911,7 +911,7 @@ exports[`A11YPanel should render report 1`] = `
                     data-emotion="css"
                   >
                     
-                    .emotion-8{cursor:pointer;}
+                    .emotion-8{cursor:not-allowed;}
                   </style>,
                   <style
                     data-emotion="css"
@@ -1163,11 +1163,13 @@ exports[`A11YPanel should render report 1`] = `
                                   >
                                     <Styled(button)
                                       active={true}
+                                      data-index={0}
                                       key="0"
                                       onClick={[Function]}
                                     >
                                       <button
                                         className="emotion-1"
+                                        data-index={0}
                                         onClick={[Function]}
                                       >
                                         <Styled(span)>
@@ -1181,11 +1183,14 @@ exports[`A11YPanel should render report 1`] = `
                                       </button>
                                     </Styled(button)>
                                     <Styled(button)
+                                      active={false}
+                                      data-index={1}
                                       key="1"
                                       onClick={[Function]}
                                     >
                                       <button
                                         className="emotion-3"
+                                        data-index={1}
                                         onClick={[Function]}
                                       >
                                         <Styled(span)>
@@ -1199,11 +1204,14 @@ exports[`A11YPanel should render report 1`] = `
                                       </button>
                                     </Styled(button)>
                                     <Styled(button)
+                                      active={false}
+                                      data-index={2}
                                       key="2"
                                       onClick={[Function]}
                                     >
                                       <button
                                         className="emotion-3"
+                                        data-index={2}
                                         onClick={[Function]}
                                       >
                                         <Styled(span)>
@@ -1242,6 +1250,7 @@ exports[`A11YPanel should render report 1`] = `
                                         addElement={[Function]}
                                         elementsToHighlight={Array []}
                                         highlightedElementsMap={Map {}}
+                                        indeterminate={false}
                                         isToggledOn={false}
                                         label="Highlight results"
                                         toggleId="0-global-checkbox"

--- a/addons/a11y/src/redux-config.tsx
+++ b/addons/a11y/src/redux-config.tsx
@@ -1,16 +1,17 @@
 import { createStore } from 'redux';
 import { ADD_ELEMENT, CLEAR_ELEMENTS } from './constants';
+import { HighlightedElementData } from './components/Report/HighlightToggle';
 
 // actions
 
 // add element is passed a HighlightedElementData object as the payload
-export function addElement(payload: any) {
+export function addElement(payload: { element: HTMLElement; data: HighlightedElementData }) {
   return { type: ADD_ELEMENT, payload };
 }
 
 // clear elements is a function to remove elements from the map and reset elements to their original state
-export function clearElements(payload: any) {
-  return { type: CLEAR_ELEMENTS, payload };
+export function clearElements() {
+  return { type: CLEAR_ELEMENTS };
 }
 
 // reducers


### PR DESCRIPTION
Issue: N/A

## What I did
Basically, I add [indeterminate](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate) checkbox state for partially checking the group. I hope it does not worsen UX.

Besides, mini refactor, types, tslint fixes, and other.
![2019-04-02 22 22 30](https://user-images.githubusercontent.com/3195714/55506217-90098100-565d-11e9-8ec8-ed7a60d77cdd.gif)

