### PR TITLE
UI: Fix proptype for isToolshown

### DIFF
--- a/lib/ui/src/components/layout/container.js
+++ b/lib/ui/src/components/layout/container.js
@@ -549,7 +549,7 @@ Layout.propTypes = {
     showNav: PropTypes.bool.isRequired,
     showPanel: PropTypes.bool.isRequired,
     panelPosition: PropTypes.string.isRequired,
-    isToolshown: PropTypes.string.isRequired,
+    isToolshown: PropTypes.bool.isRequired,
   }).isRequired,
   viewMode: PropTypes.oneOf(['story', 'info', 'docs', 'settings']),
   theme: PropTypes.shape({ layoutMargin: PropTypes.number }).isRequired,


### PR DESCRIPTION
isToolshown is a bool in all other proptype definitions and having it as a string causes a warning in the Layout.

Issue:

## What I did

- changed the PropType for `isToolshown` from `string` to `bool`

## How to test

Before:

- ran Storybook
- opened Chrome console
- observed the following:
```
Warning: Failed prop type: Invalid prop `options.isToolshown` of type `boolean` supplied to `Layout`, expected `string`.
```

After:

- ran Storybook
- opened Chrome console
- observed no warning.

```
rg 'isToolshown.*PropTypes' ui
ui/src/components/layout/mobile.js
207:    isToolshown: PropTypes.bool,

ui/src/components/layout/container.js
552:    isToolshown: PropTypes.string.isRequired,

ui/src/components/preview/preview.js
335:    isToolshown: PropTypes.bool,

ui/src/components/layout/desktop.js
66:    isToolshown: PropTypes.bool.isRequired,
```