### PR TITLE
Removed  overflow: 'auto' from addon centered that causes unnecessary scroll bar

### DIFF
--- a/addons/centered/src/styles.ts
+++ b/addons/centered/src/styles.ts
@@ -12,7 +12,6 @@ const styles = {
   innerStyle: {
     margin: 'auto',
     maxHeight: '100%', // Hack for centering correctly in IE11
-    overflow: 'auto',
   },
 } as const;
 

--- a/examples/angular-cli/src/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/angular-cli/src/stories/__snapshots__/addon-centered.stories.storyshot
@@ -13,7 +13,7 @@ exports[`Storyshots Addon|Centered centered component 1`] = `
     >
       <div
         ng-reflect-ng-style="[object Object]"
-        style="margin: auto; max-height: 100%; overflow: auto;"
+        style="margin: auto; max-height: 100%;"
       >
         <storybook-app-root>
           <div
@@ -89,7 +89,7 @@ exports[`Storyshots Addon|Centered centered template 1`] = `
     >
       <div
         ng-reflect-ng-style="[object Object]"
-        style="margin: auto; max-height: 100%; overflow: auto;"
+        style="margin: auto; max-height: 100%;"
       >
         <storybook-button-component
           _nghost-a-c6=""

--- a/examples/html-kitchen-sink/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/html-kitchen-sink/stories/__snapshots__/addon-centered.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Addons|Centered button in center 1`] = `
 >
   <div
     id="sb-addon-centered-inner"
-    style="margin: auto; max-height: 100%; overflow: auto;"
+    style="margin: auto; max-height: 100%;"
   >
     <button>
       I am a Button !

--- a/examples/official-storybook/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-centered.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Addons|Centered story 1 1`] = `
   style="position:fixed;top:0;left:0;bottom:0;right:0;display:flex;align-items:center;overflow:auto"
 >
   <div
-    style="margin:auto;max-height:100%;overflow:auto"
+    style="margin:auto;max-height:100%"
   >
     <button
       type="button"

--- a/examples/preact-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/preact-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
@@ -20,7 +20,6 @@ exports[`Storyshots Addons|Centered Button 1`] = `
       Object {
         "margin": "auto",
         "maxHeight": "100%",
-        "overflow": "auto",
       }
     }
   >

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/addon-centered.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Addon|Centered rounded 1`] = `
   style="position: fixed; top: 0px; left: 0px; bottom: 0px; right: 0px; display: flex; align-items: center; overflow: auto;"
 >
   <div
-    style="margin: auto; max-height: 100%; overflow: auto;"
+    style="margin: auto; max-height: 100%;"
   >
     <button
       class="button rounded"


### PR DESCRIPTION
Issue: 
Scrollbar shows up when components are larger than the window which also causes weird side effects for other components. Examples are below (the expected is without overflow 'auto', actual is with overflow 'auto'):

Expected (scroll bar is on the edge)
![image](https://user-images.githubusercontent.com/29763590/58220804-4ee93100-7cde-11e9-885b-c04f9c4de4c6.png)

Actual (scroll bar is pulled in next to the component)
![image](https://user-images.githubusercontent.com/29763590/58220832-67f1e200-7cde-11e9-9fc4-f00cad8aba58.png)


Expected
![image](https://user-images.githubusercontent.com/29763590/58220701-e0a46e80-7cdd-11e9-87ca-d6ddc24c55e8.png)

Actual
![image](https://user-images.githubusercontent.com/29763590/58220722-f4e86b80-7cdd-11e9-8461-bda173ec190f.png)


## What I did
I removed overflow: 'auto' from the addon centered styles. This style was introduced in version: 5.1.0-alpha.21

## How to test

- Is this testable with Jest or Chromatic screenshots? maybe
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
