### PR TITLE
docs: Clarify how to get local example running

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,9 +287,9 @@ Within the `examples` folder of the Storybook repo, you will find kitchen sink e
 Not only do these show many of the options and add-ons available, they are also automatically linked to all the development packages. We highly encourage you to use these to develop/test contributions on.
 
 #### React and Vue
-
-1.  `yarn storybook`
-2.  Verify that your local version works
+1. `cd examples/official-storybook`
+2.  `yarn storybook`
+3.  Verify that your local version works
 
 ### Working with your own app
 


### PR DESCRIPTION
## What I did

I updated the Contributing docs to clarify the steps needed to get the `official-storybook` running locally.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
