### PR TITLE
Fix "Storybook for HTML" Edit link

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -16,6 +16,7 @@ module.exports = {
       guides: [
         '/guides/quick-start-guide/',
         '/guides/slow-start-guide/',
+        '/guides/guide-html/',
         '/guides/guide-react/',
         '/guides/guide-react-native/',
         '/guides/guide-vue/',


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6657

## What I did
The guide for HTML wasn't in `siteMetadata.docSections` which caused the link to be wrong.

I added `Storybook for HTML` as the 3rd link but let me know if you want me to change the order.
