### PR TITLE
Addon-docs: Force hidden attribute on #root element

### DIFF
--- a/lib/core/src/server/templates/index.ejs
+++ b/lib/core/src/server/templates/index.ejs
@@ -14,6 +14,13 @@
     files.css.forEach(file => { %>
     <link href="<%= file %>" rel="stylesheet" />
     <% }); %>
+
+    <style>
+      #root[hidden],
+      #docs-root[hidden] {
+        display: none !important;
+      }
+    </style>
   </head>
   <body>
     <% if (typeof bodyHtmlSnippet !== 'undefined') { %>


### PR DESCRIPTION
Issue: #7840 

## What I did

Force hidden on both `#root` and `#docs-root` for good measure.

## How to test

Style `#root { display: flex; }` in your app code
