### PR TITLE
DocsPage: show docs.storyDescription above story

### DIFF
--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -83,14 +83,15 @@ const StoryHeading = H3;
 const DocsStory: React.FunctionComponent<DocsStoryProps> = ({
   id,
   name,
-  description,
   expanded = true,
   withToolbar = false,
   parameters,
 }) => (
   <Anchor storyId={id}>
     {expanded && <StoryHeading>{(parameters && parameters.displayName) || name}</StoryHeading>}
-    {expanded && description && <Description markdown={description} />}
+    {expanded && parameters && parameters.docs && parameters.docs.storyDescription && (
+      <Description markdown={parameters.docs.storyDescription} />
+    )}
     <Preview withToolbar={withToolbar}>
       <Story id={id} />
     </Preview>

--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -35,7 +35,6 @@ export interface DocsPageProps {
 interface DocsStoryProps {
   id: string;
   name: string;
-  description?: string;
   expanded?: boolean;
   withToolbar?: boolean;
   parameters?: any;

--- a/examples/official-storybook/stories/demo/button.stories.js
+++ b/examples/official-storybook/stories/demo/button.stories.js
@@ -5,6 +5,11 @@ import { Button } from '@storybook/react/demo';
 export default {
   title: 'Other|Demo/Button',
   component: Button,
+  parameters: {
+    docs: {
+      inlineStories: false,
+    },
+  },
 };
 
 export const withText = () => <Button onClick={action('clicked')}>Hello Button</Button>;
@@ -31,4 +36,9 @@ export const withCounter = () => {
 
 withCounter.story = {
   name: 'with counter',
+  parameters: {
+    docs: {
+      storyDescription: 'This demonstrates react hooks working inside stories. Go team! 🚀',
+    },
+  },
 };


### PR DESCRIPTION
Issue: N/A

## What I did

Show story description above the story on DocsPage based on the `docs.storyDescription` parameter

## How to test

See `official-storybook` example. I also edited it to show the stories in iframes, just to verify the parameter merging is working properly.