### PR TITLE
Fix defaultViewport in @addon-viewport

### DIFF
--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -133,6 +133,14 @@ export const ViewportTool: FunctionComponent<{}> = React.memo(
     });
     const list = toList(viewports);
 
+    useEffect(() => {
+      setState({
+        selected:
+          defaultViewport || (viewports[state.selected] ? state.selected : responsiveViewport.id),
+        isRotated: state.isRotated,
+      });
+    }, [defaultViewport]);
+
     const { selected, isRotated } = state;
     const item =
       list.find(i => i.id === selected) ||


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/7717

## What I did

This is a fix for the viewport addon, where the defaultViewport was not taken into account.
We basically set up a useEffect hook and redefine the current state of the Tool component so that:
- The defaultViewport (if there is any) is properly set for the current story loaded.
- The viewport is stored and passed from one story to the other.

## How to test

Use the the `official-storybook` example.

Scenario 1 (no defaultViewport set):
- Go to http://localhost:9011/?path=/story/addons-viewport--default-fn.
=> Result: it should have the responsive viewport.

Scenario 2 (with a defaultViewport set):
- Go to http://localhost:9011/?path=/story/addons-viewport-custom-default-kindle-fire-2--overridden-via-with-viewport-parameterized-decorator.
- Then go to http://localhost:9011/?path=/story/addons-viewport--default-fn.
=> Result: both of them should have the iPad viewport.

Scenario 3 (two stories with different viewports, one has MINIMAL_VIEWPORTS, the other INITIAL_VIEWPORTS):
- Go to http://localhost:9011/?path=/story/addons-viewport-custom-default-kindle-fire-2--overridden-via-with-viewport-parameterized-decorator.
- Then go to http://localhost:9011/?path=/story/addons-contexts--simple-css-theming.
=> Result: the first story should have the iPad viewport, the second one should have the responsive viewport.