### PR TITLE
Typo in writing-addons/index.md

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -187,7 +187,7 @@ Notice how the storybook API itself has `.on()`, `.off()` and `.emit()` methods 
 ```js
 import React from 'react';
 import addons from '@storybook/addons';
-import { STORY_RENDERED } from '@storybook/core-events';
+import { STORY_CHANGED } from '@storybook/core-events';
 
 class MyPanel extends React.Component {
   onSomeAction = text => {
@@ -200,12 +200,12 @@ class MyPanel extends React.Component {
   componentDidMount() {
     const { api } = this.props;
     api.on('foo/doSomeAction', this.onSomeAction);
-    api.on(STORY_RENDERED, this.onStoryChange);
+    api.on(STORY_CHANGED, this.onStoryChange);
   }
   componentWillUnmount() {
     const { api } = this.props;
     api.off('foo/doSomeAction', this.onSomeAction);
-    api.off(STORY_RENDERED, this.onStoryChange);
+    api.off(STORY_CHANGED, this.onStoryChange);
   }
 
   render() {

--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -187,7 +187,7 @@ Notice how the storybook API itself has `.on()`, `.off()` and `.emit()` methods 
 ```js
 import React from 'react';
 import addons from '@storybook/addons';
-import { STORY_CHANGED } from '@storybook/core-events';
+import { STORY_RENDERED } from '@storybook/core-events';
 
 class MyPanel extends React.Component {
   onSomeAction = text => {

--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -61,7 +61,7 @@ We write an addon that responds to a change in story selection like so:
 // register.js
 
 import React from 'react';
-import { STORY_RENDERED } from '@storybook/core-events';
+import { STORY_CHANGED } from '@storybook/core-events';
 import addons, { types } from '@storybook/addons';
 
 const ADDON_ID = 'myaddon';
@@ -74,13 +74,13 @@ class MyPanel extends React.Component {
   componentDidMount() {
     const { api } = this.props;
 
-    api.on(STORY_RENDERED, this.onStoryChange);
+    api.on(STORY_CHANGED, this.onStoryChange);
   }
 
   componentWillUnmount() {
     const { api } = this.props;
 
-    api.off(STORY_RENDERED, this.onStoryChange);
+    api.off(STORY_CHANGED, this.onStoryChange);
   }
 
   onStoryChange = id => {


### PR DESCRIPTION
`STORY_CHANGED` is imported but then `STORY_RENDERED` is used in the example.

- Is this testable with Jest or Chromatic screenshots?
No
- Does this need a new example in the kitchen sink apps?
No
- Does this need an update to the documentation?
Yes