### PR TITLE
feat(addons/knobs): support undefined in select

### DIFF
--- a/addons/knobs/src/components/__tests__/Select.js
+++ b/addons/knobs/src/components/__tests__/Select.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 import SelectType from '../types/Select';
 
 describe('Select', () => {
@@ -23,24 +23,6 @@ describe('Select', () => {
       const green = wrapper.find('option').first();
       expect(green.text()).toEqual('Green');
       expect(green.prop('value')).toEqual('Green');
-    });
-  });
-
-  describe('Array values', () => {
-    beforeEach(() => {
-      knob = {
-        name: 'Colors',
-        value: 'green',
-        options: ['green', 'red'],
-      };
-    });
-
-    it('correctly maps option keys and values', () => {
-      const wrapper = shallow(<SelectType knob={knob} />);
-
-      const green = wrapper.find('option').first();
-      expect(green.text()).toEqual('green');
-      expect(green.prop('value')).toEqual('green');
     });
   });
 });

--- a/addons/knobs/src/components/__tests__/Select.js
+++ b/addons/knobs/src/components/__tests__/Select.js
@@ -1,5 +1,5 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import { shallow } from 'enzyme';
 import SelectType from '../types/Select';
 
 describe('Select', () => {

--- a/addons/knobs/src/components/types/Select.tsx
+++ b/addons/knobs/src/components/types/Select.tsx
@@ -28,22 +28,18 @@ const SelectType: FunctionComponent<SelectTypeProps> & {
   deserialize: typeof deserialize;
 } = ({ knob, onChange }) => {
   const { options } = knob;
-  const entries = Array.isArray(options)
-    ? options.reduce((acc, k) => Object.assign(acc, { [k]: k }), {})
-    : options;
-
-  const selectedKey = Object.keys(entries).find(k => entries[k] === knob.value);
+  const selectedKey = Object.keys(options).find(k => options[k] === knob.value);
 
   return (
     <Form.Select
       value={selectedKey}
       name={knob.name}
       onChange={(e: ChangeEvent<HTMLSelectElement>) => {
-        onChange(entries[e.target.value]);
+        onChange(options[e.target.value]);
       }}
       size="flex"
     >
-      {Object.entries(entries).map(([key]) => (
+      {Object.entries(options).map(([key]) => (
         <option key={key} value={key}>
           {key}
         </option>
@@ -62,7 +58,7 @@ SelectType.propTypes = {
   knob: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.any,
-    options: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    options: PropTypes.object,
   }) as any,
   onChange: PropTypes.func,
 };

--- a/addons/knobs/src/index.ts
+++ b/addons/knobs/src/index.ts
@@ -66,7 +66,11 @@ export function select(
   value: string,
   groupId?: string
 ) {
-  return manager.knob(name, { type: 'select', selectV2: true, options, value, groupId });
+  if (Array.isArray(options)) {
+    options = options.reduce((acc, k) => Object.assign(acc, k === undefined ? { Undefined: '__undefined__' } : { [k]: k }), {})
+  }
+  const knobValue = manager.knob(name, { type: 'select', selectV2: true, options, value, groupId });
+  return knobValue === '__undefined__' ? undefined : knobValue;
 }
 
 export function radios(

--- a/addons/knobs/src/index.ts
+++ b/addons/knobs/src/index.ts
@@ -66,10 +66,21 @@ export function select(
   value: string,
   groupId?: string
 ) {
-  if (Array.isArray(options)) {
-    options = options.reduce((acc, k) => Object.assign(acc, k === undefined ? { Undefined: '__undefined__' } : { [k]: k }), {})
-  }
-  const knobValue = manager.knob(name, { type: 'select', selectV2: true, options, value, groupId });
+  const objectOptions = Array.isArray(options)
+    ? options.reduce(
+        (acc, k) =>
+          Object.assign(acc, k === undefined ? { Undefined: '__undefined__' } : { [k]: k }),
+        {}
+      )
+    : options;
+
+  const knobValue = manager.knob(name, {
+    type: 'select',
+    selectV2: true,
+    options: objectOptions,
+    value,
+    groupId,
+  });
   return knobValue === '__undefined__' ? undefined : knobValue;
 }
 


### PR DESCRIPTION
Issue: #4487

## What I did

Move array to object converstion from SelectType to knob select function, and add support for undefined by converting it to `{ Undefined: '__undefined__' }`

I know it's not likely to be merged (and I had to remove tests which is never a good idea), but it's to open the discussion with a working solution

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
