### PR TITLE
Addon-contexts: Ensure nodes is Array

### DIFF
--- a/addons/contexts/src/manager/ContextsManager.tsx
+++ b/addons/contexts/src/manager/ContextsManager.tsx
@@ -21,7 +21,7 @@ export const ContextsManager: ContextsManager = ({ api }) => {
   );
 
   // from preview
-  useChannel(UPDATE_MANAGER, newNodes => setNodes(newNodes), []);
+  useChannel(UPDATE_MANAGER, newNodes => setNodes(newNodes || []), []);
 
   // to preview
   useEffect(() => api.emit(REBOOT_MANAGER), []);


### PR DESCRIPTION
Issue: #7324 

## What I did

Fix rendering crash when a user navigates to non-Canvas tab to Canvas tab, by preventing emitting `addon-contexts/UPDATE_MANAGER` with falsy value.

## How to test

Configure contexts addon in `examples/official-storybook` and select Docs tab then back to Canvas tab.

FYI: I tried [`yarn storybook` in `cra-kitchen-sink` described in CONTRIBUTING.md](https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md#in-the-monorepo) but nothing rendered on the browser and there is a `PREVIEW_URL is not defined` error in the console.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
