### PR TITLE
Fix react-native preview only ui

### DIFF
--- a/app/react-native/src/preview/components/StoryView/index.tsx
+++ b/app/react-native/src/preview/components/StoryView/index.tsx
@@ -77,6 +77,9 @@ export default class StoryView extends Component<Props, State> {
   }
 
   renderListening = () => {
+    if (!this.state) {
+      return null;
+    }
     const { storyFn, selection } = this.state;
     const { kind, story } = selection;
 

--- a/app/react-native/src/preview/index.tsx
+++ b/app/react-native/src/preview/index.tsx
@@ -78,7 +78,7 @@ export default class Preview {
         channel = new Channel({ async: true });
       } else {
         const host = getHost(params.host || 'localhost');
-        const port = params.port ? `:${params.port || 7007}` : '';
+        const port = `:${params.port || 7007}`;
 
         const query = params.query || '';
         const { secured } = params;


### PR DESCRIPTION
##  Issue
After the typescript migration (#6448) a couple regressions were introduced.
 - Default port for server ui was no longer getting set properly
 - preview only ui failed on initial render (#6545)

## What I did
Fixed the above issues, see individual commits for more details.

## How to test
 - Run the storybook for react-native with `onDeviceUI` true and false. Switch between stories using the web ui.