### PR TITLE
fix(api): remove `sanitize` call on reducing stories to groups

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -207,7 +207,7 @@ const initStoriesApi = ({
           (soFar, group, index, original) => {
             const { name } = group;
             const parent = index > 0 && soFar[index - 1].id;
-            const id = sanitize(parent ? `${parent}-${name}` : name);
+            const id = parent ? `${parent}-${name}` : name;
 
             const result: Group = {
               ...group,


### PR DESCRIPTION
Issue: #6128 

DISCLAIMER: it's not fix, it's my opinion for fix that issue

## What I did
I removed `sanitize`. It's excess filter.  
I dont see problem when user calls he story with using special chars.

About @tuchk4 issue: 
If story name `Vue <docs/>` and not set 'hierarchySeparator', 'hierarchySeparator' fallback to '/' and story split to group and then compat 'storyname'. Eg: 'a/b' -> a--b. In your case, last '>' symbol removed after sanitizing and story child has been equal to the story parent. It's throwing the recursive error. 

I hope I described the error correctly. Feel free to correct me.

## How to test
Check that I didn't have broken any stories cases.