### PR TITLE
(feature): Support loglevel for production/ci builds.

### DIFF
--- a/docs/src/pages/configurations/cli-options/index.md
+++ b/docs/src/pages/configurations/cli-options/index.md
@@ -46,6 +46,7 @@ Options:
 -o, --output-dir [dir-name]   Directory where to store built files
 -c, --config-dir [dir-name]   Directory where to load Storybook configurations from
 -w, --watch                   Enable watch mode
+--loglevel [level]            Control level of logging during build. Can be one of: [silly, verbose, info (default), warn, error, silent]
 --quiet                       Suppress verbose build output
 --no-dll                      Do not use dll reference
 --debug-webpack               Display final webpack configurations for debugging purposes

--- a/lib/core/src/server/cli/prod.js
+++ b/lib/core/src/server/cli/prod.js
@@ -13,10 +13,12 @@ function getCLI(packageJson) {
     .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
     .option('-w, --watch', 'Enable watch mode')
     .option('--quiet', 'Suppress verbose build output')
+    .option('--loglevel [level]', 'Control level of logging during build')
     .option('--no-dll', 'Do not use dll reference')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .parse(process.argv);
 
+  logger.setLevel(program.loglevel);
   logger.info(chalk.bold(`${packageJson.name} v${packageJson.version}\n`));
 
   // The key is the field created in `program` variable for

--- a/lib/node-logger/src/index.ts
+++ b/lib/node-logger/src/index.ts
@@ -21,6 +21,9 @@ export const logger = {
   error: (message: string): void => npmLog.error('', message),
   trace: ({ message, time }: { message: string; time: [number, number] }): void =>
     npmLog.info('', `${message} (${colors.purple(prettyTime(time))})`),
+  setLevel: (level: string = 'info'): void => {
+    npmLog.level = level;
+  },
 };
 
 export { npmLog as instance };


### PR DESCRIPTION
Issue:

In order to better support various ci and package management workflows, it would be nice to have the ability to suppress some (or all) of build-storybook's logging output. Given Storybook uses npmLog, and npmLog has a feature to support this functionality, it's simple to surface that functionality to the cli through the addition of a `--loglevel` argument.

## What I did

Surfaced cli argument `--loglevel` for build-storybook to hook into npmlog's level setting.

## How to test

- Does this need a new example in the kitchen sink apps?
Maybe? Does Storybook show examples for all build options? It wasn't immediately clear to me.
- Does this need an update to the documentation?
Yes. The cli-options index.md is updated in this PR to reflect the change.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
