### PR TITLE
fix(about): clickable footer links

### DIFF
--- a/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
+++ b/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
@@ -5827,6 +5827,7 @@ exports[`Storyshots UI|Settings/SettingsFooter basic 1`] = `
     <a
       class="emotion-1"
       href="https://storybook.js.org"
+      target="_blank"
     >
       <span
         class="emotion-0"
@@ -5837,6 +5838,7 @@ exports[`Storyshots UI|Settings/SettingsFooter basic 1`] = `
     <a
       class="emotion-1"
       href="https://github.com/storybooks/storybook"
+      target="_blank"
     >
       <span
         class="emotion-0"
@@ -5847,6 +5849,7 @@ exports[`Storyshots UI|Settings/SettingsFooter basic 1`] = `
     <a
       class="emotion-1"
       href="https://storybook.js.org/support"
+      target="_blank"
     >
       <span
         class="emotion-0"
@@ -7351,6 +7354,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
             <a
               class="emotion-91"
               href="https://storybook.js.org"
+              target="_blank"
             >
               <span
                 class="emotion-90"
@@ -7361,6 +7365,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
             <a
               class="emotion-91"
               href="https://github.com/storybooks/storybook"
+              target="_blank"
             >
               <span
                 class="emotion-90"
@@ -7371,6 +7376,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
             <a
               class="emotion-91"
               href="https://storybook.js.org/support"
+              target="_blank"
             >
               <span
                 class="emotion-90"

--- a/lib/ui/src/settings/SettingsFooter.js
+++ b/lib/ui/src/settings/SettingsFooter.js
@@ -16,13 +16,13 @@ const Footer = styled.div(({ theme }) => ({
 }));
 const SettingsFooter = props => (
   <Footer {...props}>
-    <Link secondary href="https://storybook.js.org">
+    <Link secondary href="https://storybook.js.org" cancel={false} target="_blank">
       Docs
     </Link>
-    <Link secondary href="https://github.com/storybooks/storybook">
+    <Link secondary href="https://github.com/storybooks/storybook" cancel={false} target="_blank">
       GitHub
     </Link>
-    <Link secondary href="https://storybook.js.org/support">
+    <Link secondary href="https://storybook.js.org/support" cancel={false} target="_blank">
       Support
     </Link>
   </Footer>

--- a/lib/ui/src/settings/__snapshots__/about.stories.storyshot
+++ b/lib/ui/src/settings/__snapshots__/about.stories.storyshot
@@ -538,6 +538,7 @@ exports[`Storyshots UI|Settings/AboutScreen failed to fetch new version 1`] = `
             <a
               class="emotion-17"
               href="https://storybook.js.org"
+              target="_blank"
             >
               <span
                 class="emotion-16"
@@ -548,6 +549,7 @@ exports[`Storyshots UI|Settings/AboutScreen failed to fetch new version 1`] = `
             <a
               class="emotion-17"
               href="https://github.com/storybooks/storybook"
+              target="_blank"
             >
               <span
                 class="emotion-16"
@@ -558,6 +560,7 @@ exports[`Storyshots UI|Settings/AboutScreen failed to fetch new version 1`] = `
             <a
               class="emotion-17"
               href="https://storybook.js.org/support"
+              target="_blank"
             >
               <span
                 class="emotion-16"
@@ -2033,6 +2036,7 @@ exports[`Storyshots UI|Settings/AboutScreen new version required 1`] = `
             <a
               class="emotion-33"
               href="https://storybook.js.org"
+              target="_blank"
             >
               <span
                 class="emotion-32"
@@ -2043,6 +2047,7 @@ exports[`Storyshots UI|Settings/AboutScreen new version required 1`] = `
             <a
               class="emotion-33"
               href="https://github.com/storybooks/storybook"
+              target="_blank"
             >
               <span
                 class="emotion-32"
@@ -2053,6 +2058,7 @@ exports[`Storyshots UI|Settings/AboutScreen new version required 1`] = `
             <a
               class="emotion-33"
               href="https://storybook.js.org/support"
+              target="_blank"
             >
               <span
                 class="emotion-32"
@@ -3112,6 +3118,7 @@ exports[`Storyshots UI|Settings/AboutScreen up to date 1`] = `
             <a
               class="emotion-19"
               href="https://storybook.js.org"
+              target="_blank"
             >
               <span
                 class="emotion-18"
@@ -3122,6 +3129,7 @@ exports[`Storyshots UI|Settings/AboutScreen up to date 1`] = `
             <a
               class="emotion-19"
               href="https://github.com/storybooks/storybook"
+              target="_blank"
             >
               <span
                 class="emotion-18"
@@ -3132,6 +3140,7 @@ exports[`Storyshots UI|Settings/AboutScreen up to date 1`] = `
             <a
               class="emotion-19"
               href="https://storybook.js.org/support"
+              target="_blank"
             >
               <span
                 class="emotion-18"


### PR DESCRIPTION
Issue: N/A
Same fix like a https://github.com/storybooks/storybook/pull/6385

## What I did
Add `cancel=false` and `target=_blank` for footer links in about page

## How to test
Open `/?path=/settings/about` page
Click 'Docs', 'GitHub' or 'Support'