### PR TITLE
Add the ignore `first-child` selector warning flag

### DIFF
--- a/lib/components/src/tabs/tabs.tsx
+++ b/lib/components/src/tabs/tabs.tsx
@@ -13,6 +13,8 @@ import { Placeholder } from '../placeholder/placeholder';
 import { FlexBar } from '../bar/bar';
 import { TabButton } from '../bar/button';
 
+const ignoreSsrWarning = '/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */'
+
 export interface WrapperProps {
   bordered?: boolean;
   absolute?: boolean;
@@ -73,7 +75,7 @@ const Content = styled.div<ContentProps>(
           bottom: 0,
           top: 40,
           overflow: 'auto',
-          '& > *:first-child': {
+          ['& > *:first-child' + ignoreSsrWarning]: {
             position: 'absolute',
             left: 0,
             right: 0,

--- a/lib/components/src/tabs/tabs.tsx
+++ b/lib/components/src/tabs/tabs.tsx
@@ -13,7 +13,8 @@ import { Placeholder } from '../placeholder/placeholder';
 import { FlexBar } from '../bar/bar';
 import { TabButton } from '../bar/button';
 
-const ignoreSsrWarning = '/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */'
+const ignoreSsrWarning = 
+  '/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */';
 
 export interface WrapperProps {
   bordered?: boolean;
@@ -75,7 +76,7 @@ const Content = styled.div<ContentProps>(
           bottom: 0,
           top: 40,
           overflow: 'auto',
-          ['& > *:first-child' + ignoreSsrWarning]: {
+          [`& > *:first-child${ignoreSsrWarning}`]: {
             position: 'absolute',
             left: 0,
             right: 0,


### PR DESCRIPTION
Issue: #6998 

## What I did
according [[cache] Add ignore flag for the unreliable selectors warning #1209](https://github.com/emotion-js/emotion/pull/1209)

Add ignore flag to ignore console warnings

## How to test

```sh
cd examples/official-storybook
yarn storybook
```

No error alerts about `:first-child` will be issued in the development console
