### PR TITLE
CLI: Use process.env.CI if available

### DIFF
--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -56,6 +56,7 @@ async function getCLI(packageJson) {
     host: 'SBCONFIG_HOSTNAME',
     staticDir: 'SBCONFIG_STATIC_DIR',
     configDir: 'SBCONFIG_CONFIG_DIR',
+    ci: 'CI',
   });
 
   if (typeof program.port === 'string' && program.port.length > 0) {


### PR DESCRIPTION
Issue: N/A

## What I did

Respect process.env.CI as a substitute for `--ci`

## How to test

```
cd examples/official-storybook
yarn storybook
yarn storybook --ci
CI=1 yarn storybook
```