### PR TITLE
Improve tsconfig.app.json detection for app/angular

### DIFF
--- a/lib/cli/generators/ANGULAR/angular-helpers.js
+++ b/lib/cli/generators/ANGULAR/angular-helpers.js
@@ -1,0 +1,31 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { getAngularAppTsConfigPath } from '../../lib/helpers';
+
+export function readFileAsJson(jsonPath) {
+  const filePath = path.resolve(jsonPath);
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+
+  const jsonContent = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(jsonContent);
+}
+
+export function writeFileAsJson(jsonPath, content) {
+  const filePath = path.resolve(jsonPath);
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+
+  const jsonContent = fs.readFileSync(filePath, 'utf8');
+  fs.writeFileSync(filePath, JSON.stringify(content, null, 2));
+  return true;
+}
+
+export function editStorybookTsConfig(tsconfigPath) {
+  const tsConfigJson = readFileAsJson(tsconfigPath);
+  const angularProjectTsConfigPath = getAngularAppTsConfigPath();
+  tsConfigJson.extends = `../${angularProjectTsConfigPath}`;
+  writeFileAsJson(tsconfigPath, tsConfigJson);
+}

--- a/lib/cli/generators/ANGULAR/angular-helpers.js
+++ b/lib/cli/generators/ANGULAR/angular-helpers.js
@@ -2,18 +2,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { readFileAsJson, writeFileAsJson } from '../../lib/helpers';
 
-export function getAngularJson() {
-  const angularJsonPath = path.resolve('angular.json');
-  if (!fs.existsSync(angularJsonPath)) {
-    return false;
-  }
-
-  const jsonContent = fs.readFileSync(angularJsonPath, 'utf8');
-  return JSON.parse(jsonContent);
-}
-
 export function getAngularAppTsConfigPath() {
-  const angularJson = getAngularJson();
+  const angularJson = readFileAsJson('angular.json');
   const { defaultProject } = angularJson;
   const tsConfigPath = angularJson.projects[defaultProject].architect.build.options.tsConfig;
 
@@ -26,20 +16,11 @@ export function getAngularAppTsConfigPath() {
 export function getAngularAppTsConfigJson() {
   const tsConfigPath = getAngularAppTsConfigPath();
 
-  if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
+  if (!tsConfigPath) {
     return false;
   }
 
-  const jsonContent = fs.readFileSync(tsConfigPath, 'utf8');
-  return JSON.parse(jsonContent);
-}
-
-export function writeAngularAppTsConfig(tsConfigJson) {
-  const content = `${JSON.stringify(tsConfigJson, null, 2)}\n`;
-  const tsConfigPath = getAngularAppTsConfigPath();
-  if (tsConfigPath) {
-    fs.writeFileSync(path.resolve(tsConfigPath), content, 'utf8');
-  }
+  return readFileAsJson(tsConfigPath);
 }
 
 function setStorybookTsconfigExtendsPath(tsconfigJson) {

--- a/lib/cli/generators/ANGULAR/angular-helpers.js
+++ b/lib/cli/generators/ANGULAR/angular-helpers.js
@@ -1,31 +1,56 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { getAngularAppTsConfigPath } from '../../lib/helpers';
+import { readFileAsJson, writeFileAsJson } from '../../lib/helpers';
 
-export function readFileAsJson(jsonPath) {
-  const filePath = path.resolve(jsonPath);
-  if (!fs.existsSync(filePath)) {
+export function getAngularJson() {
+  const angularJsonPath = path.resolve('angular.json');
+  if (!fs.existsSync(angularJsonPath)) {
     return false;
   }
 
-  const jsonContent = fs.readFileSync(filePath, 'utf8');
+  const jsonContent = fs.readFileSync(angularJsonPath, 'utf8');
   return JSON.parse(jsonContent);
 }
 
-export function writeFileAsJson(jsonPath, content) {
-  const filePath = path.resolve(jsonPath);
-  if (!fs.existsSync(filePath)) {
+export function getAngularAppTsConfigPath() {
+  const angularJson = getAngularJson();
+  const { defaultProject } = angularJson;
+  const tsConfigPath = angularJson.projects[defaultProject].architect.build.options.tsConfig;
+
+  if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
+    return false;
+  }
+  return tsConfigPath;
+}
+
+export function getAngularAppTsConfigJson() {
+  const tsConfigPath = getAngularAppTsConfigPath();
+
+  if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
     return false;
   }
 
-  const jsonContent = fs.readFileSync(filePath, 'utf8');
-  fs.writeFileSync(filePath, JSON.stringify(content, null, 2));
-  return true;
+  const jsonContent = fs.readFileSync(tsConfigPath, 'utf8');
+  return JSON.parse(jsonContent);
+}
+
+export function writeAngularAppTsConfig(tsConfigJson) {
+  const content = `${JSON.stringify(tsConfigJson, null, 2)}\n`;
+  const tsConfigPath = getAngularAppTsConfigPath();
+  if (tsConfigPath) {
+    fs.writeFileSync(path.resolve(tsConfigPath), content, 'utf8');
+  }
+}
+
+function setStorybookTsconfigExtendsPath(tsconfigJson) {
+  const angularProjectTsConfigPath = getAngularAppTsConfigPath();
+  const newTsconfigJson = { ...tsconfigJson };
+  newTsconfigJson.extends = `../${angularProjectTsConfigPath}`;
+  return newTsconfigJson;
 }
 
 export function editStorybookTsConfig(tsconfigPath) {
-  const tsConfigJson = readFileAsJson(tsconfigPath);
-  const angularProjectTsConfigPath = getAngularAppTsConfigPath();
-  tsConfigJson.extends = `../${angularProjectTsConfigPath}`;
+  let tsConfigJson = readFileAsJson(tsconfigPath);
+  tsConfigJson = setStorybookTsconfigExtendsPath(tsConfigJson);
   writeFileAsJson(tsconfigPath, tsConfigJson);
 }

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -1,5 +1,6 @@
 import mergeDirs from 'merge-dirs';
 import path from 'path';
+import { editStorybookTsConfig } from './angular-helpers';
 import {
   getVersions,
   getPackageJson,
@@ -70,4 +71,5 @@ export default async npmOptions => {
 
   await addDependencies(npmOptions);
   editAngularAppTsConfig();
+  editStorybookTsConfig(path.resolve('./.storybook/tsconfig.json'));
 };

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -1,14 +1,16 @@
 import mergeDirs from 'merge-dirs';
 import path from 'path';
-import { editStorybookTsConfig } from './angular-helpers';
+import {
+  editStorybookTsConfig,
+  getAngularAppTsConfigJson,
+  writeAngularAppTsConfig,
+} from './angular-helpers';
 import {
   getVersions,
   getPackageJson,
   writePackageJson,
   getBabelDependencies,
   installDependencies,
-  getAngularAppTsConfigJson,
-  writeAngularAppTsConfig,
 } from '../../lib/helpers';
 
 async function addDependencies(npmOptions) {

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -3,7 +3,7 @@ import path from 'path';
 import {
   editStorybookTsConfig,
   getAngularAppTsConfigJson,
-  writeAngularAppTsConfig,
+  getAngularAppTsConfigPath,
 } from './angular-helpers';
 import {
   getVersions,
@@ -11,6 +11,7 @@ import {
   writePackageJson,
   getBabelDependencies,
   installDependencies,
+  writeFileAsJson,
 } from '../../lib/helpers';
 
 async function addDependencies(npmOptions) {
@@ -65,7 +66,7 @@ function editAngularAppTsConfig() {
   }
 
   tsConfigJson.exclude = [...exclude, glob];
-  writeAngularAppTsConfig(tsConfigJson);
+  writeFileAsJson(getAngularAppTsConfigPath(), tsConfigJson);
 }
 
 export default async npmOptions => {

--- a/lib/cli/generators/ANGULAR/template/.storybook/tsconfig.json
+++ b/lib/cli/generators/ANGULAR/template/.storybook/tsconfig.json
@@ -1,20 +1,9 @@
 {
-  "extends": "../src/tsconfig.app.json",
+  "extends": "%SET_DURING_SB_INIT%",
   "compilerOptions": {
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
-  "exclude": [
-    "../src/test.ts",
-    "../src/**/*.spec.ts",
-    "../projects/**/*.spec.ts"
-  ],
-  "include": [
-    "../src/**/*",
-    "../projects/**/*"
-  ],
-  "files": [
-    "./typings.d.ts"
-  ]
+  "exclude": ["../src/test.ts", "../src/**/*.spec.ts", "../projects/**/*.spec.ts"],
+  "include": ["../src/**/*", "../projects/**/*"],
+  "files": ["./typings.d.ts"]
 }

--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -62,44 +62,25 @@ export function getBowerJson() {
   return JSON.parse(jsonContent);
 }
 
-export function getAngularJson() {
-  const angularJsonPath = path.resolve('angular.json');
-  if (!fs.existsSync(angularJsonPath)) {
+export function readFileAsJson(jsonPath) {
+  const filePath = path.resolve(jsonPath);
+  if (!fs.existsSync(filePath)) {
     return false;
   }
 
-  const jsonContent = fs.readFileSync(angularJsonPath, 'utf8');
+  const jsonContent = fs.readFileSync(filePath, 'utf8');
   return JSON.parse(jsonContent);
 }
 
-export function getAngularAppTsConfigPath() {
-  const angularJson = getAngularJson();
-  const { defaultProject } = angularJson;
-  const tsConfigPath = angularJson.projects[defaultProject].architect.build.options.tsConfig;
-
-  if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
-    return false;
-  }
-  return tsConfigPath;
-}
-
-export function getAngularAppTsConfigJson() {
-  const tsConfigPath = getAngularAppTsConfigPath();
-
-  if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
+export function writeFileAsJson(jsonPath, content) {
+  const filePath = path.resolve(jsonPath);
+  if (!fs.existsSync(filePath)) {
     return false;
   }
 
-  const jsonContent = fs.readFileSync(tsConfigPath, 'utf8');
-  return JSON.parse(jsonContent);
-}
-
-export function writeAngularAppTsConfig(tsConfigJson) {
-  const content = `${JSON.stringify(tsConfigJson, null, 2)}\n`;
-  const tsConfigPath = getAngularAppTsConfigPath();
-  if (tsConfigPath) {
-    fs.writeFileSync(path.resolve(tsConfigPath), content, 'utf8');
-  }
+  const jsonContent = fs.readFileSync(filePath, 'utf8');
+  fs.writeFileSync(filePath, JSON.stringify(content, null, 2));
+  return true;
 }
 
 export function writePackageJson(packageJson) {

--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -79,7 +79,7 @@ export function writeFileAsJson(jsonPath, content) {
   }
 
   const jsonContent = fs.readFileSync(filePath, 'utf8');
-  fs.writeFileSync(filePath, JSON.stringify(content, null, 2));
+  fs.writeFileSync(filePath, `${JSON.stringify(content, null, 2)}\n`);
   return true;
 }
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/6934

## What I did

I improved the `tsconfig.app.json` detection as it was broken because of a breaking change in Angular 8. They moved `tsconfig.app.json` from `src/tsconfig.app.json` to `./tsconfig.app.json` 

I changed it so that it reads the correct path from `angular.json` instead of setting a fixed path. That way every Angular version should be compatible 

## How to test

- Checkout this branch
- Link `lib/cli` 
- `sb init -f` a project and check if it can start 
