### PR TITLE
fix: Add html lang attribute to iframe

### DIFF
--- a/lib/core/src/server/templates/index.ejs
+++ b/lib/core/src/server/templates/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title><%= options.title || 'Storybook'%></title>


### PR DESCRIPTION
Issue: related to [Issue #2538 and PR #3065](https://github.com/storybookjs/storybook/pull/3065)

## What I did
- Now that Storybook is refactored to use Typescript, the `html` element's `lang` attribute is missing in the core `index.ejs` template. This PR adds that attribute back in. This fix will improve the accessibility of the app (html elements need a lang attribute), and it will ensure components that use the CSS . `hyphens` property will display hyphenated text as intended. If you're curious, here's some links for learning more about [why pages need the lang attribute](https://www.w3.org/TR/WCAG21/#language-of-page) and  [why the lang attribute is needed for CSS hyphenation](http://clagnut.com/blog/2395/).

## How to test

- Is this testable with Jest or Chromatic screenshots?  No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
