### PR TITLE
fix: add @types/webpack-env to apps that depend on it, fixes #8110

### DIFF
--- a/app/html/package.json
+++ b/app/html/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@storybook/addons": "5.3.0-alpha.2",
     "@storybook/core": "5.3.0-alpha.2",
+    "@types/webpack-env": "^1.13.9",
     "common-tags": "^1.8.0",
     "core-js": "^3.0.1",
     "global": "^4.3.2",

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -36,6 +36,7 @@
     "@storybook/addons": "5.3.0-alpha.2",
     "@storybook/core": "5.3.0-alpha.2",
     "common-tags": "^1.8.0",
+    "@types/webpack-env": "^1.13.9",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "regenerator-runtime": "^0.12.1"

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -40,6 +40,7 @@
     "@storybook/core": "5.3.0-alpha.2",
     "@storybook/node-logger": "5.3.0-alpha.2",
     "@svgr/webpack": "^4.0.3",
+    "@types/webpack-env": "^1.13.7",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-named-asset-import": "^0.3.1",
     "babel-plugin-react-docgen": "^3.0.0",

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@storybook/addons": "5.3.0-alpha.2",
     "@storybook/core": "5.3.0-alpha.2",
+    "@types/webpack-env": "^1.13.9",
     "common-tags": "^1.8.0",
     "core-js": "^3.0.1",
     "global": "^4.3.2",


### PR DESCRIPTION
Issue: fixes  #8110

## What I did

add webpack-env types to react, they are needed for the build

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
