### PR TITLE
CSF: Allow duplicate kinds

### DIFF
--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -336,9 +336,6 @@ export default function start(render, { decorateStory } = {}) {
 
   let previousExports = new Set();
   const loadStories = (loadable, framework) => () => {
-    // Make sure we don't try to define a kind more than once within the same load
-    const loadedKinds = new Set();
-
     let reqs = null;
     if (Array.isArray(loadable)) {
       reqs = loadable;
@@ -392,14 +389,6 @@ export default function start(render, { decorateStory } = {}) {
 
       const { default: meta, ...exports } = fileExports;
       const { title: kindName, parameters: params, decorators: decos, component } = meta;
-
-      if (loadedKinds.has(kindName)) {
-        throw new Error(
-          `Duplicate title '${kindName}' used in multiple files; use unique titles or combine '${kindName}' stories into a single file.`
-        );
-      }
-      loadedKinds.add(kindName);
-
       // We pass true here to avoid the warning about HMR. It's cool clientApi, we got this
       const kind = clientApi.storiesOf(kindName, true);
 


### PR DESCRIPTION
Issue: 

## What I did

Duplicates story titles used to work and actually work quite easily in the new code.

For example a we have a few components that have have multiple storyfiles.

*Example storybook sidebar:*

```txt
Choice
-- Checkbox
-- Radio
```

In the project these two subcomponent are in separate folders and their stories are in those folders.

In the old format you could:

*Checkbox.stories.js*

```js
storiesOf('Choice', module).add('Checkbox', () => <div />)
```

*Radio.stories.js*

```js
storiesOf('Choice', module).add('Radio', () => <div />)
```

This would produce the structure i mention (`Example storybook sidebar`). 

If I try to switch to the new CSF i get the error `Duplicate title`. It suggests combining the files, but in most cases this make the stories harder to read and less focused, it also wouldn't be able to match the structure we use.

Since it used to be support and works quite well, we shouldn't stop this behavior in CSF.

## How to test

- Is this testable with Jest or Chromatic screenshots? yeah?
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no (well maybe)

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
