### PR TITLE
Improve actions type

### DIFF
--- a/addons/actions/src/models/ActionsFunction.ts
+++ b/addons/actions/src/models/ActionsFunction.ts
@@ -1,6 +1,5 @@
 import { ActionOptions } from './ActionOptions';
 import { ActionsMap } from './ActionsMap';
-import { HandlerFunction } from './HandlerFunction';
 
 export interface ActionsFunction {
   <T extends string>(handlerMap: Record<T, string>, options?: ActionOptions): ActionsMap<T>;
@@ -8,10 +7,7 @@ export interface ActionsFunction {
 
   <T extends string>(handler1: T, options?: ActionOptions): ActionsMap<T>;
   <T extends string>(handler1: T, handler2: T, options?: ActionOptions): ActionsMap<T>;
-  <T extends string>(handler1: T, handler2: T, handler3: T, options?: ActionOptions): Record<
-    T,
-    HandlerFunction
-  >;
+  <T extends string>(handler1: T, handler2: T, handler3: T, options?: ActionOptions): ActionsMap<T>;
   <T extends string>(
     handler1: T,
     handler2: T,

--- a/addons/actions/src/models/ActionsFunction.ts
+++ b/addons/actions/src/models/ActionsFunction.ts
@@ -1,0 +1,85 @@
+import { ActionOptions } from './ActionOptions';
+import { ActionsMap } from './ActionsMap';
+import { HandlerFunction } from './HandlerFunction';
+
+export interface ActionsFunction {
+  <T extends string>(handlerMap: Record<T, string>, options?: ActionOptions): ActionsMap<T>;
+  <T extends string>(...handlers: T[]): ActionsMap<T>;
+
+  <T extends string>(handler1: T, options?: ActionOptions): ActionsMap<T>;
+  <T extends string>(handler1: T, handler2: T, options?: ActionOptions): ActionsMap<T>;
+  <T extends string>(handler1: T, handler2: T, handler3: T, options?: ActionOptions): Record<
+    T,
+    HandlerFunction
+  >;
+  <T extends string>(
+    handler1: T,
+    handler2: T,
+    handler3: T,
+    handler4: T,
+    options?: ActionOptions
+  ): ActionsMap<T>;
+  <T extends string>(
+    handler1: T,
+    handler2: T,
+    handler3: T,
+    handler4: T,
+    handler5: T,
+    options?: ActionOptions
+  ): ActionsMap<T>;
+  <T extends string>(
+    handler1: T,
+    handler2: T,
+    handler3: T,
+    handler4: T,
+    handler5: T,
+    handler6: T,
+    options?: ActionOptions
+  ): ActionsMap<T>;
+  <T extends string>(
+    handler1: T,
+    handler2: T,
+    handler3: T,
+    handler4: T,
+    handler5: T,
+    handler6: T,
+    handler7: T,
+    options?: ActionOptions
+  ): ActionsMap<T>;
+  <T extends string>(
+    handler1: T,
+    handler2: T,
+    handler3: T,
+    handler4: T,
+    handler5: T,
+    handler6: T,
+    handler7: T,
+    handler8: T,
+    options?: ActionOptions
+  ): ActionsMap<T>;
+  <T extends string>(
+    handler1: T,
+    handler2: T,
+    handler3: T,
+    handler4: T,
+    handler5: T,
+    handler6: T,
+    handler7: T,
+    handler8: T,
+    handler9: T,
+    options?: ActionOptions
+  ): ActionsMap<T>;
+  <T extends string>(
+    handler1: T,
+    handler2: T,
+    handler3: T,
+    handler4: T,
+    handler5: T,
+    handler6: T,
+    handler7: T,
+    handler8: T,
+    handler9: T,
+    handler10: T,
+    options?: ActionOptions
+  ): ActionsMap<T>;
+}

--- a/addons/actions/src/models/ActionsMap.ts
+++ b/addons/actions/src/models/ActionsMap.ts
@@ -1,5 +1,3 @@
 import { HandlerFunction } from './HandlerFunction';
 
-export interface ActionsMap {
-  [key: string]: HandlerFunction;
-}
+export type ActionsMap<T extends string = string> = Record<T, HandlerFunction>;

--- a/addons/actions/src/models/index.ts
+++ b/addons/actions/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from './ActionDisplay';
+export * from './ActionsFunction';
 export * from './ActionOptions';
 export * from './ActionsMap';
 export * from './DecoratorFunction';

--- a/addons/actions/src/preview/actions.ts
+++ b/addons/actions/src/preview/actions.ts
@@ -1,8 +1,8 @@
 import { action } from './action';
-import { ActionOptions, ActionsMap } from '../models';
+import { ActionsFunction, ActionOptions, ActionsMap } from '../models';
 import { config } from './configureActions';
 
-export function actions(...args: any[]): ActionsMap {
+export const actions: ActionsFunction = (...args: any[]) => {
   let options: ActionOptions = config;
   const names = args;
   // last argument can be options
@@ -26,4 +26,4 @@ export function actions(...args: any[]): ActionsMap {
     actionsObject[name] = action(namesObject[name], options);
   });
   return actionsObject;
-}
+};


### PR DESCRIPTION
Issue:

This fixes the issue where spreading `actions('onChange', 'onSubmit')` into a component which requires `onChange` and `onSubmit` props would still result in an error requesting those props be specified. I did not see an existing issue which describes this. 

## What I did

This improves the `actions` type definition to return an object with the specific handler names provided. This is achieved via generic overloads.

With this change, the return type of the above call would be `Record<'onChange' | 'onSubmit', ActionHandler>` and can fulfill required props.

The overloads are a bit awkward because the trailing optional options param cannot follow a rest param.

## How to test

Inspect the return type of calls to `actions` of the form `actions('a', 'b', {})`, `actions({ a: 'a', b: 'b' }, {})`, etc to ensure they return an object with specific keys rather than an indexed object. Alternatively, attempt to spread the return value of `actions` into e.g. a React component with required handler props.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
