### PR TITLE
issue #6763 : set a better value for process in the manager webpack config

### DIFF
--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -55,12 +55,11 @@ export default ({ configDir, configType, entries, dll, outputDir, cache, babelOp
         }),
         template: require.resolve(`../templates/index.ejs`),
       }),
-      new webpack.DefinePlugin({ 'process.env': stringified }),
       new CaseSensitivePathsPlugin(),
       new Dotenv({ silent: true }),
       // graphql sources check process variable
       new DefinePlugin({
-        process: JSON.stringify(true),
+        process: { browser: true, env: stringified },
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       }),
       // See https://github.com/graphql/graphql-language-service/issues/111#issuecomment-306723400


### PR DESCRIPTION
Issue:

## What I did
I have fixed the trouble with libraries making use of the process variable.
In the manager configuration, the variable is set to true, 
Which causes several troubles when using additional libraries (like crypto)
So instead of true, I am setting a more relevant value
this also fixes issue #6763 

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
