### PR TITLE
Addon-docs: Fixed some sample code to be more valid

### DIFF
--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -31,14 +31,14 @@ Perhaps you want to write your stories in CSF, but document them in MDX? Here's 
 **Button.stories.mdx**
 
 ```md
-import { Story } from '@storybook/docs/blocks';
+import { Story } from '@storybook/addon-docs/blocks';
 import { SomeComponent } from 'somewhere';
 
 # Button
 
 I can embed a story (but not define one, since this file should not contain a `Meta`):
 
-<Story id="some--id">
+<Story id="some--id" />
 
 And of course I can also embed arbitrary markdown & JSX in this file.
 


### PR DESCRIPTION
Issue: I copied some sample code in the recipes.md file, and there was a pathing problem to the blocks, and a syntax issue with jsx in the mdx file.

## What I did
Fixed the pathing and the syntax issue in the sample code.