### PR TITLE
make it compatible with new version of read-pkg-up

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/hasDependency.js
+++ b/addons/storyshots/storyshots-core/src/frameworks/hasDependency.js
@@ -2,12 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import readPkgUp from 'read-pkg-up';
 
-const { pkg } = readPkgUp.sync();
+const { package: { dependencies, devDependencies } = {} } = readPkgUp.sync() || {};
 
 export default function hasDependency(name) {
   return (
-    (pkg.devDependencies && pkg.devDependencies[name]) ||
-    (pkg.dependencies && pkg.dependencies[name]) ||
+    (devDependencies && devDependencies[name]) ||
+    (dependencies && dependencies[name]) ||
     fs.existsSync(path.join('node_modules', name, 'package.json'))
   );
 }


### PR DESCRIPTION
Issue: storyshots doesn't work due to incompatibility with the newest version of the `read-pkg-up` module.

## What I did

Modified properties read from the object returned by the module.