### PR TITLE
Mention TSX index file requirement in README

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -113,7 +113,7 @@ The default `tsconfig.json` that comes with CRA works great. If your stories are
 
 ## Create a TSX storybook index 
 
-The default storybook index file is `stories/index.js` -- you'll want to rename this to `stories/index.storybook.tsx`.
+The default storybook index file is `stories/index.js` -- you'll want to rename this to `stories/index.tsx`.
 
 ## Import tsx stories
 

--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -111,6 +111,10 @@ module.exports = ({ config, mode }) => {
 
 The default `tsconfig.json` that comes with CRA works great. If your stories are outside the `src` folder, for example the `stories` folder in root, then `"rootDirs": ["src", "stories"]` needs to be added to be added to `compilerOptions` so it knows what folders to compile. Make sure `jsx` is set to preserve. Should be unchanged.
 
+## Create a TSX storybook index 
+
+The default storybook index file is `stories/index.js` -- you'll want to rename this to `stories/index.storybook.tsx`.
+
 ## Import tsx stories
 
 Change `config.ts` inside the Storybook config directory (by default, it’s `.storybook`) to import stories made with TypeScript:


### PR DESCRIPTION
I was stuck getting Storybook working with TypeScript following the steps here. My components weren't showing up in the Storybook index. 
Issue:

Following the [instructions](https://storybook.js.org/docs/configurations/typescript-config/) for integrating Storybook with TypeScript in a project started with the `create-react-app` script, the components I added in my `stories/index` were not showing up on the storybook index page.

## What I did

Diffed my project with the [demo repo](https://github.com/johot/storybook4-cra2-typescript-react-docgen-typescript-demo), realized that my index file had a different name. Not sure where this requirement comes from, but stories won't show up in the index if it has the name `stories/index.tsx`, which is the likeliest name the user is going to give this file since the default is `stories/index.js`.

## How to test

- Is this testable with Jest or Chromatic screenshots?
No

- Does this need a new example in the kitchen sink apps?
No

- Does this need an update to the documentation?
No, it is an update to the documentation
