### PR TITLE
FIX null brandImage

### DIFF
--- a/lib/theming/src/create.ts
+++ b/lib/theming/src/create.ts
@@ -172,7 +172,7 @@ export const convert = (inherit: ThemeVars = lightThemeVars): Theme => {
     brand: {
       title: brandTitle,
       url: brandUrl,
-      image: brandImage || brandTitle ? null : undefined,
+      image: brandImage || (brandTitle ? null : undefined),
     },
 
     code: createSyntax({


### PR DESCRIPTION
Issue: #5866

## What I did
Make it so that `brandImage` is used if defined instead of `null`

(Addresses the issue introduced in https://github.com/storybooks/storybook/pull/6120)