### PR TITLE
UI: Preferred color scheme awareness

### DIFF
--- a/docs/src/pages/configurations/theming/index.md
+++ b/docs/src/pages/configurations/theming/index.md
@@ -9,7 +9,7 @@ Storybook is theme-able! Just set a `theme` in the [options parameter](../option
 
 It's really easy to theme Storybook globally.
 
-We've created two basic themes that look good of the box: "normal" (a light theme) and "dark" (a dark theme).
+We've created two basic themes that look good of the box: "normal" (a light theme) and "dark" (a dark theme). Unless you've set your preferred color scheme as dark Storybook will use the light theme as default.
 
 As the simplest example, you can tell Storybook to use the "dark" theme by modifying `.storybook/config.js`:
 

--- a/lib/core/src/client/preview/start.test.js
+++ b/lib/core/src/client/preview/start.test.js
@@ -13,6 +13,7 @@ jest.mock('global', () => ({
     addEventListener: jest.fn(),
     location: { search: '' },
     history: { replaceState: jest.fn() },
+    matchMedia: jest.fn().mockReturnValue({ matches: false }),
   },
   document: {
     addEventListener: jest.fn(),

--- a/lib/core/src/typings.d.ts
+++ b/lib/core/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'global';

--- a/lib/core/tsconfig.json
+++ b/lib/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**.test.ts"]
+}

--- a/lib/theming/src/convert.ts
+++ b/lib/theming/src/convert.ts
@@ -4,8 +4,8 @@ import { background, typography, color } from './base';
 import { Theme, Color, ThemeVars } from './types';
 import { easing, animation } from './animation';
 import { create as createSyntax, chromeLight, chromeDark } from './modules/syntax';
-
-import lightThemeVars from './themes/light';
+import { getPreferredColorScheme } from './utils';
+import { themes } from './create';
 
 const lightSyntaxColors = {
   green1: '#008000',
@@ -72,7 +72,7 @@ const createColors = (vars: ThemeVars): Color => ({
   inverseText: vars.textInverseColor || color.lightest,
 });
 
-export const convert = (inherit: ThemeVars = lightThemeVars): Theme => {
+export const convert = (inherit: ThemeVars = themes[getPreferredColorScheme()]): Theme => {
   const {
     base,
     colorPrimary,

--- a/lib/theming/src/create.ts
+++ b/lib/theming/src/create.ts
@@ -3,6 +3,7 @@ import lightThemeVars from './themes/light';
 import darkThemeVars from './themes/dark';
 
 import { ThemeVars } from './types';
+import { getPreferredColorScheme } from './utils';
 
 export const themes: { light: ThemeVars; dark: ThemeVars; normal: ThemeVars } = {
   light: lightThemeVars,
@@ -14,12 +15,17 @@ interface Rest {
   [key: string]: any;
 }
 
-export const create = (vars: ThemeVars = { base: 'light' }, rest?: Rest): ThemeVars => {
+const preferredColorScheme = getPreferredColorScheme();
+
+export const create = (
+  vars: ThemeVars = { base: preferredColorScheme },
+  rest?: Rest
+): ThemeVars => {
   const inherit: ThemeVars = {
-    ...themes.light,
+    ...themes[preferredColorScheme],
     ...(themes[vars.base] || {}),
     ...vars,
-    ...{ base: themes[vars.base] ? vars.base : 'light' },
+    ...{ base: themes[vars.base] ? vars.base : preferredColorScheme },
   };
   return {
     ...rest,

--- a/lib/theming/src/tests/util.test.js
+++ b/lib/theming/src/tests/util.test.js
@@ -77,6 +77,13 @@ describe('utils', () => {
   });
 
   describe('getPreferredColorScheme', () => {
+    it('should return "light" if "window" is unavailable', () => {
+      jest.mock('global', () => ({ window: undefined }));
+
+      const colorScheme = getPreferredColorScheme();
+      expect(colorScheme).toBe('light');
+    });
+
     it('should return "light" if the preferred color scheme is light or undefined', () => {
       window.matchMedia = jest.fn().mockImplementation(() => ({
         matches: false,

--- a/lib/theming/src/tests/util.test.js
+++ b/lib/theming/src/tests/util.test.js
@@ -1,4 +1,5 @@
-import { lightenColor as lighten, darkenColor as darken } from '../utils';
+import { window } from 'global';
+import { lightenColor as lighten, darkenColor as darken, getPreferredColorScheme } from '../utils';
 
 describe('utils', () => {
   it('should apply polished when valid arguments are passed', () => {
@@ -73,5 +74,28 @@ describe('utils', () => {
     const result = lighten(color);
 
     expect(result).toEqual(color);
+  });
+
+  describe('getPreferredColorScheme', () => {
+    it('should return "light" if the preferred color scheme is light or undefined', () => {
+      window.matchMedia = jest.fn().mockImplementation(() => ({
+        matches: false,
+      }));
+
+      const colorScheme = getPreferredColorScheme();
+      expect(colorScheme).toBe('light');
+    });
+
+    it('should return "dark" if the preferred color scheme is dark', () => {
+      // By setting matches to always be true any checks for prefer-color-scheme
+      // will match and since we only check if the preferred scheme is dark this
+      // is a simple way to test it
+      window.matchMedia = jest.fn().mockImplementation(() => ({
+        matches: true,
+      }));
+
+      const colorScheme = getPreferredColorScheme();
+      expect(colorScheme).toBe('dark');
+    });
   });
 });

--- a/lib/theming/src/typings.d.ts
+++ b/lib/theming/src/typings.d.ts
@@ -1,2 +1,3 @@
 // todo the following packages need definition files or a TS migration
 declare module 'react-inspector';
+declare module 'global';

--- a/lib/theming/src/utils.ts
+++ b/lib/theming/src/utils.ts
@@ -62,11 +62,10 @@ export const darkenColor = colorFactory('darken');
 // The default color scheme is light so unless the preferred color
 // scheme is set to dark we always want to use the light theme
 export const getPreferredColorScheme = () => {
-  const isDarkThemePreferred = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (!window || !window.matchMedia) return 'light';
 
-  if (isDarkThemePreferred) {
-    return 'dark';
-  }
+  const isDarkThemePreferred = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (isDarkThemePreferred) return 'dark';
 
   return 'light';
 };

--- a/lib/theming/src/utils.ts
+++ b/lib/theming/src/utils.ts
@@ -1,4 +1,5 @@
 import { rgba, lighten, darken } from 'polished';
+import { window } from 'global';
 
 import { logger } from '@storybook/client-logger';
 
@@ -57,3 +58,15 @@ const colorFactory = (type: string) => (color: string) => {
 
 export const lightenColor = colorFactory('lighten');
 export const darkenColor = colorFactory('darken');
+
+// The default color scheme is light so unless the preferred color
+// scheme is set to dark we always want to use the light theme
+export const getPreferredColorScheme = () => {
+  const isDarkThemePreferred = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+  if (isDarkThemePreferred) {
+    return 'dark';
+  }
+
+  return 'light';
+};

--- a/scripts/jest.init.js
+++ b/scripts/jest.init.js
@@ -51,3 +51,17 @@ const throwError = message => throwMessage('error: ', message);
 
 global.console.error = throwError;
 global.console.warn = throwWarning;
+
+// Mock for matchMedia since it's not yet implemented in JSDOM (https://jestjs.io/docs/en/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom)
+global.window.matchMedia = jest.fn().mockImplementation(query => {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  };
+});


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/6088

## What I did
- Add awareness for preferred color scheme and set the default theme accordingly
- Update the theming documentation to mention the awareness

## How to test
1) Use a browser that supports `prefers-color-scheme`
2) Set your preferred color scheme
3) Open a Storybook without a provided theme
3a) Clear your localStorage and refresh the page if it's not already clean
4) Check that it shows the dark/light theme matching your preference
5) Change your preferred color scheme
6) Refresh the page
7) Check that it shows the dark/light theme matching your preference

If anyone has an idea for updating the tests for `create` and `convert` help would be greatly appreciated. Unfortunately I couldn't change the mock of `watchMedia` during the test and therefore updating the existing tests to account for the preferred color scheme awareness wasn't possible. I decided to leave the existing tests as they still pass since the `light` theme is still handled as the default.