### PR TITLE
Fix duplicate key in svelte guide

### DIFF
--- a/docs/src/pages/guides/guide-svelte/index.md
+++ b/docs/src/pages/guides/guide-svelte/index.md
@@ -100,7 +100,7 @@ storiesOf('MyButton', module)
       buttonText: 'some text',
     },
   }))
-  .add('with text', () => ({
+  .add('with some emojies', () => ({
     Component: MyButton,
 
     props: {


### PR DESCRIPTION
Issue:
- In storybook, the emojies example erases the first example (same key)in svelte docs
- Implies that the example contains only one example instead of two

## What I did
Change the key of the emojies example to be compliant with the other examples

## How to test
When running the examples in Storybook, we should get two stories instead of one. 