### PR TITLE
IMPROVE type of storyFn for react

### DIFF
--- a/app/react/src/client/preview/types.ts
+++ b/app/react/src/client/preview/types.ts
@@ -6,7 +6,7 @@ export interface ShowErrorArgs {
 }
 
 export interface RenderMainArgs {
-  storyFn: () => React.ReactElement | undefined;
+  storyFn: React.FunctionComponent<any>;
   selectedKind: string;
   selectedStory: string;
   showMain: () => void;


### PR DESCRIPTION
Issue: #8116 

## What I did

CHANGE the type of a storyFn to an React.FunctionComponent, as it's being rendered as a component in the renderer