### PR TITLE
Addon-docs: Fix MDX Story ID to match new CSF

### DIFF
--- a/addons/docs/src/blocks/DocsContext.ts
+++ b/addons/docs/src/blocks/DocsContext.ts
@@ -6,15 +6,11 @@ export interface DocsContextProps {
   selectedStory?: string;
 
   /**
-   * mdxKind is a statically-generated "kind" that corresponds to the
-   * component that's being documented in the MDX file, It's combined
-   * with the MDX story name `<Story name='story name'>...</Story>` to
-   * generate a storyId. In the case that the user is viewing a non-MDX
-   * story, the value of `mdxKind` will be the currently-selected kind.
-   * (I can't remember the corner case in which using the currentl-selected
-   * kind breaks down in MDX-defined stories, but there is one!)
+   * mdxStoryNameToId is an MDX-compiler-generated mapping of an MDX story's
+   * display name to its storyId. It's used internally by the `<Story>`
+   * doc block.
    */
-  mdxKind?: string;
+  mdxStoryNameToId?: Record<string, string>;
   parameters?: any;
   storyStore?: any;
   forceRender?: () => void;

--- a/addons/docs/src/blocks/Preview.tsx
+++ b/addons/docs/src/blocks/Preview.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNodeArray } from 'react';
 import { Preview as PurePreview, PreviewProps as PurePreviewProps } from '@storybook/components';
-import { toId } from '@storybook/router';
 import { getSourceProps } from './Source';
 import { DocsContext, DocsContextProps } from './DocsContext';
 
@@ -20,7 +19,7 @@ const getPreviewProps = (
     children,
     ...props
   }: PreviewProps & { children?: React.ReactNode },
-  { mdxKind, storyStore }: DocsContextProps
+  { mdxStoryNameToId, storyStore }: DocsContextProps
 ): PurePreviewProps => {
   if (withSource === SourceState.NONE && !children) {
     return props;
@@ -29,7 +28,7 @@ const getPreviewProps = (
   const stories = childArray.filter(
     (c: React.ReactElement) => c.props && (c.props.id || c.props.name)
   ) as React.ReactElement[];
-  const targetIds = stories.map(s => s.props.id || toId(mdxKind, s.props.name));
+  const targetIds = stories.map(s => s.props.id || mdxStoryNameToId[s.props.name]);
   const sourceProps = getSourceProps({ ids: targetIds }, { storyStore });
   return {
     ...props, // pass through columns etc.

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { toId } from '@storybook/router';
 import { Story, StoryProps as PureStoryProps } from '@storybook/components';
 import { CURRENT_SELECTION } from './shared';
 

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -32,12 +32,12 @@ const inferInlineStories = (framework: string): boolean => {
 
 export const getStoryProps = (
   props: StoryProps,
-  { id: currentId, storyStore, parameters, mdxKind }: DocsContextProps
+  { id: currentId, storyStore, parameters, mdxStoryNameToId }: DocsContextProps
 ): PureStoryProps => {
   const { id } = props as StoryRefProps;
   const { name } = props as StoryDefProps;
   const inputId = id === CURRENT_SELECTION ? currentId : id;
-  const previewId = inputId || toId(mdxKind, name);
+  const previewId = inputId || mdxStoryNameToId[name];
 
   const { height, inline } = props;
   const data = storyStore.fromId(previewId);

--- a/addons/docs/src/mdx/__snapshots__/mdx-compiler-plugin.test.js.snap
+++ b/addons/docs/src/mdx/__snapshots__/mdx-compiler-plugin.test.js.snap
@@ -73,11 +73,12 @@ const componentMeta = {
   includeStories: ['one'],
 };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = { one: 'button--one' };
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -128,11 +129,12 @@ storybookDocsOnly.story = { parameters: { docsOnly: true } };
 
 const componentMeta = { title: 'docs-only', includeStories: ['storybookDocsOnly'] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = {};
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -192,11 +194,12 @@ helloStory.story.parameters = { mdxSource: '<Button>Hello button</Button>' };
 
 const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory'] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = { one: 'button--one', 'hello story': 'button--hellostory' };
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -276,11 +279,15 @@ const componentMeta = {
   includeStories: ['componentNotes', 'storyNotes'],
 };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = {
+  'component notes': 'button--componentnotes',
+  'story notes': 'button--storynotes',
+};
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -355,11 +362,12 @@ const componentMeta = {
   includeStories: ['helloButton', 'two'],
 };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = { 'hello button': 'button--hellobutton', two: 'button--two' };
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -399,11 +407,12 @@ MDXContent.isMDXComponent = true;
 
 const componentMeta = { includeStories: [] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = {};
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -451,11 +460,12 @@ text.story.parameters = { mdxSource: \\"'Plain text'\\" };
 
 const componentMeta = { title: 'Text', includeStories: ['text'] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = { text: 'text--text' };
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -520,11 +530,16 @@ wPunctuation.story.parameters = { mdxSource: '<Button>with punctuation</Button>'
 
 const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory', 'wPunctuation'] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = {
+  one: 'button--one',
+  'hello story': 'button--hellostory',
+  'w/punctuation': 'button--wpunctuation',
+};
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -566,26 +581,27 @@ function MDXContent({ components, ...props }) {
 
 MDXContent.isMDXComponent = true;
 
-export const story0 = () => {
+export const functionStory = () => {
   const btn = document.createElement('button');
   btn.innerHTML = 'Hello Button';
   btn.addEventListener('click', action('Click'));
   return btn;
 };
-story0.story = {};
-story0.story.name = 'function';
-story0.story.parameters = {
+functionStory.story = {};
+functionStory.story.name = 'function';
+functionStory.story.parameters = {
   mdxSource:
     \\"() => {\\\\n  const btn = document.createElement('button');\\\\n  btn.innerHTML = 'Hello Button';\\\\n  btn.addEventListener('click', action('Click'));\\\\n  return btn;\\\\n}\\",
 };
 
-const componentMeta = { includeStories: ['story0'] };
+const componentMeta = { includeStories: ['functionStory'] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = {};
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -654,11 +670,12 @@ toStorybook.story.parameters = {
 
 const componentMeta = { title: 'MDX|Welcome', includeStories: ['toStorybook'] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = { 'to storybook': 'mdx-welcome--tostorybook' };
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -698,11 +715,12 @@ MDXContent.isMDXComponent = true;
 
 const componentMeta = { includeStories: [] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = {};
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };
@@ -743,11 +761,12 @@ MDXContent.isMDXComponent = true;
 
 const componentMeta = { includeStories: [] };
 
-const mdxKind = componentMeta.title;
+const mdxStoryNameToId = {};
+
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
   container: ({ context, children }) => (
-    <DocsContainer context={{ ...context, mdxKind }}>{children}</DocsContainer>
+    <DocsContainer context={{ ...context, mdxStoryNameToId }}>{children}</DocsContainer>
   ),
   page: MDXContent,
 };

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -175,11 +175,14 @@ componentMeta.parameters.docs = {
 };
 `.trim();
 
+// Use this rather than JSON.stringify because `Meta`'s attributes
+// are already valid code strings, so we want to insert them raw
+// rather than add an extra set of quotes
 function stringifyMeta(meta) {
   let result = '{ ';
   Object.entries(meta).forEach(([key, val]) => {
     if (val) {
-      result += `'${key}': ${val}, `;
+      result += `${key}: ${val}, `;
     }
   });
   result += ' }';

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -3,6 +3,7 @@ const parser = require('@babel/parser');
 const generate = require('@babel/generator').default;
 const camelCase = require('lodash/camelCase');
 const jsStringEscape = require('js-string-escape');
+const { toId } = require('@storybook/router');
 
 // Generate the MDX as is, but append named exports for every
 // story in the contents
@@ -17,17 +18,19 @@ function getAttr(elt, what) {
   return attr && attr.value;
 }
 
-function getStoryFn(name, counter) {
-  if (name) {
-    const storyFn = camelCase(name.replace(/[^a-z0-9-]/g, '-'));
-    if (storyFn.length > 1 && !RESERVED.exec(storyFn)) {
-      return storyFn;
-    }
-  }
-  return `story${counter}`;
-}
+const isReserved = name => RESERVED.exec(name);
 
-function genStoryExport(ast, counter) {
+const sanitizeName = name => {
+  let key = camelCase(name);
+  if (isReserved(key)) {
+    key = `${key}Story`;
+  }
+  return key;
+};
+
+const getStoryKey = (name, counter) => (name ? sanitizeName(name) : `story${counter}`);
+
+function genStoryExport(ast, context) {
   let storyName = getAttr(ast.openingElement, 'name');
   let storyId = getAttr(ast.openingElement, 'id');
   storyName = storyName && storyName.value;
@@ -45,7 +48,7 @@ function genStoryExport(ast, counter) {
   // console.log('genStoryExport', JSON.stringify(ast, null, 2));
 
   const statements = [];
-  const storyKey = getStoryFn(storyName, counter);
+  const storyKey = getStoryKey(storyName, context.counter);
 
   let body = ast.children.find(n => n.type !== 'JSXText');
   let storyCode = null;
@@ -93,23 +96,26 @@ function genStoryExport(ast, counter) {
     statements.push(`${storyKey}.story.decorators = ${decos};`);
   }
 
+  // eslint-disable-next-line no-param-reassign
+  context.storyNameToKey[storyName] = storyKey;
+
   return {
     [storyKey]: statements.join('\n'),
   };
 }
 
-function genPreviewExports(ast, counter) {
+function genPreviewExports(ast, context) {
   // console.log('genPreviewExports', JSON.stringify(ast, null, 2));
 
-  let localCounter = counter;
   const previewExports = {};
   for (let i = 0; i < ast.children.length; i += 1) {
     const child = ast.children[i];
     if (child.type === 'JSXElement' && child.openingElement.name.name === 'Story') {
-      const storyExport = genStoryExport(child, localCounter);
+      const storyExport = genStoryExport(child, context);
       if (storyExport) {
         Object.assign(previewExports, storyExport);
-        localCounter += 1;
+        // eslint-disable-next-line no-param-reassign
+        context.counter += 1;
       }
     }
   }
@@ -162,19 +168,18 @@ function getExports(node, counter) {
 // insert `mdxKind` into the context so that we can know what "kind" we're rendering into
 // when we render <Story name="xxx">...</Story>, since this MDX can be attached to any `selectedKind`!
 const wrapperJs = `
-const mdxKind = componentMeta.title;
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
-  container: ({ context, children }) => <DocsContainer context={{...context, mdxKind}}>{children}</DocsContainer>,
+  container: ({ context, children }) => <DocsContainer context={{...context, mdxStoryNameToId}}>{children}</DocsContainer>,
   page: MDXContent,
 };
 `.trim();
 
-function stringifyMeta(meta) {
+function stringifyObject(obj) {
   let result = '{ ';
-  Object.entries(meta).forEach(([key, val]) => {
+  Object.entries(obj).forEach(([key, val]) => {
     if (val) {
-      result += `${key}: ${val}, `;
+      result += `'${key}': ${val}, `;
     }
   });
   result += ' }';
@@ -187,16 +192,18 @@ function extractExports(node, options) {
   const storyExports = [];
   const includeStories = [];
   let metaExport = null;
-  let counter = 0;
+  const context = {
+    counter: 0,
+    storyNameToKey: {},
+  };
   node.children.forEach(n => {
-    const exports = getExports(n, counter);
+    const exports = getExports(n, context);
     if (exports) {
       const { stories, meta } = exports;
       if (stories) {
         Object.entries(stories).forEach(([key, story]) => {
           includeStories.push(key);
           storyExports.push(story);
-          counter += 1;
         });
       }
       if (meta) {
@@ -220,11 +227,23 @@ function extractExports(node, options) {
   }
   metaExport.includeStories = JSON.stringify(includeStories);
 
+  const { title } = metaExport;
+  const mdxStoryNameToId = Object.entries(context.storyNameToKey).reduce(
+    (acc, [storyName, storyKey]) => {
+      if (title) {
+        acc[storyName] = `'${toId(title, storyKey)}'`;
+      }
+      return acc;
+    },
+    {}
+  );
+
   const fullJsx = [
     'import { DocsContainer } from "@storybook/addon-docs/blocks";',
     defaultJsx,
     ...storyExports,
-    `const componentMeta = ${stringifyMeta(metaExport)};`,
+    `const componentMeta = ${stringifyObject(metaExport)};`,
+    `const mdxStoryNameToId = ${stringifyObject(mdxStoryNameToId)};`,
     wrapperJs,
     'export default componentMeta;',
   ].join('\n\n');

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -175,9 +175,9 @@ componentMeta.parameters.docs = {
 };
 `.trim();
 
-function stringifyObject(obj) {
+function stringifyMeta(meta) {
   let result = '{ ';
-  Object.entries(obj).forEach(([key, val]) => {
+  Object.entries(meta).forEach(([key, val]) => {
     if (val) {
       result += `'${key}': ${val}, `;
     }
@@ -231,7 +231,7 @@ function extractExports(node, options) {
   const mdxStoryNameToId = Object.entries(context.storyNameToKey).reduce(
     (acc, [storyName, storyKey]) => {
       if (title) {
-        acc[storyName] = `'${toId(title, storyKey)}'`;
+        acc[storyName] = toId(title, storyKey);
       }
       return acc;
     },
@@ -242,8 +242,8 @@ function extractExports(node, options) {
     'import { DocsContainer } from "@storybook/addon-docs/blocks";',
     defaultJsx,
     ...storyExports,
-    `const componentMeta = ${stringifyObject(metaExport)};`,
-    `const mdxStoryNameToId = ${stringifyObject(mdxStoryNameToId)};`,
+    `const componentMeta = ${stringifyMeta(metaExport)};`,
+    `const mdxStoryNameToId = ${JSON.stringify(mdxStoryNameToId)};`,
     wrapperJs,
     'export default componentMeta;',
   ].join('\n\n');


### PR DESCRIPTION
Issue: #7893 

## What I did

MDX compiler now generates story Id's and stores them in `mdxStoryNameToId` map, to match the updated CSF handling introduced in #7878

## How to test

```
yarn jest --testPathPattern mdx-compiler-plugin.test.js
```

Also browse `Addons|Docs` stories in:
```
cd examples/official-storybook
yarn storybook
```

