### PR TITLE
Add a migration guide for Angular 7 and Storybook 5.0.x to 5.1.x

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -77,6 +77,29 @@ If you wish to run the optional web server, you will need to do the following mi
 
 And with that you should be good to go!
 
+### Angular 7
+
+Storybook 5.1 relies on `core-js@^3.0.0` and therefore causes a conflict with Angular 7 that relies on `core-js@^2.0.0`. In order to get Storybook running on Angular 7 you can either update to Angular 8 (which dropped core-js as a dependency) or follow the upcoming steps:
+
+- Remove `node_modules/@storybook`
+- `npm i core-js@^3.0.0` / `yarn add core-js@^3.0.0`
+- Add the following paths to your `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "core-js/es7/reflect": ["node_modules/core-js/proposals/reflect-metadata"],
+      "core-js/es6/*": ["node_modules/core-js/es"]
+    }
+  }
+}
+```
+
+You should now be able to run Storybook and Angular 7 without any errors.
+
+Reference issue: [https://github.com/angular/angular-cli/issues/13954](https://github.com/angular/angular-cli/issues/13954)
+
 ## From version 5.0.1 to 5.0.2
 
 ### Deprecate webpack extend mode
@@ -133,11 +156,11 @@ var modules = context.keys();
 // sort them
 var sortedModules = modules.slice().sort((a, b) => {
   // sort the stories based on filename/path
-  return a < b ? -1 : (a > b ? 1 : 0);
+  return a < b ? -1 : a > b ? 1 : 0;
 });
 
 // execute them
-sortedModules.forEach((key) => {
+sortedModules.forEach(key => {
   context(key);
 });
 ```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,7 @@
 
 - [From version 5.0.x to 5.1.x](#from-version-50x-to-51x)
   - [React native server](#react-native-server)
+  - [Angular 7](#angular-7)
 - [From version 5.0.1 to 5.0.2](#from-version-501-to-502)
   - [Deprecate webpack extend mode](#deprecate-webpack-extend-mode)
 - [From version 4.1.x to 5.0.x](#from-version-41x-to-50x)
@@ -79,7 +80,7 @@ And with that you should be good to go!
 
 ### Angular 7
 
-Storybook 5.1 relies on `core-js@^3.0.0` and therefore causes a conflict with Angular 7 that relies on `core-js@^2.0.0`. In order to get Storybook running on Angular 7 you can either update to Angular 8 (which dropped core-js as a dependency) or follow the upcoming steps:
+Storybook 5.1 relies on `core-js@^3.0.0` and therefore causes a conflict with Angular 7 that relies on `core-js@^2.0.0`. In order to get Storybook running on Angular 7 you can either update to Angular 8 (which dropped `core-js` as a dependency) or follow these steps:
 
 - Remove `node_modules/@storybook`
 - `npm i core-js@^3.0.0` / `yarn add core-js@^3.0.0`


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/6804

## What I did

I couldn't find a proper way to support core-js 2 for Angular 7 and core-js 3 for Storybook in the same project.

A workaround should be fine. People can either update to Angular 8 (which dropped core-js as a dependency) or use the migration-guide I added in this PR

## How to test

- `npx @angular/cli@^7.3.0 new angular7-test`
- `npx @storybook/cli@next init`
- Follow the steps in MIGRATION.md
- `yarn storybook` should work
- `ng serve` should work
