### PR TITLE
Update Addons-Storysource README.md

### DIFF
--- a/addons/storysource/README.md
+++ b/addons/storysource/README.md
@@ -48,12 +48,14 @@ Allowed values:
 - `typescript`
 - `flow`
 
+Be sure to update the regex test for the webpack rule if utilizing Typescript files.
+
 Usage:
 
 ```js
 module.exports = function({ config }) {
   config.module.rules.push({
-    test: /\.stories\.jsx?$/,
+    test: /\.stories\.tsx?$/,
     loaders: [
       {
         loader: require.resolve('@storybook/source-loader'),


### PR DESCRIPTION
Updates the README to explain that changing the parser to Typescript will require updating the Regex test in the custom webpack rule to `tsx` as apposed to `jsx`.

Issue:

The README does not mention changing the regex rule for the webpack config when changing parser type, and the example doesn't have a changed rule (and so won't work with most Typescript projects).

## What I did
N/A

## How to test
N/A
