### PR TITLE
React: Add hooks support to stories

### DIFF
--- a/app/react/src/client/preview/render.tsx
+++ b/app/react/src/client/preview/render.tsx
@@ -15,14 +15,14 @@ function render(node: React.ReactElement, el: Element) {
 }
 
 export default function renderMain({
-  storyFn,
+  storyFn: StoryFn,
   selectedKind,
   selectedStory,
   showMain,
   showError,
   forceRender,
 }: RenderMainArgs) {
-  const element = storyFn();
+  const element = <StoryFn />;
 
   if (!element) {
     showError({

--- a/examples/official-storybook/stories/demo/button.stories.js
+++ b/examples/official-storybook/stories/demo/button.stories.js
@@ -23,12 +23,11 @@ withSomeEmoji.story = {
   name: 'with some emoji',
 };
 
-export const withCounter = () =>
-  React.createElement(() => {
-    const [counter, setCounter] = useState(0);
-    const label = `Testing: ${counter}`;
-    return <Button onClick={() => setCounter(counter + 1)}>{label}</Button>;
-  });
+export const withCounter = () => {
+  const [counter, setCounter] = useState(0);
+  const label = `Testing: ${counter}`;
+  return <Button onClick={() => setCounter(counter + 1)}>{label}</Button>;
+};
 
 withCounter.story = {
   name: 'with counter',

--- a/examples/official-storybook/stories/demo/button.stories.mdx
+++ b/examples/official-storybook/stories/demo/button.stories.mdx
@@ -27,10 +27,10 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 
 <Preview>
   <Story name="with counter">
-    {React.createElement(() => {
+    {() => {
       const [counter, setCounter] = useState(0);
       const label = `Testing: ${counter}`;
       return <Button onClick={() => setCounter(counter + 1)}>{label}</Button>;
-    })}
+    }}
   </Story>
 </Preview>

--- a/examples/official-storybook/stories/demo/csf-embedding.test.js
+++ b/examples/official-storybook/stories/demo/csf-embedding.test.js
@@ -1,5 +1,6 @@
+import React from 'react';
 import { render, fireEvent } from 'react-testing-library';
-import { withText, withCounter } from './button.stories';
+import { withText as WithText, withCounter as WithCounter } from './button.stories';
 
 const mockAction = jest.fn();
 jest.mock('@storybook/addon-actions', () => ({
@@ -8,13 +9,13 @@ jest.mock('@storybook/addon-actions', () => ({
 
 describe('module story embedding', () => {
   it('should test actions', () => {
-    const comp = render(withText());
+    const comp = render(<WithText />);
     fireEvent.click(comp.getByText('Hello Button'));
     expect(mockAction).toHaveBeenCalled();
   });
 
   it('should test story state', () => {
-    const comp = render(withCounter());
+    const comp = render(<WithCounter />);
     fireEvent.click(comp.getByText('Testing: 0'));
     expect(comp.getByText('Testing: 1')).toBeTruthy();
   });


### PR DESCRIPTION
Issue: #5721 #6925 #4691 

## What I did

Invoke story function as `React.createElement` in `react` renderer to support hooks in stories.

## How to test

See modified stories in `official-storybook`
