### PR TITLE
CHANGE alignment for preview/iframe via grid because flexbox forces width

### DIFF
--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -195,12 +195,13 @@ export const ViewportTool: FunctionComponent<{}> = React.memo(
                 },
                 [`#${wrapperId}`]: {
                   padding: theme.layoutMargin,
-                  display: 'flex',
+                  display: 'grid',
                   alignContent: 'center',
                   alignItems: 'center',
                   justifyContent: 'center',
                   justifyItems: 'center',
                   overflow: 'auto',
+                  gridTemplateColumns: 'minmax(0, 1fr)',
                 },
               }}
             />


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/7646

## What I did
I tried to reproduce the issue, but wasn't successful. I was able to find a problem with the iframe not being the correct width (it would get sqaushed by flexbox). This PR fixes that with this hack:
https://css-tricks.com/preventing-a-grid-blowout/