### PR TITLE
Addon-docs: Fix LI styling for dark color theme

### DIFF
--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -295,6 +295,7 @@ const listCommon: CSSObject = {
 
 export const LI = styled.li<{}>(withReset, ({ theme }) => ({
   fontSize: theme.typography.size.s2,
+  color: theme.color.defaultText,
   lineHeight: '24px',
   '& + li': {
     marginTop: '.25em',


### PR DESCRIPTION
Issue: related to #7982

## What I did

Make color of `<li>` elements on DocPage to white when in dark mode.

Before: 
![Screenshot_2019-09-06 Storybook(1)](https://user-images.githubusercontent.com/8491552/64433265-547d5200-d0e8-11e9-979e-fa9161193bb8.png)
After:
![Screenshot_2019-09-06 Storybook(2)](https://user-images.githubusercontent.com/8491552/64433279-5a733300-d0e8-11e9-9954-4baef6462c0b.png)

## How to test

1. Run official-storybook example in dark mode
2. Open `addons|Docs/markdown-docs` inside storybook
3. Scroll to the list sections.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
