### PR TITLE
Addon-docs: Add DocsPage automagically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ scripts/storage
 htpasswd
 /false
 storybook-out
+/addons/docs/common/config-*

--- a/addons/docs/angular/config.js
+++ b/addons/docs/angular/config.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const { addParameters } = require('@storybook/angular');
+const { DocsPage } = require('@storybook/addon-docs/blocks');
+
+addParameters({
+  docs: DocsPage,
+});

--- a/addons/docs/angular/preset.js
+++ b/addons/docs/angular/preset.js
@@ -1,1 +1,1 @@
-module.exports = require('../common/preset');
+module.exports = require('../common/makePreset')('angular');

--- a/addons/docs/common/makePreset.js
+++ b/addons/docs/common/makePreset.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const common = require('./preset');
+
+module.exports = framework => {
+  const configModule = `${__dirname}/config-${framework}`;
+  const configContents = `
+const { addParameters } = require('@storybook/${framework}');
+const { DocsPage } = require('@storybook/addon-docs/blocks');
+
+addParameters({
+  docs: DocsPage,
+});
+  `.trim();
+  fs.writeFileSync(`${configModule}.js`, configContents);
+
+  function config(entry = []) {
+    return [configModule, ...entry];
+  }
+
+  return {
+    ...common,
+    config,
+  };
+};

--- a/addons/docs/common/makePreset.js
+++ b/addons/docs/common/makePreset.js
@@ -2,19 +2,11 @@ const fs = require('fs');
 const common = require('./preset');
 
 module.exports = framework => {
-  const configModule = `${__dirname}/config-${framework}`;
-  const configContents = `
-const { addParameters } = require('@storybook/${framework}');
-const { DocsPage } = require('@storybook/addon-docs/blocks');
-
-addParameters({
-  docs: DocsPage,
-});
-  `.trim();
-  fs.writeFileSync(`${configModule}.js`, configContents);
+  const frameworkConfig = `${__dirname}/../${framework}/config.js`;
+  const preconfig = fs.existsSync(frameworkConfig) ? [frameworkConfig] : [];
 
   function config(entry = []) {
-    return [configModule, ...entry];
+    return [...preconfig, ...entry];
   }
 
   return {

--- a/addons/docs/html/config.js
+++ b/addons/docs/html/config.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const { addParameters } = require('@storybook/html');
+const { DocsPage } = require('@storybook/addon-docs/blocks');
+
+addParameters({
+  docs: DocsPage,
+});

--- a/addons/docs/html/preset.js
+++ b/addons/docs/html/preset.js
@@ -1,1 +1,1 @@
-module.exports = require('../common/preset');
+module.exports = require('../common/makePreset')('html');

--- a/addons/docs/react/config.js
+++ b/addons/docs/react/config.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const { addParameters } = require('@storybook/react');
+const { DocsPage } = require('@storybook/addon-docs/blocks');
+
+addParameters({
+  docs: DocsPage,
+});

--- a/addons/docs/react/preset.js
+++ b/addons/docs/react/preset.js
@@ -1,1 +1,1 @@
-module.exports = require('../common/preset');
+module.exports = require('../common/makePreset')('react');

--- a/addons/docs/vue/config.js
+++ b/addons/docs/vue/config.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const { addParameters } = require('@storybook/vue');
+const { DocsPage } = require('@storybook/addon-docs/blocks');
+
+addParameters({
+  docs: DocsPage,
+});

--- a/addons/docs/vue/preset.js
+++ b/addons/docs/vue/preset.js
@@ -1,1 +1,1 @@
-module.exports = require('../common/preset');
+module.exports = require('../common/makePreset')('vue');

--- a/examples/angular-cli/.storybook/config.ts
+++ b/examples/angular-cli/.storybook/config.ts
@@ -1,6 +1,5 @@
 import { load, addParameters, addDecorator } from '@storybook/angular';
 import { withA11y } from '@storybook/addon-a11y';
-import { DocsPage } from '@storybook/addon-docs/blocks';
 import addCssWarning from '../src/cssWarning';
 
 addDecorator(withA11y);
@@ -13,7 +12,6 @@ addParameters({
       iframeHeight: '60px',
     },
   },
-  docs: DocsPage,
 });
 
 load(require.context('../src/stories', true, /\.stories\.(ts|mdx)$/), module);

--- a/examples/angular-cli/.storybook/presets.js
+++ b/examples/angular-cli/.storybook/presets.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    name: '@storybook/addon-docs/common/preset',
+    name: '@storybook/addon-docs/angular/preset',
     options: {
       configureJSX: true,
     },

--- a/examples/cra-kitchen-sink/.storybook/config.js
+++ b/examples/cra-kitchen-sink/.storybook/config.js
@@ -1,7 +1,6 @@
 import { load, addParameters, addDecorator } from '@storybook/react';
 import { create } from '@storybook/theming';
 import { withA11y } from '@storybook/addon-a11y';
-import { DocsPage } from '@storybook/addon-docs/blocks';
 
 addDecorator(withA11y);
 addParameters({
@@ -21,7 +20,6 @@ addParameters({
     }),
     storySort: (a, b) => a[1].id.localeCompare(b[1].id),
   },
-  docs: DocsPage,
 });
 
 load(require.context('../src/stories', true, /\.stories\.(js|mdx)$/), module);

--- a/examples/cra-kitchen-sink/.storybook/presets.js
+++ b/examples/cra-kitchen-sink/.storybook/presets.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    name: '@storybook/addon-docs/common/preset',
+    name: '@storybook/addon-docs/react/preset',
     options: {
       configureJSX: true,
     },

--- a/examples/html-kitchen-sink/.storybook/config.js
+++ b/examples/html-kitchen-sink/.storybook/config.js
@@ -1,6 +1,5 @@
 import { load, addParameters, addDecorator } from '@storybook/html';
 import { withA11y } from '@storybook/addon-a11y';
-import { DocsPage } from '@storybook/addon-docs/blocks';
 
 addDecorator(withA11y);
 
@@ -18,7 +17,6 @@ addParameters({
       iframeHeight: '200px',
     },
   },
-  docs: DocsPage,
 });
 
 load(require.context('../stories', true, /\.stories\.(js|mdx)$/), module);

--- a/examples/html-kitchen-sink/.storybook/presets.js
+++ b/examples/html-kitchen-sink/.storybook/presets.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    name: '@storybook/addon-docs/common/preset',
+    name: '@storybook/addon-docs/html/preset',
     options: {
       configureJSX: true,
     },

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { load, addDecorator, addParameters } from '@storybook/react';
 import { Global, ThemeProvider, themes, createReset, convert } from '@storybook/theming';
-import { DocsPage } from '@storybook/addon-docs/blocks';
-
 import { withCssResources } from '@storybook/addon-cssresources';
 import { withA11y } from '@storybook/addon-a11y';
 import { withNotes } from '@storybook/addon-notes';
@@ -57,7 +55,6 @@ addParameters({
     { name: 'light', value: '#eeeeee' },
     { name: 'dark', value: '#222222' },
   ],
-  docs: DocsPage,
 });
 
 load(

--- a/examples/official-storybook/presets.js
+++ b/examples/official-storybook/presets.js
@@ -1,1 +1,1 @@
-module.exports = ['@storybook/addon-docs/common/preset'];
+module.exports = ['@storybook/addon-docs/react/preset'];

--- a/examples/vue-kitchen-sink/.storybook/config.js
+++ b/examples/vue-kitchen-sink/.storybook/config.js
@@ -2,7 +2,6 @@ import { load, addParameters, addDecorator } from '@storybook/vue';
 import Vue from 'vue';
 import Vuex from 'vuex';
 import { withA11y } from '@storybook/addon-a11y';
-import { DocsPage } from '@storybook/addon-docs/blocks';
 
 import MyButton from '../src/stories/Button.vue';
 
@@ -17,7 +16,6 @@ addParameters({
       iframeHeight: '60px',
     },
   },
-  docs: DocsPage,
 });
 
 load(require.context('../src/stories', true, /\.stories\.(js|mdx)$/), module);

--- a/examples/vue-kitchen-sink/.storybook/presets.js
+++ b/examples/vue-kitchen-sink/.storybook/presets.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    name: '@storybook/addon-docs/common/preset',
+    name: '@storybook/addon-docs/vue/preset',
     options: {
       configureJSX: true,
     },


### PR DESCRIPTION
Issue: #7316

## What I did

- Made framework-specific docs presets smarter to add `docs: DocsPage` param
- Remove this from examples

This is backwards compatible because users can still set `docs` param to whatever they want in `config.js`.

## How to test

Test the example storybooks (Angular, HTML, Vue, Official, CRA)