### PR TITLE
Remove `weak` dependency for Node 12 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,8 +216,7 @@
     "trash": "^6.0.0",
     "ts-dedent": "^1.1.0",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.4.0",
-    "weak": "^1.0.1"
+    "typescript": "^3.4.0"
   },
   "engines": {
     "node": ">=8.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6894,13 +6894,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.2.tgz#c83c3d74233ba7674e4f313cb2a2b70f54e94b7c"
   integrity sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg==
 
-bindings@^1.2.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
-
 bindings@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
@@ -13198,11 +13191,6 @@ file-system-cache@^1.0.5:
     bluebird "^3.3.5"
     fs-extra "^0.30.0"
     ramda "^0.21.0"
-
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -20370,7 +20358,7 @@ najax@^1.0.3:
     lodash.defaultsdeep "^4.6.0"
     qs "^6.2.0"
 
-nan@^2.0.5, nan@^2.12.1, nan@^2.13.2:
+nan@^2.12.1, nan@^2.13.2:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -30384,14 +30372,6 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
-
-weak@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/weak/-/weak-1.0.1.tgz#ab99aab30706959aa0200cb8cf545bb9cb33b99e"
-  integrity sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=
-  dependencies:
-    bindings "^1.2.1"
-    nan "^2.0.5"
 
 web-namespaces@^1.0.0, web-namespaces@^1.1.2:
   version "1.1.3"


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8002

## Context

To give some context about weak dependency, it's used only for jest related stuff and only affects some developers. The good news is Jest has been working on that and the next release of Jest will certainly allow us to remove weak from our deps.
See facebook/jest#8686

## What I did

I removed `weak` dependency from SB project.

--

----


_OLD DESCRIPTION_

This is sadly not a fix for https://github.com/storybookjs/storybook/issues/8002 but a workaround to force dev to use Node <12 as long as the issue with `node-weak`  is not fixed.

What I did

I updated `engine` property of root `package.json` to force node to be between version 8 and 11 as `node-weak` dependency is not working on Node 12: https://github.com/TooTallNate/node-weak/issues/99
This node max version can be removed as soon as we found a fix/workaround to `node-weak` and Node 12 incompatibility.
