### PR TITLE
Remove min-height CSS rule from DocsPage wrapper

### DIFF
--- a/lib/components/src/blocks/DocsPage.tsx
+++ b/lib/components/src/blocks/DocsPage.tsx
@@ -53,7 +53,6 @@ export const DocsWrapper = styled.div<{}>(({ theme }) => ({
   background: theme.background.content,
   display: 'flex',
   justifyContent: 'center',
-  minHeight: '100vh',
   padding: '4rem 20px',
 
   [`@media (min-width: ${breakpoint * 1}px)`]: {},


### PR DESCRIPTION
Even when content inside DocsPage has significantly less height than browser's viewport, is still shows a scrollbar that scrolls through empty space.
