### PR TITLE
Add color inherit to StyledStoryLink

### DIFF
--- a/addons/storysource/src/StoryPanel.js
+++ b/addons/storysource/src/StoryPanel.js
@@ -11,6 +11,7 @@ const StyledStoryLink = styled(Link)(({ theme }) => ({
   display: 'block',
   textDecoration: 'none',
   borderRadius: theme.appBorderRadius,
+  color: 'inherit',
 
   '&:hover': {
     background: theme.background.hoverable,


### PR DESCRIPTION
This prevents some text to change its original color before/after clicking the link.

Issue:

## What I did

I added storysource to my dark themed storybook. After that, I found that if I click in the source of a story, some text changed its color: 

### Mouse hover

![image](https://user-images.githubusercontent.com/15050200/58335972-2ca7fe00-7e19-11e9-8b1c-8e08c0276731.png)

### Mouse focus

![image](https://user-images.githubusercontent.com/15050200/58336000-3cbfdd80-7e19-11e9-84e6-68de2581ecf0.png)

### Default & expected color

![image](https://user-images.githubusercontent.com/15050200/58336048-4f3a1700-7e19-11e9-92db-fe5eebea440b.png)

## How to test

- Is this testable with Jest or Chromatic screenshots?
  - No.
- Does this need a new example in the kitchen sink apps?
  - No.
- Does this need an update to the documentation?
  - No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
