### PR TITLE
Update telejson dependency to 2.2.2

### DIFF
--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -35,7 +35,7 @@
     "semver": "^6.0.0",
     "shallow-equal": "^1.1.0",
     "store2": "^2.7.1",
-    "telejson": "^2.2.1",
+    "telejson": "^2.2.2",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {

--- a/lib/channel-postmessage/package.json
+++ b/lib/channel-postmessage/package.json
@@ -25,7 +25,7 @@
     "@storybook/client-logger": "5.2.0-beta.13",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "telejson": "^2.2.1"
+    "telejson": "^2.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -53,7 +53,7 @@
     "resolve-from": "^5.0.0",
     "semver": "^6.0.0",
     "store2": "^2.7.1",
-    "telejson": "^2.2.1",
+    "telejson": "^2.2.2",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28653,7 +28653,7 @@ teeny-request@^3.11.3:
     node-fetch "^2.2.0"
     uuid "^3.3.2"
 
-telejson@^2.1.1, telejson@^2.2.1:
+telejson@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/telejson/-/telejson-2.2.1.tgz#d9ee7e7eba0c81d9378257342fde7142a03787e2"
   integrity sha512-JtFAnITek+Z9t+uQjVl4Fxur9Z3Bi3flytBLc3KZVXmMUHLXdtAxiP0g8IBkHvKn1kQIYZC57IG0jjGH1s64HQ==
@@ -28664,6 +28664,19 @@ telejson@^2.1.1, telejson@^2.2.1:
     is-symbol "^1.0.2"
     isobject "^3.0.1"
     lodash.get "^4.4.2"
+    memoizerific "^1.11.3"
+
+telejson@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/telejson/-/telejson-2.2.2.tgz#d61d721d21849a6e4070d547aab302a9bd22c720"
+  integrity sha512-YyNwnKY0ilabOwYgC/J754En1xOe5PBIUIw+C9e0+5HjVVcnQE5/gdu2yET2pmSbp5bxIDqYNjvndj2PUkIiYA==
+  dependencies:
+    global "^4.3.2"
+    is-function "^1.0.1"
+    is-regex "^1.0.4"
+    is-symbol "^1.0.2"
+    isobject "^3.0.1"
+    lodash "^4.17.11"
     memoizerific "^1.11.3"
 
 temp-dir@^1.0.0:


### PR DESCRIPTION
Issue:
Storybook depends on telejson 2.2.1, which depends on a stale lodash.get dependency.

## What I did
Updated telejson dependency to latest lodash and released telejson 2.2.2
Updated Storybook dependency to latest telejson 2.2.2

## How to test
yarn test, full regression, make sure all tests continue passing
