### PR TITLE
Fix regression with deep linking

### DIFF
--- a/lib/ui/src/components/preview/iframe.js
+++ b/lib/ui/src/components/preview/iframe.js
@@ -12,8 +12,8 @@ export class IFrame extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    const { scale } = this.props;
-    return scale !== nextProps.scale;
+    const { scale, src } = this.props;
+    return scale !== nextProps.scale || src !== nextProps.src;
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Issue: #5925

The issue was the `iframe` did not update when its `src` was changed as we navigated to the story id.

The reason it sometimes worked depended on whether the preview had set up its channel in time (the event *was* emitted).

## What I did

Ensured the preview's URL changed.

## How to test

http://localhost:9011/?selectedKind=UI%7CPanel&selectedStory=no+panels