### PR TITLE
UI: Fix enableShortcuts option

### DIFF
--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -118,142 +118,144 @@ export default function initShortcuts({ store }: Module) {
     handleShortcutFeature(fullApi, feature) {
       const {
         layout: { isFullscreen, showNav, showPanel },
+        ui: { enableShortcuts },
       } = store.getState();
-
-      switch (feature) {
-        case 'escape': {
-          if (isFullscreen) {
-            fullApi.toggleFullscreen();
-          } else if (!showNav) {
-            fullApi.toggleNav();
-          }
-          break;
-        }
-
-        case 'focusNav': {
-          if (isFullscreen) {
-            fullApi.toggleFullscreen();
-          }
-          if (!showNav) {
-            fullApi.toggleNav();
-          }
-          fullApi.focusOnUIElement(focusableUIElements.storyListMenu);
-          break;
-        }
-
-        case 'search': {
-          if (isFullscreen) {
-            fullApi.toggleFullscreen();
-          }
-          if (!showNav) {
-            fullApi.toggleNav();
-          }
-
-          setTimeout(() => {
-            fullApi.focusOnUIElement(focusableUIElements.storySearchField);
-          }, 0);
-          break;
-        }
-
-        case 'focusIframe': {
-          const element = document.getElementById('storybook-preview-iframe');
-
-          if (element) {
-            try {
-              // should be like a channel message and all that, but yolo for now
-              element.contentWindow.focus();
-            } catch (e) {
-              //
+      if (enableShortcuts) {
+        switch (feature) {
+          case 'escape': {
+            if (isFullscreen) {
+              fullApi.toggleFullscreen();
+            } else if (!showNav) {
+              fullApi.toggleNav();
             }
+            break;
           }
-          break;
-        }
 
-        case 'focusPanel': {
-          if (isFullscreen) {
-            fullApi.toggleFullscreen();
+          case 'focusNav': {
+            if (isFullscreen) {
+              fullApi.toggleFullscreen();
+            }
+            if (!showNav) {
+              fullApi.toggleNav();
+            }
+            fullApi.focusOnUIElement(focusableUIElements.storyListMenu);
+            break;
           }
-          if (!showPanel) {
+
+          case 'search': {
+            if (isFullscreen) {
+              fullApi.toggleFullscreen();
+            }
+            if (!showNav) {
+              fullApi.toggleNav();
+            }
+
+            setTimeout(() => {
+              fullApi.focusOnUIElement(focusableUIElements.storySearchField);
+            }, 0);
+            break;
+          }
+
+          case 'focusIframe': {
+            const element = document.getElementById('storybook-preview-iframe');
+
+            if (element) {
+              try {
+                // should be like a channel message and all that, but yolo for now
+                element.contentWindow.focus();
+              } catch (e) {
+                //
+              }
+            }
+            break;
+          }
+
+          case 'focusPanel': {
+            if (isFullscreen) {
+              fullApi.toggleFullscreen();
+            }
+            if (!showPanel) {
+              fullApi.togglePanel();
+            }
+            fullApi.focusOnUIElement(focusableUIElements.storyPanelRoot);
+            break;
+          }
+
+          case 'nextStory': {
+            fullApi.jumpToStory(1);
+            break;
+          }
+
+          case 'prevStory': {
+            fullApi.jumpToStory(-1);
+            break;
+          }
+
+          case 'nextComponent': {
+            fullApi.jumpToComponent(1);
+            break;
+          }
+
+          case 'prevComponent': {
+            fullApi.jumpToComponent(-1);
+            break;
+          }
+
+          case 'fullScreen': {
+            fullApi.toggleFullscreen();
+            break;
+          }
+
+          case 'togglePanel': {
+            if (isFullscreen) {
+              fullApi.toggleFullscreen();
+              fullApi.resetLayout();
+            }
+
             fullApi.togglePanel();
-          }
-          fullApi.focusOnUIElement(focusableUIElements.storyPanelRoot);
-          break;
-        }
-
-        case 'nextStory': {
-          fullApi.jumpToStory(1);
-          break;
-        }
-
-        case 'prevStory': {
-          fullApi.jumpToStory(-1);
-          break;
-        }
-
-        case 'nextComponent': {
-          fullApi.jumpToComponent(1);
-          break;
-        }
-
-        case 'prevComponent': {
-          fullApi.jumpToComponent(-1);
-          break;
-        }
-
-        case 'fullScreen': {
-          fullApi.toggleFullscreen();
-          break;
-        }
-
-        case 'togglePanel': {
-          if (isFullscreen) {
-            fullApi.toggleFullscreen();
-            fullApi.resetLayout();
+            break;
           }
 
-          fullApi.togglePanel();
-          break;
-        }
+          case 'toggleNav': {
+            if (isFullscreen) {
+              fullApi.toggleFullscreen();
+              fullApi.resetLayout();
+            }
 
-        case 'toggleNav': {
-          if (isFullscreen) {
-            fullApi.toggleFullscreen();
-            fullApi.resetLayout();
+            fullApi.toggleNav();
+            break;
           }
 
-          fullApi.toggleNav();
-          break;
-        }
-
-        case 'toolbar': {
-          fullApi.toggleToolbar();
-          break;
-        }
-
-        case 'panelPosition': {
-          if (isFullscreen) {
-            fullApi.toggleFullscreen();
-          }
-          if (!showPanel) {
-            fullApi.togglePanel();
+          case 'toolbar': {
+            fullApi.toggleToolbar();
+            break;
           }
 
-          fullApi.togglePanelPosition();
-          break;
-        }
+          case 'panelPosition': {
+            if (isFullscreen) {
+              fullApi.toggleFullscreen();
+            }
+            if (!showPanel) {
+              fullApi.togglePanel();
+            }
 
-        case 'aboutPage': {
-          fullApi.navigate('/settings/about');
-          break;
-        }
+            fullApi.togglePanelPosition();
+            break;
+          }
 
-        case 'shortcutsPage': {
-          fullApi.navigate('/settings/shortcuts');
-          break;
-        }
+          case 'aboutPage': {
+            fullApi.navigate('/settings/about');
+            break;
+          }
 
-        default:
-          break;
+          case 'shortcutsPage': {
+            fullApi.navigate('/settings/shortcuts');
+            break;
+          }
+
+          default:
+            break;
+        }
       }
     },
   };
@@ -267,14 +269,13 @@ export default function initShortcuts({ store }: Module) {
     ),
   };
 
-  const init = ({ api: fullApi }: API) => {
+  const init = ({ api: fullApi, ...rest }: API) => {
     function focusInInput(event: Event) {
       return (
         /input|textarea/i.test(event.target.tagName) ||
         event.target.getAttribute('contenteditable') !== null
       );
     }
-
     // Listen for keydown events in the manager
     document.addEventListener('keydown', (event: Event) => {
       if (!focusInInput(event)) {

--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -120,142 +120,143 @@ export default function initShortcuts({ store }: Module) {
         layout: { isFullscreen, showNav, showPanel },
         ui: { enableShortcuts },
       } = store.getState();
-      if (enableShortcuts) {
-        switch (feature) {
-          case 'escape': {
-            if (isFullscreen) {
-              fullApi.toggleFullscreen();
-            } else if (!showNav) {
-              fullApi.toggleNav();
-            }
-            break;
-          }
-
-          case 'focusNav': {
-            if (isFullscreen) {
-              fullApi.toggleFullscreen();
-            }
-            if (!showNav) {
-              fullApi.toggleNav();
-            }
-            fullApi.focusOnUIElement(focusableUIElements.storyListMenu);
-            break;
-          }
-
-          case 'search': {
-            if (isFullscreen) {
-              fullApi.toggleFullscreen();
-            }
-            if (!showNav) {
-              fullApi.toggleNav();
-            }
-
-            setTimeout(() => {
-              fullApi.focusOnUIElement(focusableUIElements.storySearchField);
-            }, 0);
-            break;
-          }
-
-          case 'focusIframe': {
-            const element = document.getElementById('storybook-preview-iframe');
-
-            if (element) {
-              try {
-                // should be like a channel message and all that, but yolo for now
-                element.contentWindow.focus();
-              } catch (e) {
-                //
-              }
-            }
-            break;
-          }
-
-          case 'focusPanel': {
-            if (isFullscreen) {
-              fullApi.toggleFullscreen();
-            }
-            if (!showPanel) {
-              fullApi.togglePanel();
-            }
-            fullApi.focusOnUIElement(focusableUIElements.storyPanelRoot);
-            break;
-          }
-
-          case 'nextStory': {
-            fullApi.jumpToStory(1);
-            break;
-          }
-
-          case 'prevStory': {
-            fullApi.jumpToStory(-1);
-            break;
-          }
-
-          case 'nextComponent': {
-            fullApi.jumpToComponent(1);
-            break;
-          }
-
-          case 'prevComponent': {
-            fullApi.jumpToComponent(-1);
-            break;
-          }
-
-          case 'fullScreen': {
+      if (!enableShortcuts) {
+        return;
+      }
+      switch (feature) {
+        case 'escape': {
+          if (isFullscreen) {
             fullApi.toggleFullscreen();
-            break;
-          }
-
-          case 'togglePanel': {
-            if (isFullscreen) {
-              fullApi.toggleFullscreen();
-              fullApi.resetLayout();
-            }
-
-            fullApi.togglePanel();
-            break;
-          }
-
-          case 'toggleNav': {
-            if (isFullscreen) {
-              fullApi.toggleFullscreen();
-              fullApi.resetLayout();
-            }
-
+          } else if (!showNav) {
             fullApi.toggleNav();
-            break;
           }
-
-          case 'toolbar': {
-            fullApi.toggleToolbar();
-            break;
-          }
-
-          case 'panelPosition': {
-            if (isFullscreen) {
-              fullApi.toggleFullscreen();
-            }
-            if (!showPanel) {
-              fullApi.togglePanel();
-            }
-
-            fullApi.togglePanelPosition();
-            break;
-          }
-
-          case 'aboutPage': {
-            fullApi.navigate('/settings/about');
-            break;
-          }
-
-          case 'shortcutsPage': {
-            fullApi.navigate('/settings/shortcuts');
-            break;
-          }
-
-          default:
-            break;
+          break;
         }
+
+        case 'focusNav': {
+          if (isFullscreen) {
+            fullApi.toggleFullscreen();
+          }
+          if (!showNav) {
+            fullApi.toggleNav();
+          }
+          fullApi.focusOnUIElement(focusableUIElements.storyListMenu);
+          break;
+        }
+
+        case 'search': {
+          if (isFullscreen) {
+            fullApi.toggleFullscreen();
+          }
+          if (!showNav) {
+            fullApi.toggleNav();
+          }
+
+          setTimeout(() => {
+            fullApi.focusOnUIElement(focusableUIElements.storySearchField);
+          }, 0);
+          break;
+        }
+
+        case 'focusIframe': {
+          const element = document.getElementById('storybook-preview-iframe');
+
+          if (element) {
+            try {
+              // should be like a channel message and all that, but yolo for now
+              element.contentWindow.focus();
+            } catch (e) {
+              //
+            }
+          }
+          break;
+        }
+
+        case 'focusPanel': {
+          if (isFullscreen) {
+            fullApi.toggleFullscreen();
+          }
+          if (!showPanel) {
+            fullApi.togglePanel();
+          }
+          fullApi.focusOnUIElement(focusableUIElements.storyPanelRoot);
+          break;
+        }
+
+        case 'nextStory': {
+          fullApi.jumpToStory(1);
+          break;
+        }
+
+        case 'prevStory': {
+          fullApi.jumpToStory(-1);
+          break;
+        }
+
+        case 'nextComponent': {
+          fullApi.jumpToComponent(1);
+          break;
+        }
+
+        case 'prevComponent': {
+          fullApi.jumpToComponent(-1);
+          break;
+        }
+
+        case 'fullScreen': {
+          fullApi.toggleFullscreen();
+          break;
+        }
+
+        case 'togglePanel': {
+          if (isFullscreen) {
+            fullApi.toggleFullscreen();
+            fullApi.resetLayout();
+          }
+
+          fullApi.togglePanel();
+          break;
+        }
+
+        case 'toggleNav': {
+          if (isFullscreen) {
+            fullApi.toggleFullscreen();
+            fullApi.resetLayout();
+          }
+
+          fullApi.toggleNav();
+          break;
+        }
+
+        case 'toolbar': {
+          fullApi.toggleToolbar();
+          break;
+        }
+
+        case 'panelPosition': {
+          if (isFullscreen) {
+            fullApi.toggleFullscreen();
+          }
+          if (!showPanel) {
+            fullApi.togglePanel();
+          }
+
+          fullApi.togglePanelPosition();
+          break;
+        }
+
+        case 'aboutPage': {
+          fullApi.navigate('/settings/about');
+          break;
+        }
+
+        case 'shortcutsPage': {
+          fullApi.navigate('/settings/shortcuts');
+          break;
+        }
+
+        default:
+          break;
       }
     },
   };

--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -269,7 +269,7 @@ export default function initShortcuts({ store }: Module) {
     ),
   };
 
-  const init = ({ api: fullApi, ...rest }: API) => {
+  const init = ({ api: fullApi }: API) => {
     function focusInInput(event: Event) {
       return (
         /input|textarea/i.test(event.target.tagName) ||

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -15,85 +15,90 @@ const focusableUIElements = {
   storyPanelRoot: 'storybook-panel-root',
 };
 
-const createMenu = memoize(1)((api, shortcutKeys, isFullscreen, showPanel, showNav) => [
-  {
-    id: 'S',
-    title: 'Show sidebar',
-    onClick: () => api.toggleNav(),
-    right: shortcutToHumanString(shortcutKeys.toggleNav),
-    left: showNav ? <ListItemIcon icon="check" /> : <ListItemIcon />,
-  },
-  {
-    id: 'A',
-    title: 'Show addons',
-    onClick: () => api.togglePanel(),
-    right: shortcutToHumanString(shortcutKeys.togglePanel),
-    left: showPanel ? <ListItemIcon icon="check" /> : <ListItemIcon />,
-  },
-  {
-    id: 'D',
-    title: 'Change addons orientation',
-    onClick: () => api.togglePanelPosition(),
-    right: shortcutToHumanString(shortcutKeys.panelPosition),
-    left: <ListItemIcon />,
-  },
-  {
-    id: 'F',
-    title: 'Go full screen',
-    onClick: api.toggleFullscreen,
-    right: shortcutToHumanString(shortcutKeys.fullScreen),
-    left: isFullscreen ? 'check' : <ListItemIcon />,
-  },
-  {
-    id: '/',
-    title: 'Search',
-    onClick: () => api.focusOnUIElement(focusableUIElements.storySearchField),
-    right: shortcutToHumanString(shortcutKeys.search),
-    left: <ListItemIcon />,
-  },
-  {
-    id: 'up',
-    title: 'Previous component',
-    onClick: () => api.jumpToComponent(-1),
-    right: shortcutToHumanString(shortcutKeys.prevComponent),
-    left: <ListItemIcon />,
-  },
-  {
-    id: 'down',
-    title: 'Next component',
-    onClick: () => api.jumpToComponent(1),
-    right: shortcutToHumanString(shortcutKeys.nextComponent),
-    left: <ListItemIcon />,
-  },
-  {
-    id: 'prev',
-    title: 'Previous story',
-    onClick: () => api.jumpToStory(-1),
-    right: shortcutToHumanString(shortcutKeys.prevStory),
-    left: <ListItemIcon />,
-  },
-  {
-    id: 'next',
-    title: 'Next story',
-    onClick: () => api.jumpToStory(1),
-    right: shortcutToHumanString(shortcutKeys.nextStory),
-    left: <ListItemIcon />,
-  },
-  {
-    id: 'about',
-    title: 'About your Storybook',
-    onClick: () => api.navigate('/settings/about'),
-    right: api.versionUpdateAvailable() && <Badge status="positive">Update</Badge>,
-    left: <ListItemIcon />,
-  },
-  {
-    id: 'shortcuts',
-    title: 'Keyboard shortcuts',
-    onClick: () => api.navigate('/settings/shortcuts'),
-    right: shortcutToHumanString(shortcutKeys.shortcutsPage),
-    left: <ListItemIcon />,
-  },
-]);
+const shortcutToHumanStringIfEnabled = (shortcuts, enableShortcuts) =>
+  enableShortcuts ? shortcutToHumanString(shortcuts) : null;
+
+const createMenu = memoize(1)(
+  (api, shortcutKeys, isFullscreen, showPanel, showNav, enableShortcuts) => [
+    {
+      id: 'S',
+      title: 'Show sidebar',
+      onClick: () => api.toggleNav(),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.toggleNav, enableShortcuts),
+      left: showNav ? <ListItemIcon icon="check" /> : <ListItemIcon />,
+    },
+    {
+      id: 'A',
+      title: 'Show addons',
+      onClick: () => api.togglePanel(),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.togglePanel, enableShortcuts),
+      left: showPanel ? <ListItemIcon icon="check" /> : <ListItemIcon />,
+    },
+    {
+      id: 'D',
+      title: 'Change addons orientation',
+      onClick: () => api.togglePanelPosition(),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.panelPosition, enableShortcuts),
+      left: <ListItemIcon />,
+    },
+    {
+      id: 'F',
+      title: 'Go full screen',
+      onClick: api.toggleFullscreen,
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.fullScreen, enableShortcuts),
+      left: isFullscreen ? 'check' : <ListItemIcon />,
+    },
+    {
+      id: '/',
+      title: 'Search',
+      onClick: () => api.focusOnUIElement(focusableUIElements.storySearchField),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.search, enableShortcuts),
+      left: <ListItemIcon />,
+    },
+    {
+      id: 'up',
+      title: 'Previous component',
+      onClick: () => api.jumpToComponent(-1),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.prevComponent, enableShortcuts),
+      left: <ListItemIcon />,
+    },
+    {
+      id: 'down',
+      title: 'Next component',
+      onClick: () => api.jumpToComponent(1),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.nextComponent, enableShortcuts),
+      left: <ListItemIcon />,
+    },
+    {
+      id: 'prev',
+      title: 'Previous story',
+      onClick: () => api.jumpToStory(-1),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.prevStory, enableShortcuts),
+      left: <ListItemIcon />,
+    },
+    {
+      id: 'next',
+      title: 'Next story',
+      onClick: () => api.jumpToStory(1),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.nextStory, enableShortcuts),
+      left: <ListItemIcon />,
+    },
+    {
+      id: 'about',
+      title: 'About your Storybook',
+      onClick: () => api.navigate('/settings/about'),
+      right: api.versionUpdateAvailable() && <Badge status="positive">Update</Badge>,
+      left: <ListItemIcon />,
+    },
+    {
+      id: 'shortcuts',
+      title: 'Keyboard shortcuts',
+      onClick: () => api.navigate('/settings/shortcuts'),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.shortcutsPage, enableShortcuts),
+      left: <ListItemIcon />,
+    },
+  ]
+);
 
 const collapseDocsOnlyStories = storiesHash => {
   // keep track of component IDs that have been rewritten to the ID of their first leaf child
@@ -140,16 +145,14 @@ const collapseDocsOnlyStories = storiesHash => {
 
 export const mapper = ({ state, api }) => {
   const {
-    ui: { name, url },
+    ui: { name, url, enableShortcuts },
     viewMode,
     storyId,
-    layout: { isFullscreen, showPanel, showNav, panelPosition },
+    layout: { isFullscreen, showPanel, showNav },
     storiesHash,
     storiesConfigured,
   } = state;
-
   const stories = collapseDocsOnlyStories(storiesHash);
-
   const shortcutKeys = api.getShortcutKeys();
   return {
     loading: !storiesConfigured,
@@ -158,7 +161,7 @@ export const mapper = ({ state, api }) => {
     stories,
     storyId,
     viewMode,
-    menu: createMenu(api, shortcutKeys, isFullscreen, showPanel, showNav, panelPosition),
+    menu: createMenu(api, shortcutKeys, isFullscreen, showPanel, showNav, enableShortcuts),
     menuHighlighted: api.versionUpdateAvailable(),
   };
 };


### PR DESCRIPTION
Issue: #6569

## What I did

if options.enableShortcuts is set to false:
* remove the display of the shortcuts next to the menu items
* disable handling of shortcut activities 

tried to disturb the existing code as little as possible.
## How to test
Please review if indeed all the features should be disabled in `shortcuts.ts` after the line `switch (feature) {`

in official storybook, change the 
```
addParameters({
  options: {
    ...
    enableShortcuts: false,
  },
});
```

**NB** the options seem to take some time until the local storage expires, so you might have to delete the local storage `@storybook/ui/store`