### PR TITLE
Use `http-server` instead of `serve` in the example

### DIFF
--- a/docs/src/pages/basics/exporting-storybook/index.md
+++ b/docs/src/pages/basics/exporting-storybook/index.md
@@ -28,7 +28,7 @@ Now you can deploy the content in the `.out` directory wherever you want.
 To test it locally:
 
 ```sh
-npx serve .
+npx http-server .out
 ```
 
 ## Deploying to GitHub Pages


### PR DESCRIPTION
Unfortunately, current version of `serve` doesn't work without [configuration](https://github.com/zeit/serve/issues/393#issuecomment-395978195), as it removes the query string from iframe URL