### PR TITLE
[docs] Remove (*.stories).tsx from example config

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -121,8 +121,8 @@ Change `config.ts` inside the Storybook config directory (by default, it’s `.s
 
 ```js
 import { configure } from '@storybook/react';
-// automatically import all files ending in *.stories.tsx
-const req = require.context('../stories', true, /\.stories\.tsx$/);
+// automatically import all files ending in *.tsx
+const req = require.context('../stories', true, /\.tsx$/);
 
 function loadStories() {
   req.keys().forEach(req);


### PR DESCRIPTION
The example above this line uses `stores/index.tsx` not `stories/index.stories.tsx` so when you copy/paste the config, it doesn't work by default, which is confusing.