### PR TITLE
Do not suggest to call setState in constructor

### DIFF
--- a/docs/src/pages/basics/faq/index.md
+++ b/docs/src/pages/basics/faq/index.md
@@ -48,14 +48,11 @@ import { storiesOf } from '@storybook/react';
 class MyComponent extends Component {
   constructor(props) {
     super(props)
+
     this.state = {
       someVar: 'defaultValue',
-    }
-  }
-  componentDidMount() {
-     this.setState({
       ...this.props.initialState
-    })
+    }
   }
   // ...
 }

--- a/docs/src/pages/basics/faq/index.md
+++ b/docs/src/pages/basics/faq/index.md
@@ -51,7 +51,7 @@ class MyComponent extends Component {
 
     this.state = {
       someVar: 'defaultValue',
-      ...this.props.initialState
+      ...props.initialState
     }
   }
   // ...

--- a/docs/src/pages/basics/faq/index.md
+++ b/docs/src/pages/basics/faq/index.md
@@ -48,9 +48,13 @@ import { storiesOf } from '@storybook/react';
 class MyComponent extends Component {
   constructor(props) {
     super(props)
-    this.setState({
+    this.state = {
       someVar: 'defaultValue',
-      ...props.initialState
+    }
+  }
+  componentDidMount() {
+     this.setState({
+      ...this.props.initialState
     })
   }
   // ...


### PR DESCRIPTION
As per https://reactjs.org/docs/react-component.html#constructor calling setState in constructor is not recommended.

Issue:

## What I did

Proposed to take the initialState into account in componentDidMount instead of in the constructor

## How to test
No tests

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
