### PR TITLE
FIX 8083

### DIFF
--- a/lib/addons/src/hooks.ts
+++ b/lib/addons/src/hooks.ts
@@ -1,4 +1,4 @@
-import { window } from 'global';
+import window from 'global';
 import { logger } from '@storybook/client-logger';
 import { FORCE_RE_RENDER, STORY_RENDERED, DOCS_RENDERED } from '@storybook/core-events';
 import addons, { StoryGetter, StoryContext } from './public_api';


### PR DESCRIPTION
Issue: #8083

## What I did
The problem was that the import of `import { window } from 'global'` would return `window` as `undefined`.

I changed it so `window` is the global object, this should now work in node as well.

## How to test

Everything should just work the exact same way.