### PR TITLE
Bugfix: Have no cancel option in UI if the context have no param

### DIFF
--- a/addons/contexts/src/manager/ContextsManager.tsx
+++ b/addons/contexts/src/manager/ContextsManager.tsx
@@ -3,10 +3,10 @@ import { useChannel } from './libs/useChannel';
 import { ToolBar } from './components/ToolBar';
 import { deserialize, serialize } from '../shared/serializers';
 import { PARAM, REBOOT_MANAGER, UPDATE_MANAGER, UPDATE_PREVIEW } from '../shared/constants';
-import { FCNoChildren, ManagerAPI, SelectionState } from '../shared/types.d';
+import { FCNoChildren, ManagerAPI } from '../shared/types.d';
 
 /**
- * A smart component for handling manager-preview interactions
+ * A smart component for handling manager-preview interactions.
  */
 type ContextsManager = FCNoChildren<{
   api: ManagerAPI;
@@ -14,7 +14,7 @@ type ContextsManager = FCNoChildren<{
 
 export const ContextsManager: ContextsManager = ({ api }) => {
   const [nodes, setNodes] = useState([]);
-  const [state, setState] = useState<SelectionState>(deserialize(api.getQueryParam(PARAM)));
+  const [state, setState] = useState(deserialize(api.getQueryParam(PARAM)));
   const setSelected = useCallback(
     (nodeId, name) => setState(obj => ({ ...obj, [nodeId]: name })),
     []

--- a/addons/contexts/src/manager/components/ToolBar.tsx
+++ b/addons/contexts/src/manager/components/ToolBar.tsx
@@ -13,16 +13,14 @@ export const ToolBar: ToolBar = React.memo(({ nodes, state, setSelected }) =>
   nodes.length ? (
     <>
       <Separator />
-      {nodes.map(({ components, ...forwardProps }) =>
-        forwardProps.params.length > 1 ? (
-          <ToolbarControl
-            {...forwardProps}
-            setSelected={setSelected}
-            selected={state[forwardProps.nodeId]}
-            key={forwardProps.nodeId}
-          />
-        ) : null
-      )}
+      {nodes.map(({ components, ...forwardProps }) => (
+        <ToolbarControl
+          {...forwardProps}
+          setSelected={setSelected}
+          selected={state[forwardProps.nodeId]}
+          key={forwardProps.nodeId}
+        />
+      ))}
     </>
   ) : null
 );

--- a/addons/contexts/src/manager/components/ToolBarMenu.tsx
+++ b/addons/contexts/src/manager/components/ToolBarMenu.tsx
@@ -4,7 +4,7 @@ import { ToolBarMenuOptions } from './ToolBarMenuOptions';
 import { ContextNode, FCNoChildren } from '../../shared/types.d';
 
 type ToolBarMenu = FCNoChildren<{
-  icon: ContextNode['icon'];
+  icon: ComponentProps<typeof Icons>['icon'];
   title: ContextNode['title'];
   active: boolean;
   expanded: boolean;
@@ -19,18 +19,17 @@ export const ToolBarMenu: ToolBarMenu = ({
   expanded,
   setExpanded,
   optionsProps,
-}) =>
-  icon ? (
-    <WithTooltip
-      closeOnClick
-      trigger="click"
-      placement="top"
-      tooltipShown={expanded}
-      onVisibilityChange={setExpanded}
-      tooltip={<ToolBarMenuOptions {...optionsProps} />}
-    >
-      <IconButton active={active} title={title}>
-        <Icons icon={icon} />
-      </IconButton>
-    </WithTooltip>
-  ) : null;
+}) => (
+  <WithTooltip
+    closeOnClick
+    trigger="click"
+    placement="top"
+    tooltipShown={expanded}
+    onVisibilityChange={setExpanded}
+    tooltip={<ToolBarMenuOptions {...optionsProps} />}
+  >
+    <IconButton active={active} title={title}>
+      <Icons icon={icon} />
+    </IconButton>
+  </WithTooltip>
+);

--- a/addons/contexts/src/manager/components/ToolbarControl.tsx
+++ b/addons/contexts/src/manager/components/ToolbarControl.tsx
@@ -33,7 +33,6 @@ export const ToolbarControl: ToolbarControl = ({
     params[0].name;
   const list = options.cancelable ? [OPT_OUT, ...paramNames] : paramNames;
   const props = {
-    icon,
     title,
     active: activeName !== OPT_OUT,
     expanded,
@@ -48,5 +47,5 @@ export const ToolbarControl: ToolbarControl = ({
     },
   };
 
-  return options.disable || list.length < 2 ? null : <ToolBarMenu {...props} />;
+  return icon && list.length && !options.disable ? <ToolBarMenu icon={icon} {...props} /> : null;
 };

--- a/addons/contexts/src/manager/components/ToolbarControl.tsx
+++ b/addons/contexts/src/manager/components/ToolbarControl.tsx
@@ -26,12 +26,12 @@ export const ToolbarControl: ToolbarControl = ({
   const paramNames = params.map(({ name }) => name);
   const activeName =
     // validate the integrity of the selected name
-    (paramNames.concat(options.cancelable && OPT_OUT).includes(selected) && selected) ||
+    ([...paramNames, options.cancelable && OPT_OUT].includes(selected) && selected) ||
     // fallback to default
     (params.find(param => !!param.default) || { name: null }).name ||
     // fallback to the first
     params[0].name;
-  const list = options.cancelable === false ? paramNames : [OPT_OUT, ...paramNames];
+  const list = options.cancelable ? [OPT_OUT, ...paramNames] : paramNames;
   const props = {
     icon,
     title,

--- a/addons/contexts/src/preview/ContextsPreviewAPI.ts
+++ b/addons/contexts/src/preview/ContextsPreviewAPI.ts
@@ -1,5 +1,5 @@
-import { window } from 'global';
 import addons from '@storybook/addons';
+import { window } from 'global';
 import { parse } from 'qs';
 import { getContextNodes, getPropsMap, getRendererFrom, singleton } from './libs';
 import { deserialize } from '../shared/serializers';
@@ -14,11 +14,11 @@ import {
 import { ContextNode, PropsMap, SelectionState } from '../shared/types.d';
 
 /**
- * A singleton for handling preview-manager and one-time-only side-effects
+ * A singleton for handling preview-manager and one-time-only side-effects.
  */
 export const ContextsPreviewAPI = singleton(() => {
   const channel = addons.getChannel();
-  let contextsNodesMemo: ContextNode[] = null;
+  let contextsNodesMemo: ContextNode[] | null = null;
   let selectionState: SelectionState = {};
 
   /**
@@ -26,40 +26,37 @@ export const ContextsPreviewAPI = singleton(() => {
    * which is useful for performing image snapshot testing or URL sharing.
    */
   if (window && window.location) {
-    const contextQuery = parse(window.location.search)[PARAM];
-    if (contextQuery) {
-      selectionState = deserialize(contextQuery);
-    }
+    selectionState = deserialize(parse(window.location.search)[PARAM]) || {};
   }
 
   /**
    * (Vue specific)
-   * Vue will inject getter/setters on the first rendering of the addon,
-   * which is the reason why we have to keep an internal reference and use `Object.assign` to update it.
+   * Vue will inject getter/setter watchers on the first rendering of the addon,
+   * which is why we have to keep an internal reference and use `Object.assign` to notify the watcher.
    */
   const reactivePropsMap = {};
-  const updateReactiveSystem = (propsMap: PropsMap) =>
-    /* tslint:disable:prefer-object-spread */
-    Object.assign(reactivePropsMap, propsMap);
+  const updateReactiveSystem = (propsMap: PropsMap) => Object.assign(reactivePropsMap, propsMap);
 
   /**
    * Preview-manager communications.
    */
   // from manager
-  channel.on(SET_CURRENT_STORY, () => {
-    contextsNodesMemo = null;
-  });
-  channel.on(REBOOT_MANAGER, () => channel.emit(UPDATE_MANAGER, contextsNodesMemo));
   channel.on(UPDATE_PREVIEW, state => {
     if (state) {
       selectionState = state;
       channel.emit(FORCE_RE_RENDER);
     }
   });
+  channel.on(REBOOT_MANAGER, () => {
+    channel.emit(UPDATE_MANAGER, contextsNodesMemo);
+  });
+  channel.on(SET_CURRENT_STORY, () => {
+    // trash the memorization since the story-level setting may change (diffing it is much expensive)
+    contextsNodesMemo = null;
+  });
 
   // to manager
   const getContextNodesWithSideEffects: typeof getContextNodes = (...arg) => {
-    // we want to notify the manager only when the story changed since `parameter` can be changed
     if (contextsNodesMemo === null) {
       contextsNodesMemo = getContextNodes(...arg);
       channel.emit(UPDATE_MANAGER, contextsNodesMemo);

--- a/addons/contexts/src/preview/libs/getContextNodes.ts
+++ b/addons/contexts/src/preview/libs/getContextNodes.ts
@@ -19,7 +19,7 @@ export const _getMergedSettings: _getMergedSettings = (topLevel, storyLevel) => 
   components: topLevel.components || storyLevel.components || [],
   params:
     topLevel.params || storyLevel.params
-      ? [].concat(topLevel.params, storyLevel.params).filter(Boolean)
+      ? [topLevel.params, storyLevel.params].flat().filter(Boolean)
       : [{ name: '', props: {} }],
   options: {
     deep: false,
@@ -38,8 +38,8 @@ export const _getMergedSettings: _getMergedSettings = (topLevel, storyLevel) => 
 type getContextNodes = (settings: WrapperSettings) => ContextNode[];
 
 export const getContextNodes: getContextNodes = ({ options, parameters }) => {
-  const titles = []
-    .concat(options, parameters)
+  const titles = [options, parameters]
+    .flat()
     .filter(Boolean)
     .map(({ title }) => title);
 

--- a/addons/contexts/src/preview/libs/getContextNodes.ts
+++ b/addons/contexts/src/preview/libs/getContextNodes.ts
@@ -19,7 +19,7 @@ export const _getMergedSettings: _getMergedSettings = (topLevel, storyLevel) => 
   components: topLevel.components || storyLevel.components || [],
   params:
     topLevel.params || storyLevel.params
-      ? [topLevel.params, storyLevel.params].flat().filter(Boolean)
+      ? [...(topLevel.params || []), ...(storyLevel.params || [])].filter(Boolean)
       : [{ name: '', props: {} }],
   options: {
     deep: false,
@@ -38,8 +38,7 @@ export const _getMergedSettings: _getMergedSettings = (topLevel, storyLevel) => 
 type getContextNodes = (settings: WrapperSettings) => ContextNode[];
 
 export const getContextNodes: getContextNodes = ({ options, parameters }) => {
-  const titles = [options, parameters]
-    .flat()
+  const titles = [...(options || []), ...(parameters || [])]
     .filter(Boolean)
     .map(({ title }) => title);
 

--- a/addons/contexts/src/shared/serializers.ts
+++ b/addons/contexts/src/shared/serializers.ts
@@ -3,7 +3,7 @@ import { SelectionState } from './types.d';
 /**
  * Serialize the selection state in its string representation.
  */
-type serialize = (state: SelectionState) => string | null;
+type serialize = (state: ReturnType<deserialize>) => string | null;
 
 export const serialize: serialize = state =>
   !state
@@ -15,7 +15,7 @@ export const serialize: serialize = state =>
 /**
  * Deserialize URL query param into the specified selection state.
  */
-type deserialize = (param: string) => SelectionState | null;
+type deserialize = (param?: string) => SelectionState | null;
 
 export const deserialize: deserialize = param =>
   !param

--- a/addons/contexts/tsconfig.json
+++ b/addons/contexts/tsconfig.json
@@ -5,10 +5,11 @@
     "paths": {
       "preact": ["src/shared/@mock-types/_preact.d.ts"]
     },
+    "strictNullChecks": true,
     "removeComments": true,
     "rootDir": "./src",
     "types": ["webpack-env", "jest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/register.ts", "src/__tests__/**/*", "src/**/*.test.ts"]
+  "exclude": ["src/register.ts", "src/**/*.test.ts"]
 }

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -83,7 +83,7 @@ const initialUrlSupport = ({ navigate, location, path }: Module) => {
 };
 
 export interface QueryParams {
-  [key: string]: string;
+  [key: string]: string | null;
 }
 
 export interface SubAPI {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
       "jest"
     ],
     "lib": [
-      "es2017",
+      "esnext",
       "dom"
     ]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
       "jest"
     ],
     "lib": [
-      "esnext",
+      "es2017",
       "dom"
     ]
   },


### PR DESCRIPTION
Issue: #6668 

## What I did
- [bugfix] Have no cancel option in UI if the context have no param.
- [type] enable more strict typing with `--strictNullChecks` (@`addon-contexts` level).
- [chore] simplify to make code more readable.

## How to test
N/A