### PR TITLE
MIGRATE addon-storysource from using channel to api

### DIFF
--- a/addons/storysource/src/StoryPanel.js
+++ b/addons/storysource/src/StoryPanel.js
@@ -44,9 +44,9 @@ export default class StoryPanel extends Component {
 
   componentDidMount() {
     this.mounted = true;
-    const { channel } = this.props;
+    const { api } = this.props;
 
-    channel.on(EVENT_ID, this.listener);
+    api.on(EVENT_ID, this.listener);
   }
 
   componentDidUpdate() {
@@ -56,9 +56,9 @@ export default class StoryPanel extends Component {
   }
 
   componentWillUnmount() {
-    const { channel } = this.props;
+    const { api } = this.props;
 
-    channel.removeListener(EVENT_ID, this.listener);
+    api.off(EVENT_ID, this.listener);
   }
 
   setSelectedStoryRef = ref => {
@@ -181,10 +181,8 @@ StoryPanel.propTypes = {
   active: PropTypes.bool.isRequired,
   api: PropTypes.shape({
     selectStory: PropTypes.func.isRequired,
-  }).isRequired,
-  channel: PropTypes.shape({
     emit: PropTypes.func,
     on: PropTypes.func,
-    removeListener: PropTypes.func,
+    off: PropTypes.func,
   }).isRequired,
 };

--- a/addons/storysource/src/manager.js
+++ b/addons/storysource/src/manager.js
@@ -1,17 +1,15 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import addons from '@storybook/addons';
+
 import StoryPanel from './StoryPanel';
 import { ADDON_ID, PANEL_ID } from '.';
 
 export function register() {
   addons.register(ADDON_ID, api => {
-    const channel = addons.getChannel();
     addons.addPanel(PANEL_ID, {
       title: 'Story',
-      // eslint-disable-next-line react/prop-types
-      render: ({ active, key }) => (
-        <StoryPanel key={key} channel={channel} api={api} active={active} />
-      ),
+      render: ({ active, key }) => <StoryPanel key={key} api={api} active={active} />,
     });
   });
 }


### PR DESCRIPTION
Issue:
We want to promote the usage of api over channel

## What I did
CLEANUP channel should not be used in manager, just use api instead