### PR TITLE
Fix 'SidebarHeading' according to its inputs 

### DIFF
--- a/lib/theming/src/create.ts
+++ b/lib/theming/src/create.ts
@@ -172,7 +172,7 @@ export const convert = (inherit: ThemeVars = lightThemeVars): Theme => {
     brand: {
       title: brandTitle,
       url: brandUrl,
-      image: brandImage || brandTitle ? null : undefined,
+      image: brandImage,
     },
 
     code: createSyntax({

--- a/lib/ui/src/components/sidebar/SidebarHeading.js
+++ b/lib/ui/src/components/sidebar/SidebarHeading.js
@@ -69,35 +69,43 @@ const Head = styled.div({
   justifyContent: 'space-between',
 });
 
-const Brand = withTheme(({ theme: { brand: { title = 'Storybook', url = './', image } } }) => {
-  const targetValue = url === './' ? '' : '_blank';
-  if (image === undefined && url === null) {
-    return <Logo alt={title} />;
-  }
-  if (image === undefined && url) {
+const Brand = withTheme(({ theme: { brand } }) => {
+  const { image, url } = brand;
+  const defaultTitle = 'Storybook';
+  const defaultUrl = './';
+  const title = brand.title || defaultTitle;
+  const targetValue = url ? '_blank' : '';
+  if (image && url) {
     return (
       <LogoLink href={url} target={targetValue}>
-        <Logo alt={title} />
-      </LogoLink>
-    );
-  }
-  if (image === null && url === null) {
-    return title;
-  }
-  if (image === null && url) {
-    return (
-      <LogoLink href={url} target={targetValue}>
-        {title}
+        <Img src={image} alt={title} />
       </LogoLink>
     );
   }
   if (image && url === null) {
     return <Img src={image} alt={title} />;
   }
-  if (image && url) {
+  if (image && typeof url === 'undefined') {
+    return (
+      <LogoLink href={defaultUrl} target={targetValue}>
+        <Img src={image} alt={title} />
+      </LogoLink>
+    );
+  }
+  if (!image && url) {
     return (
       <LogoLink href={url} target={targetValue}>
-        <Img src={image} alt={title} />
+        {title}
+      </LogoLink>
+    );
+  }
+  if (!image && url === null) {
+    return brand.title || <Logo alt={defaultTitle} />;
+  }
+  if (!image && typeof url === 'undefined') {
+    return (
+      <LogoLink href={defaultUrl} target={targetValue}>
+        {brand.title || <Logo alt={defaultTitle} />}
       </LogoLink>
     );
   }


### PR DESCRIPTION
Issue: #5866

When creating theme object, `brandTitle, brandUrl, brandImage` are optional but It is partially working as intended.(Cases such as defining `brandTitle` doesn't change the title)

## How to reproduce

-  Create theme object with defining only `brandTitle`. I expect sidebar's heading to be changed but It doesn't.
```
import { create } from '@storybook/theming';
const myTheme = create({
  base: 'light',
  brandTitle: 'My custom storybook',
});
```

- When `brandUrl` is only defined and with `null` , It should show the default storybook logo, but text 'Storybook' is shown 
```
import { create } from '@storybook/theming';
const myTheme = create({
  base: 'light',
  brandUrl: null
});
```

## What I did
I changed the logic of using theme's brand  object to match all the possible cases(combinations of value being defined, undefined, null on `brandTitle, brandUrl, brandImage`)

## How to test

- Is this testable with Jest or Chromatic screenshots? I'm not sure.
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

About the test can you please guide me if it is needed or how to do it? [Maybe here?](https://github.com/storybooks/storybook/blob/next/lib/theming/src/tests/create.test.js#L51)  But the problem here is not when creating theme object, rather when it is before rendered. Then It sounds like an snapshot or e2e tests, as I've tried to find some tests on this I couldn't find it. [Here?](https://github.com/storybooks/storybook/tree/next/lib/ui/src/components/sidebar/__snapshots__)

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
