### PR TITLE
Source-loader: Fix CSF display name handling

### DIFF
--- a/lib/source-loader/src/server/abstract-syntax-tree/traverse-helpers.js
+++ b/lib/source-loader/src/server/abstract-syntax-tree/traverse-helpers.js
@@ -1,3 +1,4 @@
+import { storyNameFromExport } from '@storybook/router/utils';
 import { handleADD, handleSTORYOF, patchNode, handleExportedName } from './parse-helpers';
 
 const estraverse = require('estraverse');
@@ -73,37 +74,6 @@ export function findAddsMap(ast, storiesOfIdentifiers) {
   return { addsMap, idsToFrameworks };
 }
 
-// Handle cases like:
-//   export const withText = () => <Button />;
-//   withText.story = { name: 'with text' };
-function findStoryTitle(storyVar, ast) {
-  const titleAssignment = ast.program.body.find(
-    d =>
-      d.type === 'ExpressionStatement' &&
-      d.expression &&
-      d.expression.type === 'AssignmentExpression' &&
-      d.expression.left &&
-      d.expression.left.type === 'MemberExpression' &&
-      d.expression.left.object &&
-      d.expression.left.object.type === 'Identifier' &&
-      d.expression.left.object.name === storyVar &&
-      d.expression.left.property.type === 'Identifier' &&
-      d.expression.left.property.name === 'story' &&
-      d.expression.right &&
-      d.expression.right.type === 'ObjectExpression'
-  );
-  const nameProp =
-    titleAssignment &&
-    titleAssignment.expression.right.properties.find(
-      prop =>
-        prop.key.type === 'Identifier' &&
-        prop.key.name === 'name' &&
-        prop.value.type === 'StringLiteral'
-    );
-
-  return nameProp && nameProp.value.value;
-}
-
 export function findExportsMap(ast) {
   const addsMap = {};
   const idsToFrameworks = {};
@@ -145,8 +115,7 @@ export function findExportsMap(ast) {
           node.declaration.declarations[0].init.type
         )
       ) {
-        let storyName = node.declaration.declarations[0].id.name;
-        storyName = findStoryTitle(storyName, ast) || storyName;
+        const storyName = storyNameFromExport(node.declaration.declarations[0].id.name);
         const toAdd = handleExportedName(title, storyName, node.declaration.declarations[0].init);
         Object.assign(addsMap, toAdd);
       }


### PR DESCRIPTION
Issue: #7936 

## What I did

The recent CSF changes (to handle `exportVar.story.name` as a display name only) broke `source-loader` so that camel-cased exports did not get their code correctly associated. This fixes that.

## How to test

The `Source.stories.tsx` files use camel case and were broken in `official-storybook`. They work now.
