### PR TITLE
FIX prepare script to delete tests & snapshots etc from dist

### DIFF
--- a/scripts/compile-babel.js
+++ b/scripts/compile-babel.js
@@ -6,24 +6,11 @@ const shell = require('shelljs');
 function getCommand(watch) {
   const babel = path.join(__dirname, '..', 'node_modules', '.bin', 'babel');
 
-  const ignore = [
-    '**/__mocks__/',
-    '**/tests/',
-    '**/__tests__/',
-    '**/*.test.*',
-    '**/stories/',
-    '**/*.story.*',
-    '**/*.stories.*',
-    '**/__snapshots__',
-    '**/*.d.ts',
-  ];
-
   const args = [
     './src',
     '--out-dir ./dist',
     `--config-file ${path.resolve(__dirname, '../.babelrc.js')}`,
     `--copy-files`,
-    `--ignore "${ignore.join('","')}"`,
   ];
 
   /*
@@ -68,6 +55,7 @@ function babelify(options = {}) {
   }
 
   const command = getCommand(watch);
+
   const { code, stderr } = shell.exec(command, { silent });
 
   handleExit(code, stderr, errorCallback);

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -19,15 +19,32 @@ function removeDist() {
   shell.rm('-rf', 'dist');
 }
 
+const ignore = [
+  '__mocks__',
+  '__snapshots__',
+  '__tests__',
+  '/tests/',
+  '/stories/',
+  /.+\.test\..+/,
+  /\/.+\.story\..+/,
+  /\/.+\.stories\..+/,
+];
+
 function cleanup() {
-  // add .ts filtering to babel args and remove after babel - 7 is adopted
+  // remove files after babel --copy-files output
   // --copy-files option doesn't work with --ignore
-  // https://github.com/babel/babel/issues/5404
+  // https://github.com/babel/babel/issues/6226
   if (fs.existsSync(path.join(process.cwd(), 'dist'))) {
-    // ^(?!.*\.d\.ts$).*\.(ts|tsx)$ => Remove everything except .d.ts files https://regex101.com/r/gEBQ0U/16
-    const files = shell.find('dist').filter(tsFile => tsFile.match(/^(?!.*\.d\.ts$).*\.(ts|tsx)$/));
+    const files = shell.find('dist').filter(filePath => {
+      if (fs.lstatSync(filePath).isDirectory()) {
+        return false;
+      }
+      return ignore.reduce((acc, pattern) => {
+        return acc || !!filePath.match(pattern);
+      }, false);
+    });
     if (files.length) {
-      shell.rm(files);
+      shell.rm('-f', ...files);
     }
   }
 }
@@ -42,9 +59,10 @@ function logError(type, packageJson, errorLogs) {
 const packageJson = getPackageJson();
 
 removeDist();
-babelify({ errorCallback: errorLogs => logError('js', packageJson, errorLogs) });
-cleanup();
 
+babelify({ errorCallback: errorLogs => logError('js', packageJson, errorLogs) });
 tscfy({ errorCallback: errorLogs => logError('ts', packageJson, errorLogs) });
+
+cleanup();
 
 console.log(chalk.gray(`Built: ${chalk.bold(`${packageJson.name}@${packageJson.version}`)}`));

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -24,10 +24,10 @@ const ignore = [
   '__snapshots__',
   '__tests__',
   '/tests/',
-  '/stories/',
+  // '/stories/',
   /.+\.test\..+/,
-  /\/.+\.story\..+/,
-  /\/.+\.stories\..+/,
+  // /\/.+\.story\..+/,
+  // /\/.+\.stories\..+/,
 ];
 
 function cleanup() {


### PR DESCRIPTION
Issue:
- We're shipping snapshots & tests in our dist packages
- snapshots in the dist may be detected by jest and flagged for deletion. These can be impossible to resolve because they are ignored by source control.

## What I did
FIX prepare script so it deletes the files copied by babel --copy-files arg, but should have been copied at all
