### PR TITLE
added in configuration to enable feature

### DIFF
--- a/lib/core/src/server/preview/base-webpack.config.js
+++ b/lib/core/src/server/preview/base-webpack.config.js
@@ -5,6 +5,11 @@ export function createDefaultWebpackConfig(storybookBaseConfig) {
     ...storybookBaseConfig,
     module: {
       ...storybookBaseConfig.module,
+      devServer: {
+        stats: {
+          errorDetails: true, // --display-error-details
+        },
+      },
       rules: [
         ...storybookBaseConfig.module.rules,
         {


### PR DESCRIPTION
Issue: #6596
there was an open PR to enable --display-error-details
## What I did
I went into the base-webpack.config file and enabled the configuration by setting the config to true.
I then ran yarn test and yarn lint to confirm everything was still working.
## How to test
no additional testing should be needed.

