### PR TITLE
docspage.md broken link fix

### DIFF
--- a/addons/docs/docs/docspage.md
+++ b/addons/docs/docs/docspage.md
@@ -24,7 +24,7 @@ However, `DocsPage` brings the following improvements:
 - It supports all frameworks that Storybook supports, including React, Vue, Angular and [many others](../README.md#framework-support).
 - It generates better documentation that can be used as a standalone docs site, independently of Storybook.
 - It supports better configuration, so you can capture project specific information with ease.
-- It's built to work with [`MDX`](./mdx.md`) when you need more control of your documentation.
+- It's built to work with [`MDX`](./mdx.md) when you need more control of your documentation.
 
 ## Component parameter
 


### PR DESCRIPTION
Issue:

`mdx.md` reference link in `docspage.md` was broken because of `` ` ``

## How to test

Click on it.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
