### PR TITLE
Fix unresponsive textarea from addon-event

### DIFF
--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -29,6 +29,7 @@
     "@storybook/theming": "5.1.0-rc.3",
     "core-js": "^3.0.1",
     "format-json": "^1.0.3",
+    "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-lifecycles-compat": "^3.0.4",

--- a/addons/events/src/components/Event.js
+++ b/addons/events/src/components/Event.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { polyfill } from 'react-lifecycles-compat';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { styled } from '@storybook/theming';
 import json from 'format-json';

--- a/addons/events/src/components/Event.js
+++ b/addons/events/src/components/Event.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { polyfill } from 'react-lifecycles-compat';
+import { isEqual } from 'lodash';
 
 import { styled } from '@storybook/theming';
 import json from 'format-json';
@@ -133,14 +134,14 @@ class Item extends Component {
   };
 
   static getDerivedStateFromProps = ({ payload }, { prevPayload }) => {
-    if (payload !== prevPayload) {
+    if (!isEqual(payload, prevPayload)) {
       const payloadString = json.plain(payload);
-
+      const refinedPayload = getJSONFromString(payloadString);
       return {
         failed: false,
-        payload: getJSONFromString(payloadString),
+        payload: refinedPayload,
         payloadString,
-        prevPayload,
+        prevPayload: refinedPayload,
       };
     }
     return null;


### PR DESCRIPTION
Issue: Fixes #6936

## What I did
#### Problem
  From `getDerivedStateFromProps`, comparing some props and some state(always `undefined`) always initializes state which makes changing on textarea unresponsive.

#### Implementation
- Assign payload value to prevPayload
- Using lodash `isEqual` to properly compare changing props' payload and state's prevPayload

## How to test

- Is this testable with Jest or Chromatic screenshots? 
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
