### PR TITLE
DOCS improve registration in VueJs guide

### DIFF
--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -150,18 +150,21 @@ Button
 ```
 
 > If your story is returning a plain template you can only use globally registered components.
+>
 > To register them, use `Vue.component('my-button', Mybutton)` in your `config.js` file.
+>
 > <details>
 >   <summary>details</summary>
-> If your story looks like this, you will need to register `my-component` globally.
+> If your story looks like this, returns a plain string, you will need to register each VueJs compoent it uses globally.
 >
 > ```js
 >  .add('with text', () => '<my-component>with text</my-component>')
 > ```
 >
-> To avoid registering all components globally, you have 2 simple solutions:
-> - use the component parameter of the vue component shape
-> - use a JSX render function
+> You do not want to register components globally, you have 2 simple solutions:
+>
+> - use the components parameter of the vue component shape
+> - use a JSX render function like this
 >
 > ```jsx
 >   .add('with text', () => ({

--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -156,17 +156,17 @@ Button
 > <details>
 >   <summary>details</summary>
 > 
-> If your story returns a plain string like below, you will need to register each VueJs component that it uses globally. 
+> If your story returns a plain string like below, you will need to register globally each VueJs component that it uses. 
 >
 > ```js
 >  .add('with text', () => '<my-component>with text</my-component>')
 > ```
 >
 > Globally registered components can conflict with each other.
-> If you do not want to register components globally.
+> If you another way to use components.
 >
-> - use the "components" parameter of the vue component object as shown above in "as a component"
-> - use a JSX render function like below
+> - register components locally in the "components" member of the vue component object. See the story "as a component" above.
+> - use a JSX render function like below, no need to register anything then.
 >
 > ```jsx
 >   .add('with text', () => ({

--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -167,7 +167,7 @@ Button
 > Here are two other ways to use components in your stories without globally registering them.
 >
 > - register components locally in the "components" member of the vue component object. See the story "as a component" above.
-> - use a JSX render function like below, no need to register anything then.
+> - use a JSX render function like below. No need to register anything.
 >
 > ```jsx
 >   .add('with text', () => ({

--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -155,15 +155,16 @@ Button
 >
 > <details>
 >   <summary>details</summary>
-> 
+>
 > If your story returns a plain string like below, you will need to register globally each VueJs component that it uses. 
 >
 > ```js
 >  .add('with text', () => '<my-component>with text</my-component>')
 > ```
 >
-> Globally registered components can conflict with each other.
-> If you another way to use components.
+> In big solutions, globally registered components can conflict with each other.
+>
+> Here are two other ways to use components in your stories without globally registering them.
 >
 > - register components locally in the "components" member of the vue component object. See the story "as a component" above.
 > - use a JSX render function like below, no need to register anything then.

--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -149,6 +149,28 @@ Button
   └── as a component
 ```
 
+> If your story is returning a plain template you can only use globally registered components.
+> To register them, use `Vue.component('my-button', Mybutton)` in your `config.js` file.
+> <details>
+>   <summary>details</summary>
+> If your story looks like this, you will need to register `my-component` globally.
+>
+> ```js
+>  .add('with text', () => '<my-component>with text</my-component>')
+> ```
+>
+> To avoid registering all components globally, you have 2 simple solutions:
+> - use the component parameter of the vue component shape
+> - use a JSX render function
+>
+> ```jsx
+>   .add('with text', () => ({
+>      render: h => <my-component>with text</my-component>
+>   }))
+> ```
+>
+> </details>
+
 ## Finally: Run your Storybook
 
 Now everything is ready. Run your storybook with:

--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -155,16 +155,18 @@ Button
 >
 > <details>
 >   <summary>details</summary>
-> If your story looks like this, returns a plain string, you will need to register each VueJs compoent it uses globally.
+> 
+> If your story returns a plain string like below, you will need to register each VueJs component that it uses globally. 
 >
 > ```js
 >  .add('with text', () => '<my-component>with text</my-component>')
 > ```
 >
-> You do not want to register components globally, you have 2 simple solutions:
+> Globally registered components can conflict with each other.
+> If you do not want to register components globally.
 >
-> - use the components parameter of the vue component shape
-> - use a JSX render function like this
+> - use the "components" parameter of the vue component object as shown above in "as a component"
+> - use a JSX render function like below
 >
 > ```jsx
 >   .add('with text', () => ({


### PR DESCRIPTION
Issue: #6357

## What I did

Following issue #6357, I added a `<details>` section to the vue guide, to signal the need for global registration if the stories return plain text.

I added a JSX solution as well.

## How to test

Read the docs on zeit

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
