### PR TITLE
6994 context title fallback

### DIFF
--- a/addons/contexts/src/manager/components/ToolBarControl.tsx
+++ b/addons/contexts/src/manager/components/ToolBarControl.tsx
@@ -47,5 +47,5 @@ export const ToolBarControl: ToolBarControl = ({
     },
   };
 
-  return icon && list.length && !options.disable ? <ToolBarMenu icon={icon} {...props} /> : null;
+  return list.length && !options.disable ? <ToolBarMenu icon={icon} {...props} /> : null;
 };

--- a/addons/contexts/src/manager/components/ToolBarControl.tsx
+++ b/addons/contexts/src/manager/components/ToolBarControl.tsx
@@ -47,5 +47,7 @@ export const ToolBarControl: ToolBarControl = ({
     },
   };
 
-  return list.length && !options.disable ? <ToolBarMenu icon={icon} {...props} /> : null;
+  return Array.isArray(list) && list.length && !options.disable ? (
+    <ToolBarMenu icon={icon} {...props} />
+  ) : null;
 };

--- a/addons/contexts/src/manager/components/ToolBarMenu.test.tsx
+++ b/addons/contexts/src/manager/components/ToolBarMenu.test.tsx
@@ -53,4 +53,51 @@ describe('Tests on addon-contexts component: ToolBarMenu', () => {
       </lifecycle(WithTooltipPure)>
     `);
   });
+
+  it('should render TabButton with title if the icon is given', () => {
+    // given
+    const someProps = {
+      title: 'Some Context',
+      active: true,
+      expanded: false,
+      setExpanded: jest.fn,
+      optionsProps: {
+        activeName: 'A',
+        list: ['A', 'B'],
+        onSelectOption: jest.fn,
+      },
+    };
+
+    // when
+    const result = shallow(<ToolBarMenu {...someProps} />);
+
+    // then
+    expect(result).toMatchInlineSnapshot(`
+      <lifecycle(WithTooltipPure)
+        closeOnClick={true}
+        onVisibilityChange={[Function]}
+        placement="top"
+        tooltip={
+          <ToolBarMenuOptions
+            activeName="A"
+            list={
+              Array [
+                "A",
+                "B",
+              ]
+            }
+            onSelectOption={[Function]}
+          />
+        }
+        tooltipShown={false}
+        trigger="click"
+      >
+        <TabButton
+          active={true}
+        >
+          Some Context
+        </TabButton>
+      </lifecycle(WithTooltipPure)>
+    `);
+  });
 });

--- a/addons/contexts/src/manager/components/ToolBarMenu.tsx
+++ b/addons/contexts/src/manager/components/ToolBarMenu.tsx
@@ -1,10 +1,10 @@
 import React, { ComponentProps } from 'react';
-import { Icons, IconButton, WithTooltip } from '@storybook/components';
+import { Icons, IconButton, WithTooltip, TabButton } from '@storybook/components';
 import { ToolBarMenuOptions } from './ToolBarMenuOptions';
 import { ContextNode, FCNoChildren } from '../../shared/types.d';
 
 type ToolBarMenu = FCNoChildren<{
-  icon: ComponentProps<typeof Icons>['icon'];
+  icon?: ComponentProps<typeof Icons>['icon'] | '' | void;
   title: ContextNode['title'];
   active: boolean;
   expanded: boolean;
@@ -28,8 +28,12 @@ export const ToolBarMenu: ToolBarMenu = ({
     onVisibilityChange={setExpanded}
     tooltip={<ToolBarMenuOptions {...optionsProps} />}
   >
-    <IconButton active={active} title={title}>
-      <Icons icon={icon} />
-    </IconButton>
+    {icon ? (
+      <IconButton active={active} title={title}>
+        <Icons icon={icon} />
+      </IconButton>
+    ) : (
+      <TabButton active={active}>{title}</TabButton>
+    )}
   </WithTooltip>
 );

--- a/examples/official-storybook/stories/addon-contexts.stories.js
+++ b/examples/official-storybook/stories/addon-contexts.stories.js
@@ -5,7 +5,6 @@ import { withContexts } from '@storybook/addon-contexts/react';
 // Example A: Simple CSS Theming
 const topLevelContexts = [
   {
-    icon: 'sidebaralt',
     title: 'CSS Themes',
     components: ['div'],
     params: [

--- a/lib/api/src/version.ts
+++ b/lib/api/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '5.2.0-unreleased.0';
+export const version = '5.2.0-alpha.23';


### PR DESCRIPTION
Issue: #6994 

## What I did
Changed the adddon-contexts to have no icon like described in the Docs

## How to test
tested with `yarn test` and updated the test case for `ToolBarMenu.tsx`
also visually tested in by removing the icon from one of the contexts in 
`examples/official-storybook/stories/addon-contexts.stories.js`

