### PR TITLE
REMOVE hooks from extracted StoryItem

### DIFF
--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -36,6 +36,9 @@ const toExtracted = <T>(obj: T) =>
     if (typeof value === 'function') {
       return acc;
     }
+    if (key === 'hooks') {
+      return acc;
+    }
     if (Array.isArray(value)) {
       return Object.assign(acc, { [key]: value.slice().sort() });
     }


### PR DESCRIPTION
Issue:
Minor improvement to speed up the channel

## What I did
storybook extract method doesn't care about hooks, now they don't need to be serialised & parsed over the channel