### PR TITLE
fix: Preserve dimensions on resizing for panel

### DIFF
--- a/lib/ui/src/components/layout/container.js
+++ b/lib/ui/src/components/layout/container.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-did-update-set-state */
+
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { styled, withTheme } from '@storybook/theming';
@@ -285,13 +287,35 @@ class Layout extends Component {
     };
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps, prevState) {
     const { resizerPanel, resizerNav } = this.state;
 
     persistance.set({
       resizerPanel,
       resizerNav,
     });
+    const { width: prevWidth, height: prevHeight } = prevProps.bounds;
+    const { bounds, options } = this.props;
+    const { width, height } = bounds;
+    if (width !== prevWidth || height !== prevHeight) {
+      const { panelPosition } = options;
+      const isPanelBottom = panelPosition === 'bottom';
+      if (isPanelBottom) {
+        this.setState({
+          resizerPanel: {
+            x: prevState.resizerPanel.x,
+            y: prevState.resizerPanel.y - (prevHeight - height),
+          },
+        });
+      } else {
+        this.setState({
+          resizerPanel: {
+            x: prevState.resizerPanel.x - (prevWidth - width),
+            y: prevState.resizerPanel.y,
+          },
+        });
+      }
+    }
   }
 
   static getDerivedStateFromProps(props, state) {


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6343

## What I did

- Update resizer position when changing the boundaries of the container
for the addon panel and preview


## How to test

![storybookPR](https://user-images.githubusercontent.com/4264247/57001956-f087d180-6bbb-11e9-8399-eba1543c847c.gif)
