### PR TITLE
fix(ondevice-knobs): graceful fail on missing default

### DIFF
--- a/addons/ondevice-knobs/src/types/Select.js
+++ b/addons/ondevice-knobs/src/types/Select.js
@@ -19,7 +19,8 @@ class SelectType extends React.Component {
 
     const options = this.getOptions(knob);
 
-    const selected = options.filter(({ key }) => knob.value === key)[0].label;
+    const active = options.filter(({ key }) => knob.value === key)[0];
+    const selected = active && active.label;
 
     return (
       <View>


### PR DESCRIPTION
Issue: #7532

## What I did

Simply make sure there's a default we can find.
