### PR TITLE
Addon-notes: Upgrade markdown-to-jsx dependency

### DIFF
--- a/addons/notes/package.json
+++ b/addons/notes/package.json
@@ -32,7 +32,7 @@
     "@storybook/theming": "5.2.0-beta.23",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "markdown-to-jsx": "^6.9.3",
+    "markdown-to-jsx": "^6.10.3",
     "memoizerific": "^1.11.3",
     "prop-types": "^15.7.2",
     "util-deprecate": "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18916,6 +18916,14 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
+markdown-to-jsx@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz#7f0946684acd321125ff2de7fd258a9b9c7c40b7"
+  integrity sha512-PSoUyLnW/xoW6RsxZrquSSz5eGEOTwa15H5eqp3enmrp8esmgDJmhzd6zmQ9tgAA9TxJzx1Hmf3incYU/IamoQ==
+  dependencies:
+    prop-types "^15.6.2"
+    unquote "^1.1.0"
+
 markdown-to-jsx@^6.9.1, markdown-to-jsx@^6.9.3:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.10.2.tgz#644f602b81d088f10aef1c3674874876146cf38b"


### PR DESCRIPTION
Issue: #6869.

## What I did

Upgraded the package.json version. Verified that this solves and closes #6869 in demo repo here: https://github.com/robaxelsen/markdown-to-jsx-table-pipe-test

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
