### PR TITLE
Angular: remove webpack-env from tsconfig types

### DIFF
--- a/app/angular/tsconfig.json
+++ b/app/angular/tsconfig.json
@@ -3,7 +3,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "dist",
-    "types": ["webpack-env"],
+    "types": [],
     "rootDir": "./src",
     "resolveJsonModule": true
   }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/7855

## What I did
Removed `webpack-env` from tsconfig.json in `app/angular`. I'm not sure why it was added but it seems to work locally plus it removes the tripple-slash reference path from `dist` which causes the related build issue for all @storybook/angular consumers

## How to test
- Green CI
- Running app/angular locally
- Check if the tripple-slash reference is now removed from `dist/`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
