### PR TITLE
fix required engine for app

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -55,7 +55,7 @@
     "zone.js": "^0.8.29"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/ember/package.json
+++ b/app/ember/package.json
@@ -37,7 +37,7 @@
     "ember-source": "^3.4.0"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/html/package.json
+++ b/app/html/package.json
@@ -36,7 +36,7 @@
     "babel-loader": "^7.0.0 || ^8.0.0"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/marko/package.json
+++ b/app/marko/package.json
@@ -40,7 +40,7 @@
     "marko-widgets": "^7.0.1"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/mithril/package.json
+++ b/app/mithril/package.json
@@ -41,7 +41,7 @@
     "mithril": "^1.1.6"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/polymer/package.json
+++ b/app/polymer/package.json
@@ -43,7 +43,7 @@
     "polymer-webpack-loader": "^2.0.2"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -41,7 +41,7 @@
     "preact": "^8.4.2"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/react-native-server/package.json
+++ b/app/react-native-server/package.json
@@ -42,7 +42,7 @@
     "babel-loader": "^7.0.0 || ^8.0.0"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -40,7 +40,7 @@
     "react-native": ">=0.57.0"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -52,7 +52,7 @@
     "react-dom": "*"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/riot/package.json
+++ b/app/riot/package.json
@@ -46,7 +46,7 @@
     "riot-tag-loader": "^2.0.0 || ^3.0.0"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -42,7 +42,7 @@
     "svelte-loader": "^2.9.1"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -45,7 +45,7 @@
     "vue-template-compiler": "^2.6.8"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8.0.0" 
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When running yarn bootstrap on a node 10 engine, I get the following error

```
TSFILE: /Users/ledouxb/Documents/github/storybook/lib/ui/dist/keyboard/platform.d.ts
TSFILE: /Users/ledouxb/Documents/github/storybook/lib/ui/dist/keyboard/keyCodes.d.ts
TSFILE: /Users/ledouxb/Documents/github/storybook/lib/ui/dist/keyboard/keyModel.d.ts
TSFILE: /Users/ledouxb/Documents/github/storybook/lib/ui/dist/keyboard/scanCode.d.ts
Built: @storybook/ui@5.1.0-beta.1
lerna ERR! yarn run prepare exited 1 in '@storybook/react-native'
lerna ERR! yarn run prepare stdout:
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

lerna ERR! yarn run prepare stderr:
error @storybook/react-native@5.1.0-beta.1: The engine "node" is incompatible with this module. Expected version "^8". Got "10.14.2"
error Commands cannot run with an incompatible environment.

lerna ERR! yarn run prepare exited 1 in '@storybook/react-native'
lerna WARN complete Waiting for 3 child processes to exit. CTRL-C to exit immediately.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

according to [this doc](https://docs.npmjs.com/files/package.json#engines), engines should be specified in a different way than dependencies. 

this fixes yarn bootstrap