### PR TITLE
Addon-docs: Error on non-string description

### DIFF
--- a/addons/docs/src/blocks/Description.tsx
+++ b/addons/docs/src/blocks/Description.tsx
@@ -20,11 +20,20 @@ interface DescriptionProps {
   markdown?: string;
 }
 
-const str = (o: any) => (typeof o === 'string' ? o : '');
+const str = (o: any) => {
+  if (!o) {
+    return '';
+  }
+  if (typeof o === 'string') {
+    return o as string;
+  }
+  throw new Error(`Description: expected string, got: ${JSON.stringify(o)}`);
+};
 
-const getNotes = (notes?: Notes) => notes && (str(notes) || str(notes.markdown) || str(notes.text));
+const getNotes = (notes?: Notes) =>
+  notes && (typeof notes === 'string' ? notes : str(notes.markdown) || str(notes.text));
 
-const getInfo = (info?: Info) => info && (str(info) || str(info.text));
+const getInfo = (info?: Info) => info && (typeof info === 'string' ? info : str(info.text));
 
 const getDocgen = (component?: Component) =>
   component && component.__docgenInfo && str(component.__docgenInfo.description);

--- a/addons/docs/src/blocks/Description.tsx
+++ b/addons/docs/src/blocks/Description.tsx
@@ -20,13 +20,14 @@ interface DescriptionProps {
   markdown?: string;
 }
 
-const getNotes = (notes?: Notes) =>
-  (notes && (typeof notes === 'string' ? notes : notes.markdown || notes.text)) || '';
+const str = (o: any) => (typeof o === 'string' ? o : '');
 
-const getInfo = (info?: Info) => (info && (typeof info === 'string' ? info : info.text)) || '';
+const getNotes = (notes?: Notes) => notes && (str(notes) || str(notes.markdown) || str(notes.text));
+
+const getInfo = (info?: Info) => info && (str(info) || str(info.text));
 
 const getDocgen = (component?: Component) =>
-  (component && component.__docgenInfo && component.__docgenInfo.description) || '';
+  component && component.__docgenInfo && str(component.__docgenInfo.description);
 
 export const getDescriptionProps = (
   { of, type, markdown }: DescriptionProps,
@@ -50,7 +51,7 @@ export const getDescriptionProps = (
         markdown: `
 ${getNotes(notes) || getInfo(info) || ''}
 
-${getDocgen(target)}
+${getDocgen(target) || ''}
 `.trim(),
       };
   }


### PR DESCRIPTION
Issue: #7398 

## What I did

Sometimes peoples' webpack is not set up properly so, e.g. importing text from a `.md` file could cause the description component to break. Fail with a debuggable error in this case.