### PR TITLE
Better default storySort function

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -87,7 +87,8 @@ For example, here's how to sort by story ID using `storySort`:
 ```js
 addParameters({
   options: {
-    storySort: (a, b) => a[1].id.localeCompare(b[1].id),
+    storySort: (a, b) =>
+      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
   },
 });
 ```

--- a/examples/cra-kitchen-sink/.storybook/config.js
+++ b/examples/cra-kitchen-sink/.storybook/config.js
@@ -18,7 +18,8 @@ addParameters({
       brandUrl: 'https://github.com/storybookjs/storybook/tree/master/examples/cra-kitchen-sink',
       gridCellSize: 12,
     }),
-    storySort: (a, b) => a[1].id.localeCompare(b[1].id),
+    storySort: (a, b) =>
+      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
   },
 });
 

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -49,6 +49,8 @@ addParameters({
     hierarchySeparator: /\/|\./,
     hierarchyRootSeparator: '|',
     theme: themes.light, // { base: 'dark', brandTitle: 'Storybook!' },
+    storySort: (a, b) =>
+      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
   },
   backgrounds: [
     { name: 'storybook app', value: themes.light.appBg, default: true },


### PR DESCRIPTION
Issue: the current `storySort` function does not yield the most sensible sorting order. Besides sorting directories, it also sorts stories themselves, while these are usually specified in a particular order to form a narrative. Furthermore, the current version does not handle numeric sorting in a natural way.

## What I did

I replaced the `storySort` option in the kitchen sink example, added it to the official-storybook and updated the suggested configuration in the docs. The new `storySort` function only sorts folders/groups and leaves stories as-is.

## How to test

Run the `cra-kitchen-sink` or `official-storybook` example and verify that the folders/groups are now sorted alphabetically (natural sort), while underlying stories remain in the order they were specified in code.