### PR TITLE
FIX docs-mode by using storyFn instead of getDecorated

### DIFF
--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -49,7 +49,7 @@ export const getStoryProps = (
   return {
     inline: typeof inline === 'boolean' ? inline : inlineStories,
     id: previewId,
-    storyFn: data && data.getDecorated(),
+    storyFn: data && data.storyFn,
     height: height || iframeHeight,
     title: data && data.name,
   };

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -7,7 +7,7 @@ import { stripIndents } from 'common-tags';
 import { Channel } from '@storybook/channels';
 import Events from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
-import { StoryContext, StoryFn, Parameters } from '@storybook/addons';
+import { StoryFn, Parameters } from '@storybook/addons';
 import {
   DecoratorFunction,
   LegacyData,

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -188,7 +188,7 @@ export default class StoryStore extends EventEmitter {
       applyDecorators(getOriginal(), getDecorators())
     );
 
-    const storyFn: StoryFn = (p: StoryContext) =>
+    const storyFn: StoryFn = (p: object) =>
       getDecorated()({ ...identification, parameters: { ...parameters, ...p } });
 
     _data[id] = {


### PR DESCRIPTION
Issue: docs-mode was broken

## What I did
I fixed it by changing it to use the correct api: `storyFn` over `getDecorated`.

@shilman can you cast your eye over this?