### PR TITLE
chore(notes): add angular documentation

### DIFF
--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -58,6 +58,27 @@ storiesOf('MyButton', module).add(
 );
 ```
 
+### With Angular
+
+```js
+import { storiesOf } from '@storybook/vue';
+
+import { ButtonComponent } from './button.component';
+
+storiesOf('Button', module).add(
+  'with some emoji',
+  () => ({
+    component: ButtonComponent,
+    props: {
+      text: '😀 😎 👍 💯'
+    }
+  }),
+  {
+    notes: 'A very simple example of addon notes',
+  }
+);
+```
+
 ## Using Markdown
 
 Using Markdown in your notes is supported, Storybook will load Markdown as raw by default.


### PR DESCRIPTION
Issue: n/a

## What I did
Include angular documentation for notes addon.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["documentation"]`

-->
