### PR TITLE
Update iframe.js to fix disappearing component caused by zoom 

### DIFF
--- a/lib/ui/src/components/preview/iframe.js
+++ b/lib/ui/src/components/preview/iframe.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 
 import { styled } from '@storybook/theming';
 
+const FIREFOX_BROWSER = 'Firefox';
+
 const StyledIframe = styled.iframe({
   position: 'absolute',
   display: 'block',
@@ -25,14 +27,19 @@ export class IFrame extends Component {
 
   shouldComponentUpdate(nextProps) {
     const { scale } = this.props;
-
-    if (scale !== nextProps.scale) {
-      this.setIframeBodyStyle({
-        width: `${nextProps.scale * 100}%`,
-        height: `${nextProps.scale * 100}%`,
-        transform: `scale(${1 / nextProps.scale})`,
-        transformOrigin: 'top left',
-      });
+    if(scale != nextProps.scale) {
+      if (navigator.userAgent.indexOf(FIREFOX_BROWSER) !== -1) {
+        this.setIframeBodyStyle({
+          width: `${nextProps.scale * 100}%`,
+          height: `${nextProps.scale * 100}%`,
+          transform: `scale(${1 / nextProps.scale})`,
+          transformOrigin: 'top left',
+        });
+      } else {
+        this.setIframeBodyStyle({
+          zoom: 1 / nextProps.scale,
+        });
+      }
     }
 
     // this component renders an iframe, which gets updates via post-messages

--- a/lib/ui/src/components/preview/iframe.js
+++ b/lib/ui/src/components/preview/iframe.js
@@ -27,7 +27,7 @@ export class IFrame extends Component {
 
   shouldComponentUpdate(nextProps) {
     const { scale } = this.props;
-    if(scale != nextProps.scale) {
+    if(scale !== nextProps.scale) {
       if (navigator.userAgent.indexOf(FIREFOX_BROWSER) !== -1) {
         this.setIframeBodyStyle({
           width: `${nextProps.scale * 100}%`,


### PR DESCRIPTION
Issue: #7167

## What I did
Fix the issue where zoom functionality mixed with addon centered causes the component to disappear. This fix works for all browsers except Firefox.

@shilman, this was the solution we discussed a while back. If we find a solution that doesn't become impacted by multiple transforms and works for all browsers, this can be replaced at that time.

## How to test

- Is this testable with Jest or Chromatic screenshots? maybe
- Does this need a new example in the kitchen sink apps? no 
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
