### PR TITLE
CSF: Remove makeDisplayName option

### DIFF
--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -75,21 +75,13 @@ addParameters({
      */
     theme: undefined,
     /**
-    * function to sort stories in the tree view
-    * common use is alphabetical `(a, b) => a[1].id.localeCompare(b[1].id)`
-    * if left undefined, then the order in which the stories are imported will
-    * be the order they display
-    * @type {Function}
-    */
-    storySort: undefined
-
-    /**
-    * Function to transform Component Story Format named exports (typically camel-case
-    * variables) into display names. If the story specifies a `story.name` option, that
-    * will not be transformed and will always take precedence over a named export.
-    * @type {Function}
-    */
-    makeDisplayName: lodash.startCase
+     * function to sort stories in the tree view
+     * common use is alphabetical `(a, b) => a[1].id.localeCompare(b[1].id)`
+     * if left undefined, then the order in which the stories are imported will
+     * be the order they display
+     * @type {Function}
+     */
+    storySort: undefined,
   },
 });
 ```

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import startCase from 'lodash/startCase';
 import { configure, addDecorator, addParameters } from '@storybook/react';
 import { Global, ThemeProvider, themes, createReset, convert } from '@storybook/theming';
 import { withCssResources } from '@storybook/addon-cssresources';

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -53,7 +53,6 @@ addParameters({
     theme: themes.light, // { base: 'dark', brandTitle: 'Storybook!' },
     storySort: (a, b) =>
       a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
-    makeDisplayName: key => startCase(key).toLowerCase(),
   },
   backgrounds: [
     { name: 'storybook app', value: themes.light.appBg, default: true },

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { logger } from '@storybook/client-logger';
 import addons, { mockChannel } from '@storybook/addons';
-import ClientApi, { defaultMakeDisplayName } from './client_api';
+import ClientApi, { makeDisplayName } from './client_api';
 import ConfigApi from './config_api';
 import StoryStore from './story_store';
 
@@ -26,17 +26,17 @@ jest.mock('@storybook/client-logger', () => ({
 }));
 
 describe('preview.client_api', () => {
-  describe('defaultMakeDisplayName', () => {
+  describe('makeDisplayName', () => {
     it('should format CSF exports with sensible defaults', () => {
       const testCases = {
         name: 'Name',
         someName: 'Some Name',
         someNAME: 'Some NAME',
         some_custom_NAME: 'Some Custom NAME',
+        someName1234: 'Some Name 1234',
+        someName1_2_3_4: 'Some Name 1 2 3 4',
       };
-      Object.entries(testCases).forEach(([key, val]) =>
-        expect(defaultMakeDisplayName(key)).toBe(val)
-      );
+      Object.entries(testCases).forEach(([key, val]) => expect(makeDisplayName(key)).toBe(val));
     });
   });
 

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -83,7 +83,7 @@ const withSubscriptionTracking = (storyFn: StoryFn) => {
   return result;
 };
 
-export const defaultMakeDisplayName = (key: string) => startCase(key);
+export const makeDisplayName = (key: string) => startCase(key);
 
 export default class ClientApi {
   private _storyStore: StoryStore;
@@ -126,7 +126,7 @@ export default class ClientApi {
       this._globalParameters.options
     );
 
-  getMakeDisplayName = () => defaultMakeDisplayName;
+  getMakeDisplayName = () => makeDisplayName;
 
   addDecorator = (decorator: DecoratorFunction) => {
     this._globalDecorators.push(decorator);

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -126,9 +126,7 @@ export default class ClientApi {
       this._globalParameters.options
     );
 
-  getMakeDisplayName = () =>
-    (this._globalParameters.options && this._globalParameters.options.makeDisplayName) ||
-    defaultMakeDisplayName;
+  getMakeDisplayName = () => defaultMakeDisplayName;
 
   addDecorator = (decorator: DecoratorFunction) => {
     this._globalDecorators.push(decorator);


### PR DESCRIPTION
Issue: #7599

## What I did

This partially reverts the change made in #7878, keeping the displayName concept, but removing its configurability.

Now we transform the CSF named export using `lodash.startCase` as the default. If you want other behavior you can use the `namedExport.story = { name: 'anything goes' }` construct.

```js
    it('should format CSF exports with sensible defaults', () => {
      const testCases = {
        name: 'Name',
        someName: 'Some Name',
        someNAME: 'Some NAME',
        some_custom_NAME: 'Some Custom NAME',
        someName1234: 'Some Name 1234',
        someName1_2_3_4: 'Some Name 1 2 3 4',
      };
      Object.entries(testCases).forEach(([key, val]) => expect(makeDisplayName(key)).toBe(val));
    });
```

## Why I did it

We made `hierarchySeparator` and `hierarchyRootSeparator` configurable, and it has been a maintenance nightmare, adding complexity across our codebase and bringing that nightmare to other tools in the Storybook ecosystem.

`makeDisplayName` is a similar foundational configuration. However since it can contain arbitrary JS code, we expect it will cause an order of magnitude MORE headaches. At the very least we're not ready to sign up for it without a lot more evidence that it's necessary.

## How to test

```
yarn jest --testPathPattern=client_api.test.ts
```