### PR TITLE
[BREAKING CHANGE] [feature request] addon:(knob) ISSUE-2118: Knobs can now be updated to reflect app state without having to touch the knob physically

### DIFF
--- a/addons/knobs/src/KnobManager.js
+++ b/addons/knobs/src/KnobManager.js
@@ -70,7 +70,8 @@ export default class KnobManager {
       options.type === existingKnob.type &&
       navigator &&
       // userAgent is not set in react-native
-      (!navigator.userAgent || !navigator.userAgent.includes('jsdom'))
+      (!navigator.userAgent || !navigator.userAgent.includes('jsdom')) &&
+      !options.set
     ) {
       return this.getKnobValue(existingKnob);
     }

--- a/addons/knobs/src/index.js
+++ b/addons/knobs/src/index.js
@@ -8,15 +8,39 @@ export function knob(name, optionsParam) {
   return manager.knob(name, optionsParam);
 }
 
-export function text(name, value, groupId) {
-  return manager.knob(name, { type: 'text', value, groupId });
+/**
+ * TODO: Typescript would be really great here.
+ * But overall A knob implementation function should conform to 3 maximum arguments.
+  name, value, options !
+
+  https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)
+  https://stackoverflow.com/questions/174968/how-many-parameters-are-too-many#answer-175035
+
+ * @param  {String} name - label to identify a knob
+ * @param  {Any} value - value of the knob could be a callback
+ * @param  {Object} options - value of the knob could be a callback
+  * @param  {String|Number} options.groupId - (optional) knob grouping to allow same names but different groups / buckets.
+  * @param  {Boolean} options.set - (optional) allows you to set a knob from the api allowing two way data updates
+  *    Where set of true allows you to set / update the knob value. False will return the current knob value
+  *    without setting (old default behavior).
+  * 
+  *    1st way component updates values from the knob itself
+  *    2nd way outside updates from the api
+  * 
+  *    This allows knobs to not be mere just drivers of an interface (option 1). With option 2
+  *    this allows knobs to report the current stories app state easily with no added JSX.
+  * @param  {Object} options.options (optional)
+ *
+ */
+export function text(name, value, { groupId, set } = {}) {
+  return manager.knob(name, { type: 'text', value, groupId, set });
 }
 
-export function boolean(name, value, groupId) {
-  return manager.knob(name, { type: 'boolean', value, groupId });
+export function boolean(name, value, { groupId, set } = {}) {
+  return manager.knob(name, { type: 'boolean', value, groupId, set });
 }
 
-export function number(name, value, options = {}, groupId) {
+export function number(name, value, { options = {}, groupId, set } = {}) {
   const rangeDefaults = {
     min: 0,
     max: 10,
@@ -40,41 +64,48 @@ export function number(name, value, options = {}, groupId) {
   return manager.knob(name, finalOptions);
 }
 
-export function color(name, value, groupId) {
-  return manager.knob(name, { type: 'color', value, groupId });
+export function color(name, value, { groupId, set } = {}) {
+  return manager.knob(name, { type: 'color', value, groupId, set });
 }
 
-export function object(name, value, groupId) {
-  return manager.knob(name, { type: 'object', value, groupId });
+export function object(name, value, { groupId, set } = {}) {
+  return manager.knob(name, { type: 'object', value, groupId, set });
 }
 
-export function select(name, options, value, groupId) {
-  return manager.knob(name, { type: 'select', selectV2: true, options, value, groupId });
+export function select(name, value, { options, groupId, set } = {}) {
+  return manager.knob(name, { type: 'select', selectV2: true, options, value, groupId, set });
 }
 
-export function radios(name, options, value, groupId) {
-  return manager.knob(name, { type: 'radios', options, value, groupId });
+export function radios(name, value, { options, groupId, set } = {}) {
+  return manager.knob(name, { type: 'radios', options, value, groupId, set });
 }
 
-export function array(name, value, separator = ',', groupId) {
-  return manager.knob(name, { type: 'array', value, separator, groupId });
+export function array(name, value, { separator = ',', groupId, set } = {}) {
+  return manager.knob(name, { type: 'array', value, separator, groupId, set });
 }
 
-export function date(name, value = new Date(), groupId) {
+export function date(name, value = new Date(), { groupId, set } = {}) {
   const proxyValue = value ? value.getTime() : null;
-  return manager.knob(name, { type: 'date', value: proxyValue, groupId });
+  return manager.knob(name, { type: 'date', value: proxyValue, groupId, set });
 }
 
-export function button(name, callback, groupId) {
-  return manager.knob(name, { type: 'button', callback, hideLabel: true, groupId });
+export function button(name, callback, { groupId, set } = {}) {
+  return manager.knob(name, { type: 'button', callback, hideLabel: true, groupId, set });
 }
 
-export function files(name, accept, value = [], groupId) {
-  return manager.knob(name, { type: 'files', accept, value, groupId });
+export function files(name, value = [], { groupId, accept, set } = {}) {
+  return manager.knob(name, { type: 'files', accept, value, groupId, set });
 }
 
-export function optionsKnob(name, valuesObj, value, optionsObj, groupId) {
-  return manager.knob(name, { type: 'options', options: valuesObj, value, optionsObj, groupId });
+export function optionsKnob(name, value, { values, options, groupId, set } = {}) {
+  return manager.knob(name, {
+    type: 'options',
+    options: values,
+    value,
+    optionsObj: options,
+    groupId,
+    set,
+  });
 }
 
 const defaultOptions = {

--- a/examples-native/crna-kitchen-sink/storybook/stories/Knobs/index.js
+++ b/examples-native/crna-kitchen-sink/storybook/stories/Knobs/index.js
@@ -15,20 +15,20 @@ import {
 
 export default () => {
   const name = text('Name', 'Storyteller');
-  const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 });
+  const age = number('Age', 70, { options: { range: true, min: 0, max: 90, step: 5 } });
   const fruits = {
     Apple: 'apple',
     Banana: 'banana',
     Cherry: 'cherry',
   };
-  const fruit = select('Fruit', fruits, 'apple');
+  const fruit = select('Fruit', 'apple', { options: fruits });
 
   const otherFruits = {
     Kiwi: 'kiwi',
     Guava: 'guava',
     Watermelon: 'watermelon',
   };
-  const otherFruit = radios('Other Fruit', otherFruits, 'watermelon');
+  const otherFruit = radios('Other Fruit', 'watermelon', { options: otherFruits });
   const dollars = number('Dollars', 12.5);
 
   // NOTE: color picker is currently broken

--- a/examples/angular-cli/src/stories/addon-knobs.stories.ts
+++ b/examples/angular-cli/src/stories/addon-knobs.stories.ts
@@ -63,13 +63,13 @@ storiesOf('Addon|Knobs', module)
       Banana: 'bananas',
       Cherry: 'cherries',
     };
-    const fruit = select('fruit', fruits, 'apples');
+    const fruit = select('fruit', 'apples', { options: fruits });
     const otherFruits = {
       Kiwi: 'kiwi',
       Guava: 'guava',
       Watermelon: 'watermelon',
     };
-    const otherFruit = radios('Other Fruit', otherFruits, 'watermelon');
+    const otherFruit = radios('Other Fruit', 'watermelon', { options: otherFruits });
     const price = number('price', 2.25);
 
     const border = color('border', 'deeppink');

--- a/examples/html-kitchen-sink/stories/addon-knobs.stories.js
+++ b/examples/html-kitchen-sink/stories/addon-knobs.stories.js
@@ -51,7 +51,7 @@ storiesOf('Addons|Knobs', module)
       Banana: 'bananas',
       Cherry: 'cherries',
     };
-    const fruit = select('Fruit', fruits, 'apples');
+    const fruit = select('Fruit', 'apples', { options: fruits });
 
     const price = number('Price', 2.25);
 

--- a/examples/mithril-kitchen-sink/src/stories/addon-knobs.stories.js
+++ b/examples/mithril-kitchen-sink/src/stories/addon-knobs.stories.js
@@ -40,7 +40,7 @@ storiesOf('Addons|Knobs', module)
       Banana: 'bananas',
       Cherry: 'cherries',
     };
-    const fruit = select('Fruit', fruits, 'apples');
+    const fruit = select('Fruit', 'apples', { options: fruits });
     const price = number('Price', 2.25);
 
     const colour = color('Border', 'deeppink');

--- a/examples/official-storybook/stories/addon-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs.stories.js
@@ -54,14 +54,14 @@ storiesOf('Addons|Knobs.withKnobs', module)
       Banana: 'banana',
       Cherry: 'cherry',
     };
-    const fruit = select('Fruit', fruits, 'apple');
+    const fruit = select('Fruit', 'apple', { options: fruits });
 
     const otherFruits = {
       Kiwi: 'kiwi',
       Guava: 'guava',
       Watermelon: 'watermelon',
     };
-    const otherFruit = radios('Other Fruit', otherFruits, 'watermelon');
+    const otherFruit = radios('Other Fruit', 'watermelon', { options: otherFruits });
     const dollars = number('Dollars', 12.5, { min: 0, max: 100, step: 0.01 });
     const years = number('Years in NY', 9);
 
@@ -131,25 +131,33 @@ storiesOf('Addons|Knobs.withKnobs', module)
     const ungrouped = text('Ungrouped', 'Mumble');
 
     // General
-    const name = text('Name', 'Storyteller', GROUP_IDS.GENERAL);
-    const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 }, GROUP_IDS.GENERAL);
-    const birthday = date('Birthday', defaultBirthday, GROUP_IDS.GENERAL);
-    const dollars = number(
-      'Account Balance',
-      12.5,
-      { min: 0, max: 100, step: 0.01 },
-      GROUP_IDS.GENERAL
-    );
-    const years = number('Years in NY', 9, {}, GROUP_IDS.GENERAL);
+    const name = text('Name', 'Storyteller', { groupId: GROUP_IDS.GENERAL });
+    const age = number('Age', 70, {
+      options: { range: true, min: 0, max: 90, step: 5 },
+      groupId: GROUP_IDS.GENERAL,
+    });
+    const birthday = date('Birthday', defaultBirthday, { groupId: GROUP_IDS.GENERAL });
+    const dollars = number('Account Balance', 12.5, {
+      options: { min: 0, max: 100, step: 0.01 },
+      groupId: GROUP_IDS.GENERAL,
+    });
+    const years = number('Years in NY', 9, { groupId: GROUP_IDS.GENERAL });
 
     // Favorites
-    const nice = boolean('Nice', true, GROUP_IDS.FAVORITES);
-    const fruit = select('Fruit', fruits, 'apple', GROUP_IDS.FAVORITES);
-    const otherFruit = radios('Other Fruit', otherFruits, 'watermelon', GROUP_IDS.FAVORITES);
-    const items = array('Items', ['Laptop', 'Book', 'Whiskey'], ',', GROUP_IDS.FAVORITES);
+    const nice = boolean('Nice', true, { groupId: GROUP_IDS.FAVORITES });
+    const fruit = select('Fruit', 'apple', { options: fruits, groupId: GROUP_IDS.FAVORITES });
+    const otherFruit = radios('Other Fruit', 'watermelon', {
+      options: otherFruits,
+      groupId: GROUP_IDS.FAVORITES,
+    });
+    const items = array('Items', ['Laptop', 'Book', 'Whiskey'], ',', {
+      groupId: GROUP_IDS.FAVORITES,
+    });
 
     // Display
-    const backgroundColor = color('Color', 'rgba(126, 211, 33, 0.22)', GROUP_IDS.DISPLAY);
+    const backgroundColor = color('Color', 'rgba(126, 211, 33, 0.22)', {
+      groupId: GROUP_IDS.DISPLAY,
+    });
     const otherStyles = object(
       'Styles',
       {
@@ -157,7 +165,7 @@ storiesOf('Addons|Knobs.withKnobs', module)
         borderRadius: 10,
         padding: '10px',
       },
-      GROUP_IDS.DISPLAY
+      { groupId: GROUP_IDS.DISPLAY }
     );
 
     const style = { backgroundColor, ...otherStyles };
@@ -223,14 +231,20 @@ storiesOf('Addons|Knobs.withKnobs', module)
       Tuesday: 'Tuesday',
       Wednesday: 'Wednesday',
     };
-    const optionRadio = options('Radio', valuesRadio, 'Tuesday', { display: 'radio' });
+    const optionRadio = options('Radio', 'Tuesday', {
+      values: valuesRadio,
+      options: { display: 'radio' },
+    });
 
     const valuesInlineRadio = {
       Saturday: 'Saturday',
       Sunday: 'Sunday',
     };
-    const optionInlineRadio = options('Inline Radio', valuesInlineRadio, 'Saturday', {
-      display: 'inline-radio',
+    const optionInlineRadio = options('Inline Radio', 'Saturday', {
+      values: valuesInlineRadio,
+      options: {
+        display: 'inline-radio',
+      },
     });
 
     const valuesSelect = {
@@ -238,15 +252,21 @@ storiesOf('Addons|Knobs.withKnobs', module)
       February: 'February',
       March: 'March',
     };
-    const optionSelect = options('Select', valuesSelect, 'January', { display: 'select' });
+    const optionSelect = options('Select', 'January', {
+      values: valuesSelect,
+      options: { display: 'select' },
+    });
 
     const valuesMultiSelect = {
       Apple: 'apple',
       Banana: 'banana',
       Cherry: 'cherry',
     };
-    const optionsMultiSelect = options('Multi Select', valuesMultiSelect, ['apple'], {
-      display: 'multi-select',
+    const optionsMultiSelect = options('Multi Select', ['apple'], {
+      values: valuesMultiSelect,
+      options: {
+        display: 'multi-select',
+      },
     });
 
     const valuesCheck = {
@@ -254,15 +274,21 @@ storiesOf('Addons|Knobs.withKnobs', module)
       Carrot: 'carrot',
       Cucumber: 'cucumber',
     };
-    const optionsCheck = options('Check', valuesCheck, ['carrot'], { display: 'check' });
+    const optionsCheck = options('Check', ['carrot'], {
+      values: valuesCheck,
+      options: { display: 'check' },
+    });
 
     const valuesInlineCheck = {
       Milk: 'milk',
       Cheese: 'cheese',
       Butter: 'butter',
     };
-    const optionsInlineCheck = options('Inline Check', valuesInlineCheck, ['milk'], {
-      display: 'inline-check',
+    const optionsInlineCheck = options('Inline Check', ['milk'], {
+      values: valuesInlineCheck,
+      options: {
+        display: 'inline-check',
+      },
     });
 
     return (

--- a/examples/polymer-cli/src/stories/addon-knobs.stories.js
+++ b/examples/polymer-cli/src/stories/addon-knobs.stories.js
@@ -38,7 +38,7 @@ storiesOf('Addon|Knobs', module)
       Banana: 'bananas',
       Cherry: 'cherries',
     };
-    const fruit = select('Fruit', fruits, 'apples');
+    const fruit = select('Fruit', 'apples', { options: fruits });
     const price = number('Price', 2.25);
     const colour = color('Border', 'deeppink');
     const today = date('Today', new Date('Jan 20 2017 GMT+0'));

--- a/examples/preact-kitchen-sink/src/stories/addon-knobs.stories.js
+++ b/examples/preact-kitchen-sink/src/stories/addon-knobs.stories.js
@@ -38,7 +38,7 @@ storiesOf('Addons|Knobs', module)
       Banana: 'bananas',
       Cherry: 'cherries',
     };
-    const fruit = select('Fruit', fruits, 'apples');
+    const fruit = select('Fruit', 'apples', { options: fruits });
     const price = number('Price', 2.25);
 
     const colour = color('Border', 'deeppink');

--- a/examples/riot-kitchen-sink/src/stories/addon-knobs.stories.js
+++ b/examples/riot-kitchen-sink/src/stories/addon-knobs.stories.js
@@ -36,7 +36,7 @@ storiesOf('Addon|Knobs', module)
       Banana: 'bananas',
       Cherry: 'cherries',
     };
-    const fruit = select('Fruit', fruits, 'apples');
+    const fruit = select('Fruit', 'apples', { options: fruits });
     const price = number('Price', 2.25);
 
     const colour = color('Border', 'deeppink');

--- a/examples/vue-kitchen-sink/src/stories/addon-knobs.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/addon-knobs.stories.js
@@ -57,7 +57,7 @@ storiesOf('Addon|Knobs', module)
             step: 5,
           }),
         },
-        fruit: { default: select('Fruit', fruits, 'apples') },
+        fruit: { default: select('Fruit', 'apples', { options: fruits }) },
         price: { default: number('Price', 2.25) },
         colour: { default: color('Border', 'deeppink') },
         today: { default: date('Today', new Date('Jan 20 2017 GMT+0')) },


### PR DESCRIPTION
Issue: #2118

addon:(knob) ISSUE-2118: Knobs can now be updated to reflect app state without having to touch the knob physically  to reflect app state without having to touch the knob physically

## What I did

Added option.set to KnobManager, added option.set to all knob implementations.

Modified all knob implementations to have a consistent function interface of three arguments

- name
- value
- options

## How to test

- Is this testable with Jest or Chromatic screenshots?
Jest yes, unfamiliar with Chromatic

One test was failing `inject-decorators.test.js` `positive - ts' -> 'returns "changed" flag'` 
- Does this need a new example in the kitchen sink apps?
Maybe, I updated all of the examples that seemed relevant.

- Does this need an update to the documentation?
Yes

If your answer is yes to any of these, please make sure to include it in your PR.

**If it seems like this PR will get accepted then I will progress on the documentation.**
<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->