### PR TITLE
Core: Don't allow duplicate titles

### DIFF
--- a/docs/src/pages/basics/writing-stories/index.md
+++ b/docs/src/pages/basics/writing-stories/index.md
@@ -36,7 +36,7 @@ This is what you'll see in Storybook:
 
 ![Basic stories](../static/basic-stories.png)
 
-The named exports define the Button's stories, and the `default` export defines metadata that applies to the group. In this case, the `component` is `Button`. The title determines the title of the group in Storybook's left-hand navigation panel. In this case it's located at the top level, but typically it's [positioned within the story hierarchy](#story-hierarchy).
+The named exports define the Button's stories, and the `default` export defines metadata that applies to the group. In this case, the `component` is `Button`. The `title` determines the title of the group in Storybook's left-hand navigation panel and should be unique, i.e. not re-used across files. In this case it's located at the top level, but typically it's [positioned within the story hierarchy](#story-hierarchy).
 
 This example is written in Storybook's [Module format](../../formats/module-story-format/). Storybook also supports:
 

--- a/docs/src/pages/formats/module-story-format/index.md
+++ b/docs/src/pages/formats/module-story-format/index.md
@@ -11,7 +11,7 @@ The module format is supported in all frameworks except React Native, where you 
 
 ## Default export
 
-The default export defines metadata about your component, including the `component` itself, its `title` (where it will show up in the [navigation UI story hierarchy](../../basics/writing-stories/#story-hierarchy)), [decorators](../../basics/writing-stories/#decorators), and [parameters](../../basics/writing-stories/#parameters).
+The default export defines metadata about your component, including the `component` itself, its `title` (where it will show up in the [navigation UI story hierarchy](../../basics/writing-stories/#story-hierarchy)), [decorators](../../basics/writing-stories/#decorators), and [parameters](../../basics/writing-stories/#parameters). `title` should be unique, i.e. not re-used across files.
 
 ```js
 import MyComponent from './MyComponent';

--- a/examples/official-storybook/stories/demo/button.stories.js
+++ b/examples/official-storybook/stories/demo/button.stories.js
@@ -31,5 +31,5 @@ export const withCounter = () =>
   });
 
 withCounter.story = {
-  name: 'with coumter',
+  name: 'with counter',
 };

--- a/examples/official-storybook/stories/demo/button.stories.mdx
+++ b/examples/official-storybook/stories/demo/button.stories.mdx
@@ -26,7 +26,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 ## Counter w/ Code
 
 <Preview>
-  <Story name="with coumter">
+  <Story name="with counter">
     {React.createElement(() => {
       const [counter, setCounter] = useState(0);
       const label = `Testing: ${counter}`;

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -356,7 +356,9 @@ export default function start(render, { decorateStory } = {}) {
       const { title: kindName, parameters: params, decorators: decos, component } = meta;
 
       if (loadedKinds.has(kindName)) {
-        throw new Error(`Duplicate kind: ${kindName} defined in multiple files`);
+        throw new Error(
+          `Duplicate title '${kindName}' used in multiple files; use unique titles or combine '${kindName}' stories into a single file.`
+        );
       }
       loadedKinds.add(kindName);
 

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -306,6 +306,9 @@ export default function start(render, { decorateStory } = {}) {
 
   let previousExports = new Set();
   const loadStories = (loadable, framework) => () => {
+    // Make sure we don't try to define a kind more than once within the same load
+    const loadedKinds = new Set();
+
     let reqs = null;
     if (Array.isArray(loadable)) {
       reqs = loadable;
@@ -351,6 +354,11 @@ export default function start(render, { decorateStory } = {}) {
 
       const { default: meta, ...exports } = fileExports;
       const { title: kindName, parameters: params, decorators: decos, component } = meta;
+
+      if (loadedKinds.has(kindName)) {
+        throw new Error(`Duplicate kind: ${kindName} defined in multiple files`);
+      }
+      loadedKinds.add(kindName);
 
       // We pass true here to avoid the warning about HMR. It's cool clientApi, we got this
       const kind = clientApi.storiesOf(kindName, true);


### PR DESCRIPTION
Issue: #7493

## What I did

Restrict load function to unique "titles" per file & document

## How to test

Edit a title in one file to match another, and load the storybook.

NOTE: it's currently possible to edit the title on HMR and sneak it through (it replaces the old one). But throws an error as intended on clean start. I think this is good enough.
