### PR TITLE
fix(knobs): add groupId for files knob

### DIFF
--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -69,8 +69,8 @@ export function button(name, callback, groupId) {
   return manager.knob(name, { type: 'button', callback, hideLabel: true, groupId });
 }
 
-export function files(name, accept, value = []) {
-  return manager.knob(name, { type: 'files', accept, value });
+export function files(name, accept, value = [], groupId) {
+  return manager.knob(name, { type: 'files', accept, value, groupId });
 }
 
 export function optionsKnob(name, valuesObj, value, optionsObj, groupId) {


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6520

## What I did
Add groupId in args

## How to test
Add file knob with group id

After fix:
<img width="412" alt="Снимок экрана 2019-04-16 в 1 05 09" src="https://user-images.githubusercontent.com/3195714/56168377-b4614800-5fe3-11e9-8e0b-3150c5851be4.png">
