### PR TITLE
Use v4 UUID instead of v1 for action IDs

### DIFF
--- a/addons/actions/src/preview/action.ts
+++ b/addons/actions/src/preview/action.ts
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v1';
+import uuid from 'uuid/v4';
 import { addons } from '@storybook/addons';
 import { EVENT_ID } from '../constants';
 import { ActionDisplay, ActionOptions, HandlerFunction } from '../models';


### PR DESCRIPTION
Issue: none

## What I did

I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within the code base of storybook.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

I found one occurrence where v1 UUIDs were being used instead of v4 UUIDs and I was wondering if this case really requires the semantically much more complex v1 UUIDs or whether we could live equally well with purely random v4 UUIDs?

At least the test suite still passes after my changes, so apparently this doesn't seem to introduce any known regressions.

I'd be really curious to understand the motivation for choosing v1 over v4 UUIDs in the first place, so any feedback on this would be highly appreciated!

@marcfallows, as far as I can tell from the git history you introduced this in https://github.com/storybookjs/storybook/pull/1347, I'd be really curious about your feedback!

## How to test

No noticeable change behavior expected.