### PR TITLE
Maintenance: Quick fix for graphql (last query line blanks)

### DIFF
--- a/addons/graphql/src/shared.ts
+++ b/addons/graphql/src/shared.ts
@@ -16,7 +16,7 @@ export const getDefaultFetcher = (url: string) => {
 };
 
 export const reIndentQuery = (query: string) => {
-  const lines = query.split('\n');
+  const lines = query.trim().split('\n');
   const spaces = lines[lines.length - 1].length - 1;
   return lines.map((l, i) => (i === 0 ? l : l.slice(spaces))).join('\n');
 };


### PR DESCRIPTION
Issue: #4975

## What I did
Added a trim in graphql addon

## How to test
You can test it by pasting a blank last line to your query string. This leads to a broken query on the current next branch.
- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
