### PR TITLE
Source-loader: Selectively ignore typescript errors in generated code

### DIFF
--- a/lib/source-loader/src/server/build.js
+++ b/lib/source-loader/src/server/build.js
@@ -15,16 +15,22 @@ export function transform(inputSource) {
         localDependencies,
         idsToFrameworks,
       }) => `
-  // @ts-ignore-start
+  // @ts-ignore
   var withSourceLoader = require('@storybook/source-loader/preview').withSource;
+  // @ts-ignore
   var __SOURCE_PREFIX__ = "${prefix.replace(/\\([^\\ ])/g, '\\\\$1')}";
+  // @ts-ignore
   var __STORY__ = ${sourceJson};
+  // @ts-ignore
   var __ADDS_MAP__ = ${JSON.stringify(addsMap)};
+  // @ts-ignore
   var __MAIN_FILE_LOCATION__ = ${JSON.stringify(resource)};
+  // @ts-ignore
   var __MODULE_DEPENDENCIES__ = ${JSON.stringify(dependencies)};
+  // @ts-ignore
   var __LOCAL_DEPENDENCIES__ = ${JSON.stringify(localDependencies)};
+  // @ts-ignore
   var __IDS_TO_FRAMEWORKS__ = ${JSON.stringify(idsToFrameworks)};
-  // @ts-ignore-end
 
   ${source}
   `


### PR DESCRIPTION
Issue: #7829 

## What I did
Converted `// @ts-ignore-start` and `// @ts-ignore-end` to line-by-line ignores

## How to test
- Start storybook in `--docs` mode on `beta.39` with a Typescript story
