### PR TITLE
updated npm broken link issue documentation #6556

### DIFF
--- a/addons/actions/README.md
+++ b/addons/actions/README.md
@@ -4,7 +4,7 @@ Storybook Addon Actions can be used to display data received by event handlers i
 
 [Framework Support](https://github.com/storybooks/storybook/blob/master/ADDONS_SUPPORT.md)
 
-![Screenshot](docs/screenshot.png)
+![Screenshot](https://raw.githubusercontent.com/storybooks/storybook/HEAD/addons/actions/docs/screenshot.png)
 
 ## Getting Started
 

--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -4,7 +4,7 @@ StoryShots adds automatic Jest Snapshot Testing for [Storybook](https://storyboo
 
 [Framework Support](https://github.com/storybooks/storybook/blob/master/ADDONS_SUPPORT.md)
 
-![StoryShots In Action](docs/storyshots-fail.png)
+![StoryShots In Action](https://raw.githubusercontent.com/storybooks/storybook/HEAD/addons/storyshots/storyshots-core/docs/storyshots-fail.png)
 
 To use StoryShots, you must use your existing Storybook stories as the input for Jest Snapshot Testing.
 
@@ -194,7 +194,7 @@ That's all.
 
 Now run your Jest test command. (Usually, `npm test`.) Then you can see all of your stories are converted as Jest snapshot tests.
 
-![Screenshot](docs/storyshots.png)
+![Screenshot](https://raw.githubusercontent.com/storybooks/storybook/HEAD/addons/storyshots/storyshots-core/docs/storyshots.png)
 
 
 ### Using `createNodeMock` to mock refs


### PR DESCRIPTION
Updated link  in readme files for displaying across npm
1)https://www.npmjs.com/package/@storybook/addon-actions
2)https://www.npmjs.com/package/@storybook/addon-storyshots
Let me know if any doubts.
Fixed #6556
Thanks