### PR TITLE
React: Add DecoratorFn type to exports

### DIFF
--- a/app/react/src/client/index.ts
+++ b/app/react/src/client/index.ts
@@ -2,6 +2,7 @@ export {
   storiesOf,
   setAddon,
   addDecorator,
+  Decorator,
   addParameters,
   configure,
   getStorybook,

--- a/app/react/src/client/index.ts
+++ b/app/react/src/client/index.ts
@@ -2,7 +2,7 @@ export {
   storiesOf,
   setAddon,
   addDecorator,
-  StoryDecorator,
+  DecoratorFn,
   addParameters,
   configure,
   getStorybook,

--- a/app/react/src/client/index.ts
+++ b/app/react/src/client/index.ts
@@ -2,7 +2,7 @@ export {
   storiesOf,
   setAddon,
   addDecorator,
-  Decorator,
+  StoryDecorator,
   addParameters,
   configure,
   getStorybook,

--- a/app/react/src/client/preview/index.ts
+++ b/app/react/src/client/preview/index.ts
@@ -27,6 +27,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
+export type Decorator = Parameters<typeof addDecorator>[0];
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;

--- a/app/react/src/client/preview/index.ts
+++ b/app/react/src/client/preview/index.ts
@@ -27,7 +27,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
-export type Decorator = Parameters<typeof addDecorator>[0];
+export type StoryDecorator = Parameters<typeof addDecorator>[0];
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;

--- a/app/react/src/client/preview/index.ts
+++ b/app/react/src/client/preview/index.ts
@@ -27,7 +27,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
-export type StoryDecorator = Parameters<typeof addDecorator>[0];
+export type DecoratorFn = Parameters<typeof addDecorator>[0];
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;


### PR DESCRIPTION
# What I did

With the old `@types/storybook__react`, users could use `StoryDecorator` to make a decorator outside of the `addDecorator` function. With the new types I had to do a little type math to get it to work

```tsx
import { storiesOf, addDecorator } from '@storybook/react';

type StoryDecorator = Parameters<typeof addDecorator>[0]

const container: StoryDecorator = storyFn => (
  <div style={{ maxWidth: 800, margin: 'auto', padding: '20px 0' }}>
    {storyFn()}
  </div>
);

storiesOf('Components|Deck/Carrousel', module)
  .addDecorator(container)
```

This PR add `Decorator` to the `@storybook/react` types.

```tsx
import { storiesOf, StoryDecorator } from '@storybook/react';

const container: StoryDecorator = storyFn => (
  <div style={{ maxWidth: 800, margin: 'auto', padding: '20px 0' }}>
    {storyFn()}
  </div>
);

storiesOf('Components|Deck/Carrousel', module)
  .addDecorator(container)
```


## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
