### PR TITLE
add missing type def to addon-knobs fixes #8105

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -28,6 +28,7 @@
     "@storybook/components": "5.3.0-alpha.0",
     "@storybook/core-events": "5.3.0-alpha.0",
     "@storybook/theming": "5.3.0-alpha.0",
+    "@types/react-color": "^3.0.1",
     "copy-to-clipboard": "^3.0.8",
     "core-js": "^3.0.1",
     "escape-html": "^1.0.3",
@@ -48,7 +49,6 @@
   },
   "devDependencies": {
     "@types/escape-html": "0.0.20",
-    "@types/react-color": "^3.0.1",
     "@types/react-lifecycles-compat": "^3.0.1",
     "@types/react-select": "^2.0.19"
   }


### PR DESCRIPTION
Issue: fixes #8105 

## What I did

Move types for `react-color` to deps since those types end up in the build output and are required

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
