### PR TITLE
FIX viewmode being hard-coded making custom addons of type TAB impossible

### DIFF
--- a/lib/router/src/utils.ts
+++ b/lib/router/src/utils.ts
@@ -6,7 +6,7 @@ interface StoryData {
   storyId?: string;
 }
 
-const knownViewModesRegex = /(story|info)/;
+export const knownNonViewModesRegex = /(settings)/;
 const splitPath = /\/([^/]+)\/([^/]+)?/;
 
 // Remove punctuation https://gist.github.com/davidjrice/9d2af51100e41c6c4b4a
@@ -39,7 +39,7 @@ export const storyDataFromString: (path?: string) => StoryData = memoize(1000)(
 
     if (path) {
       const [, viewMode, storyId] = path.match(splitPath) || [undefined, undefined, undefined];
-      if (viewMode && viewMode.match(knownViewModesRegex)) {
+      if (viewMode && !viewMode.match(knownNonViewModesRegex)) {
         Object.assign(result, {
           viewMode,
           storyId,

--- a/lib/ui/src/components/layout/__snapshots__/layout.stories.storyshot
+++ b/lib/ui/src/components/layout/__snapshots__/layout.stories.storyshot
@@ -1472,7 +1472,7 @@ exports[`Storyshots UI|Layout/Desktop page 1`] = `
   overflow: hidden;
 }
 
-.emotion-4 {
+.emotion-9 {
   position: absolute;
   box-sizing: border-box;
   top: 0;
@@ -1544,6 +1544,20 @@ exports[`Storyshots UI|Layout/Desktop page 1`] = `
   -ms-flex-align: center;
   align-items: center;
   overflow: hidden;
+}
+
+.emotion-4 {
+  position: absolute;
+  box-sizing: border-box;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  z-index: 9;
+  -webkit-transition: width 0.1s ease-out,height 0.1s ease-out,top 0.1s ease-out,left 0.1s ease-out,background 0.1s ease-out,opacity 0.1s ease-out,-webkit-transform 0.1s ease-out;
+  -webkit-transition: width 0.1s ease-out,height 0.1s ease-out,top 0.1s ease-out,left 0.1s ease-out,background 0.1s ease-out,opacity 0.1s ease-out,transform 0.1s ease-out;
+  transition: width 0.1s ease-out,height 0.1s ease-out,top 0.1s ease-out,left 0.1s ease-out,background 0.1s ease-out,opacity 0.1s ease-out,transform 0.1s ease-out;
 }
 
 .emotion-6 {
@@ -1621,7 +1635,7 @@ exports[`Storyshots UI|Layout/Desktop page 1`] = `
     </div>
   </div>
   <div
-    class="emotion-4"
+    class="emotion-9"
     style="height:748px;left:210px;top:10px;width:804px"
   >
     <div
@@ -1629,6 +1643,7 @@ exports[`Storyshots UI|Layout/Desktop page 1`] = `
     >
       <div
         class="emotion-4"
+        hidden=""
       >
         <div
           class="emotion-3"
@@ -2844,7 +2859,7 @@ exports[`Storyshots UI|Layout/Mobile page 1`] = `
   overflow: hidden;
 }
 
-.emotion-11 {
+.emotion-12 {
   position: fixed;
   left: 0;
   top: 0;
@@ -2933,7 +2948,7 @@ exports[`Storyshots UI|Layout/Mobile page 1`] = `
   border-left: 1px solid rgba(0,0,0,.1);
 }
 
-.emotion-10 {
+.emotion-11 {
   position: fixed;
   bottom: 0;
   left: 0;
@@ -2947,14 +2962,14 @@ exports[`Storyshots UI|Layout/Mobile page 1`] = `
   background: #FFFFFF;
 }
 
-.emotion-10 > * {
+.emotion-11 > * {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
 <div
-  class="emotion-11"
+  class="emotion-12"
 >
   <div
     class="emotion-7"
@@ -2980,9 +2995,7 @@ exports[`Storyshots UI|Layout/Mobile page 1`] = `
       class="emotion-4"
     >
       <div>
-        <div
-          hidden=""
-        >
+        <div>
           <div
             class="emotion-2"
             color="deepskyblue"
@@ -2995,6 +3008,7 @@ exports[`Storyshots UI|Layout/Mobile page 1`] = `
             <pre>
               {
   "id": "main",
+  "viewMode": "settings",
   "debug": {
     "initialActive": 1
   }
@@ -3031,14 +3045,14 @@ exports[`Storyshots UI|Layout/Mobile page 1`] = `
         </h2>
         <pre>
           {
-  "hidden": true
+  "hidden": false
 }
         </pre>
       </div>
     </div>
   </div>
   <nav
-    class="emotion-10"
+    class="emotion-11"
   >
     <button
       class="emotion-8"
@@ -3048,7 +3062,12 @@ exports[`Storyshots UI|Layout/Mobile page 1`] = `
     <button
       class="emotion-8"
     >
-      settings
+      Canvassettings
+    </button>
+    <button
+      class="emotion-8"
+    >
+      Addons
     </button>
   </nav>
 </div>

--- a/lib/ui/src/components/layout/__snapshots__/layout.stories.storyshot
+++ b/lib/ui/src/components/layout/__snapshots__/layout.stories.storyshot
@@ -1472,7 +1472,7 @@ exports[`Storyshots UI|Layout/Desktop page 1`] = `
   overflow: hidden;
 }
 
-.emotion-9 {
+.emotion-4 {
   position: absolute;
   box-sizing: border-box;
   top: 0;
@@ -1544,20 +1544,6 @@ exports[`Storyshots UI|Layout/Desktop page 1`] = `
   -ms-flex-align: center;
   align-items: center;
   overflow: hidden;
-}
-
-.emotion-4 {
-  position: absolute;
-  box-sizing: border-box;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  z-index: 9;
-  -webkit-transition: width 0.1s ease-out,height 0.1s ease-out,top 0.1s ease-out,left 0.1s ease-out,background 0.1s ease-out,opacity 0.1s ease-out,-webkit-transform 0.1s ease-out;
-  -webkit-transition: width 0.1s ease-out,height 0.1s ease-out,top 0.1s ease-out,left 0.1s ease-out,background 0.1s ease-out,opacity 0.1s ease-out,transform 0.1s ease-out;
-  transition: width 0.1s ease-out,height 0.1s ease-out,top 0.1s ease-out,left 0.1s ease-out,background 0.1s ease-out,opacity 0.1s ease-out,transform 0.1s ease-out;
 }
 
 .emotion-6 {
@@ -1635,7 +1621,7 @@ exports[`Storyshots UI|Layout/Desktop page 1`] = `
     </div>
   </div>
   <div
-    class="emotion-9"
+    class="emotion-4"
     style="height:748px;left:210px;top:10px;width:804px"
   >
     <div
@@ -1643,7 +1629,6 @@ exports[`Storyshots UI|Layout/Desktop page 1`] = `
     >
       <div
         class="emotion-4"
-        hidden=""
       >
         <div
           class="emotion-3"

--- a/lib/ui/src/components/layout/desktop.js
+++ b/lib/ui/src/components/layout/desktop.js
@@ -21,10 +21,7 @@ const Desktop = React.memo(
                 <Nav debug={navProps} />
               </S.Nav>
               <S.Main {...mainProps}>
-                <S.Preview
-                  {...previewProps}
-                  hidden={!(viewMode === 'story' || viewMode === 'info')}
-                >
+                <S.Preview {...previewProps} hidden={viewMode === 'settings'}>
                   <Preview id="main" debug={previewProps} />
                 </S.Preview>
 

--- a/lib/ui/src/components/layout/layout.stories.js
+++ b/lib/ui/src/components/layout/layout.stories.js
@@ -178,7 +178,7 @@ storiesOf('UI|Layout/Desktop', module)
           render: () => <MockPage />,
         },
       ]}
-      viewMode={undefined}
+      viewMode="settings"
     />
   ));
 
@@ -208,6 +208,6 @@ storiesOf('UI|Layout/Mobile', module)
           render: () => <MockPage />,
         },
       ]}
-      viewMode={undefined}
+      viewMode="settings"
     />
   ));


### PR DESCRIPTION
Issue:
I was documenting the TAB addon type, and discovered we had the `info` and `story` viewmodes hardcoded, this meant it was pretty much impossible to create custom viewmodes & thus addons of type TAB.

This PR changes the way we detect whether we're in `/settings/xyz`.

Now addons can easily create their own TAB! no hassle.

## What I did
FIX router & desktop layout, which made it impossible to add custom viewmodes