### PR TITLE
Update how we install dev dependencies in cli

### DIFF
--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -46,7 +46,6 @@ async function addDependencies(npmOptions) {
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 }
 

--- a/lib/cli/generators/EMBER/index.js
+++ b/lib/cli/generators/EMBER/index.js
@@ -42,6 +42,5 @@ export default async npmOptions => {
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/HTML/index.js
+++ b/lib/cli/generators/HTML/index.js
@@ -30,9 +30,5 @@ export default async npmOptions => {
 
   const babelDependencies = await getBabelDependencies(npmOptions, packageJson);
 
-  installDependencies(npmOptions, [
-    `@storybook/html@${storybookVersion}`,
-    ...babelDependencies,
-    '-D',
-  ]);
+  installDependencies(npmOptions, [`@storybook/html@${storybookVersion}`, ...babelDependencies]);
 };

--- a/lib/cli/generators/MARKO/index.js
+++ b/lib/cli/generators/MARKO/index.js
@@ -36,6 +36,5 @@ export default async npmOptions => {
     `@storybook/addon-actions@${addonActionVersion}`,
     `@storybook/addon-knobs@${addonKnobsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/METEOR/index.js
+++ b/lib/cli/generators/METEOR/index.js
@@ -83,7 +83,7 @@ export default async npmOptions => {
   }
 
   if (dependencies.length > 0) {
-    installDependencies(npmOptions, dependencies);
+    installDependencies({ ...npmOptions, installAsDevDependencies: false }, dependencies);
   }
 
   installDependencies(npmOptions, [...devDependencies, ...babelDependencies, '-D']);

--- a/lib/cli/generators/METEOR/index.js
+++ b/lib/cli/generators/METEOR/index.js
@@ -86,5 +86,5 @@ export default async npmOptions => {
     installDependencies({ ...npmOptions, installAsDevDependencies: false }, dependencies);
   }
 
-  installDependencies(npmOptions, [...devDependencies, ...babelDependencies, '-D']);
+  installDependencies(npmOptions, [...devDependencies, ...babelDependencies]);
 };

--- a/lib/cli/generators/MITHRIL/index.js
+++ b/lib/cli/generators/MITHRIL/index.js
@@ -38,6 +38,5 @@ export default async npmOptions => {
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/POLYMER/index.js
+++ b/lib/cli/generators/POLYMER/index.js
@@ -37,5 +37,5 @@ export default async npmOptions => {
 
   const babelDependencies = await getBabelDependencies(npmOptions, packageJson);
 
-  installDependencies(npmOptions, [...devDependencies, ...babelDependencies, '-D']);
+  installDependencies(npmOptions, [...devDependencies, ...babelDependencies]);
 };

--- a/lib/cli/generators/PREACT/index.js
+++ b/lib/cli/generators/PREACT/index.js
@@ -38,6 +38,5 @@ export default async npmOptions => {
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/REACT/index.js
+++ b/lib/cli/generators/REACT/index.js
@@ -38,6 +38,5 @@ export default async npmOptions => {
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/REACT_NATIVE/index.js
+++ b/lib/cli/generators/REACT_NATIVE/index.js
@@ -79,6 +79,5 @@ export default async (npmOptions, installServer) => {
   installDependencies(npmOptions, [
     ...devDependencies,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/REACT_SCRIPTS/index.js
+++ b/lib/cli/generators/REACT_SCRIPTS/index.js
@@ -49,6 +49,5 @@ export default async npmOptions => {
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/RIOT/index.js
+++ b/lib/cli/generators/RIOT/index.js
@@ -51,5 +51,5 @@ export default async npmOptions => {
 
   const babelDependencies = await getBabelDependencies(npmOptions, packageJson);
 
-  installDependencies(npmOptions, [...dependencies, ...babelDependencies, '-D']);
+  installDependencies(npmOptions, [...dependencies, ...babelDependencies]);
 };

--- a/lib/cli/generators/SFC_VUE/index.js
+++ b/lib/cli/generators/SFC_VUE/index.js
@@ -38,6 +38,5 @@ export default async npmOptions => {
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/SVELTE/index.js
+++ b/lib/cli/generators/SVELTE/index.js
@@ -49,6 +49,5 @@ export default async npmOptions => {
     `svelte@${svelte}`,
     `svelte-loader@${svelteLoader}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/UPDATE_PACKAGE_ORGANIZATIONS/index.js
+++ b/lib/cli/generators/UPDATE_PACKAGE_ORGANIZATIONS/index.js
@@ -46,7 +46,9 @@ async function updatePackageJson(npmOptions) {
 
   const babelDependencies = await getBabelDependencies(npmOptions, packageJson);
 
-  installDependencies(npmOptions, [...babelDependencies, '-D']);
+  if (babelDependencies.length > 0) {
+    installDependencies(npmOptions, babelDependencies);
+  }
 }
 
 function updateSourceCode(parser) {

--- a/lib/cli/generators/VUE/index.js
+++ b/lib/cli/generators/VUE/index.js
@@ -61,6 +61,5 @@ export default async npmOptions => {
     `@storybook/addons@${addonsVersion}`,
     `babel-preset-vue@${babelPresetVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/generators/WEBPACK_REACT/index.js
+++ b/lib/cli/generators/WEBPACK_REACT/index.js
@@ -38,6 +38,5 @@ export default async npmOptions => {
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
-    '-D',
   ]);
 };

--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -200,22 +200,27 @@ export function installDepsFromPackageJson(options) {
 /**
  * Add dependencies to a project using `yarn add` or `npm install`.
  *
- * @param {Object} npmOptions contains `useYarn` which we use to determine how we install packages.
- * @param {Array} dependencies contains a list of packages to add. if you're trying to install dev dependencies you can append `'-D'` to the array.
+ * @param {Object} npmOptions contains `useYarn` and `installAsDevDependencies` which we use to determine how we install packages.
+ * @param {Array} dependencies contains a list of packages to add.
  * @example
  * installDependencies(npmOptions, [
  *   `@storybook/react@${storybookVersion}`,
  *   `@storybook/addon-actions@${actionsVersion}`,
  *   `@storybook/addon-links@${linksVersion}`,
  *   `@storybook/addons@${addonsVersion}`,
- *   '-D',
  * ]);
  */
 export function installDependencies(npmOptions, dependencies) {
   const spawnCommand = npmOptions.useYarn ? 'yarn' : 'npm';
   const installCommand = npmOptions.useYarn ? 'add' : 'install';
 
-  const dependencyResult = spawnSync(spawnCommand, [installCommand, ...dependencies], {
+  const installArgs = [installCommand, ...dependencies];
+
+  if (npmOptions.installAsDevDependencies) {
+    installArgs.push('-D');
+  }
+
+  const dependencyResult = spawnSync(spawnCommand, installArgs, {
     stdio: 'inherit',
   });
 
@@ -236,7 +241,6 @@ export function installDependencies(npmOptions, dependencies) {
  * installDependencies(npmOptions, [
  *   `@storybook/react@${storybookVersion}`,
  *   ...babelDependencies,
- *   '-D',
  * ]);
  */
 export async function getBabelDependencies(npmOptions, packageJson) {

--- a/lib/cli/lib/initiate.js
+++ b/lib/cli/lib/initiate.js
@@ -36,6 +36,7 @@ const installStorybook = (projectType, options) => {
 
   const npmOptions = {
     useYarn,
+    installAsDevDependencies: true,
   };
 
   const runStorybookCommand = useYarn ? 'yarn storybook' : 'npm run storybook';


### PR DESCRIPTION
Issue: #4805 

## What I did
_Scoped to `lib/cli/`_
- add a new option, `installAsDevDependencies`, to `npmOptions` in `initiate.js`
- update `installDependencies` helper function to use that new option
  - update usage of this function to not pass `'-D'` in list of dependencies anymore

Relates to a comment from a previous PR: [comment](https://github.com/storybooks/storybook/pull/6629#discussion_r278770095)

## How to test
`yarn test --cli`

- While this is testing, it might be good to look into `test/run/` and look at the `package.json`s to ensure dependencies are being installed as expected
  - a good candidate to look at is the meteor fixture since it tries to install normal dependencies and dev dependencies
- If it helps you can comment out `trap cleanup EXIT` in `run_tests.sh` to avoid deleting the `run` directory after testing

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
