### PR TITLE
fix: add missing core-js dependency

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -28,6 +28,7 @@
     "@storybook/channels": "5.1.1",
     "@storybook/client-api": "5.1.1",
     "@storybook/core-events": "5.1.1",
+    "core-js": "^3.0.1",
     "react-native-swipe-gestures": "^1.0.3",
     "rn-host-detect": "^1.1.5"
   },


### PR DESCRIPTION
This should resolve the issue some people are seeing in #6204 

## What I did

Added an explicit dependency on core-js. This was mostly working before because the dependency flattening means most people have a copy of core-js in their node_modules folder, but after version 3 was released, some people had version 2 and others had version 3. This explicitly adds the dependency on version 3.