### PR TITLE
BUGFIX v5.1.x change breaks Boolean knob (#6366)

### DIFF
--- a/addons/knobs/src/components/PropForm.js
+++ b/addons/knobs/src/components/PropForm.js
@@ -9,8 +9,8 @@ const InvalidType = () => <span>Invalid Type</span>;
 export default class PropForm extends Component {
   makeChangeHandler(name, type) {
     const { onFieldChange } = this.props;
-    return value => {
-      const change = { name, type, value: value || '' };
+    return (value = '') => {
+      const change = { name, type, value };
 
       onFieldChange(change);
     };


### PR DESCRIPTION
Issue: #6366

## What I did
- Use ES6 argument default value assignment to handle `undefined` case, which is never wanted; this prevent `false` cast to empty string (bug).

## How to test

- Find a story that contains a toggle boolean knob.  Toggle it to see no type warning.

---

I have a strong feeling that we need to rewrite knob from the ground up with TS since it was too buggy.  But I haven't talk with @ndelangen about what is the plan or roadmap for that yet...

And sorry for this easy bug I committed to fix lately, I get many things pile up unfortunately 😂...