### PR TITLE
Addon-knobs: enable Typescript `strict` flag

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@storybook/addons": "5.2.0-beta.5",
+    "@storybook/api": "5.2.0-beta.5",
     "@storybook/client-api": "5.2.0-beta.5",
     "@storybook/components": "5.2.0-beta.5",
     "@storybook/core-events": "5.2.0-beta.5",

--- a/addons/knobs/src/KnobManager.ts
+++ b/addons/knobs/src/KnobManager.ts
@@ -54,11 +54,11 @@ interface KnobManagerOptions {
 export default class KnobManager {
   knobStore = new KnobStore();
 
-  channel: Channel;
+  channel: Channel | undefined;
 
   options: KnobManagerOptions = {};
 
-  calling: boolean;
+  calling: boolean = false;
 
   setChannel(channel: Channel) {
     this.channel = channel;
@@ -139,7 +139,7 @@ export default class KnobManager {
     setTimeout(() => {
       this.calling = false;
       // emit to the channel and trigger a panel re-render
-      this.channel.emit(SET, { knobs: this.knobStore.getAll(), timestamp });
+      if (this.channel) this.channel.emit(SET, { knobs: this.knobStore.getAll(), timestamp });
     }, PANEL_UPDATE_INTERVAL);
   }
 }

--- a/addons/knobs/src/KnobStore.ts
+++ b/addons/knobs/src/KnobStore.ts
@@ -19,7 +19,7 @@ export default class KnobStore {
 
   callbacks: Callback[] = [];
 
-  timer: number;
+  timer: number | undefined;
 
   has(key: string) {
     return this.store[key] !== undefined;

--- a/addons/knobs/src/KnobStore.ts
+++ b/addons/knobs/src/KnobStore.ts
@@ -19,7 +19,7 @@ export default class KnobStore {
 
   callbacks: Callback[] = [];
 
-  timer: NodeJS.Timeout;
+  timer: number;
 
   has(key: string) {
     return this.store[key] !== undefined;
@@ -36,7 +36,7 @@ export default class KnobStore {
     if (this.timer) {
       clearTimeout(this.timer);
     }
-    this.timer = setTimeout(callAll, 50, this.callbacks);
+    this.timer = setTimeout(callAll, 50, this.callbacks) as number;
   }
 
   get(key: string) {

--- a/addons/knobs/src/__types__/knob-test-cases.ts
+++ b/addons/knobs/src/__types__/knob-test-cases.ts
@@ -105,7 +105,10 @@ expectKnobOfType<string>(
   select('select with string array', ['yes', 'no'], 'yes'),
   select('select with string literal array', stringLiteralArray, stringLiteralArray[0]),
   select('select with readonly array', ['red', 'blue'] as const, 'red'),
-  select<ButtonVariant>('select with string enum options', ButtonVariant, ButtonVariant.primary),
+  select<ButtonVariant>('select with string enum options', ButtonVariant, ButtonVariant.primary)
+);
+
+expectKnobOfType<string | null>(
   select('select with null option', { a: 'Option', b: null }, null, groupId)
 );
 

--- a/addons/knobs/src/__types__/knob-test-cases.ts
+++ b/addons/knobs/src/__types__/knob-test-cases.ts
@@ -57,8 +57,8 @@ expectKnobOfType<number>(
 
 /** Radios knob */
 
-expectKnobOfType(
-  radios<string>(
+expectKnobOfType<string>(
+  radios(
     'radio with string values',
     {
       1100: '1100',
@@ -66,8 +66,12 @@ expectKnobOfType(
       3300: '3300',
     },
     '2200'
-  ),
-  radios<number>('radio with number values', { 3: 3, 7: 7, 23: 23 }, 3),
+  )
+);
+
+expectKnobOfType<number>(radios('radio with number values', { 3: 3, 7: 7, 23: 23 }, 3));
+
+expectKnobOfType<string | number | null>(
   radios(
     'radio with mixed value',
     {
@@ -121,6 +125,10 @@ expectKnobOfType<number>(
   ),
   select('select with number array', [1, 2, 3, 4], 1),
   select('select with readonly number array', [1, 2] as const, 1)
+);
+
+expectKnobOfType<number | null>(
+  select('select with null option', { a: 1, b: null }, null, groupId)
 );
 
 /** Object knob */

--- a/addons/knobs/src/components/Panel.tsx
+++ b/addons/knobs/src/components/Panel.tsx
@@ -89,7 +89,7 @@ export default class KnobPanel extends PureComponent<KnobPanelProps> {
 
   mounted = false;
 
-  stopListeningOnStory: Function;
+  stopListeningOnStory!: Function;
 
   componentDidMount() {
     this.mounted = true;

--- a/addons/knobs/src/components/Panel.tsx
+++ b/addons/knobs/src/components/Panel.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from 'react';
+import React, { PureComponent, Fragment, Validator } from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
 import { document } from 'global';
@@ -42,11 +42,11 @@ interface KnobPanelProps {
   active: boolean;
   onReset?: object;
   api: {
-    on: Function;
-    off: Function;
-    emit: Function;
-    getQueryParam: Function;
-    setQueryParams: Function;
+    on: (action: string, fn: Function) => any;
+    off: (action: string, fn: Function) => any;
+    emit: (action: string, fn?: KnobStoreKnob) => any;
+    getQueryParam: (param: string) => any;
+    setQueryParams: (param: Record<string, KnobStoreKnob>) => any;
   };
 }
 
@@ -60,13 +60,26 @@ interface KnobPanelOptions {
 
 export default class KnobPanel extends PureComponent<KnobPanelProps> {
   static propTypes = {
-    active: PropTypes.bool.isRequired,
-    onReset: PropTypes.object, // eslint-disable-line
+    active: PropTypes.bool.isRequired as Validator<KnobPanelProps['active']>,
+    onReset: PropTypes.object as Validator<KnobPanelProps['onReset']>, // eslint-disable-line
     api: PropTypes.shape({
       on: PropTypes.func,
+      off: PropTypes.func,
+      emit: PropTypes.func,
       getQueryParam: PropTypes.func,
       setQueryParams: PropTypes.func,
-    }).isRequired,
+    }).isRequired as Validator<Partial<KnobPanelProps['api']>>,
+  };
+
+  static defaultProps: KnobPanelProps = {
+    active: true,
+    api: {
+      on: () => {},
+      off: () => {},
+      emit: () => {},
+      getQueryParam: () => {},
+      setQueryParams: () => {},
+    },
   };
 
   state: KnobPanelState = {

--- a/addons/knobs/src/components/Panel.tsx
+++ b/addons/knobs/src/components/Panel.tsx
@@ -14,6 +14,7 @@ import {
   Link,
   ScrollArea,
 } from '@storybook/components';
+import { API } from '@storybook/api';
 import { RESET, SET, CHANGE, SET_OPTIONS, CLICK } from '../shared';
 
 import { getKnobControl } from './types';
@@ -41,13 +42,7 @@ interface PanelKnobGroups {
 interface KnobPanelProps {
   active: boolean;
   onReset?: object;
-  api: {
-    on: (action: string, fn: Function) => any;
-    off: (action: string, fn: Function) => any;
-    emit: (action: string, fn?: KnobStoreKnob) => any;
-    getQueryParam: (param: string) => any;
-    setQueryParams: (param: Record<string, KnobStoreKnob>) => any;
-  };
+  api: Pick<API, 'on' | 'off' | 'emit' | 'getQueryParam' | 'setQueryParams'>;
 }
 
 interface KnobPanelState {
@@ -68,16 +63,16 @@ export default class KnobPanel extends PureComponent<KnobPanelProps> {
       emit: PropTypes.func,
       getQueryParam: PropTypes.func,
       setQueryParams: PropTypes.func,
-    }).isRequired as Validator<Partial<KnobPanelProps['api']>>,
+    }).isRequired as Validator<KnobPanelProps['api']>,
   };
 
   static defaultProps: KnobPanelProps = {
     active: true,
     api: {
-      on: () => {},
+      on: () => () => {},
       off: () => {},
       emit: () => {},
-      getQueryParam: () => {},
+      getQueryParam: () => undefined,
       setQueryParams: () => {},
     },
   };

--- a/addons/knobs/src/components/PropForm.tsx
+++ b/addons/knobs/src/components/PropForm.tsx
@@ -1,4 +1,4 @@
-import React, { Component, WeakValidationMap, ComponentType, Requireable } from 'react';
+import React, { Component, ComponentType, Validator } from 'react';
 import PropTypes from 'prop-types';
 
 import { Form } from '@storybook/components';
@@ -7,8 +7,8 @@ import { KnobStoreKnob } from '../KnobStore';
 
 interface PropFormProps {
   knobs: KnobStoreKnob[];
-  onFieldChange: Function;
-  onFieldClick: Function;
+  onFieldChange: (changedKnob: KnobStoreKnob) => void;
+  onFieldClick: (knob: KnobStoreKnob) => void;
 }
 
 const InvalidType = () => <span>Invalid Type</span>;
@@ -18,24 +18,25 @@ export default class PropForm extends Component<PropFormProps> {
 
   static defaultProps = {
     knobs: [] as KnobStoreKnob[],
+    onFieldChange: () => {},
+    onFieldClick: () => {},
   };
 
-  static propTypes: WeakValidationMap<PropFormProps> = {
-    // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
+  static propTypes = {
     knobs: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string,
         value: PropTypes.any,
       })
-    ).isRequired as Requireable<any[]>,
-    onFieldChange: PropTypes.func.isRequired,
-    onFieldClick: PropTypes.func.isRequired,
+    ).isRequired as Validator<PropFormProps['knobs']>,
+    onFieldChange: PropTypes.func.isRequired as Validator<PropFormProps['onFieldChange']>,
+    onFieldClick: PropTypes.func.isRequired as Validator<PropFormProps['onFieldClick']>,
   };
 
   makeChangeHandler(name: string, type: string) {
     const { onFieldChange } = this.props;
     return (value = '') => {
-      const change = { name, type, value };
+      const change: KnobStoreKnob = { name, type, value } as any;
 
       onFieldChange(change);
     };

--- a/addons/knobs/src/components/types/Array.tsx
+++ b/addons/knobs/src/components/types/Array.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { ChangeEvent, Component, WeakValidationMap } from 'react';
+import React, { ChangeEvent, Component, Validator } from 'react';
 
 import { Form } from '@storybook/components';
 import { KnobControlConfig, KnobControlProps } from './types';
@@ -27,14 +27,13 @@ export default class ArrayType extends Component<ArrayTypeProps> {
     onChange: (value: ArrayTypeKnobValue) => value,
   };
 
-  static propTypes: WeakValidationMap<ArrayTypeProps> = {
-    // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
+  static propTypes = {
     knob: PropTypes.shape({
       name: PropTypes.string,
       value: PropTypes.array,
       separator: PropTypes.string,
-    }) as any,
-    onChange: PropTypes.func,
+    }) as Validator<ArrayTypeProps['knob']>,
+    onChange: PropTypes.func as Validator<ArrayTypeProps['onChange']>,
   };
 
   static serialize = (value: ArrayTypeKnobValue) => value;

--- a/addons/knobs/src/components/types/Boolean.tsx
+++ b/addons/knobs/src/components/types/Boolean.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, Validator } from 'react';
 
 import { styled } from '@storybook/theming';
 import { KnobControlConfig, KnobControlProps } from './types';
@@ -45,12 +45,11 @@ BooleanType.defaultProps = {
 };
 
 BooleanType.propTypes = {
-  // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
   knob: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.bool,
-  }) as any,
-  onChange: PropTypes.func,
+  }) as Validator<BooleanTypeProps['knob']>,
+  onChange: PropTypes.func as Validator<BooleanTypeProps['onChange']>,
 };
 
 BooleanType.serialize = serialize;

--- a/addons/knobs/src/components/types/Button.tsx
+++ b/addons/knobs/src/components/types/Button.tsx
@@ -27,14 +27,14 @@ const ButtonType: FunctionComponent<ButtonTypeProps> & {
 
 ButtonType.defaultProps = {
   knob: {} as any,
+  onClick: () => {},
 };
 
 ButtonType.propTypes = {
-  // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
   knob: PropTypes.shape({
     name: PropTypes.string,
-  }).isRequired as Validator<any>,
-  onClick: PropTypes.func.isRequired,
+  }).isRequired as Validator<ButtonTypeProps['knob']>,
+  onClick: PropTypes.func.isRequired as Validator<ButtonTypeProps['onClick']>,
 };
 
 ButtonType.serialize = serialize;

--- a/addons/knobs/src/components/types/Checkboxes.tsx
+++ b/addons/knobs/src/components/types/Checkboxes.tsx
@@ -23,7 +23,7 @@ interface CheckboxesWrapperProps {
   isInline: boolean;
 }
 
-const CheckboxesWrapper = styled.div(({ isInline }: CheckboxesWrapperProps) =>
+const CheckboxesWrapper = styled.div<CheckboxesWrapperProps>(({ isInline }) =>
   isInline
     ? {
         display: 'flex',

--- a/addons/knobs/src/components/types/Checkboxes.tsx
+++ b/addons/knobs/src/components/types/Checkboxes.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ChangeEvent, WeakValidationMap } from 'react';
+import React, { Component, ChangeEvent, Validator } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
 import { KnobControlConfig, KnobControlProps } from './types';
@@ -55,15 +55,14 @@ export default class CheckboxesType extends Component<CheckboxesTypeProps, Check
     isInline: false,
   };
 
-  static propTypes: WeakValidationMap<CheckboxesTypeProps> = {
-    // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
+  static propTypes = {
     knob: PropTypes.shape({
       name: PropTypes.string,
       value: PropTypes.array,
       options: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-    }) as any,
-    onChange: PropTypes.func,
-    isInline: PropTypes.bool,
+    }) as Validator<CheckboxesTypeProps['knob']>,
+    onChange: PropTypes.func as Validator<CheckboxesTypeProps['onChange']>,
+    isInline: PropTypes.bool as Validator<CheckboxesTypeProps['isInline']>,
   };
 
   static serialize = (value: CheckboxesTypeKnobValue) => value;

--- a/addons/knobs/src/components/types/Color.tsx
+++ b/addons/knobs/src/components/types/Color.tsx
@@ -130,7 +130,7 @@ export default class ColorType extends Component<ColorTypeProps, ColorTypeState>
         {displayColorPicker ? (
           <Popover
             ref={e => {
-              this.popover = e;
+              if (e) this.popover = e;
             }}
           >
             <SketchPicker color={knob.value} onChange={this.handleChange} />

--- a/addons/knobs/src/components/types/Color.tsx
+++ b/addons/knobs/src/components/types/Color.tsx
@@ -67,7 +67,7 @@ export default class ColorType extends Component<ColorTypeProps, ColorTypeState>
     displayColorPicker: false,
   };
 
-  popover: HTMLDivElement;
+  popover!: HTMLDivElement;
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleWindowMouseDown);

--- a/addons/knobs/src/components/types/Color.tsx
+++ b/addons/knobs/src/components/types/Color.tsx
@@ -1,6 +1,6 @@
 import { document } from 'global';
 import PropTypes from 'prop-types';
-import React, { Component, WeakValidationMap } from 'react';
+import React, { Component, Validator } from 'react';
 import { SketchPicker, ColorResult } from 'react-color';
 
 import { styled } from '@storybook/theming';
@@ -46,13 +46,12 @@ const Popover = styled.div({
 });
 
 export default class ColorType extends Component<ColorTypeProps, ColorTypeState> {
-  static propTypes: WeakValidationMap<ColorTypeProps> = {
-    // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
+  static propTypes = {
     knob: PropTypes.shape({
       name: PropTypes.string,
       value: PropTypes.string,
-    }) as any,
-    onChange: PropTypes.func,
+    }) as Validator<ColorTypeProps['knob']>,
+    onChange: PropTypes.func as Validator<ColorTypeProps['onChange']>,
   };
 
   static defaultProps: ColorTypeProps = {

--- a/addons/knobs/src/components/types/Color.tsx
+++ b/addons/knobs/src/components/types/Color.tsx
@@ -36,7 +36,7 @@ const Swatch = styled.div<{}>(({ theme }) => ({
   borderRadius: '1rem',
 }));
 
-const ColorButton = styled(Button)(({ active }: ColorButtonProps) => ({
+const ColorButton = styled(Button)<ColorButtonProps>(({ active }) => ({
   zIndex: active ? 3 : 'unset',
 }));
 

--- a/addons/knobs/src/components/types/Date.tsx
+++ b/addons/knobs/src/components/types/Date.tsx
@@ -67,9 +67,9 @@ export default class DateType extends Component<DateTypeProps, DateTypeState> {
     valid: undefined,
   };
 
-  dateInput: HTMLInputElement;
+  dateInput!: HTMLInputElement;
 
-  timeInput: HTMLInputElement;
+  timeInput!: HTMLInputElement;
 
   componentDidUpdate() {
     const { knob } = this.props;

--- a/addons/knobs/src/components/types/Date.tsx
+++ b/addons/knobs/src/components/types/Date.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ChangeEvent, WeakValidationMap } from 'react';
+import React, { Component, ChangeEvent, Validator } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
 import { Form } from '@storybook/components';
@@ -45,13 +45,12 @@ export default class DateType extends Component<DateTypeProps, DateTypeState> {
     onChange: value => value,
   };
 
-  static propTypes: WeakValidationMap<DateTypeProps> = {
-    // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
+  static propTypes = {
     knob: PropTypes.shape({
       name: PropTypes.string,
       value: PropTypes.number,
-    }) as any,
-    onChange: PropTypes.func,
+    }) as Validator<DateTypeProps['knob']>,
+    onChange: PropTypes.func as Validator<DateTypeProps['onChange']>,
   };
 
   static serialize = (value: DateTypeKnobValue) =>

--- a/addons/knobs/src/components/types/Files.tsx
+++ b/addons/knobs/src/components/types/Files.tsx
@@ -39,9 +39,11 @@ const FilesType: FunctionComponent<FilesTypeProps> & {
     type="file"
     name={knob.name}
     multiple
-    onChange={(e: ChangeEvent<HTMLInputElement>) =>
-      Promise.all(Array.from(e.target.files).map(fileReaderPromise)).then(onChange)
-    }
+    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files) {
+        Promise.all(Array.from(e.target.files).map(fileReaderPromise)).then(onChange);
+      }
+    }}
     accept={knob.accept}
     size="flex"
   />

--- a/addons/knobs/src/components/types/Files.tsx
+++ b/addons/knobs/src/components/types/Files.tsx
@@ -1,5 +1,5 @@
 import { FileReader } from 'global';
-import PropTypes from 'prop-types';
+import PropTypes, { Validator } from 'prop-types';
 import React, { ChangeEvent, FunctionComponent } from 'react';
 import { styled } from '@storybook/theming';
 
@@ -53,11 +53,10 @@ FilesType.defaultProps = {
 };
 
 FilesType.propTypes = {
-  // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
   knob: PropTypes.shape({
     name: PropTypes.string,
-  }) as any,
-  onChange: PropTypes.func,
+  }) as Validator<FilesTypeProps['knob']>,
+  onChange: PropTypes.func as Validator<FilesTypeProps['onChange']>,
 };
 
 FilesType.serialize = serialize;

--- a/addons/knobs/src/components/types/Number.tsx
+++ b/addons/knobs/src/components/types/Number.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component, ChangeEvent } from 'react';
+import React, { Component, ChangeEvent, Validator } from 'react';
 
 import { styled } from '@storybook/theming';
 import { Form } from '@storybook/components';
@@ -63,8 +63,13 @@ export default class NumberType extends Component<NumberTypeProps> {
       min: PropTypes.number,
       max: PropTypes.number,
       step: PropTypes.number,
-    }).isRequired,
-    onChange: PropTypes.func.isRequired,
+    }).isRequired as Validator<NumberTypeProps['knob']>,
+    onChange: PropTypes.func.isRequired as Validator<NumberTypeProps['onChange']>,
+  };
+
+  static defaultProps: NumberTypeProps = {
+    knob: {} as any,
+    onChange: value => value,
   };
 
   static serialize = (value: NumberTypeKnobValue | null | undefined) =>

--- a/addons/knobs/src/components/types/Number.tsx
+++ b/addons/knobs/src/components/types/Number.tsx
@@ -20,7 +20,7 @@ export interface NumberTypeKnob
   value: NumberTypeKnobValue;
 }
 
-interface NumberTypeProps extends KnobControlProps<NumberTypeKnobValue> {
+interface NumberTypeProps extends KnobControlProps<NumberTypeKnobValue | null> {
   knob: NumberTypeKnob;
 }
 
@@ -87,7 +87,7 @@ export default class NumberType extends Component<NumberTypeProps> {
     const { onChange } = this.props;
     const { value } = event.target;
 
-    let parsedValue = Number(value);
+    let parsedValue: number | null = Number(value);
 
     if (Number.isNaN(parsedValue) || value === '') {
       parsedValue = null;

--- a/addons/knobs/src/components/types/Object.tsx
+++ b/addons/knobs/src/components/types/Object.tsx
@@ -35,7 +35,7 @@ class ObjectType<T> extends Component<ObjectTypeProps<T>> {
   static getDerivedStateFromProps<T>(
     props: ObjectTypeProps<T>,
     state: ObjectTypeState<T>
-  ): ObjectTypeState<T> {
+  ): ObjectTypeState<T> | null {
     if (!deepEqual(props.knob.value, state.json)) {
       try {
         return {
@@ -86,7 +86,7 @@ class ObjectType<T> extends Component<ObjectTypeProps<T>> {
     return (
       <Form.Textarea
         name={knob.name}
-        valid={failed ? 'error' : null}
+        valid={failed ? 'error' : undefined}
         value={value}
         onChange={this.handleChange}
         size="flex"
@@ -95,6 +95,6 @@ class ObjectType<T> extends Component<ObjectTypeProps<T>> {
   }
 }
 
-polyfill(ObjectType);
+polyfill(ObjectType as any);
 
 export default ObjectType;

--- a/addons/knobs/src/components/types/Object.tsx
+++ b/addons/knobs/src/components/types/Object.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ChangeEvent } from 'react';
+import React, { Component, ChangeEvent, Validator } from 'react';
 import PropTypes from 'prop-types';
 import deepEqual from 'fast-deep-equal';
 import { polyfill } from 'react-lifecycles-compat';
@@ -19,8 +19,13 @@ class ObjectType<T> extends Component<ObjectTypeProps<T>> {
     knob: PropTypes.shape({
       name: PropTypes.string,
       value: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-    }).isRequired,
-    onChange: PropTypes.func.isRequired,
+    }).isRequired as Validator<ObjectTypeProps<any>['knob']>,
+    onChange: PropTypes.func.isRequired as Validator<ObjectTypeProps<any>['onChange']>,
+  };
+
+  static defaultProps: ObjectTypeProps<any> = {
+    knob: {} as any,
+    onChange: value => value,
   };
 
   static serialize: { <T>(object: T): string } = object => JSON.stringify(object);

--- a/addons/knobs/src/components/types/Options.tsx
+++ b/addons/knobs/src/components/types/Options.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, Validator } from 'react';
 import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
-import { ValueType } from 'react-select/lib/types';
 import { styled } from '@storybook/theming';
 import { KnobControlConfig, KnobControlProps } from './types';
 
@@ -42,16 +41,15 @@ export interface OptionsTypeProps<T extends OptionsTypeKnobValue> extends KnobCo
   display: OptionsKnobOptionsDisplay;
 }
 
-// : React.ComponentType<ReactSelectProps>
 const OptionsSelect = styled(ReactSelect)({
   width: '100%',
   maxWidth: '300px',
   color: 'black',
 });
 
-type ReactSelectOnChangeFn<OptionType = OptionsSelectValueItem> = (
-  value: ValueType<OptionType>
-) => void;
+type ReactSelectOnChangeFn =
+  | { (v: OptionsSelectValueItem): void }
+  | { (v: OptionsSelectValueItem[]): void };
 
 interface OptionsSelectValueItem {
   value: any;

--- a/addons/knobs/src/components/types/Options.tsx
+++ b/addons/knobs/src/components/types/Options.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, Validator } from 'react';
 import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
 import { ValueType } from 'react-select/lib/types';
@@ -114,12 +114,11 @@ OptionsType.defaultProps = {
 };
 
 OptionsType.propTypes = {
-  // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
   knob: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
     options: PropTypes.object,
-  }) as any,
+  }) as Validator<OptionsTypeProps<any>['knob']>,
   display: PropTypes.oneOf<OptionsKnobOptionsDisplay>([
     'radio',
     'inline-radio',
@@ -127,8 +126,8 @@ OptionsType.propTypes = {
     'inline-check',
     'select',
     'multi-select',
-  ]),
-  onChange: PropTypes.func,
+  ]) as Validator<OptionsTypeProps<any>['display']>,
+  onChange: PropTypes.func as Validator<OptionsTypeProps<any>['onChange']>,
 };
 
 OptionsType.serialize = serialize;

--- a/addons/knobs/src/components/types/Radio.tsx
+++ b/addons/knobs/src/components/types/Radio.tsx
@@ -1,4 +1,4 @@
-import React, { Component, WeakValidationMap } from 'react';
+import React, { Component, Validator } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@storybook/theming';
 import { KnobControlConfig, KnobControlProps } from './types';
@@ -45,15 +45,14 @@ class RadiosType extends Component<RadiosTypeProps> {
     isInline: false,
   };
 
-  static propTypes: WeakValidationMap<RadiosTypeProps> = {
-    // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
+  static propTypes = {
     knob: PropTypes.shape({
       name: PropTypes.string,
       value: PropTypes.string,
       options: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-    }) as any,
-    onChange: PropTypes.func,
-    isInline: PropTypes.bool,
+    }) as Validator<RadiosTypeProps['knob']>,
+    onChange: PropTypes.func as Validator<RadiosTypeProps['onChange']>,
+    isInline: PropTypes.bool as Validator<RadiosTypeProps['isInline']>,
   };
 
   static serialize = (value: RadiosTypeKnobValue) => value;

--- a/addons/knobs/src/components/types/Radio.tsx
+++ b/addons/knobs/src/components/types/Radio.tsx
@@ -19,7 +19,7 @@ interface RadiosWrapperProps {
   isInline: boolean;
 }
 
-const RadiosWrapper = styled.div(({ isInline }: RadiosWrapperProps) =>
+const RadiosWrapper = styled.div<RadiosWrapperProps>(({ isInline }) =>
   isInline
     ? {
         display: 'flex',

--- a/addons/knobs/src/components/types/Radio.tsx
+++ b/addons/knobs/src/components/types/Radio.tsx
@@ -78,7 +78,7 @@ class RadiosType extends Component<RadiosTypeProps> {
           type="radio"
           id={id}
           name={name}
-          value={opts.value}
+          value={opts.value || undefined}
           onChange={e => onChange(e.target.value)}
           checked={value === knob.value}
         />

--- a/addons/knobs/src/components/types/Select.tsx
+++ b/addons/knobs/src/components/types/Select.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ChangeEvent } from 'react';
+import React, { FunctionComponent, ChangeEvent, Validator } from 'react';
 import PropTypes from 'prop-types';
 
 import { Form } from '@storybook/components';
@@ -63,13 +63,12 @@ SelectType.defaultProps = {
 };
 
 SelectType.propTypes = {
-  // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
   knob: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.any,
     options: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-  }) as any,
-  onChange: PropTypes.func,
+  }) as Validator<SelectTypeProps['knob']>,
+  onChange: PropTypes.func as Validator<SelectTypeProps['onChange']>,
 };
 
 SelectType.serialize = serialize;

--- a/addons/knobs/src/components/types/Select.tsx
+++ b/addons/knobs/src/components/types/Select.tsx
@@ -7,10 +7,10 @@ import { KnobControlConfig, KnobControlProps } from './types';
 export type SelectTypeKnobValue = string | number | null | undefined;
 
 export type SelectTypeOptionsProp<T extends SelectTypeKnobValue = SelectTypeKnobValue> =
-  | Record<string, T>
-  | Record<T, T[keyof T]>
-  | T[]
-  | readonly T[];
+  | Record<string | number, T>
+  | Record<Exclude<T, null | undefined>, T[keyof T]>
+  | Exclude<T, null | undefined>[]
+  | readonly Exclude<T, null | undefined>[];
 
 export interface SelectTypeKnob<T extends SelectTypeKnobValue = SelectTypeKnobValue>
   extends KnobControlConfig<T> {
@@ -31,10 +31,7 @@ const SelectType: FunctionComponent<SelectTypeProps> & {
 } = ({ knob, onChange }) => {
   const { options } = knob;
   const entries = Array.isArray(options)
-    ? options.reduce<Record<number, SelectTypeKnobValue>>(
-        (acc, k) => Object.assign(acc, { [k]: k }),
-        {}
-      )
+    ? options.reduce<Record<string, SelectTypeKnobValue>>((acc, k) => ({ ...acc, [k]: k }), {})
     : (options as Record<string, SelectTypeKnobValue>);
 
   const selectedKey = Object.keys(entries).find(k => entries[k] === knob.value);

--- a/addons/knobs/src/components/types/Text.tsx
+++ b/addons/knobs/src/components/types/Text.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component, ChangeEvent, WeakValidationMap } from 'react';
+import React, { Component, ChangeEvent, Validator } from 'react';
 
 import { Form } from '@storybook/components';
 import { KnobControlConfig, KnobControlProps } from './types';
@@ -14,13 +14,12 @@ export default class TextType extends Component<TextTypeProps> {
     onChange: value => value,
   };
 
-  static propTypes: WeakValidationMap<TextTypeProps> = {
-    // TODO: remove `any` once DefinitelyTyped/DefinitelyTyped#31280 has been resolved
+  static propTypes = {
     knob: PropTypes.shape({
       name: PropTypes.string,
       value: PropTypes.string,
-    }) as any,
-    onChange: PropTypes.func,
+    }) as Validator<TextTypeProps['knob']>,
+    onChange: PropTypes.func as Validator<TextTypeProps['onChange']>,
   };
 
   static serialize = (value: TextTypeKnobValue) => value;

--- a/addons/knobs/src/components/types/index.ts
+++ b/addons/knobs/src/components/types/index.ts
@@ -37,7 +37,7 @@ export type KnobControlType = ComponentType<any> & {
 };
 
 // Note: this is a utility function that helps in resolving types more orderly
-export const getKnobControl = (type: KnobType): KnobControlType => KnobControls[type];
+export const getKnobControl = (type: KnobType) => KnobControls[type] as KnobControlType;
 
 export { TextTypeKnob } from './Text';
 export { NumberTypeKnob, NumberTypeKnobOptions } from './Number';

--- a/addons/knobs/src/converters.ts
+++ b/addons/knobs/src/converters.ts
@@ -16,7 +16,7 @@ export const converters = {
   },
   toBoolean: (value: any): boolean => value === 'true',
   toDate: (value: any): number => new Date(value).getTime() || new Date().getTime(),
-  toFloat: (value: any): number => (value === '' ? null : parseFloat(value)),
+  toFloat: (value: any): number | null => (value === '' ? null : parseFloat(value)),
 };
 
 export const serializers = {

--- a/addons/knobs/src/index.ts
+++ b/addons/knobs/src/index.ts
@@ -98,7 +98,7 @@ export function array(name: string, value: ArrayTypeKnobValue, separator = ',', 
 }
 
 export function date(name: string, value = new Date(), groupId?: string) {
-  const proxyValue = value ? value.getTime() : null;
+  const proxyValue = value ? value.getTime() : new Date().getTime();
   return manager.knob(name, { type: 'date', value: proxyValue, groupId });
 }
 

--- a/addons/knobs/src/registerKnobs.ts
+++ b/addons/knobs/src/registerKnobs.ts
@@ -46,7 +46,7 @@ function knobChanged(change: KnobStoreKnob) {
 
 function knobClicked(clicked: KnobStoreKnob) {
   const knobOptions = knobStore.get(clicked.name);
-  if (knobOptions.callback() !== false) {
+  if (knobOptions.callback && knobOptions.callback() !== false) {
     forceReRender();
   }
 }

--- a/addons/knobs/tsconfig.json
+++ b/addons/knobs/tsconfig.json
@@ -4,7 +4,6 @@
     "rootDir": "./src",
     "types": ["webpack-env"],
     "strict": true,
-    "strictPropertyInitialization": false,
     "noUnusedLocals": true
   },
   "include": ["src/**/*"],

--- a/addons/knobs/tsconfig.json
+++ b/addons/knobs/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "types": ["webpack-env"]
+    "types": ["webpack-env"],
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "noUnusedLocals": true
   },
   "include": ["src/**/*"],
   "exclude": ["src/__tests__/**/*"]


### PR DESCRIPTION
Issue: People using Typescript with the `strict` flag on may see some type mismatches due to the added type sensitivity, e.g., https://github.com/storybookjs/storybook/issues/7348#issuecomment-512846401.

## What I did

- Enables TS's `strict` flag in the knobs add-on (Enabling for the entire storybook repo is a tall order and can be done incrementally over time).
- Leverages the types from `@storybook/api` to align function definitions (see `Panel.tsx`).
- Removes former uses of `any` around PropTypes.
- Generally reconciles types to meet strict check requirements

## How to test

There should be no noticeable runtime changes, only a better experience for users using Typescript in `strict` mode. I've updated `__types__/knob-test-cases.ts` to more explicitly reflect some of the nullable scenarios.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
