### PR TITLE
Fix webpack `process.*` variable definitions

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -59,8 +59,7 @@ export default ({
         template: require.resolve(`../templates/index.ejs`),
       }),
       new DefinePlugin({
-        'process.env': stringified,
-        process: JSON.stringify(true),
+        process: { browser: true, env: stringified },
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       }),
       isProd ? null : new WatchMissingNodeModulesPlugin(nodeModulesPaths),


### PR DESCRIPTION
Issue: #6813 

## What I did

Apply manager webpack update https://github.com/storybookjs/storybook/pull/6767 to preview iframe process definition

## How to test

I'm not sure 🤷‍♂ 