### PR TITLE
UI: Improved component nav UI

### DIFF
--- a/lib/ui/src/components/sidebar/SidebarItem.tsx
+++ b/lib/ui/src/components/sidebar/SidebarItem.tsx
@@ -135,11 +135,7 @@ const SidebarItem = ({
       {...props}
       className={isSelected ? 'sidebar-item selected' : 'sidebar-item'}
     >
-      <Expander
-        className="sidebar-expander"
-        isExpandable={!isLeaf && !isComponent}
-        isExpanded={isExpanded}
-      />
+      <Expander className="sidebar-expander" isExpandable={!isLeaf} isExpanded={isExpanded} />
       <Icon className="sidebar-svg-icon" icon={iconName} isSelected={isSelected} />
       <span>{name}</span>
     </Item>

--- a/lib/ui/src/components/sidebar/SidebarItem.tsx
+++ b/lib/ui/src/components/sidebar/SidebarItem.tsx
@@ -135,7 +135,11 @@ const SidebarItem = ({
       {...props}
       className={isSelected ? 'sidebar-item selected' : 'sidebar-item'}
     >
-      <Expander className="sidebar-expander" isExpandable={!isLeaf} isExpanded={isExpanded} />
+      <Expander
+        className="sidebar-expander"
+        isExpandable={!isLeaf && !isComponent}
+        isExpanded={isExpanded}
+      />
       <Icon className="sidebar-svg-icon" icon={iconName} isSelected={isSelected} />
       <span>{name}</span>
     </Item>

--- a/lib/ui/src/components/sidebar/SidebarStories.tsx
+++ b/lib/ui/src/components/sidebar/SidebarStories.tsx
@@ -69,8 +69,9 @@ export const Link = ({
   onClick,
   onKeyUp,
   childIds,
+  isExpanded,
 }) => {
-  return isLeaf || isComponent ? (
+  return isLeaf || (isComponent && !isExpanded) ? (
     <Location>
       {({ viewMode }) => (
         <PlainRouterLink
@@ -100,9 +101,11 @@ Link.propTypes = {
   onKeyUp: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
   childIds: PropTypes.arrayOf(PropTypes.string),
+  isExpanded: PropTypes.bool,
 };
 Link.defaultProps = {
   childIds: null,
+  isExpanded: false,
 };
 
 export interface StoriesProps {

--- a/lib/ui/src/components/sidebar/SidebarStories.tsx
+++ b/lib/ui/src/components/sidebar/SidebarStories.tsx
@@ -56,14 +56,27 @@ const refinedViewMode = (viewMode: string) => {
   return viewMode === 'settings' ? 'story' : viewMode;
 };
 
-export const Link = ({ id, prefix, name, children, isLeaf, onClick, onKeyUp }) =>
-  isLeaf ? (
+const targetId = (childIds?: string[]) =>
+  childIds && childIds.find((childId: string) => /.*--.*/.exec(childId));
+
+export const Link = ({
+  id,
+  prefix,
+  name,
+  children,
+  isLeaf,
+  isComponent,
+  onClick,
+  onKeyUp,
+  childIds,
+}) => {
+  return isLeaf || isComponent ? (
     <Location>
       {({ viewMode }) => (
         <PlainRouterLink
           title={name}
           id={prefix + id}
-          to={`/${viewMode ? refinedViewMode(viewMode) : 'story'}/${id}`}
+          to={`/${viewMode ? refinedViewMode(viewMode) : 'story'}/${targetId(childIds) || id}`}
           onKeyUp={onKeyUp}
           onClick={onClick}
         >
@@ -76,6 +89,7 @@ export const Link = ({ id, prefix, name, children, isLeaf, onClick, onKeyUp }) =
       {children}
     </PlainLink>
   );
+};
 Link.displayName = 'Link';
 Link.propTypes = {
   children: PropTypes.node.isRequired,
@@ -85,6 +99,10 @@ Link.propTypes = {
   prefix: PropTypes.string.isRequired,
   onKeyUp: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
+  childIds: PropTypes.arrayOf(PropTypes.string),
+};
+Link.defaultProps = {
+  childIds: null,
 };
 
 export interface StoriesProps {

--- a/lib/ui/src/components/sidebar/treeview/treeview.js
+++ b/lib/ui/src/components/sidebar/treeview/treeview.js
@@ -124,6 +124,7 @@ const Tree = props => {
             depth={depth}
             isExpanded={expanded[node.id]}
             isSelected={selected[node.id]}
+            childIds={children}
           />
           {children && expanded[node.id] ? <List>{children.map(mapNode)}</List> : null}
         </Fragment>


### PR DESCRIPTION
Issue: #6644 

## What I did

Improved Storybook's navigation UI to help with SB docs-related UI needs. Clicking on components now automatically selects the component's first story, like this:

![updated-nav-ui](https://user-images.githubusercontent.com/488689/62674758-6c24c600-b9d6-11e9-938a-d8f0fbb43000.gif)

Expand & collapse of folders works the same as before.

## How to test

```
cd examples/official-storybook
yarn storybook
```