### PR TITLE
fix: Allow JSX.Element story

### DIFF
--- a/app/preact/src/client/preview/types.ts
+++ b/app/preact/src/client/preview/types.ts
@@ -1,6 +1,6 @@
 import { StoryFn, ClientStoryApi, Loadable } from '@storybook/addons';
 
-export type StoryFnPreactReturnType = string | Node;
+export type StoryFnPreactReturnType = string | Node | JSX.Element;
 
 export interface ShowErrorArgs {
   title: string;


### PR DESCRIPTION
## What I did

- Added JSX.Element story
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d948328df314ccf7b854f9e593c570cc9f6c7cbd/types/storybook__preact/index.d.ts#L13

## How to test

- Added tsconfig.json 

```json
{
  "compilerOptions": {
    "jsx": "preserve",
    "module": "esnext",
    "moduleResolution": "node",
    "jsxFactory": "h",
    "strict": true,
    "target": "esnext"
  }
}
```

- And use styled-components and PreactX

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
