### PR TITLE
[Documentation] Point Storybook new version cli changelog link to master

### DIFF
--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -148,7 +148,7 @@ function createUpdateMessage(updateInfo, version) {
             `A new version (${chalk.bold(updateInfo.data.latest.version)}) is available!`
           )}
 
-          ${chalk.gray('Read full changelog here:')} ${chalk.gray.underline('https://git.io/fhFYe')}
+          ${chalk.gray('Read full changelog here:')} ${chalk.gray.underline('https://git.io/fjwOB')}
         `
         : '';
   } catch (e) {


### PR DESCRIPTION
Issue: I was working with Storybook 5.1.8 and saw that a new version, 5.1.9, was available. When I went to read the full changelog from the URL provided, it pointed me to the `CHANGELOG` for the `next` branch, which hasn't been updated since 5.1.1.

![Screen Shot 2019-06-21 at 11 24 50 AM](https://user-images.githubusercontent.com/13544620/59943563-6a4b7700-9417-11e9-965d-2172deab2421.png)

https://git.io/fhFYe --> https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md

It looks like master was merged into `next` 16 days ago, but it seems more correct to me to have this URL always point at master. It is my understanding that with version changes that will always be the source of truth if this CLI changelog messages shows.

## What I did

I did not see any open issues or PRs about this, so I forked storybook and updated the existing `git.io` URL that points at the `next` CHANGELOG with one I created that points at the `master` branch CHANGELOG.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

N/A to all the above, as far as I can tell. 

I am noting that I am submitting this PR against the `master` branch instead of the `next` release because it seems specific to what will always be the most current release. 
