### PR TITLE
Addon-viewports: Fix docs with new defaults

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -76,7 +76,7 @@ You can get the old default back by adding the following to your `config.js`:
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 addParameters({
-  options: {
+  viewport: {
     viewports: INITIAL_VIEWPORTS,
   },
 });

--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -25,6 +25,7 @@ Then, add following content to .storybook/addons.js
 ```js
 import '@storybook/addon-viewport/register';
 ```
+
 You should now be able to see the viewport addon icon in the the toolbar at the top of the screen.
 
 ## Configuration
@@ -34,7 +35,12 @@ The viewport addon is configured by story parameters with the `viewport` key. To
 ```js
 import { addParameters } from '@storybook/react';
 
-addParameters({ viewport: { viewports: newViewports } });
+addParameters({
+  viewport: {
+    viewports: newViewports, // newViewports would be an ViewportMap. (see below for examples)
+    defaultViewport: 'someDefault',
+  },
+});
 ```
 
 Options can take a object with the following keys:
@@ -49,7 +55,7 @@ Setting this property to, let say `iphone6`, will make `iPhone 6` the default de
 
 ---
 
-A key-value pair of viewport's key and properties (see `Viewport` definition below) for all viewports to be displayed. Default is [`INITIAL_VIEWPORTS`](src/defaults.ts)
+A key-value pair of viewport's key and properties (see `Viewport` definition below) for all viewports to be displayed. Default is [`MINIMAL_VIEWPORTS`](src/defaults.ts)
 
 #### Viewport Model
 
@@ -94,6 +100,21 @@ addStories('Stories', module)
 ```
 
 ## Examples
+
+### Use Detailed Set of Devices
+
+The default viewports being used is [`MINIMAL_VIEWPORTS`](src/defaults.ts). If you'd like to use a more granular list of devices, you can use [`INITIAL_VIEWPORTS`](src/defaults.ts) like so in your `config.js` file in your `.storybook` directory.
+
+```js
+import { addParameters } from '@storybook/react';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+
+addParameters({
+  viewport: {
+    viewports: INITIAL_VIEWPORTS,
+  },
+});
+```
 
 ### Use Custom Set of Devices
 


### PR DESCRIPTION
Issue:
The addon-viewport readme says that `INITIAL_VIEWPORTS` is the default, but that was changed in [this PR]  (https://github.com/storybookjs/storybook/commit/b7722217aeafd87e4b58b5e077eac3fffe4fbe04) to be `MINIMAL_VIEWPORTS`

## What I did
Updated the addon-viewport docs to more accurate about the default viewports, and added an example at the beginning to show how to get the more granular list of devices for the viewports.
Also tweaked the migration doc to use the correct key of `viewport` instead of `options`

## How to test
Just check the docs