### PR TITLE
FIX a critical api missing

### DIFF
--- a/lib/channels/src/index.ts
+++ b/lib/channels/src/index.ts
@@ -126,6 +126,10 @@ export class Channel {
     this.addListener(eventName, listener);
   }
 
+  off(eventName: string, listener: Listener) {
+    this.removeListener(eventName, listener);
+  }
+
   private handleEvent(event: ChannelEvent, isPeer = false) {
     const listeners = this.listeners(event.type);
     if (listeners && (isPeer || event.from !== this.sender)) {


### PR DESCRIPTION
Issue: going fullscreen is broken, so is hiding the navigator

## What I did
I found there was an api missing on the channel, It was simple to add, I'm not sure why it broke/was removed or exactly what changed. I'll investigate.

Seems to be broken on master
EDIT: I tested master locally, it's OK.