### PR TITLE
Addon-docs: DocsPage slots for fine-grained user control

### DIFF
--- a/addons/docs/src/blocks/Description.tsx
+++ b/addons/docs/src/blocks/Description.tsx
@@ -30,12 +30,12 @@ const str = (o: any) => {
   throw new Error(`Description: expected string, got: ${JSON.stringify(o)}`);
 };
 
-const getNotes = (notes?: Notes) =>
+export const getNotes = (notes?: Notes) =>
   notes && (typeof notes === 'string' ? notes : str(notes.markdown) || str(notes.text));
 
-const getInfo = (info?: Info) => info && (typeof info === 'string' ? info : str(info.text));
+export const getInfo = (info?: Info) => info && (typeof info === 'string' ? info : str(info.text));
 
-const getDocgen = (component?: Component) =>
+export const getDocgen = (component?: Component) =>
   component && component.__docgenInfo && str(component.__docgenInfo.description);
 
 export const getDescriptionProps = (

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -4,6 +4,7 @@ import { Global, ThemeProvider, themes, createReset, convert } from '@storybook/
 import { withCssResources } from '@storybook/addon-cssresources';
 import { withA11y } from '@storybook/addon-a11y';
 import { withNotes } from '@storybook/addon-notes';
+import { DocsPage } from '@storybook/addon-docs/blocks';
 
 import 'storybook-chromatic';
 
@@ -57,6 +58,10 @@ addParameters({
     { name: 'light', value: '#eeeeee' },
     { name: 'dark', value: '#222222' },
   ],
+  // eslint-disable-next-line react/prop-types
+  docs: ({ context }) => (
+    <DocsPage context={context} subtitleSlot={({ selectedKind }) => `Subtitle: ${selectedKind}`} />
+  ),
 });
 
 configure(


### PR DESCRIPTION
Issue: #7456 

## What I did

First cut at a "slots" feature for fine-grained control of what shows up on DocsPage, with sensible defaults.

What can be controlled:
- title
- subtitle
- description
- display of each story

Technically this is a breaking change because it modifies a public API. However, it's a mostly undocumented API that I don't expect anybody to use, and it's still beta. If you just used `DocsPage` out of the box, this change should be fully backwards-compatible.

## How to test

See my update to `official-storybook/config.js` for an example usage

