### PR TITLE
fix(addons-info): change stylesheetBase info height from 110vh to 100vh

### DIFF
--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -38,7 +38,7 @@ const stylesheetBase = {
     background: 'white',
     top: 0,
     left: 0,
-    height: '110vh',
+    height: '100vh',
     width: '100vw',
     overflow: 'auto',
     zIndex: 99999,


### PR DESCRIPTION
Resolves #7140 

## What I did

In this case, changing the height from `110vh` to `100vh` fixes the issue identified in #7140, where the last propTypes table in a given "Info" pane/section gets cut off for any component you view.

Please let me know if you need more info from me about this issue, if you disagree, or if you prefer a different fix. 

We identified this issue originally in our internal storybook when upgrading from the stable release to `v5.2.0-alpha.28` (in order to get the code block fixes 😅 )

## How to test

1. Check out this page in the PR deployment, for example: https://monorepo-git-fork-jendowns-patch-2.storybook.now.sh/examples/official-storybook/?path=/story/addons-info-markdown--displays-markdown-in-description
2. Click "show info" and reduce your browser window height a bit so you get a scrollbar in the Info pane
3. Scroll down, note that the last part of the propTypes table looks fine
4. Inspect the "Info" pane & find the `.info__overlay` element
5. Change `height: 100vh` to `height: 110vh` (previous value)
6. Scroll up and down, note that the propTypes table is cut off at the bottom of the Info pane