### PR TITLE
CSF: Add @next to sb migrate docs

### DIFF
--- a/lib/codemod/README.md
+++ b/lib/codemod/README.md
@@ -10,13 +10,13 @@ The preferred way to run these codemods is via the CLI's `migrate` command.
 To get a list of available codemods:
 
 ```
-npx -p @storybook/cli sb migrate --list
+npx -p @storybook/cli@next sb migrate --list
 ```
 
 To run a codemod `<name-of-codemod>`:
 
 ```
-npx -p @storybook/cli sb migrate <name-of-codemod> --glob "**/*.stories.js"
+npx -p @storybook/cli@next sb migrate <name-of-codemod> --glob "**/*.stories.js"
 ```
 
 ## Installation


### PR DESCRIPTION
Issue:
I ran into some issues with the codemods, such as missing `migrate` command and missing `storiesof-to-csf.js`.

## What I did
Added `@next` version target to `@storybook/cli` when invoking `npx`.