### PR TITLE
Remove `next` tag from docs

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -94,7 +94,7 @@ features as well. This chart captures the current state of support
 First add the package. Make sure that the versions for your `@storybook/*` packages match:
 
 ```sh
-yarn add -D @storybook/addon-docs@next
+yarn add -D @storybook/addon-docs
 ```
 
 Docs has peer dependencies on `react` and `babel-loader`. If you want to write stories in MDX, you may need to add these dependencies as well:


### PR DESCRIPTION
Docs addon is now stable
