### PR TITLE
Core: Revert "Fix #7167 addon-centered causes component to disappear when zooming"

### DIFF
--- a/lib/core/src/server/templates/base-preview-head.html
+++ b/lib/core/src/server/templates/base-preview-head.html
@@ -1,11 +1,6 @@
 <base target="_parent">
 
 <style>
-  html, body{
-    width: 100%;
-    height: 100%;
-  }
-
   :not(.sb-show-main) > .sb-main,
   :not(.sb-show-nopreview) > .sb-nopreview,
   :not(.sb-show-errordisplay) > .sb-errordisplay {


### PR DESCRIPTION
Issue: #7749 #7724 

Reverts storybookjs/storybook#7400. We shouldn't be modifying the preview styles. It can break visual regression tests.