### PR TITLE
Addon-Jest: Fix inconsistent file naming in README

### DIFF
--- a/addons/jest/README.md
+++ b/addons/jest/README.md
@@ -26,14 +26,14 @@ When running **Jest**, be sure to save the results in a json file:
 
 ```js
 "scripts": {
-  "test:generate-output": "jest --json --outputFile=jest-test-results.json"
+  "test:generate-output": "jest --json --outputFile=.jest-test-results.json"
 }
 ```
 
 You may want to add it the result file to `.gitignore`, since it's a generated file:
 
 ```
-jest-test-results.json
+.jest-test-results.json
 ```
 
 But much like lockfiles and snapshots checking-in generated files can have certain advantages as well. It's up to you.


### PR DESCRIPTION
I recently added the jest addon to my project by following the setup guide in the readme for the addon. However it wouldn’t work and took me a fair amount of time to notice that the test result file had not the same name as used in the config code snippets. With this PR I want to make sure that others don’t have to waste their time on this inconsistency.

Issue: none

## What I did
Update the readme for the jest addon. The file name for the test result now matches the file name used in config code snippets. The file should now always be named `.jest-test-results.json`.

## How to test
By reading the readme.

- Is this testable with Jest or Chromatic screenshots? `No`
- Does this need a new example in the kitchen sink apps? `No` 
- Does this need an update to the documentation? `Maybe?`
