### PR TITLE
Addon-centered/contexts: Move optionalDependencies to peerDependencies

### DIFF
--- a/addons/centered/package.json
+++ b/addons/centered/package.json
@@ -28,9 +28,12 @@
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
-    "@types/mithril": "^1.1.16"
+    "@types/mithril": "^1.1.16",
+    "mithril": "*",
+    "preact": "*",
+    "react": "*"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "mithril": "*",
     "preact": "*",
     "react": "*"

--- a/addons/contexts/package.json
+++ b/addons/contexts/package.json
@@ -36,9 +36,12 @@
   },
   "peerDependencies": {
     "global": "*",
-    "qs": "*"
+    "qs": "*",
+    "preact": "*",
+    "react": "*",
+    "vue": "*"
   },
-  "optionalDependencies": {
+  "devDependencies": {
     "preact": "*",
     "react": "*",
     "vue": "*"

--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -32,7 +32,7 @@
     "puppeteer": "^1.12.2"
   },
   "peerDependencies": {
-    "@storybook/addon-storyshots": "5.2.0-alpha.23",
+    "@storybook/addon-storyshots": "5.2.0-alpha.35",
     "puppeteer": "^1.12.2"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/root",
-  "version": "5.2.0-alpha.23",
+  "version": "5.2.0-alpha.35",
   "private": true,
   "description": "Storybook is an open source tool for developing UI components in isolation for React, Vue and Angular. It makes building stunning UIs organized and efficient.",
   "keywords": [


### PR DESCRIPTION
Issue: #7087 

## What I did

According to #7087 `addon-centered` installs unneeded packages. The packages in question are listed as `optionalDependencies`.

- Moved them to peerDeps
- Added them to devDeps
- A little more cleanup

Now users will get warnings about missing peer deps, but their build won't blow up. I think this is the better tradeoff?

## How to test

CI?