### PR TITLE
Addon-docs: Fix docs-only story ID suffix

### DIFF
--- a/addons/docs/src/mdx/__snapshots__/mdx-compiler-plugin.test.js.snap
+++ b/addons/docs/src/mdx/__snapshots__/mdx-compiler-plugin.test.js.snap
@@ -121,13 +121,13 @@ function MDXContent({ components, ...props }) {
 
 MDXContent.isMDXComponent = true;
 
-export const storybookDocsOnly = () => {
+export const __page = () => {
   throw new Error('Docs-only story');
 };
 
-storybookDocsOnly.story = { parameters: { docsOnly: true } };
+__page.story = { parameters: { docsOnly: true } };
 
-const componentMeta = { title: 'docs-only', includeStories: ['storybookDocsOnly'] };
+const componentMeta = { title: 'docs-only', includeStories: ['__page'] };
 
 const mdxStoryNameToId = {};
 

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -219,11 +219,9 @@ function extractExports(node, options) {
   });
   if (metaExport) {
     if (!storyExports.length) {
-      storyExports.push(
-        'export const storybookDocsOnly = () => { throw new Error("Docs-only story"); };'
-      );
-      storyExports.push('storybookDocsOnly.story = { parameters: { docsOnly: true } };');
-      includeStories.push('storybookDocsOnly');
+      storyExports.push('export const __page = () => { throw new Error("Docs-only story"); };');
+      storyExports.push('__page.story = { parameters: { docsOnly: true } };');
+      includeStories.push('__page');
     }
   } else {
     metaExport = {};


### PR DESCRIPTION
Issue: #6644 

## What I did

Fix the ID suffix for docs-only stories, e.g.:

`http://localhost:6006/?path=/docs/design-system-intro--storybook-docs-only` => `http://localhost:6006/?path=/docs/design-system-intro--page`

## How to test

See the docs-only stories in `official-storybook` under `Addons|Docs`