### PR TITLE
Addon-docs: Fix DocsPage to respect displayName

### DIFF
--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -37,6 +37,7 @@ interface DocsStoryProps {
   description?: string;
   expanded?: boolean;
   withToolbar?: boolean;
+  parameters?: any;
 }
 
 interface StoryData {
@@ -84,9 +85,10 @@ const DocsStory: React.FunctionComponent<DocsStoryProps> = ({
   description,
   expanded = true,
   withToolbar = false,
+  parameters,
 }) => (
   <>
-    {expanded && <StoryHeading>{name}</StoryHeading>}
+    {expanded && <StoryHeading>{(parameters && parameters.displayName) || name}</StoryHeading>}
     {expanded && description && <Description markdown={description} />}
     <Preview withToolbar={withToolbar}>
       <Story id={id} />


### PR DESCRIPTION
Issue: #7599 

## What I did

Fix DocsPage to respect displayName if present

## How to test

View DocsPage for components before & after in `official-storybook` and verify that headings match the display name in the left-hand nav. 