### PR TITLE
UI: Fix inline code styling for dark theme

### DIFF
--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -318,6 +318,7 @@ const codeCommon = ({ theme }: { theme: Theme }): CSSObject => ({
   backgroundColor: theme.color.lighter,
   borderRadius: '3px',
   fontSize: theme.typography.size.s2 - 1,
+  color: theme.base === 'dark' && theme.color.darkest,
 });
 
 export const P = styled.p<{}>(withReset, withMargin, ({ theme }) => ({

--- a/lib/components/src/typography/DocumentWrapper.tsx
+++ b/lib/components/src/typography/DocumentWrapper.tsx
@@ -436,6 +436,7 @@ export const DocumentWrapper = styled.div(
       border: 1px solid ${theme.color.mediumlight};
       background-color: ${theme.color.lighter};
       border-radius: 3px;
+      color: ${theme.base === 'dark' && theme.color.darkest};
     }
   `
 );


### PR DESCRIPTION
Issues: #8211 #8094 

1. Dark theme renders unreadable text on the about page and 
2. Dark theme missing dark `<code>` style

## What I did

I updated the `code` styling so it displays correctly on the dark theme. This solves #8211 and #8094. 

## How to test

Example 1 - 8211 
-----------------
Configure storybook with a dark theme
Click on 'About storybook' in the top-left dropdown

Example 2 - 8094
-----------------
Configure Storybook to use the dark theme.
Create a story using MDX and use backticks to create a code tag - `for example`
View story

Screenshots with updated code for referenced issues
----------------------------------

<img width="673" alt="Screenshot 2019-10-01 at 17 17 00" src="https://user-images.githubusercontent.com/6873736/65981743-aa3be480-e471-11e9-8f97-728d1a021239.png">

<img width="637" alt="Screenshot 2019-10-01 at 17 38 07" src="https://user-images.githubusercontent.com/6873736/65982036-44039180-e472-11e9-8734-17c147856319.png">


