### PR TITLE
Add out-of-the-box support for *.md in Angular apps

### DIFF
--- a/lib/cli/generators/ANGULAR/template/.storybook/tsconfig.json
+++ b/lib/cli/generators/ANGULAR/template/.storybook/tsconfig.json
@@ -13,5 +13,8 @@
   "include": [
     "../src/**/*",
     "../projects/**/*"
+  ],
+  "files": [
+    "./typings.d.ts"
   ]
 }

--- a/lib/cli/generators/ANGULAR/template/.storybook/typings.d.ts
+++ b/lib/cli/generators/ANGULAR/template/.storybook/typings.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6434

## What I did
In Angular apps (in theory this affects every TS-project) you had to add a module for being able to import `*.md` files or Storybook cannot start 

I added this module declaration in `sb init`

## How to test

- Checkout this branch
- `yarn && yarn bootstrap --core`
- Link `lib/cli` locally 
- Create a new Angular app and run `sb init`
- Create a markdown file and use it inside a story

Storybook should be able to start and markdown should work out-of-the-box