### PR TITLE
Validate the state content in addon-ondevice-notes

### DIFF
--- a/addons/ondevice-notes/src/components/Notes.tsx
+++ b/addons/ondevice-notes/src/components/Notes.tsx
@@ -39,6 +39,10 @@ export class Notes extends React.Component<NotesProps, NotesState> {
       return null;
     }
 
+    if (!this.state) {
+      return null;
+    }
+
     const story = api
       .store()
       .getStoryAndParameters(this.state.selection.kind, this.state.selection.story);


### PR DESCRIPTION
Issue:

## What I did

Validate the state content to secure render and prevent `Cannot read property 'selection' of null` error
