### PR TITLE
Remove Object.append(...) from index.ejs

### DIFF
--- a/lib/core/src/server/templates/index.ejs
+++ b/lib/core/src/server/templates/index.ejs
@@ -25,7 +25,11 @@
 
     <% if (typeof globals !== 'undefined' && Object.keys(globals).length) { %>
       <script>
-        Object.assign(window, <%= JSON.stringify(globals) %>);
+        <% for (var varName in globals) { %>
+            <% if (globals[varName] != undefined) { %>
+              window['<%=varName%>'] = <%= JSON.stringify(globals[varName]) %>;
+            <% } %>
+        <% } %>
       </script>
     <% } %>
     


### PR DESCRIPTION
Issue: #7706 

## What I did
Replaced the following EJS code in [lib/core/src/server/templates/index.ejs](https://github.com/storybookjs/storybook/blob/next/lib/core/src/server/templates/index.ejs) for the sake of IE11 compatibility:

**before:**
```ejs
<% if (typeof globals !== 'undefined' && Object.keys(globals).length) { %>
  <script>
    Object.assign(window, <%= JSON.stringify(globals) %>);
  </script>
<% } %>
```

**after:**

```ejs
<% if (typeof globals !== 'undefined' && Object.keys(globals).length) { %>
  <script>
    <% for (var varName in globals) { %>
        <% if (globals[varName] != undefined) { %>
          window['<%=varName%>'] = <%= JSON.stringify(globals[varName]) %>;
        <% } %>
    <% } %>
  </script>
<% } %>
```


## How to test

- See "To Reproduce" subheading in issue #7706
