### PR TITLE
Core: Add polyfill for fetch

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -82,6 +82,7 @@
     "shelljs": "^0.8.3",
     "style-loader": "^0.23.1",
     "terser-webpack-plugin": "^1.2.4",
+    "unfetch": "^4.1.0",
     "url-loader": "^2.0.1",
     "util-deprecate": "^1.0.2",
     "webpack": "^4.33.0",

--- a/lib/core/src/client/manager/conditional-polyfills.js
+++ b/lib/core/src/client/manager/conditional-polyfills.js
@@ -1,0 +1,17 @@
+import { window } from 'global';
+
+export const importPolyfills = () => {
+  const polyfills = [];
+
+  if (!window.fetch) {
+    // manually patch window.fetch;
+    //    see issue: <https://github.com/developit/unfetch/issues/101#issuecomment-454451035>
+    const patch = ({ default: fetch }) => {
+      window.fetch = fetch;
+    };
+
+    polyfills.push(import('unfetch/dist/unfetch').then(patch));
+  }
+
+  return Promise.all(polyfills);
+};

--- a/lib/core/src/client/manager/index.js
+++ b/lib/core/src/client/manager/index.js
@@ -1,6 +1,9 @@
 import { document } from 'global';
 import renderStorybookUI from '@storybook/ui';
 import Provider from './provider';
+import { importPolyfills } from './conditional-polyfills';
 
-const rootEl = document.getElementById('root');
-renderStorybookUI(rootEl, new Provider());
+importPolyfills().then(() => {
+  const rootEl = document.getElementById('root');
+  renderStorybookUI(rootEl, new Provider());
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -29105,6 +29105,11 @@ undertaker@^1.2.1:
     object.reduce "^1.0.0"
     undertaker-registry "^1.0.0"
 
+unfetch@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
+  integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
+
 unherit@^1.0.4:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.2.tgz#14f1f397253ee4ec95cec167762e77df83678449"


### PR DESCRIPTION
Issue: #7263 

## What I did
- Added `@storybook/core` dependency on [fetch-wg polyfill](https://github.com/whatwg/fetch) for fetch
- Imported polyfill in `lib/core/src/server/common/polyfill.js`

## How to test
**Reproduce issue:**
1. Open Storybook baseline in IE11 (without PR)
2. Press [F12] to open 'Developer Tools'
3. Switch to Javascript console
4. Reload browser
5. Observe that console has the following warning:  `Failed to fetch latest version from server: TypeError: Object expected`

**Test the fix:**
1. Open Storybook with PR in IE11
2. Repeat steps 2 - 4 from above
3. Observe that instead of the warning about a failed fetch, there's now a CORS notice:  `XMLHttpRequest for https://storybook.js.org/versions.json?current=5.2.0-alpha.42 required Cross Origin Resource Sharing (CORS).`

**Note** that the version check stores a timestamp for the latest successful attempt in local storage and _won't check again until 24 hours_ past that timestamp.  You can work around that in IE11 by invoking `localStorage.clear()` on the Javascript console.

**Also note** that in the latest version there also exists issue #7388 that also prevents IE from loading.  Until that issue is resolved, IE11 still won't completely load.  The author of #7263 was using `v4.1.0`, which didn't yet have this additional IE issue.
