### PR TITLE
Added `AntDesign` to Preset Gallery

### DIFF
--- a/docs/src/pages/presets/preset-gallery/index.md
+++ b/docs/src/pages/presets/preset-gallery/index.md
@@ -17,6 +17,10 @@ One-line Typescript w/ docgen configuration for storybook.
 
 One-line SCSS configuration for storybook.
 
+### [AntDesign](https://github.com/storybookjs/presets/tree/master/packages/preset-ant-design)
+
+One-line AntDesign configuration for storybook.
+
 ## Community presets
 
 There are no community presets available yet. Check back here or edit this page to add yours.


### PR DESCRIPTION
Tested the `preset-ant-design` and prove to be working that tackle [this](https://github.com/storybookjs/presets/issues/35). 

Adding into the preset-gallery since is part of the storybook repo. Let me know if it should be moved into community presets if needed.