### PR TITLE
Addon-docs: Fix DocsPage primary story switching

### DIFF
--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -119,7 +119,7 @@ export const DocsPage: React.FunctionComponent<DocsPageProps> = ({
       return (
         <PureDocsPage title={title} subtitle={subtitle}>
           <Description markdown={description} />
-          {primary && <DocsStory {...primary} expanded={false} withToolbar />}
+          {primary && <DocsStory key={primary.id} {...primary} expanded={false} withToolbar />}
           {propsTableProps && <PropsTable {...propsTableProps} />}
           {stories && stories.length > 0 && <StoriesHeading>Stories</StoriesHeading>}
           {stories &&


### PR DESCRIPTION
Issue: #7846 

## What I did

Add a key to the primary story

## How to test

Try `examples/vue-kitchen-sink`