### PR TITLE
Addon-docs: Make config API consistent with other addons

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -189,8 +189,10 @@ import { addParameters } from '@storybook/react';
 import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 
 addParameters({
-  docsContainer: DocsContainer,
-  docs: DocsPage,
+  docs: {
+    container: DocsContainer,
+    page: DocsPage,
+  },
 });
 ```
 

--- a/addons/docs/docs/docspage.md
+++ b/addons/docs/docs/docspage.md
@@ -196,7 +196,7 @@ And here are the return type signatures for each of the slot functions
 
 What if you don't want a `DocsPage` for your storybook, for a specific component, or even for a specific story?
 
-You can replace DocsPage at any level by overriding the `docs` parameter:
+You can replace DocsPage at any level by overriding the `docs.page` parameter:
 
 - With `null` to remove docs
 - [With MDX](#csf-stories-with-mdx-docs) docs
@@ -206,7 +206,7 @@ You can replace DocsPage at any level by overriding the `docs` parameter:
 
 ```js
 import { addParameters } from '@storybook/react';
-addParameters({ docs: null });
+addParameters({ docs: { page: null } });
 ```
 
 **Component-level (Button.stories.js)**
@@ -216,7 +216,7 @@ import { Button } from './Button';
 export default {
   title: 'Demo/Button',
   component: Button,
-  parameters: { docs: null },
+  parameters: { docs: { page: null } },
 };
 ```
 
@@ -227,7 +227,7 @@ import { Button } from './Button';
 // export default { ... }
 export const basic => () => <Button>Basic</Button>
 basic.story = {
-  parameters: { docs: null }
+  parameters: { docs: { page: null } }
 }
 ```
 

--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -47,7 +47,7 @@ export const DocsContainer: React.FunctionComponent<DocsContainerProps> = ({
   const parameters = (context && context.parameters) || {};
   const options = parameters.options || {};
   const theme = ensureTheme(options.theme);
-  const { components: userComponents = null } = options.docs || {};
+  const { components: userComponents = null } = parameters.docs || {};
   const components = { ...defaultComponents, ...userComponents };
   return (
     <DocsContext.Provider value={context}>

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -30,8 +30,9 @@ export const getPropsTableProps = (
       throw new Error(PropsTableError.NO_COMPONENT);
     }
 
-    const { framework = null } = parameters || {};
-    const { getPropDefs = inferPropDefs(framework) } = (parameters && parameters.docs) || {};
+    const params = parameters || {};
+    const { framework = null } = params;
+    const { getPropDefs = inferPropDefs(framework) } = params.docs || {};
 
     if (!getPropDefs) {
       throw new Error(PropsTableError.PROPS_UNSUPPORTED);

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -31,8 +31,7 @@ export const getPropsTableProps = (
     }
 
     const { framework = null } = parameters || {};
-    const { getPropDefs = inferPropDefs(framework) } =
-      (parameters && parameters.options && parameters.options.docs) || {};
+    const { getPropDefs = inferPropDefs(framework) } = (parameters && parameters.docs) || {};
 
     if (!getPropDefs) {
       throw new Error(PropsTableError.PROPS_UNSUPPORTED);

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -23,17 +23,16 @@ export const getPropsTableProps = (
   { exclude, of }: PropsProps,
   { parameters }: DocsContextProps
 ): PropsTableProps => {
-  const { component } = parameters;
   try {
+    const params = parameters || {};
+    const { component, framework = null } = params;
+
     const target = of === CURRENT_SELECTION ? component : of;
     if (!target) {
       throw new Error(PropsTableError.NO_COMPONENT);
     }
 
-    const params = parameters || {};
-    const { framework = null } = params;
     const { getPropDefs = inferPropDefs(framework) } = params.docs || {};
-
     if (!getPropDefs) {
       throw new Error(PropsTableError.PROPS_UNSUPPORTED);
     }

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -45,7 +45,7 @@ export const getStoryProps = (
 
   // prefer props, then global options, then framework-inferred values
   const { inlineStories = inferInlineStories(framework), iframeHeight = undefined } =
-    (parameters && parameters.options && parameters.options.docs) || {};
+    (parameters && parameters.docs) || {};
   return {
     inline: typeof inline === 'boolean' ? inline : inlineStories,
     id: previewId,

--- a/addons/docs/src/frameworks/angular/config.js
+++ b/addons/docs/src/frameworks/angular/config.js
@@ -3,6 +3,8 @@ import { addParameters } from '@storybook/angular';
 import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 
 addParameters({
-  docsContainer: DocsContainer,
-  docs: DocsPage,
+  docs: {
+    container: DocsContainer,
+    page: DocsPage,
+  },
 });

--- a/addons/docs/src/frameworks/html/config.js
+++ b/addons/docs/src/frameworks/html/config.js
@@ -3,6 +3,8 @@ import { addParameters } from '@storybook/html';
 import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 
 addParameters({
-  docsContainer: DocsContainer,
-  docs: DocsPage,
+  docs: {
+    container: DocsContainer,
+    page: DocsPage,
+  },
 });

--- a/addons/docs/src/frameworks/react/config.js
+++ b/addons/docs/src/frameworks/react/config.js
@@ -3,6 +3,8 @@ import { addParameters } from '@storybook/react';
 import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 
 addParameters({
-  docsContainer: DocsContainer,
-  docs: DocsPage,
+  docs: {
+    container: DocsContainer,
+    page: DocsPage,
+  },
 });

--- a/addons/docs/src/frameworks/vue/config.js
+++ b/addons/docs/src/frameworks/vue/config.js
@@ -3,6 +3,8 @@ import { addParameters } from '@storybook/vue';
 import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 
 addParameters({
-  docsContainer: DocsContainer,
-  docs: DocsPage,
+  docs: {
+    container: DocsContainer,
+    page: DocsPage,
+  },
 });

--- a/addons/docs/src/mdx/__snapshots__/mdx-compiler-plugin.test.js.snap
+++ b/addons/docs/src/mdx/__snapshots__/mdx-compiler-plugin.test.js.snap
@@ -74,10 +74,12 @@ const componentMeta = {
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -127,10 +129,12 @@ const componentMeta = { title: 'docs-only', includeStories: ['storybookDocsOnly'
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -188,10 +192,12 @@ const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory'] }
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -270,10 +276,12 @@ const componentMeta = {
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -346,10 +354,12 @@ const componentMeta = {
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -388,10 +398,12 @@ const componentMeta = { includeStories: [] };
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -437,10 +449,12 @@ const componentMeta = { title: 'Text', includeStories: ['text'] };
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -503,10 +517,12 @@ const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory', '
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -562,10 +578,12 @@ const componentMeta = { includeStories: ['story0'] };
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -633,10 +651,12 @@ const componentMeta = { title: 'MDX|Welcome', includeStories: ['toStorybook'] };
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -675,10 +695,12 @@ const componentMeta = { includeStories: [] };
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "
@@ -718,10 +740,12 @@ const componentMeta = { includeStories: [] };
 
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => (
-  <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
-);
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => (
+    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+  ),
+  page: MDXContent,
+};
 
 export default componentMeta;
 "

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -165,8 +165,10 @@ function getExports(node, counter) {
 const wrapperJs = `
 const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
-componentMeta.parameters.docsContainer = ({ context, children }) => <DocsContainer context={{...context, mdxKind}}>{children}</DocsContainer>;
-componentMeta.parameters.docs = MDXContent;
+componentMeta.parameters.docs = {
+  container: ({ context, children }) => <DocsContainer context={{...context, mdxKind}}>{children}</DocsContainer>,
+  page: MDXContent,
+};
 `.trim();
 
 function stringifyMeta(meta) {

--- a/examples/angular-cli/.storybook/config.ts
+++ b/examples/angular-cli/.storybook/config.ts
@@ -8,9 +8,9 @@ addCssWarning();
 addParameters({
   options: {
     hierarchyRootSeparator: /\|/,
-    docs: {
-      iframeHeight: '60px',
-    },
+  },
+  docs: {
+    iframeHeight: '60px',
   },
 });
 

--- a/examples/angular-cli/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/angular-cli/src/stories/__snapshots__/core.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots Core|Parameters passed to story 1`] = `
     <button
       _ngcontent-a-c7=""
     >
-      Parameters are {"options":{"hierarchyRootSeparator":{},"hierarchySeparator":{},"docs":{"iframeHeight":"60px"}},"globalParameter":"globalParameter","framework":"angular","chapterParameter":"chapterParameter","storyParameter":"storyParameter"}
+      Parameters are {"options":{"hierarchyRootSeparator":{},"hierarchySeparator":{}},"docs":{"iframeHeight":"60px"},"globalParameter":"globalParameter","framework":"angular","chapterParameter":"chapterParameter","storyParameter":"storyParameter"}
     </button>
   </storybook-button-component>
 </storybook-dynamic-app-root>

--- a/examples/html-kitchen-sink/.storybook/config.js
+++ b/examples/html-kitchen-sink/.storybook/config.js
@@ -13,9 +13,9 @@ addParameters({
   },
   options: {
     hierarchyRootSeparator: /\|/,
-    docs: {
-      iframeHeight: '200px',
-    },
+  },
+  docs: {
+    iframeHeight: '200px',
   },
 });
 

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -4,7 +4,7 @@ import { Global, ThemeProvider, themes, createReset, convert } from '@storybook/
 import { withCssResources } from '@storybook/addon-cssresources';
 import { withA11y } from '@storybook/addon-a11y';
 import { withNotes } from '@storybook/addon-notes';
-import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
+import { DocsPage } from '@storybook/addon-docs/blocks';
 
 import 'storybook-chromatic';
 

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -4,7 +4,7 @@ import { Global, ThemeProvider, themes, createReset, convert } from '@storybook/
 import { withCssResources } from '@storybook/addon-cssresources';
 import { withA11y } from '@storybook/addon-a11y';
 import { withNotes } from '@storybook/addon-notes';
-import { DocsPage } from '@storybook/addon-docs/blocks';
+import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 
 import 'storybook-chromatic';
 
@@ -58,10 +58,15 @@ addParameters({
     { name: 'light', value: '#eeeeee' },
     { name: 'dark', value: '#222222' },
   ],
-  // eslint-disable-next-line react/prop-types
-  docs: ({ context }) => (
-    <DocsPage context={context} subtitleSlot={({ selectedKind }) => `Subtitle: ${selectedKind}`} />
-  ),
+  docs: {
+    // eslint-disable-next-line react/prop-types
+    page: ({ context }) => (
+      <DocsPage
+        context={context}
+        subtitleSlot={({ selectedKind }) => `Subtitle: ${selectedKind}`}
+      />
+    ),
+  },
 });
 
 configure(

--- a/examples/official-storybook/stories/addon-docs/addon-docs.stories.js
+++ b/examples/official-storybook/stories/addon-docs/addon-docs.stories.js
@@ -13,7 +13,7 @@ export const basic = () => <div>Click docs tab to see basic docs</div>;
 export const noDocs = () => <div>Click docs tab to see no docs error</div>;
 noDocs.story = {
   name: 'no docs',
-  parameters: { docs: null },
+  parameters: { docs: { page: null } },
 };
 
 export const withNotes = () => <div>Click docs tab to see DocsPage docs</div>;
@@ -34,7 +34,7 @@ export const mdxOverride = () => <div>Click docs tab to see MDX-overridden docs<
 mdxOverride.story = {
   name: 'mdx override',
   parameters: {
-    docs: mdxNotes,
+    docs: { page: mdxNotes },
   },
 };
 
@@ -42,6 +42,6 @@ export const jsxOverride = () => <div>Click docs tab to see JSX-overridden docs<
 jsxOverride.story = {
   name: 'jsx override',
   parameters: {
-    docs: () => <div>Hello docs</div>,
+    docs: { page: () => <div>Hello docs</div> },
   },
 };

--- a/examples/official-storybook/stories/addon-docs/mdx.stories.js
+++ b/examples/official-storybook/stories/addon-docs/mdx.stories.js
@@ -9,6 +9,6 @@ export default {
 
 // This renders the contents of the docs panel into story content
 export const typography = () => {
-  const Docs = markdown.parameters.docs;
+  const Docs = markdown.parameters.docs.page;
   return <Docs />;
 };

--- a/examples/riot-kitchen-sink/__snapshots__/riotshots.test.js.snap
+++ b/examples/riot-kitchen-sink/__snapshots__/riotshots.test.js.snap
@@ -187,7 +187,7 @@ exports[`Storyshots Core|Parameters passed to story 1`] = `
   id="root"
 >
   <div>
-    Parameters are {"options":{"hierarchyRootSeparator":{},"hierarchySeparator":{}},"globalParameter":"globalParameter","framework":"riot","chapterParameter":"chapterParameter","storyParameter":"storyParameter","id":"root","dataIs":"parameters"}
+    Parameters are {"options":{"hierarchyRootSeparator":{},"hierarchySeparator":{}},"docs":{},"globalParameter":"globalParameter","framework":"riot","chapterParameter":"chapterParameter","storyParameter":"storyParameter","id":"root","dataIs":"parameters"}
   </div>
 </div>
 `;

--- a/examples/vue-kitchen-sink/.storybook/config.js
+++ b/examples/vue-kitchen-sink/.storybook/config.js
@@ -12,9 +12,9 @@ Vue.use(Vuex);
 addParameters({
   options: {
     hierarchyRootSeparator: /\|/,
-    docs: {
-      iframeHeight: '60px',
-    },
+  },
+  docs: {
+    iframeHeight: '60px',
   },
 });
 

--- a/examples/vue-kitchen-sink/__snapshots__/vueshots.test.js.snap
+++ b/examples/vue-kitchen-sink/__snapshots__/vueshots.test.js.snap
@@ -280,7 +280,7 @@ exports[`Storyshots Button square 1`] = `
 
 exports[`Storyshots Core|Parameters passed to story 1`] = `
 <div>
-  Parameters are {"options":{"hierarchyRootSeparator":{},"hierarchySeparator":{},"docs":{"iframeHeight":"60px"}},"globalParameter":"globalParameter","framework":"vue","chapterParameter":"chapterParameter","storyParameter":"storyParameter"}
+  Parameters are {"options":{"hierarchyRootSeparator":{},"hierarchySeparator":{}},"docs":{"iframeHeight":"60px"},"globalParameter":"globalParameter","framework":"vue","chapterParameter":"chapterParameter","storyParameter":"storyParameter"}
 </div>
 `;
 
@@ -344,10 +344,10 @@ exports[`Storyshots Custom|Decorator for Vue withData 1`] = `
   "parameters": {
     "options": {
       "hierarchyRootSeparator": {},
-      "hierarchySeparator": {},
-      "docs": {
-        "iframeHeight": "60px"
-      }
+      "hierarchySeparator": {}
+    },
+    "docs": {
+      "iframeHeight": "60px"
     },
     "globalParameter": "globalParameter",
     "framework": "vue",

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -121,7 +121,7 @@ describe('preview.client_api', () => {
       clientApi.addParameters({ a: '1' });
 
       // @ts-ignore
-      expect(clientApi._globalParameters).toEqual({ a: '1', options: {} });
+      expect(clientApi._globalParameters).toEqual({ a: '1', options: {}, docs: {} });
     });
 
     it('should merge options', () => {
@@ -131,7 +131,7 @@ describe('preview.client_api', () => {
       clientApi.addParameters({ options: { b: '2' } });
 
       // @ts-ignore
-      expect(clientApi._globalParameters).toEqual({ options: { a: '1', b: '2' } });
+      expect(clientApi._globalParameters).toEqual({ options: { a: '1', b: '2' }, docs: {} });
     });
 
     it('should override specific properties in options', () => {
@@ -144,6 +144,7 @@ describe('preview.client_api', () => {
       expect(clientApi._globalParameters).toEqual({
         backgrounds: ['value'],
         options: { a: '2', b: '3' },
+        docs: {},
       });
     });
 
@@ -157,6 +158,7 @@ describe('preview.client_api', () => {
       expect(clientApi._globalParameters).toEqual({
         backgrounds: [],
         options: { a: '2', b: '3' },
+        docs: {},
       });
     });
 
@@ -169,6 +171,7 @@ describe('preview.client_api', () => {
       // @ts-ignore
       expect(clientApi._globalParameters).toEqual({
         options: { a: '1', b: '2', theming: { c: '4', d: '5' } },
+        docs: {},
       });
     });
   });
@@ -454,6 +457,7 @@ describe('preview.client_api', () => {
         c: 'story',
         fileName: expect.any(String),
         options: expect.any(Object),
+        docs: expect.any(Object),
       });
     });
 
@@ -471,6 +475,7 @@ describe('preview.client_api', () => {
           sub: { global: true },
         },
         options: expect.any(Object),
+        docs: expect.any(Object),
       });
 
       storiesOf('kind', module)
@@ -508,6 +513,7 @@ describe('preview.client_api', () => {
         },
         fileName: expect.any(String),
         options: expect.any(Object),
+        docs: expect.any(Object),
       });
     });
   });

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -134,6 +134,10 @@ export default class ClientApi {
       options: {
         ...merge(get(this._globalParameters, 'options', {}), get(parameters, 'options', {})),
       },
+      // FIXME: https://github.com/storybookjs/storybook/issues/7872
+      docs: {
+        ...merge(get(this._globalParameters, 'docs', {}), get(parameters, 'docs', {})),
+      },
     };
   };
 

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -234,7 +234,7 @@ export default function start(render, { decorateStory } = {}) {
         const docs = (parameters && parameters.docs) || {};
         // eslint-disable-next-line react/prop-types
         const DocsContainer = docs.container || (({ children }) => <>{children}</>);
-        const Page = (docs && docs.page) || NoDocs;
+        const Page = docs.page || NoDocs;
         ReactDOM.render(
           <DocsContainer context={renderContext}>
             <Page />

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -231,13 +231,13 @@ export default function start(render, { decorateStory } = {}) {
     // Given a cleaned up state, render the appropriate view mode
     switch (viewMode) {
       case 'docs': {
-        const DocsContainer =
-          // eslint-disable-next-line react/prop-types
-          (parameters && parameters.docsContainer) || (({ children }) => <>{children}</>);
-        const Docs = (parameters && parameters.docs) || NoDocs;
+        const docs = (parameters && parameters.docs) || {};
+        // eslint-disable-next-line react/prop-types
+        const DocsContainer = docs.container || (({ children }) => <>{children}</>);
+        const Page = (docs && docs.page) || NoDocs;
         ReactDOM.render(
           <DocsContainer context={renderContext}>
-            <Docs />
+            <Page />
           </DocsContainer>,
           document.getElementById('docs-root')
         );


### PR DESCRIPTION
Issue: #7871 

## What I did

- `parameters.docsContainer` => `parameters.docs.page`
- `parameters.docs` => `parameters.docs.page`
- `parameters.options.docs.*` => `parameters.docs.*`
- Override global merge behavior for `parameters.docs` (see #7872 for followup)
- Update docs & tests

## How to test

```
cd examples/official-storybook
yarn storybook
cd ../examples/vue-kitchen-sink
yarn storybook
```