### PR TITLE
Don't mutate user's babel config

### DIFF
--- a/lib/core/src/server/utils/load-custom-babel-config.js
+++ b/lib/core/src/server/utils/load-custom-babel-config.js
@@ -46,7 +46,7 @@ function loadFromPath(babelConfigPath) {
       throw error.js;
     }
 
-    config.babelrc = false;
+    config = { ...config, babelrc: false };
   }
 
   if (!config) return null;


### PR DESCRIPTION
In my case, it leads to errors because I use my own babel-loader
