### PR TITLE
feat(a11y): drop a11y filter on dbl click

### DIFF
--- a/addons/a11y/src/components/ColorBlindness.tsx
+++ b/addons/a11y/src/components/ColorBlindness.tsx
@@ -114,6 +114,7 @@ export class ColorBlindness extends Component<ColorBlindnessProps, ColorBlindnes
         onVisibilityChange={this.onVisibilityChange}
         tooltip={<TooltipLinkList links={colorList} />}
         closeOnClick
+        onDoubleClick={() => this.setFilter(null)}
       >
         <IconButton key="filter" active={!!filter} title="Color Blindness Emulation">
           <Icons icon="mirror" />


### PR DESCRIPTION
Issue: N/A

## What I did
preview addon can reset on dbl click to the panel. I added the same functionality to a11y panel.

## How to test
set custom blindless emulation
dbl click to icon
emulation has been reset

- Is this testable with Jest or Chromatic screenshots?
no
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
no
