### PR TITLE
Fixing Grammar

### DIFF
--- a/docs/src/pages/guides/guide-react/index.md
+++ b/docs/src/pages/guides/guide-react/index.md
@@ -37,7 +37,7 @@ npm install react react-dom --save
 npm install babel-loader @babel/core --save-dev 
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add an npm script
 
 Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
 


### PR DESCRIPTION
Should be `an npm script` rather than `a npm script`.

Issue:
Fixing Grammar.

## What I did
Replace `a npm` with `an npm`.

## How to test
Visible on React guide.

- Is this testable with Jest or Chromatic screenshots?
No.

- Does this need a new example in the kitchen sink apps?
No.

- Does this need an update to the documentation?
No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
