### PR TITLE
Addon-knobs: Fix select options types to allow string[] and null

### DIFF
--- a/addons/knobs/src/components/types/Select.tsx
+++ b/addons/knobs/src/components/types/Select.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Form } from '@storybook/components';
 
-type SelectTypeKnobValue = string;
+export type SelectTypeKnobValue = string | number | null | undefined;
 
 export interface SelectTypeKnob {
   name: string;
@@ -11,9 +11,9 @@ export interface SelectTypeKnob {
   options: SelectTypeOptionsProp;
 }
 
-export interface SelectTypeOptionsProp {
-  [key: string]: SelectTypeKnobValue;
-}
+export type SelectTypeOptionsProp =
+  | Record<string, SelectTypeKnobValue>
+  | NonNullable<SelectTypeKnobValue>[];
 
 export interface SelectTypeProps {
   knob: SelectTypeKnob;

--- a/addons/knobs/src/components/types/index.ts
+++ b/addons/knobs/src/components/types/index.ts
@@ -31,7 +31,7 @@ export { NumberTypeKnob, NumberTypeKnobOptions } from './Number';
 export { ColorTypeKnob } from './Color';
 export { BooleanTypeKnob } from './Boolean';
 export { ObjectTypeKnob } from './Object';
-export { SelectTypeKnob, SelectTypeOptionsProp } from './Select';
+export { SelectTypeKnob, SelectTypeOptionsProp, SelectTypeKnobValue } from './Select';
 export { RadiosTypeKnob, RadiosTypeOptionsProp } from './Radio';
 export { ArrayTypeKnob } from './Array';
 export { DateTypeKnob } from './Date';

--- a/addons/knobs/src/index.ts
+++ b/addons/knobs/src/index.ts
@@ -7,6 +7,7 @@ import {
   ButtonTypeOnClickProp,
   RadiosTypeOptionsProp,
   SelectTypeOptionsProp,
+  SelectTypeKnobValue,
   OptionsTypeOptionsProp,
   OptionsKnobOptions,
 } from './components/types';
@@ -63,7 +64,7 @@ export function object<T>(name: string, value: T, groupId?: string) {
 export function select(
   name: string,
   options: SelectTypeOptionsProp,
-  value: string,
+  value: SelectTypeKnobValue,
   groupId?: string
 ) {
   return manager.knob(name, { type: 'select', selectV2: true, options, value, groupId });


### PR DESCRIPTION
Issue: #7348

## What I did

Fixed `select(...)` knob types to allow for:
- Values of type `string`, `string[]` and `null`.
- Options passed as `string[]` in addition to objects.

This better aligns with the [Knobs Addons select docs](https://github.com/storybookjs/storybook/tree/master/addons/knobs#select), i.e.:

```
const options = {
  Red: 'red',
  Blue: 'blue',
  Yellow: 'yellow',
  Rainbow: ['red', 'orange', 'etc'],
  None: null,
};

...

You can also provide options as an array like this: ['red', 'blue', 'yellow']
```
