### PR TITLE
Fix button knob story

### DIFF
--- a/examples/official-storybook/stories/addon-knobs/with-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs/with-knobs.stories.js
@@ -318,10 +318,16 @@ export const triggersActionsViaButton = () => {
       injectedItems = [];
     }
   });
+  // Needed to enforce @babel/transform-react-constant-elements deoptimization
+  // See https://github.com/babel/babel/issues/10522
+  const loaderProps = {
+    isLoading: injectedIsLoading,
+    items: injectedItems,
+  };
   return (
     <Fragment>
       <p>Hit the knob button and it will toggle the items list into multiple states.</p>
-      <ItemLoader isLoading={injectedIsLoading} items={injectedItems} />
+      <ItemLoader {...loaderProps} />
     </Fragment>
   );
 };


### PR DESCRIPTION
Issue: [button knob story](https://storybookjs-next.now.sh/official-storybook/?path=/story/addons-knobs-withknobs--triggers-actions-via-button) doesn't update because of https://github.com/babel/babel/issues/10522

## What I did
Added object spread to enforce deoptimization, see [docs](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements#)

## How to test
Open [button knob story](https://monorepo-onlp45fyl.now.sh/official-storybook/?path=/story/addons-knobs-withknobs--triggers-actions-via-button), click the button in Knobs panel
