### PR TITLE
Add 'Start App' process after run storybook

### DIFF
--- a/docs/src/pages/guides/guide-react-native/index.md
+++ b/docs/src/pages/guides/guide-react-native/index.md
@@ -204,6 +204,9 @@ Finally:
 npm run storybook
 ```
 
+### Start App
+To see your Storybook stories on the device, you should start your mobile app for the <platform> of your choice (typically ios or android). (Note that due to an implementation detail, your stories will only show up in the left pane of your browser window after your device has connected to this storybook server.)
+
 ### Historical notes
 
 Some context may be useful if you've used older versions of Storybook for RN and find these instructions confusing.


### PR DESCRIPTION
Hello i am try to install react native storybook.

Then I was confused because the story did not rise on the left penel.

How about that 'Start App' Process after npm run storybook for Storybook starter.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
