### PR TITLE
Fix the edit docs link in svelte guide

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -24,6 +24,7 @@ module.exports = {
         '/guides/guide-mithril/',
         '/guides/guide-ember/',
         '/guides/guide-riot/',
+        '/guides/guide-svelte/',
       ],
       configurations: [
         '/configurations/options-parameter/',


### PR DESCRIPTION
Issue : The edit docs link is KO in the svelte guide (https://github.com/storybooks/storybook/blob/master/docs/src/pages/undefined/guide-svelte/index.md) 
![image](https://user-images.githubusercontent.com/23191482/57380705-c4ff7b00-71a9-11e9-83e8-c41b492f9f10.png)

## What I did
Fix this link due to missing configuration in gatsby

## How to test
The links should now lead to the documentation in github. 