### PR TITLE
FIX an issue where forwardRefs make addon-info throw

### DIFF
--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -358,17 +358,22 @@ class Story extends Component {
         extract(innerChildren.props.children);
       }
       if (isForwardRef(innerChildren)) {
-        extract(innerChildren.type.render(innerChildren.props));
+        try {
+          // this might fail because of hooks being used
+          extract(innerChildren.type.render(innerChildren.props));
+        } catch (e) {
+          // do nothing
+        }
       }
       if (
         typeof innerChildren === 'string' ||
         typeof innerChildren.type === 'string' ||
-        isForwardRef(innerChildren) ||
         (Array.isArray(propTablesExclude) && // also ignore excluded types
           ~propTablesExclude.indexOf(innerChildren.type)) // eslint-disable-line no-bitwise
       ) {
         return;
       }
+
       if (innerChildren.type && !types.has(innerChildren.type)) {
         types.set(innerChildren.type, true);
       }

--- a/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-info.stories.storyshot
@@ -555,6 +555,128 @@ exports[`Storyshots Addons|Info/ForwardRef Displays forwarded ref components cor
               </tbody>
             </table>
           </div>
+          <div>
+            <h3
+              style="margin:20px 0 0 0"
+            >
+              "Unknown" Component
+            </h3>
+            <table
+              class="info-table"
+            >
+              <thead>
+                <tr>
+                  <th>
+                    property
+                  </th>
+                  <th>
+                    propType
+                  </th>
+                  <th>
+                    required
+                  </th>
+                  <th>
+                    default
+                  </th>
+                  <th>
+                    description
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    disabled
+                  </td>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    <span>
+                      bool
+                    </span>
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    <span>
+                      false
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    label
+                  </td>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    <span>
+                      string
+                    </span>
+                  </td>
+                  <td>
+                    yes
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    onClick
+                  </td>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    <span>
+                      func
+                    </span>
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    <span>
+                      onClick
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    style
+                  </td>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    <span>
+                      other
+                    </span>
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    <span>
+                      {}
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>
@@ -674,6 +796,128 @@ exports[`Storyshots Addons|Info/ForwardRef Uses forwardRef displayName if availa
               style="margin:20px 0 0 0"
             >
               "BaseButton" Component
+            </h3>
+            <table
+              class="info-table"
+            >
+              <thead>
+                <tr>
+                  <th>
+                    property
+                  </th>
+                  <th>
+                    propType
+                  </th>
+                  <th>
+                    required
+                  </th>
+                  <th>
+                    default
+                  </th>
+                  <th>
+                    description
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    disabled
+                  </td>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    <span>
+                      bool
+                    </span>
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    <span>
+                      false
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    label
+                  </td>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    <span>
+                      string
+                    </span>
+                  </td>
+                  <td>
+                    yes
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    onClick
+                  </td>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    <span>
+                      func
+                    </span>
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    <span>
+                      onClick
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+                <tr>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    style
+                  </td>
+                  <td
+                    class="info-table-monospace"
+                  >
+                    <span>
+                      other
+                    </span>
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    <span>
+                      {}
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <h3
+              style="margin:20px 0 0 0"
+            >
+              "ButtonDisplayName" Component
             </h3>
             <table
               class="info-table"


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/6848

Related: https://github.com/storybooks/storybook/pull/4961#issuecomment-494712757

## What I did
I wrapped a `try-catch` around the section of code that was failing, ignoring the error.

