### PR TITLE
feat: adds new app "web-components"

### DIFF
--- a/addons/docs/src/frameworks/web-components/config.js
+++ b/addons/docs/src/frameworks/web-components/config.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { addParameters } from '@storybook/web-components';
+import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
+
+addParameters({
+  docs: {
+    container: DocsContainer,
+    page: DocsPage,
+  },
+});

--- a/addons/docs/web-components/config.js
+++ b/addons/docs/web-components/config.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/frameworks/web-components/config');

--- a/addons/docs/web-components/index.js
+++ b/addons/docs/web-components/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/frameworks/common/index');

--- a/addons/docs/web-components/preset.js
+++ b/addons/docs/web-components/preset.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/frameworks/common/makePreset').default('web-components');

--- a/app/web-components/README.md
+++ b/app/web-components/README.md
@@ -1,0 +1,91 @@
+# Storybook for web-components
+
+---
+
+Storybook for web-components is a UI development environment for your plain web-component snippets.
+With it, you can visualize different states of your UI components and develop them interactively.
+
+![Storybook Screenshot](https://github.com/storybookjs/storybook/blob/master/media/storybook-intro.gif)
+
+Storybook runs outside of your app.
+So you can develop UI components in isolation without worrying about app specific dependencies and requirements.
+
+## Getting Started
+
+```sh
+cd my-app
+npx -p @storybook/cli sb init -t web-components
+```
+
+For more information visit: [storybook.js.org](https://storybook.js.org)
+
+---
+
+Storybook also comes with a lot of [addons](https://storybook.js.org/addons/introduction) and a great API to customize as you wish.
+You can also build a [static version](https://storybook.js.org/basics/exporting-storybook) of your storybook and deploy it anywhere you want.
+
+# Setup page reload via HMR
+
+As web components register on a global registry which only accepts a certain name/class once it can lead to errors when using classical HMR.
+There are ideas on how to archive HMR with a static registry but there is no proven solution yet.
+
+Therefore the best approach for now is to do full page reloads.
+If you keep your stories to specific states of components (which we would recommend anyways) this usually means it is fast.
+To activate full page reload
+
+```js
+// ==> REPLACE
+configure(require.context('../stories', true, /\.stories\.(js|mdx)$/), module);
+
+// ==> WITH
+// force full reload to not reregister web components
+const req = require.context('../stories', true, /\.stories\.(js|mdx)$/);
+configure(req, module);
+if (module.hot) {
+  module.hot.accept(req.id, () => {
+    const currentLocationHref = window.location.href;
+    window.history.pushState(null, null, currentLocationHref);
+    window.location.reload();
+  });
+}
+```
+
+# Setup es6/7 dependencies
+
+By default storybook only works with precompiled es5 code but as most web components themselves and their libs are distributed as es7 you will need to manually mark those packages as "needs transpilation".
+
+For example if you have a library called `my-library` which is in es7 then you can add it like so
+
+```js
+// .storybook/webpack.config.js
+
+module.exports = ({ config }) => {
+  // find web-components rule for extra transpilation
+  const webComponentsRule = config.module.rules.find(
+    rule => rule.use && rule.use.options && rule.use.options.babelrc === false
+  );
+  // add your own `my-library`
+  webComponentsRule.test.push(new RegExp(`node_modules(\\/|\\\\)my-library(.*)\\.js$`));
+
+  return config;
+};
+```
+
+By default the following folders are included
+
+- `src/*.js`
+- `packages/*/src/*.js`
+- `node_modules/lit-html/*.js`
+- `node_modules/lit-element/*.js`
+- `node_modules/@open-wc/*.js`
+- `node_modules/@polymer/*.js`
+- `node_modules/@vaadin/*.js`
+
+As you can see the `src` folder is also included.
+The reason for that is as it has some extra configuration to allow for example `import.meta`.
+If you use a different folder you will need to make sure webpack/babel can handle it.
+
+# FAQ
+
+- While working on my component I get the error `Failed to execute 'define' on 'CustomElementRegistry': the name "..." has already been used with this registry`
+  => please see <a href="#user-content-setup-page-reload-via-hmr">Setup page reload via HMR</a>

--- a/app/web-components/bin/build.js
+++ b/app/web-components/bin/build.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+require('../dist/server/build');

--- a/app/web-components/bin/index.js
+++ b/app/web-components/bin/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../dist/server');

--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@storybook/web-components",
+  "version": "5.3.0-alpha.23",
+  "description": "Storybook for web-components: View web components snippets in isolation with Hot Reloading.",
+  "keywords": [
+    "lit-html",
+    "storybook",
+    "web-components"
+  ],
+  "homepage": "https://github.com/storybookjs/storybook/tree/master/app/web-components",
+  "bugs": {
+    "url": "https://github.com/storybookjs/storybook/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storybookjs/storybook.git",
+    "directory": "app/web-components"
+  },
+  "license": "MIT",
+  "files": [
+    "bin/**/*",
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts"
+  ],
+  "main": "dist/client/index.js",
+  "types": "dist/client/index.d.ts",
+  "bin": {
+    "build-storybook": "./bin/build.js",
+    "start-storybook": "./bin/index.js",
+    "storybook-server": "./bin/index.js"
+  },
+  "scripts": {
+    "prepare": "node ../../scripts/prepare.js"
+  },
+  "dependencies": {
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+    "@babel/plugin-syntax-import-meta": "^7.2.0",
+    "@storybook/addons": "5.3.0-alpha.23",
+    "@storybook/core": "5.3.0-alpha.23",
+    "@types/webpack-env": "^1.13.9",
+    "babel-plugin-bundled-import-meta": "^0.3.1",
+    "core-js": "^3.0.1",
+    "global": "^4.3.2",
+    "regenerator-runtime": "^0.13.3",
+    "ts-dedent": "^1.1.0"
+  },
+  "devDependencies": {
+    "lit-html": "^1.0.0"
+  },
+  "peerDependencies": {
+    "babel-loader": "^7.0.0 || ^8.0.0",
+    "lit-html": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/app/web-components/src/client/index.ts
+++ b/app/web-components/src/client/index.ts
@@ -1,0 +1,16 @@
+export {
+  storiesOf,
+  setAddon,
+  addDecorator,
+  addParameters,
+  configure,
+  getStorybook,
+  forceReRender,
+  raw,
+} from './preview';
+
+if (module && module.hot && module.hot.decline) {
+  module.hot.decline();
+}
+
+// TODO: disable HMR and do full page loads because of customElements.define

--- a/app/web-components/src/client/preview/globals.ts
+++ b/app/web-components/src/client/preview/globals.ts
@@ -1,0 +1,3 @@
+import { window } from 'global';
+
+window.STORYBOOK_ENV = 'web-components';

--- a/app/web-components/src/client/preview/index.ts
+++ b/app/web-components/src/client/preview/index.ts
@@ -1,0 +1,35 @@
+/* eslint-disable prefer-destructuring */
+import { start } from '@storybook/core/client';
+import { ClientStoryApi, Loadable } from '@storybook/addons';
+
+import './globals';
+import render from './render';
+import { StoryFnHtmlReturnType, IStorybookSection } from './types';
+
+const framework = 'html';
+
+interface ClientApi extends ClientStoryApi<StoryFnHtmlReturnType> {
+  setAddon(addon: any): void;
+  configure(loader: Loadable, module: NodeModule): void;
+  getStorybook(): IStorybookSection[];
+  clearDecorators(): void;
+  forceReRender(): void;
+  raw: () => any; // todo add type
+}
+
+const api = start(render);
+
+export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
+  return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
+    framework,
+  });
+};
+
+export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
+export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
+export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
+export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
+export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;
+export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;
+export const getStorybook: ClientApi['getStorybook'] = api.clientApi.getStorybook;
+export const raw: ClientApi['raw'] = api.clientApi.raw;

--- a/app/web-components/src/client/preview/types.ts
+++ b/app/web-components/src/client/preview/types.ts
@@ -1,0 +1,27 @@
+import { StoryFn } from '@storybook/addons';
+
+export type StoryFnHtmlReturnType = string | Node;
+
+export interface IStorybookStory {
+  name: string;
+  render: () => any;
+}
+
+export interface IStorybookSection {
+  kind: string;
+  stories: IStorybookStory[];
+}
+
+export interface ShowErrorArgs {
+  title: string;
+  description: string;
+}
+
+export interface RenderMainArgs {
+  storyFn: () => StoryFn<StoryFnHtmlReturnType>;
+  selectedKind: string;
+  selectedStory: string;
+  showMain: () => void;
+  showError: (args: ShowErrorArgs) => void;
+  forceRender: boolean;
+}

--- a/app/web-components/src/server/build.ts
+++ b/app/web-components/src/server/build.ts
@@ -1,0 +1,4 @@
+import { buildStatic } from '@storybook/core/server';
+import options from './options';
+
+buildStatic(options);

--- a/app/web-components/src/server/framework-preset-web-components.ts
+++ b/app/web-components/src/server/framework-preset-web-components.ts
@@ -1,0 +1,46 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Configuration } from 'webpack';
+
+export function webpack(config: Configuration) {
+  return {
+    ...config,
+    module: {
+      ...config.module,
+      rules: [
+        ...config.module.rules,
+        {
+          test: [
+            new RegExp(`src(.*)\\.js$`),
+            new RegExp(`packages(\\/|\\\\)*(\\/|\\\\)src(\\/|\\\\)(.*)\\.js$`),
+            new RegExp(`node_modules(\\/|\\\\)lit-html(.*)\\.js$`),
+            new RegExp(`node_modules(\\/|\\\\)lit-element(.*)\\.js$`),
+            new RegExp(`node_modules(\\/|\\\\)@open-wc(.*)\\.js$`),
+            new RegExp(`node_modules(\\/|\\\\)@polymer(.*)\\.js$`),
+            new RegExp(`node_modules(\\/|\\\\)@vaadin(.*)\\.js$`),
+          ],
+          use: {
+            loader: 'babel-loader',
+            options: {
+              plugins: [
+                '@babel/plugin-syntax-dynamic-import',
+                '@babel/plugin-syntax-import-meta',
+                // webpack does not support import.meta.url yet, so we rewrite them in babel
+                ['bundled-import-meta', { importStyle: 'baseURI' }],
+              ],
+              presets: [
+                [
+                  '@babel/preset-env',
+                  {
+                    useBuiltIns: 'entry',
+                    corejs: 3,
+                  },
+                ],
+              ],
+              babelrc: false,
+            },
+          },
+        },
+      ],
+    },
+  };
+}

--- a/app/web-components/src/server/index.ts
+++ b/app/web-components/src/server/index.ts
@@ -1,0 +1,4 @@
+import { buildDev } from '@storybook/core/server';
+import options from './options';
+
+buildDev(options);

--- a/app/web-components/src/server/options.ts
+++ b/app/web-components/src/server/options.ts
@@ -1,0 +1,7 @@
+// tslint:disable-next-line: no-var-requires
+const packageJson = require('../../package.json');
+
+export default {
+  packageJson,
+  frameworkPresets: [require.resolve('./framework-preset-web-components.js')],
+};

--- a/app/web-components/src/typings.d.ts
+++ b/app/web-components/src/typings.d.ts
@@ -1,0 +1,5 @@
+declare module '@storybook/core/*';
+declare module 'global';
+
+// will be provided by the webpack define plugin
+declare var NODE_ENV: string | undefined;

--- a/app/web-components/standalone.js
+++ b/app/web-components/standalone.js
@@ -1,0 +1,8 @@
+const build = require('@storybook/core/standalone');
+const frameworkOptions = require('./dist/server/options').default;
+
+async function buildStandalone(options) {
+  return build(options, frameworkOptions);
+}
+
+module.exports = buildStandalone;

--- a/app/web-components/tsconfig.json
+++ b/app/web-components/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "types": ["webpack-env"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__/**/*"]
+}

--- a/examples/web-components-kitchen-sink/.storybook/addons.js
+++ b/examples/web-components-kitchen-sink/.storybook/addons.js
@@ -1,0 +1,8 @@
+import '@storybook/addon-a11y/register';
+import '@storybook/addon-actions/register';
+import '@storybook/addon-backgrounds/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-links/register';
+import '@storybook/addon-options/register';
+import '@storybook/addon-storysource/register';
+import '@storybook/addon-viewport/register';

--- a/examples/web-components-kitchen-sink/.storybook/config.js
+++ b/examples/web-components-kitchen-sink/.storybook/config.js
@@ -1,0 +1,35 @@
+/* global window */
+
+import { configure, addParameters, addDecorator } from '@storybook/web-components';
+import { withA11y } from '@storybook/addon-a11y';
+
+addDecorator(withA11y);
+
+addParameters({
+  a11y: {
+    config: {},
+    options: {
+      checks: { 'color-contrast': { options: { noScroll: true } } },
+      restoreScroll: true,
+    },
+  },
+  options: {
+    hierarchyRootSeparator: /\|/,
+  },
+  docs: {
+    iframeHeight: '200px',
+  },
+});
+
+// configure(require.context('../stories', true, /\.stories\.(js|mdx)$/), module);
+
+// force full reload to not reregister web components
+const req = require.context('../stories', true, /\.stories\.(js|mdx)$/);
+configure(req, module);
+if (module.hot) {
+  module.hot.accept(req.id, () => {
+    const currentLocationHref = window.location.href;
+    window.history.pushState(null, null, currentLocationHref);
+    window.location.reload();
+  });
+}

--- a/examples/web-components-kitchen-sink/.storybook/presets.js
+++ b/examples/web-components-kitchen-sink/.storybook/presets.js
@@ -1,0 +1,1 @@
+module.exports = ['@storybook/addon-docs/web-components/preset'];

--- a/examples/web-components-kitchen-sink/README.md
+++ b/examples/web-components-kitchen-sink/README.md
@@ -1,0 +1,5 @@
+# Storybook Web Components Demo
+
+This example directory represents the application you wish to integrate storybook into.
+
+Run `yarn install` to sync Storybook module with the source code and run `yarn storybook` to start the Storybook.

--- a/examples/web-components-kitchen-sink/demo-wc-card.js
+++ b/examples/web-components-kitchen-sink/demo-wc-card.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/extensions */
+/* global customElements */
+
+import { DemoWcCard } from './src/DemoWcCard.js';
+
+customElements.define('demo-wc-card', DemoWcCard);

--- a/examples/web-components-kitchen-sink/package.json
+++ b/examples/web-components-kitchen-sink/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "web-components-kitchen-sink",
+  "version": "5.3.0-alpha.23",
+  "private": true,
+  "description": "",
+  "keywords": [],
+  "license": "MIT",
+  "author": "",
+  "main": "index.js",
+  "scripts": {
+    "build-storybook": "build-storybook",
+    "storybook": "start-storybook -p 9006"
+  },
+  "devDependencies": {
+    "@storybook/addon-a11y": "5.3.0-alpha.23",
+    "@storybook/addon-actions": "5.3.0-alpha.23",
+    "@storybook/addon-backgrounds": "5.3.0-alpha.23",
+    "@storybook/addon-centered": "5.3.0-alpha.23",
+    "@storybook/addon-docs": "5.3.0-alpha.23",
+    "@storybook/addon-events": "5.3.0-alpha.23",
+    "@storybook/addon-jest": "5.3.0-alpha.23",
+    "@storybook/addon-knobs": "5.3.0-alpha.23",
+    "@storybook/addon-links": "5.3.0-alpha.23",
+    "@storybook/addon-notes": "5.3.0-alpha.23",
+    "@storybook/addon-options": "5.3.0-alpha.23",
+    "@storybook/addon-storyshots": "5.3.0-alpha.23",
+    "@storybook/addon-storysource": "5.3.0-alpha.23",
+    "@storybook/addon-viewport": "5.3.0-alpha.23",
+    "@storybook/addons": "5.3.0-alpha.23",
+    "@storybook/client-api": "5.3.0-alpha.23",
+    "@storybook/core": "5.3.0-alpha.23",
+    "@storybook/core-events": "5.3.0-alpha.23",
+    "@storybook/source-loader": "5.3.0-alpha.23",
+    "@storybook/web-components": "5.3.0-alpha.23",
+    "eventemitter3": "^4.0.0",
+    "format-json": "^1.0.3",
+    "global": "^4.3.2",
+    "lit-element": "^2.2.1"
+  }
+}

--- a/examples/web-components-kitchen-sink/src/DemoWcCard.js
+++ b/examples/web-components-kitchen-sink/src/DemoWcCard.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-underscore-dangle, import/extensions */
+import { Event } from 'global';
+import { LitElement, html } from 'lit-element';
+import { demoWcCardStyle } from './demoWcCardStyle.css.js';
+
+export class DemoWcCard extends LitElement {
+  static get properties() {
+    return {
+      backSide: { type: Boolean, reflect: true, attribute: 'back-side' },
+      header: { type: String },
+      rows: { type: Object },
+    };
+  }
+
+  /**
+   * A card setter can have side A or B
+   *
+   * @param {("A"|"B")} value
+   */
+  set side(value) {
+    this.__side = value;
+    this.dispatchEvent(new Event('side-changed'));
+    this.requestUpdate();
+  }
+
+  /**
+   * @returns {("A"|"B")}
+   */
+  get side() {
+    return this.__side;
+  }
+
+  static get styles() {
+    return demoWcCardStyle;
+  }
+
+  constructor() {
+    super();
+    this.backSide = false;
+    this.header = 'Your Message';
+    this.rows = [];
+  }
+
+  toggle() {
+    this.backSide = !this.backSide;
+  }
+
+  render() {
+    return html`
+      <div id="front">
+        <div class="header">
+          ${this.header}
+        </div>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <div class="footer">
+          <div class="note">A</div>
+          <button @click=${this.toggle}>></button>
+        </div>
+      </div>
+      <div id="back">
+        <div class="header">
+          ${this.header}
+        </div>
+
+        <div class="content">
+          ${this.rows.length === 0
+            ? html``
+            : html`
+                <dl>
+                  ${this.rows.map(
+                    row => html`
+                      <dt>${row.header}</dt>
+                      <dd>${row.value}</dd>
+                    `
+                  )}
+                </dl>
+              `}
+        </div>
+        <div class="footer">
+          <div class="note">B</div>
+          <button @click=${this.toggle}>></button>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/examples/web-components-kitchen-sink/src/demoWcCardStyle.css.js
+++ b/examples/web-components-kitchen-sink/src/demoWcCardStyle.css.js
@@ -1,0 +1,97 @@
+import { css } from 'lit-element';
+
+export const demoWcCardStyle = css`
+  :host {
+    display: block;
+    position: relative;
+    width: 250px;
+    height: 200px;
+    border-radius: 10px;
+    transform-style: preserve-3d;
+    transition: all 0.8s ease;
+  }
+
+  .header {
+    font-weight: bold;
+    font-size: var(--demo-wc-card-header-font-size, 16px);
+    text-align: center;
+  }
+
+  .content {
+    padding: 20px 10px 0 10px;
+    flex-grow: 1;
+  }
+
+  .footer {
+    display: flex;
+  }
+
+  dl {
+    margin: 0;
+    text-align: left;
+  }
+
+  dd {
+    margin-left: 15px;
+  }
+
+  button {
+    border-radius: 15px;
+    width: 30px;
+    height: 30px;
+    background: #fff;
+    border: 1px solid #ccc;
+    color: #000;
+    font-size: 21px;
+    line-height: 27px;
+    font-weight: bold;
+    cursor: pointer;
+    margin: 5px;
+  }
+
+  .note {
+    flex-grow: 1;
+    color: #666;
+    font-size: 16px;
+    font-weight: bold;
+    text-align: left;
+    padding-top: 15px;
+  }
+
+  :host([back-side]) {
+    transform: rotateY(180deg);
+  }
+
+  #front,
+  #back {
+    position: absolute;
+    width: 250px;
+    box-sizing: border-box;
+    box-shadow: #ccc 3px 3px 2px 1px;
+    padding: 10px;
+    display: flex;
+    flex-flow: column;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: 10px;
+    backface-visibility: hidden;
+    overflow: hidden;
+  }
+
+  #front {
+    background: linear-gradient(141deg, #aaa 25%, #eee 40%, #ddd 55%);
+    color: var(--demo-wc-card-front-color, #000);
+  }
+
+  #back {
+    background: linear-gradient(141deg, #333 25%, #aaa 40%, #666 55%);
+    color: var(--demo-wc-card-back-color, #fff);
+    text-align: center;
+    transform: rotateY(180deg);
+  }
+
+  #back .note {
+    color: #fff;
+  }
+`;

--- a/examples/web-components-kitchen-sink/stories/addon-a11y.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-a11y.stories.js
@@ -1,0 +1,36 @@
+import { document, setTimeout } from 'global';
+import { withA11y } from '@storybook/addon-a11y';
+import { html } from 'lit-html';
+
+const text = 'Testing the a11y addon';
+
+export default {
+  title: 'Addons|a11y',
+  decorators: [withA11y],
+  parameters: {
+    options: { selectedPanel: 'storybook/a11y/panel' },
+  },
+};
+
+export const Default = () => html`
+  <button></button>
+`;
+export const Label = () => html`
+  <button>${text}</button>
+`;
+export const Disabled = () => html`
+  <button disabled>${text}</button>
+`;
+export const story4 = () => html`
+  <button style="color: black; background-color: brown;">${text}</button>
+`;
+story4.story = { name: 'Invalid contrast' };
+
+export const story5 = () => {
+  const div = document.createElement('div');
+  setTimeout(() => {
+    div.innerHTML = `<button>This button has a delayed render of 1s</button>`;
+  }, 1000);
+  return div;
+};
+story5.story = { name: 'Delayed render' };

--- a/examples/web-components-kitchen-sink/stories/addon-actions.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-actions.stories.js
@@ -1,0 +1,47 @@
+import { withActions, decorate } from '@storybook/addon-actions';
+import { html } from 'lit-html';
+
+const pickTarget = decorate([args => [args[0].target]]);
+
+const button = () => html`
+  <button type="button">Hello World</button>
+`;
+
+export default {
+  title: 'Addons|Actions',
+};
+
+export const story1 = () => withActions('click')(button);
+story1.story = { name: 'Hello World' };
+export const story2 = () => withActions('click', 'contextmenu')(button);
+story2.story = { name: 'Multiple actions' };
+
+export const story3 = () =>
+  withActions('click', 'contextmenu', { clearOnStoryChange: false })(button);
+story3.story = { name: 'Multiple actions + config' };
+
+export const story4 = () => withActions({ click: 'clicked', contextmenu: 'right clicked' })(button);
+story4.story = { name: 'Multiple actions, object' };
+
+export const story5 = () =>
+  withActions({ 'click .btn': 'clicked', contextmenu: 'right clicked' })(
+    () => html`
+      <div>
+        Clicks on this button will be logged: <button class="btn" type="button">Button</button>
+      </div>
+    `
+  );
+story5.story = { name: 'Multiple actions, selector' };
+
+export const story6 = () =>
+  withActions({ click: 'clicked', contextmenu: 'right clicked' }, { clearOnStoryChange: false })(
+    button
+  );
+story6.story = { name: 'Multiple actions, object + config' };
+
+export const story7 = () => pickTarget.withActions('click', 'contextmenu')(button);
+story7.story = { name: 'Decorated actions' };
+
+export const story8 = () =>
+  pickTarget.withActions('click', 'contextmenu', { clearOnStoryChange: false })(button);
+story8.story = { name: 'Decorated actions + config' };

--- a/examples/web-components-kitchen-sink/stories/addon-backgrounds.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-backgrounds.stories.js
@@ -1,0 +1,23 @@
+/* eslint-disable import/extensions */
+import { html } from 'lit-html';
+import '../demo-wc-card.js';
+
+export default {
+  title: 'Addons|Backgrounds',
+  parameters: {
+    backgrounds: [
+      { name: 'light', value: '#eeeeee' },
+      { name: 'dark', value: '#222222', default: true },
+    ],
+  },
+};
+
+export const story1 = () => html`
+  <demo-wc-card>You should be able to switch backgrounds for this story</demo-wc-card>
+`;
+story1.story = { name: 'story 1' };
+
+export const story2 = () => html`
+  <demo-wc-card back-side>This one too!</demo-wc-card>
+`;
+story2.story = { name: 'story 2' };

--- a/examples/web-components-kitchen-sink/stories/addon-docs.stories.mdx
+++ b/examples/web-components-kitchen-sink/stories/addon-docs.stories.mdx
@@ -1,0 +1,53 @@
+import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
+import { action } from '@storybook/addon-actions';
+import { html } from 'lit-html';
+import '../demo-wc-card.js';
+
+# Storybook Docs for Web Components
+
+<Meta title="Addons|Docs" />
+
+## Story definition
+
+A story can be a simple return of `html`
+
+<Story name="simple" height="220px">
+  {html`
+    <demo-wc-card>Hello World</demo-wc-card>
+  `}
+</Story>
+
+## Function stories
+
+Or a function
+
+<Story name="function" height="220px">
+  {() => {
+    const rows = [{ header: 'health', value: '200' }, { header: 'mana', value: '100' }];
+    return html`
+      <demo-wc-card back-side .rows=${rows}>
+        A card with data on the back
+      </demo-wc-card>
+    `;
+  }}
+</Story>
+
+## Wrapper
+
+You can also wrap your live demos in a nice little wrapper.
+
+<Preview withToolbar>
+  <Story name="wrapper" height="220px">
+    {html`
+      <demo-wc-card>Hello World</demo-wc-card>
+    `}
+  </Story>
+</Preview>
+
+## Story reference
+
+You can also reference an existing story from within your MDX file.
+
+<Preview withToolbar>
+  <Story id="welcome--welcome" height="500px" />
+</Preview>

--- a/examples/web-components-kitchen-sink/stories/addon-knobs.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-knobs.stories.js
@@ -1,0 +1,107 @@
+/* eslint-disable import/extensions */
+import { action } from '@storybook/addon-actions';
+import { html } from 'lit-html';
+import '../demo-wc-card.js';
+
+import {
+  array,
+  boolean,
+  button,
+  color,
+  date,
+  select,
+  withKnobs,
+  text,
+  number,
+} from '@storybook/addon-knobs';
+
+export default {
+  title: 'Addons|Knobs',
+  decorators: [withKnobs],
+};
+
+export const Simple = () => {
+  const header = text('header', 'Power Ranger');
+  const age = number('Age', 44);
+  return html`
+    <demo-wc-card .header=${header}>
+      I am ${text('Name', 'John Doe')} and I'm ${age} years old.
+    </demo-wc-card>
+  `;
+};
+
+export const story3 = () => {
+  const header = text('header', 'Power Ranger');
+  const textColor = color('Text color', 'orangered');
+  return html`
+    <demo-wc-card .header=${header}>
+      I am ${text('Name', 'John Doe')} and I'm 30 years old.
+    </demo-wc-card>
+    <style>
+      html {
+        --demo-wc-card-front-color: ${textColor};
+      }
+    </style>
+  `;
+};
+story3.story = { name: 'Color Selection' };
+
+export const story4 = () => {
+  const name = text('Name', 'Jane');
+  const stock = number('Stock', 20, {
+    range: true,
+    min: 0,
+    max: 30,
+    step: 5,
+  });
+  const fruits = {
+    Apple: 'apples',
+    Banana: 'bananas',
+    Cherry: 'cherries',
+  };
+  const fruit = select('Fruit', fruits, 'apples');
+  const price = number('Price', 2.25);
+  const colour = color('Border', 'deeppink');
+  const today = date('Today', new Date('Jan 20 2017 GMT+0'));
+  const items = array('Items', ['Laptop', 'Book', 'Whiskey']);
+  const nice = boolean('Nice', true);
+
+  const stockMessage = stock
+    ? `I have a stock of ${stock} ${fruit}, costing &dollar;${price} each.`
+    : `I'm out of ${fruit}${nice ? ', Sorry!' : '.'}`;
+
+  const salutation = nice ? 'Nice to meet you!' : 'Leave me alone!';
+  const dateOptions = { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' };
+
+  button('Arbitrary action', action('You clicked it!'));
+
+  const style = `border: 2px dotted ${colour}; padding: 8px 22px; border-radius: 8px`;
+
+  return html`
+    <div style="${style}">
+      <h1>My name is ${name},</h1>
+      <h3>today is ${new Date(today).toLocaleDateString('en-US', dateOptions)}</h3>
+      <p>${stockMessage}</p>
+      <p>Also, I have:</p>
+      <ul>
+        ${items.map(
+          item => html`
+            <li>${item}</li>
+          `
+        )}
+      </ul>
+      <p>${salutation}</p>
+    </div>
+  `;
+};
+story4.story = { name: 'All knobs' };
+
+export const XssSafety = () => {
+  const content = text('content', '<img src=x onerror="alert(\'XSS Attack\')" >');
+  return html`
+    <demo-wc-card>
+      Code text works :)<br />
+      Xss insert? ${content}
+    </demo-wc-card>
+  `;
+};

--- a/examples/web-components-kitchen-sink/stories/card.stories.js
+++ b/examples/web-components-kitchen-sink/stories/card.stories.js
@@ -1,0 +1,28 @@
+/* eslint-disable import/extensions */
+import { html } from 'lit-html';
+import '../demo-wc-card.js';
+
+export default {
+  title: 'Demo Card',
+};
+
+export const Front = () => html`
+  <demo-wc-card>A simple card</demo-wc-card>
+`;
+
+export const Back = () => html`
+  <demo-wc-card back-side>A simple card</demo-wc-card>
+`;
+
+export const FrontOwnHeader = () => html`
+  <demo-wc-card header="My own Header">A simple card</demo-wc-card>
+`;
+
+export const BackWithData = () => html`
+  <demo-wc-card
+    back-side
+    .rows=${[{ header: 'health', value: '200' }, { header: 'mana', value: '100' }]}
+  >
+    A simple card
+  </demo-wc-card>
+`;

--- a/examples/web-components-kitchen-sink/stories/welcome.stories.js
+++ b/examples/web-components-kitchen-sink/stories/welcome.stories.js
@@ -1,0 +1,64 @@
+import { html } from 'lit-html';
+import { withLinks } from '@storybook/addon-links';
+
+export default {
+  title: 'Welcome',
+  decorators: [withLinks],
+};
+
+export const Welcome = () => html`
+  <div class="main">
+    <h1>Welcome to Storybook for Web Components</h1>
+    <p>This is a UI component dev environment for your plain HTML snippets.</p>
+    <p>
+      We've added some basic stories inside the <code class="code">stories</code> directory.
+      <br />
+      A story is a single state of one or more UI components. You can have as many stories as you
+      want.
+      <br />
+      (Basically a story is like a visual test case.)
+    </p>
+    <p>
+      See these sample
+      <a class="link" href="#" data-sb-kind="Demo Card" data-sb-story="Front">stories</a>
+    </p>
+    <p>
+      Just like that, you can add your own snippets as stories.
+      <br />
+      You can also edit those snippets and see changes right away.
+      <br />
+    </p>
+    <p>
+      Usually we create stories with smaller UI components in the app.<br />
+      Have a look at the
+      <a class="link" href="https://storybook.js.org/basics/writing-stories" target="_blank">
+        Writing Stories
+      </a>
+      section in our documentation.
+    </p>
+  </div>
+
+  <style>
+    .main {
+      padding: 15px;
+      line-height: 1.4;
+      font-family: 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, freesans, sans-serif;
+      background-color: #ffffff;
+    }
+
+    .logo {
+      width: 256px;
+      margin: 15px;
+    }
+
+    .code {
+      font-size: 15px;
+      font-weight: 600;
+      padding: 2px 5px;
+      border: 1px solid #eae9e9;
+      border-radius: 4px;
+      background-color: #f3f2f2;
+      color: #3a3a3a;
+    }
+  </style>
+`;

--- a/lib/cli/generators/WEB-COMPONENTS/index.js
+++ b/lib/cli/generators/WEB-COMPONENTS/index.js
@@ -1,0 +1,34 @@
+import fse from 'fs-extra';
+import path from 'path';
+import npmInit from '../../lib/npm_init';
+import {
+  getVersion,
+  getPackageJson,
+  writePackageJson,
+  getBabelDependencies,
+  installDependencies,
+} from '../../lib/helpers';
+
+export default async npmOptions => {
+  const storybookVersion = await getVersion(npmOptions, '@storybook/html');
+  fse.copySync(path.resolve(__dirname, 'template/'), '.', { overwrite: true });
+
+  let packageJson = getPackageJson();
+  if (!packageJson) {
+    await npmInit();
+    packageJson = getPackageJson();
+  }
+
+  packageJson.dependencies = packageJson.dependencies || {};
+  packageJson.devDependencies = packageJson.devDependencies || {};
+
+  packageJson.scripts = packageJson.scripts || {};
+  packageJson.scripts.storybook = 'start-storybook -p 6006';
+  packageJson.scripts['build-storybook'] = 'build-storybook';
+
+  writePackageJson(packageJson);
+
+  const babelDependencies = await getBabelDependencies(npmOptions, packageJson);
+
+  installDependencies(npmOptions, [`@storybook/html@${storybookVersion}`, ...babelDependencies]);
+};

--- a/lib/cli/generators/WEB-COMPONENTS/template/.storybook/config.js
+++ b/lib/cli/generators/WEB-COMPONENTS/template/.storybook/config.js
@@ -1,0 +1,4 @@
+import { configure } from '@storybook/html';
+
+// automatically import all files ending in *.stories.js
+configure(require.context('../stories', true, /\.stories\.js$/), module);

--- a/lib/cli/generators/WEB-COMPONENTS/template/stories/index.stories.js
+++ b/lib/cli/generators/WEB-COMPONENTS/template/stories/index.stories.js
@@ -1,0 +1,26 @@
+import { html } from 'lit-html';
+
+// import '../my-component.js';
+
+export default {
+  title: 'Demo',
+};
+
+export const heading = () => html`
+  <h1>Hello World</h1>
+`;
+
+export const settingProperties = () => html`
+  <my-component .data=${{ header: 'foo', state: true }}>Hello World</my-component>
+`;
+
+export const events = () => html`
+  <button @click=${ev => console.log('clicked button')}>clicking will get logged to console</button>
+`;
+
+export const withFunction = () => {
+  const header = 'My Header';
+  return html`
+    <h1>${header}</h1>
+  `;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,6 +789,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-import-meta@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.2.0.tgz#2333ef4b875553a3bcd1e93f8ebc09f5b9213a40"
+  integrity sha512-Hq6kFSZD7+PHkmBN8bCpHR6J8QEoCuEV/B38AIQscYjgMZkGlXB7cHNFzP5jR4RCh5545yP1ujHdmO7hAgKtBA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470"
@@ -5968,6 +5975,14 @@ babel-plugin-apply-mdx-type-prop@^1.5.0:
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0"
     "@mdx-js/util" "^1.5.0"
+
+babel-plugin-bundled-import-meta@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-bundled-import-meta/-/babel-plugin-bundled-import-meta-0.3.1.tgz#878e28830c8d20a3ebc639b503ea73ebebd927d0"
+  integrity sha512-tmg3/GQ+broWbE2v9DI8GZRVtPQqJCRrgZPj49xC5Z05M409QdjuJS0Vzj4IqOzmObnpoEsISlH4x/XQ3orewg==
+  dependencies:
+    "@babel/plugin-syntax-import-meta" "^7.2.0"
+    "@babel/template" "^7.4.4"
 
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
@@ -18519,6 +18534,13 @@ listr@^0.14.3:
     listr-verbose-renderer "^0.5.0"
     p-map "^2.0.0"
     rxjs "^6.3.3"
+
+lit-element@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.2.1.tgz#79c94d8cfdc2d73b245656e37991bd1e4811d96f"
+  integrity sha512-ipDcgQ1EpW6Va2Z6dWm79jYdimVepO5GL0eYkZrFvdr0OD/1N260Q9DH+K5HXHFrRoC7dOg+ZpED2XE0TgGdXw==
+  dependencies:
+    lit-html "^1.0.0"
 
 lit-html@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
hey there 🤗 

happy Hacktoberfest 💪 

closes: https://github.com/storybookjs/storybook/issues/4958 https://github.com/storybookjs/storybook/issues/6208

## What I did

- [x] Added a new app called `web-components`
- [x] Added a preset for addon-docs 
- [x] Added a kitchen sink example
- [x] Transpiling code setup (e.g. most code is es7 even in node_modules so we need to mark that and compile it => also added info to the readme how you can add your own packages)
- [x] Added to generator
- [x] ~~How to handle HMR? in the kitchen sync I currently force a hard refresh => I am using this since quite a while and it works fine even for bigger apps~~
  => documented howto add page refresh  

It is sort of an alternative to https://github.com/storybookjs/storybook/pull/7731. 

## How to test

- Open kitchen sink example