### PR TITLE
Fix for issue #6338: Changed default value for sourceMap property of angulars webpack config

### DIFF
--- a/app/angular/src/server/angular-cli_config.js
+++ b/app/angular/src/server/angular-cli_config.js
@@ -71,7 +71,7 @@ export function getAngularCliWebpackConfigOptions(dirToSearch) {
     tsConfig,
     supportES2015: false,
     buildOptions: {
-      sourceMap: {},
+      sourceMap: false,
       optimization: {},
       ...projectOptions,
       assets: normalizedAssets,


### PR DESCRIPTION
Issue: #6338

## What I did

changed value of sourceMap from {} to false

## How to test

Create a project via latest angular-cli and add storybook, it will fail, because sourceMap property should be boolean 
