### PR TITLE
React strings as markdown

### DIFF
--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -1,14 +1,15 @@
 /* eslint-disable react/destructuring-assignment */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { ThemeProvider, ensure as ensureTheme } from '@storybook/theming';
-import { DocsWrapper, DocsContent, Source } from '@storybook/components';
+import { DocsWrapper, DocsContent, Source, Description } from '@storybook/components';
 import { components as htmlComponents, Code } from '@storybook/components/html';
 import { DocsContextProps, DocsContext } from './DocsContext';
 
 interface DocsContainerProps {
   context: DocsContextProps;
+  children: React.ReactElement;
 }
 
 interface CodeOrSourceProps {
@@ -54,7 +55,13 @@ export const DocsContainer: React.FunctionComponent<DocsContainerProps> = ({
       <ThemeProvider theme={theme}>
         <MDXProvider components={components}>
           <DocsWrapper>
-            <DocsContent>{children}</DocsContent>
+            <DocsContent>
+              {children && typeof children.type === 'string' ? (
+                <Description markdown={children.type} {...children.props} />
+              ) : (
+                children
+              )}
+            </DocsContent>
           </DocsWrapper>
         </MDXProvider>
       </ThemeProvider>

--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -1,15 +1,14 @@
 /* eslint-disable react/destructuring-assignment */
 
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { ThemeProvider, ensure as ensureTheme } from '@storybook/theming';
-import { DocsWrapper, DocsContent, Source, Description } from '@storybook/components';
+import { DocsWrapper, DocsContent, Source } from '@storybook/components';
 import { components as htmlComponents, Code } from '@storybook/components/html';
 import { DocsContextProps, DocsContext } from './DocsContext';
 
 interface DocsContainerProps {
   context: DocsContextProps;
-  children: React.ReactElement;
 }
 
 interface CodeOrSourceProps {
@@ -55,13 +54,7 @@ export const DocsContainer: React.FunctionComponent<DocsContainerProps> = ({
       <ThemeProvider theme={theme}>
         <MDXProvider components={components}>
           <DocsWrapper>
-            <DocsContent>
-              {children && typeof children.type === 'string' ? (
-                <Description markdown={children.type} {...children.props} />
-              ) : (
-                children
-              )}
-            </DocsContent>
+            <DocsContent>{children}</DocsContent>
           </DocsWrapper>
         </MDXProvider>
       </ThemeProvider>

--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
 
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { ThemeProvider, ensure as ensureTheme } from '@storybook/theming';
 import { DocsWrapper, DocsContent, Source, Description } from '@storybook/components';

--- a/examples/official-storybook/stories/addon-docs/mdx.stories.js
+++ b/examples/official-storybook/stories/addon-docs/mdx.stories.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import Markdown from 'markdown-to-jsx';
-import { DocsContainer, Description } from '@storybook/addon-docs/blocks';
+import { DocsContainer } from '@storybook/addon-docs/blocks';
 import markdown from './markdown.stories.mdx';
-import Readme from '../../README.md';
 
 export default {
   title: 'Addons|Docs/mdx-in-story',
@@ -14,9 +12,3 @@ export const typography = () => {
   const Docs = markdown.parameters.docs.page;
   return <Docs />;
 };
-
-export const plainMD = () => <Readme />;
-
-export const markdownToJsx = () => <Markdown>{Readme}</Markdown>;
-
-export const markdownToDescription = () => <Description markdown={Readme} />;

--- a/examples/official-storybook/stories/addon-docs/mdx.stories.js
+++ b/examples/official-storybook/stories/addon-docs/mdx.stories.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { DocsContainer } from '@storybook/addon-docs/blocks';
+import Markdown from 'markdown-to-jsx';
+import { DocsContainer, Description } from '@storybook/addon-docs/blocks';
 import markdown from './markdown.stories.mdx';
+import Readme from '../../README.md';
 
 export default {
   title: 'Addons|Docs/mdx-in-story',
@@ -12,3 +14,9 @@ export const typography = () => {
   const Docs = markdown.parameters.docs.page;
   return <Docs />;
 };
+
+export const plainMD = () => <Readme />;
+
+export const markdownToJsx = () => <Markdown>{Readme}</Markdown>;
+
+export const markdownToDescription = () => <Description markdown={Readme} />;


### PR DESCRIPTION
Issue: #7644

## What I did
Added a check on rendering docs if the react element is a string - if yes, render as markdown content

Note: if we decide to add a `<Markdown />` block component, using the `<Description />` will be replaced.

## How to test
added several tests to `mdx.stories.js`

```
import Readme from '../../README.md';
...
export const plainMD = () => <Readme />;

export const markdownToJsx = () => <Markdown>{Readme}</Markdown>;

export const markdownToDescription = () => <Description markdown={Readme} />;
```