### PR TITLE
Addon-docs: Improved "No docs" message

### DIFF
--- a/examples/official-storybook/stories/addon-docs/addon-docs.stories.js
+++ b/examples/official-storybook/stories/addon-docs/addon-docs.stories.js
@@ -10,6 +10,12 @@ export default {
 
 export const basic = () => <div>Click docs tab to see basic docs</div>;
 
+export const noDocs = () => <div>Click docs tab to see no docs error</div>;
+noDocs.story = {
+  name: 'no docs',
+  parameters: { docs: null },
+};
+
 export const withNotes = () => <div>Click docs tab to see DocsPage docs</div>;
 withNotes.story = {
   name: 'with notes',

--- a/lib/core/src/client/preview/NoDocs.js
+++ b/lib/core/src/client/preview/NoDocs.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { styled } from '@storybook/theming';
+
+const Wrapper = styled.div({
+  fontSize: '14px',
+  letterSpacing: '0.2px',
+  margin: '10px 0',
+});
+
+const Main = styled.div({
+  margin: 'auto',
+  padding: '30px',
+  borderRadius: '10px',
+  background: 'rgba(0,0,0,0.03)',
+});
+
+const Heading = styled.h1({
+  textAlign: 'center',
+});
+
+export const NoDocs = () => (
+  <Wrapper className="sb-nodocs sb-wrapper">
+    <Main>
+      <Heading>No Docs</Heading>
+      <p>
+        Sorry, but there are no docs for the selected story. To add them, set the story's{' '}
+        <code>docs</code> parameter. If you think this is an error:
+      </p>
+      <ul>
+        <li>Please check the story definition.</li>
+        <li>Please check the Storybook config.</li>
+        <li>Try reloading the page.</li>
+      </ul>
+      <p>
+        If the problem persists, check the browser console, or the terminal you've run Storybook
+        from.
+      </p>
+    </Main>
+  </Wrapper>
+);

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -12,6 +12,7 @@ import { logger } from '@storybook/client-logger';
 import Events from '@storybook/core-events';
 
 import { initializePath, setPath } from './url';
+import { NoDocs } from './NoDocs';
 
 const ansiConverter = new AnsiToHtml();
 
@@ -215,7 +216,6 @@ export default function start(render, { decorateStory } = {}) {
     // Given a cleaned up state, render the appropriate view mode
     switch (viewMode) {
       case 'docs': {
-        const NoDocs = () => <div style={{ fontFamily: 'sans-serif' }}>No docs found</div>;
         const StoryDocs = (parameters && parameters.docs) || NoDocs;
         ReactDOM.render(
           <StoryDocs context={renderContext} />,


### PR DESCRIPTION
Issue: N/A

## What I did

Improved "no docs" to parallel no story message:

<img width="913" alt="Storybook" src="https://user-images.githubusercontent.com/488689/63204271-86daf700-c0c8-11e9-834f-f72dc8c470b5.png">


## How to test

Navigate to `Addons|Docs/stories` => `no docs` in `official-storybook`, or set `docs: null` parameter for another story