### PR TITLE
Update index.md

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -124,6 +124,21 @@ import 'path/to/register.js';
 Now restart/rebuild storybook and the addon should show up!
 When changing stories, the addon's onStoryChange method will be invoked with the new storyId.
 
+#### Note:
+If you get an error similar to:
+
+```
+ModuleParseError: Module parse failed: Unexpected token (92:22)
+You may need an appropriate loader to handle this file type.
+|       var value = this.state.value;
+|       var active = this.props.active;
+>       return active ? <div>{value}</div> : null;
+|     }
+|   }]);
+```
+
+It is likely because you do not have a `.babelrc` file or do not have it configured with the correct presets `{ "presets": ["@babel/preset-env", "@babel/preset-react"] }`
+
 ## A more complex addon
 
 If we want to create a more complex addon, one that wraps the component being rendered for example, there are a few more steps.


### PR DESCRIPTION
Added a note about the solution for when there is an error building storybook after registering an addon.

Issue:

Using the page for writing an add on, it can produce an error when running storybook.

## What I did

Updated the documentation for writing an add on to include a note about how to solve errors about needing a loader for the file type.

## How to test

N/A documentation update