### PR TITLE
update typescript docs to reference docgen loader

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -13,7 +13,7 @@ This is a central reference for using Storybook with TypeScript.
 yarn add -D typescript
 yarn add -D awesome-typescript-loader
 yarn add -D @types/storybook__react # typings
-yarn add -D @storybook/addon-info react-docgen-typescript-webpack-plugin # optional but recommended
+yarn add -D @storybook/addon-info react-docgen-typescript-loader # optional but recommended
 yarn add -D jest "@types/jest" ts-jest #testing
 ```
 


### PR DESCRIPTION
I'm guessing this was an oversight from some recent upgrade.

Issue: documentation told me to install a plugin, but it appears it then wants me to use a loader.

## What I did
Checked what the modern approach is (use the loader) and updated the documentation.

## How to test
- Does this need an update to the documentation?

Yes.