### PR TITLE
specifying where to get `withInfo`

### DIFF
--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -23,7 +23,11 @@ It is possible to add `info` by default to all or a subsection of stories by usi
 It is important to declare this decorator as **the first decorator**, otherwise it won't work well.
 
 ```js
-addDecorator(withInfo); // Globally in your .storybook/config.js.
+// Globally in your .storybook/config.js.
+import { addDecorator } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+addDecorator(withInfo); 
 ```
 
 or


### PR DESCRIPTION
Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
