### PR TITLE
Core: Revert "Addon-centered: Fix disappearing when zoomed"

### DIFF
--- a/lib/core/src/server/templates/base-preview-head.html
+++ b/lib/core/src/server/templates/base-preview-head.html
@@ -5,10 +5,6 @@
     width: 100%;
     height: 100%;
   }
-  
-  body {
-    width: calc(100% - 16px);
-  }
 
   :not(.sb-show-main) > .sb-main,
   :not(.sb-show-nopreview) > .sb-nopreview,

--- a/lib/ui/src/components/preview/iframe.js
+++ b/lib/ui/src/components/preview/iframe.js
@@ -28,7 +28,7 @@ export class IFrame extends Component {
 
     if (scale !== nextProps.scale) {
       this.setIframeBodyStyle({
-        width: `calc(${nextProps.scale * 100}% - 16px)`,
+        width: `${nextProps.scale * 100}%`,
         height: `${nextProps.scale * 100}%`,
         transform: `scale(${1 / nextProps.scale})`,
         transformOrigin: 'top left',


### PR DESCRIPTION
Issue:  #7724 #7167 

Reverts storybookjs/storybook#7640. We shouldn't be modifying the preview styling at all since it breaks visual regression tests among other things.