### PR TITLE
Fix(cli): error if angular.json not specify default project

### DIFF
--- a/lib/cli/generators/ANGULAR/angular-helpers.js
+++ b/lib/cli/generators/ANGULAR/angular-helpers.js
@@ -35,3 +35,8 @@ export function editStorybookTsConfig(tsconfigPath) {
   tsConfigJson = setStorybookTsconfigExtendsPath(tsConfigJson);
   writeFileAsJson(tsconfigPath, tsConfigJson);
 }
+
+export function checkForDefaultProjectExist() {
+  const angularJson = readFileAsJson('angular.json');
+  return angularJson && !!angularJson.defaultProject;
+}

--- a/lib/cli/generators/ANGULAR/angular-helpers.js
+++ b/lib/cli/generators/ANGULAR/angular-helpers.js
@@ -36,7 +36,7 @@ export function editStorybookTsConfig(tsconfigPath) {
   writeFileAsJson(tsconfigPath, tsConfigJson);
 }
 
-export function checkForDefaultProjectExist() {
+export function isDefaultProjectSet() {
   const angularJson = readFileAsJson('angular.json');
   return angularJson && !!angularJson.defaultProject;
 }

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -1,7 +1,7 @@
 import fse from 'fs-extra';
 import path from 'path';
 import {
-  checkForDefaultProjectExist,
+  isDefaultProjectSet,
   editStorybookTsConfig,
   getAngularAppTsConfigJson,
   getAngularAppTsConfigPath,
@@ -71,7 +71,7 @@ function editAngularAppTsConfig() {
 }
 
 export default async npmOptions => {
-  if (!checkForDefaultProjectExist()) {
+  if (!isDefaultProjectSet()) {
     throw new Error('the default project is not specified in angular.json');
   }
 

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -1,6 +1,7 @@
 import fse from 'fs-extra';
 import path from 'path';
 import {
+  checkForDefaultProjectExist,
   editStorybookTsConfig,
   getAngularAppTsConfigJson,
   getAngularAppTsConfigPath,
@@ -70,6 +71,10 @@ function editAngularAppTsConfig() {
 }
 
 export default async npmOptions => {
+  if (!checkForDefaultProjectExist()) {
+    throw new Error('the default project is not specified in angular.json');
+  }
+
   fse.copySync(path.resolve(__dirname, 'template/'), '.', { overwrite: true });
 
   await addDependencies(npmOptions);

--- a/lib/cli/generators/ANGULAR/index.js
+++ b/lib/cli/generators/ANGULAR/index.js
@@ -72,7 +72,9 @@ function editAngularAppTsConfig() {
 
 export default async npmOptions => {
   if (!isDefaultProjectSet()) {
-    throw new Error('the default project is not specified in angular.json');
+    throw new Error(
+      'Could not find a default project in your Angular workspace. Add a project and re-run the installation.'
+    );
   }
 
   fse.copySync(path.resolve(__dirname, 'template/'), '.', { overwrite: true });


### PR DESCRIPTION
Issue: #7442 

## What I did

I added a check for the presence of a default project to anuglar.json and if there is no default project, then I throw the error and complete the storybook initialization process.

## How to test

I am not sure how to test it and whether it should be tested. Now, it seems, CLI project supports only positive tests for different project types (Angular, React, ...).
