### PR TITLE
Addon API: Clean preview hooks when removing a story

### DIFF
--- a/lib/addons/src/hooks.ts
+++ b/lib/addons/src/hooks.ts
@@ -118,16 +118,12 @@ export class HooksContext {
   addRenderListeners() {
     this.removeRenderListeners();
     const channel = addons.getChannel();
-    if (channel != null) {
-      RenderEvents.forEach(e => channel.on(e, this.renderListener));
-    }
+    RenderEvents.forEach(e => channel.on(e, this.renderListener));
   }
 
   removeRenderListeners() {
     const channel = addons.getChannel();
-    if (channel != null) {
-      RenderEvents.forEach(e => channel.removeListener(e, this.renderListener));
-    }
+    RenderEvents.forEach(e => channel.removeListener(e, this.renderListener));
   }
 }
 

--- a/lib/addons/src/hooks.ts
+++ b/lib/addons/src/hooks.ts
@@ -118,12 +118,16 @@ export class HooksContext {
   addRenderListeners() {
     this.removeRenderListeners();
     const channel = addons.getChannel();
-    RenderEvents.forEach(e => channel.on(e, this.renderListener));
+    if (channel != null) {
+      RenderEvents.forEach(e => channel.on(e, this.renderListener));
+    }
   }
 
   removeRenderListeners() {
     const channel = addons.getChannel();
-    RenderEvents.forEach(e => channel.removeListener(e, this.renderListener));
+    if (channel != null) {
+      RenderEvents.forEach(e => channel.removeListener(e, this.renderListener));
+    }
   }
 }
 

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -1,5 +1,6 @@
 import createChannel from '@storybook/channel-postmessage';
 import { toId } from '@storybook/router/utils';
+import addons from '@storybook/addons';
 
 import StoryStore from './story_store';
 import { defaultDecorateStory } from './client_api';
@@ -97,6 +98,7 @@ describe('preview.story_store', () => {
     });
     it('should remove the kind in both modern and legacy APIs', () => {
       const store = new StoryStore({ channel });
+      addons.setChannel(channel);
       store.addStory(...make('kind-1', 'story-1.1', () => 0));
       store.addStory(...make('kind-1', 'story-1.2', () => 0));
       store.addStory(...make('kind-2', 'story-2.1', () => 0));
@@ -117,6 +119,7 @@ describe('preview.story_store', () => {
   describe('remove', () => {
     it('should remove the kind in both modern and legacy APIs', () => {
       const store = new StoryStore({ channel });
+      addons.setChannel(channel);
       store.addStory(...make('kind-1', 'story-1.1', () => 0));
       store.addStory(...make('kind-1', 'story-1.2', () => 0));
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -165,6 +165,7 @@ export default class StoryStore extends EventEmitter {
     delete _data[id];
 
     if (story) {
+      story.hooks.clean();
       const { kind, name } = story;
       const kindData = this._legacydata[toKey(kind)];
       if (kindData) {
@@ -360,7 +361,7 @@ export default class StoryStore extends EventEmitter {
   removeStoryKind(kind: string) {
     if (this.hasStoryKind(kind)) {
       this._legacydata[toKey(kind)].stories = {};
-
+      this.cleanHooksForKind(kind);
       this._data = Object.entries(this._data).reduce((acc, [id, story]) => {
         if (story.kind !== kind) {
           Object.assign(acc, { [id]: story });
@@ -397,7 +398,9 @@ export default class StoryStore extends EventEmitter {
   }
 
   cleanHooks(id: string) {
-    this._data[id].hooks.clean();
+    if (this._data[id]) {
+      this._data[id].hooks.clean();
+    }
   }
 
   cleanHooksForKind(kind: string) {


### PR DESCRIPTION
Partial fix for https://github.com/storybookjs/storybook/issues/8306
Also fixes https://github.com/storybookjs/storybook/issues/8298

## How to test
Open any story, then remove the corresponding story or kind from sources