### PR TITLE
Addon-docs: Support non-story exports in module format

### DIFF
--- a/lib/components/src/blocks/PropsTable/PropRow.stories.tsx
+++ b/lib/components/src/blocks/PropsTable/PropRow.stories.tsx
@@ -7,6 +7,7 @@ import { DocsPageWrapper } from '../DocsPage';
 export default {
   Component: PropRow,
   title: 'Docs|PropRow',
+  excludeStories: /.*Def$/,
   decorators: [
     getStory => (
       <DocsPageWrapper>
@@ -18,7 +19,7 @@ export default {
   ],
 };
 
-const stringDef = {
+export const stringDef = {
   name: 'someString',
   type: { name: 'string' },
   required: true,
@@ -26,17 +27,17 @@ const stringDef = {
   defaultValue: 'fixme',
 };
 
-const longNameDef = {
+export const longNameDef = {
   ...stringDef,
   name: 'reallyLongStringThatTakesUpSpace',
 };
 
-const longDescDef = {
+export const longDescDef = {
   ...stringDef,
   description: 'really long description that takes up a lot of space. sometimes this happens.',
 };
 
-const numberDef = {
+export const numberDef = {
   name: 'someNumber',
   type: { name: 'number' },
   required: false,
@@ -44,7 +45,7 @@ const numberDef = {
   defaultValue: 0,
 };
 
-const objectDef = {
+export const objectDef = {
   name: 'someObject',
   type: { name: 'objectOf', value: { name: 'number' } },
   required: false,
@@ -52,7 +53,7 @@ const objectDef = {
   defaultValue: { value: '{ key: 1 }', computed: false },
 };
 
-const arrayDef = {
+export const arrayDef = {
   name: 'someOArray',
   type: { name: 'arrayOf', value: { name: 'number' } },
   required: false,
@@ -60,7 +61,7 @@ const arrayDef = {
   defaultValue: { value: '[1, 2, 3]', computed: false },
 };
 
-const complexDef = {
+export const complexDef = {
   name: 'someComplex',
   type: {
     name: 'objectOf',

--- a/lib/components/src/blocks/PropsTable/PropsTable.stories.tsx
+++ b/lib/components/src/blocks/PropsTable/PropsTable.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PropsTable, PropsTableError } from './PropsTable';
 import { DocsPageWrapper } from '../DocsPage';
-import * as rowStories from './PropRow.stories';
+import { stringDef, numberDef } from './PropRow.stories';
 
 export default {
   Component: PropsTable,
@@ -13,6 +13,4 @@ export const error = () => <PropsTable error={PropsTableError.NO_COMPONENT} />;
 
 export const empty = () => <PropsTable rows={[]} />;
 
-const { row: stringRow } = rowStories.string().props;
-const { row: numberRow } = rowStories.number().props;
-export const normal = () => <PropsTable rows={[stringRow, numberRow]} />;
+export const normal = () => <PropsTable rows={[stringDef, numberDef]} />;

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -283,7 +283,7 @@ export default function start(render, { decorateStory } = {}) {
         );
       }
 
-      const { default: meta, ...examples } = fileExports;
+      const { default: meta, ...stories } = fileExports;
       const kindName = meta.title;
 
       if (previousExports[filename]) {
@@ -307,10 +307,10 @@ export default function start(render, { decorateStory } = {}) {
         kind.addParameters(meta.parameters);
       }
 
-      Object.keys(examples).forEach(key => {
-        const example = examples[key];
-        const { title = example.title || key, parameters } = example;
-        kind.add(title, example, parameters);
+      Object.keys(stories).forEach(key => {
+        const story = stories[key];
+        const { title = story.title || key, parameters } = story;
+        kind.add(title, story, parameters);
       });
 
       previousExports[filename] = fileExports;

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -28,10 +28,10 @@ function matches(storyKey, arrayOrRegex) {
   return storyKey.match(arrayOrRegex);
 }
 
-export function includeStory(storyKey, { includeStories, excludeStories }) {
+export function isExportStory(key, { includeStories, excludeStories }) {
   return (
-    (!includeStories || matches(storyKey, includeStories)) &&
-    (!excludeStories || !matches(storyKey, excludeStories))
+    (!includeStories || matches(key, includeStories)) &&
+    (!excludeStories || !matches(key, excludeStories))
   );
 }
 
@@ -297,7 +297,7 @@ export default function start(render, { decorateStory } = {}) {
         );
       }
 
-      const { default: meta, ...stories } = fileExports;
+      const { default: meta, ...exports } = fileExports;
       const kindName = meta.title;
 
       if (previousExports[filename]) {
@@ -321,9 +321,9 @@ export default function start(render, { decorateStory } = {}) {
         kind.addParameters(meta.parameters);
       }
 
-      Object.keys(stories).forEach(key => {
-        if (includeStory(key, meta)) {
-          const story = stories[key];
+      Object.keys(exports).forEach(key => {
+        if (isExportStory(key, meta)) {
+          const story = exports[key];
           const { title = story.title || key, parameters } = story;
           kind.add(title, story, parameters);
         }

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -21,6 +21,20 @@ const classes = {
   ERROR: 'sb-show-errordisplay',
 };
 
+function matches(storyKey, arrayOrRegex) {
+  if (Array.isArray(arrayOrRegex)) {
+    return arrayOrRegex.includes(storyKey);
+  }
+  return storyKey.match(arrayOrRegex);
+}
+
+export function includeStory(storyKey, { includeStories, excludeStories }) {
+  return (
+    (!includeStories || matches(storyKey, includeStories)) &&
+    (!excludeStories || !matches(storyKey, excludeStories))
+  );
+}
+
 function showMain() {
   document.body.classList.remove(classes.NOPREVIEW);
   document.body.classList.remove(classes.ERROR);
@@ -308,9 +322,11 @@ export default function start(render, { decorateStory } = {}) {
       }
 
       Object.keys(stories).forEach(key => {
-        const story = stories[key];
-        const { title = story.title || key, parameters } = story;
-        kind.add(title, story, parameters);
+        if (includeStory(key, meta)) {
+          const story = stories[key];
+          const { title = story.title || key, parameters } = story;
+          kind.add(title, story, parameters);
+        }
       });
 
       previousExports[filename] = fileExports;

--- a/lib/core/src/client/preview/start.test.js
+++ b/lib/core/src/client/preview/start.test.js
@@ -2,7 +2,7 @@
 import { history, document, window } from 'global';
 
 import Events from '@storybook/core-events';
-import start, { includeStory } from './start';
+import start, { isExportStory } from './start';
 
 jest.mock('@storybook/client-logger');
 jest.mock('global', () => ({
@@ -145,34 +145,34 @@ describe('STORY_INIT', () => {
 
 describe('story filters for module exports', () => {
   it('should include all stories when there are no filters', () => {
-    expect(includeStory('a', {})).toBeTruthy();
+    expect(isExportStory('a', {})).toBeTruthy();
   });
 
   it('should filter stories by arrays', () => {
-    expect(includeStory('a', { includeStories: ['a'] })).toBeTruthy();
-    expect(includeStory('a', { includeStories: [] })).toBeFalsy();
-    expect(includeStory('a', { includeStories: ['b'] })).toBeFalsy();
+    expect(isExportStory('a', { includeStories: ['a'] })).toBeTruthy();
+    expect(isExportStory('a', { includeStories: [] })).toBeFalsy();
+    expect(isExportStory('a', { includeStories: ['b'] })).toBeFalsy();
 
-    expect(includeStory('a', { excludeStories: ['a'] })).toBeFalsy();
-    expect(includeStory('a', { excludeStories: [] })).toBeTruthy();
-    expect(includeStory('a', { excludeStories: ['b'] })).toBeTruthy();
+    expect(isExportStory('a', { excludeStories: ['a'] })).toBeFalsy();
+    expect(isExportStory('a', { excludeStories: [] })).toBeTruthy();
+    expect(isExportStory('a', { excludeStories: ['b'] })).toBeTruthy();
 
-    expect(includeStory('a', { includeStories: ['a'], excludeStories: ['a'] })).toBeFalsy();
-    expect(includeStory('a', { includeStories: [], excludeStories: [] })).toBeFalsy();
-    expect(includeStory('a', { includeStories: ['a'], excludeStories: ['b'] })).toBeTruthy();
+    expect(isExportStory('a', { includeStories: ['a'], excludeStories: ['a'] })).toBeFalsy();
+    expect(isExportStory('a', { includeStories: [], excludeStories: [] })).toBeFalsy();
+    expect(isExportStory('a', { includeStories: ['a'], excludeStories: ['b'] })).toBeTruthy();
   });
 
   it('should filter stories by regex', () => {
-    expect(includeStory('a', { includeStories: /a/ })).toBeTruthy();
-    expect(includeStory('a', { includeStories: /.*/ })).toBeTruthy();
-    expect(includeStory('a', { includeStories: /b/ })).toBeFalsy();
+    expect(isExportStory('a', { includeStories: /a/ })).toBeTruthy();
+    expect(isExportStory('a', { includeStories: /.*/ })).toBeTruthy();
+    expect(isExportStory('a', { includeStories: /b/ })).toBeFalsy();
 
-    expect(includeStory('a', { excludeStories: /a/ })).toBeFalsy();
-    expect(includeStory('a', { excludeStories: /.*/ })).toBeFalsy();
-    expect(includeStory('a', { excludeStories: /b/ })).toBeTruthy();
+    expect(isExportStory('a', { excludeStories: /a/ })).toBeFalsy();
+    expect(isExportStory('a', { excludeStories: /.*/ })).toBeFalsy();
+    expect(isExportStory('a', { excludeStories: /b/ })).toBeTruthy();
 
-    expect(includeStory('a', { includeStories: /a/, excludeStories: ['a'] })).toBeFalsy();
-    expect(includeStory('a', { includeStories: /.*/, excludeStories: /.*/ })).toBeFalsy();
-    expect(includeStory('a', { includeStories: /a/, excludeStories: /b/ })).toBeTruthy();
+    expect(isExportStory('a', { includeStories: /a/, excludeStories: ['a'] })).toBeFalsy();
+    expect(isExportStory('a', { includeStories: /.*/, excludeStories: /.*/ })).toBeFalsy();
+    expect(isExportStory('a', { includeStories: /a/, excludeStories: /b/ })).toBeTruthy();
   });
 });

--- a/lib/core/src/client/preview/start.test.js
+++ b/lib/core/src/client/preview/start.test.js
@@ -2,7 +2,7 @@
 import { history, document, window } from 'global';
 
 import Events from '@storybook/core-events';
-import start from './start';
+import start, { includeStory } from './start';
 
 jest.mock('@storybook/client-logger');
 jest.mock('global', () => ({
@@ -140,5 +140,39 @@ describe('STORY_INIT', () => {
     store.emit(Events.STORY_INIT);
     expect(history.replaceState).toHaveBeenCalledWith({}, '', 'pathname?bar=baz&id=kind--story');
     expect(store.setSelection).toHaveBeenCalledWith({ storyId: 'kind--story' });
+  });
+});
+
+describe('story filters for module exports', () => {
+  it('should include all stories when there are no filters', () => {
+    expect(includeStory('a', {})).toBeTruthy();
+  });
+
+  it('should filter stories by arrays', () => {
+    expect(includeStory('a', { includeStories: ['a'] })).toBeTruthy();
+    expect(includeStory('a', { includeStories: [] })).toBeFalsy();
+    expect(includeStory('a', { includeStories: ['b'] })).toBeFalsy();
+
+    expect(includeStory('a', { excludeStories: ['a'] })).toBeFalsy();
+    expect(includeStory('a', { excludeStories: [] })).toBeTruthy();
+    expect(includeStory('a', { excludeStories: ['b'] })).toBeTruthy();
+
+    expect(includeStory('a', { includeStories: ['a'], excludeStories: ['a'] })).toBeFalsy();
+    expect(includeStory('a', { includeStories: [], excludeStories: [] })).toBeFalsy();
+    expect(includeStory('a', { includeStories: ['a'], excludeStories: ['b'] })).toBeTruthy();
+  });
+
+  it('should filter stories by regex', () => {
+    expect(includeStory('a', { includeStories: /a/ })).toBeTruthy();
+    expect(includeStory('a', { includeStories: /.*/ })).toBeTruthy();
+    expect(includeStory('a', { includeStories: /b/ })).toBeFalsy();
+
+    expect(includeStory('a', { excludeStories: /a/ })).toBeFalsy();
+    expect(includeStory('a', { excludeStories: /.*/ })).toBeFalsy();
+    expect(includeStory('a', { excludeStories: /b/ })).toBeTruthy();
+
+    expect(includeStory('a', { includeStories: /a/, excludeStories: ['a'] })).toBeFalsy();
+    expect(includeStory('a', { includeStories: /.*/, excludeStories: /.*/ })).toBeFalsy();
+    expect(includeStory('a', { includeStories: /a/, excludeStories: /b/ })).toBeTruthy();
   });
 });


### PR DESCRIPTION
Issue: #7071 

## What I did

Added includeStories/excludeStories component metadata to make it easy to control which file exports get treated as stories. (So that story files can also export data)

## How to test

```
yarn jest --testPathPattern start.test.js
```
