### PR TITLE
Update index.md

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -65,6 +65,7 @@ import { STORY_CHANGED } from '@storybook/core-events';
 import addons, { types } from '@storybook/addons';
 
 const ADDON_ID = 'myaddon';
+const PARAM_KEY = 'myAddon';
 const PANEL_ID = `${ADDON_ID}/panel`;
 
 class MyPanel extends React.Component {


### PR DESCRIPTION
Defining a `PARAM_KEY` that will match what is used in the story.

Issue:
`PARAM_KEY` is not defined anywhere in the code. Additionally, it's not immediately clear that it should match the key used in the story (i.e. `myAddon`)

## What I did

Added a line to define the `PARAM_KEY` and set it to `myAddon`

## How to test
N/A -- Updated documentation

If you want to test the documentation, copy & paste the code as if you were creating your first add-on