### PR TITLE
CLI: Add migrate command

### DIFF
--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -2,8 +2,6 @@
 
 Storybook CLI (_Command Line Interface_) is the easiest way to add [Storybook](https://github.com/storybookjs/storybook) to your project.
 
-In the future it will also add other useful generators and migration tooling.
-
 ![Screenshot](docs/getstorybook.png)
 
 Just go to your project and run:
@@ -13,7 +11,13 @@ cd my-app
 npx -p @storybook/cli sb init
 ```
 
-That's all you've to do.
+In addition to `init`, the CLI also has other commands:
+
+- `add` - add an addon and register it
+- `info` - print out system information for bug reports
+- `migrate` - run codemods to migrate your code
+
+See the command-line help with `-h` for details.
 
 ---
 

--- a/lib/cli/bin/generate.js
+++ b/lib/cli/bin/generate.js
@@ -5,6 +5,7 @@ import pkg from '../package.json';
 import initiate from '../lib/initiate';
 import { codeLog } from '../lib/helpers';
 import add from '../lib/add';
+import { migrate } from '../lib/migrate';
 
 const logger = console;
 
@@ -45,6 +46,22 @@ if (process.argv[1].includes('getstorybook')) {
           npmGlobalPackages: ['@storybook/cli'],
         })
         .then(logger.log);
+    });
+
+  program
+    .command('migrate [migration]')
+    .option('-l --list', 'List available migrations')
+    .option('-g --glob <glob>', 'Glob for files upon which to apply the migration', '**/*.js')
+    .option(
+      '-n --dry-run',
+      'Dry run: verify the migration exists and show the files to which it will be applied'
+    )
+    .description('Run a storybook code migration from an addon')
+    .action((migration, { configDir, glob, dryRun, list }) => {
+      migrate(migration, { configDir, glob, dryRun, list, logger }).catch(err => {
+        logger.error(err);
+        process.exit(1);
+      });
     });
 
   program.command('*', { noHelp: true }).action(cmd => {

--- a/lib/cli/bin/generate.js
+++ b/lib/cli/bin/generate.js
@@ -49,7 +49,7 @@ if (process.argv[1].includes('getstorybook')) {
     });
 
   program
-    .command('migrate <migration>')
+    .command('migrate [migration]')
     .description('Run a storybook codemod migration on your source files')
     .option('-l --list', 'List available migrations')
     .option('-g --glob <glob>', 'Glob for files upon which to apply the migration', '**/*.js')

--- a/lib/cli/bin/generate.js
+++ b/lib/cli/bin/generate.js
@@ -49,7 +49,7 @@ if (process.argv[1].includes('getstorybook')) {
     });
 
   program
-    .command('migrate [migration]')
+    .command('migrate <migration>')
     .description('Run a storybook codemod migration on your source files')
     .option('-l --list', 'List available migrations')
     .option('-g --glob <glob>', 'Glob for files upon which to apply the migration', '**/*.js')

--- a/lib/cli/bin/generate.js
+++ b/lib/cli/bin/generate.js
@@ -57,8 +57,12 @@ if (process.argv[1].includes('getstorybook')) {
       '-n --dry-run',
       'Dry run: verify the migration exists and show the files to which it will be applied'
     )
-    .action((migration, { configDir, glob, dryRun, list }) => {
-      migrate(migration, { configDir, glob, dryRun, list, logger }).catch(err => {
+    .option(
+      '-r --rename <from-to>',
+      'Rename suffix of matching files after codemod has been applied, e.g. ".js:.ts"'
+    )
+    .action((migration, { configDir, glob, dryRun, list, rename }) => {
+      migrate(migration, { configDir, glob, dryRun, list, rename, logger }).catch(err => {
         logger.error(err);
         process.exit(1);
       });

--- a/lib/cli/bin/generate.js
+++ b/lib/cli/bin/generate.js
@@ -50,13 +50,13 @@ if (process.argv[1].includes('getstorybook')) {
 
   program
     .command('migrate [migration]')
+    .description('Run a storybook codemod migration on your source files')
     .option('-l --list', 'List available migrations')
     .option('-g --glob <glob>', 'Glob for files upon which to apply the migration', '**/*.js')
     .option(
       '-n --dry-run',
       'Dry run: verify the migration exists and show the files to which it will be applied'
     )
-    .description('Run a storybook code migration from an addon')
     .action((migration, { configDir, glob, dryRun, list }) => {
       migrate(migration, { configDir, glob, dryRun, list, logger }).catch(err => {
         logger.error(err);

--- a/lib/cli/lib/migrate.js
+++ b/lib/cli/lib/migrate.js
@@ -1,0 +1,12 @@
+import { listCodemods, runCodemod } from '@storybook/codemod';
+import hasYarn from './has_yarn';
+
+export async function migrate(migration, { configDir, glob, dryRun, list, logger }) {
+  if (list) {
+    listCodemods().forEach(key => logger.log(key));
+  } else if (migration) {
+    await runCodemod(migration, { configDir, glob, dryRun, logger, hasYarn: hasYarn() });
+  } else {
+    throw new Error('Migrate: please specify a migration name or --list');
+  }
+}

--- a/lib/cli/lib/migrate.js
+++ b/lib/cli/lib/migrate.js
@@ -1,11 +1,11 @@
 import { listCodemods, runCodemod } from '@storybook/codemod';
 import hasYarn from './has_yarn';
 
-export async function migrate(migration, { configDir, glob, dryRun, list, logger }) {
+export async function migrate(migration, { configDir, glob, dryRun, list, rename, logger }) {
   if (list) {
     listCodemods().forEach(key => logger.log(key));
   } else if (migration) {
-    await runCodemod(migration, { configDir, glob, dryRun, logger, hasYarn: hasYarn() });
+    await runCodemod(migration, { configDir, glob, dryRun, logger, rename, hasYarn: hasYarn() });
   } else {
     throw new Error('Migrate: please specify a migration name or --list');
   }

--- a/lib/codemod/README.md
+++ b/lib/codemod/README.md
@@ -3,7 +3,25 @@
 Storybook Codemods is a collection of codemod scripts written with JSCodeshift.
 It will help you migrate breaking changes & deprecations.
 
+## CLI Integration
+
+The preferred way to run these codemods is via the CLI's `migrate` command.
+
+To get a list of available codemods:
+
+```
+npx -p @storybook/cli sb migrate --list
+```
+
+To run a codemod:
+
+```
+npx -p @storybook/cli sb migrate name-of-codemod --glob "**/*.stories.js"
+```
+
 ## Installation
+
+If you want to run these codemods by hand:
 
 ```sh
 yarn add jscodeshift @storybook/codemod --dev

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@storybook/node-logger": "5.2.0-alpha.42",
     "core-js": "^3.0.1",
+    "cross-spawn": "^6.0.5",
+    "globby": "^10.0.1",
     "jscodeshift": "^0.6.3",
     "lodash": "^4.17.11",
     "prettier": "^1.16.4",

--- a/lib/codemod/src/index.js
+++ b/lib/codemod/src/index.js
@@ -19,11 +19,26 @@ export function listCodemods() {
     .map(fname => fname.slice(0, -3));
 }
 
-export async function runCodemod(codemod, { glob, logger, dryRun, hasYarn }) {
+async function renameFile(file, from, to, { logger }) {
+  const newFile = file.replace(from, to);
+  logger.log(`Rename: ${file} ${newFile}`);
+  return fs.rename(file, newFile);
+}
+
+export async function runCodemod(codemod, { glob, logger, dryRun, rename, hasYarn }) {
   const codemods = listCodemods();
   if (!codemods.includes(codemod)) {
     throw new Error(`Unknown codemod ${codemod}. Run --list for options.`);
   }
+
+  let renameParts = null;
+  if (rename) {
+    renameParts = rename.split(':');
+    if (renameParts.length !== 2) {
+      throw new Error(`Codemod rename: expected format "from:to", got "${rename}"`);
+    }
+  }
+
   const files = await globby([glob, '!node_modules', '!dist']);
   logger.log(`=> Applying ${codemod}: ${files.length} files`);
   if (!dryRun) {
@@ -31,5 +46,11 @@ export async function runCodemod(codemod, { glob, logger, dryRun, hasYarn }) {
     spawnSync(runner, ['run', 'jscodeshift', '-t', `${TRANSFORM_DIR}/${codemod}.js`, ...files], {
       stdio: 'inherit',
     });
+  }
+
+  if (renameParts) {
+    const [from, to] = renameParts;
+    logger.log(`=> Renaming ${rename}: ${files.length} files`);
+    await Promise.all(files.map(file => renameFile(file, new RegExp(`${from}$`), to, { logger })));
   }
 }

--- a/lib/codemod/src/index.js
+++ b/lib/codemod/src/index.js
@@ -1,4 +1,7 @@
 /* eslint import/prefer-default-export: "off" */
+import fs from 'fs';
+import globby from 'globby';
+import { sync as spawnSync } from 'cross-spawn';
 
 export {
   default as updateOrganisationName,
@@ -6,3 +9,27 @@ export {
 } from './transforms/update-organisation-name';
 
 export { default as updateAddonInfo } from './transforms/update-addon-info';
+
+const TRANSFORM_DIR = `${__dirname}/transforms`;
+
+export function listCodemods() {
+  return fs
+    .readdirSync(TRANSFORM_DIR)
+    .filter(fname => fname.endsWith('.js'))
+    .map(fname => fname.slice(0, -3));
+}
+
+export async function runCodemod(codemod, { glob, logger, dryRun, hasYarn }) {
+  const codemods = listCodemods();
+  if (!codemods.includes(codemod)) {
+    throw new Error(`Unknown codemod ${codemod}. Run --list for options.`);
+  }
+  const files = await globby([glob, '!node_modules', '!dist']);
+  logger.log(`=> Applying ${codemod}: ${files.length} files`);
+  if (!dryRun) {
+    const runner = hasYarn ? 'yarn' : 'npm';
+    spawnSync(runner, ['run', 'jscodeshift', '-t', `${TRANSFORM_DIR}/${codemod}.js`, ...files], {
+      stdio: 'inherit',
+    });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3271,10 +3271,31 @@
     tree-kill "1.2.1"
     webpack-sources "1.3.0"
 
+"@nodelib/fs.scandir@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz#7fa8fed654939e1a39753d286b48b4836d00e0eb"
+  integrity sha512-NT/skIZjgotDSiXs0WqYhgcuBKhUMgfekCmCGtkUAiLqZdOnrdjmZr9wRl3ll64J9NF79uZ4fk16Dx0yMc/Xbg==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.1"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.1", "@nodelib/fs.stat@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz#814f71b1167390cfcb6a6b3d9cdeb0951a192c14"
+  integrity sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@nodelib/fs.walk@^1.2.1":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.2.tgz#6a6450c5e17012abd81450eb74949a4d970d2807"
+  integrity sha512-J/DR3+W12uCzAJkw7niXDcqcKBg6+5G5Q/ZpThpGNzAUz70eOR6RV4XnnSN01qHZiVl0eavoxJsBypQoKsV2QQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.1"
+    fastq "^1.6.0"
 
 "@octokit/endpoint@^5.1.0":
   version "5.2.0"
@@ -5449,6 +5470,11 @@ array-union@^1.0.1:
   integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
   dependencies:
     array-uniq "^1.0.1"
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array-uniq@^1.0.1:
   version "1.0.3"
@@ -10790,6 +10816,13 @@ dir-glob@^2.0.0:
   dependencies:
     path-type "^3.0.0"
 
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
@@ -13104,6 +13137,18 @@ fast-glob@^2.0.2, fast-glob@^2.2.2:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
+fast-glob@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.0.4.tgz#d484a41005cb6faeb399b951fd1bd70ddaebb602"
+  integrity sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.1"
+    "@nodelib/fs.walk" "^1.2.1"
+    glob-parent "^5.0.0"
+    is-glob "^4.0.1"
+    merge2 "^1.2.3"
+    micromatch "^4.0.2"
+
 fast-json-stable-stringify@2.0.0, fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -13139,6 +13184,13 @@ fastparse@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
 
 fault@^1.0.0, fault@^1.0.2:
   version "1.0.3"
@@ -14208,6 +14260,13 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob-parent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
+  integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-promise@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-3.4.0.tgz#b6b8f084504216f702dc2ce8c9bc9ac8866fdb20"
@@ -14419,6 +14478,20 @@ globby@8.0.2, globby@^8.0.1:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+globby@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.1.tgz#4782c34cb75dd683351335c5829cc3420e606b22"
+  integrity sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -15471,6 +15544,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.2.tgz#e28e584d43ad7e92f96995019cc43b9e1ac49558"
+  integrity sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==
 
 ignoring-watcher@^1.0.5:
   version "1.1.0"
@@ -20155,7 +20233,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8, mic
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.0:
+micromatch@^4.0.0, micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
@@ -22209,6 +22287,11 @@ path-type@^3.0.0:
   integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
+
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 paths.macro@^2.0.2:
   version "2.0.2"
@@ -26255,6 +26338,11 @@ retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
+reusify@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 reverse-path@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/reverse-path/-/reverse-path-0.0.1.tgz#855adc35c1d4218e28f5530fd7297bcd0cfa225a"
@@ -26450,6 +26538,11 @@ run-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
   integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Issue: #1108

## What I did

Add CLI migrate command:

```
Usage: migrate [options] [migration]

Run a storybook codemod migration on your source files

Options:
  -l --list         List available migrations
  -g --glob <glob>  Glob for files upon which to apply the migration (default: "**/*.js")
  -n --dry-run      Dry run: verify the migration exists and show the files to which it will be applied
  -h, --help        output usage information
```

## How to test

```
./lib/cli/bin/index.js migrate --list"
./lib/cli/bin/index.js migrate convert-to-module-format --glob "lib/ui/**/*.stories.js"
```

