### PR TITLE
Fix custom themes breaking the welcome demo.

### DIFF
--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.enzyme.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.enzyme.test.js.snap
@@ -121,6 +121,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
       style={
         Object {
           "backgroundColor": "#fff",
+          "color": "#000",
           "fontFamily": "\\"Helvetica Neue\\", Helvetica, \\"Segoe UI\\", Arial, freesans, sans-serif",
           "lineHeight": 1.4,
           "padding": 15,

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.snapshotWithOptionsFunction.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.snapshotWithOptionsFunction.test.js.snap
@@ -101,6 +101,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
   style={
     Object {
       "backgroundColor": "#fff",
+      "color": "#000",
       "fontFamily": "\\"Helvetica Neue\\", Helvetica, \\"Segoe UI\\", Arial, freesans, sans-serif",
       "lineHeight": 1.4,
       "padding": 15,

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.foo
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.foo
@@ -5,6 +5,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
   style={
     Object {
       "backgroundColor": "#fff",
+      "color": "#000",
       "fontFamily": "\\"Helvetica Neue\\", Helvetica, \\"Segoe UI\\", Arial, freesans, sans-serif",
       "lineHeight": 1.4,
       "padding": 15,

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.storyshot
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.storyshot
@@ -5,6 +5,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
   style={
     Object {
       "backgroundColor": "#fff",
+      "color": "#000",
       "fontFamily": "\\"Helvetica Neue\\", Helvetica, \\"Segoe UI\\", Arial, freesans, sans-serif",
       "lineHeight": 1.4,
       "padding": 15,

--- a/app/react/src/demo/Welcome.tsx
+++ b/app/react/src/demo/Welcome.tsx
@@ -9,6 +9,7 @@ const Main = (props?: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>,
       lineHeight: 1.4,
       fontFamily: '"Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif',
       backgroundColor: '#fff',
+      color: '#000',
     }}
   />
 );


### PR DESCRIPTION
Having applied a dark theme to storybook I noticed that the react demo sets the background white but does not set the text color. This resulted in white text (from my custom theme) rendered on a white background. This change will make the text readable

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
