### PR TITLE
FIX unnecessary large bundlesize

### DIFF
--- a/addons/storysource/src/StoryPanel.js
+++ b/addons/storysource/src/StoryPanel.js
@@ -4,7 +4,7 @@ import { styled } from '@storybook/theming';
 import { Link } from '@storybook/router';
 import { SyntaxHighlighter } from '@storybook/components';
 
-import { createElement } from 'react-syntax-highlighter';
+import createElement from 'react-syntax-highlighter/create-element';
 import { EVENT_ID } from './events';
 
 const StyledStoryLink = styled(Link)(({ theme }) => ({


### PR DESCRIPTION
Issue: highlight.js was included in our bundle without need

## What I did
Found a really bad import, leading to the entire library of highlight.js being included