### PR TITLE
Fix attribute warning on shortcuts button clicked

### DIFF
--- a/lib/components/src/tooltip/ListItem.tsx
+++ b/lib/components/src/tooltip/ListItem.tsx
@@ -8,8 +8,9 @@ export interface TitleProps {
   loading?: boolean;
   disabled?: boolean;
 }
-
-const Title = styled.span<TitleProps>(
+const Title = styled(({ loading, disabled, active, ...rest }: TitleProps) => (
+  <span {...rest}></span>
+))<{ active: boolean; loading: boolean; disabled: boolean }>(
   ({ theme }) => ({
     color: theme.color.defaultText,
     // Previously was theme.typography.weight.normal but this weight does not exists in Theme
@@ -208,14 +209,18 @@ const ListItem: FunctionComponent<ListItemProps> = ({
   ...rest
 }) => {
   const itemProps = getItemProps(onClick, href, LinkWrapper);
-  const commonProps = { active, disabled, loading };
+  const commonProps = { active, disabled };
 
   return (
     <Item {...commonProps} {...rest} {...itemProps}>
       {left && <Left {...commonProps}>{left}</Left>}
       {title || center ? (
         <Center>
-          {title && <Title {...commonProps}>{title}</Title>}
+          {title && (
+            <Title {...commonProps} loading={loading}>
+              {title}
+            </Title>
+          )}
           {center && <CenterText {...commonProps}>{center}</CenterText>}
         </Center>
       ) : null}

--- a/lib/components/src/tooltip/ListItem.tsx
+++ b/lib/components/src/tooltip/ListItem.tsx
@@ -8,7 +8,7 @@ export interface TitleProps {
   loading?: boolean;
   disabled?: boolean;
 }
-const Title = styled(({ loading, disabled, active, ...rest }: TitleProps) => (
+const Title = styled(({ active, loading, disabled, ...rest }: TitleProps) => (
   <span {...rest}></span>
 ))<{ active: boolean; loading: boolean; disabled: boolean }>(
   ({ theme }) => ({


### PR DESCRIPTION
Issue: #7219 

## What I did

-  Pass `loading` value to where it needs only(here `<Title />` component)
-  Pass original attributes only to `<span />`

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
