### PR TITLE
Corrected failing example in Vue guide

### DIFF
--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -132,8 +132,14 @@ import { storiesOf } from '@storybook/vue';
 import MyButton from './Button.vue';
 
 storiesOf('Button', module)
-  .add('with text', () => '<my-button>with text</my-button>')
-  .add('with emoji', () => '<my-button>😀 😎 👍 💯</my-button>')
+  .add('with text', () => ({
+    components: { MyButton },
+    template: '<my-button>with text</my-button>'
+  }))
+  .add('with emoji', () => ({
+    components: { MyButton },
+    template: '<my-button>😀 😎 👍 💯</my-button>'
+  }))
   .add('as a component', () => ({
     components: { MyButton },
     template: '<my-button :rounded="true">rounded</my-button>'


### PR DESCRIPTION
This example failed out of the box. Registering every time is necessary, apparently

Issue:
Example in Vue guide threw errors on fresh install

## What I did
Added component registration in every `.add()`
