### PR TITLE
CLI: suggest possible matches on invalid command

### DIFF
--- a/lib/cli/bin/generate.js
+++ b/lib/cli/bin/generate.js
@@ -1,6 +1,7 @@
 import program from 'commander';
 import chalk from 'chalk';
 import envinfo from 'envinfo';
+import didYouMean from 'didyoumean';
 import pkg from '../package.json';
 import initiate from '../lib/initiate';
 import { codeLog } from '../lib/helpers';
@@ -70,7 +71,11 @@ if (process.argv[1].includes('getstorybook')) {
     });
 
   program.command('*', { noHelp: true }).action(cmd => {
-    logger.error('Invalid command: %s.\nSee --help for a list of available commands.', cmd);
+    logger.error(' Invalid command: %s.\n See --help for a list of available commands.', cmd);
+    const suggestion = didYouMean(cmd, program.commands.map(cmd => cmd._name));
+    if (suggestion) {
+    	logger.log(`\n Did you mean ${suggestion}?`);
+    }
     process.exit(1);
   });
 

--- a/lib/cli/bin/generate.js
+++ b/lib/cli/bin/generate.js
@@ -70,11 +70,15 @@ if (process.argv[1].includes('getstorybook')) {
       });
     });
 
-  program.command('*', { noHelp: true }).action(cmd => {
-    logger.error(' Invalid command: %s.\n See --help for a list of available commands.', cmd);
-    const suggestion = didYouMean(cmd, program.commands.map(cmd => cmd._name));
+  program.command('*', { noHelp: true }).action(invalidCmd => {
+    logger.error(
+      ' Invalid command: %s.\n See --help for a list of available commands.',
+      invalidCmd
+    );
+    // eslint-disable-next-line
+    const suggestion = didYouMean(invalidCmd, program.commands.map(cmd => cmd._name)); 
     if (suggestion) {
-    	logger.log(`\n Did you mean ${suggestion}?`);
+      logger.log(`\n Did you mean ${suggestion}?`);
     }
     process.exit(1);
   });

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -35,6 +35,7 @@
     "commander": "^2.19.0",
     "core-js": "^3.0.1",
     "cross-spawn": "^6.0.5",
+    "didyoumean": "^1.2.1",
     "envinfo": "^7.3.1",
     "fs-extra": "^8.0.1",
     "inquirer": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10345,6 +10345,11 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
+didyoumean@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"
+  integrity sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=
+
 diff-sequences@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"


### PR DESCRIPTION
Assume if the user makes a typo:- `sb ini`

Updated warning message:-
```
Invalid command: ini.
 See --help for a list of available commands.

 Did you mean init?
```