### PR TITLE
chore: replace link URL from stroybook-chrome-screenshot to storycap

### DIFF
--- a/docs/src/pages/addons/addon-gallery/index.md
+++ b/docs/src/pages/addons/addon-gallery/index.md
@@ -126,7 +126,7 @@ Preview your stories at a variety of breakpoints, so that you can be sure that y
 
 Wrap your stories with the Apollo client for mocking GraphQL queries/mutations.
 
-### [Screenshot](https://github.com/tsuyoshiwada/storybook-chrome-screenshot)
+### [Storycap](https://github.com/reg-viz/storycap)
 
 Save the screenshot image of your stories. via [Puppeteer](https://github.com/GoogleChrome/puppeteer).
 


### PR DESCRIPTION
Issue:

## What I did
`storybook-chrome-screenshot` was renamed to *Storycap* ( https://www.npmjs.com/package/storycap ). So I want to change the link for this on the Addon Gallery.

Cc: @tsuyoshiwada 

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
