### PR TITLE
Core: Fix HMR error recovery

### DIFF
--- a/lib/client-api/src/config_api.ts
+++ b/lib/client-api/src/config_api.ts
@@ -70,7 +70,7 @@ export default class ConfigApi {
 
         throw errors[0];
       } else {
-        this._storyStore.setSelection(undefined, undefined);
+        this._storyStore.setSelection(undefined, null);
       }
     };
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -119,7 +119,7 @@ export default class StoryStore extends EventEmitter {
   setSelection(data: Selection | undefined, error: ErrorLike): void {
     this._selection =
       data === undefined ? this._selection : { storyId: data.storyId, viewMode: data.viewMode };
-    this._error = error === undefined && data === undefined ? this._error : error;
+    this._error = error === undefined ? this._error : error;
 
     setTimeout(() => {
       // preferred method to emit event.

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -119,7 +119,7 @@ export default class StoryStore extends EventEmitter {
   setSelection(data: Selection | undefined, error: ErrorLike): void {
     this._selection =
       data === undefined ? this._selection : { storyId: data.storyId, viewMode: data.viewMode };
-    this._error = error === undefined ? this._error : error;
+    this._error = error === undefined && data === undefined ? this._error : error;
 
     setTimeout(() => {
       // preferred method to emit event.


### PR DESCRIPTION
Issue: #7165 

## What I did

Error was not getting properly cleared in the story store, so I tried a few ways:

- First commit changes story_store. The issue is that when user navigates, the error gets cleared.

- Second commit undoes the first, and clears the error in the config_api (call `configure(...)`). This one clears the error when the user fixes the error OR when the user updates a different file

- I cannot figure out how to clear the error only when the original error is fixed. I think the second approach is OK for now.

## How to test

```
cd examples/official-storybook
yarn storybook
# edit a story & introduce a syntax error => error message
# navigate to another story => error message
# fix the error => story
```
