### PR TITLE
Marko support rerendering

### DIFF
--- a/app/marko/src/client/preview/render.js
+++ b/app/marko/src/client/preview/render.js
@@ -16,12 +16,12 @@ export default function renderMain({
 }) {
   const config = storyFn();
 
-  if (!config || !(config.appendTo || config.template || parameters.template)) {
+  if (!config || !(config.appendTo || config.component || parameters.component)) {
     showError({
-      title: `Expecting an object with a template property to be returned from the story: "${selectedStory}" of "${selectedKind}".`,
+      title: `Expecting an object with a component property to be returned from the story: "${selectedStory}" of "${selectedKind}".`,
       description: stripIndents`
-        Did you forget to return the template from the story?
-        Use "() => ({ template: MyTemplate, input: { hello: 'world' } })" when defining the story.
+        Did you forget to return the component from the story?
+        Use "() => ({ component: MyComponent, input: { hello: 'world' } })" when defining the story.
       `,
     });
 
@@ -29,7 +29,7 @@ export default function renderMain({
   }
   if (config.appendTo) {
     console.warn(
-      '@storybook/marko: returning a rendered component for a story is deprecated, return an object with `{ template, input }` instead.'
+      '@storybook/marko: returning a rendered component for a story is deprecated, return an object with `{ component, input }` instead.'
     );
 
     // The deprecated API always destroys the previous component instance.
@@ -39,7 +39,7 @@ export default function renderMain({
 
     activeComponent = config.appendTo(rootEl).getComponent();
   } else {
-    const template = config.template || parameters.template;
+    const template = config.component || parameters.component;
 
     if (activeTemplate === template) {
       // When rendering the same template with new input, we reuse the same instance.

--- a/app/marko/src/client/preview/render.js
+++ b/app/marko/src/client/preview/render.js
@@ -11,11 +11,12 @@ export default function renderMain({
   selectedStory,
   showMain,
   showError,
+  parameters,
   // forceRender,
 }) {
   const config = storyFn();
 
-  if (!config || !(config.appendTo || config.template)) {
+  if (!config || !(config.appendTo || config.template || parameters.template)) {
     showError({
       title: `Expecting an object with a template property to be returned from the story: "${selectedStory}" of "${selectedKind}".`,
       description: stripIndents`
@@ -37,20 +38,24 @@ export default function renderMain({
     }
 
     activeComponent = config.appendTo(rootEl).getComponent();
-  } else if (activeTemplate === config.template) {
-    // When rendering the same template with new input, we reuse the same instance.
-    activeComponent.input = config.input;
-    activeComponent.update();
   } else {
-    if (activeComponent) {
-      activeComponent.destroy();
-    }
+    const template = config.template || parameters.template;
 
-    activeTemplate = config.template;
-    activeComponent = activeTemplate
-      .renderSync(config.input)
-      .appendTo(rootEl)
-      .getComponent();
+    if (activeTemplate === template) {
+      // When rendering the same template with new input, we reuse the same instance.
+      activeComponent.input = config.input;
+      activeComponent.update();
+    } else {
+      if (activeComponent) {
+        activeComponent.destroy();
+      }
+
+      activeTemplate = template;
+      activeComponent = activeTemplate
+        .renderSync(config.input)
+        .appendTo(rootEl)
+        .getComponent();
+    }
   }
 
   showMain();

--- a/app/marko/src/client/preview/render.js
+++ b/app/marko/src/client/preview/render.js
@@ -2,7 +2,8 @@ import { document } from 'global';
 import { stripIndents } from 'common-tags';
 
 const rootEl = document.getElementById('root');
-let currLoadedComponent = null; // currently loaded marko widget!
+let activeComponent = null; // currently loaded marko component.
+let activeTemplate = null; // template for the currently loaded component.
 
 export default function renderMain({
   storyFn,
@@ -12,24 +13,45 @@ export default function renderMain({
   showError,
   // forceRender,
 }) {
-  const element = storyFn();
+  const config = storyFn();
 
-  // We need to unmount the existing set of components in the DOM node.
-  if (currLoadedComponent) {
-    currLoadedComponent.destroy();
-  }
-
-  if (!element || !element.out) {
+  if (!config || !(config.appendTo || config.template)) {
     showError({
-      title: `Expecting a Marko element from the story: "${selectedStory}" of "${selectedKind}".`,
+      title: `Expecting an object with a template property to be returned from the story: "${selectedStory}" of "${selectedKind}".`,
       description: stripIndents`
-        Did you forget to return the Marko element from the story?
-        Use "() => MyComp.renderSync({})" or "() => { return MyComp.renderSync({}); }" when defining the story.
+        Did you forget to return the template from the story?
+        Use "() => ({ template: MyTemplate, input: { hello: 'world' } })" when defining the story.
       `,
     });
+
     return;
+  }
+  if (config.appendTo) {
+    console.warn(
+      '@storybook/marko: returning a rendered component for a story is deprecated, return an object with `{ template, input }` instead.'
+    );
+
+    // The deprecated API always destroys the previous component instance.
+    if (activeComponent) {
+      activeComponent.destroy();
+    }
+
+    activeComponent = config.appendTo(rootEl).getComponent();
+  } else if (activeTemplate === config.template) {
+    // When rendering the same template with new input, we reuse the same instance.
+    activeComponent.input = config.input;
+    activeComponent.update();
+  } else {
+    if (activeComponent) {
+      activeComponent.destroy();
+    }
+
+    activeTemplate = config.template;
+    activeComponent = activeTemplate
+      .renderSync(config.input)
+      .appendTo(rootEl)
+      .getComponent();
   }
 
   showMain();
-  currLoadedComponent = element.appendTo(rootEl).getComponent();
 }

--- a/docs/src/pages/guides/guide-marko/index.md
+++ b/docs/src/pages/guides/guide-marko/index.md
@@ -88,15 +88,18 @@ That'll load stories in `../stories/index.js`. You can choose where to place sto
 Now create a `../stories/index.js` file, and write your first story like this:
 
 ```js
-/** @jsx m */
-
-import m from 'marko';
 import { storiesOf } from '@storybook/marko';
 import Button from '../components/button/index.marko';
 
 storiesOf('Button', module)
-  .add('with text', () => Button.renderSync({ text: 'some text'}))
-  .add('with emoji', () => Button.renderSync({ text: '😀 😎 👍 💯'}));
+  .add('with text', () => ({
+    template: Button,
+    input: { text 'some text' }
+  }))
+  .add('with emoji', () => ({
+    template: Button,
+    input: { text '😀 😎 👍 💯' }
+  }));
 ```
 
 Each story is a single state of your component. In the above case, there are two stories for the demo button component:

--- a/docs/src/pages/guides/guide-marko/index.md
+++ b/docs/src/pages/guides/guide-marko/index.md
@@ -93,11 +93,11 @@ import Button from '../components/button/index.marko';
 
 storiesOf('Button', module)
   .add('with text', () => ({
-    template: Button,
+    component: Button,
     input: { text 'some text' }
   }))
   .add('with emoji', () => ({
-    template: Button,
+    component: Button,
     input: { text '😀 😎 👍 💯' }
   }));
 ```

--- a/examples/marko-cli/src/stories/addon-actions.stories.js
+++ b/examples/marko-cli/src/stories/addon-actions.stories.js
@@ -4,13 +4,14 @@ import Button from '../components/action-button/index.marko';
 export default {
   title: 'Addons|Actions/Button',
   parameters: {
+    component: Button,
     options: {
-      component: Button,
       panelPosition: 'right',
     },
   },
 };
 
 export const Simple = () => ({
+  component: Button,
   input: { click: action('action logged!') },
 });

--- a/examples/marko-cli/src/stories/addon-actions.stories.js
+++ b/examples/marko-cli/src/stories/addon-actions.stories.js
@@ -4,11 +4,13 @@ import Button from '../components/action-button/index.marko';
 export default {
   title: 'Addons|Actions/Button',
   parameters: {
-    options: { panelPosition: 'right' },
+    options: {
+      component: Button,
+      panelPosition: 'right',
+    },
   },
 };
 
 export const Simple = () => ({
-  template: Button,
   input: { click: action('action logged!') },
 });

--- a/examples/marko-cli/src/stories/addon-actions.stories.js
+++ b/examples/marko-cli/src/stories/addon-actions.stories.js
@@ -4,8 +4,11 @@ import Button from '../components/action-button/index.marko';
 export default {
   title: 'Addons|Actions/Button',
   parameters: {
-    component: Button,
+    options: { panelPosition: 'right' },
   },
 };
 
-export const Simple = () => Button.renderSync({ click: action('action logged!') });
+export const Simple = () => ({
+  template: Button,
+  input: { click: action('action logged!') },
+});

--- a/examples/marko-cli/src/stories/addon-knobs.stories.js
+++ b/examples/marko-cli/src/stories/addon-knobs.stories.js
@@ -5,12 +5,12 @@ export default {
   title: 'Addons|Knobs/Hello',
   decorators: [withKnobs],
   parameters: {
+    template: Hello,
     options: { panelPosition: 'right' },
   },
 };
 
 export const Simple = () => ({
-  template: Hello,
   input: {
     name: text('Name', 'John Doe'),
     age: number('Age', 44),

--- a/examples/marko-cli/src/stories/addon-knobs.stories.js
+++ b/examples/marko-cli/src/stories/addon-knobs.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Addons|Knobs/Hello',
   decorators: [withKnobs],
   parameters: {
-    template: Hello,
+    component: Hello,
     options: { panelPosition: 'right' },
   },
 };

--- a/examples/marko-cli/src/stories/addon-knobs.stories.js
+++ b/examples/marko-cli/src/stories/addon-knobs.stories.js
@@ -5,16 +5,14 @@ export default {
   title: 'Addons|Knobs/Hello',
   decorators: [withKnobs],
   parameters: {
-    component: Hello,
     options: { panelPosition: 'right' },
   },
 };
 
-export const Simple = () => {
-  const name = text('Name', 'John Doe');
-  const age = number('Age', 44);
-  return Hello.renderSync({
-    name,
-    age,
-  });
-};
+export const Simple = () => ({
+  template: Hello,
+  input: {
+    name: text('Name', 'John Doe'),
+    age: number('Age', 44),
+  },
+});

--- a/examples/marko-cli/src/stories/clickcount.stories.js
+++ b/examples/marko-cli/src/stories/clickcount.stories.js
@@ -2,10 +2,6 @@ import ClickCount from '../components/click-count/index.marko';
 
 export default {
   title: 'Main|ClickCount',
-
-  parameters: {
-    component: ClickCount,
-  },
 };
 
-export const Simple = () => ClickCount.renderSync({});
+export const Simple = () => ({ template: ClickCount });

--- a/examples/marko-cli/src/stories/clickcount.stories.js
+++ b/examples/marko-cli/src/stories/clickcount.stories.js
@@ -2,6 +2,9 @@ import ClickCount from '../components/click-count/index.marko';
 
 export default {
   title: 'Main|ClickCount',
+  parameters: {
+    component: ClickCount,
+  },
 };
 
-export const Simple = () => ({ template: ClickCount });
+export const Simple = () => ({ component: ClickCount });

--- a/examples/marko-cli/src/stories/hello.stories.js
+++ b/examples/marko-cli/src/stories/hello.stories.js
@@ -2,8 +2,11 @@ import Hello from '../components/hello/index.marko';
 
 export default {
   title: 'Main|Hello',
+  parameters: {
+    component: Hello,
+  },
 };
 
-export const Simple = () => ({ template: Hello, input: { name: 'abc', age: 20 } });
+export const Simple = () => ({ input: { name: 'abc', age: 20 } });
 export const story2 = () => 'NOT A MARKO RENDER_RESULT';
 story2.story = { name: 'with ERROR!' };

--- a/examples/marko-cli/src/stories/hello.stories.js
+++ b/examples/marko-cli/src/stories/hello.stories.js
@@ -2,11 +2,8 @@ import Hello from '../components/hello/index.marko';
 
 export default {
   title: 'Main|Hello',
-  parameters: {
-    component: Hello,
-  },
 };
 
-export const Simple = () => Hello.renderSync({ name: 'abc', age: 20 });
+export const Simple = () => ({ template: Hello, input: { name: 'abc', age: 20 } });
 export const story2 = () => 'NOT A MARKO RENDER_RESULT';
 story2.story = { name: 'with ERROR!' };

--- a/examples/marko-cli/src/stories/stopwatch.stories.js
+++ b/examples/marko-cli/src/stories/stopwatch.stories.js
@@ -2,6 +2,9 @@ import StopWatch from '../components/stop-watch/index.marko';
 
 export default {
   title: 'Main|StopWatch',
+  parameters: {
+    component: StopWatch,
+  },
 };
 
-export const Simple = () => ({ template: StopWatch });
+export const Simple = () => ({ component: StopWatch });

--- a/examples/marko-cli/src/stories/stopwatch.stories.js
+++ b/examples/marko-cli/src/stories/stopwatch.stories.js
@@ -2,9 +2,6 @@ import StopWatch from '../components/stop-watch/index.marko';
 
 export default {
   title: 'Main|StopWatch',
-  parameters: {
-    component: StopWatch,
-  },
 };
 
-export const Simple = () => StopWatch.renderSync({});
+export const Simple = () => ({ template: StopWatch });

--- a/examples/marko-cli/src/stories/welcome.stories.js
+++ b/examples/marko-cli/src/stories/welcome.stories.js
@@ -2,6 +2,9 @@ import Welcome from '../components/welcome/index.marko';
 
 export default {
   title: 'Main|Welcome',
+  parameters: {
+    component: Welcome,
+  },
 };
 
-export const welcome = () => ({ template: Welcome });
+export const welcome = () => ({ component: Welcome });

--- a/examples/marko-cli/src/stories/welcome.stories.js
+++ b/examples/marko-cli/src/stories/welcome.stories.js
@@ -2,9 +2,6 @@ import Welcome from '../components/welcome/index.marko';
 
 export default {
   title: 'Main|Welcome',
-  parameters: {
-    component: Welcome,
-  },
 };
 
-export const welcome = () => Welcome.renderSync({});
+export const welcome = () => ({ template: Welcome });

--- a/lib/cli/generators/MARKO/template/stories/index.stories.js
+++ b/lib/cli/generators/MARKO/template/stories/index.stories.js
@@ -1,4 +1,4 @@
 import { storiesOf } from '@storybook/marko';
 import Welcome from './components/welcome/index.marko';
 
-storiesOf('Welcome', module).add('welcome', () => ({ template: Welcome }));
+storiesOf('Welcome', module).add('welcome', () => ({ component: Welcome }));

--- a/lib/cli/generators/MARKO/template/stories/index.stories.js
+++ b/lib/cli/generators/MARKO/template/stories/index.stories.js
@@ -1,4 +1,4 @@
 import { storiesOf } from '@storybook/marko';
 import Welcome from './components/welcome/index.marko';
 
-storiesOf('Welcome', module).add('welcome', () => Welcome.renderSync({}));
+storiesOf('Welcome', module).add('welcome', () => ({ template: Welcome }));


### PR DESCRIPTION
Issue:

Currently the Marko API for stories is to return a render result. This limits the ability for stories to be efficiently rerendered while maintaining state and also locks in users to a specific render API for Marko.

## What I did

This PR adds a deprecation warning for the old api of returning the `renderSync` result of a component, and now accepts an object result with the template to render and the input for the template similar to the `vue`, `angular`, `svelte` and some other implementations.

With this change I was able to keep track of the currently rendered component instance and only destroy the existing component if the constructor has been modified. This means that when using an addon like `knobs` the component is efficiently rerendered instead of destroyed. This also means that the entire lifecycle of the component is no longer rerun during updates which I think is more inline with what developers expect.

## How to test

I am unsure what the best way to test this is, however I have updated all examples I could find.
