### PR TITLE
Bump react-draggable from 3.1.1 to 3.3.2

### DIFF
--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -47,7 +47,7 @@
     "qs": "^6.6.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "react-draggable": "^3.1.1",
+    "react-draggable": "^3.3.2",
     "react-helmet-async": "^1.0.2",
     "react-hotkeys": "2.0.0-pre4",
     "react-sizeme": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24217,10 +24217,10 @@ react-dom@^16.8.3, react-dom@^16.8.4:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-draggable@^3.1.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-3.3.0.tgz#2ed7ea3f92e7d742d747f9e6324860606cd4d997"
-  integrity sha512-U7/jD0tAW4T0S7DCPK0kkKLyL0z61sC/eqU+NUfDjnq+JtBKaYKDHpsK2wazctiA4alEzCXUnzkREoxppOySVw==
+react-draggable@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-3.3.2.tgz#966ef1d90f2387af3c2d8bd3516f601ea42ca359"
+  integrity sha512-oaz8a6enjbPtx5qb0oDWxtDNuybOylvto1QLydsXgKmwT7e3GXC2eMVDwEMIUYJIFqVG72XpOv673UuuAq6LhA==
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.0"


### PR DESCRIPTION
The main thing this version bump fixes, is the `componentWillMount` deprecation warning in React 16.9.

![Skærmbillede 2019-08-29 kl  13 13 26](https://user-images.githubusercontent.com/3764345/63935923-cf969680-ca5e-11e9-87bd-a7916a9922ef.png)


