### PR TITLE
[bug] Move '@emotion/*' path-resolutions to the dependent package

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -32,6 +32,7 @@
     "@storybook/core-events": "5.1.0-alpha.22",
     "@storybook/node-logger": "5.1.0-alpha.22",
     "@storybook/router": "5.1.0-alpha.22",
+    "@storybook/theming": "5.1.0-alpha.22",
     "@storybook/ui": "5.1.0-alpha.22",
     "airbnb-js-shims": "^1 || ^2",
     "autoprefixer": "^9.4.9",

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -3,6 +3,7 @@ import webpack from 'webpack';
 import Dotenv from 'dotenv-webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
+import themingPaths from '@storybook/theming/paths';
 import uiPaths from '@storybook/ui/paths';
 
 import findCacheDir from 'find-cache-dir';
@@ -65,6 +66,7 @@ export default ({ configDir, configType, entries, dll, outputDir, cache, babelOp
       extensions: ['.mjs', '.js', '.jsx', '.json'],
       modules: ['node_modules'].concat(raw.NODE_PATH || []),
       alias: {
+        ...themingPaths,
         ...uiPaths,
       },
     },

--- a/lib/theming/paths.js
+++ b/lib/theming/paths.js
@@ -5,4 +5,5 @@ const { dirname } = require('path');
 module.exports = {
   '@emotion/core': dirname(require.resolve('@emotion/core/package.json')),
   '@emotion/styled': dirname(require.resolve('@emotion/styled/package.json')),
+  'emotion-theming': dirname(require.resolve('emotion-theming/package.json')),
 };

--- a/lib/theming/paths.js
+++ b/lib/theming/paths.js
@@ -1,0 +1,8 @@
+const { dirname } = require('path');
+
+// These paths need to be aliased in the manager webpack config to ensure that all
+// code running inside the manager uses the *same* versions of each package.
+module.exports = {
+  '@emotion/core': dirname(require.resolve('@emotion/core/package.json')),
+  '@emotion/styled': dirname(require.resolve('@emotion/styled/package.json')),
+};

--- a/lib/ui/paths.js
+++ b/lib/ui/paths.js
@@ -12,7 +12,6 @@ module.exports = {
   '@storybook/theming': dirname(require.resolve('@storybook/theming/package.json')),
   '@storybook/ui': dirname(require.resolve('@storybook/ui/package.json')),
   'core-js': dirname(require.resolve('core-js/package.json')),
-  'emotion-theming': dirname(require.resolve('emotion-theming/package.json')),
   'prop-types': dirname(require.resolve('prop-types/package.json')),
   react: dirname(require.resolve('react/package.json')),
   'react-dom': dirname(require.resolve('react-dom/package.json')),

--- a/lib/ui/paths.js
+++ b/lib/ui/paths.js
@@ -3,8 +3,6 @@ const { dirname } = require('path');
 // These paths need to be aliased in the manager webpack config to ensure that all
 // code running inside the manager uses the *same* version of react[-dom] that we use.
 module.exports = {
-  '@emotion/core': dirname(require.resolve('@emotion/core/package.json')),
-  '@emotion/styled': dirname(require.resolve('@emotion/styled/package.json')),
   '@storybook/addons': dirname(require.resolve('@storybook/addons/package.json')),
   '@storybook/api': dirname(require.resolve('@storybook/api/package.json')),
   '@storybook/channels': dirname(require.resolve('@storybook/channels/package.json')),


### PR DESCRIPTION
Issue: #5817, #6255 

In certain cases, `yarn install` would create a directory structure where `@emotion/core` lived inside the `./node_modules/@storybook/theming/node_modules` directory. This caused `require.resolve('@emotion/core/package.json')` within `./node_modules/@storybook/ui/paths.js` to fail.

## What I did

I moved the `require.resolve` stuff for the `@emotion` packages into `@storybook/theming`, which actually lists them as dependencies. I then set up `manager-webpack.config.js` to import those paths from `@storybook/theming`.

## How to test

- Is this testable with Jest or Chromatic screenshots? _No_
- Does this need a new example in the kitchen sink apps? _No_
- Does this need an update to the documentation? _No_
