### PR TITLE
docs(deployment): add instructions about deployment on ZEIT Now

### DIFF
--- a/docs/src/pages/basics/exporting-storybook/index.md
+++ b/docs/src/pages/basics/exporting-storybook/index.md
@@ -36,3 +36,19 @@ npx http-server .out
 Additionally, you can deploy Storybook directly into GitHub pages with our [storybook-deployer](https://github.com/storybookjs/storybook-deployer) tool.
 
 Or, you can simply export your storybook into the docs directory and use it as the root for GitHub pages. Have a look at [this guide](https://github.com/blog/2233-publish-your-project-documentation-with-github-pages) for more information.
+
+## Deploying to ZEIT Now
+
+[ZEIT Now](https://zeit.co/home) is a cloud platform for websites and serverless APIs, that you can use to deploy your Storybook projects to your personal domain (or a free `.now.sh` suffixed URL).
+
+- Install the [Now CLI](https://github.com/zeit/now):
+
+  `npm i -g now`
+
+- Configure your `build` script:
+
+  `"build": "build-storybook -c .storybook -o public"`
+
+- Execute `now` on your terminal.
+
+[Example project](https://github.com/zeit/now-examples/tree/master/storybook) for reference.


### PR DESCRIPTION
Issue: N/A

## What I did
Improved documentation about deployment, adding instructions to deploy Storybook on [ZEIT Now](https://zeit.co/home) on the page [Exporting Storybook as a Static App](https://storybook.js.org/docs/basics/exporting-storybook/).

Let me know if something is not following the [documentation guidelines](https://github.com/storybookjs/storybook/tree/next/docs#guidelines-for-writing-good-documentation).