### PR TITLE
Addon-docs: Doc blocks fixes for dark theme

### DIFF
--- a/lib/components/src/blocks/ColorPalette.tsx
+++ b/lib/components/src/blocks/ColorPalette.tsx
@@ -7,6 +7,7 @@ import { ResetWrapper } from '../typography/DocumentFormatting';
 
 const ItemTitle = styled.div<{}>(({ theme }) => ({
   fontWeight: theme.typography.weight.bold,
+  color: theme.color.defaultText,
 }));
 
 const ItemSubtitle = styled.div<{}>(({ theme }) => ({
@@ -92,7 +93,6 @@ const ListHeading = styled.div<{}>(({ theme }) => ({
   alignItems: 'center',
   paddingBottom: 20,
   fontWeight: theme.typography.weight.bold,
-
   color:
     theme.base === 'light'
       ? transparentize(0.4, theme.color.defaultText)

--- a/lib/components/src/blocks/DocsPage.tsx
+++ b/lib/components/src/blocks/DocsPage.tsx
@@ -51,7 +51,6 @@ export const DocsContent = styled.div({
 
 export const DocsWrapper = styled.div<{}>(({ theme }) => ({
   background: theme.background.content,
-  color: theme.color.defaultText,
   display: 'flex',
   justifyContent: 'center',
   minHeight: '100vh',

--- a/lib/components/src/blocks/DocsPage.tsx
+++ b/lib/components/src/blocks/DocsPage.tsx
@@ -51,6 +51,7 @@ export const DocsContent = styled.div({
 
 export const DocsWrapper = styled.div<{}>(({ theme }) => ({
   background: theme.background.content,
+  color: theme.color.defaultText,
   display: 'flex',
   justifyContent: 'center',
   minHeight: '100vh',

--- a/lib/components/src/blocks/PropsTable/PropsTable.tsx
+++ b/lib/components/src/blocks/PropsTable/PropsTable.tsx
@@ -11,7 +11,7 @@ export const Table = styled.table<{}>(({ theme }) => ({
     // Resets for cascading/system styles
     borderCollapse: 'collapse',
     borderSpacing: 0,
-
+    color: theme.color.defaultText,
     tr: {
       border: 'none',
       background: 'none',

--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -1,11 +1,12 @@
 import { styled, CSSObject, Theme } from '@storybook/theming';
 import { withReset } from './withReset';
 
-const headerCommon: CSSObject = {
+const headerCommon = ({ theme }: { theme: Theme }): CSSObject => ({
   margin: '20px 0 8px',
   padding: 0,
   cursor: 'text',
   position: 'relative',
+  color: theme.color.defaultText,
   '&:first-of-type': {
     marginTop: 0,
     paddingTop: 0,
@@ -16,7 +17,7 @@ const headerCommon: CSSObject = {
   '& tt, & code': {
     fontSize: 'inherit',
   },
-};
+});
 
 const withMargin: CSSObject = {
   margin: '16px 0',
@@ -25,29 +26,24 @@ const withMargin: CSSObject = {
 export const H1 = styled.h1<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.l1}px`,
   fontWeight: theme.typography.weight.black,
-  color: theme.color.defaultText,
 }));
 
 export const H2 = styled.h2<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.m2}px`,
   paddingBottom: '4px',
   borderBottom: `1px solid ${theme.appBorderColor}`,
-  color: theme.color.defaultText,
 }));
 
 export const H3 = styled.h3<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.m1}px`,
-  color: theme.color.defaultText,
 }));
 
 export const H4 = styled.h4<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.s3}px`,
-  color: theme.color.defaultText,
 }));
 
 export const H5 = styled.h5<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.s2}px`,
-  color: theme.color.defaultText,
 }));
 
 export const H6 = styled.h6<{}>(withReset, headerCommon, ({ theme }) => ({

--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -25,24 +25,29 @@ const withMargin: CSSObject = {
 export const H1 = styled.h1<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.l1}px`,
   fontWeight: theme.typography.weight.black,
+  color: theme.color.defaultText,
 }));
 
 export const H2 = styled.h2<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.m2}px`,
   paddingBottom: '4px',
   borderBottom: `1px solid ${theme.appBorderColor}`,
+  color: theme.color.defaultText,
 }));
 
 export const H3 = styled.h3<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.m1}px`,
+  color: theme.color.defaultText,
 }));
 
 export const H4 = styled.h4<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.s3}px`,
+  color: theme.color.defaultText,
 }));
 
 export const H5 = styled.h5<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.s2}px`,
+  color: theme.color.defaultText,
 }));
 
 export const H6 = styled.h6<{}>(withReset, headerCommon, ({ theme }) => ({
@@ -321,6 +326,7 @@ const codeCommon = ({ theme }: { theme: Theme }): CSSObject => ({
 export const P = styled.p<{}>(withReset, withMargin, ({ theme }) => ({
   fontSize: theme.typography.size.s2,
   lineHeight: '24px',
+  color: theme.color.defaultText,
   '& code': codeCommon({ theme }),
 }));
 


### PR DESCRIPTION
Issue: #7982

## What I did
set color in DocPage to `theme.color.defaultText,` to accommodate for dark theme

## How to test
set `options.theme: themes.dark,` (wait if local storage still not refreshed) 
