### PR TITLE
Add doc to explain nesting stories under titles

### DIFF
--- a/docs/src/pages/basics/writing-stories/index.md
+++ b/docs/src/pages/basics/writing-stories/index.md
@@ -181,6 +181,23 @@ storiesOf('My App/Buttons/Emoji', module).add('with some emoji', () => (
 ));
 ```
 
+## Organising stories with titles
+
+Stories can be organized under a title using "|" as a separator:
+
+```jsx
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Button from '../components/Button';
+
+/**
+ * The Button stories will show up underneath the 'Components' title.
+ */
+storiesOf('Components|Button', module).add('base', () => (
+  <Button onClick={() => console.log('Clicked')}>Example Button</Button>
+));
+```
+
 ## Generating nesting path based on \_\_dirname
 
 Nesting paths can be programmatically generated with template literals because story names are strings.

--- a/docs/src/pages/basics/writing-stories/index.md
+++ b/docs/src/pages/basics/writing-stories/index.md
@@ -198,6 +198,10 @@ storiesOf('Components|Button', module).add('base', () => (
 ));
 ```
 
+If you would prefer to use another character as the separator then you can
+configure it using the `hierarchyRootSeparator` config option. Visit the
+[configuration options parameter](/configurations/options-parameter) page to learn more.
+
 ## Generating nesting path based on \_\_dirname
 
 Nesting paths can be programmatically generated with template literals because story names are strings.


### PR DESCRIPTION
Issue: N/A

## What I did

Added a section to the 'Writing Stories' documentation explaining how to nest stories under titles in the Storybook sidebar.

