### PR TITLE
'Escape' onKeyUp event doesn't work

### DIFF
--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -127,7 +127,6 @@ export default function initShortcuts({ store }: Module) {
           } else if (!showNav) {
             fullApi.toggleNav();
           }
-          document.activeElement.blur();
           break;
         }
 


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6023

## What I did
Followed the recommended action from the Issue.

## How to test
In storybook cra button story, you can do something like this:
```
<div><Button onClick={action('clicked', { depth: 1 })}>Hello Button</Button><div tabIndex={1} onKeyUp={(e) => console.log(e)} style={{width: '200px', height: '200px', border: '1px solid red'}}></div></div>
```

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
