### PR TITLE
Addon-knobs: improve types via generics and readonlyarray

### DIFF
--- a/addons/knobs/src/KnobManager.ts
+++ b/addons/knobs/src/KnobManager.ts
@@ -7,7 +7,7 @@ import { getQueryParams } from '@storybook/client-api';
 import { Channel } from '@storybook/channels';
 
 import KnobStore, { KnobStoreKnob } from './KnobStore';
-import { Knob, KnobType } from './type-defs';
+import { Knob, KnobType, Mutable } from './type-defs';
 import { SET } from './shared';
 
 import { deserializers } from './converters';
@@ -72,7 +72,7 @@ export default class KnobManager {
     return this.options.escapeHTML ? escapeStrings(value) : value;
   }
 
-  knob<T extends KnobType = any>(name: string, options: Knob<T>): Knob<T>['value'] {
+  knob<T extends KnobType = any>(name: string, options: Knob<T>): Mutable<Knob<T>['value']> {
     this._mayCallChannel();
 
     const knobName = options.groupId ? `${name}_${options.groupId}` : name;

--- a/addons/knobs/src/__types__/knob-test-cases.ts
+++ b/addons/knobs/src/__types__/knob-test-cases.ts
@@ -86,6 +86,10 @@ enum SomeEnum {
   Type1 = 1,
   Type2,
 }
+enum ButtonVariant {
+  primary = 'primary',
+  secondary = 'secondary',
+}
 const stringLiteralArray: ('Apple' | 'Banana' | 'Grapes')[] = ['Apple', 'Banana', 'Grapes'];
 
 expectKnobOfType<string>(
@@ -101,13 +105,14 @@ expectKnobOfType<string>(
   select('select with string array', ['yes', 'no'], 'yes'),
   select('select with string literal array', stringLiteralArray, stringLiteralArray[0]),
   select('select with readonly array', ['red', 'blue'] as const, 'red'),
+  select<ButtonVariant>('select with string enum options', ButtonVariant, ButtonVariant.primary),
   select('select with null option', { a: 'Option', b: null }, null, groupId)
 );
 
 expectKnobOfType<number>(
   select('select with number options', { 'type a': 1, 'type b': 2 }, 1),
   select<SomeEnum>(
-    'select with enum options',
+    'select with numeric enum options',
     { 'type a': SomeEnum.Type1, 'type b': SomeEnum.Type2 },
     SomeEnum.Type2
   ),

--- a/addons/knobs/src/__types__/knob-test-cases.ts
+++ b/addons/knobs/src/__types__/knob-test-cases.ts
@@ -1,0 +1,199 @@
+import {
+  number,
+  color,
+  files,
+  object,
+  boolean,
+  text,
+  select,
+  date,
+  array,
+  button,
+  knob,
+  radios,
+  optionsKnob as options,
+} from '../index';
+
+// Note: this is a helper to batch test return types and avoid "declared but never read" errors
+function expectKnobOfType<T>(..._: T[]) {}
+
+const groupId = 'GROUP-ID1';
+
+/** Text knob */
+
+expectKnobOfType<string>(
+  text('text simple', 'Batman'),
+  text('text with group', 'default', groupId)
+);
+
+/** Date knob */
+
+expectKnobOfType<number>(
+  date('date simple', new Date('January 20 1887')),
+  date('date with group', new Date(), groupId)
+);
+
+/** Boolean knob */
+
+expectKnobOfType<boolean>(
+  boolean('boolean simple', false),
+  boolean('boolean with group', true, groupId)
+);
+
+/** Color knob */
+
+expectKnobOfType<string>(
+  color('color simple', 'black'),
+  color('color with group', '#ffffff', groupId)
+);
+
+/** Number knob */
+
+expectKnobOfType<number>(
+  number('number basic', 42),
+  number('number with options', 72, { range: true, min: 60, max: 90, step: 1 }),
+  number('number with group', 1, {}, groupId)
+);
+
+/** Radios knob */
+
+expectKnobOfType(
+  radios<string>(
+    'radio with string values',
+    {
+      1100: '1100',
+      2200: '2200',
+      3300: '3300',
+    },
+    '2200'
+  ),
+  radios<number>('radio with number values', { 3: 3, 7: 7, 23: 23 }, 3),
+  radios(
+    'radio with mixed value',
+    {
+      1100: '1100',
+      2200: 2200,
+      3300: '3300',
+    },
+    null,
+    groupId
+  )
+);
+
+/** Select knob */
+
+enum SomeEnum {
+  Type1 = 1,
+  Type2,
+}
+const stringLiteralArray: ('Apple' | 'Banana' | 'Grapes')[] = ['Apple', 'Banana', 'Grapes'];
+
+expectKnobOfType<string>(
+  select(
+    'select with string options',
+    {
+      None: 'none',
+      Underline: 'underline',
+      'Line-through': 'line-through',
+    },
+    'none'
+  ),
+  select('select with string array', ['yes', 'no'], 'yes'),
+  select('select with string literal array', stringLiteralArray, stringLiteralArray[0]),
+  select('select with readonly array', ['red', 'blue'] as const, 'red'),
+  select('select with null option', { a: 'Option', b: null }, null, groupId)
+);
+
+expectKnobOfType<number>(
+  select('select with number options', { 'type a': 1, 'type b': 2 }, 1),
+  select<SomeEnum>(
+    'select with enum options',
+    { 'type a': SomeEnum.Type1, 'type b': SomeEnum.Type2 },
+    SomeEnum.Type2
+  ),
+  select('select with number array', [1, 2, 3, 4], 1),
+  select('select with readonly number array', [1, 2] as const, 1)
+);
+
+/** Object knob */
+
+expectKnobOfType(
+  object('object simple', {
+    fontFamily: 'Arial',
+    padding: 20,
+  }),
+  object('object with group', {}, groupId)
+);
+
+/** Options knob */
+
+type Tool = 'hammer' | 'saw' | 'drill';
+const visibleToolOptions: Record<string, Tool> = {
+  hammer: 'hammer',
+  saw: 'saw',
+  drill: 'drill',
+};
+
+expectKnobOfType(
+  options<Tool>('options with single selection', visibleToolOptions, 'hammer', {
+    display: 'check',
+  }),
+  options<Tool>('options with multi selection', visibleToolOptions, ['hammer', 'saw'], {
+    display: 'inline-check',
+  }),
+  options<Tool>('options with readonly multi selection', visibleToolOptions, ['hammer'] as const, {
+    display: 'radio',
+  }),
+  options('options with group', {}, '', { display: 'check' })
+);
+
+/** Array knob */
+
+const arrayReadonly = array('array as readonly', ['hi', 'there'] as const);
+
+expectKnobOfType<string[]>(
+  array('array simple', ['red', 'green', 'blue']),
+  arrayReadonly,
+  array('array with group', [], ',', groupId)
+);
+
+// Should return a mutable array despite the readonly input
+arrayReadonly.push('Make sure that the output is still mutable although the input need not be!');
+
+/** Button knob */
+
+expectKnobOfType(
+  button('button simple', () => {}),
+  button('button with group', () => undefined, groupId)
+);
+
+/** Files knob */
+
+expectKnobOfType<string[]>(
+  files('files simple', 'image/*', []),
+  files('files with group', 'image/*', ['img.jpg'], groupId)
+);
+
+/** Generic knob */
+
+expectKnobOfType<string>(
+  knob('generic knob as text', { type: 'text', value: 'a' }),
+  knob('generic knob as color', { type: 'color', value: 'black' }),
+  knob<'select', string>('generic knob as string select', {
+    type: 'select',
+    value: 'yes',
+    options: ['yes', 'no'],
+    selectV2: true,
+  })
+);
+
+expectKnobOfType<number>(
+  knob('generic knob as number', { type: 'number', value: 42 }),
+  knob('generic knob as select', { type: 'radios', value: 3, options: { 3: 3, 7: 7, 23: 23 } }),
+  knob('generic knob as number select', {
+    type: 'select',
+    value: 1,
+    options: [1, 2],
+    selectV2: true,
+  })
+);

--- a/addons/knobs/src/components/types/Array.tsx
+++ b/addons/knobs/src/components/types/Array.tsx
@@ -2,18 +2,16 @@ import PropTypes from 'prop-types';
 import React, { ChangeEvent, Component, WeakValidationMap } from 'react';
 
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
-type ArrayTypeKnobValue = string[];
+export type ArrayTypeKnobValue = string[] | readonly string[];
 
-export interface ArrayTypeKnob {
-  name: string;
-  value: ArrayTypeKnobValue;
+export interface ArrayTypeKnob extends KnobControlConfig<ArrayTypeKnobValue> {
   separator: string;
 }
 
-interface ArrayTypeProps {
+interface ArrayTypeProps extends KnobControlProps<ArrayTypeKnobValue> {
   knob: ArrayTypeKnob;
-  onChange: (value: ArrayTypeKnobValue) => ArrayTypeKnobValue;
 }
 
 function formatArray(value: string, separator: string) {
@@ -41,7 +39,7 @@ export default class ArrayType extends Component<ArrayTypeProps> {
 
   static serialize = (value: ArrayTypeKnobValue) => value;
 
-  static deserialize = (value: ArrayTypeKnobValue) => {
+  static deserialize = (value: string[]) => {
     if (Array.isArray(value)) return value;
 
     return Object.keys(value)

--- a/addons/knobs/src/components/types/Boolean.tsx
+++ b/addons/knobs/src/components/types/Boolean.tsx
@@ -2,18 +2,14 @@ import PropTypes from 'prop-types';
 import React, { FunctionComponent } from 'react';
 
 import { styled } from '@storybook/theming';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 type BooleanTypeKnobValue = boolean;
 
-export interface BooleanTypeKnob {
-  name: string;
-  value: BooleanTypeKnobValue;
-  separator: string;
-}
+export type BooleanTypeKnob = KnobControlConfig<BooleanTypeKnobValue>;
 
-export interface BooleanTypeProps {
+export interface BooleanTypeProps extends KnobControlProps<BooleanTypeKnobValue> {
   knob: BooleanTypeKnob;
-  onChange: (value: BooleanTypeKnobValue) => BooleanTypeKnobValue;
 }
 
 const Input = styled.input({

--- a/addons/knobs/src/components/types/Button.tsx
+++ b/addons/knobs/src/components/types/Button.tsx
@@ -2,18 +2,16 @@ import PropTypes from 'prop-types';
 import React, { FunctionComponent, Validator } from 'react';
 
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
-export interface ButtonTypeKnob {
-  name: string;
-  value: unknown;
-}
+export type ButtonTypeKnob = KnobControlConfig<never>;
 
-export type ButtonTypeOnClickProp = (knob: ButtonTypeKnob) => any;
-
-export interface ButtonTypeProps {
+export interface ButtonTypeProps extends KnobControlProps<never> {
   knob: ButtonTypeKnob;
   onClick: ButtonTypeOnClickProp;
 }
+
+export type ButtonTypeOnClickProp = (knob: ButtonTypeKnob) => any;
 
 const serialize = (): undefined => undefined;
 const deserialize = (): undefined => undefined;

--- a/addons/knobs/src/components/types/Checkboxes.tsx
+++ b/addons/knobs/src/components/types/Checkboxes.tsx
@@ -1,30 +1,26 @@
 import React, { Component, ChangeEvent, WeakValidationMap } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 type CheckboxesTypeKnobValue = string[];
 
-interface CheckboxesWrapperProps {
-  isInline: boolean;
+export interface CheckboxesTypeKnob extends KnobControlConfig<CheckboxesTypeKnobValue> {
+  options: Record<string, string>;
 }
 
-export interface CheckboxesTypeKnob {
-  name: string;
-  value: CheckboxesTypeKnobValue;
-  defaultValue: CheckboxesTypeKnobValue;
-  options: {
-    [key: string]: string;
-  };
-}
-
-interface CheckboxesTypeProps {
+interface CheckboxesTypeProps
+  extends KnobControlProps<CheckboxesTypeKnobValue>,
+    CheckboxesWrapperProps {
   knob: CheckboxesTypeKnob;
-  isInline: boolean;
-  onChange: (value: CheckboxesTypeKnobValue) => CheckboxesTypeKnobValue;
 }
 
 interface CheckboxesTypeState {
   values: CheckboxesTypeKnobValue;
+}
+
+interface CheckboxesWrapperProps {
+  isInline: boolean;
 }
 
 const CheckboxesWrapper = styled.div(({ isInline }: CheckboxesWrapperProps) =>

--- a/addons/knobs/src/components/types/Color.tsx
+++ b/addons/knobs/src/components/types/Color.tsx
@@ -5,18 +5,11 @@ import { SketchPicker, ColorResult } from 'react-color';
 
 import { styled } from '@storybook/theming';
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 type ColorTypeKnobValue = string;
-
-export interface ColorTypeKnob {
-  name: string;
-  value: ColorTypeKnobValue;
-}
-
-interface ColorTypeProps {
-  knob: ColorTypeKnob;
-  onChange: (value: ColorTypeKnobValue) => ColorTypeKnobValue;
-}
+export type ColorTypeKnob = KnobControlConfig<ColorTypeKnobValue>;
+type ColorTypeProps = KnobControlProps<ColorTypeKnobValue>;
 
 interface ColorTypeState {
   displayColorPicker: boolean;

--- a/addons/knobs/src/components/types/Date.tsx
+++ b/addons/knobs/src/components/types/Date.tsx
@@ -2,18 +2,11 @@ import React, { Component, ChangeEvent, WeakValidationMap } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 type DateTypeKnobValue = number;
-
-export interface DateTypeKnob {
-  name: string;
-  value: DateTypeKnobValue;
-}
-
-interface DateTypeProps {
-  knob: DateTypeKnob;
-  onChange: (value: DateTypeKnobValue) => DateTypeKnobValue;
-}
+export type DateTypeKnob = KnobControlConfig<DateTypeKnobValue>;
+type DateTypeProps = KnobControlProps<DateTypeKnobValue>;
 
 interface DateTypeState {
   valid: boolean | undefined;

--- a/addons/knobs/src/components/types/Files.tsx
+++ b/addons/knobs/src/components/types/Files.tsx
@@ -4,18 +4,16 @@ import React, { ChangeEvent, FunctionComponent } from 'react';
 import { styled } from '@storybook/theming';
 
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 type DateTypeKnobValue = string[];
 
-export interface FileTypeKnob {
-  name: string;
+export interface FileTypeKnob extends KnobControlConfig<DateTypeKnobValue> {
   accept: string;
-  value: DateTypeKnobValue;
 }
 
-export interface FilesTypeProps {
+export interface FilesTypeProps extends KnobControlProps<DateTypeKnobValue> {
   knob: FileTypeKnob;
-  onChange: (value: DateTypeKnobValue) => DateTypeKnobValue;
 }
 
 const FileInput = styled(Form.Input)({

--- a/addons/knobs/src/components/types/Number.tsx
+++ b/addons/knobs/src/components/types/Number.tsx
@@ -3,6 +3,7 @@ import React, { Component, ChangeEvent } from 'react';
 
 import { styled } from '@storybook/theming';
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 type NumberTypeKnobValue = number;
 
@@ -13,14 +14,14 @@ export interface NumberTypeKnobOptions {
   step?: number;
 }
 
-export interface NumberTypeKnob extends NumberTypeKnobOptions {
-  name: string;
-  value: number;
+export interface NumberTypeKnob
+  extends KnobControlConfig<NumberTypeKnobValue>,
+    NumberTypeKnobOptions {
+  value: NumberTypeKnobValue;
 }
 
-interface NumberTypeProps {
+interface NumberTypeProps extends KnobControlProps<NumberTypeKnobValue> {
   knob: NumberTypeKnob;
-  onChange: (value: NumberTypeKnobValue) => NumberTypeKnobValue;
 }
 
 const RangeInput = styled.input(

--- a/addons/knobs/src/components/types/Object.tsx
+++ b/addons/knobs/src/components/types/Object.tsx
@@ -3,16 +3,10 @@ import PropTypes from 'prop-types';
 import deepEqual from 'fast-deep-equal';
 import { polyfill } from 'react-lifecycles-compat';
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
-export interface ObjectTypeKnob<T> {
-  name: string;
-  value: T;
-}
-
-interface ObjectTypeProps<T> {
-  knob: ObjectTypeKnob<T>;
-  onChange: (value: T) => T;
-}
+export type ObjectTypeKnob<T> = KnobControlConfig<T>;
+type ObjectTypeProps<T> = KnobControlProps<T>;
 
 interface ObjectTypeState<T> {
   value: string;

--- a/addons/knobs/src/components/types/Options.tsx
+++ b/addons/knobs/src/components/types/Options.tsx
@@ -3,11 +3,18 @@ import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
 import { ValueType } from 'react-select/lib/types';
 import { styled } from '@storybook/theming';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 import RadiosType from './Radio';
 import CheckboxesType from './Checkboxes';
 
 // TODO: Apply the Storybook theme to react-select
+
+export type OptionsTypeKnobSingleValue = string | number | null | undefined;
+
+export type OptionsTypeKnobValue<
+  T extends OptionsTypeKnobSingleValue = OptionsTypeKnobSingleValue
+> = T | NonNullable<T>[] | readonly NonNullable<T>[];
 
 export type OptionsKnobOptionsDisplay =
   | 'radio'
@@ -21,10 +28,7 @@ export interface OptionsKnobOptions {
   display?: OptionsKnobOptionsDisplay;
 }
 
-export interface OptionsTypeKnob<T> {
-  name: string;
-  value: T;
-  defaultValue: T;
+export interface OptionsTypeKnob<T extends OptionsTypeKnobValue> extends KnobControlConfig<T> {
   options: OptionsTypeOptionsProp<T>;
   optionsObj: OptionsKnobOptions;
 }
@@ -33,10 +37,9 @@ export interface OptionsTypeOptionsProp<T> {
   [key: string]: T;
 }
 
-export interface OptionsTypeProps<T> {
+export interface OptionsTypeProps<T extends OptionsTypeKnobValue> extends KnobControlProps<T> {
   knob: OptionsTypeKnob<T>;
   display: OptionsKnobOptionsDisplay;
-  onChange: (value: T) => T;
 }
 
 // : React.ComponentType<ReactSelectProps>

--- a/addons/knobs/src/components/types/Radio.tsx
+++ b/addons/knobs/src/components/types/Radio.tsx
@@ -1,24 +1,18 @@
 import React, { Component, WeakValidationMap } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
+import { KnobControlConfig, KnobControlProps } from './types';
 
-type RadiosTypeKnobValue = string;
+export type RadiosTypeKnobValue = string | number | null | undefined;
 
-export interface RadiosTypeKnob {
-  name: string;
-  value: RadiosTypeKnobValue;
-  defaultValue: RadiosTypeKnobValue;
-  options: RadiosTypeOptionsProp;
+export type RadiosTypeOptionsProp<T extends RadiosTypeKnobValue> = Record<string | number, T>;
+
+export interface RadiosTypeKnob extends KnobControlConfig<RadiosTypeKnobValue> {
+  options: RadiosTypeOptionsProp<RadiosTypeKnobValue>;
 }
 
-export interface RadiosTypeOptionsProp {
-  [key: string]: RadiosTypeKnobValue;
-}
-
-interface RadiosTypeProps {
+interface RadiosTypeProps extends KnobControlProps<RadiosTypeKnobValue>, RadiosWrapperProps {
   knob: RadiosTypeKnob;
-  isInline: boolean;
-  onChange: (value: RadiosTypeKnobValue) => RadiosTypeKnobValue;
 }
 
 interface RadiosWrapperProps {

--- a/addons/knobs/src/components/types/Select.tsx
+++ b/addons/knobs/src/components/types/Select.tsx
@@ -2,22 +2,23 @@ import React, { FunctionComponent, ChangeEvent } from 'react';
 import PropTypes from 'prop-types';
 
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 export type SelectTypeKnobValue = string | number | null | undefined;
 
-export interface SelectTypeKnob {
-  name: string;
-  value: SelectTypeKnobValue;
-  options: SelectTypeOptionsProp;
+export type SelectTypeOptionsProp<T extends SelectTypeKnobValue = SelectTypeKnobValue> =
+  | Record<string, T>
+  | T[]
+  | readonly T[];
+
+export interface SelectTypeKnob<T extends SelectTypeKnobValue = SelectTypeKnobValue>
+  extends KnobControlConfig<T> {
+  options: SelectTypeOptionsProp<T>;
 }
 
-export type SelectTypeOptionsProp =
-  | Record<string, SelectTypeKnobValue>
-  | NonNullable<SelectTypeKnobValue>[];
-
-export interface SelectTypeProps {
-  knob: SelectTypeKnob;
-  onChange: (value: SelectTypeKnobValue) => SelectTypeKnobValue;
+export interface SelectTypeProps<T extends SelectTypeKnobValue = SelectTypeKnobValue>
+  extends KnobControlProps<T> {
+  knob: SelectTypeKnob<T>;
 }
 
 const serialize = (value: SelectTypeKnobValue) => value;
@@ -29,8 +30,11 @@ const SelectType: FunctionComponent<SelectTypeProps> & {
 } = ({ knob, onChange }) => {
   const { options } = knob;
   const entries = Array.isArray(options)
-    ? options.reduce((acc, k) => Object.assign(acc, { [k]: k }), {})
-    : options;
+    ? options.reduce<Record<number, SelectTypeKnobValue>>(
+        (acc, k) => Object.assign(acc, { [k]: k }),
+        {}
+      )
+    : (options as Record<string, SelectTypeKnobValue>);
 
   const selectedKey = Object.keys(entries).find(k => entries[k] === knob.value);
 

--- a/addons/knobs/src/components/types/Select.tsx
+++ b/addons/knobs/src/components/types/Select.tsx
@@ -8,6 +8,7 @@ export type SelectTypeKnobValue = string | number | null | undefined;
 
 export type SelectTypeOptionsProp<T extends SelectTypeKnobValue = SelectTypeKnobValue> =
   | Record<string, T>
+  | Record<T, T[keyof T]>
   | T[]
   | readonly T[];
 

--- a/addons/knobs/src/components/types/Text.tsx
+++ b/addons/knobs/src/components/types/Text.tsx
@@ -2,18 +2,11 @@ import PropTypes from 'prop-types';
 import React, { Component, ChangeEvent, WeakValidationMap } from 'react';
 
 import { Form } from '@storybook/components';
+import { KnobControlConfig, KnobControlProps } from './types';
 
 type TextTypeKnobValue = string;
-
-export interface TextTypeKnob {
-  name: string;
-  value: TextTypeKnobValue;
-}
-
-interface TextTypeProps {
-  knob: TextTypeKnob;
-  onChange: (value: TextTypeKnobValue) => TextTypeKnobValue;
-}
+export type TextTypeKnob = KnobControlConfig<TextTypeKnobValue>;
+type TextTypeProps = KnobControlProps<TextTypeKnobValue>;
 
 export default class TextType extends Component<TextTypeProps> {
   static defaultProps: TextTypeProps = {

--- a/addons/knobs/src/components/types/index.ts
+++ b/addons/knobs/src/components/types/index.ts
@@ -45,9 +45,15 @@ export { ColorTypeKnob } from './Color';
 export { BooleanTypeKnob } from './Boolean';
 export { ObjectTypeKnob } from './Object';
 export { SelectTypeKnob, SelectTypeOptionsProp, SelectTypeKnobValue } from './Select';
-export { RadiosTypeKnob, RadiosTypeOptionsProp } from './Radio';
-export { ArrayTypeKnob } from './Array';
+export { RadiosTypeKnob, RadiosTypeOptionsProp, RadiosTypeKnobValue } from './Radio';
+export { ArrayTypeKnob, ArrayTypeKnobValue } from './Array';
 export { DateTypeKnob } from './Date';
 export { ButtonTypeKnob, ButtonTypeOnClickProp } from './Button';
 export { FileTypeKnob } from './Files';
-export { OptionsTypeKnob, OptionsTypeOptionsProp, OptionsKnobOptions } from './Options';
+export {
+  OptionsTypeKnob,
+  OptionsKnobOptions,
+  OptionsTypeOptionsProp,
+  OptionsTypeKnobSingleValue,
+  OptionsTypeKnobValue,
+} from './Options';

--- a/addons/knobs/src/components/types/types.ts
+++ b/addons/knobs/src/components/types/types.ts
@@ -1,0 +1,10 @@
+export interface KnobControlConfig<T = never> {
+  name: string;
+  value: T;
+  defaultValue?: T;
+}
+
+export interface KnobControlProps<T> {
+  knob: KnobControlConfig<T>;
+  onChange: (value: T) => T;
+}

--- a/addons/knobs/src/index.ts
+++ b/addons/knobs/src/index.ts
@@ -2,19 +2,26 @@ import addons, { makeDecorator } from '@storybook/addons';
 
 import { SET_OPTIONS } from './shared';
 import { manager, registerKnobs } from './registerKnobs';
-import { Knob, KnobType } from './type-defs';
+import { Knob, KnobType, Mutable } from './type-defs';
 import {
   NumberTypeKnobOptions,
   ButtonTypeOnClickProp,
   RadiosTypeOptionsProp,
   SelectTypeOptionsProp,
   SelectTypeKnobValue,
+  OptionsTypeKnobValue,
   OptionsTypeOptionsProp,
+  OptionsTypeKnobSingleValue,
   OptionsKnobOptions,
+  RadiosTypeKnobValue,
+  ArrayTypeKnobValue,
 } from './components/types';
 
-export function knob<T extends KnobType>(name: string, options: Knob<T>) {
-  return manager.knob(name, options);
+export function knob<T extends KnobType, V = Mutable<Knob<T>['value']>>(
+  name: string,
+  options: Knob<T>
+): V {
+  return manager.knob(name, options) as V;
 }
 
 export function text(name: string, value: string, groupId?: string) {
@@ -62,25 +69,31 @@ export function object<T>(name: string, value: T, groupId?: string): T {
   return manager.knob(name, { type: 'object', value, groupId });
 }
 
-export function select(
+export function select<T extends SelectTypeKnobValue>(
   name: string,
-  options: SelectTypeOptionsProp,
-  value: SelectTypeKnobValue,
+  options: SelectTypeOptionsProp<T>,
+  value: T,
   groupId?: string
-) {
-  return manager.knob(name, { type: 'select', selectV2: true, options, value, groupId });
+): T {
+  return manager.knob(name, {
+    type: 'select',
+    selectV2: true,
+    options: options as SelectTypeOptionsProp,
+    value,
+    groupId,
+  }) as T;
 }
 
-export function radios(
+export function radios<T extends RadiosTypeKnobValue>(
   name: string,
-  options: RadiosTypeOptionsProp,
-  value: string,
+  options: RadiosTypeOptionsProp<T>,
+  value: T,
   groupId?: string
-) {
-  return manager.knob(name, { type: 'radios', options, value, groupId });
+): T {
+  return manager.knob(name, { type: 'radios', options, value, groupId }) as T;
 }
 
-export function array(name: string, value: string[], separator = ',', groupId?: string) {
+export function array(name: string, value: ArrayTypeKnobValue, separator = ',', groupId?: string) {
   return manager.knob(name, { type: 'array', value, separator, groupId });
 }
 
@@ -97,10 +110,10 @@ export function files(name: string, accept: string, value: string[] = [], groupI
   return manager.knob(name, { type: 'files', accept, value, groupId });
 }
 
-export function optionsKnob<T>(
+export function optionsKnob<T extends OptionsTypeKnobSingleValue>(
   name: string,
   valuesObj: OptionsTypeOptionsProp<T>,
-  value: T,
+  value: OptionsTypeKnobValue<T>,
   optionsObj: OptionsKnobOptions,
   groupId?: string
 ): T {

--- a/addons/knobs/src/type-defs.ts
+++ b/addons/knobs/src/type-defs.ts
@@ -14,6 +14,10 @@ import {
   KnobType,
 } from './components/types';
 
+export type Mutable<T> = {
+  -readonly [P in keyof T]: T[P] extends readonly (infer U)[] ? U[] : T[P];
+};
+
 type KnobPlus<T extends KnobType, K> = K & { type: T; groupId?: string };
 
 export type Knob<T extends KnobType = any> = T extends 'text'


### PR DESCRIPTION
Issue: Needed to add more fidelity to the knobs value types to cover even more test cases, including [`ReadonlyArray` cases](https://github.com/storybookjs/storybook/issues/7348#issuecomment-510461977) (#7348) and enum cases (#7420).

## What I did

- Added more fidelity to the knobs value types, particularly where many different kinds of values are allowed.
- Added types to cover cases where a `ReadonlyArray` may be provided (Typescript seems to treat this differently as a normal array)
- Added a ts file with various use cases as a form of "tests" (would love to get feedback on approach)

## How to test

The knobs addon spans a fair number of use cases; therefore, I had the need to create a set of test cases with which I want to ensure compilation passes. To this effect, I added a file under `src/__types__/` with a series of test cases. The successful compilation of this file should indicate types are passing correctly, at least as far as that file is intending to document.

I don't believe there's currently an established process for testing type definitions specifically in the repo, so I'd love to get thoughts/feedback on the approach.
