### PR TITLE
Enabled error details webpack

### DIFF
--- a/lib/core/src/server/dev-server.js
+++ b/lib/core/src/server/dev-server.js
@@ -53,6 +53,7 @@ export default function(options) {
             error.error = err;
             error.close = true;
             error.stats = stats;
+            stats.toJson(options.errorDetails);
             logger.line();
             logger.line();
             try {


### PR DESCRIPTION
Issue:
enable verbose errors within webpack
## What I did
added in the configuration to manager.webpack.configure
## How to test
no additional tests should be needed 