### PR TITLE
CLI: Remove babel-register in favor of esm

### DIFF
--- a/lib/cli/bin/index.js
+++ b/lib/cli/bin/index.js
@@ -1,9 +1,3 @@
-#!/usr/bin/env node
-const path = require('path');
+#!/usr/bin/env node -r esm
 
-require('@babel/register')({
-  // see https://github.com/babel/babel/issues/7701#issuecomment-389720069
-  cwd: path.resolve(__dirname, '..'),
-  only: [new RegExp(`(@storybook|lib)${path.sep === '\\' ? '\\\\' : path.sep}cli`)],
-});
-require('./generate');
+import './generate';

--- a/lib/cli/bin/index.js
+++ b/lib/cli/bin/index.js
@@ -1,3 +1,3 @@
-#!/usr/bin/env node -r esm
+#!/usr/bin/env node
 
-import './generate';
+require('esm')(module)('./generate.js');

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -29,12 +29,12 @@
   "dependencies": {
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
-    "@babel/register": "^7.0.0",
     "@storybook/codemod": "5.2.0-beta.37",
     "chalk": "^2.4.1",
     "commander": "^2.19.0",
     "core-js": "^3.0.1",
     "cross-spawn": "^6.0.5",
+    "esm": "3.2.25",
     "didyoumean": "^1.2.1",
     "envinfo": "^7.3.1",
     "fs-extra": "^8.0.1",

--- a/lib/cli/test/run_tests.sh
+++ b/lib/cli/test/run_tests.sh
@@ -36,10 +36,10 @@ do
   if [ $dir == *"native"* ]
   then
     # run @storybook/cli
-    ../../../bin/index.js init --skip-install --yes --install-server
+    yarn sb init --skip-install --yes --install-server
   else
     # run @storybook/cli
-    ../../../bin/index.js init --skip-install --yes
+    yarn sb init --skip-install --yes
   fi
 
   cd ..

--- a/yarn.lock
+++ b/yarn.lock
@@ -11768,7 +11768,7 @@ eslint@^5.10.0, eslint@^5.14.1, eslint@^5.16.0:
     table "^5.2.3"
     text-table "^0.2.0"
 
-esm@^3.2.25, esm@^3.2.4:
+esm@3.2.25, esm@^3.2.25, esm@^3.2.4:
   version "3.2.25"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==


### PR DESCRIPTION
Issue: having babel-register to transpile our CLI code when starting is bad

## What I did
I migrated it to use `-r esm` instead