### PR TITLE
FIX addon-notes rendering

### DIFF
--- a/addons/notes/package.json
+++ b/addons/notes/package.json
@@ -33,6 +33,7 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "markdown-to-jsx": "^6.9.3",
+    "memoizerific": "^1.11.3",
     "prop-types": "^15.7.2",
     "util-deprecate": "^1.0.2"
   },

--- a/addons/notes/src/Panel.tsx
+++ b/addons/notes/src/Panel.tsx
@@ -13,6 +13,8 @@ import {
 import Markdown from 'markdown-to-jsx';
 import Giphy from './giphy';
 
+import { formatter } from './formatter';
+
 import { PARAM_KEY, Parameters } from './shared';
 
 const Panel = styled.div(({ theme }) => ({
@@ -135,7 +137,7 @@ const NotesPanel = ({ active }: Props) => {
         return value ? (
           <Panel className="addon-notes-container">
             <DocumentFormatting>
-              <Markdown options={options}>{value}</Markdown>
+              <Markdown options={options}>{formatter(value)}</Markdown>
             </DocumentFormatting>
           </Panel>
         ) : (

--- a/addons/notes/src/formatter.ts
+++ b/addons/notes/src/formatter.ts
@@ -1,0 +1,26 @@
+import memoize from 'memoizerific';
+
+export const formatter = memoize(2)((code: string) => {
+  // code provided to the component is often coming from template literals, which preserve whitespace.
+  // sometimes the first line doesn't have padding, but the second does.
+  // we split the code-string into lines, then if we find padding on line 0 or 1,
+  // we assume that padding is bad, and remove that much padding on all following lines
+  return code
+    .split(/\n/)
+    .reduce(
+      (acc, i, index) => {
+        const match = i.match(/^((:?\s|\t)+)/);
+        const padding = match ? match[1] : '';
+
+        if (acc.firstIndent === '' && padding && index < 3) {
+          return { result: `${acc.result}\n${i.replace(padding, '')}`, firstIndent: padding };
+        }
+        return {
+          result: `${acc.result}\n${i.replace(acc.firstIndent, '').replace(/\s*$/, '')}`,
+          firstIndent: acc.firstIndent,
+        };
+      },
+      { firstIndent: '', result: '' }
+    )
+    .result.trim();
+});


### PR DESCRIPTION
Issue: addons notes sometimes doesn't render html & markdown correctly, sometimes the html appears as code.

## What I did
FIX a rendering issue with addon-notes, where whitespace would render all content in codeblock