### PR TITLE
fix link to `Intro to Presets page`

### DIFF
--- a/docs/src/pages/presets/introduction/index.md
+++ b/docs/src/pages/presets/introduction/index.md
@@ -5,7 +5,7 @@ title: 'Intro to Presets'
 
 Storybook **presets** are grouped collections of `babel`, `webpack`, and `addons` configurations that support specific use cases.
 
-For example, to write your stories in Typescript, rather than [manually configuring Storybook for typescript](../configurations/typescript-config/) with individual [babel](../configurations/custom-babel-config/) and [webpack](../configurations/custom-webpack-config/) configs, you can simply use the `@storybook/preset-typescript` package, which does the heavy lifting for you.
+For example, to write your stories in Typescript, rather than [manually configuring Storybook for typescript](../../configurations/typescript-config/) with individual [babel](../../configurations/custom-babel-config/) and [webpack](../../configurations/custom-webpack-config/) configs, you can simply use the `@storybook/preset-typescript` package, which does the heavy lifting for you.
 
 ## Basic usage
 


### PR DESCRIPTION
Issue:

## What I did
https://storybook.js.org/docs/presets/introduction/ fix links

![スクリーンショット 2019-08-16 19 38 42](https://user-images.githubusercontent.com/15010907/63162454-822d2900-c05d-11e9-803b-e4d25c00651f.png)

- `manually configuring Storybook for typescript` Link ( https://storybook.js.org/docs/presets/configurations/typescript-config/ )
- `babel ` Link ( https://storybook.js.org/docs/presets/configurations/custom-babel-config/ )
- `webpack` Link ( https://storybook.js.org/docs/presets/configurations/custom-webpack-config/ )

## How to test

```
cd docs
yarn dev
```
- => http://localhost:8000/presets/introduction/

- `manually configuring Storybook for typescript` Click Link
- `babel ` Click Link
- `webpack` Click Link


