### PR TITLE
Addon-docs: Add jest-transform.js to convert .mdx => .js for storyshots

### DIFF
--- a/addons/docs/jest-transform.js
+++ b/addons/docs/jest-transform.js
@@ -1,0 +1,22 @@
+const createCompiler = require("./mdx-compiler-plugin");
+const mdx = require("@mdx-js/mdx");
+const babel = require("babel-jest");
+const deasyncPromise = require("deasync-promise");
+
+const compilers = [createCompiler({})];
+
+module.exports = {
+  process(src, filename, config, options) {
+    let result = deasyncPromise(
+      mdx(src, { compilers: compilers, filepath: filename }),
+    );
+
+    result = `/* @jsx mdx */
+    import React from 'react'
+    import { mdx } from '@mdx-js/react'
+    ${result}
+    `;
+
+    return babel.process(result, filename, config, options);
+  },
+};

--- a/addons/docs/jest-transform.js
+++ b/addons/docs/jest-transform.js
@@ -1,15 +1,13 @@
-const createCompiler = require("./mdx-compiler-plugin");
-const mdx = require("@mdx-js/mdx");
-const babel = require("babel-jest");
-const deasyncPromise = require("deasync-promise");
+const mdx = require('@mdx-js/mdx');
+const babel = require('babel-jest');
+const deasyncPromise = require('deasync-promise');
+const createCompiler = require('./mdx-compiler-plugin');
 
 const compilers = [createCompiler({})];
 
 module.exports = {
   process(src, filename, config, options) {
-    let result = deasyncPromise(
-      mdx(src, { compilers: compilers, filepath: filename }),
-    );
+    let result = deasyncPromise(mdx(src, { compilers, filepath: filename }));
 
     result = `/* @jsx mdx */
     import React from 'react'

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -34,6 +34,7 @@
     "@storybook/router": "5.2.0-alpha.36",
     "@storybook/theming": "5.2.0-alpha.36",
     "core-js": "^3.0.1",
+    "deasync-promise": "^1.0.1",
     "global": "^4.3.2",
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2"

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -45,7 +45,8 @@
     "@types/webpack-env": "^1.13.7"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "babel-jest": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10335,7 +10335,14 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
-deasync@^0.1.14:
+deasync-promise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deasync-promise/-/deasync-promise-1.0.1.tgz#2b27de478167af4ef34ba99879c52ec0cedd61c2"
+  integrity sha1-KyfeR4Fnr07zS6mYecUuwM7dYcI=
+  dependencies:
+    deasync "^0.1.7"
+
+deasync@^0.1.14, deasync@^0.1.7:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.15.tgz#788c4bbe6d32521233b28d23936de1bbadd2e112"
   integrity sha512-pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==


### PR DESCRIPTION
Issue: #7223

## What I did

Wrote a jest transform for mdx files.

## How to test

add the following to your jest config:
```json
{
  "transform": {
    "^.+\\.[tj]sx?$": "babel-jest",
    "^.+\\.mdx?$": "@storybook/addon-docs/jest-transform",
  }
}
```

and run jest in a project with storyshots setup and MDX stories.

might need some additional work for things like vue/etc of which i am clueless.