### PR TITLE
Remove deprecated info on Theme's doc

### DIFF
--- a/docs/src/pages/configurations/theming/index.md
+++ b/docs/src/pages/configurations/theming/index.md
@@ -38,7 +38,6 @@ import { themes } from '@storybook/theming';
 // Option defaults.
 addParameters({
   options: {
-    name: 'Foo',
     theme: themes.dark,
   },
 });


### PR DESCRIPTION
From storybook v5, `name` and `url` are deprecated and moved to `theme` object with `brandTitle, brandUrl`. It is working now since `name, url` are backward compatibility until 6.0.    It would be better if it is removed from the doc for less confusion.

## What I did
I removed `name`  key/value on arguments `of addParameter()`

## How to test

- Is this testable with Jest or Chromatic screenshots?  NO
- Does this need a new example in the kitchen sink apps? NO
- Does this need an update to the documentation?  YES

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
