### PR TITLE
Fix/indenting for addon-notes & addon-info on markdown code blocks

### DIFF
--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -1331,7 +1331,7 @@ exports[`addon Info should render component description if story kind matches co
               bordered={true}
               className={null}
               copyable={true}
-              format={true}
+              format={false}
               language="js"
               padded={false}
             >
@@ -5888,7 +5888,7 @@ exports[`addon Info should render component description if story name matches co
               bordered={true}
               className={null}
               copyable={true}
-              format={true}
+              format={false}
               language="js"
               padded={false}
             >

--- a/addons/info/src/components/markdown/code.js
+++ b/addons/info/src/components/markdown/code.js
@@ -5,7 +5,7 @@ import { ThemeProvider, convert } from '@storybook/theming';
 
 const Code = ({ code, language = 'plaintext', ...rest }) => (
   <ThemeProvider theme={convert()}>
-    <SyntaxHighlighter bordered copyable language={language} {...rest}>
+    <SyntaxHighlighter bordered copyable format={false} language={language} {...rest}>
       {code}
     </SyntaxHighlighter>
   </ThemeProvider>

--- a/addons/notes/src/Panel.tsx
+++ b/addons/notes/src/Panel.tsx
@@ -68,7 +68,13 @@ export const SyntaxHighlighter = ({ className, children, ...props }: SyntaxHighl
   // className: "lang-jsx"
   const language = className.split('-');
   return (
-    <SyntaxHighlighterBase language={language[1] || 'plaintext'} bordered copyable {...props}>
+    <SyntaxHighlighterBase
+      language={language[1] || 'plaintext'}
+      bordered
+      format={false}
+      copyable
+      {...props}
+    >
       {children}
     </SyntaxHighlighterBase>
   );

--- a/examples/official-storybook/stories/__snapshots__/addon-docs.stories.storyshot
+++ b/examples/official-storybook/stories/__snapshots__/addon-docs.stories.storyshot
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Storyshots Addons|Docs default 1`] = `
-<div>
-  Click the docs tab to see the docs
-</div>
-`;

--- a/examples/official-storybook/stories/addon-info.stories.js
+++ b/examples/official-storybook/stories/addon-info.stories.js
@@ -74,6 +74,30 @@ Sometimes you might want to manually include some \`code\` examples:
 const Button = () => <button />;
 ~~~
 
+classes in javascript
+
+~~~javascript
+export class FromComponent {
+  form = new FormControl({
+    searchTerm: new FromControl(''),
+    searchDate: new FromControl(''),
+    endDate: new FromControl(''),
+  })
+}
+~~~
+
+html with special formatting
+
+~~~html
+<foo-outer property-a="value"
+           property-b="value"
+           property-c="value">
+  <foo-inner property-a="value"
+             property-b="value" />
+</foo-outer>
+~~~
+
+
 Maybe include a [link](http://storybook.js.org) to your project as well.
 `;
 

--- a/examples/official-storybook/stories/addon-notes.stories.js
+++ b/examples/official-storybook/stories/addon-notes.stories.js
@@ -30,6 +30,31 @@ storiesOf('Addons|Notes', module)
     }
   )
 ~~~
+
+
+## Code examples for syntax-highlighter to deal with
+
+### classes in javascript
+~~~javascript
+export class FromComponent {
+  form = new FormControl({
+    searchTerm: new FromControl(''),
+    searchDate: new FromControl(''),
+    endDate: new FromControl(''),
+  })
+}
+~~~
+
+### html with special formatting
+~~~html
+<foo-outer property-a="value"
+           property-b="value"
+           property-c="value">
+  <foo-inner property-a="value"
+             property-b="value" />
+</foo-outer>
+~~~
+
 `;
 
 const markdownTable = `


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/5574

## What I did
When code examples come from markdown, they don't have the issue that the format prop is designed to solve, and so setting `format={false}` solves the problem.