### PR TITLE
fix(background): move 'iframe' styles to background wrapper

### DIFF
--- a/lib/ui/src/components/preview/__snapshots__/preview.stories.storyshot
+++ b/lib/ui/src/components/preview/__snapshots__/preview.stories.storyshot
@@ -305,6 +305,15 @@ Array [
   background: #FFFFFF;
 }
 
+.emotion-0 iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0 none;
+}
+
 <div
     class="emotion-1"
     offset="40"
@@ -320,7 +329,6 @@ Array [
           id="storybook-preview-iframe"
           scrolling="yes"
           src="http://example.com?id=string"
-          style="width:100%;height:100%;position:absolute;top:0;left:0;border:0 none"
           title="string"
         />
       </div>
@@ -766,6 +774,15 @@ Array [
   background: #FFFFFF;
 }
 
+.emotion-0 iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0 none;
+}
+
 <div
     class="emotion-1"
     offset="40"
@@ -781,7 +798,6 @@ Array [
           id="storybook-preview-iframe"
           scrolling="yes"
           src="http://example.com?id=string"
-          style="width:100%;height:100%;position:absolute;top:0;left:0;border:0 none"
           title="string"
         />
       </div>

--- a/lib/ui/src/components/preview/background.js
+++ b/lib/ui/src/components/preview/background.js
@@ -95,6 +95,14 @@ const Background = styled.div(
     width: '100%',
     height: '100%',
     transition: 'background .1s linear',
+    iframe: {
+      width: '100%',
+      height: '100%',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      border: '0 none',
+    },
   },
   ({ theme }) => ({ background: theme.background.content })
 );

--- a/lib/ui/src/components/preview/preview.js
+++ b/lib/ui/src/components/preview/preview.js
@@ -38,14 +38,6 @@ const renderIframe = (storyId, id, baseUrl, scale, queryParams) => (
     src={`${baseUrl}?id=${storyId}${stringifyQueryParams(queryParams)}`}
     allowFullScreen
     scale={scale}
-    style={{
-      width: '100%',
-      height: '100%',
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      border: '0 none',
-    }}
   />
 );
 


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6392

## What I did
Fix iframe styles: remove iframe inline styles, set styles from bg wrapper

## How to test
Run your storybook
Check bg
Check zoom
Check iframe behavior - all must work as expected

- Is this testable with Jest or Chromatic screenshots?
yes
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
no