### PR TITLE
Allow injecting preview-body.html

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -33,6 +33,7 @@ module.exports = {
         '/configurations/custom-babel-config/',
         '/configurations/typescript-config/',
         '/configurations/add-custom-head-tags/',
+        '/configurations/add-custom-body/',
         '/configurations/serving-static-files/',
         '/configurations/env-vars/',
         '/configurations/theming/',

--- a/docs/src/components/Homepage/MainLinks/index.js
+++ b/docs/src/components/Homepage/MainLinks/index.js
@@ -113,6 +113,9 @@ class MainLinks extends React.Component {
                   <Link to="/configurations/add-custom-head-tags/">Custom scripts & styling</Link>
                 </li>
                 <li>
+                  <Link to="/configurations/add-custom-body/">Custom html body</Link>
+                </li>
+                <li>
                   <Link to="/configurations/serving-static-files/">Serving static files</Link>
                 </li>
               </ul>

--- a/docs/src/pages/configurations/add-custom-body/index.md
+++ b/docs/src/pages/configurations/add-custom-body/index.md
@@ -1,0 +1,18 @@
+---
+id: 'add-custom-body'
+title: 'Add Custom Body'
+---
+
+Sometimes, you may need to add different tags to the HTML body. This is useful for adding some custom content roots.
+
+You can do this very easily. Simply create a file called `preview-body.html` inside the Storybook config directory and add tags like this:
+
+```html
+<div id="custom-root"></div>
+```
+
+That's it. Storybook will inject these tags to html body.
+
+> **Important**
+>
+> Storybook will inject these tags to the iframe where your components are rendered. So, these won’t be loaded into the main Storybook UI.

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -56,7 +56,7 @@ export default ({
           version: packageJson.version,
           headHtmlSnippet: getPreviewHeadHtml(configDir, process.env),
           dlls: [],
-          bodyHtmlSnippet: getPreviewBodyHtml(),
+          bodyHtmlSnippet: getPreviewBodyHtml(configDir, process.env),
         }),
         template: require.resolve(`../templates/index.ejs`),
       }),

--- a/lib/core/src/server/utils/template.js
+++ b/lib/core/src/server/utils/template.js
@@ -4,8 +4,26 @@ import fs from 'fs';
 const interpolate = (string, data = {}) =>
   Object.entries(data).reduce((acc, [k, v]) => acc.replace(new RegExp(`%${k}%`, 'g'), v), string);
 
-export function getPreviewBodyHtml() {
-  return fs.readFileSync(path.resolve(__dirname, '../templates/base-preview-body.html'), 'utf8');
+export function getPreviewBodyHtml(configDirPath, interpolations) {
+  const base = fs.readFileSync(
+    path.resolve(__dirname, '../templates/base-preview-body.html'),
+    'utf8'
+  );
+
+  const preBodyHtmlPath = path.resolve(configDirPath, 'preview-pre-body.html');
+  const postBodyHtmlPath = path.resolve(configDirPath, 'preview-post-body.html');
+
+  let result = base;
+
+  if (fs.existsSync(preBodyHtmlPath)) {
+    result = fs.readFileSync(preBodyHtmlPath, 'utf8') + result;
+  }
+
+  if (fs.existsSync(postBodyHtmlPath)) {
+    result += fs.readFileSync(postBodyHtmlPath, 'utf8');
+  }
+
+  return interpolate(result, interpolations);
 }
 
 export function getPreviewHeadHtml(configDirPath, interpolations) {

--- a/lib/core/src/server/utils/template.js
+++ b/lib/core/src/server/utils/template.js
@@ -10,17 +10,11 @@ export function getPreviewBodyHtml(configDirPath, interpolations) {
     'utf8'
   );
 
-  const preBodyHtmlPath = path.resolve(configDirPath, 'preview-pre-body.html');
-  const postBodyHtmlPath = path.resolve(configDirPath, 'preview-post-body.html');
-
+  const bodyHtmlPath = path.resolve(configDirPath, 'preview-body.html');
   let result = base;
 
-  if (fs.existsSync(preBodyHtmlPath)) {
-    result = fs.readFileSync(preBodyHtmlPath, 'utf8') + result;
-  }
-
-  if (fs.existsSync(postBodyHtmlPath)) {
-    result += fs.readFileSync(postBodyHtmlPath, 'utf8');
+  if (fs.existsSync(bodyHtmlPath)) {
+    result = fs.readFileSync(bodyHtmlPath, 'utf8') + result;
   }
 
   return interpolate(result, interpolations);

--- a/lib/core/src/server/utils/template.test.js
+++ b/lib/core/src/server/utils/template.test.js
@@ -1,8 +1,12 @@
 import mock from 'mock-fs';
-import { getPreviewHeadHtml } from './template';
+import { getPreviewHeadHtml, getPreviewBodyHtml } from './template';
 
 const HEAD_HTML_CONTENTS = '<script>console.log("custom script!");</script>';
 const BASE_HTML_CONTENTS = '<script>console.log("base script!");</script>';
+
+const BASE_BODY_CONTENTS = '<div>story contents</div>';
+const PRE_BODY_CONTENTS = '<div>pre injected contents</div>';
+const POST_BODY_CONTENTS = '<div>post injected contents</div>';
 
 describe('server.getPreviewHeadHtml', () => {
   describe('when .storybook/preview-head.html does not exist', () => {
@@ -40,6 +44,87 @@ describe('server.getPreviewHeadHtml', () => {
     it('return the contents of the file', () => {
       const result = getPreviewHeadHtml('./config');
       expect(result).toEqual(BASE_HTML_CONTENTS + HEAD_HTML_CONTENTS);
+    });
+  });
+});
+
+describe('server.getPreviewBodyHtml', () => {
+  describe('when .storybook/preview-pre-body.html and .storybook/preview-post-body.html do not exist', () => {
+    beforeEach(() => {
+      mock({
+        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_CONTENTS,
+        config: {},
+      });
+    });
+
+    afterEach(() => {
+      mock.restore();
+    });
+
+    it('return an empty string', () => {
+      const result = getPreviewBodyHtml('./config');
+      expect(result).toEqual(BASE_BODY_CONTENTS);
+    });
+  });
+
+  describe('when .storybook/preview-pre-body.html exists', () => {
+    beforeEach(() => {
+      mock({
+        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_CONTENTS,
+        config: {
+          'preview-pre-body.html': PRE_BODY_CONTENTS,
+        },
+      });
+    });
+
+    afterEach(() => {
+      mock.restore();
+    });
+
+    it('return the contents of the file', () => {
+      const result = getPreviewBodyHtml('./config');
+      expect(result).toEqual(PRE_BODY_CONTENTS + BASE_BODY_CONTENTS);
+    });
+  });
+
+  describe('when .storybook/preview-post-body.html exists', () => {
+    beforeEach(() => {
+      mock({
+        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_CONTENTS,
+        config: {
+          'preview-post-body.html': POST_BODY_CONTENTS,
+        },
+      });
+    });
+
+    afterEach(() => {
+      mock.restore();
+    });
+
+    it('return the contents of the file', () => {
+      const result = getPreviewBodyHtml('./config');
+      expect(result).toEqual(BASE_BODY_CONTENTS + POST_BODY_CONTENTS);
+    });
+  });
+
+  describe('when both .storybook/preview-pre-body.html and .storybook/preview-post-body.html exist', () => {
+    beforeEach(() => {
+      mock({
+        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_CONTENTS,
+        config: {
+          'preview-pre-body.html': PRE_BODY_CONTENTS,
+          'preview-post-body.html': POST_BODY_CONTENTS,
+        },
+      });
+    });
+
+    afterEach(() => {
+      mock.restore();
+    });
+
+    it('return the contents of the file', () => {
+      const result = getPreviewBodyHtml('./config');
+      expect(result).toEqual(PRE_BODY_CONTENTS + BASE_BODY_CONTENTS + POST_BODY_CONTENTS);
     });
   });
 });

--- a/lib/core/src/server/utils/template.test.js
+++ b/lib/core/src/server/utils/template.test.js
@@ -4,9 +4,8 @@ import { getPreviewHeadHtml, getPreviewBodyHtml } from './template';
 const HEAD_HTML_CONTENTS = '<script>console.log("custom script!");</script>';
 const BASE_HTML_CONTENTS = '<script>console.log("base script!");</script>';
 
-const BASE_BODY_CONTENTS = '<div>story contents</div>';
-const PRE_BODY_CONTENTS = '<div>pre injected contents</div>';
-const POST_BODY_CONTENTS = '<div>post injected contents</div>';
+const BASE_BODY_HTML_CONTENTS = '<div>story contents</div>';
+const BODY_HTML_CONTENTS = '<div>custom body contents</div>';
 
 describe('server.getPreviewHeadHtml', () => {
   describe('when .storybook/preview-head.html does not exist', () => {
@@ -49,10 +48,10 @@ describe('server.getPreviewHeadHtml', () => {
 });
 
 describe('server.getPreviewBodyHtml', () => {
-  describe('when .storybook/preview-pre-body.html and .storybook/preview-post-body.html do not exist', () => {
+  describe('when .storybook/preview-body.html does not exist', () => {
     beforeEach(() => {
       mock({
-        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_CONTENTS,
+        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_HTML_CONTENTS,
         config: {},
       });
     });
@@ -63,16 +62,16 @@ describe('server.getPreviewBodyHtml', () => {
 
     it('return an empty string', () => {
       const result = getPreviewBodyHtml('./config');
-      expect(result).toEqual(BASE_BODY_CONTENTS);
+      expect(result).toEqual(BASE_BODY_HTML_CONTENTS);
     });
   });
 
   describe('when .storybook/preview-pre-body.html exists', () => {
     beforeEach(() => {
       mock({
-        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_CONTENTS,
+        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_HTML_CONTENTS,
         config: {
-          'preview-pre-body.html': PRE_BODY_CONTENTS,
+          'preview-body.html': BODY_HTML_CONTENTS,
         },
       });
     });
@@ -83,48 +82,7 @@ describe('server.getPreviewBodyHtml', () => {
 
     it('return the contents of the file', () => {
       const result = getPreviewBodyHtml('./config');
-      expect(result).toEqual(PRE_BODY_CONTENTS + BASE_BODY_CONTENTS);
-    });
-  });
-
-  describe('when .storybook/preview-post-body.html exists', () => {
-    beforeEach(() => {
-      mock({
-        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_CONTENTS,
-        config: {
-          'preview-post-body.html': POST_BODY_CONTENTS,
-        },
-      });
-    });
-
-    afterEach(() => {
-      mock.restore();
-    });
-
-    it('return the contents of the file', () => {
-      const result = getPreviewBodyHtml('./config');
-      expect(result).toEqual(BASE_BODY_CONTENTS + POST_BODY_CONTENTS);
-    });
-  });
-
-  describe('when both .storybook/preview-pre-body.html and .storybook/preview-post-body.html exist', () => {
-    beforeEach(() => {
-      mock({
-        [`${__dirname}/../templates/base-preview-body.html`]: BASE_BODY_CONTENTS,
-        config: {
-          'preview-pre-body.html': PRE_BODY_CONTENTS,
-          'preview-post-body.html': POST_BODY_CONTENTS,
-        },
-      });
-    });
-
-    afterEach(() => {
-      mock.restore();
-    });
-
-    it('return the contents of the file', () => {
-      const result = getPreviewBodyHtml('./config');
-      expect(result).toEqual(PRE_BODY_CONTENTS + BASE_BODY_CONTENTS + POST_BODY_CONTENTS);
+      expect(result).toEqual(BODY_HTML_CONTENTS + BASE_BODY_HTML_CONTENTS);
     });
   });
 });


### PR DESCRIPTION
Issue:

In my project I have some components which require specified div element `<div id="portal-id"></div>`. So the only way to make it working with Storybook is to allow extending preview body.

## What I did

I extended `getPreviewBodyHtml` function to look for `preview-body.html` (same as `preview-head.html`) and inject its contents to the body of story previewer
