### PR TITLE
Remove zonejs from devDeps; allow ^0.8.0 || ^0.9.0

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -38,9 +38,6 @@
     "tsconfig-paths-webpack-plugin": "^3.2.0",
     "webpack": "^4.32.2"
   },
-  "devDependencies": {
-    "zone.js": "^0.8.29"
-  },
   "peerDependencies": {
     "@angular-devkit/core": "^0.6.1 || >=7.0.0",
     "@angular/common": ">=6.0.0",
@@ -52,7 +49,7 @@
     "autoprefixer": "^8.1.0",
     "babel-loader": "^7.0.0 || ^8.0.0",
     "rxjs": "^6.0.0",
-    "zone.js": "^0.8.29"
+    "zone.js": "^0.8.29 || ^0.9.0"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/6951

## What I did

Trying to remove zonejs from devDeps if possible 
Updating the peerDep to `^0.8.0 || ^0.9.0` for supporting both: Angular 7 and 8
