### PR TITLE
Updated template to not import addons

### DIFF
--- a/lib/cli/generators/REACT_NATIVE/template/storybook/index.js
+++ b/lib/cli/generators/REACT_NATIVE/template/storybook/index.js
@@ -1,7 +1,6 @@
 import { AppRegistry } from 'react-native';
 import { getStorybookUI, configure } from '@storybook/react-native';
 
-import './addons';
 import './rn-addons';
 
 // import stories


### PR DESCRIPTION
These should not be imported in React Native. They are used for web and imported automatically.
