### PR TITLE
🛑yarn prepare errors in the logs

### DIFF
--- a/scripts/compile-js.js
+++ b/scripts/compile-js.js
@@ -22,10 +22,10 @@ function getCommand(watch) {
   return `${babel} ${args.join(' ')}`;
 }
 
-function handleExit(code, errorCallback) {
+function handleExit(code, stderr, errorCallback) {
   if (code !== 0) {
     if (errorCallback && typeof errorCallback === 'function') {
-      errorCallback();
+      errorCallback(stderr);
     }
 
     shell.exit(code);
@@ -43,9 +43,10 @@ function babelify(options = {}) {
   }
 
   const command = getCommand(watch);
-  const { code } = shell.exec(command, { silent });
 
-  handleExit(code, errorCallback);
+  const { code, stderr } = shell.exec(command, { silent });
+
+  handleExit(code, stderr, errorCallback);
 }
 
 module.exports = {

--- a/scripts/compile-ts.js
+++ b/scripts/compile-ts.js
@@ -15,10 +15,10 @@ function getCommand(watch) {
   return `${tsc} ${args.join(' ')}`;
 }
 
-function handleExit(code, errorCallback) {
+function handleExit(code, stderr, errorCallback) {
   if (code !== 0) {
     if (errorCallback && typeof errorCallback === 'function') {
-      errorCallback();
+      errorCallback(stderr);
     }
 
     shell.exit(code);
@@ -47,9 +47,9 @@ function tscfy(options = {}) {
   }
 
   const command = getCommand(watch);
-  const { code } = shell.exec(command, { silent });
+  const { code, stderr } = shell.exec(command, { silent });
 
-  handleExit(code, errorCallback);
+  handleExit(code, stderr, errorCallback);
 }
 
 module.exports = {

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -29,7 +29,8 @@ function removeTsFromDist() {
   }
 }
 
-function logError(type, packageJson) {
+function logError(type, packageJson, errorLogs) {
+  log.error(`FAILED (${type}) : ${errorLogs}`);
   log.error(
     `FAILED to compile ${type}: ${chalk.bold(`${packageJson.name}@${packageJson.version}`)}`
   );
@@ -39,11 +40,11 @@ const packageJson = getPackageJson();
 
 removeDist();
 if (packageJson && packageJson.types && packageJson.types.indexOf('d.ts') !== -1) {
-  tscfy({ errorCallback: () => logError('ts', packageJson) });
+  tscfy({ errorCallback: errorLogs => logError('ts', packageJson, errorLogs) });
 } else {
-  babelify({ errorCallback: () => logError('js', packageJson) });
+  babelify({ errorCallback: errorLogs => logError('js', packageJson, errorLogs) });
   removeTsFromDist();
-  tscfy({ errorCallback: () => logError('ts', packageJson) });
+  tscfy({ errorCallback: errorLogs => logError('ts', packageJson, errorLogs) });
 }
 
 console.log(chalk.gray(`Built: ${chalk.bold(`${packageJson.name}@${packageJson.version}`)}`));


### PR DESCRIPTION
Issue:

## What I did
when `yarn prepare` is failing, we only see 'FAILED'. Sometimes we are just merging next in our branch and we are unaware of what can have caused the compilation error.

So I propose to display the babel errors in the logs

## How to test

Just modify a source and inject a compilation error, then run `yarn prepare` on the project.

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

![image](https://user-images.githubusercontent.com/1233790/55544539-98000a00-56cb-11e9-8f30-4cf77c58b004.png)
