### PR TITLE
Fix overriding webpack loaders example

### DIFF
--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -253,6 +253,6 @@ const path = require('path');
 const custom = require('../webpack.config.js');
 
 module.exports = async ({ config, mode }) => {
-  return { ...config, loaders: custom.loaders };
+  return { ...config, module: { ...config.module, rules: custom.module.rules } };
 };
 ```


### PR DESCRIPTION
Issue: none

## What I did
Fix example to actual structure webpack's config

## How to test
Create a storybook with custom webpack config like at example
