### PR TITLE
Fix css import when sideEffects is false

### DIFF
--- a/lib/core/src/server/preview/base-webpack.config.js
+++ b/lib/core/src/server/preview/base-webpack.config.js
@@ -9,6 +9,7 @@ export function createDefaultWebpackConfig(storybookBaseConfig) {
         ...storybookBaseConfig.module.rules,
         {
           test: /\.css$/,
+          sideEffects: true,
           use: [
             require.resolve('style-loader'),
             {


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/4918

## What I did
When `sideEffects: false` was set in a project's `package.json`, `css` import were discarded which is not the intended behavior. This PR fix this issue by forcing the value of `sideEffects` for `css` import.

From what I saw, this change was already done on `scss` files but forgotten for `css` files.

## How to test
Importing a css file should affect the build assets even if `sideEffects` is set to false in the `package.json`
