### PR TITLE
Official-storybook: Add a story with duplicate decorators

### DIFF
--- a/examples/official-storybook/stories/addon-knobs/with-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs/with-knobs.stories.js
@@ -362,3 +362,8 @@ acceptsStoryParameters.story = {
     knobs: { escapeHTML: false },
   },
 };
+
+export const withDuplicateDecorator = () => {
+  return text('Text', 'Hello');
+};
+withDuplicateDecorator.story = { decorators: [withKnobs] };


### PR DESCRIPTION
This doesn't fix anything, only helps to verify that having duplicate decorators is not an issue anymore, see https://github.com/storybookjs/storybook/issues/8376#issuecomment-541111397

This doesn't seem to have anything to do with the original #8376, so please don't close it after merging this PR.