### PR TITLE
fix recommended typescript config in docs

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -122,13 +122,7 @@ Change `config.ts` inside the Storybook config directory (by default, it’s `.s
 ```js
 import { configure } from '@storybook/react';
 // automatically import all files ending in *.stories.tsx
-const req = require.context('../stories', true, /\.stories\.tsx$/);
-
-function loadStories() {
-  req.keys().forEach(req);
-}
-
-configure(loadStories, module);
+configure(require.context('../src', true, /\.stories\.tsx?$/), module)
 ```
 
 ## Using TypeScript with the TSDocgen addon


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8185

## What I did

## How to test

n/a, docs change only

Note: I don't know why the TS config was recommended in a different format in the first place. Someone who knows a little bit more about how this all works should take a look. I can provide a sample repo if needed
