### PR TITLE
Ondevice-knobs: Expose withKnobs from addon-knobs

### DIFF
--- a/addons/ondevice-knobs/src/index.js
+++ b/addons/ondevice-knobs/src/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import addons from '@storybook/addons';
 import Panel from './panel';
 
+export { withKnobs } from '@storybook/addon-knobs';
+
 export function register() {
   addons.register('RNKNOBS', () => {
     const channel = addons.getChannel();


### PR DESCRIPTION
Issue: #7163

## What I did
I exposed `withKnobs` of `@storybook/addon-knobs` from `@storybook/addon-ondevice-knobs`. @Gongreg Is this what you were expecting? 
