### PR TITLE
ISS-6802 Fix issue with init in create-react-library projects

### DIFF
--- a/lib/cli/generators/REACT_SCRIPTS/index.js
+++ b/lib/cli/generators/REACT_SCRIPTS/index.js
@@ -39,7 +39,10 @@ export default async npmOptions => {
 
   // When working with `create-react-app@>=2.0.0`, we know `babel-loader` is installed.
   let babelDependencies = [];
-  if (semver.gtr('2.0.0', packageJson.dependencies['react-scripts'])) {
+  const reactScriptsDep =
+    packageJson.dependencies['react-scripts'] || packageJson.devDependencies['react-scripts'];
+
+  if (reactScriptsDep && semver.gtr('2.0.0', reactScriptsDep)) {
     babelDependencies = await getBabelDependencies(npmOptions, packageJson);
   }
 


### PR DESCRIPTION
Issue: #6802 

There's two causes to this issue: 
- `create-react-library` puts `react-scripts` in devDeps
- `semver.gtr()` fails if you pass it `undefined`

## What I did
- In the `REACT_SCRIPTS` generator, check both dependencies and devDependencies for `react-scripts`
- Also, make sure it exists before trying to use `semver`

## How to test

1. npm install -g create-react-library
2. create-react-library -s -t default test
3. cd test
4. npx -p @storybook/cli@next sb init

I tested init before and after the changes and looked good to me 👍 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
