### PR TITLE
CSF: Ignore __esModule export

### DIFF
--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -31,6 +31,8 @@ function matches(storyKey, arrayOrRegex) {
 
 export function isExportStory(key, { includeStories, excludeStories }) {
   return (
+    // https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs
+    key !== '__esModule' &&
     (!includeStories || matches(key, includeStories)) &&
     (!excludeStories || !matches(key, excludeStories))
   );

--- a/lib/core/src/client/preview/start.test.js
+++ b/lib/core/src/client/preview/start.test.js
@@ -145,6 +145,10 @@ describe('STORY_INIT', () => {
 });
 
 describe('story filters for module exports', () => {
+  it('should exclude __esModule', () => {
+    expect(isExportStory('__esModule', {})).toBeFalsy();
+  });
+
   it('should include all stories when there are no filters', () => {
     expect(isExportStory('a', {})).toBeTruthy();
   });


### PR DESCRIPTION
Issue: #8080 

## What I did

Gatsby's default configuration seems to add `__esModule: true` to exports, which screws up CSF loading. Rather than fight it, let's just ignore those stories, since this seems like a standard thing for CommonJS / ESM interop (whatever that means)

## How to test

```
yarn jest --testPathPattern start.test.js
```
