### PR TITLE
Document environment variables usage in HTML

### DIFF
--- a/docs/src/pages/configurations/env-vars/index.md
+++ b/docs/src/pages/configurations/env-vars/index.md
@@ -24,6 +24,14 @@ out.log(process.env.STORYBOOK_DATA_KEY);
 
 > Even though we can access these env variables anywhere in the client side JS code, it's better to use them only inside stories and inside the main Storybook config file.
 
+## Usage in custom head/body
+
+These environment variables can be used in [custom head](/configurations/add-custom-head-tags] and [custom body](/configurations/add-custom-body) files.
+
+Storybook will replace percent-delimited variable names with their values; e.g. `%STORYBOOK_THEME%` will become `red`.
+
+> If using the environment variables as attributes or values in JavaScript, you may need to add quotes, as the value will be inserted directly. e.g. `<link rel="stylesheet" href="%STORYBOOK_STYLE_URL%" />`
+
 ## Build time environment variables
 
 You can also pass these environment variables when you are [building your storybook](/basics/exporting-storybook) with `build-storybook`.

--- a/docs/src/pages/configurations/env-vars/index.md
+++ b/docs/src/pages/configurations/env-vars/index.md
@@ -26,7 +26,7 @@ out.log(process.env.STORYBOOK_DATA_KEY);
 
 ## Usage in custom head/body
 
-These environment variables can be used in [custom head](/configurations/add-custom-head-tags] and [custom body](/configurations/add-custom-body) files.
+These environment variables can be used in [custom head](/configurations/add-custom-head-tags) and [custom body](/configurations/add-custom-body) files.
 
 Storybook will replace percent-delimited variable names with their values; e.g. `%STORYBOOK_THEME%` will become `red`.
 


### PR DESCRIPTION
Issue: (none)

## What I did

Added documentation about using environment variables in preview HTML files.

I had to go read the source to discover that these existed, so would be good to have this documented.

## How to test

- Is this testable with Jest or Chromatic screenshots? *No*
- Does this need a new example in the kitchen sink apps? *No*
- Does this need an update to the documentation? *Yes*, docs-only change.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

Sidenote: the PR notice says "submit all PRs to the `next` branch unless they are specific to current release", however the "Edit this page" link from the site takes you to `master`, so I had to re-create this PR manually. Would be good to resolve that to simplify contributions.
