### PR TITLE
UI: Optimize treeview render/filter performance

### DIFF
--- a/examples/cra-kitchen-sink/src/stories/perf.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/perf.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
+import { Button } from '@storybook/react/demo';
+
+for (let i = 0; i < 0; i += 1) {
+  const randomDemoName = Math.random()
+    .toString(36)
+    .substring(7);
+  const stories = storiesOf(`Perf|${i}/${randomDemoName}`);
+
+  for (let j = 0; j < 100; j += 1) {
+    stories
+      .add(`with text ${j}`, () => <Button>Hello Button</Button>)
+      .add(`with emoji ${j}`, () => (
+        <Button>
+          <span role="img" aria-label="so cool">
+            😀 😎 👍 💯
+          </span>
+        </Button>
+      ));
+  }
+}

--- a/examples/cra-kitchen-sink/src/stories/perf.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/perf.stories.js
@@ -4,13 +4,13 @@ import { storiesOf } from '@storybook/react';
 
 import { Button } from '@storybook/react/demo';
 
-for (let i = 0; i < 0; i += 1) {
+for (let i = 0; i < 1; i += 1) {
   const randomDemoName = Math.random()
     .toString(36)
     .substring(7);
-  const stories = storiesOf(`Perf|${i}/${randomDemoName}`);
+  const stories = storiesOf(`Perf.${randomDemoName}`);
 
-  for (let j = 0; j < 100; j += 1) {
+  for (let j = 0; j < 10; j += 1) {
     stories
       .add(`with text ${j}`, () => <Button>Hello Button</Button>)
       .add(`with emoji ${j}`, () => (

--- a/lib/ui/src/components/sidebar/treeview/treeview.js
+++ b/lib/ui/src/components/sidebar/treeview/treeview.js
@@ -150,14 +150,10 @@ const calculateTreeState = memoize(50)(
 
     // If a new selection is made, we need to ensure it is part of the expanded set
     const selectedAncestorIds = selectedId ? getParents(selectedId, dataset).map(i => i.id) : [];
-
-    const newExpanded = Object.keys(dataset).reduce(
-      (acc, key) => ({
-        ...acc,
-        [key]: selectedAncestorIds.includes(key) || unfilteredExpanded[key],
-      }),
-      {}
-    );
+    const newExpanded = Object.keys(dataset).reduce((acc, key) => {
+      acc[key] = selectedAncestorIds.includes(key) || unfilteredExpanded[key];
+      return acc;
+    }, {});
 
     return {
       lastSelectedId: selectedId,

--- a/lib/ui/src/components/sidebar/treeview/utils.js
+++ b/lib/ui/src/components/sidebar/treeview/utils.js
@@ -172,20 +172,17 @@ export const toFiltered = (dataset, filter) => {
 
   // get all parents for all results
   const result = found.reduce((acc, item) => {
-    const parents = getParents(item.id, dataset).reduce(
-      (pacc, pitem) => ({ ...pacc, [pitem.id]: { ...pitem } }),
-      {}
-    );
+    getParents(item.id, dataset).forEach(pitem => {
+      acc[pitem.id] = pitem;
+    });
 
-    return { ...acc, [item.id]: item, ...parents };
+    acc[item.id] = item;
+    return acc;
   }, {});
 
   // filter the children of the found items (and their parents) so only found entries are present
-  return Object.entries(result).reduce(
-    (acc, [k, v]) => ({
-      ...acc,
-      [k]: v.children ? { ...v, children: v.children.filter(c => !!result[c]) } : v,
-    }),
-    {}
-  );
+  return Object.entries(result).reduce((acc, [k, v]) => {
+    acc[k] = v.children ? { ...v, children: v.children.filter(c => !!result[c]) } : v;
+    return acc;
+  }, {});
 };


### PR DESCRIPTION
Issue: #7907

## What I did

- Recreated a simplified version of @kevinweber's perf test inside `cra-kitchen-sink`
- Optimized a few key loops in the treeview UI (w/ 2000 extra `perf` stories)
  - calculateTreeState (render):
    - before: ~750ms
    - after: ~10ms
  - toFiltered (search):
    - before: ~800ms
    - after: ~50ms

## How to test

Edit `perf.stories.js` to set the outer loop max to 10 & inner to 100. Then:

```
cd examples/cra-kitchen-sink
yarn storybook --no-dll
```
