### PR TITLE
6998: fix for the pseudo class ":first-child" is potentially unsafe

### DIFF
--- a/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
+++ b/examples/official-storybook/tests/__snapshots__/storyshots.test.js.snap
@@ -6181,7 +6181,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   overflow: auto;
 }
 
-.emotion-99 > *:first-child {
+.emotion-99 > *:first-of-type {
   position: absolute;
   left: 0;
   right: 0;
@@ -6674,7 +6674,7 @@ exports[`Storyshots UI|Settings/ShortcutsScreen default shortcuts 1`] = `
   overflow: auto;
 }
 
-.emotion-99 > *:first-child {
+.emotion-99 > *:first-of-type {
   position: absolute;
   left: 0;
   right: 0;

--- a/lib/components/src/tabs/__snapshots__/tabs.stories.storyshot
+++ b/lib/components/src/tabs/__snapshots__/tabs.stories.storyshot
@@ -1065,7 +1065,7 @@ exports[`Storyshots Basics|Tabs stateless - absolute 1`] = `
   overflow: auto;
 }
 
-.emotion-11 > *:first-child {
+.emotion-11 > *:first-of-type {
   position: absolute;
   left: 0;
   right: 0;

--- a/lib/components/src/tabs/tabs.tsx
+++ b/lib/components/src/tabs/tabs.tsx
@@ -73,7 +73,7 @@ const Content = styled.div<ContentProps>(
           bottom: 0,
           top: 40,
           overflow: 'auto',
-          '& > *:first-child': {
+          '& > *:first-of-type': {
             position: 'absolute',
             left: 0,
             right: 0,

--- a/lib/ui/src/components/panel/__snapshots__/panel.stories.storyshot
+++ b/lib/ui/src/components/panel/__snapshots__/panel.stories.storyshot
@@ -236,7 +236,7 @@ exports[`Storyshots UI|Panel default 1`] = `
   overflow: auto;
 }
 
-.emotion-13 > *:first-child {
+.emotion-13 > *:first-of-type {
   position: absolute;
   left: 0;
   right: 0;

--- a/lib/ui/src/settings/__snapshots__/about.stories.storyshot
+++ b/lib/ui/src/settings/__snapshots__/about.stories.storyshot
@@ -162,7 +162,7 @@ exports[`Storyshots UI|Settings/AboutScreen failed to fetch new version 1`] = `
   overflow: auto;
 }
 
-.emotion-25 > *:first-child {
+.emotion-25 > *:first-of-type {
   position: absolute;
   left: 0;
   right: 0;
@@ -703,7 +703,7 @@ exports[`Storyshots UI|Settings/AboutScreen new version required 1`] = `
   overflow: auto;
 }
 
-.emotion-41 > *:first-child {
+.emotion-41 > *:first-of-type {
   position: absolute;
   left: 0;
   right: 0;
@@ -2220,7 +2220,7 @@ exports[`Storyshots UI|Settings/AboutScreen up to date 1`] = `
   overflow: auto;
 }
 
-.emotion-27 > *:first-child {
+.emotion-27 > *:first-of-type {
   position: absolute;
   left: 0;
   right: 0;


### PR DESCRIPTION
changed ':first-child' to ':first-of-type' in tabs

Issue: #6998

## What I did
changed the pseudo class for tabs from ':first-child' to ':first-of-type'

## How to test
Check to see if any error is present in development console.
