### PR TITLE
Make stories exportable

### DIFF
--- a/lib/client-api/src/client_api.js
+++ b/lib/client-api/src/client_api.js
@@ -137,6 +137,7 @@ export default class ClientApi {
     let hasAdded = false;
     const api = {
       kind,
+      stories: {}
     };
 
     // apply addons
@@ -163,6 +164,7 @@ export default class ClientApi {
         });
       }
 
+      api.stories[storyName] = storyFn;
       const fileName = m && m.id ? `${m.id}` : undefined;
 
       const { hierarchyRootSeparator, hierarchySeparator } = this.getSeparators();


### PR DESCRIPTION
This is NOT a feature complete pull request but more a start point for a proposal or discussion.

I would like to to reuse a story from one place at another place:

file1.stories.js
```
export const stories = storiesOf(..).add('default', ..).add(..)
```

file2:

```
import {stories} from './file1.stories.js'
const FancyStory = stories.default // Matches the storyFn from file1.stories.js .add('default', storyFn)
storiesOf(..).add('default', 
  () => (
      <div>  
          some wrapping content
          <FancyStory />
          some more wrapping content
       </div>)
   )
```

This would allow me to combine multiple stories for example a `Logo`(with a demo url) and a `BreadCrumb` (with some demo links) and a `MainNavigation` (with a lot of demo links) and show a story how all those components would look liked if they are sitting next to each other.

## What I did

I created a small helper object to store all `storyFn` functions once they are added for a given kind.

Would love to know what you think
<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
