### PR TITLE
Fix TypeError on KnobManager channel

### DIFF
--- a/addons/knobs/src/KnobManager.ts
+++ b/addons/knobs/src/KnobManager.ts
@@ -121,7 +121,7 @@ export default class KnobManager {
     // triggering a panel re-render.
     
     if (!_this.channel) {
-      // to prevent call to undefined channel and therefor throwing TypeError
+      // to prevent call to undefined channel and therefore throwing TypeError
       return;
     }
     

--- a/addons/knobs/src/KnobManager.ts
+++ b/addons/knobs/src/KnobManager.ts
@@ -120,7 +120,7 @@ export default class KnobManager {
     // unused knobs from the panel. This function sends the `setKnobs` message to the channel
     // triggering a panel re-render.
     
-    if (!_this.channel) {
+    if (!this.channel) {
       // to prevent call to undefined channel and therefore throwing TypeError
       return;
     }

--- a/addons/knobs/src/KnobManager.ts
+++ b/addons/knobs/src/KnobManager.ts
@@ -119,7 +119,12 @@ export default class KnobManager {
     // Some knobs may go unused. So we need to update the panel accordingly. For example remove the
     // unused knobs from the panel. This function sends the `setKnobs` message to the channel
     // triggering a panel re-render.
-
+    
+    if (!_this.channel) {
+      // to prevent call to undefined channel and therefor throwing TypeError
+      return;
+    }
+    
     if (this.calling) {
       // If a call to channel has already registered ignore this call.
       // Once the previous call is completed all the changes to knobStore including the one that


### PR DESCRIPTION
When Storybook is loaded the KnobManager channel can be undefined. Include this code to prevent `Uncaught TypeError: Cannot read property 'emit' of undefined` error.

Issue:

## What I did

Include a checking on `_this.channel` before it is used. 

## How to test

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
