### PR TITLE
API: Add method to set config for manager

### DIFF
--- a/app/react-native-server/src/client/manager/provider.js
+++ b/app/react-native-server/src/client/manager/provider.js
@@ -46,6 +46,10 @@ export default class ReactProvider extends Provider {
     return addons.getElements(type);
   }
 
+  getConfig() {
+    return this.addons.getConfig();
+  }
+
   renderPreview() {
     return (
       <Consumer filter={mapper} pure>

--- a/examples/dev-kits/addons.js
+++ b/examples/dev-kits/addons.js
@@ -1,2 +1,9 @@
 import '@storybook/addon-roundtrip/register';
 import '@storybook/addon-parameter/register';
+
+import { addons } from '@storybook/addons';
+import { themes } from '@storybook/theming';
+
+addons.setConfig({
+  theme: themes.dark,
+});

--- a/lib/addons/src/index.ts
+++ b/lib/addons/src/index.ts
@@ -39,6 +39,10 @@ interface Elements {
   [key: string]: Collection;
 }
 
+interface Config {
+  [key: string]: any;
+}
+
 export class AddonStore {
   constructor() {
     this.promise = new Promise(res => {
@@ -49,6 +53,8 @@ export class AddonStore {
   private loaders: Loaders = {};
 
   private elements: Elements = {};
+
+  private config: Config = {};
 
   private channel: Channel | undefined;
 
@@ -95,6 +101,12 @@ export class AddonStore {
     const collection = this.getElements(type);
     collection[name] = { id: name, ...addon };
   };
+
+  setConfig = (value: Config) => {
+    Object.assign(this.config, value);
+  };
+
+  getConfig = () => this.config;
 
   register = (name: string, registerCallback: (api: API) => void): void => {
     if (this.loaders[name]) {

--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -8,6 +8,7 @@ import { themes, ThemeVars } from '@storybook/theming';
 import merge from '../lib/merge';
 import { State } from '../index';
 import Store from '../store';
+import { Provider } from '../init-provider-api';
 
 export type PanelPositions = 'bottom' | 'right';
 
@@ -153,7 +154,7 @@ export const focusableUIElements = {
 };
 
 let hasSetOptions = false;
-export default function({ store }: { store: Store }) {
+export default function({ store, provider }: { store: Store; provider: Provider }) {
   const api = {
     toggleFullscreen(toggled?: boolean) {
       return store.setState((state: State) => {
@@ -248,6 +249,17 @@ export default function({ store }: { store: Store }) {
       }
     },
 
+    getInitialOptions() {
+      const { theme } = provider.getConfig();
+
+      console.log({ theme });
+
+      return {
+        ...initial,
+        theme: theme || initial.theme,
+      };
+    },
+
     setOptions: (options: any) => {
       // The very first time the user sets their options, we don't consider what is in the store.
       // At this point in time, what is in the store is what we *persisted*. We did that in order
@@ -255,7 +267,9 @@ export default function({ store }: { store: Store }) {
       // However, we don't want to have a memory about these things, otherwise we see bugs like the
       // user setting a name for their storybook, persisting it, then never being able to unset it
       // without clearing localstorage. See https://github.com/storybookjs/storybook/issues/5857
-      const { layout, ui, selectedPanel, theme } = hasSetOptions ? store.getState() : initial;
+      const { layout, ui, selectedPanel, theme } = hasSetOptions
+        ? store.getState()
+        : api.getInitialOptions();
 
       if (options) {
         const updatedLayout = {
@@ -301,5 +315,5 @@ export default function({ store }: { store: Store }) {
 
   const persisted = pick(store.getState(), 'layout', 'ui', 'selectedPanel', 'theme');
 
-  return { api, state: merge(initial, persisted) };
+  return { api, state: merge(api.getInitialOptions(), persisted) };
 }

--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -252,8 +252,6 @@ export default function({ store, provider }: { store: Store; provider: Provider 
     getInitialOptions() {
       const { theme } = provider.getConfig();
 
-      console.log({ theme });
-
       return {
         ...initial,
         theme: theme || initial.theme,

--- a/lib/api/src/tests/layout.test.js
+++ b/lib/api/src/tests/layout.test.js
@@ -33,7 +33,7 @@ describe('layout API', () => {
         getState: () => currentState,
         setState: jest.fn(),
       };
-      layoutApi = initLayout({ store }).api;
+      layoutApi = initLayout({ store, provider: { getConfig: jest.fn(() => ({})) } }).api;
     });
 
     it('should not change selectedPanel if it is undefined in the options', () => {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -36,6 +36,9 @@ const toExtracted = <T>(obj: T) =>
     if (typeof value === 'function') {
       return acc;
     }
+    if (key === 'hooks') {
+      return acc;
+    }
     if (Array.isArray(value)) {
       return Object.assign(acc, { [key]: value.slice().sort() });
     }

--- a/lib/core/src/client/manager/provider.js
+++ b/lib/core/src/client/manager/provider.js
@@ -20,6 +20,10 @@ export default class ReactProvider extends Provider {
     return this.addons.getElements(type);
   }
 
+  getConfig() {
+    return this.addons.getConfig();
+  }
+
   handleAPI(api) {
     this.addons.loadAddons(api);
   }

--- a/lib/ui/src/app.stories.js
+++ b/lib/ui/src/app.stories.js
@@ -28,6 +28,10 @@ class FakeProvider extends Provider {
   handleAPI(api) {
     addons.loadAddons(api);
   }
+
+  getConfig() {
+    return {};
+  }
 }
 
 storiesOf('UI|Layout/App', module)

--- a/lib/ui/src/provider.js
+++ b/lib/ui/src/provider.js
@@ -6,4 +6,8 @@ export default class Provider {
   handleAPI() {
     throw new Error('Provider.handleAPI() is not implemented!');
   }
+
+  getConfig() {
+    throw new Error('Provider.getConfig() is not implemented!');
+  }
 }


### PR DESCRIPTION
Issue:
Setting theme via parameters is really bad for performance
This is true for other config too.

## What I did
ADD a setConfig option on lib/addons, to pass data/config into the manager directly VS via parameters

This PR adds a API:

```js
import { addons } from '@storybook/addons';
import { themes } from '@storybook/theming';

addons.setConfig({
  theme: themes.dark,
});
```

You set this within `addons.js`.

## How to test
I've changed the dev-kits example to dark theme.

There's no flash of light theme anymore.