### PR TITLE
Angular: Support default `storybook` project configuration

### DIFF
--- a/app/angular/src/server/angular-cli_config.js
+++ b/app/angular/src/server/angular-cli_config.js
@@ -46,10 +46,15 @@ export function getAngularCliWebpackConfigOptions(dirToSearch) {
     throw new Error('angular.json must have projects entry.');
   }
 
-  let project = projects[Object.keys(projects)[0]];
+  // By default, look for a `storybook` project in angular.json to use as configuration default
+  let project = projects.storybook;
 
-  if (defaultProject) {
-    project = projects[defaultProject];
+  if (!project) {
+    project = projects[Object.keys(projects)[0]];
+
+    if (defaultProject) {
+      project = projects[defaultProject];
+    }
   }
 
   const { options: projectOptions } = project.architect.build;

--- a/app/angular/src/server/angular-cli_config.js
+++ b/app/angular/src/server/angular-cli_config.js
@@ -46,16 +46,9 @@ export function getAngularCliWebpackConfigOptions(dirToSearch) {
     throw new Error('angular.json must have projects entry.');
   }
 
-  // By default, look for a `storybook` project in angular.json to use as configuration default
-  let project = projects.storybook;
-
-  if (!project) {
-    project = projects[Object.keys(projects)[0]];
-
-    if (defaultProject) {
-      project = projects[defaultProject];
-    }
-  }
+  const fallbackProject = defaultProject && projects[defaultProject];
+  const firstProject = projects[Object.keys(projects)[0]];
+  const project = projects.storybook || fallbackProject || firstProject;
 
   const { options: projectOptions } = project.architect.build;
 

--- a/app/angular/src/server/angular-cli_config.test.js
+++ b/app/angular/src/server/angular-cli_config.test.js
@@ -27,5 +27,33 @@ describe('angualr-cli_config', () => {
         },
       });
     });
+
+    it('should use `storybook` project by default when project is defined', () => {
+      // Lazy clone example angular json
+      const overrideAngularJson = JSON.parse(JSON.stringify(angularJson));
+      // Add storybook project
+      overrideAngularJson.projects.storybook = {
+        architect: {
+          build: {
+            options: {
+              assets: [],
+              styles: ['custom/styles'],
+            },
+          },
+        },
+      };
+
+      setupFiles({ 'angular.json': JSON.stringify(overrideAngularJson) });
+
+      const config = getAngularCliWebpackConfigOptions('/');
+
+      // Assure configuration matches values from `storybook` project
+      expect(config).toMatchObject({
+        buildOptions: {
+          assets: [],
+          styles: ['custom/styles'],
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
Issue: Storybook Angular assumes use of `defaultProject` defined in angular.json as its source for project configuration.  In larger projects it would be beneficial to define a separate project for storybook that can define configuration settings separate from the default project.

## What I did

When resolving the angular project to use for configuration, default to look for a project named `storybook`.  If no project named `storybook` exists, use the existing resolution process.

## How to test

Added test to angular CLI config to identify that storybook project is used when available in angular.json file.


NOTE: I recognize this could be a breaking change if an existing project in angular.json is named storybook but is not intended to be the project configured used when running storybook.  However I suspect this potential conflict is very rare in existing applications.
