### PR TITLE
updated broken link images for npm in readme file

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -4,7 +4,7 @@ This storybook addon can be helpful to make your UI components more accessible.
 
 [Framework Support](https://github.com/storybooks/storybook/blob/master/ADDONS_SUPPORT.md)
 
-![](docs/screenshot.png)
+![Screenshot](https://raw.githubusercontent.com/storybooks/storybook/HEAD/addons/a11y/docs/screenshot.png)
 
 ## Getting started
 

--- a/addons/graphql/README.md
+++ b/addons/graphql/README.md
@@ -4,7 +4,7 @@ Storybook GraphQL Addon can be used to display the GraphiQL IDE with example que
 
 [Framework Support](https://github.com/storybooks/storybook/blob/master/ADDONS_SUPPORT.md)
 
-![Screenshot](docs/screenshot.png)
+![Screenshot](https://raw.githubusercontent.com/storybooks/storybook/HEAD/addons/graphql/docs/screenshot.png)
 
 ## Getting Started
 

--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -5,7 +5,7 @@ Useful when you want to display usage or other types of documentation alongside 
 
 [Framework Support](https://github.com/storybooks/storybook/blob/master/ADDONS_SUPPORT.md)
 
-![Screenshot](docs/home-screenshot.png)
+![Screenshot](https://raw.githubusercontent.com/storybooks/storybook/HEAD/addons/info/docs/home-screenshot.png)
 
 ## Installation
 

--- a/addons/options/README.md
+++ b/addons/options/README.md
@@ -13,7 +13,7 @@ The Options addon can be used to (re-)configure the [Storybook](https://storyboo
 
 [Framework Support](https://github.com/storybooks/storybook/blob/master/ADDONS_SUPPORT.md)
 
-![Screenshot](docs/screenshot.png)
+![Screenshot](https://raw.githubusercontent.com/storybooks/storybook/HEAD/addons/options/docs/screenshot.png)
 
 ## Getting Started
 


### PR DESCRIPTION
Issue:
Broken link images for npm in readme
Fixed:
Updated the image link for the same for below npm packages
1)https://www.npmjs.com/package/@storybook/addon-a11y
2)https://www.npmjs.com/package/@storybook/addon-graphql
3)https://www.npmjs.com/package/@storybook/addon-info
4)https://www.npmjs.com/package/@storybook/addon-options