### PR TITLE
Addon-Info: Fix nesting breaking component descriptions

### DIFF
--- a/addons/info/src/__snapshots__/index.test.js.snap
+++ b/addons/info/src/__snapshots__/index.test.js.snap
@@ -4989,6 +4989,2440 @@ exports[`addon Info should render component description if story kind matches co
 </Info>
 `;
 
+exports[`addon Info should render component description if story kind matches component with a title 1`] = `
+<Info>
+  <Story
+    PropTable={[Function]}
+    components={
+      Object {
+        "a": [Function],
+        "code": [Function],
+        "h1": [Function],
+        "h2": [Function],
+        "h3": [Function],
+        "h4": [Function],
+        "h5": [Function],
+        "h6": [Function],
+        "li": [Function],
+        "p": [Function],
+        "ul": [Function],
+      }
+    }
+    context={
+      Object {
+        "kind": "Componets|TestComponent",
+        "name": "Basic test",
+      }
+    }
+    excludedPropTypes={Array []}
+    info=""
+    maxPropArrayLength={3}
+    maxPropObjectKeys={3}
+    maxPropStringLength={50}
+    maxPropsIntoLine={3}
+    propTables={null}
+    propTablesExclude={Array []}
+    showHeader={true}
+    showInline={true}
+    showSource={true}
+    styles={[Function]}
+  >
+    <div>
+      <div>
+        <div
+          style={
+            Object {
+              "backgroundColor": "#fff",
+              "border": "1px solid #eee",
+              "borderRadius": "2px",
+              "color": "black",
+              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+              "fontSize": "15px",
+              "fontWeight": 300,
+              "lineHeight": 1.45,
+              "marginBottom": "20px",
+              "marginTop": "20px",
+              "padding": "20px 40px 40px",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "borderBottom": "1px solid #eee",
+                "marginBottom": 10,
+                "paddingTop": 10,
+              }
+            }
+          >
+            <h1
+              style={
+                Object {
+                  "fontSize": "35px",
+                  "margin": 0,
+                  "padding": 0,
+                }
+              }
+            >
+              TestComponent
+            </h1>
+            <h2
+              style={
+                Object {
+                  "fontSize": "22px",
+                  "fontWeight": 400,
+                  "margin": "0 0 10px 0",
+                  "padding": 0,
+                }
+              }
+            >
+              Basic test
+            </h2>
+          </div>
+        </div>
+      </div>
+      <div
+        id="story-root"
+        style={Object {}}
+      >
+        <div>
+          It's a 
+          Basic test
+           story:
+          <TestComponent
+            array={
+              Array [
+                1,
+                2,
+                3,
+              ]
+            }
+            bool={true}
+            func={[Function]}
+            number={7}
+            obj={
+              Object {
+                "a": "a",
+                "b": "b",
+              }
+            }
+            string="seven"
+          >
+            <div>
+              <h1>
+                x =&gt; x + 1
+              </h1>
+              <h2>
+                [object Object]
+              </h2>
+              <h3>
+                1,2,3
+              </h3>
+              <h4>
+                7
+              </h4>
+              <h5>
+                seven
+              </h5>
+              <h6>
+                true
+              </h6>
+              <p>
+                undefined
+              </p>
+              <a
+                href="#"
+              >
+                test
+              </a>
+              <code>
+                storiesOf
+              </code>
+              <ul>
+                <li>
+                  1
+                </li>
+                <li>
+                  2
+                </li>
+              </ul>
+            </div>
+          </TestComponent>
+        </div>
+      </div>
+      <div>
+        <div
+          style={
+            Object {
+              "backgroundColor": "#fff",
+              "border": "1px solid #eee",
+              "borderRadius": "2px",
+              "color": "black",
+              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+              "fontSize": "15px",
+              "fontWeight": 300,
+              "lineHeight": 1.45,
+              "marginBottom": "20px",
+              "marginTop": "20px",
+              "padding": "20px 40px 40px",
+            }
+          }
+        >
+          <div>
+            <H1
+              context={Object {}}
+              id="awesome-test-component-description"
+              key="0"
+            >
+              <h1
+                id="awesome-test-component-description"
+                style={
+                  Object {
+                    "borderBottom": "1px solid #eee",
+                    "fontSize": "40px",
+                    "fontWeight": 600,
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                Awesome test component description
+              </h1>
+            </H1>
+            <H2
+              context={Object {}}
+              id="awesome-test-component-description-with-markdown-support"
+              key="1"
+            >
+              <h2
+                id="awesome-test-component-description-with-markdown-support"
+                style={
+                  Object {
+                    "fontSize": "30px",
+                    "fontWeight": 600,
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                with markdown support
+              </h2>
+            </H2>
+            <P
+              context={Object {}}
+              key="4"
+            >
+              <div
+                style={
+                  Object {
+                    "fontSize": "15px",
+                  }
+                }
+              >
+                <strong
+                  key="2"
+                >
+                  bold
+                </strong>
+                 
+                <em
+                  key="3"
+                >
+                  cursive
+                </em>
+              </div>
+            </P>
+          </div>
+          <div>
+            <h1
+              style={
+                Object {
+                  "borderBottom": "1px solid #EEE",
+                  "fontSize": "25px",
+                  "margin": "20px 0 0 0",
+                  "padding": "0 0 5px 0",
+                }
+              }
+            >
+              Story Source
+            </h1>
+            <Pre
+              theme={Object {}}
+            >
+              <pre
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "#fafafa",
+                    "display": "flex",
+                    "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+                    "fontSize": ".88em",
+                    "justifyContent": "space-between",
+                    "lineHeight": 1.5,
+                    "overflowX": "scroll",
+                    "padding": ".5rem",
+                  }
+                }
+              >
+                <div>
+                  <Node
+                    depth={0}
+                    key="0/.0"
+                    maxPropArrayLength={3}
+                    maxPropObjectKeys={3}
+                    maxPropStringLength={50}
+                    maxPropsIntoLine={3}
+                    node={
+                      <div>
+                        It's a 
+                        Basic test
+                         story:
+                        <TestComponent
+                          array={
+                            Array [
+                              1,
+                              2,
+                              3,
+                            ]
+                          }
+                          bool={true}
+                          func={[Function]}
+                          number={7}
+                          obj={
+                            Object {
+                              "a": "a",
+                              "b": "b",
+                            }
+                          }
+                          string="seven"
+                        />
+                      </div>
+                    }
+                  >
+                    <div>
+                      <div
+                        style={
+                          Object {
+                            "paddingLeft": 18,
+                            "paddingRight": 3,
+                          }
+                        }
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#444",
+                            }
+                          }
+                        >
+                          &lt;
+                          div
+                        </span>
+                        <Props
+                          maxPropArrayLength={3}
+                          maxPropObjectKeys={3}
+                          maxPropStringLength={50}
+                          maxPropsIntoLine={3}
+                          node={
+                            <div>
+                              It's a 
+                              Basic test
+                               story:
+                              <TestComponent
+                                array={
+                                  Array [
+                                    1,
+                                    2,
+                                    3,
+                                  ]
+                                }
+                                bool={true}
+                                func={[Function]}
+                                number={7}
+                                obj={
+                                  Object {
+                                    "a": "a",
+                                    "b": "b",
+                                  }
+                                }
+                                string="seven"
+                              />
+                            </div>
+                          }
+                          singleLine={false}
+                        >
+                          <span />
+                        </Props>
+                        <span
+                          style={
+                            Object {
+                              "color": "#444",
+                            }
+                          }
+                        >
+                          &gt;
+                        </span>
+                      </div>
+                      <Node
+                        depth={1}
+                        key=".0"
+                        maxPropArrayLength={3}
+                        maxPropObjectKeys={3}
+                        maxPropStringLength={50}
+                        maxPropsIntoLine={3}
+                        node="It's a "
+                      >
+                        <div
+                          style={
+                            Object {
+                              "paddingLeft": 33,
+                              "paddingRight": 3,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                            It's a 
+                          </span>
+                        </div>
+                      </Node>
+                      <Node
+                        depth={1}
+                        key=".1"
+                        maxPropArrayLength={3}
+                        maxPropObjectKeys={3}
+                        maxPropStringLength={50}
+                        maxPropsIntoLine={3}
+                        node="Basic test"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "paddingLeft": 33,
+                              "paddingRight": 3,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                            Basic test
+                          </span>
+                        </div>
+                      </Node>
+                      <Node
+                        depth={1}
+                        key=".2"
+                        maxPropArrayLength={3}
+                        maxPropObjectKeys={3}
+                        maxPropStringLength={50}
+                        maxPropsIntoLine={3}
+                        node=" story:"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "paddingLeft": 33,
+                              "paddingRight": 3,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                             story:
+                          </span>
+                        </div>
+                      </Node>
+                      <Node
+                        depth={1}
+                        key=".3"
+                        maxPropArrayLength={3}
+                        maxPropObjectKeys={3}
+                        maxPropStringLength={50}
+                        maxPropsIntoLine={3}
+                        node={
+                          <TestComponent
+                            array={
+                              Array [
+                                1,
+                                2,
+                                3,
+                              ]
+                            }
+                            bool={true}
+                            func={[Function]}
+                            number={7}
+                            obj={
+                              Object {
+                                "a": "a",
+                                "b": "b",
+                              }
+                            }
+                            string="seven"
+                          />
+                        }
+                      >
+                        <div
+                          style={
+                            Object {
+                              "paddingLeft": 33,
+                              "paddingRight": 3,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                            &lt;
+                            TestComponent
+                          </span>
+                          <Props
+                            maxPropArrayLength={3}
+                            maxPropObjectKeys={3}
+                            maxPropStringLength={50}
+                            maxPropsIntoLine={3}
+                            node={
+                              <TestComponent
+                                array={
+                                  Array [
+                                    1,
+                                    2,
+                                    3,
+                                  ]
+                                }
+                                bool={true}
+                                func={[Function]}
+                                number={7}
+                                obj={
+                                  Object {
+                                    "a": "a",
+                                    "b": "b",
+                                  }
+                                }
+                                string="seven"
+                              />
+                            }
+                            singleLine={true}
+                          >
+                            <span>
+                              <span
+                                key="func"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  func
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    {
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val={[Function]}
+                                      valueStyles={null}
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "color": "#170",
+                                          }
+                                        }
+                                      >
+                                        func
+                                      </span>
+                                    </PropVal>
+                                    }
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="obj"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  obj
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    {
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val={
+                                        Object {
+                                          "a": "a",
+                                          "b": "b",
+                                        }
+                                      }
+                                      valueStyles={null}
+                                    >
+                                      <PreviewObject
+                                        level={1}
+                                        maxPropObjectKeys={3}
+                                        maxPropStringLength={50}
+                                        maxPropsIntoLine={3}
+                                        val={
+                                          Object {
+                                            "a": "a",
+                                            "b": "b",
+                                          }
+                                        }
+                                        valueStyles={
+                                          Object {
+                                            "array": Object {
+                                              "color": "#666",
+                                            },
+                                            "attr": Object {
+                                              "color": "#666",
+                                            },
+                                            "bool": Object {
+                                              "color": "#a11",
+                                            },
+                                            "empty": Object {
+                                              "color": "#444",
+                                            },
+                                            "func": Object {
+                                              "color": "#170",
+                                            },
+                                            "number": Object {
+                                              "color": "#a11",
+                                            },
+                                            "object": Object {
+                                              "color": "#666",
+                                            },
+                                            "string": Object {
+                                              "color": "#22a",
+                                              "wordBreak": "break-word",
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          style={
+                                            Object {
+                                              "color": "#666",
+                                            }
+                                          }
+                                        >
+                                          {
+                                          <span
+                                            key="k0/.0"
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "color": "#666",
+                                                }
+                                              }
+                                            >
+                                              a
+                                            </span>
+                                          </span>
+                                          : 
+                                          <PropVal
+                                            key="v0/.0"
+                                            level={2}
+                                            maxPropArrayLength={3}
+                                            maxPropObjectKeys={3}
+                                            maxPropStringLength={50}
+                                            maxPropsIntoLine={3}
+                                            theme={Object {}}
+                                            val="a"
+                                            valueStyles={
+                                              Object {
+                                                "array": Object {
+                                                  "color": "#666",
+                                                },
+                                                "attr": Object {
+                                                  "color": "#666",
+                                                },
+                                                "bool": Object {
+                                                  "color": "#a11",
+                                                },
+                                                "empty": Object {
+                                                  "color": "#444",
+                                                },
+                                                "func": Object {
+                                                  "color": "#170",
+                                                },
+                                                "number": Object {
+                                                  "color": "#a11",
+                                                },
+                                                "object": Object {
+                                                  "color": "#666",
+                                                },
+                                                "string": Object {
+                                                  "color": "#22a",
+                                                  "wordBreak": "break-word",
+                                                },
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "color": "#22a",
+                                                  "wordBreak": "break-word",
+                                                }
+                                              }
+                                            >
+                                              'a'
+                                            </span>
+                                          </PropVal>
+                                          ,
+                                          <span
+                                            key="k1/.0"
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "color": "#666",
+                                                }
+                                              }
+                                            >
+                                              b
+                                            </span>
+                                          </span>
+                                          : 
+                                          <PropVal
+                                            key="v1/.0"
+                                            level={2}
+                                            maxPropArrayLength={3}
+                                            maxPropObjectKeys={3}
+                                            maxPropStringLength={50}
+                                            maxPropsIntoLine={3}
+                                            theme={Object {}}
+                                            val="b"
+                                            valueStyles={
+                                              Object {
+                                                "array": Object {
+                                                  "color": "#666",
+                                                },
+                                                "attr": Object {
+                                                  "color": "#666",
+                                                },
+                                                "bool": Object {
+                                                  "color": "#a11",
+                                                },
+                                                "empty": Object {
+                                                  "color": "#444",
+                                                },
+                                                "func": Object {
+                                                  "color": "#170",
+                                                },
+                                                "number": Object {
+                                                  "color": "#a11",
+                                                },
+                                                "object": Object {
+                                                  "color": "#666",
+                                                },
+                                                "string": Object {
+                                                  "color": "#22a",
+                                                  "wordBreak": "break-word",
+                                                },
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "color": "#22a",
+                                                  "wordBreak": "break-word",
+                                                }
+                                              }
+                                            >
+                                              'b'
+                                            </span>
+                                          </PropVal>
+                                          }
+                                        </span>
+                                      </PreviewObject>
+                                    </PropVal>
+                                    }
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="array"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  array
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    {
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val={
+                                        Array [
+                                          1,
+                                          2,
+                                          3,
+                                        ]
+                                      }
+                                      valueStyles={null}
+                                    >
+                                      <PreviewArray
+                                        level={1}
+                                        maxPropArrayLength={3}
+                                        maxPropStringLength={50}
+                                        maxPropsIntoLine={3}
+                                        val={
+                                          Array [
+                                            1,
+                                            2,
+                                            3,
+                                          ]
+                                        }
+                                        valueStyles={
+                                          Object {
+                                            "array": Object {
+                                              "color": "#666",
+                                            },
+                                            "attr": Object {
+                                              "color": "#666",
+                                            },
+                                            "bool": Object {
+                                              "color": "#a11",
+                                            },
+                                            "empty": Object {
+                                              "color": "#444",
+                                            },
+                                            "func": Object {
+                                              "color": "#170",
+                                            },
+                                            "number": Object {
+                                              "color": "#a11",
+                                            },
+                                            "object": Object {
+                                              "color": "#666",
+                                            },
+                                            "string": Object {
+                                              "color": "#22a",
+                                              "wordBreak": "break-word",
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          style={
+                                            Object {
+                                              "color": "#666",
+                                            }
+                                          }
+                                        >
+                                          [
+                                          <span
+                                            key="n0/.0"
+                                          >
+                                            <PropVal
+                                              level={2}
+                                              maxPropArrayLength={3}
+                                              maxPropObjectKeys={3}
+                                              maxPropStringLength={50}
+                                              maxPropsIntoLine={3}
+                                              theme={Object {}}
+                                              val={1}
+                                              valueStyles={
+                                                Object {
+                                                  "array": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "attr": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "bool": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "empty": Object {
+                                                    "color": "#444",
+                                                  },
+                                                  "func": Object {
+                                                    "color": "#170",
+                                                  },
+                                                  "number": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "object": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "string": Object {
+                                                    "color": "#22a",
+                                                    "wordBreak": "break-word",
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                style={
+                                                  Object {
+                                                    "color": "#a11",
+                                                  }
+                                                }
+                                              >
+                                                1
+                                              </span>
+                                            </PropVal>
+                                          </span>
+                                          ,
+                                          <span
+                                            key="n1/.0"
+                                          >
+                                            <PropVal
+                                              level={2}
+                                              maxPropArrayLength={3}
+                                              maxPropObjectKeys={3}
+                                              maxPropStringLength={50}
+                                              maxPropsIntoLine={3}
+                                              theme={Object {}}
+                                              val={2}
+                                              valueStyles={
+                                                Object {
+                                                  "array": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "attr": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "bool": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "empty": Object {
+                                                    "color": "#444",
+                                                  },
+                                                  "func": Object {
+                                                    "color": "#170",
+                                                  },
+                                                  "number": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "object": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "string": Object {
+                                                    "color": "#22a",
+                                                    "wordBreak": "break-word",
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                style={
+                                                  Object {
+                                                    "color": "#a11",
+                                                  }
+                                                }
+                                              >
+                                                2
+                                              </span>
+                                            </PropVal>
+                                          </span>
+                                          ,
+                                          <span
+                                            key="n2/.0"
+                                          >
+                                            <PropVal
+                                              level={2}
+                                              maxPropArrayLength={3}
+                                              maxPropObjectKeys={3}
+                                              maxPropStringLength={50}
+                                              maxPropsIntoLine={3}
+                                              theme={Object {}}
+                                              val={3}
+                                              valueStyles={
+                                                Object {
+                                                  "array": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "attr": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "bool": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "empty": Object {
+                                                    "color": "#444",
+                                                  },
+                                                  "func": Object {
+                                                    "color": "#170",
+                                                  },
+                                                  "number": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "object": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "string": Object {
+                                                    "color": "#22a",
+                                                    "wordBreak": "break-word",
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                style={
+                                                  Object {
+                                                    "color": "#a11",
+                                                  }
+                                                }
+                                              >
+                                                3
+                                              </span>
+                                            </PropVal>
+                                          </span>
+                                          ]
+                                        </span>
+                                      </PreviewArray>
+                                    </PropVal>
+                                    }
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="number"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  number
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    {
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val={7}
+                                      valueStyles={null}
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "color": "#a11",
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </span>
+                                    </PropVal>
+                                    }
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="string"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  string
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    "
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val="seven"
+                                      valueStyles={null}
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "color": "#22a",
+                                            "wordBreak": "break-word",
+                                          }
+                                        }
+                                      >
+                                        seven
+                                      </span>
+                                    </PropVal>
+                                    "
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="bool"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  bool
+                                </span>
+                                <br />
+                              </span>
+                            </span>
+                          </Props>
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                            /&gt;
+                          </span>
+                        </div>
+                      </Node>
+                      <div
+                        style={
+                          Object {
+                            "paddingLeft": 18,
+                            "paddingRight": 3,
+                          }
+                        }
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#444",
+                            }
+                          }
+                        >
+                          &lt;/
+                          div
+                          &gt;
+                        </span>
+                      </div>
+                    </div>
+                  </Node>
+                </div>
+                <CopyButton
+                  onClick={[Function]}
+                  toggled={false}
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "alignSelf": "flex-start",
+                        "backgroundColor": "rgb(255, 255, 255)",
+                        "borderColor": "rgb(238, 238, 238)",
+                        "borderImage": "initial",
+                        "borderRadius": "3px",
+                        "borderStyle": "solid",
+                        "borderWidth": "1px",
+                        "cursor": "pointer",
+                        "flexShrink": "0",
+                        "fontSize": "13px",
+                        "overflow": "hidden",
+                        "padding": "3px 10px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Copy
+                  </button>
+                </CopyButton>
+              </pre>
+            </Pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Story>
+</Info>
+`;
+
+exports[`addon Info should render component description if story kind matches component with nesting 1`] = `
+<Info>
+  <Story
+    PropTable={[Function]}
+    components={
+      Object {
+        "a": [Function],
+        "code": [Function],
+        "h1": [Function],
+        "h2": [Function],
+        "h3": [Function],
+        "h4": [Function],
+        "h5": [Function],
+        "h6": [Function],
+        "li": [Function],
+        "p": [Function],
+        "ul": [Function],
+      }
+    }
+    context={
+      Object {
+        "kind": "Components/Tests/TestComponent",
+        "name": "Basic test",
+      }
+    }
+    excludedPropTypes={Array []}
+    info=""
+    maxPropArrayLength={3}
+    maxPropObjectKeys={3}
+    maxPropStringLength={50}
+    maxPropsIntoLine={3}
+    propTables={null}
+    propTablesExclude={Array []}
+    showHeader={true}
+    showInline={true}
+    showSource={true}
+    styles={[Function]}
+  >
+    <div>
+      <div>
+        <div
+          style={
+            Object {
+              "backgroundColor": "#fff",
+              "border": "1px solid #eee",
+              "borderRadius": "2px",
+              "color": "black",
+              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+              "fontSize": "15px",
+              "fontWeight": 300,
+              "lineHeight": 1.45,
+              "marginBottom": "20px",
+              "marginTop": "20px",
+              "padding": "20px 40px 40px",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "borderBottom": "1px solid #eee",
+                "marginBottom": 10,
+                "paddingTop": 10,
+              }
+            }
+          >
+            <h1
+              style={
+                Object {
+                  "fontSize": "35px",
+                  "margin": 0,
+                  "padding": 0,
+                }
+              }
+            >
+              TestComponent
+            </h1>
+            <h2
+              style={
+                Object {
+                  "fontSize": "22px",
+                  "fontWeight": 400,
+                  "margin": "0 0 10px 0",
+                  "padding": 0,
+                }
+              }
+            >
+              Basic test
+            </h2>
+          </div>
+        </div>
+      </div>
+      <div
+        id="story-root"
+        style={Object {}}
+      >
+        <div>
+          It's a 
+          Basic test
+           story:
+          <TestComponent
+            array={
+              Array [
+                1,
+                2,
+                3,
+              ]
+            }
+            bool={true}
+            func={[Function]}
+            number={7}
+            obj={
+              Object {
+                "a": "a",
+                "b": "b",
+              }
+            }
+            string="seven"
+          >
+            <div>
+              <h1>
+                x =&gt; x + 1
+              </h1>
+              <h2>
+                [object Object]
+              </h2>
+              <h3>
+                1,2,3
+              </h3>
+              <h4>
+                7
+              </h4>
+              <h5>
+                seven
+              </h5>
+              <h6>
+                true
+              </h6>
+              <p>
+                undefined
+              </p>
+              <a
+                href="#"
+              >
+                test
+              </a>
+              <code>
+                storiesOf
+              </code>
+              <ul>
+                <li>
+                  1
+                </li>
+                <li>
+                  2
+                </li>
+              </ul>
+            </div>
+          </TestComponent>
+        </div>
+      </div>
+      <div>
+        <div
+          style={
+            Object {
+              "backgroundColor": "#fff",
+              "border": "1px solid #eee",
+              "borderRadius": "2px",
+              "color": "black",
+              "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+              "fontSize": "15px",
+              "fontWeight": 300,
+              "lineHeight": 1.45,
+              "marginBottom": "20px",
+              "marginTop": "20px",
+              "padding": "20px 40px 40px",
+            }
+          }
+        >
+          <div>
+            <H1
+              context={Object {}}
+              id="awesome-test-component-description"
+              key="0"
+            >
+              <h1
+                id="awesome-test-component-description"
+                style={
+                  Object {
+                    "borderBottom": "1px solid #eee",
+                    "fontSize": "40px",
+                    "fontWeight": 600,
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                Awesome test component description
+              </h1>
+            </H1>
+            <H2
+              context={Object {}}
+              id="awesome-test-component-description-with-markdown-support"
+              key="1"
+            >
+              <h2
+                id="awesome-test-component-description-with-markdown-support"
+                style={
+                  Object {
+                    "fontSize": "30px",
+                    "fontWeight": 600,
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                with markdown support
+              </h2>
+            </H2>
+            <P
+              context={Object {}}
+              key="4"
+            >
+              <div
+                style={
+                  Object {
+                    "fontSize": "15px",
+                  }
+                }
+              >
+                <strong
+                  key="2"
+                >
+                  bold
+                </strong>
+                 
+                <em
+                  key="3"
+                >
+                  cursive
+                </em>
+              </div>
+            </P>
+          </div>
+          <div>
+            <h1
+              style={
+                Object {
+                  "borderBottom": "1px solid #EEE",
+                  "fontSize": "25px",
+                  "margin": "20px 0 0 0",
+                  "padding": "0 0 5px 0",
+                }
+              }
+            >
+              Story Source
+            </h1>
+            <Pre
+              theme={Object {}}
+            >
+              <pre
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "#fafafa",
+                    "display": "flex",
+                    "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+                    "fontSize": ".88em",
+                    "justifyContent": "space-between",
+                    "lineHeight": 1.5,
+                    "overflowX": "scroll",
+                    "padding": ".5rem",
+                  }
+                }
+              >
+                <div>
+                  <Node
+                    depth={0}
+                    key="0/.0"
+                    maxPropArrayLength={3}
+                    maxPropObjectKeys={3}
+                    maxPropStringLength={50}
+                    maxPropsIntoLine={3}
+                    node={
+                      <div>
+                        It's a 
+                        Basic test
+                         story:
+                        <TestComponent
+                          array={
+                            Array [
+                              1,
+                              2,
+                              3,
+                            ]
+                          }
+                          bool={true}
+                          func={[Function]}
+                          number={7}
+                          obj={
+                            Object {
+                              "a": "a",
+                              "b": "b",
+                            }
+                          }
+                          string="seven"
+                        />
+                      </div>
+                    }
+                  >
+                    <div>
+                      <div
+                        style={
+                          Object {
+                            "paddingLeft": 18,
+                            "paddingRight": 3,
+                          }
+                        }
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#444",
+                            }
+                          }
+                        >
+                          &lt;
+                          div
+                        </span>
+                        <Props
+                          maxPropArrayLength={3}
+                          maxPropObjectKeys={3}
+                          maxPropStringLength={50}
+                          maxPropsIntoLine={3}
+                          node={
+                            <div>
+                              It's a 
+                              Basic test
+                               story:
+                              <TestComponent
+                                array={
+                                  Array [
+                                    1,
+                                    2,
+                                    3,
+                                  ]
+                                }
+                                bool={true}
+                                func={[Function]}
+                                number={7}
+                                obj={
+                                  Object {
+                                    "a": "a",
+                                    "b": "b",
+                                  }
+                                }
+                                string="seven"
+                              />
+                            </div>
+                          }
+                          singleLine={false}
+                        >
+                          <span />
+                        </Props>
+                        <span
+                          style={
+                            Object {
+                              "color": "#444",
+                            }
+                          }
+                        >
+                          &gt;
+                        </span>
+                      </div>
+                      <Node
+                        depth={1}
+                        key=".0"
+                        maxPropArrayLength={3}
+                        maxPropObjectKeys={3}
+                        maxPropStringLength={50}
+                        maxPropsIntoLine={3}
+                        node="It's a "
+                      >
+                        <div
+                          style={
+                            Object {
+                              "paddingLeft": 33,
+                              "paddingRight": 3,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                            It's a 
+                          </span>
+                        </div>
+                      </Node>
+                      <Node
+                        depth={1}
+                        key=".1"
+                        maxPropArrayLength={3}
+                        maxPropObjectKeys={3}
+                        maxPropStringLength={50}
+                        maxPropsIntoLine={3}
+                        node="Basic test"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "paddingLeft": 33,
+                              "paddingRight": 3,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                            Basic test
+                          </span>
+                        </div>
+                      </Node>
+                      <Node
+                        depth={1}
+                        key=".2"
+                        maxPropArrayLength={3}
+                        maxPropObjectKeys={3}
+                        maxPropStringLength={50}
+                        maxPropsIntoLine={3}
+                        node=" story:"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "paddingLeft": 33,
+                              "paddingRight": 3,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                             story:
+                          </span>
+                        </div>
+                      </Node>
+                      <Node
+                        depth={1}
+                        key=".3"
+                        maxPropArrayLength={3}
+                        maxPropObjectKeys={3}
+                        maxPropStringLength={50}
+                        maxPropsIntoLine={3}
+                        node={
+                          <TestComponent
+                            array={
+                              Array [
+                                1,
+                                2,
+                                3,
+                              ]
+                            }
+                            bool={true}
+                            func={[Function]}
+                            number={7}
+                            obj={
+                              Object {
+                                "a": "a",
+                                "b": "b",
+                              }
+                            }
+                            string="seven"
+                          />
+                        }
+                      >
+                        <div
+                          style={
+                            Object {
+                              "paddingLeft": 33,
+                              "paddingRight": 3,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                            &lt;
+                            TestComponent
+                          </span>
+                          <Props
+                            maxPropArrayLength={3}
+                            maxPropObjectKeys={3}
+                            maxPropStringLength={50}
+                            maxPropsIntoLine={3}
+                            node={
+                              <TestComponent
+                                array={
+                                  Array [
+                                    1,
+                                    2,
+                                    3,
+                                  ]
+                                }
+                                bool={true}
+                                func={[Function]}
+                                number={7}
+                                obj={
+                                  Object {
+                                    "a": "a",
+                                    "b": "b",
+                                  }
+                                }
+                                string="seven"
+                              />
+                            }
+                            singleLine={true}
+                          >
+                            <span>
+                              <span
+                                key="func"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  func
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    {
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val={[Function]}
+                                      valueStyles={null}
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "color": "#170",
+                                          }
+                                        }
+                                      >
+                                        func
+                                      </span>
+                                    </PropVal>
+                                    }
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="obj"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  obj
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    {
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val={
+                                        Object {
+                                          "a": "a",
+                                          "b": "b",
+                                        }
+                                      }
+                                      valueStyles={null}
+                                    >
+                                      <PreviewObject
+                                        level={1}
+                                        maxPropObjectKeys={3}
+                                        maxPropStringLength={50}
+                                        maxPropsIntoLine={3}
+                                        val={
+                                          Object {
+                                            "a": "a",
+                                            "b": "b",
+                                          }
+                                        }
+                                        valueStyles={
+                                          Object {
+                                            "array": Object {
+                                              "color": "#666",
+                                            },
+                                            "attr": Object {
+                                              "color": "#666",
+                                            },
+                                            "bool": Object {
+                                              "color": "#a11",
+                                            },
+                                            "empty": Object {
+                                              "color": "#444",
+                                            },
+                                            "func": Object {
+                                              "color": "#170",
+                                            },
+                                            "number": Object {
+                                              "color": "#a11",
+                                            },
+                                            "object": Object {
+                                              "color": "#666",
+                                            },
+                                            "string": Object {
+                                              "color": "#22a",
+                                              "wordBreak": "break-word",
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          style={
+                                            Object {
+                                              "color": "#666",
+                                            }
+                                          }
+                                        >
+                                          {
+                                          <span
+                                            key="k0/.0"
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "color": "#666",
+                                                }
+                                              }
+                                            >
+                                              a
+                                            </span>
+                                          </span>
+                                          : 
+                                          <PropVal
+                                            key="v0/.0"
+                                            level={2}
+                                            maxPropArrayLength={3}
+                                            maxPropObjectKeys={3}
+                                            maxPropStringLength={50}
+                                            maxPropsIntoLine={3}
+                                            theme={Object {}}
+                                            val="a"
+                                            valueStyles={
+                                              Object {
+                                                "array": Object {
+                                                  "color": "#666",
+                                                },
+                                                "attr": Object {
+                                                  "color": "#666",
+                                                },
+                                                "bool": Object {
+                                                  "color": "#a11",
+                                                },
+                                                "empty": Object {
+                                                  "color": "#444",
+                                                },
+                                                "func": Object {
+                                                  "color": "#170",
+                                                },
+                                                "number": Object {
+                                                  "color": "#a11",
+                                                },
+                                                "object": Object {
+                                                  "color": "#666",
+                                                },
+                                                "string": Object {
+                                                  "color": "#22a",
+                                                  "wordBreak": "break-word",
+                                                },
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "color": "#22a",
+                                                  "wordBreak": "break-word",
+                                                }
+                                              }
+                                            >
+                                              'a'
+                                            </span>
+                                          </PropVal>
+                                          ,
+                                          <span
+                                            key="k1/.0"
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "color": "#666",
+                                                }
+                                              }
+                                            >
+                                              b
+                                            </span>
+                                          </span>
+                                          : 
+                                          <PropVal
+                                            key="v1/.0"
+                                            level={2}
+                                            maxPropArrayLength={3}
+                                            maxPropObjectKeys={3}
+                                            maxPropStringLength={50}
+                                            maxPropsIntoLine={3}
+                                            theme={Object {}}
+                                            val="b"
+                                            valueStyles={
+                                              Object {
+                                                "array": Object {
+                                                  "color": "#666",
+                                                },
+                                                "attr": Object {
+                                                  "color": "#666",
+                                                },
+                                                "bool": Object {
+                                                  "color": "#a11",
+                                                },
+                                                "empty": Object {
+                                                  "color": "#444",
+                                                },
+                                                "func": Object {
+                                                  "color": "#170",
+                                                },
+                                                "number": Object {
+                                                  "color": "#a11",
+                                                },
+                                                "object": Object {
+                                                  "color": "#666",
+                                                },
+                                                "string": Object {
+                                                  "color": "#22a",
+                                                  "wordBreak": "break-word",
+                                                },
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "color": "#22a",
+                                                  "wordBreak": "break-word",
+                                                }
+                                              }
+                                            >
+                                              'b'
+                                            </span>
+                                          </PropVal>
+                                          }
+                                        </span>
+                                      </PreviewObject>
+                                    </PropVal>
+                                    }
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="array"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  array
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    {
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val={
+                                        Array [
+                                          1,
+                                          2,
+                                          3,
+                                        ]
+                                      }
+                                      valueStyles={null}
+                                    >
+                                      <PreviewArray
+                                        level={1}
+                                        maxPropArrayLength={3}
+                                        maxPropStringLength={50}
+                                        maxPropsIntoLine={3}
+                                        val={
+                                          Array [
+                                            1,
+                                            2,
+                                            3,
+                                          ]
+                                        }
+                                        valueStyles={
+                                          Object {
+                                            "array": Object {
+                                              "color": "#666",
+                                            },
+                                            "attr": Object {
+                                              "color": "#666",
+                                            },
+                                            "bool": Object {
+                                              "color": "#a11",
+                                            },
+                                            "empty": Object {
+                                              "color": "#444",
+                                            },
+                                            "func": Object {
+                                              "color": "#170",
+                                            },
+                                            "number": Object {
+                                              "color": "#a11",
+                                            },
+                                            "object": Object {
+                                              "color": "#666",
+                                            },
+                                            "string": Object {
+                                              "color": "#22a",
+                                              "wordBreak": "break-word",
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          style={
+                                            Object {
+                                              "color": "#666",
+                                            }
+                                          }
+                                        >
+                                          [
+                                          <span
+                                            key="n0/.0"
+                                          >
+                                            <PropVal
+                                              level={2}
+                                              maxPropArrayLength={3}
+                                              maxPropObjectKeys={3}
+                                              maxPropStringLength={50}
+                                              maxPropsIntoLine={3}
+                                              theme={Object {}}
+                                              val={1}
+                                              valueStyles={
+                                                Object {
+                                                  "array": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "attr": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "bool": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "empty": Object {
+                                                    "color": "#444",
+                                                  },
+                                                  "func": Object {
+                                                    "color": "#170",
+                                                  },
+                                                  "number": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "object": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "string": Object {
+                                                    "color": "#22a",
+                                                    "wordBreak": "break-word",
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                style={
+                                                  Object {
+                                                    "color": "#a11",
+                                                  }
+                                                }
+                                              >
+                                                1
+                                              </span>
+                                            </PropVal>
+                                          </span>
+                                          ,
+                                          <span
+                                            key="n1/.0"
+                                          >
+                                            <PropVal
+                                              level={2}
+                                              maxPropArrayLength={3}
+                                              maxPropObjectKeys={3}
+                                              maxPropStringLength={50}
+                                              maxPropsIntoLine={3}
+                                              theme={Object {}}
+                                              val={2}
+                                              valueStyles={
+                                                Object {
+                                                  "array": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "attr": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "bool": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "empty": Object {
+                                                    "color": "#444",
+                                                  },
+                                                  "func": Object {
+                                                    "color": "#170",
+                                                  },
+                                                  "number": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "object": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "string": Object {
+                                                    "color": "#22a",
+                                                    "wordBreak": "break-word",
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                style={
+                                                  Object {
+                                                    "color": "#a11",
+                                                  }
+                                                }
+                                              >
+                                                2
+                                              </span>
+                                            </PropVal>
+                                          </span>
+                                          ,
+                                          <span
+                                            key="n2/.0"
+                                          >
+                                            <PropVal
+                                              level={2}
+                                              maxPropArrayLength={3}
+                                              maxPropObjectKeys={3}
+                                              maxPropStringLength={50}
+                                              maxPropsIntoLine={3}
+                                              theme={Object {}}
+                                              val={3}
+                                              valueStyles={
+                                                Object {
+                                                  "array": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "attr": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "bool": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "empty": Object {
+                                                    "color": "#444",
+                                                  },
+                                                  "func": Object {
+                                                    "color": "#170",
+                                                  },
+                                                  "number": Object {
+                                                    "color": "#a11",
+                                                  },
+                                                  "object": Object {
+                                                    "color": "#666",
+                                                  },
+                                                  "string": Object {
+                                                    "color": "#22a",
+                                                    "wordBreak": "break-word",
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                style={
+                                                  Object {
+                                                    "color": "#a11",
+                                                  }
+                                                }
+                                              >
+                                                3
+                                              </span>
+                                            </PropVal>
+                                          </span>
+                                          ]
+                                        </span>
+                                      </PreviewArray>
+                                    </PropVal>
+                                    }
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="number"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  number
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    {
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val={7}
+                                      valueStyles={null}
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "color": "#a11",
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </span>
+                                    </PropVal>
+                                    }
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="string"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  string
+                                </span>
+                                <span>
+                                  =
+                                  <span
+                                    style={Object {}}
+                                  >
+                                    "
+                                    <PropVal
+                                      level={1}
+                                      maxPropArrayLength={3}
+                                      maxPropObjectKeys={3}
+                                      maxPropStringLength={50}
+                                      maxPropsIntoLine={3}
+                                      theme={Object {}}
+                                      val="seven"
+                                      valueStyles={null}
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "color": "#22a",
+                                            "wordBreak": "break-word",
+                                          }
+                                        }
+                                      >
+                                        seven
+                                      </span>
+                                    </PropVal>
+                                    "
+                                  </span>
+                                </span>
+                              </span>
+                              <span
+                                key="bool"
+                              >
+                                <span>
+                                  <br />
+                                    
+                                </span>
+                                <span
+                                  style={Object {}}
+                                >
+                                  bool
+                                </span>
+                                <br />
+                              </span>
+                            </span>
+                          </Props>
+                          <span
+                            style={
+                              Object {
+                                "color": "#444",
+                              }
+                            }
+                          >
+                            /&gt;
+                          </span>
+                        </div>
+                      </Node>
+                      <div
+                        style={
+                          Object {
+                            "paddingLeft": 18,
+                            "paddingRight": 3,
+                          }
+                        }
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#444",
+                            }
+                          }
+                        >
+                          &lt;/
+                          div
+                          &gt;
+                        </span>
+                      </div>
+                    </div>
+                  </Node>
+                </div>
+                <CopyButton
+                  onClick={[Function]}
+                  toggled={false}
+                >
+                  <button
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "alignSelf": "flex-start",
+                        "backgroundColor": "rgb(255, 255, 255)",
+                        "borderColor": "rgb(238, 238, 238)",
+                        "borderImage": "initial",
+                        "borderRadius": "3px",
+                        "borderStyle": "solid",
+                        "borderWidth": "1px",
+                        "cursor": "pointer",
+                        "flexShrink": "0",
+                        "fontSize": "13px",
+                        "overflow": "hidden",
+                        "padding": "3px 10px",
+                      }
+                    }
+                    type="button"
+                  >
+                    Copy
+                  </button>
+                </CopyButton>
+              </pre>
+            </Pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Story>
+</Info>
+`;
+
 exports[`addon Info should render component description if story name matches component 1`] = `
 <Info>
   <Story

--- a/addons/info/src/components/Story.js
+++ b/addons/info/src/components/Story.js
@@ -220,6 +220,16 @@ class Story extends Component {
     );
   }
 
+  _getStoryKind() {
+    let {
+      context: { kind },
+    } = this.props;
+    if (kind) {
+      kind = kind.replace(/^(.+[/|.])*/, '');
+    }
+    return kind;
+  }
+
   _getInfoHeader() {
     const { stylesheet } = this.state;
     const { context, showHeader } = this.props;
@@ -230,7 +240,7 @@ class Story extends Component {
 
     return (
       <div style={stylesheet.header.body}>
-        <h1 style={stylesheet.header.h1}>{context.kind}</h1>
+        <h1 style={stylesheet.header.h1}>{this._getStoryKind()}</h1>
         <h2 style={stylesheet.header.h2}>{context.name}</h2>
       </div>
     );
@@ -265,11 +275,11 @@ class Story extends Component {
 
   _getComponentDescription() {
     const {
-      context: { kind, name },
+      context: { name },
     } = this.props;
     let retDiv = null;
 
-    const validMatches = [kind, name];
+    const validMatches = [this._getStoryKind(), name];
 
     if (Object.keys(STORYBOOK_REACT_CLASSES).length) {
       Object.keys(STORYBOOK_REACT_CLASSES).forEach(key => {

--- a/addons/info/src/index.test.js
+++ b/addons/info/src/index.test.js
@@ -87,6 +87,28 @@ describe('addon Info', () => {
     expect(mount(<Info />)).toMatchSnapshot();
   });
 
+  it('should render the kind without nesting', () => {
+    const Info = () =>
+      withInfo({ inline: true, propTables: false })(storyFn, {
+        kind: 'Components/Test/TestComponent',
+        name: 'Basic test',
+      });
+
+    const wrapper = mount(<Info />);
+    expect(wrapper.find('div > div:first-child > h1').text()).toBe('TestComponent');
+  });
+
+  it('should render the kind without a title', () => {
+    const Info = () =>
+      withInfo({ inline: true, propTables: false })(storyFn, {
+        kind: 'Components|TestComponent',
+        name: 'Basic test',
+      });
+
+    const wrapper = mount(<Info />);
+    expect(wrapper.find('div > div:first-child > h1').text()).toBe('TestComponent');
+  });
+
   it('should render component description if story kind matches component', () => {
     const previousReactClassesValue = global.STORYBOOK_REACT_CLASSES[reactClassPath];
     Object.assign(global.STORYBOOK_REACT_CLASSES, { [reactClassPath]: storybookReactClassMock });
@@ -110,6 +132,36 @@ describe('addon Info', () => {
       withInfo({ inline: true, propTables: false })(storyFn, {
         kind: 'Test Components',
         name: 'TestComponent',
+      });
+
+    expect(mount(<Info />)).toMatchSnapshot();
+
+    Object.assign(global.STORYBOOK_REACT_CLASSES, { [reactClassPath]: previousReactClassesValue });
+  });
+
+  it('should render component description if story kind matches component with a title', () => {
+    const previousReactClassesValue = global.STORYBOOK_REACT_CLASSES[reactClassPath];
+    Object.assign(global.STORYBOOK_REACT_CLASSES, { [reactClassPath]: storybookReactClassMock });
+
+    const Info = () =>
+      withInfo({ inline: true, propTables: false })(storyFn, {
+        kind: 'Componets|TestComponent',
+        name: 'Basic test',
+      });
+
+    expect(mount(<Info />)).toMatchSnapshot();
+
+    Object.assign(global.STORYBOOK_REACT_CLASSES, { [reactClassPath]: previousReactClassesValue });
+  });
+
+  it('should render component description if story kind matches component with nesting', () => {
+    const previousReactClassesValue = global.STORYBOOK_REACT_CLASSES[reactClassPath];
+    Object.assign(global.STORYBOOK_REACT_CLASSES, { [reactClassPath]: storybookReactClassMock });
+
+    const Info = () =>
+      withInfo({ inline: true, propTables: false })(storyFn, {
+        kind: 'Components/Tests/TestComponent',
+        name: 'Basic test',
       });
 
     expect(mount(<Info />)).toMatchSnapshot();


### PR DESCRIPTION
Apologies on doing this on master, but every snapshot test seems to be broken on `next` and I can't work out what's happening.

Fixes #7655

## What I did
Made addon-info discard title & nesting prefixes when working with the story "kind"

## How to test
Jest tests written, documentation should be fine
