### PR TITLE
Check for color knob value existence before applying uppercase

### DIFF
--- a/addons/knobs/src/components/types/Color.js
+++ b/addons/knobs/src/components/types/Color.js
@@ -82,7 +82,6 @@ class ColorType extends React.Component {
     const colorStyle = {
       background: knob.value,
     };
-
     return (
       <ColorButton
         active={displayColorPicker}
@@ -91,7 +90,7 @@ class ColorType extends React.Component {
         onClick={this.handleClick}
         size="flex"
       >
-        {knob.value.toUpperCase()}
+        {knob.value && knob.value.toUpperCase()}
         <Swatch style={colorStyle} />
         {displayColorPicker ? (
           <Popover


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6597

## What I did

Fixes https://github.com/storybooks/storybook/issues/6597

## How to test

- Remove the default color value:
https://github.com/storybooks/storybook/blob/c6d704225eec98c20a729242f14987852071ddb1/examples/official-storybook/stories/addon-knobs.stories.js#L65
- Storybook should not break


`["bug"]`