### PR TITLE
Add .pdf support to file-loader

### DIFF
--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -98,7 +98,7 @@ export default ({
           ],
         },
         {
-          test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/,
+          test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
           loader: require.resolve('file-loader'),
           query: {
             name: 'static/media/[name].[hash:8].[ext]',

--- a/lib/core/src/server/preview/base-webpack.config.js
+++ b/lib/core/src/server/preview/base-webpack.config.js
@@ -34,7 +34,7 @@ export function createDefaultWebpackConfig(storybookBaseConfig) {
           ],
         },
         {
-          test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/,
+          test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
           loader: require.resolve('file-loader'),
           query: {
             name: 'static/media/[name].[hash:8].[ext]',


### PR DESCRIPTION
Issue: the current webpack config does not support PDF files

## What I did

Just added `.pdf` to file-loader supported file extentions

## How to test

Import a PDF file from a component. You should get a link to download this PDF file.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
