### PR TITLE
Addon-docs: Fix docs-only story load

### DIFF
--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -198,6 +198,7 @@ export default function start(render, { decorateStory } = {}) {
     if (viewMode !== previousViewMode) {
       switch (viewMode) {
         case 'docs': {
+          showMain();
           document.getElementById('root').setAttribute('hidden', true);
           document.getElementById('docs-root').removeAttribute('hidden');
           break;


### PR DESCRIPTION
Issue: #6644 

## What I did

Clear the preview error on rendering docs mode

## How to test

Replace `examples/official-storybook/config.js` configure with this:

```
require.context('./stories', true, /\.stories\.mdx$/),
```

It will show "no preview" before this commit, but will render the story properly after.