### PR TITLE
FIX warning of loading prop not being a string

### DIFF
--- a/lib/ui/src/components/sidebar/SidebarItem.js
+++ b/lib/ui/src/components/sidebar/SidebarItem.js
@@ -49,7 +49,9 @@ const Icon = styled(Icons)(
   ({ isSelected }) => (isSelected ? { color: 'inherit' } : {})
 );
 
-export const Item = styled.div(
+export const Item = styled(({ className, children }) => (
+  <div className={className}>{children}</div>
+))(
   {
     fontSize: 13,
     lineHeight: '16px',

--- a/lib/ui/src/components/sidebar/SidebarItem.js
+++ b/lib/ui/src/components/sidebar/SidebarItem.js
@@ -49,8 +49,10 @@ const Icon = styled(Icons)(
   ({ isSelected }) => (isSelected ? { color: 'inherit' } : {})
 );
 
-export const Item = styled(({ className, children }) => (
-  <div className={className}>{children}</div>
+export const Item = styled(({ className, children, id }) => (
+  <div className={className} id={id}>
+    {children}
+  </div>
 ))(
   {
     fontSize: 13,


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/7049

## What I did
The component for SideBarItem leaked the `loading` prop through to the html-element, which caused an warning when react was in StrictMode.

I made sure only `className` & `children` are passed on.