### PR TITLE
#7563 Support TSX in config folder

### DIFF
--- a/app/react/src/server/__mocks__/mockRules.ts
+++ b/app/react/src/server/__mocks__/mockRules.ts
@@ -1,7 +1,7 @@
 export default [
   { parser: { requireEnsure: false } },
   {
-    test: /\.(js|mjs|jsx)$/,
+    test: /\.(js|mjs|jsx|ts|tsx)$/,
     enforce: 'pre',
     use: [
       {
@@ -10,7 +10,6 @@ export default [
           eslintPath: '/mock_folder/node_modules/eslint/lib/api.js',
           baseConfig: {
             extends: ['/mock_folder/node_modules/eslint-config-react-app/index.js'],
-            settings: { react: { version: '999.999.999' } },
           },
           ignore: false,
           useEslintrc: false,
@@ -44,7 +43,7 @@ export default [
               {
                 loaderMap: {
                   svg: {
-                    ReactComponent: '@svgr/webpack?-prettier,-svgo![path]',
+                    ReactComponent: '@svgr/webpack?-svgo,+titleProp,+ref![path]',
                   },
                 },
               },

--- a/app/react/src/server/cra-config.test.ts
+++ b/app/react/src/server/cra-config.test.ts
@@ -83,18 +83,16 @@ exit $ret`
 
   describe('when used with TypeScript', () => {
     it('should return the correct config', () => {
-      // Normalise the return, as we know our new rules object will be an array, whereas a string is expected.
       const rules = getTypeScriptRules(mockRules, './.storybook');
-      const rulesObject = { ...rules[0], include: rules[0].include[0] };
-      expect(rulesObject).toMatchObject(mockRules[2].oneOf[1]);
+      expect(rules.length).toBe(2);
     });
 
     // Allows using TypeScript in the `.storybook` (or config) folder.
-    it('should add the Storybook config directory to `include`', () => {
+    it('should add the Storybook config directory to `include` for all TS related rules', () => {
       const rules = getTypeScriptRules(mockRules, './.storybook');
-      expect(rules[0].include.findIndex((string: string) => string.includes('.storybook'))).toEqual(
-        1
-      );
+      expect(
+        rules.every(rule => rule.include.find(filePath => filePath.includes('.storybook')))
+      ).toBe(true);
     });
 
     it('should get the baseUrl from a tsconfig.json', () => {


### PR DESCRIPTION
Resolves #7201.

## What I did

I have updated CRA mocked rules as per CRA 3.0.1 . Tests started to fail, because there are now 2 TS related rules. I rewrote 2 tests since they were not really testing anything and fixed the method to add proper paths to loaders