### PR TITLE
Remove spurious flag to build in Ember

### DIFF
--- a/docs/src/pages/guides/guide-ember/index.md
+++ b/docs/src/pages/guides/guide-ember/index.md
@@ -42,7 +42,7 @@ Then add the following NPM script to your package json in order to start the sto
 ```json
 {
   "scripts": {
-    "build-storybook": "ember build && build-storybook -p 9001 -s dist",
+    "build-storybook": "ember build && build-storybook -s dist",
     "storybook": "ember serve & start-storybook -p 9001 -s dist"
   }
 }


### PR DESCRIPTION
There’s no need to specify a port to only build, and
doing so produces this error:

```
error: unknown option `-p'
```

Thanks for all the work on this!