### PR TITLE
Don't redefine `process` variable

### DIFF
--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -59,7 +59,7 @@ export default ({ configDir, configType, entries, dll, outputDir, cache, babelOp
       new Dotenv({ silent: true }),
       // graphql sources check process variable
       new DefinePlugin({
-        process: { browser: true, env: stringified },
+        'process.env': stringified,
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       }),
       // See https://github.com/graphql/graphql-language-service/issues/111#issuecomment-306723400

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -59,7 +59,7 @@ export default ({
         template: require.resolve(`../templates/index.ejs`),
       }),
       new DefinePlugin({
-        process: { browser: true, env: stringified },
+        'process.env': stringified,
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       }),
       isProd ? null : new WatchMissingNodeModulesPlugin(nodeModulesPaths),


### PR DESCRIPTION
Issue: by default, webpack injects [`process/browser`](https://github.com/defunctzombie/node-process/blob/master/browser.js) import whenever `process` global variable is used. Our `DefinePlugin` overrides it which breaks packages that use stuff like `process.cwd()`. One example is `unified` package used by `react-markdown` internally.

Honestly, I don't remember why I had to add [this line](https://github.com/storybookjs/storybook/blame/86a9d2a9b0ed17878475178e2463605076e6f1d5/examples/official-storybook/webpack.config.js#L39) which were later copypasted to other places. Anyway, GraphQL addon seems to work OK after my current changes.