### PR TITLE
Module format: use story field for name/parameters annotation

### DIFF
--- a/addons/docs/__snapshots__/mdx-compiler-plugin.test.js.snap
+++ b/addons/docs/__snapshots__/mdx-compiler-plugin.test.js.snap
@@ -90,7 +90,8 @@ function MDXContent({ components, ...props }) {
 MDXContent.isMDXComponent = true;
 
 export const one = () => <Button>One</Button>;
-one.parameters = { mdxSource: \`<Button>One</Button>\` };
+one.story = {};
+one.story.parameters = { mdxSource: \`<Button>One</Button>\` };
 
 const componentMeta = {
   title: 'Button',
@@ -159,11 +160,13 @@ function MDXContent({ components, ...props }) {
 MDXContent.isMDXComponent = true;
 
 export const one = () => <Button>One</Button>;
-one.parameters = { mdxSource: \`<Button>One</Button>\` };
+one.story = {};
+one.story.parameters = { mdxSource: \`<Button>One</Button>\` };
 
 export const helloStory = () => <Button>Hello button</Button>;
-helloStory.title = 'hello story';
-helloStory.parameters = { mdxSource: \`<Button>Hello button</Button>\` };
+helloStory.story = {};
+helloStory.story.name = 'hello story';
+helloStory.story.parameters = { mdxSource: \`<Button>Hello button</Button>\` };
 
 const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory'] };
 
@@ -229,8 +232,9 @@ export const toStorybook = () => ({
     declarations: [Welcome],
   },
 });
-toStorybook.title = 'to storybook';
-toStorybook.parameters = {
+toStorybook.story = {};
+toStorybook.story.name = 'to storybook';
+toStorybook.story.parameters = {
   mdxSource: \`{
   template: \\\\\`<storybook-welcome-component (showApp)=\\"showApp()\\"></storybook-welcome-component>\\\\\`,
   props: {
@@ -304,12 +308,14 @@ function MDXContent({ components, ...props }) {
 MDXContent.isMDXComponent = true;
 
 export const componentNotes = () => <Button>Component notes</Button>;
-componentNotes.title = 'component notes';
-componentNotes.parameters = { mdxSource: \`<Button>Component notes</Button>\` };
+componentNotes.story = {};
+componentNotes.story.name = 'component notes';
+componentNotes.story.parameters = { mdxSource: \`<Button>Component notes</Button>\` };
 
 export const storyNotes = () => <Button>Story notes</Button>;
-storyNotes.title = 'story notes';
-storyNotes.parameters = {
+storyNotes.story = {};
+storyNotes.story.name = 'story notes';
+storyNotes.story.parameters = {
   mdxSource: \`<Button>Story notes</Button>\`,
   ...{
     notes: 'story notes',
@@ -385,11 +391,13 @@ function MDXContent({ components, ...props }) {
 MDXContent.isMDXComponent = true;
 
 export const helloButton = () => <Button>Hello button</Button>;
-helloButton.title = 'hello button';
-helloButton.parameters = { mdxSource: \`<Button>Hello button</Button>\` };
+helloButton.story = {};
+helloButton.story.name = 'hello button';
+helloButton.story.parameters = { mdxSource: \`<Button>Hello button</Button>\` };
 
 export const two = () => <Button>Two</Button>;
-two.parameters = { mdxSource: \`<Button>Two</Button>\` };
+two.story = {};
+two.story.parameters = { mdxSource: \`<Button>Two</Button>\` };
 
 const componentMeta = {
   title: 'Button',
@@ -448,11 +456,13 @@ function MDXContent({ components, ...props }) {
 MDXContent.isMDXComponent = true;
 
 export const one = () => <Button>One</Button>;
-one.parameters = { mdxSource: \`<Button>One</Button>\` };
+one.story = {};
+one.story.parameters = { mdxSource: \`<Button>One</Button>\` };
 
 export const helloStory = () => <Button>Hello button</Button>;
-helloStory.title = 'hello story';
-helloStory.parameters = { mdxSource: \`<Button>Hello button</Button>\` };
+helloStory.story = {};
+helloStory.story.name = 'hello story';
+helloStory.story.parameters = { mdxSource: \`<Button>Hello button</Button>\` };
 
 const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory'] };
 
@@ -542,7 +552,8 @@ function MDXContent({ components, ...props }) {
 MDXContent.isMDXComponent = true;
 
 export const text = () => 'Plain text';
-text.parameters = { mdxSource: \`'Plain text'\` };
+text.story = {};
+text.story.parameters = { mdxSource: \`'Plain text'\` };
 
 const componentMeta = { title: 'Text', includeStories: ['text'] };
 

--- a/addons/docs/mdx-compiler-plugin.js
+++ b/addons/docs/mdx-compiler-plugin.js
@@ -65,9 +65,10 @@ function genStoryExport(ast, counter) {
       ${storyCode}
     );`
   );
+  statements.push(`${storyKey}.story = {};`);
 
   if (storyName !== storyKey) {
-    statements.push(`${storyKey}.title = '${storyName}';`);
+    statements.push(`${storyKey}.story.name = '${storyName}';`);
   }
 
   let parameters = getAttr(ast.openingElement, 'parameters');
@@ -76,9 +77,9 @@ function genStoryExport(ast, counter) {
   if (parameters) {
     const { code: params } = generate(parameters, {});
     // FIXME: hack in the story's source as a parameter
-    statements.push(`${storyKey}.parameters = { mdxSource: ${source}, ...${params} };`);
+    statements.push(`${storyKey}.story.parameters = { mdxSource: ${source}, ...${params} };`);
   } else {
-    statements.push(`${storyKey}.parameters = { mdxSource: ${source} };`);
+    statements.push(`${storyKey}.story.parameters = { mdxSource: ${source} };`);
   }
 
   // console.log(statements);

--- a/examples/official-storybook/stories/addon-docs.stories.js
+++ b/examples/official-storybook/stories/addon-docs.stories.js
@@ -13,25 +13,31 @@ export default {
 export const basic = () => <div>Click docs tab to see basic docs</div>;
 
 export const withNotes = () => <div>Click docs tab to see DocsPage docs</div>;
-withNotes.title = 'with notes';
-withNotes.parameters = {
-  notes,
+withNotes.story = {
+  name: 'with notes',
+  parameters: { notes },
 };
 
 export const withInfo = () => <div>Click docs tab to see DocsPage docs</div>;
-withInfo.title = 'with info';
-withInfo.parameters = {
-  info: 'some user info string',
+withInfo.story = {
+  name: 'with info',
+  parameters: {
+    info: 'some user info string',
+  },
 };
 
 export const mdxOverride = () => <div>Click docs tab to see MDX-overridden docs</div>;
-mdxOverride.title = 'mdx override';
-mdxOverride.parameters = {
-  docs: mdxNotes,
+mdxOverride.story = {
+  name: 'mdx override',
+  parameters: {
+    docs: mdxNotes,
+  },
 };
 
 export const jsxOverride = () => <div>Click docs tab to see JSX-overridden docs</div>;
-jsxOverride.title = 'jsx override';
-jsxOverride.parameters = {
-  docs: () => <div>Hello docs</div>,
+jsxOverride.story = {
+  name: 'jsx override',
+  parameters: {
+    docs: () => <div>Hello docs</div>,
+  },
 };

--- a/examples/official-storybook/stories/core/errors.stories.js
+++ b/examples/official-storybook/stories/core/errors.stories.js
@@ -9,10 +9,12 @@ export default {
 export const exception = () => {
   throw new Error('storyFn threw an error! WHOOPS');
 };
-exception.title = 'story throws exception';
-exception.parameters = {
-  storyshots: { disable: true },
-  chromatic: { disable: true },
+exception.story = {
+  name: 'story throws exception',
+  parameters: {
+    storyshots: { disable: true },
+    chromatic: { disable: true },
+  },
 };
 
 export const badComponent = () => (
@@ -21,17 +23,21 @@ export const badComponent = () => (
     <BadComponent />
   </Fragment>
 );
-badComponent.title = 'story errors - variant error';
-badComponent.parameters = {
-  notes: 'Story does not return something react can render',
-  storyshots: { disable: true },
-  chromatic: { disable: true },
+badComponent.story = {
+  name: 'story errors - variant error',
+  parameters: {
+    notes: 'Story does not return something react can render',
+    storyshots: { disable: true },
+    chromatic: { disable: true },
+  },
 };
 
 export const badStory = () => false;
-badStory.title = 'story errors - story un-renderable type';
-badStory.parameters = {
-  notes: 'Story does not return something react can render',
-  storyshots: { disable: true },
-  chromatic: { disable: true },
+badStory.story = {
+  name: 'story errors - story un-renderable type',
+  parameters: {
+    notes: 'Story does not return something react can render',
+    storyshots: { disable: true },
+    chromatic: { disable: true },
+  },
 };

--- a/examples/official-storybook/stories/core/events.stories.js
+++ b/examples/official-storybook/stories/core/events.stories.js
@@ -14,4 +14,4 @@ export default {
 };
 
 export const force = () => <Button onClick={increment}>Clicked: {timesClicked}</Button>;
-force.title = 'Force re-render';
+force.story = { name: 'Force re-render' };

--- a/examples/official-storybook/stories/core/parameters.stories.js
+++ b/examples/official-storybook/stories/core/parameters.stories.js
@@ -19,5 +19,7 @@ export const passed = ({
   // eslint-disable-next-line react/prop-types
   parameters: { options, ...parameters },
 }) => <pre>Parameters are {JSON.stringify(parameters, null, 2)}</pre>;
-passed.title = 'passed to story';
-passed.parameters = { storyParameter: 'storyParameter' };
+passed.story = {
+  name: 'passed to story',
+  parameters: { storyParameter: 'storyParameter' },
+};

--- a/examples/official-storybook/stories/core/scroll.stories.js
+++ b/examples/official-storybook/stories/core/scroll.stories.js
@@ -14,7 +14,7 @@ export const story1 = () => (
     </pre>
   </div>
 );
-story1.title = 'story with 100vh padding 1';
+story1.story = { name: 'story with 100vh padding 1' };
 
 export const story2 = () => (
   <div>
@@ -26,4 +26,4 @@ export const story2 = () => (
     </pre>
   </div>
 );
-story2.title = 'story with 100vh padding 2';
+story2.story = { name: 'story with 100vh padding 2' };

--- a/lib/codemod/src/transforms/__testfixtures__/convert-to-module-format/basic.output.js
+++ b/lib/codemod/src/transforms/__testfixtures__/convert-to-module-format/basic.output.js
@@ -11,7 +11,10 @@ export default {
 
 export const story1 = () => <Button label="Story 1" />;
 export const story2 = () => <Button label="Story 2" onClick={action('click')} />;
-story2.title = 'second story';
+
+story2.story = {
+  name: 'second story',
+};
 
 export const story3 = () => (
   <div>
@@ -20,4 +23,6 @@ export const story3 = () => (
   </div>
 );
 
-story3.title = 'complex story';
+story3.story = {
+  name: 'complex story',
+};

--- a/lib/codemod/src/transforms/__testfixtures__/convert-to-module-format/decorators.output.js
+++ b/lib/codemod/src/transforms/__testfixtures__/convert-to-module-format/decorators.output.js
@@ -8,4 +8,7 @@ export default {
 };
 
 export const story1 = () => <Button label="The Button" />;
-story1.title = 'with decorator';
+
+story1.story = {
+  name: 'with decorator',
+};

--- a/lib/codemod/src/transforms/__testfixtures__/convert-to-module-format/parameters.output.js
+++ b/lib/codemod/src/transforms/__testfixtures__/convert-to-module-format/parameters.output.js
@@ -13,4 +13,7 @@ export default {
 };
 
 export const story1 = () => <Button label="The Button" />;
-story1.title = 'with kind parameters';
+
+story1.story = {
+  name: 'with kind parameters',
+};

--- a/lib/codemod/src/transforms/__testfixtures__/convert-to-module-format/story-parameters.output.js
+++ b/lib/codemod/src/transforms/__testfixtures__/convert-to-module-format/story-parameters.output.js
@@ -7,15 +7,20 @@ export default {
 };
 
 export const story1 = () => <Button label="The Button" />;
-story1.title = 'with story parameters';
 
-story1.parameters = {
-  header: false,
-  inline: true,
+story1.story = {
+  name: 'with story parameters',
+
+  parameters: {
+    header: false,
+    inline: true,
+  },
 };
 
 export const foo = () => <Button label="Foo" />;
 
-foo.parameters = {
-  bar: 1,
+foo.story = {
+  parameters: {
+    bar: 1,
+  },
 };

--- a/lib/codemod/src/transforms/convert-to-module-format.js
+++ b/lib/codemod/src/transforms/convert-to-module-format.js
@@ -100,38 +100,41 @@ export default function transformer(file, api, options) {
     adds.push(path);
 
     adds.forEach(add => {
-      let name = add.node.arguments[0].value;
-      let title = null;
-      if (/\s/.exec(name)) {
-        title = name;
-        name = `story${counter}`;
+      let key = add.node.arguments[0].value;
+      let name = null;
+      if (/\s/.exec(key)) {
+        name = key;
+        key = `story${counter}`;
       }
       const val = add.node.arguments[1];
       statements.push(
         j.exportDeclaration(
           false,
-          j.variableDeclaration('const', [j.variableDeclarator(j.identifier(name), val)])
+          j.variableDeclaration('const', [j.variableDeclarator(j.identifier(key), val)])
         )
       );
-      if (title) {
-        statements.push(
-          j.assignmentStatement(
-            '=',
-            j.memberExpression(j.identifier(name), j.identifier('title')),
-            j.literal(title)
-          )
-        );
+
+      const storyAnnotations = [];
+
+      if (name) {
+        storyAnnotations.push(j.property('init', j.identifier('name'), j.literal(name)));
       }
+
       if (add.node.arguments.length > 2) {
         const storyParams = add.node.arguments[2];
+        storyAnnotations.push(j.property('init', j.identifier('parameters'), storyParams));
+      }
+
+      if (storyAnnotations.length > 0) {
         statements.push(
           j.assignmentStatement(
             '=',
-            j.memberExpression(j.identifier(name), j.identifier('parameters')),
-            storyParams
+            j.memberExpression(j.identifier(key), j.identifier('story')),
+            j.objectExpression(storyAnnotations)
           )
         );
       }
+
       counter += 1;
     });
 

--- a/lib/components/src/blocks/DocsPage.stories.tsx
+++ b/lib/components/src/blocks/DocsPage.stories.tsx
@@ -33,7 +33,7 @@ export const noText = () => (
     {sourceStories.jsx()}
   </DocsPage>
 );
-noText.title = 'no text';
+noText.story = { name: 'no text' };
 
 export const text = () => (
   <DocsPage title="Sensorium">
@@ -55,6 +55,7 @@ export const withSubtitle = () => (
     {sourceStories.jsx()}
   </DocsPage>
 );
+withSubtitle.story = { name: 'with subtitle' };
 
 export const markdown = () => (
   <DocsPage title="markdown">

--- a/lib/components/src/blocks/Source.stories.tsx
+++ b/lib/components/src/blocks/Source.stories.tsx
@@ -9,10 +9,10 @@ export default {
 };
 
 export const noStory = () => <Source error={SourceError.NO_STORY} />;
-noStory.title = 'no story';
+noStory.story = { name: 'no story' };
 
 export const sourceUnavailable = () => <Source error={SourceError.SOURCE_UNAVAILABLE} />;
-sourceUnavailable.title = 'source unavailable';
+sourceUnavailable.story = { name: 'source unavailable' };
 
 const jsxCode = `
 <MyComponent boolProp scalarProp={1} complexProp={{ foo: 1, bar: '2' }}>

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -323,9 +323,9 @@ export default function start(render, { decorateStory } = {}) {
 
       Object.keys(exports).forEach(key => {
         if (isExportStory(key, meta)) {
-          const story = exports[key];
-          const { title = story.title || key, parameters } = story;
-          kind.add(title, story, parameters);
+          const storyFn = exports[key];
+          const { name, parameters } = storyFn.story || {};
+          kind.add(name || key, storyFn, parameters);
         }
       });
 

--- a/lib/ui/src/components/sidebar/SidebarItem.stories.js
+++ b/lib/ui/src/components/sidebar/SidebarItem.stories.js
@@ -23,7 +23,7 @@ export const longName = () => (
     isComponent
   />
 );
-longName.title = 'with long name';
+longName.story = { name: 'with long name' };
 export const nestedDepths = () => (
   <div>
     <SidebarItem name="Depth 0 collapsed" depth={0} />

--- a/lib/ui/src/settings/shortcuts.stories.js
+++ b/lib/ui/src/settings/shortcuts.stories.js
@@ -48,4 +48,4 @@ export default {
 };
 
 export const defaults = () => <ShortcutsScreen shortcutKeys={defaultShortcuts} {...actions} />;
-defaults.title = 'default shortcuts';
+defaults.story = { name: 'default shortcuts' };


### PR DESCRIPTION
Issue: #7164 

## What I did

- [x] Convert module format from `storyFn.title = x` to `storyFn.story = { name: x }`
- [x] Update `*.stories.[tj]sx?` to use new format
- [x] Update MDX compiler
- [x] Update codemod

## How to test

```
yarn jest --testPathPattern convert-to-module-format.test.js
yarn jest --testPathPattern mdx-compiler-plugin.test.js
```

Also:
```
cd examples/official-storybook
yarn storybook
```
Verify stories have spaces in the names :)

