### PR TITLE
Fix unstretched preview background wrapper

### DIFF
--- a/lib/ui/src/components/preview/background.js
+++ b/lib/ui/src/components/preview/background.js
@@ -93,7 +93,7 @@ const Background = styled.div(
     top: 0,
     left: 0,
     width: '100%',
-    height: '100%',
+    minHeight: '100%',
     transition: 'background .1s linear',
     iframe: {
       width: '100%',


### PR DESCRIPTION
# Pull Request

Currently the styled `Background` component which wraps the iframe with previews doesn't stretch completely. It takes the height of the viewport even if the content might be larger. While this is normally not an issue it can cause an unexpected behavior if the [backgrounds](https://github.com/storybookjs/storybook/tree/next/addons/backgrounds) and the [viewport](https://github.com/storybookjs/storybook/tree/next/addons/viewport) addon are used together. This PR changes the CSS attribute from `height` to `min-height` to cover cases like this as well.

Current (height: 100%) | After change (min-height: 100%)
:---------------------:|:-------------------------------:
<img width="1469" alt="Screenshot 2019-06-22 at 13 36 10" src="https://user-images.githubusercontent.com/1060490/59963480-b8ce4380-94f3-11e9-8616-c7ef05cbba14.png">|<img width="1468" alt="Screenshot 2019-06-22 at 13 36 26" src="https://user-images.githubusercontent.com/1060490/59963481-bf5cbb00-94f3-11e9-984a-8e07d431ce6f.png">