### PR TITLE
Backport fix for #6261

### DIFF
--- a/lib/core/src/server/common/babel.js
+++ b/lib/core/src/server/common/babel.js
@@ -16,7 +16,7 @@ export default ({ configType }) => {
 
   return {
     presets: [
-      [require.resolve('@babel/preset-env'), { shippedProposals: true, useBuiltIns: 'usage' }],
+      [require.resolve('@babel/preset-env'), { shippedProposals: true, useBuiltIns: 'usage', corejs: 2 }],
       ...prodPresets,
     ],
     plugins: [


### PR DESCRIPTION
I'm experiencing the same warnings reported in #6261 on storybook v4. It seems like the fix for that (#6267) needs to be ported back.