### PR TITLE
Remove redundant dependency on hoist-non-react-statics (#6349)

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -41,7 +41,6 @@
     "axe-core": "^3.3.2",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "hoist-non-react-statics": "^3.3.0",
     "memoizerific": "^1.11.3",
     "react": "^16.8.3",
     "react-redux": "^7.0.2",


### PR DESCRIPTION
Issue: #6349 

## What I did
Removed explicit dependency of `addons/a11y` upon `hoist-non-react-statics`.
This was originally added to fix a build issue. The dependency `@types/react-redux` which necessitated the installation of `hoist-non-react-statics` has since added it as a direct dependency: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33690.

This is now being resolved through the `@types/react-redux` dependency and does not need to be included explicitly.

## How to test

Testable via successful CI build.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
