### PR TITLE
Typo in svelte stories example (non-valid JS)

### DIFF
--- a/docs/src/pages/guides/guide-svelte/index.md
+++ b/docs/src/pages/guides/guide-svelte/index.md
@@ -99,7 +99,7 @@ storiesOf('MyButton', module)
     data: {
       buttonText: 'some text',
     },
-  })),
+  }))
   .add('with text', () => ({
     Component: MyButton,
 


### PR DESCRIPTION
## What I did
Fix non-valid JS example in svlete stories example.

## How to test
The documentation example should now be correct. 