### PR TITLE
Knobs documentation: add missing groupId parameter demos

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -323,8 +323,9 @@ const options = {
       Watermelon: 'watermelon',
 };
 const defaultValue = 'kiwi';
+const groupId = 'GROUP-ID1';
 
-const value = radios(label, options, defaultValue);
+const value = radios(label, options, defaultValue, groupId);
 ```
 
 ### options
@@ -344,8 +345,9 @@ const defaultValue = 'kiwi';
 const optionsObj = {
   display: 'inline-radio'
 };
+const groupId = 'GROUP-ID1';
 
-const value = options(label, valuesObj, defaultValue, optionsObj);
+const value = options(label, valuesObj, defaultValue, optionsObj, groupId);
 ```
 > The display property for `optionsObj` accepts:
 > - `radio`
@@ -365,8 +367,9 @@ import { files } from '@storybook/addon-knobs';
 const label = 'Images';
 const accept = '.xlsx, .pdf';
 const defaultValue = [];
+const groupId = 'GROUP-ID1';
 
-const value = files(label, accept, defaultValue);
+const value = files(label, accept, defaultValue, groupId);
 ```
 
 > You can optionally specify a [list of file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) which the file input should accept.


### PR DESCRIPTION
Issue: Documentation doesn’t show `groupId` demos for all knob types.

## What I did

Add the `groupId` parameter where it was missing.

## How to test

N/A