### PR TITLE
Export text prop in button from Svelte template

### DIFF
--- a/lib/cli/generators/SVELTE/template/stories/button.svelte
+++ b/lib/cli/generators/SVELTE/template/stories/button.svelte
@@ -16,6 +16,8 @@
 
 <script>
   import { createEventDispatcher } from 'svelte';
+  
+  export let text = '';
 
   const dispatch = createEventDispatcher();
 


### PR DESCRIPTION
Issue: I was getting `text is not defined` with the current Svelte example

## What I did

It works if I add an exported text prop. It defaults to an empty string.

## How to test

- Is this testable with Jest or Chromatic screenshots? Not sure
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.