### PR TITLE
Addon-docs: Add toolbar support to Preview

### DIFF
--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -42,6 +42,7 @@ interface DocsStoryProps {
   name: string;
   description?: string;
   expanded?: boolean;
+  withToolbar?: boolean;
 }
 
 interface StoryData {
@@ -88,11 +89,12 @@ const DocsStory: React.FunctionComponent<DocsStoryProps> = ({
   name,
   description,
   expanded = true,
+  withToolbar = false,
 }) => (
   <>
     {expanded && <StoryHeading>{name}</StoryHeading>}
     {expanded && description && <Description markdown={description} />}
-    <Preview>
+    <Preview withToolbar={withToolbar}>
       <Story id={id} />
     </Preview>
   </>
@@ -123,7 +125,7 @@ const DocsPage: React.FunctionComponent<DocsPageProps> = ({
       return (
         <PureDocsPage title={title} subtitle={subtitle}>
           <Description markdown={description} />
-          {primary && <DocsStory {...primary} expanded={false} />}
+          {primary && <DocsStory {...primary} expanded={false} withToolbar />}
           {propsTableProps && <PropsTable {...propsTableProps} />}
           <StoriesHeading>Stories</StoriesHeading>
           {stories && stories.map(story => story && <DocsStory {...story} expanded />)}

--- a/examples/official-storybook/stories/addon-docs.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs.stories.mdx
@@ -92,7 +92,9 @@ export const nonStory2 = () => <Button>Not a story</Button>; // another one
 
 ## Configurable height
 
-<Story id="basics-button--all-buttons" height="400px" />
+<Preview withToolbar>
+  <Story id="basics-button--all-buttons" height="400px" />
+</Preview>
 
 ## Description
 

--- a/lib/components/src/blocks/Preview.stories.tsx
+++ b/lib/components/src/blocks/Preview.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 
 import { Preview } from './Preview';
+import { Story } from './Story';
 import { DocsPageWrapper } from './DocsPage';
 import { Button } from '../Button/Button';
 import * as sourceStories from './Source.stories';
@@ -78,5 +78,20 @@ export const gridWith3Columns = () => (
     <Button secondary>Button 18</Button>
     <Button secondary>Button 19</Button>
     <Button secondary>Button 20</Button>
+  </Preview>
+);
+
+const buttonFn = () => <Button secondary>Hello Button</Button>;
+
+export const withToolbar = () => (
+  <Preview withToolbar>
+    <Story inline storyFn={buttonFn} title="with toolbar" />
+  </Preview>
+);
+
+export const withToolbarMulti = () => (
+  <Preview withToolbar>
+    <Story inline storyFn={buttonFn} title="story1" />
+    <Story inline storyFn={buttonFn} title="story2" />
   </Preview>
 );

--- a/lib/components/src/blocks/Story.tsx
+++ b/lib/components/src/blocks/Story.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { IFrame } from './IFrame';
 import { EmptyBlock } from './EmptyBlock';
+import { ZoomContext } from './ZoomContext';
 
 const BASE_URL = 'iframe.html';
 
@@ -12,15 +13,14 @@ export enum StoryError {
 interface CommonProps {
   title: string;
   height?: string;
+  id: string;
 }
 
 type InlineStoryProps = {
   storyFn: () => React.ElementType;
 } & CommonProps;
 
-type IFrameStoryProps = {
-  id: string;
-} & CommonProps;
+type IFrameStoryProps = CommonProps;
 
 type ErrorProps = {
   error?: StoryError;
@@ -31,8 +31,29 @@ export type StoryProps = (InlineStoryProps | IFrameStoryProps | ErrorProps) & {
   inline: boolean;
 };
 
-const InlineStory: React.FunctionComponent<InlineStoryProps> = ({ storyFn, height }) => (
-  <div style={{ height }}>{storyFn()}</div>
+const InlineZoomWrapper: React.FC<{ scale: number }> = ({ scale, children }) => {
+  return scale === 1 ? (
+    <>{children}</>
+  ) : (
+    <div style={{ overflow: 'hidden' }}>
+      <div
+        style={{
+          transform: `scale(${1 / scale})`,
+          transformOrigin: 'top left',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+const InlineStory: React.FunctionComponent<InlineStoryProps> = ({ id, storyFn, height }) => (
+  <div style={{ height }}>
+    <ZoomContext.Consumer>
+      {({ scale }) => <InlineZoomWrapper scale={scale}>{storyFn()}</InlineZoomWrapper>}
+    </ZoomContext.Consumer>
+  </div>
 );
 
 const IFrameStory: React.FunctionComponent<IFrameStoryProps> = ({
@@ -41,19 +62,25 @@ const IFrameStory: React.FunctionComponent<IFrameStoryProps> = ({
   height = '500px',
 }) => (
   <div style={{ width: '100%', height }}>
-    <IFrame
-      key="iframe"
-      id={`storybook-Story-${id}`}
-      title={title}
-      src={`${BASE_URL}?id=${id}&viewMode=story`}
-      allowFullScreen
-      scale={1}
-      style={{
-        width: '100%',
-        height: '100%',
-        border: '0 none',
+    <ZoomContext.Consumer>
+      {({ scale }) => {
+        return (
+          <IFrame
+            key="iframe"
+            id={`storybook-Story-${id}`}
+            title={title}
+            src={`${BASE_URL}?id=${id}&viewMode=story`}
+            allowFullScreen
+            scale={scale}
+            style={{
+              width: '100%',
+              height: '100%',
+              border: '0 none',
+            }}
+          />
+        );
       }}
-    />
+    </ZoomContext.Consumer>
   </div>
 );
 
@@ -64,14 +91,13 @@ const IFrameStory: React.FunctionComponent<IFrameStoryProps> = ({
 const Story: React.FunctionComponent<StoryProps> = props => {
   const { error } = props as ErrorProps;
   const { storyFn } = props as InlineStoryProps;
-  const { id } = props as IFrameStoryProps;
-  const { inline, title, height } = props;
+  const { id, inline, title, height } = props;
 
   if (error) {
     return <EmptyBlock>{error}</EmptyBlock>;
   }
   return inline ? (
-    <InlineStory storyFn={storyFn} title={title} height={height} />
+    <InlineStory id={id} storyFn={storyFn} title={title} height={height} />
   ) : (
     <IFrameStory id={id} title={title} height={height} />
   );

--- a/lib/components/src/blocks/Story.tsx
+++ b/lib/components/src/blocks/Story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { IFrame } from './IFrame';
 import { EmptyBlock } from './EmptyBlock';

--- a/lib/components/src/blocks/Toolbar.tsx
+++ b/lib/components/src/blocks/Toolbar.tsx
@@ -1,0 +1,85 @@
+import React, { Fragment } from 'react';
+import { styled } from '@storybook/theming';
+
+import { window } from 'global';
+import { FlexBar } from '../bar/bar';
+import { Icons } from '../icon/icon';
+import { IconButton } from '../bar/button';
+
+interface ZoomProps {
+  zoom: (val: number) => void;
+  resetZoom: () => void;
+}
+
+interface EjectProps {
+  storyId?: string;
+  baseUrl?: string;
+}
+
+interface BarProps {
+  border?: boolean;
+}
+
+export type ToolbarProps = BarProps & ZoomProps & EjectProps;
+
+const Zoom: React.FC<ZoomProps> = ({ zoom, resetZoom }) => (
+  <>
+    <IconButton
+      key="zoomin"
+      onClick={e => {
+        e.preventDefault();
+        zoom(0.8);
+      }}
+      title="Zoom in"
+    >
+      <Icons icon="zoom" />
+    </IconButton>
+    <IconButton
+      key="zoomout"
+      onClick={e => {
+        e.preventDefault();
+        zoom(1.25);
+      }}
+      title="Zoom out"
+    >
+      <Icons icon="zoomout" />
+    </IconButton>
+    <IconButton
+      key="zoomreset"
+      onClick={e => {
+        e.preventDefault();
+        resetZoom();
+      }}
+      title="Reset zoom"
+    >
+      <Icons icon="zoomreset" />
+    </IconButton>
+  </>
+);
+
+const Eject: React.FC<EjectProps> = ({ baseUrl, storyId }) => (
+  <IconButton
+    key="opener"
+    onClick={() => window.open(`${baseUrl}?id=${storyId}`)}
+    title="Open canvas in new tab"
+  >
+    <Icons icon="share" />
+  </IconButton>
+);
+
+const Bar = styled(props => <FlexBar {...props} />)({
+  position: 'absolute',
+  left: 0,
+  right: 0,
+  top: 0,
+  transition: 'transform .2s linear',
+});
+
+export const Toolbar: React.FC<ToolbarProps> = ({ storyId, baseUrl, zoom, resetZoom, ...rest }) => (
+  <Bar {...rest}>
+    <Fragment key="left">
+      <Zoom {...{ zoom, resetZoom }} />
+    </Fragment>
+    <Fragment key="right">{storyId && <Eject {...{ storyId, baseUrl }} />}</Fragment>
+  </Bar>
+);

--- a/lib/components/src/blocks/ZoomContext.tsx
+++ b/lib/components/src/blocks/ZoomContext.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const ZoomContext: React.Context<{ scale: number }> = React.createContext({
+  scale: 1,
+});


### PR DESCRIPTION
Issue: #7262 

## What I did

<img width="872" alt="Storybook" src="https://user-images.githubusercontent.com/488689/63094348-b1c72d00-bf9a-11e9-9dcc-d13ada0e9aa4.png">

- Added toolbar option with zoom & eject buttons
- Made DocsPage primary story show toolbar

There is currently no panning or zooming, and users need to set the height if they want extra room for the zoom. Any suggestions on better ways to handle this are welcome.

## How to test

```
cd examples/official-storybook
yarn storybook
```