### PR TITLE
CLI: Add wrapper packages: sb & storybook

### DIFF
--- a/lib/cli-sb/README.md
+++ b/lib/cli-sb/README.md
@@ -1,0 +1,3 @@
+# Storybook CLI
+
+This is a wrapper for https://www.npmjs.com/package/@storybook/cli

--- a/lib/cli-sb/index.js
+++ b/lib/cli-sb/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('@storybook/cli/bin/index');

--- a/lib/cli-sb/package.json
+++ b/lib/cli-sb/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "sb",
+  "version": "5.2.0-rc.9",
+  "description": "Storybook CLI",
+  "keywords": [
+    "storybook"
+  ],
+  "homepage": "https://github.com/storybookjs/storybook/tree/master/lib/cli",
+  "bugs": {
+    "url": "https://github.com/storybookjs/storybook/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storybookjs/storybook.git",
+    "directory": "lib/cli"
+  },
+  "bin": {
+    "sb": "./index.js"
+  },
+  "license": "MIT",
+  "scripts": {
+    "prepare": "node ../../scripts/prepare.js"
+  },
+  "dependencies": {
+    "@storybook/cli": "5.2.0-rc.9"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/lib/cli-storybook/README.md
+++ b/lib/cli-storybook/README.md
@@ -1,0 +1,3 @@
+# Storybook CLI
+
+This is a wrapper for https://www.npmjs.com/package/@storybook/cli

--- a/lib/cli-storybook/index.js
+++ b/lib/cli-storybook/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('@storybook/cli/bin/index');

--- a/lib/cli-storybook/package.json
+++ b/lib/cli-storybook/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "storybook",
+  "version": "5.2.0-rc.9",
+  "description": "Storybook CLI",
+  "keywords": [
+    "storybook"
+  ],
+  "homepage": "https://github.com/storybookjs/storybook/tree/master/lib/cli",
+  "bugs": {
+    "url": "https://github.com/storybookjs/storybook/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storybookjs/storybook.git",
+    "directory": "lib/cli"
+  },
+  "bin": {
+    "sb": "./index.js",
+    "storybook": "./index.js"
+  },
+  "license": "MIT",
+  "scripts": {
+    "prepare": "node ../../scripts/prepare.js"
+  },
+  "dependencies": {
+    "@storybook/cli": "5.2.0-rc.9"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -26,6 +26,14 @@ packages:
     access: $all
     publish: $all
 
+  'sb':
+    access: $all
+    publish: $all
+
+  'storybook':
+    access: $all
+    publish: $all
+
   '@*/*':
     access: $all
     publish: $all


### PR DESCRIPTION
Issue: the `sb` & `storybook` packages are ours, but we don't do anything with them.

## What I did
I added 2 'shallow' packages that use `@storybook/cli` underneath

## How to test
- yarn bootstrap --reg
- npx storybook