### PR TITLE
Addon-info: only render Components in propTables

### DIFF
--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -319,7 +319,7 @@ class Story extends Component {
       return null;
     }
 
-    if (Array.isArray(propTables)) {
+    if (propTables) {
       propTables.forEach(type => {
         types.set(type, true);
       });

--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -319,11 +319,9 @@ class Story extends Component {
       return null;
     }
 
-    if (propTables) {
-      propTables.forEach(type => {
-        types.set(type, true);
-      });
-    }
+    propTables.forEach(type => {
+      types.set(type, true);
+    });
 
     // depth-first traverse and collect types
     const extract = innerChildren => {
@@ -348,8 +346,7 @@ class Story extends Component {
       if (
         typeof innerChildren === 'string' ||
         typeof innerChildren.type === 'string' ||
-        (Array.isArray(propTables) &&
-        propTables.length > 0 && // if propTables is set and has items in it
+        (propTables.length > 0 && // if propTables is set and has items in it
           !propTables.includes(innerChildren.type)) || // ignore types that are missing from propTables
         (Array.isArray(propTablesExclude) && // also ignore excluded types
           ~propTablesExclude.indexOf(innerChildren.type)) // eslint-disable-line no-bitwise

--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -311,7 +311,7 @@ class Story extends Component {
     const { stylesheet } = this.state;
     const types = new Map();
 
-    if (propTables === null) {
+    if (!propTables) {
       return null;
     }
 
@@ -319,7 +319,7 @@ class Story extends Component {
       return null;
     }
 
-    if (propTables) {
+    if (Array.isArray(propTables)) {
       propTables.forEach(type => {
         types.set(type, true);
       });
@@ -348,6 +348,9 @@ class Story extends Component {
       if (
         typeof innerChildren === 'string' ||
         typeof innerChildren.type === 'string' ||
+        (Array.isArray(propTables) &&
+        propTables.length > 0 && // if propTables is set and has items in it
+          !propTables.includes(innerChildren.type)) || // ignore types that are missing from propTables
         (Array.isArray(propTablesExclude) && // also ignore excluded types
           ~propTablesExclude.indexOf(innerChildren.type)) // eslint-disable-line no-bitwise
       ) {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/7254

The [`propTables`](https://github.com/storybookjs/storybook/blob/next/addons/info/README.md) config property doesn't behave as expected.

From the README:
```
/**
   * Components used in story
   * Displays Prop Tables with these components
   * @default []
   */
  propTables: Array<React.ComponentType>,
```

Most of my stories use a `<ThemeProvider/>` and `<Box/>` as a story wrapper, and they always show up in the prop tables, which is not desired. This property seems like it is supposed to be an inclusive list of components to show in propTables, but it currently doesn't work. 

## What I did

Added a check to see if `propTables` is an array with at least one item in it, and if it is, only include story children in rendered prop tables that are in the `propTables` array.

> Note - There are no existing tests that render prop tables based on `propTables` having been set in the info config, with multiple different components in the test story.

## How to test

- Is this testable with Jest or Chromatic screenshots?
No
- Does this need a new example in the kitchen sink apps?
No
- Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
