### PR TITLE
Fix deprecationThemeOptions that always override final brand object with undefined

### DIFF
--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -116,7 +116,7 @@ const applyDeprecatedLayoutOptions = deprecate((options: Options): PartialLayout
 }, deprecationMessage(deprecatedLayoutOptions));
 
 const checkDeprecatedThemeOptions = (options: Options) => {
-  if (Object.values(deprecatedThemeOptions).find(v => !!v)) {
+  if (Object.keys(deprecatedThemeOptions).find((k: 'name' | 'url') => !!options[k])) {
     return applyDeprecatedThemeOptions(options);
   }
   return {};


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6521
Previous PR that made this issue: https://github.com/storybooks/storybook/pull/5402#discussion_r269938212

## What I did
I changed to what previous code does.

## How to test
- Is this testable with Jest or Chromatic screenshots? I'm not sure
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

## Comments
Hi, deja-vue again...   I found this while working on this [PR](https://github.com/storybooks/storybook/pull/6476). 

As you can see from previous PR that made this issue, It has been not working from after PR is merged.
My understanding is when user inputs `name, url`, it maps its values to `brandTitle, brandUrl` with deprecation warnings. However previous code always warns(`console.log`) deprecationThemeOptions warning whether user inputs `name` or `url` and [overrides](https://github.com/storybooks/storybook/blob/097d793aecad26c4d8e95dcc8b9bab2fa56ae205/lib/api/src/modules/layout.ts#L259) `brandTitle, brandUrl, brandImage` to `undefined, undefined, null`.  Thus whatever options passing from user doesn't do anything.