### PR TITLE
Feature request: Add support for onReport callback inside a11y addon

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -59,7 +59,10 @@ addParameters({
     // ... axe options
     element: '#root', // optional selector which element to inspect
     config: {}, // axe-core configurationOptions (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#parameters-1)
-    options: {} // axe-core optionsParameter (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter)
+    options: {}, // axe-core optionsParameter (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter)
+    onReport(report) { // optional callback to be called with axe report
+      console.log(report)
+    }
   },
 });
 
@@ -78,7 +81,7 @@ storiesOf('button', module)
 
 ## Roadmap
 
-* Make UI accessibile
+* Make UI accessible
 * Show in story where violations are.
 * Add more example tests
 * Add tests


### PR DESCRIPTION
## What I did

Hi!

I think it would be nice if a11y addon could provide access to the raw axe report. 
I want to run this addon in the CI with puppeteer, but parsing UI is very fragile. 
But if I can console.log the report (with some parsing), I can check console for accessibility issues, which makes this run on CI simpler.

Happy to close it if it looks like a weird api.
