### PR TITLE
typo fix in ember setup guide

### DIFF
--- a/docs/src/pages/guides/guide-ember/index.md
+++ b/docs/src/pages/guides/guide-ember/index.md
@@ -78,7 +78,7 @@ That'll load stories in `../stories/index.js`.
 
 Now you can write some stories inside the `../stories/index.js` file, like this:
 
-> It is import that you import the `hbs` function that is provided by a babel plugin in `@storybook/ember`
+> It is important that you import the `hbs` function that is provided by a babel plugin in `@storybook/ember`
 
 ```js
 import hbs from 'htmlbars-inline-precompile';


### PR DESCRIPTION
This seems to be a typo in the setup guide of the Ember storybook.

 Also, in the particular line, it is mentioned that the `hbs` file has to be imported from the storybook babel plugin. But in the sample code, `has` was imported from `htmlbars-inline-precompile`. Is that intentional?
