### PR TITLE
[Security] Bump lodash from 4.17.11 to 4.17.15

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -52,7 +52,7 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "js-string-escape": "^1.0.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -37,7 +37,7 @@
     "@storybook/theming": "5.3.0-alpha.15",
     "core-js": "^3.0.1",
     "format-json": "^1.0.3",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react": "^16.8.3",
     "react-lifecycles-compat": "^3.0.4",

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -47,7 +47,7 @@
     "escape-html": "^1.0.3",
     "fast-deep-equal": "^2.0.1",
     "global": "^4.3.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "qs": "^6.6.0",
     "react-color": "^2.17.0",

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -47,7 +47,7 @@
     "babel-preset-react-app": "^9.0.0",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.8.0",
     "prop-types": "^15.7.2",
     "react-dev-utils": "^9.0.0",

--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -51,7 +51,7 @@
     "global": "^4.3.2",
     "graphql": "^14.1.1",
     "jest-emotion": "^10.0.17",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "paths.macro": "^2.0.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.3",

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -32,7 +32,7 @@
     "core-js": "^3.0.1",
     "fast-deep-equal": "^2.0.1",
     "global": "^4.3.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "memoizerific": "^1.11.3",
     "prop-types": "^15.6.2",
     "react": "^16.8.3",

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -35,7 +35,7 @@
     "eventemitter3": "^4.0.0",
     "global": "^4.3.2",
     "is-plain-object": "^3.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "memoizerific": "^1.11.3",
     "qs": "^6.6.0",
     "ts-dedent": "^1.1.0",

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -32,7 +32,7 @@
     "cross-spawn": "^7.0.0",
     "globby": "^10.0.1",
     "jscodeshift": "^0.6.3",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prettier": "^1.16.4",
     "recast": "^0.16.1",
     "regenerator-runtime": "^0.13.3"

--- a/lib/router/package.json
+++ b/lib/router/package.json
@@ -31,7 +31,7 @@
     "@types/reach__router": "^1.2.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "memoizerific": "^1.11.3",
     "qs": "^6.6.0"
   },

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -41,7 +41,7 @@
     "fast-deep-equal": "^2.0.1",
     "fuse.js": "^3.4.4",
     "global": "^4.3.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "markdown-to-jsx": "^6.9.3",
     "memoizerific": "^1.11.3",
     "polished": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "jest-watch-typeahead": "^0.4.0",
     "lerna": "^3.14.1",
     "lint-staged": "^9.4.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "node-cleanup": "^2.1.2",
     "node-fetch": "^2.6.0",
     "npmlog": "^4.1.2",


### PR DESCRIPTION
See https://www.npmjs.com/advisories/1065

Issue:

## What I did

Updated to the latest published Lodash version. I could've just bumped to `^4.17.12` as per the advisory, but figured I might as well use the latest version. Although `^4.17.11` does allow the installation of newer non-vulnerable versions, `4.17.11` satisfies that version range and seems to cause `Snyk` to produce warnings.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
