### PR TITLE
Addon-docs: Fix renaming stories on module / MDX format

### DIFF
--- a/lib/client-api/src/story_store.js
+++ b/lib/client-api/src/story_store.js
@@ -114,12 +114,15 @@ export default class StoryStore extends EventEmitter {
 
   remove = id => {
     const { _data } = this;
-    const { kind, name } = _data[id];
+    const story = _data[id];
     delete _data[id];
 
-    const kindData = this._legacydata[toKey(kind)];
-    if (kindData) {
-      delete kindData.stories[toKey(name)];
+    if (story) {
+      const { kind, name } = story;
+      const kindData = this._legacydata[toKey(kind)];
+      if (kindData) {
+        delete kindData.stories[toKey(name)];
+      }
     }
   };
 

--- a/lib/client-api/src/story_store.js
+++ b/lib/client-api/src/story_store.js
@@ -114,7 +114,13 @@ export default class StoryStore extends EventEmitter {
 
   remove = id => {
     const { _data } = this;
+    const { kind, name } = _data[id];
     delete _data[id];
+
+    const kindData = this._legacydata[toKey(kind)];
+    if (kindData) {
+      delete kindData.stories[toKey(name)];
+    }
   };
 
   addStory(
@@ -271,6 +277,13 @@ export default class StoryStore extends EventEmitter {
   removeStoryKind(kind) {
     if (this.hasStoryKind(kind)) {
       this._legacydata[toKey(kind)].stories = {};
+
+      this._data = Object.entries(this._data).reduce((acc, [id, story]) => {
+        if (story.kind !== kind) {
+          Object.assign(acc, { [id]: story });
+        }
+        return acc;
+      }, {});
     }
   }
 

--- a/lib/client-api/src/story_store.test.js
+++ b/lib/client-api/src/story_store.test.js
@@ -95,6 +95,41 @@ describe('preview.story_store', () => {
       const store = new StoryStore({ channel });
       store.removeStoryKind('kind');
     });
+    it('should remove the kind in both modern and legacy APIs', () => {
+      const store = new StoryStore({ channel });
+      store.addStory(...make('kind-1', 'story-1.1', () => 0));
+      store.addStory(...make('kind-1', 'story-1.2', () => 0));
+      store.addStory(...make('kind-2', 'story-2.1', () => 0));
+      store.addStory(...make('kind-2', 'story-2.2', () => 0));
+
+      store.removeStoryKind('kind-1');
+
+      // _legacydata
+      expect(store.hasStory('kind-1', 'story-1.1')).toBeFalsy();
+      expect(store.hasStory('kind-2', 'story-2.1')).toBeTruthy();
+
+      // _data
+      expect(store.fromId(toId('kind-1', 'story-1.1'))).toBeFalsy();
+      expect(store.fromId(toId('kind-2', 'story-2.1'))).toBeTruthy();
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove the kind in both modern and legacy APIs', () => {
+      const store = new StoryStore({ channel });
+      store.addStory(...make('kind-1', 'story-1.1', () => 0));
+      store.addStory(...make('kind-1', 'story-1.2', () => 0));
+
+      store.remove(toId('kind-1', 'story-1.1'));
+
+      // _legacydata
+      expect(store.hasStory('kind-1', 'story-1.1')).toBeFalsy();
+      expect(store.hasStory('kind-1', 'story-1.2')).toBeTruthy();
+
+      // _data
+      expect(store.fromId(toId('kind-1', 'story-1.1'))).toBeFalsy();
+      expect(store.fromId(toId('kind-1', 'story-1.2'))).toBeTruthy();
+    });
   });
 
   describe('getStoryAndParameters', () => {


### PR DESCRIPTION
Issue: #7169

## What I did

Update story_store to keep _data and _legacydata in sync.

**NOTE:** we should deprecate _legacydata functions and remove them

## How to test

```
yarn jest --testPathPattern story_store.test.js
```

Also
```
cd examples/official-storybook
yarn storybook
```

Then edit a story name in `addon-docs.stories.mdx` and observe that it updates as expected in the UI.


