### PR TITLE
use same param key as backgrounds addon

### DIFF
--- a/addons/ondevice-backgrounds/src/BackgroundPanel.js
+++ b/addons/ondevice-backgrounds/src/BackgroundPanel.js
@@ -56,7 +56,7 @@ export default class BackgroundPanel extends Component {
   render() {
     const { active, api } = this.props;
 
-    if (!active) {
+    if (!active || !this.state) {
       return null;
     }
 

--- a/addons/ondevice-backgrounds/src/constants.js
+++ b/addons/ondevice-backgrounds/src/constants.js
@@ -1,4 +1,4 @@
-export const PARAM_KEY = 'background';
+export const PARAM_KEY = 'backgrounds';
 export const ADDON_ID = 'storybook-addon-background';
 export const PANEL_ID = `${ADDON_ID}/background-panel`;
 


### PR DESCRIPTION
Issue: #7432

## What I did

Fixed the thing.

1. The constant's value did not match with the one in addon-backgrounds.
2. When loading this addon _first_, state is null. For some reason. Now, the addon works again when loaded first.

## How to test

Run an app with the addon and see it work. Before this fix (on latest beta at least) the addon didn't run at all.
