### PR TITLE
UI: Fix TooltipLinkList not scrollable

### DIFF
--- a/docs/src/new-components/basics/tooltip/TooltipLinkList.js
+++ b/docs/src/new-components/basics/tooltip/TooltipLinkList.js
@@ -5,6 +5,9 @@ import ListItem from '../ListItem';
 
 const List = styled.div`
   min-width: 180px;
+  overflow: hidden;
+  overflow-y: auto;
+  maxHeight: ${10.5 * 32 /* 10.5 items */};
 `;
 
 function TooltipLinkList({ links, LinkWrapper }) {

--- a/lib/components/src/tooltip/TooltipLinkList.tsx
+++ b/lib/components/src/tooltip/TooltipLinkList.tsx
@@ -7,6 +7,8 @@ const List = styled.div<{}>(
   {
     minWidth: 180,
     overflow: 'hidden',
+    overflowY: 'auto',
+    maxHeight: 10.5 * 32, // 10.5 items
   },
   ({ theme }) => ({
     borderRadius: theme.appBorderRadius * 2,


### PR DESCRIPTION
Issue: #6150

TooltipLinkList was not scrollable. This was a problem for plugins with many many options. i.e.: a i18n plugin. See screenshots below:

Before:
![Screenshot 2019-08-26 at 16 48 59](https://user-images.githubusercontent.com/441058/63699663-932a2700-c821-11e9-9132-15120beec3e9.png)

After:
![Screenshot 2019-08-26 at 16 49 30](https://user-images.githubusercontent.com/441058/63699694-9fae7f80-c821-11e9-8e86-f7c7cabff0cc.png)


## What I did

I added a maxHeight of 10.5 items (the half is to make it obvious that there are more items if you scroll down), and made overflow-y: auto.

## How to test

- Try making a plugin with many many options.