### PR TITLE
Core: Disable CRA behaviors when preset detected

### DIFF
--- a/app/react/README.md
+++ b/app/react/README.md
@@ -27,6 +27,13 @@ Here are some featured storybooks that you can reference to see how Storybook wo
 - [Demo of React Dates](http://airbnb.io/react-dates/) - [source](https://github.com/airbnb/react-dates)
 - [Demo of React Native Web](http://necolas.github.io/react-native-web/storybook/) - [source](https://github.com/necolas/react-native-web)
 
+## Create React App
+
+Support for Create React App is handled by [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app).
+
+This preset enables support for all Create React App features, including Sass/SCSS and TypeScript.
+
+
 ## Typescript
 
 If you are using Typescript, make sure you have the type definitions installed via `yarn add @types/node @types/react @types/storybook__react --dev`.

--- a/app/react/src/server/framework-preset-cra.ts
+++ b/app/react/src/server/framework-preset-cra.ts
@@ -3,7 +3,29 @@ import { Configuration } from 'webpack';
 import { logger } from '@storybook/node-logger';
 import { applyCRAWebpackConfig, getReactScriptsPath, isReactScriptsInstalled } from './cra-config';
 
+type Preset = string | { name: string };
+
+// Disable the built-in preset if the new preset is detected.
+const checkForNewPreset = (configDir: string) => {
+  try {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const presets = require(path.resolve(configDir, 'presets.js'));
+
+    const hasNewPreset = presets.some((preset: Preset) => {
+      const presetName = typeof preset === 'string' ? preset : preset.name;
+      return presetName === '@storybook/preset-create-react-app';
+    });
+
+    return hasNewPreset;
+  } catch (e) {
+    return false;
+  }
+};
+
 export function webpackFinal(config: Configuration, { configDir }: { configDir: string }) {
+  if (checkForNewPreset(configDir)) {
+    return config;
+  }
   if (!isReactScriptsInstalled()) {
     logger.info('=> Using base config because react-scripts is not installed.');
     return config;
@@ -13,8 +35,8 @@ export function webpackFinal(config: Configuration, { configDir }: { configDir: 
   return applyCRAWebpackConfig(config, configDir);
 }
 
-export function managerWebpack(config: Configuration) {
-  if (!isReactScriptsInstalled()) {
+export function managerWebpack(config: Configuration,  { configDir }: { configDir: string }) {
+  if (!isReactScriptsInstalled() || checkForNewPreset(configDir)) {
     return config;
   }
 
@@ -26,8 +48,8 @@ export function managerWebpack(config: Configuration) {
   };
 }
 
-export function babelDefault(config: Configuration) {
-  if (!isReactScriptsInstalled()) {
+export function babelDefault(config: Configuration,  { configDir }: { configDir: string }) {
+  if (!isReactScriptsInstalled() || checkForNewPreset(configDir)) {
     return config;
   }
 

--- a/lib/core/src/server/preview/custom-webpack-preset.js
+++ b/lib/core/src/server/preview/custom-webpack-preset.js
@@ -24,12 +24,12 @@ export async function webpack(config, options) {
   const customConfig = loadCustomWebpackConfig(configDir);
 
   if (customConfig === null) {
-    logger.info('=> Using default webpack setup.');
+    logger.info('=> Using default Webpack setup.');
     return createFinalDefaultConfig(presets, config, options);
   }
 
   if (typeof customConfig === 'function') {
-    logger.info('=> Loading custom webpack config (full-control mode).');
+    logger.info('=> Loading custom Webpack config (full-control mode).');
     const finalDefaultConfig = await createFinalDefaultConfig(presets, config, options);
     return customConfig({ config: finalDefaultConfig, mode: configType });
   }


### PR DESCRIPTION
Disable the built-in CRA preset for `@storybook/react` when the new preset is detected.

Relates to https://github.com/storybookjs/presets/pull/25.