### PR TITLE
Parallelize CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ dependencies:
   pre:
     - yarn global add npm
 jobs:
+  parallelism: 4
   build:
     <<: *defaults
     steps:
@@ -67,6 +68,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run:
+          name: Split test file
+          command: circleci tests split < /storybook/examples
       - run:
           name: Workaround for https://github.com/GoogleChrome/puppeteer/issues/290
           command: sh ./scripts/workaround-puppeteer-issue-290.sh
@@ -329,6 +333,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run: 
+          name: Split test files
+          command: circleci tests split < storybook/lib/cli/
       - run:
           name: Test
           command: yarn test --cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
           at: .
       - run: 
           name: Split test files
-          command: circleci tests split < storybook/lib/cli/
+          command: circleci tests split < storybook/lib/cli/test
       - run:
           name: Test
           command: yarn test --cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ dependencies:
   pre:
     - yarn global add npm
 jobs:
-  parallelism: 4
   build:
     <<: *defaults
     steps:
@@ -64,13 +63,11 @@ jobs:
             yarn packtracker
   examples:
     <<: *defaults
+    parallelism: 4
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Split test file
-          command: circleci tests split < /storybook/examples
       - run:
           name: Workaround for https://github.com/GoogleChrome/puppeteer/issues/290
           command: sh ./scripts/workaround-puppeteer-issue-290.sh
@@ -327,15 +324,13 @@ jobs:
           command: yarn coverage
   cli-test:
     <<: *defaults
+    parallelism: 4
     environment:
       BASH_ENV: ~/.bashrc
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run: 
-          name: Split test files
-          command: circleci tests split < storybook/lib/cli/test
       - run:
           name: Test
           command: yarn test --cli


### PR DESCRIPTION
Potential implementation for #7210

Split both the `examples` and `cli-test` files for faster build times.

Added `parallelism: 4` as a dependency. `4` is arbitrary and can be updated if need be.

## What I did
I added `parallelism` key and set to `4` (which is arbitrary and can be updated).
I added a command to split the `examples` test files.
I added a command to split the `cli-test` test files.

## How to test
Check that build times for `examples` (12:56)  and `cli-test` (21:47) jobs are faster than what is indicated in #7210

- Is this testable with Jest or Chromatic screenshots? (No)
- Does this need a new example in the kitchen sink apps? (No)
- Does this need an update to the documentation? (No)
