### PR TITLE
CLI: Fix `--preview-url` for static builds

### DIFF
--- a/lib/core/src/server/build-static.js
+++ b/lib/core/src/server/build-static.js
@@ -124,6 +124,7 @@ async function buildManager(configType, outputDir, configDir, options) {
     corePresets: [require.resolve('./manager/manager-preset.js')],
     frameworkPresets: options.frameworkPresets,
     docsMode: options.docsMode,
+    previewUrl: options.previewUrl,
   });
 
   if (options.debugWebpack) {


### PR DESCRIPTION
Issue: #5975 

## What I did

Fixed a bug where the previewUrl wasn't getting passed through on static build.

## How to test

Run `examples/standalone-preview` in one terminal, then:

```
cd examples/cra-kitchen-sink
yarn build-storybook --preview-url=http://localhost:1337/iframe.html
```