### PR TITLE
Fix sorting of knobs Panels

### DIFF
--- a/addons/knobs/src/components/Panel.js
+++ b/addons/knobs/src/components/Panel.js
@@ -21,7 +21,7 @@ import PropForm from './PropForm';
 
 const getTimestamp = () => +new Date();
 
-const DEFAULT_GROUP_ID = 'Other';
+export const DEFAULT_GROUP_ID = 'Other';
 
 const PanelWrapper = styled(({ children, className }) => (
   <ScrollArea horizontal vertical className={className}>
@@ -198,10 +198,17 @@ export default class KnobPanel extends PureComponent {
     }
 
     // Always sort DEFAULT_GROUP_ID (ungrouped) tab last without changing the remaining tabs
-    const unsortedEntries = Object.entries(groups);
-    const entries = unsortedEntries
-      .filter(entry => entry[0] !== DEFAULT_GROUP_ID)
-      .push(unsortedEntries.find(entry => entry[0] === DEFAULT_GROUP_ID));
+    const sortEntries = g => {
+      const unsortedKeys = Object.keys(g);
+      if (unsortedKeys.indexOf(DEFAULT_GROUP_ID) !== -1) {
+        const sortedKeys = unsortedKeys.filter(key => key !== DEFAULT_GROUP_ID);
+        sortedKeys.push(DEFAULT_GROUP_ID);
+        return sortedKeys.map(key => [key, g[key]]);
+      }
+      return Object.entries(g);
+    };
+
+    const entries = sortEntries(groups);
 
     return (
       <Fragment>

--- a/addons/knobs/src/components/Panel.js
+++ b/addons/knobs/src/components/Panel.js
@@ -197,9 +197,11 @@ export default class KnobPanel extends PureComponent {
       );
     }
 
-    // Always sort 'Other' (ungrouped) tab last without changing the remaining tabs
-    const entries = Object.entries(groups).filter(entry => entry[0] !== 'Other');
-    entries.push(Object.entries(groups).find(entry => entry[0] === 'Other'));
+    // Always sort DEFAULT_GROUP_ID (ungrouped) tab last without changing the remaining tabs
+    const unsortedEntries = Object.entries(groups);
+    const entries = unsortedEntries
+      .filter(entry => entry[0] !== DEFAULT_GROUP_ID)
+      .push(unsortedEntries.find(entry => entry[0] === DEFAULT_GROUP_ID));
 
     return (
       <Fragment>

--- a/addons/knobs/src/components/Panel.js
+++ b/addons/knobs/src/components/Panel.js
@@ -197,9 +197,9 @@ export default class KnobPanel extends PureComponent {
       );
     }
 
-    const entries = Object.entries(groups);
     // Always sort 'Other' (ungrouped) tab last without changing the remaining tabs
-    entries.sort((a, b) => (a[0] === 'Other' ? 1 : 0)); // eslint-disable-line no-unused-vars
+    const entries = Object.entries(groups).filter(entry => entry[0] !== 'Other');
+    entries.push(Object.entries(groups).find(entry => entry[0] === 'Other'));
 
     return (
       <Fragment>

--- a/addons/knobs/src/components/__tests__/Panel.js
+++ b/addons/knobs/src/components/__tests__/Panel.js
@@ -4,7 +4,7 @@ import { STORY_CHANGED } from '@storybook/core-events';
 import { TabsState } from '@storybook/components';
 
 import { ThemeProvider, themes, convert } from '@storybook/theming';
-import Panel from '../Panel';
+import Panel, { DEFAULT_GROUP_ID } from '../Panel';
 import { CHANGE, SET } from '../../shared';
 import PropForm from '../PropForm';
 
@@ -153,7 +153,7 @@ describe('Panel', () => {
       root.unmount();
     });
 
-    it('should have one tab per groupId and an empty Other tab when all are defined', () => {
+    it('should have one tab per groupId when all are defined', () => {
       const root = mount(
         <ThemeProvider theme={convert(themes.light)}>
           <Panel api={testApi} active />
@@ -193,7 +193,7 @@ describe('Panel', () => {
       root.unmount();
     });
 
-    it('the Other tab should have its own additional content when there are knobs both with and without a groupId', () => {
+    it(`the ${DEFAULT_GROUP_ID} tab should have its own additional content when there are knobs both with and without a groupId`, () => {
       const root = mount(
         <ThemeProvider theme={convert(themes.light)}>
           <Panel api={testApi} active />
@@ -202,17 +202,17 @@ describe('Panel', () => {
 
       testApi.on.mock.calls[0][1]({
         knobs: {
-          foo: {
-            name: 'foo',
-            defaultValue: 'test',
-            used: true,
-            groupId: 'foo',
-          },
           bar: {
             name: 'bar',
             defaultValue: 'test2',
             used: true,
             // no groupId
+          },
+          foo: {
+            name: 'foo',
+            defaultValue: 'test',
+            used: true,
+            groupId: 'foo',
           },
         },
       });
@@ -223,7 +223,7 @@ describe('Panel', () => {
         .find(TabsState)
         .find('button')
         .map(child => child.prop('children'));
-      expect(titles).toEqual(['foo', 'Other']);
+      expect(titles).toEqual(['foo', DEFAULT_GROUP_ID]);
 
       const knobs = wrapper.find(PropForm).map(propForm => propForm.prop('knobs'));
       // there are props with no groupId so Other should also have its own PropForm

--- a/addons/knobs/src/components/__tests__/__snapshots__/Panel.js.snap
+++ b/addons/knobs/src/components/__tests__/__snapshots__/Panel.js.snap
@@ -17,7 +17,7 @@ Array [
 ]
 `;
 
-exports[`Panel groups should have one tab per groupId and an empty Other tab when all are defined 1`] = `
+exports[`Panel groups should have one tab per groupId when all are defined 1`] = `
 Array [
   .emotion-2 {
   box-sizing: border-box;

--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -124,6 +124,9 @@ storiesOf('Addons|Knobs.withKnobs', module)
     // NOTE: the default value must not change - e.g., do not do date('Label', new Date()) or date('Label')
     const defaultBirthday = new Date('Jan 20 2017 GMT+0');
 
+    // Ungrouped
+    const ungrouped = text('Ungrouped', 'Mumble');
+
     // General
     const name = text('Name', 'Storyteller', GROUP_IDS.GENERAL);
     const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 }, GROUP_IDS.GENERAL);
@@ -153,9 +156,6 @@ storiesOf('Addons|Knobs.withKnobs', module)
       },
       GROUP_IDS.DISPLAY
     );
-
-    // Ungrouped
-    const ungrouped = text('Ungrouped', 'Mumble');
 
     const style = { backgroundColor, ...otherStyles };
 


### PR DESCRIPTION
Issue: The panel for ungrouped knobs would not be moved to the end as expected

## What I did

- Instead of sorting the array of groups, we now filter the `Other` panel out of the array completely and append it to the end.
- Updated the story in official-storybook that displays multiple knobs groups so that the ungrouped knob is at the beginning.

The previous implementation of moving the ungrouped knob panel to the end was not working as expected in Chrome. I found an inconsistency in how Chrome handles `Array.prototype.sort()` compared to the other major browsers. This only happened during development (running `start-storybook`) and only when the ungrouped knobs were defined before the grouped ones. I think that is the reason this hasn’t been noticed before, since the official-storybook defined the ungrouped knobs last.

Relevant screenshot
![](https://d.pr/i/S9iChT+)

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

I'm not sure if any of these apply. I did update the story that should confirm whether this works. To replicate the error:
- run the current version on `next` locally
- move the ungrouped knob in `examples/official-storybook/stories/addon-knobs-stories.js` above the other ones (see diff of this PR for reference)
- open UI in Chrome and observe the `Other` panel on that story move to the front
- (to confirm this fix works): apply the fix in `addons/knobs/src/components/Panel.js` and observe the problem being fixed. *see diff of this PR for reference)
