### PR TITLE
UI: Fix panel toggle in fullscreen mode

### DIFF
--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -225,6 +225,19 @@ export default function({ store }: { store: Store }) {
       });
     },
 
+    resetLayout() {
+      return store.setState((state: State) => {
+        return {
+          layout: {
+            ...state.layout,
+            showNav: false,
+            showPanel: false,
+            isFullscreen: false,
+          },
+        };
+      });
+    },
+
     focusOnUIElement(elementId?: string) {
       if (!elementId) {
         return;

--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -209,6 +209,7 @@ export default function initShortcuts({ store }: Module) {
         case 'togglePanel': {
           if (isFullscreen) {
             fullApi.toggleFullscreen();
+            fullApi.resetLayout();
           }
 
           fullApi.togglePanel();
@@ -218,6 +219,7 @@ export default function initShortcuts({ store }: Module) {
         case 'toggleNav': {
           if (isFullscreen) {
             fullApi.toggleFullscreen();
+            fullApi.resetLayout();
           }
 
           fullApi.toggleNav();


### PR DESCRIPTION
Issue: #6481

## What I did

I added an API function that resets the values of showNav and showPanel. The discussion about the issue and why this was necessary can be found [here](https://github.com/storybooks/storybook/issues/6481?_pjax=%23js-repo-pjax-container). Notably, the function also sets isFullScreen to false *although it isn't technically needed* (when the function gets called, isFullScreen should be false). It acts as a fallback of sorts just in case, but this function could also be reused to redefine the way fullscreening storybook 
works. It gets called both in togglePanel() and toggleNav() to resolve the issue. This solution always preserves the last layout before the fullscreen gets activated and reverts to it once we leave the fullscreen mode if no changes were made to it.

## How to test

Additional tests are welcome but this should fix the issue. You can follow the steps of the original poster of the issue to make sure of it. 
