### PR TITLE
Fix #7167 addon-centered causes component to disappear when zooming

### DIFF
--- a/lib/core/src/server/templates/base-preview-head.html
+++ b/lib/core/src/server/templates/base-preview-head.html
@@ -1,6 +1,11 @@
 <base target="_parent">
 
 <style>
+  html, body{
+    width: 100%;
+    height: 100%;
+  }
+
   :not(.sb-show-main) > .sb-main,
   :not(.sb-show-nopreview) > .sb-nopreview,
   :not(.sb-show-errordisplay) > .sb-errordisplay {


### PR DESCRIPTION
Issue: close #7167

## What I did
I resolve the issue #7167 with styling.
The issue is due to the fact that the `width` and `height` of the body element are not fit to the iframe.
So I set the style for the body element in `iframe`.

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/4495546/61134750-3b4a9180-a4fb-11e9-84e0-dc92951fa203.gif)|![after](https://user-images.githubusercontent.com/4495546/61138211-fece6400-a501-11e9-97ab-4eef6f88f440.gif)|
 

## How to test

- Is this testable with Jest or Chromatic screenshots?
No.
- Does this need a new example in the kitchen sink apps?
No.
- Does this need an update to the documentation?
No.