### PR TITLE
CSF: Revert `makeDisplayName` & add stable `storyNameFromExport`

### DIFF
--- a/addons/docs/src/mdx/__snapshots__/mdx-compiler-plugin.test.js.snap
+++ b/addons/docs/src/mdx/__snapshots__/mdx-compiler-plugin.test.js.snap
@@ -194,7 +194,7 @@ helloStory.story.parameters = { mdxSource: '<Button>Hello button</Button>' };
 
 const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory'] };
 
-const mdxStoryNameToId = { one: 'button--one', 'hello story': 'button--hellostory' };
+const mdxStoryNameToId = { one: 'button--one', 'hello story': 'button--hello-story' };
 
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
@@ -280,8 +280,8 @@ const componentMeta = {
 };
 
 const mdxStoryNameToId = {
-  'component notes': 'button--componentnotes',
-  'story notes': 'button--storynotes',
+  'component notes': 'button--component-notes',
+  'story notes': 'button--story-notes',
 };
 
 componentMeta.parameters = componentMeta.parameters || {};
@@ -362,7 +362,7 @@ const componentMeta = {
   includeStories: ['helloButton', 'two'],
 };
 
-const mdxStoryNameToId = { 'hello button': 'button--hellobutton', two: 'button--two' };
+const mdxStoryNameToId = { 'hello button': 'button--hello-button', two: 'button--two' };
 
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {
@@ -532,8 +532,8 @@ const componentMeta = { title: 'Button', includeStories: ['one', 'helloStory', '
 
 const mdxStoryNameToId = {
   one: 'button--one',
-  'hello story': 'button--hellostory',
-  'w/punctuation': 'button--wpunctuation',
+  'hello story': 'button--hello-story',
+  'w/punctuation': 'button--w-punctuation',
 };
 
 componentMeta.parameters = componentMeta.parameters || {};
@@ -670,7 +670,7 @@ toStorybook.story.parameters = {
 
 const componentMeta = { title: 'MDX|Welcome', includeStories: ['toStorybook'] };
 
-const mdxStoryNameToId = { 'to storybook': 'mdx-welcome--tostorybook' };
+const mdxStoryNameToId = { 'to storybook': 'mdx-welcome--to-storybook' };
 
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -3,7 +3,7 @@ const parser = require('@babel/parser');
 const generate = require('@babel/generator').default;
 const camelCase = require('lodash/camelCase');
 const jsStringEscape = require('js-string-escape');
-const { toId } = require('@storybook/router');
+const { toId, storyNameFromExport } = require('@storybook/router/utils');
 
 // Generate the MDX as is, but append named exports for every
 // story in the contents
@@ -234,7 +234,7 @@ function extractExports(node, options) {
   const mdxStoryNameToId = Object.entries(context.storyNameToKey).reduce(
     (acc, [storyName, storyKey]) => {
       if (title) {
-        acc[storyName] = toId(title, storyKey);
+        acc[storyName] = toId(title, storyNameFromExport(storyKey));
       }
       return acc;
     },

--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -75,21 +75,13 @@ addParameters({
      */
     theme: undefined,
     /**
-    * function to sort stories in the tree view
-    * common use is alphabetical `(a, b) => a[1].id.localeCompare(b[1].id)`
-    * if left undefined, then the order in which the stories are imported will
-    * be the order they display
-    * @type {Function}
-    */
-    storySort: undefined
-
-    /**
-    * Function to transform Component Story Format named exports (typically camel-case
-    * variables) into display names. If the story specifies a `story.name` option, that
-    * will not be transformed and will always take precedence over a named export.
-    * @type {Function}
-    */
-    makeDisplayName: lodash.startCase
+     * function to sort stories in the tree view
+     * common use is alphabetical `(a, b) => a[1].id.localeCompare(b[1].id)`
+     * if left undefined, then the order in which the stories are imported will
+     * be the order they display
+     * @type {Function}
+     */
+    storySort: undefined,
   },
 });
 ```

--- a/examples/html-kitchen-sink/tests/__snapshots__/htmlshots.test.js.snap
+++ b/examples/html-kitchen-sink/tests/__snapshots__/htmlshots.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Addons|Actions story1 1`] = `
+exports[`Storyshots Addons|Actions Story 1 1`] = `
 <button
   type="button"
 >
@@ -8,7 +8,7 @@ exports[`Storyshots Addons|Actions story1 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions story2 1`] = `
+exports[`Storyshots Addons|Actions Story 2 1`] = `
 <button
   type="button"
 >
@@ -16,7 +16,7 @@ exports[`Storyshots Addons|Actions story2 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions story3 1`] = `
+exports[`Storyshots Addons|Actions Story 3 1`] = `
 <button
   type="button"
 >
@@ -24,7 +24,7 @@ exports[`Storyshots Addons|Actions story3 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions story4 1`] = `
+exports[`Storyshots Addons|Actions Story 4 1`] = `
 <button
   type="button"
 >
@@ -32,12 +32,12 @@ exports[`Storyshots Addons|Actions story4 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions story5 1`] = `
+exports[`Storyshots Addons|Actions Story 5 1`] = `
 
         
 `;
 
-exports[`Storyshots Addons|Actions story6 1`] = `
+exports[`Storyshots Addons|Actions Story 6 1`] = `
 <button
   type="button"
 >
@@ -45,7 +45,7 @@ exports[`Storyshots Addons|Actions story6 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions story7 1`] = `
+exports[`Storyshots Addons|Actions Story 7 1`] = `
 <button
   type="button"
 >
@@ -53,7 +53,7 @@ exports[`Storyshots Addons|Actions story7 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions story8 1`] = `
+exports[`Storyshots Addons|Actions Story 8 1`] = `
 <button
   type="button"
 >
@@ -61,7 +61,7 @@ exports[`Storyshots Addons|Actions story8 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Backgrounds story1 1`] = `
+exports[`Storyshots Addons|Backgrounds Story 1 1`] = `
 <span
   style="color: white"
 >
@@ -69,7 +69,7 @@ exports[`Storyshots Addons|Backgrounds story1 1`] = `
 </span>
 `;
 
-exports[`Storyshots Addons|Backgrounds story2 1`] = `
+exports[`Storyshots Addons|Backgrounds Story 2 1`] = `
 <span
   style="color: white"
 >
@@ -77,7 +77,7 @@ exports[`Storyshots Addons|Backgrounds story2 1`] = `
 </span>
 `;
 
-exports[`Storyshots Addons|Centered story1 1`] = `
+exports[`Storyshots Addons|Centered Story 1 1`] = `
 <div
   id="sb-addon-centered-wrapper"
   style="position: fixed; top: 0px; left: 0px; bottom: 0px; right: 0px; display: flex; align-items: center; overflow: auto;"
@@ -98,7 +98,7 @@ exports[`Storyshots Addons|Events Logger 1`] = `
     
 `;
 
-exports[`Storyshots Addons|Jest withTests 1`] = `This story shows test results`;
+exports[`Storyshots Addons|Jest With Tests 1`] = `This story shows test results`;
 
 exports[`Storyshots Addons|Knobs DOM 1`] = `
 <p>
@@ -112,7 +112,7 @@ exports[`Storyshots Addons|Knobs Simple 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addons|Knobs story3 1`] = `
+exports[`Storyshots Addons|Knobs Story 3 1`] = `
 <p
   style="transition: color 0.5s ease-out; color: orangered;"
 >
@@ -120,7 +120,7 @@ exports[`Storyshots Addons|Knobs story3 1`] = `
 </p>
 `;
 
-exports[`Storyshots Addons|Knobs story4 1`] = `
+exports[`Storyshots Addons|Knobs Story 4 1`] = `
 <div
   style="border: 2px dotted deeppink; padding: 8px 22px; border-radius: 8px"
 >
@@ -167,9 +167,9 @@ exports[`Storyshots Addons|Knobs story4 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addons|Knobs story5 1`] = `&lt;img src=x onerror="alert('XSS Attack')" &gt;`;
+exports[`Storyshots Addons|Knobs Story 5 1`] = `&lt;img src=x onerror="alert('XSS Attack')" &gt;`;
 
-exports[`Storyshots Addons|Notes story1 1`] = `
+exports[`Storyshots Addons|Notes Story 1 1`] = `
 <p>
   
       
@@ -199,7 +199,7 @@ exports[`Storyshots Addons|a11y Label 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|a11y story4 1`] = `
+exports[`Storyshots Addons|a11y Story 4 1`] = `
 <button
   style="color: black; background-color: brown;"
 >
@@ -207,15 +207,15 @@ exports[`Storyshots Addons|a11y story4 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|a11y story5 1`] = `<div />`;
+exports[`Storyshots Addons|a11y Story 5 1`] = `<div />`;
 
-exports[`Storyshots Demo button 1`] = `
+exports[`Storyshots Demo Button 1`] = `
 <button>
   Hello Button
 </button>
 `;
 
-exports[`Storyshots Demo effect 1`] = `
+exports[`Storyshots Demo Effect 1`] = `
 <button
   id="button"
 >
@@ -223,13 +223,13 @@ exports[`Storyshots Demo effect 1`] = `
 </button>
 `;
 
-exports[`Storyshots Demo heading 1`] = `
+exports[`Storyshots Demo Heading 1`] = `
 <h1>
   Hello World
 </h1>
 `;
 
-exports[`Storyshots Demo headings 1`] = `
+exports[`Storyshots Demo Headings 1`] = `
 <section>
   <h1>
     Hello World

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import startCase from 'lodash/startCase';
 import { configure, addDecorator, addParameters } from '@storybook/react';
 import { Global, ThemeProvider, themes, createReset, convert } from '@storybook/theming';
 import { withCssResources } from '@storybook/addon-cssresources';

--- a/examples/official-storybook/config.js
+++ b/examples/official-storybook/config.js
@@ -53,7 +53,6 @@ addParameters({
     theme: themes.light, // { base: 'dark', brandTitle: 'Storybook!' },
     storySort: (a, b) =>
       a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
-    makeDisplayName: key => startCase(key).toLowerCase(),
   },
   backgrounds: [
     { name: 'storybook app', value: themes.light.appBg, default: true },

--- a/examples/preact-kitchen-sink/__snapshots__/preactshots.test.js.snap
+++ b/examples/preact-kitchen-sink/__snapshots__/preactshots.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Addons|Actions actionAndMethod 1`] = `
+exports[`Storyshots Addons|Actions Action And Method 1`] = `
 <button
   class="button"
   onclick={[Function]}
@@ -9,7 +9,7 @@ exports[`Storyshots Addons|Actions actionAndMethod 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions actionOnly 1`] = `
+exports[`Storyshots Addons|Actions Action Only 1`] = `
 <button
   class="button"
   onclick={[Function]}
@@ -18,7 +18,7 @@ exports[`Storyshots Addons|Actions actionOnly 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions multipleActions 1`] = `
+exports[`Storyshots Addons|Actions Multiple Actions 1`] = `
 <button
   class="button"
   onclick={[Function]}
@@ -28,7 +28,7 @@ exports[`Storyshots Addons|Actions multipleActions 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Actions multipleActionsObject 1`] = `
+exports[`Storyshots Addons|Actions Multiple Actions Object 1`] = `
 <button
   class="button"
   onclick={[Function]}
@@ -38,7 +38,7 @@ exports[`Storyshots Addons|Actions multipleActionsObject 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Backgrounds example1 1`] = `
+exports[`Storyshots Addons|Backgrounds Example 1 1`] = `
 <button
   class="button"
 >
@@ -46,7 +46,7 @@ exports[`Storyshots Addons|Backgrounds example1 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Backgrounds example2 1`] = `
+exports[`Storyshots Addons|Backgrounds Example 2 1`] = `
 <button
   class="button"
 >
@@ -54,7 +54,7 @@ exports[`Storyshots Addons|Backgrounds example2 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Centered button 1`] = `
+exports[`Storyshots Addons|Centered Button 1`] = `
 <div
   style={
     Object {
@@ -86,7 +86,7 @@ exports[`Storyshots Addons|Centered button 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addons|Contexts simpleCssTheming 1`] = `
+exports[`Storyshots Addons|Contexts Simple Css Theming 1`] = `
 <div
   style={
     Object {
@@ -103,13 +103,7 @@ exports[`Storyshots Addons|Contexts simpleCssTheming 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addons|Knobs Simple 1`] = `
-<div>
-  I am John Doe and I'm 44 years old.
-</div>
-`;
-
-exports[`Storyshots Addons|Knobs allKnobs 1`] = `
+exports[`Storyshots Addons|Knobs All Knobs 1`] = `
 <div
   style="border:2px dotted deeppink; padding: 8px 22px; border-radius: 8px"
 >
@@ -142,7 +136,13 @@ exports[`Storyshots Addons|Knobs allKnobs 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addons|Links goToWelcome 1`] = `
+exports[`Storyshots Addons|Knobs Simple 1`] = `
+<div>
+  I am John Doe and I'm 44 years old.
+</div>
+`;
+
+exports[`Storyshots Addons|Links Go To Welcome 1`] = `
 <button
   class="button"
   onclick={[Function]}
@@ -151,7 +151,7 @@ exports[`Storyshots Addons|Links goToWelcome 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addons|Notes noteWithHtml 1`] = `
+exports[`Storyshots Addons|Notes Note With Html 1`] = `
 <p>
   <span>
     🤔😳😯😮
@@ -167,7 +167,7 @@ exports[`Storyshots Addons|Notes noteWithHtml 1`] = `
 </p>
 `;
 
-exports[`Storyshots Addons|Notes simpleNote 1`] = `
+exports[`Storyshots Addons|Notes Simple Note 1`] = `
 <p>
   <strong>
     Etiam vulputate elit eu venenatis eleifend. Duis nec lectus augue. Morbi egestas diam sed vulputate mollis. Fusce egestas pretium vehicula. Integer sed neque diam. Donec consectetur velit vitae enim varius, ut placerat arcu imperdiet. Praesent sed faucibus arcu. Nullam sit amet nibh a enim eleifend rhoncus. Donec pretium elementum leo at fermentum. Nulla sollicitudin, mauris quis semper tempus, sem metus tristique diam, efficitur pulvinar mi urna id urna.
@@ -175,7 +175,7 @@ exports[`Storyshots Addons|Notes simpleNote 1`] = `
 </p>
 `;
 
-exports[`Storyshots Button withSomeEmoji 1`] = `
+exports[`Storyshots Button With Some Emoji 1`] = `
 <button
   class="button"
   onclick={[Function]}
@@ -189,7 +189,7 @@ exports[`Storyshots Button withSomeEmoji 1`] = `
 </button>
 `;
 
-exports[`Storyshots Button withText 1`] = `
+exports[`Storyshots Button With Text 1`] = `
 <button
   class="button"
   onclick={[Function]}
@@ -198,7 +198,7 @@ exports[`Storyshots Button withText 1`] = `
 </button>
 `;
 
-exports[`Storyshots Welcome toStorybook 1`] = `
+exports[`Storyshots Welcome To Storybook 1`] = `
 <article
   style={
     Object {

--- a/examples/riot-kitchen-sink/__snapshots__/riotshots.test.js.snap
+++ b/examples/riot-kitchen-sink/__snapshots__/riotshots.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Addon|Actions actionOnly 1`] = `
+exports[`Storyshots Addon|Actions Action Only 1`] = `
 <div
   data-is="my-button"
   id="root"
@@ -14,7 +14,7 @@ exports[`Storyshots Addon|Actions actionOnly 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Actions multipleActions 1`] = `
+exports[`Storyshots Addon|Actions Multiple Actions 1`] = `
 <div
   data-is="my-button"
   id="root"
@@ -28,7 +28,7 @@ exports[`Storyshots Addon|Actions multipleActions 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Backgrounds story1 1`] = `
+exports[`Storyshots Addon|Backgrounds Story 1 1`] = `
 <div
   data-is="root"
   id="root"
@@ -44,7 +44,7 @@ exports[`Storyshots Addon|Backgrounds story1 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Backgrounds story2 1`] = `
+exports[`Storyshots Addon|Backgrounds Story 2 1`] = `
 <div
   data-is="root"
   id="root"
@@ -60,18 +60,7 @@ exports[`Storyshots Addon|Backgrounds story2 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Knobs Simple 1`] = `
-<div
-  data-is="root"
-  id="root"
->
-  <div>
-    I am John Doe and I'm 44 years old.
-  </div>
-</div>
-`;
-
-exports[`Storyshots Addon|Knobs allKnobs 1`] = `
+exports[`Storyshots Addon|Knobs All Knobs 1`] = `
 <div
   data-is="root"
   id="root"
@@ -126,7 +115,18 @@ exports[`Storyshots Addon|Knobs allKnobs 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Knobs xssSafety 1`] = `
+exports[`Storyshots Addon|Knobs Simple 1`] = `
+<div
+  data-is="root"
+  id="root"
+>
+  <div>
+    I am John Doe and I'm 44 years old.
+  </div>
+</div>
+`;
+
+exports[`Storyshots Addon|Knobs Xss Safety 1`] = `
 <div
   data-is="root"
   id="root"
@@ -137,7 +137,7 @@ exports[`Storyshots Addon|Knobs xssSafety 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Links goToWelcome 1`] = `
+exports[`Storyshots Addon|Links Go To Welcome 1`] = `
 <div
   data-is="my-button"
   id="root"
@@ -151,7 +151,7 @@ exports[`Storyshots Addon|Links goToWelcome 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Notes noteWithHtml 1`] = `
+exports[`Storyshots Addon|Notes Note With Html 1`] = `
 <div
   data-is="root"
   id="root"
@@ -168,7 +168,7 @@ exports[`Storyshots Addon|Notes noteWithHtml 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Notes simpleNote 1`] = `
+exports[`Storyshots Addon|Notes Simple Note 1`] = `
 <div
   data-is="root"
   id="root"
@@ -181,7 +181,7 @@ exports[`Storyshots Addon|Notes simpleNote 1`] = `
 </div>
 `;
 
-exports[`Storyshots Core|Parameters passedToStory 1`] = `
+exports[`Storyshots Core|Parameters Passed To Story 1`] = `
 <div
   data-is="parameters"
   id="root"
@@ -192,7 +192,7 @@ exports[`Storyshots Core|Parameters passedToStory 1`] = `
 </div>
 `;
 
-exports[`Storyshots Story|How to create a story builtAsString 1`] = `
+exports[`Storyshots Story|How to create a story Built As String 1`] = `
 <div
   data-is="root"
   id="root"
@@ -205,7 +205,7 @@ exports[`Storyshots Story|How to create a story builtAsString 1`] = `
 </div>
 `;
 
-exports[`Storyshots Story|How to create a story builtFromRawImport 1`] = `
+exports[`Storyshots Story|How to create a story Built From Raw Import 1`] = `
 <div
   data-is="simpletest"
   id="root"
@@ -216,7 +216,7 @@ exports[`Storyshots Story|How to create a story builtFromRawImport 1`] = `
 </div>
 `;
 
-exports[`Storyshots Story|How to create a story builtFromTagsAndTemplate 1`] = `
+exports[`Storyshots Story|How to create a story Built From Tags And Template 1`] = `
 <div
   data-is="root"
   id="root"
@@ -231,7 +231,7 @@ exports[`Storyshots Story|How to create a story builtFromTagsAndTemplate 1`] = `
 </div>
 `;
 
-exports[`Storyshots Story|How to create a story builtFromThePrecompilation 1`] = `
+exports[`Storyshots Story|How to create a story Built From The Precompilation 1`] = `
 <div
   data-is="anothertest"
   id="root"
@@ -242,7 +242,7 @@ exports[`Storyshots Story|How to create a story builtFromThePrecompilation 1`] =
 </div>
 `;
 
-exports[`Storyshots Story|How to create a story builtWithTag 1`] = `
+exports[`Storyshots Story|How to create a story Built With Tag 1`] = `
 <div
   data-is="test"
   id="root"
@@ -253,7 +253,7 @@ exports[`Storyshots Story|How to create a story builtWithTag 1`] = `
 </div>
 `;
 
-exports[`Storyshots Story|How to create a story tagsTemplateAndTagConstructorAtOnce 1`] = `
+exports[`Storyshots Story|How to create a story Tags Template And Tag Constructor At Once 1`] = `
 <div
   data-is="root"
   id="root"
@@ -269,7 +269,7 @@ exports[`Storyshots Story|How to create a story tagsTemplateAndTagConstructorAtO
 </div>
 `;
 
-exports[`Storyshots Story|How to create a story theMountInstructionIsNotNecessary 1`] = `
+exports[`Storyshots Story|How to create a story The Mount Instruction Is Not Necessary 1`] = `
 <div
   data-is="anothertest"
   id="root"
@@ -280,7 +280,7 @@ exports[`Storyshots Story|How to create a story theMountInstructionIsNotNecessar
 </div>
 `;
 
-exports[`Storyshots Story|How to create a story theOptsValueIsNotNecessary 1`] = `
+exports[`Storyshots Story|How to create a story The Opts Value Is Not Necessary 1`] = `
 <div
   data-is="anothertest"
   id="root"
@@ -349,7 +349,7 @@ exports[`Storyshots Story|Nest tags Matriochka 1`] = `
 </div>
 `;
 
-exports[`Storyshots Story|Nest tags threeTags 1`] = `
+exports[`Storyshots Story|Nest tags Three Tags 1`] = `
 <div
   data-is="root"
   id="root"

--- a/examples/svelte-kitchen-sink/__snapshots__/svelteshots.test.js.snap
+++ b/examples/svelte-kitchen-sink/__snapshots__/svelteshots.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Addon|Actions actionOnComponentMethod 1`] = `
+exports[`Storyshots Addon|Actions Action On Component Method 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -19,7 +19,7 @@ exports[`Storyshots Addon|Actions actionOnComponentMethod 1`] = `
 </section>
 `;
 
-exports[`Storyshots Addon|Actions actionOnViewMethod 1`] = `
+exports[`Storyshots Addon|Actions Action On View Method 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -61,7 +61,7 @@ exports[`Storyshots Addon|Actions actionOnViewMethod 1`] = `
 </section>
 `;
 
-exports[`Storyshots Addon|Backgrounds story1 1`] = `
+exports[`Storyshots Addon|Backgrounds Story 1 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -103,7 +103,7 @@ exports[`Storyshots Addon|Backgrounds story1 1`] = `
 </section>
 `;
 
-exports[`Storyshots Addon|Centered rounded 1`] = `
+exports[`Storyshots Addon|Centered Rounded 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -122,7 +122,7 @@ exports[`Storyshots Addon|Centered rounded 1`] = `
 </section>
 `;
 
-exports[`Storyshots Addon|Centered withAction 1`] = `
+exports[`Storyshots Addon|Centered With Action 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -155,7 +155,7 @@ exports[`Storyshots Addon|Knobs Simple 1`] = `
 </section>
 `;
 
-exports[`Storyshots Addon|Links goToWelcomeView 1`] = `
+exports[`Storyshots Addon|Links Go To Welcome View 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -183,7 +183,7 @@ exports[`Storyshots Addon|Links goToWelcomeView 1`] = `
 </section>
 `;
 
-exports[`Storyshots Addon|Notes noteWithHtml 1`] = `
+exports[`Storyshots Addon|Notes Note With Html 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -225,7 +225,7 @@ exports[`Storyshots Addon|Notes noteWithHtml 1`] = `
 </section>
 `;
 
-exports[`Storyshots Addon|Notes simpleNote 1`] = `
+exports[`Storyshots Addon|Notes Simple Note 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -267,7 +267,7 @@ exports[`Storyshots Addon|Notes simpleNote 1`] = `
 </section>
 `;
 
-exports[`Storyshots Button rounded 1`] = `
+exports[`Storyshots Button Rounded 1`] = `
 <section
   class="storybook-snapshot-container"
 >
@@ -309,7 +309,7 @@ exports[`Storyshots Button rounded 1`] = `
 </section>
 `;
 
-exports[`Storyshots Button square 1`] = `
+exports[`Storyshots Button Square 1`] = `
 <section
   class="storybook-snapshot-container"
 >

--- a/examples/vue-kitchen-sink/__snapshots__/vueshots.test.js.snap
+++ b/examples/vue-kitchen-sink/__snapshots__/vueshots.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Addon|Actions actionAndMethod 1`] = `
+exports[`Storyshots Addon|Actions Action And Method 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -9,7 +9,7 @@ exports[`Storyshots Addon|Actions actionAndMethod 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addon|Actions actionOnly 1`] = `
+exports[`Storyshots Addon|Actions Action Only 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -18,7 +18,7 @@ exports[`Storyshots Addon|Actions actionOnly 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addon|Actions multipleActions 1`] = `
+exports[`Storyshots Addon|Actions Multiple Actions 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -27,7 +27,7 @@ exports[`Storyshots Addon|Actions multipleActions 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addon|Actions multipleActionsObject 1`] = `
+exports[`Storyshots Addon|Actions Multiple Actions Object 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -36,19 +36,19 @@ exports[`Storyshots Addon|Actions multipleActionsObject 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addon|Backgrounds story1 1`] = `
+exports[`Storyshots Addon|Backgrounds Story 1 1`] = `
 <button>
   You should be able to switch backgrounds for this story
 </button>
 `;
 
-exports[`Storyshots Addon|Backgrounds story2 1`] = `
+exports[`Storyshots Addon|Backgrounds Story 2 1`] = `
 <button>
   This one too!
 </button>
 `;
 
-exports[`Storyshots Addon|Centered rounded 1`] = `
+exports[`Storyshots Addon|Centered Rounded 1`] = `
 <div
   style="position: fixed; top: 0px; left: 0px; bottom: 0px; right: 0px; display: flex; align-items: center; overflow: auto;"
 >
@@ -77,7 +77,7 @@ exports[`Storyshots Addon|Contexts Languages 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Contexts simpleCssTheming 1`] = `
+exports[`Storyshots Addon|Contexts Simple Css Theming 1`] = `
 <div
   style="color: white; background: rgb(23, 63, 95); height: 100vh; padding: 10px;"
 >
@@ -87,13 +87,7 @@ exports[`Storyshots Addon|Contexts simpleCssTheming 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Knobs Simple 1`] = `
-<div>
-  I am John Doe and I'm 40 years old.
-</div>
-`;
-
-exports[`Storyshots Addon|Knobs allKnobs 1`] = `
+exports[`Storyshots Addon|Knobs All Knobs 1`] = `
 <div
   style="border: 2px dotted; padding: 8px 22px; border-radius: 8px; border-color: deeppink;"
 >
@@ -131,13 +125,19 @@ exports[`Storyshots Addon|Knobs allKnobs 1`] = `
 </div>
 `;
 
-exports[`Storyshots Addon|Knobs xssSafety 1`] = `
+exports[`Storyshots Addon|Knobs Simple 1`] = `
+<div>
+  I am John Doe and I'm 40 years old.
+</div>
+`;
+
+exports[`Storyshots Addon|Knobs Xss Safety 1`] = `
 <div>
   &lt;img src=x onerror="alert('XSS Attack')" &gt;
 </div>
 `;
 
-exports[`Storyshots Addon|Links goToWelcome 1`] = `
+exports[`Storyshots Addon|Links Go To Welcome 1`] = `
 <button
   class="button rounded"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -146,7 +146,7 @@ exports[`Storyshots Addon|Links goToWelcome 1`] = `
 </button>
 `;
 
-exports[`Storyshots Addon|Notes noteWithHtml 1`] = `
+exports[`Storyshots Addon|Notes Note With Html 1`] = `
 <p>
   🤔😳😯😮
   <br />
@@ -156,7 +156,7 @@ exports[`Storyshots Addon|Notes noteWithHtml 1`] = `
 </p>
 `;
 
-exports[`Storyshots Addon|Notes simpleNote 1`] = `
+exports[`Storyshots Addon|Notes Simple Note 1`] = `
 <p>
   <strong>
     Etiam vulputate elit eu venenatis eleifend. Duis nec lectus augue. Morbi egestas diam sed vulputate mollis. Fusce egestas pretium vehicula. Integer sed neque diam. Donec consectetur velit vitae enim varius, ut placerat arcu imperdiet. Praesent sed faucibus arcu. Nullam sit amet nibh a enim eleifend rhoncus. Donec pretium elementum leo at fermentum. Nulla sollicitudin, mauris quis semper tempus, sem metus tristique diam, efficitur pulvinar mi urna id urna.
@@ -164,7 +164,7 @@ exports[`Storyshots Addon|Notes simpleNote 1`] = `
 </p>
 `;
 
-exports[`Storyshots App app 1`] = `
+exports[`Storyshots App App 1`] = `
 <div
   id="app"
 >
@@ -260,7 +260,7 @@ exports[`Storyshots App app 1`] = `
 </div>
 `;
 
-exports[`Storyshots Button rounded 1`] = `
+exports[`Storyshots Button Rounded 1`] = `
 <button
   class="button rounded"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -269,7 +269,7 @@ exports[`Storyshots Button rounded 1`] = `
 </button>
 `;
 
-exports[`Storyshots Button square 1`] = `
+exports[`Storyshots Button Square 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -278,13 +278,13 @@ exports[`Storyshots Button square 1`] = `
 </button>
 `;
 
-exports[`Storyshots Core|Parameters passedToStory 1`] = `
+exports[`Storyshots Core|Parameters Passed To Story 1`] = `
 <div>
   Parameters are {"options":{"hierarchyRootSeparator":{},"hierarchySeparator":{}},"docs":{"iframeHeight":"60px"},"globalParameter":"globalParameter","framework":"vue","chapterParameter":"chapterParameter","storyParameter":"storyParameter","displayName":"passed to story"}
 </div>
 `;
 
-exports[`Storyshots Core|Template stringOnly 1`] = `
+exports[`Storyshots Core|Template String Only 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -293,7 +293,7 @@ exports[`Storyshots Core|Template stringOnly 1`] = `
 </button>
 `;
 
-exports[`Storyshots Custom|Decorator for Vue render 1`] = `
+exports[`Storyshots Custom|Decorator for Vue Render 1`] = `
 <div
   style="border: medium solid blue;"
 >
@@ -310,7 +310,7 @@ exports[`Storyshots Custom|Decorator for Vue render 1`] = `
 </div>
 `;
 
-exports[`Storyshots Custom|Decorator for Vue template 1`] = `
+exports[`Storyshots Custom|Decorator for Vue Template 1`] = `
 <div
   style="border: medium solid blue;"
 >
@@ -327,7 +327,7 @@ exports[`Storyshots Custom|Decorator for Vue template 1`] = `
 </div>
 `;
 
-exports[`Storyshots Custom|Decorator for Vue withData 1`] = `
+exports[`Storyshots Custom|Decorator for Vue With Data 1`] = `
 <div
   style="border: medium solid blue;"
 >
@@ -336,10 +336,10 @@ exports[`Storyshots Custom|Decorator for Vue withData 1`] = `
   >
     <pre>
       {
-  "id": "custom-decorator-for-vue--withdata",
+  "id": "custom-decorator-for-vue--with-data",
   "kind": "Custom|Decorator for Vue",
-  "name": "withData",
-  "story": "withData",
+  "name": "With Data",
+  "story": "With Data",
   "customContext": 52,
   "parameters": {
     "options": {
@@ -351,7 +351,6 @@ exports[`Storyshots Custom|Decorator for Vue withData 1`] = `
     },
     "globalParameter": "globalParameter",
     "framework": "vue",
-    "displayName": "With Data",
     "customParameter": 42
   }
 }
@@ -369,7 +368,7 @@ exports[`Storyshots Custom|Method for rendering Vue JSX 1`] = `
 </button>
 `;
 
-exports[`Storyshots Custom|Method for rendering Vue preRegisteredComponent 1`] = `
+exports[`Storyshots Custom|Method for rendering Vue Pre Registered Component 1`] = `
 <p>
   <em>
     This component was pre-registered in .storybook/config.js
@@ -385,13 +384,13 @@ exports[`Storyshots Custom|Method for rendering Vue preRegisteredComponent 1`] =
 </p>
 `;
 
-exports[`Storyshots Custom|Method for rendering Vue render 1`] = `
+exports[`Storyshots Custom|Method for rendering Vue Render 1`] = `
 <div>
   renders a div with some text in it..
 </div>
 `;
 
-exports[`Storyshots Custom|Method for rendering Vue renderComponent 1`] = `
+exports[`Storyshots Custom|Method for rendering Vue Render Component 1`] = `
 <button
   class="button"
   style="color: pink; border-color: pink;"
@@ -400,7 +399,7 @@ exports[`Storyshots Custom|Method for rendering Vue renderComponent 1`] = `
 </button>
 `;
 
-exports[`Storyshots Custom|Method for rendering Vue template 1`] = `
+exports[`Storyshots Custom|Method for rendering Vue Template 1`] = `
 <div>
   <h1>
     A template
@@ -412,7 +411,7 @@ exports[`Storyshots Custom|Method for rendering Vue template 1`] = `
 </div>
 `;
 
-exports[`Storyshots Custom|Method for rendering Vue templateComponent 1`] = `
+exports[`Storyshots Custom|Method for rendering Vue Template Component 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -421,7 +420,7 @@ exports[`Storyshots Custom|Method for rendering Vue templateComponent 1`] = `
 </button>
 `;
 
-exports[`Storyshots Custom|Method for rendering Vue templateMethods 1`] = `
+exports[`Storyshots Custom|Method for rendering Vue Template Methods 1`] = `
 <p>
   <em>
     Clicking the button will navigate to another story using the 'addon-links'
@@ -437,7 +436,7 @@ exports[`Storyshots Custom|Method for rendering Vue templateMethods 1`] = `
 </p>
 `;
 
-exports[`Storyshots Custom|Method for rendering Vue vuexActions 1`] = `
+exports[`Storyshots Custom|Method for rendering Vue Vuex Actions 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -446,7 +445,7 @@ exports[`Storyshots Custom|Method for rendering Vue vuexActions 1`] = `
 </button>
 `;
 
-exports[`Storyshots Custom|Method for rendering Vue whateverYouWant 1`] = `
+exports[`Storyshots Custom|Method for rendering Vue Whatever You Want 1`] = `
 <button
   class="button"
   style="color: rgb(66, 185, 131); border-color: #42b983;"
@@ -455,7 +454,7 @@ exports[`Storyshots Custom|Method for rendering Vue whateverYouWant 1`] = `
 </button>
 `;
 
-exports[`Storyshots Welcome welcome 1`] = `
+exports[`Storyshots Welcome Welcome 1`] = `
 <div
   class="main"
 >

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { logger } from '@storybook/client-logger';
 import addons, { mockChannel } from '@storybook/addons';
-import ClientApi, { defaultMakeDisplayName } from './client_api';
+import ClientApi, { makeDisplayName } from './client_api';
 import ConfigApi from './config_api';
 import StoryStore from './story_store';
 
@@ -26,17 +26,17 @@ jest.mock('@storybook/client-logger', () => ({
 }));
 
 describe('preview.client_api', () => {
-  describe('defaultMakeDisplayName', () => {
+  describe('makeDisplayName', () => {
     it('should format CSF exports with sensible defaults', () => {
       const testCases = {
         name: 'Name',
         someName: 'Some Name',
         someNAME: 'Some NAME',
         some_custom_NAME: 'Some Custom NAME',
+        someName1234: 'Some Name 1234',
+        someName1_2_3_4: 'Some Name 1 2 3 4',
       };
-      Object.entries(testCases).forEach(([key, val]) =>
-        expect(defaultMakeDisplayName(key)).toBe(val)
-      );
+      Object.entries(testCases).forEach(([key, val]) => expect(makeDisplayName(key)).toBe(val));
     });
   });
 

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { logger } from '@storybook/client-logger';
 import addons, { mockChannel } from '@storybook/addons';
-import ClientApi, { makeDisplayName } from './client_api';
+import ClientApi from './client_api';
 import ConfigApi from './config_api';
 import StoryStore from './story_store';
 
@@ -26,20 +26,6 @@ jest.mock('@storybook/client-logger', () => ({
 }));
 
 describe('preview.client_api', () => {
-  describe('makeDisplayName', () => {
-    it('should format CSF exports with sensible defaults', () => {
-      const testCases = {
-        name: 'Name',
-        someName: 'Some Name',
-        someNAME: 'Some NAME',
-        some_custom_NAME: 'Some Custom NAME',
-        someName1234: 'Some Name 1234',
-        someName1_2_3_4: 'Some Name 1 2 3 4',
-      };
-      Object.entries(testCases).forEach(([key, val]) => expect(makeDisplayName(key)).toBe(val));
-    });
-  });
-
   describe('setAddon', () => {
     it('should register addons', () => {
       const { clientApi } = getContext(undefined);

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -83,7 +83,7 @@ const withSubscriptionTracking = (storyFn: StoryFn) => {
   return result;
 };
 
-export const defaultMakeDisplayName = (key: string) => startCase(key);
+export const makeDisplayName = (key: string) => startCase(key);
 
 export default class ClientApi {
   private _storyStore: StoryStore;
@@ -126,7 +126,7 @@ export default class ClientApi {
       this._globalParameters.options
     );
 
-  getMakeDisplayName = () => defaultMakeDisplayName;
+  getMakeDisplayName = () => makeDisplayName;
 
   addDecorator = (decorator: DecoratorFunction) => {
     this._globalDecorators.push(decorator);

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -126,9 +126,7 @@ export default class ClientApi {
       this._globalParameters.options
     );
 
-  getMakeDisplayName = () =>
-    (this._globalParameters.options && this._globalParameters.options.makeDisplayName) ||
-    defaultMakeDisplayName;
+  getMakeDisplayName = () => defaultMakeDisplayName;
 
   addDecorator = (decorator: DecoratorFunction) => {
     this._globalDecorators.push(decorator);

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -1,7 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
 import deprecate from 'util-deprecate';
 import isPlainObject from 'is-plain-object';
-import startCase from 'lodash/startCase';
 import { logger } from '@storybook/client-logger';
 import addons, { StoryContext, StoryFn, Parameters, OptionsParameter } from '@storybook/addons';
 import Events from '@storybook/core-events';
@@ -83,8 +82,6 @@ const withSubscriptionTracking = (storyFn: StoryFn) => {
   return result;
 };
 
-export const makeDisplayName = (key: string) => startCase(key);
-
 export default class ClientApi {
   private _storyStore: StoryStore;
 
@@ -125,8 +122,6 @@ export default class ClientApi {
       },
       this._globalParameters.options
     );
-
-  getMakeDisplayName = () => makeDisplayName;
 
   addDecorator = (decorator: DecoratorFunction) => {
     this._globalDecorators.push(decorator);

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -7,7 +7,7 @@ import AnsiToHtml from 'ansi-to-html';
 import addons from '@storybook/addons';
 import createChannel from '@storybook/channel-postmessage';
 import { ClientApi, StoryStore, ConfigApi } from '@storybook/client-api';
-import { toId } from '@storybook/router/utils';
+import { toId, storyNameFromExport } from '@storybook/router/utils';
 import { logger } from '@storybook/client-logger';
 import Events from '@storybook/core-events';
 
@@ -398,9 +398,6 @@ export default function start(render, { decorateStory } = {}) {
       // We pass true here to avoid the warning about HMR. It's cool clientApi, we got this
       const kind = clientApi.storiesOf(kindName, true);
 
-      // Transform the CSF named export if the user hasn't specified a name
-      const makeDisplayName = clientApi.getMakeDisplayName();
-
       // we should always have a framework, rest optional
       kind.addParameters({ framework, component, ...params });
 
@@ -418,7 +415,7 @@ export default function start(render, { decorateStory } = {}) {
           }
           const decoratorParams = decorators ? { decorators } : null;
           const displayNameParams = name ? { displayName: name } : {};
-          kind.add(makeDisplayName(key), storyFn, {
+          kind.add(storyNameFromExport(key), storyFn, {
             ...parameters,
             ...decoratorParams,
             ...displayNameParams,

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -417,10 +417,12 @@ export default function start(render, { decorateStory } = {}) {
             `${kindName} => ${name || key}: story.parameters.decorators is deprecated; use story.decorators instead.`)();
           }
           const decoratorParams = decorators ? { decorators } : null;
-          const displayNameParams = {
-            displayName: name || makeDisplayName(key),
-          };
-          kind.add(key, storyFn, { ...parameters, ...decoratorParams, ...displayNameParams });
+          const displayNameParams = name ? { displayName: name } : {};
+          kind.add(makeDisplayName(key), storyFn, {
+            ...parameters,
+            ...decoratorParams,
+            ...displayNameParams,
+          });
         }
       });
     });

--- a/lib/router/package.json
+++ b/lib/router/package.json
@@ -25,6 +25,7 @@
     "@types/reach__router": "^1.2.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
+    "lodash": "^4.17.11",
     "memoizerific": "^1.11.3",
     "qs": "^6.6.0"
   },

--- a/lib/router/src/utils.test.js
+++ b/lib/router/src/utils.test.js
@@ -1,4 +1,4 @@
-import { toId } from '../utils';
+import { toId, storyNameFromExport } from './utils';
 
 describe('toId', () => {
   [
@@ -35,5 +35,19 @@ describe('toId', () => {
 
   it('does not allow empty story', () => {
     expect(() => toId('kind', '')).toThrow(`Invalid name '', must include alphanumeric characters`);
+  });
+});
+
+describe('storyNameFromExport', () => {
+  it('should format CSF exports with sensible defaults', () => {
+    const testCases = {
+      name: 'Name',
+      someName: 'Some Name',
+      someNAME: 'Some NAME',
+      some_custom_NAME: 'Some Custom NAME',
+      someName1234: 'Some Name 1234',
+      someName1_2_3_4: 'Some Name 1 2 3 4',
+    };
+    Object.entries(testCases).forEach(([key, val]) => expect(storyNameFromExport(key)).toBe(val));
   });
 });

--- a/lib/router/src/utils.ts
+++ b/lib/router/src/utils.ts
@@ -1,5 +1,6 @@
 import qs from 'qs';
 import memoize from 'memoizerific';
+import startCase from 'lodash/startCase';
 
 interface StoryData {
   viewMode?: string;
@@ -91,3 +92,6 @@ export const parseKind = (kind: string, { rootSeparator, groupSeparator }: Separ
     groups,
   };
 };
+
+// Transform the CSF named export into a readable story name
+export const storyNameFromExport = (key: string) => startCase(key);


### PR DESCRIPTION
Issue: #7599 

## What I did

This partially reverts the change made in #7878, keeping the displayName concept, but removing its configurability and adding a new `storyNameFromExport` concept.

## Why I did it

We made `hierarchySeparator` and `hierarchyRootSeparator` configurable, and it has been a maintenance nightmare, adding complexity across our codebase and bringing that nightmare to other tools in the Storybook ecosystem.

`makeDisplayName` is a similar foundational configuration. However since it can contain arbitrary JS code, we expect it will cause an order of magnitude MORE headaches. At the very least we're not ready to sign up for it without a lot more evidence that it's necessary.

This:

- Improves compatibility with legacy tools that don't support `displayName`
- Improves the readability of generated IDs
- Removes the concept of `makeDisplayName` entirely, replacing it with a stable `storyNameFromExport` utility function

Now we transform the CSF named export using `lodash.startCase` as the default. If you want other behavior you can use the `namedExport.story = { name: 'anything goes' }` construct.

```js
    it('should format CSF exports with sensible defaults', () => {
      const testCases = {
        name: 'Name',
        someName: 'Some Name',
        someNAME: 'Some NAME',
        some_custom_NAME: 'Some Custom NAME',
        someName1234: 'Some Name 1234',
        someName1_2_3_4: 'Some Name 1 2 3 4',
      };
      Object.entries(testCases).forEach(([key, val]) => expect(storyNameFromExport(key)).toBe(val));
    });
```

Consider the following CSF:

```js
export default { title: 'comp' };
export const fooBar = () => <>hello</>
```

**Before this change:**

```js
storiesOf('comp', module).add('fooBar', () => <>hello</>, { displayName: 'Foo Bar' });
```

Story ID in URL: `comp--foobar`

**After this change:**

```js
storiesOf('comp', module).add('Foo Bar', () => <>hello</>);
```

Note that if the user manually specifies a display name, it will still get passed through:

```
fooBar.story = { name: 'whatever' }
```

=> 
```js
storiesOf('comp', module).add('Foo Bar', () => <>hello</>, { displayName: 'whatever' });
```

Story ID in URL: `comp--foo-bar`

## How to test

```
cd examples/official-storybook
yarn storybook
```
