### PR TITLE
Resolve deprecated methods in react-native

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/absolute-positioned-keyboard-aware-view.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/absolute-positioned-keyboard-aware-view.tsx
@@ -27,7 +27,8 @@ export default class AbsolutePositionedKeyboardAwareView extends PureComponent<P
 
   keyboardOpen: boolean;
 
-  componentWillMount() {
+  constructor(props: Props) {
+    super(props);
     this.keyboardDidShowListener = Keyboard.addListener(
       'keyboardDidShow',
       this.keyboardDidShowHandler


### PR DESCRIPTION
Issue: `componentWillMount` made warning `deprecated` continually when use `@storybook/react-native` in project at React >= 16.3.

## What I did

Convert deprecated methods in react-native.
Move `componentWillMount`s logic into `constructor`

`componentWillMount` made warning `deprecated` continually when use `@storybook/react-native` in project. Thus, I moved logic into `contructor` method from `componentWillMount`.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

It is tested manually through `examples-native/crna-kitchen-sink`.



<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
