### PR TITLE
Update `read-pkg-up` usage to work with version `7`

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/hasDependency.js
+++ b/addons/storyshots/storyshots-core/src/frameworks/hasDependency.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import readPkgUp from 'read-pkg-up';
 
-const { package: { dependencies, devDependencies } = {} } = readPkgUp.sync() || {};
+const { packageJson: { dependencies, devDependencies } = {} } = readPkgUp.sync() || {};
 
 export default function hasDependency(name) {
   return (


### PR DESCRIPTION
## What I did

`read-pkg-up` was updated from version `6` to `7` in https://github.com/storybookjs/storybook/commit/a89e02e27c920a69f6a863c922c10a3273d3edc1
But the breaking change explained here https://github.com/sindresorhus/read-pkg-up/releases/tag/v7.0.0 wasn't applied so I just applied it

Not need to backport this fix to `5.2.x` as version update was merged in `next` after `5.3.0-alpha8`