### PR TITLE
Update index.ts of jest addon to make withTests type generic

### DIFF
--- a/addons/jest/src/index.ts
+++ b/addons/jest/src/index.ts
@@ -1,4 +1,4 @@
-import addons, { Parameters, DecoratorFunction, StoryFn } from '@storybook/addons';
+import addons, { Parameters, StoryFn } from '@storybook/addons';
 import deprecate from 'util-deprecate';
 import { normalize, sep } from 'upath';
 import { ADD_TESTS } from './shared';

--- a/addons/jest/src/index.ts
+++ b/addons/jest/src/index.ts
@@ -51,15 +51,15 @@ const emitAddTests = ({ kind, story, testFiles, options }: EmitAddTestsArg) => {
 export const withTests = (userOptions: {
   results: any;
   filesExt?: string;
-}): DecoratorFunction<unknown> => {
+}) => {
   const defaultOptions = {
     filesExt: '((\\.specs?)|(\\.tests?))?(\\.[jt]sx?)?$',
   };
   const options = { ...defaultOptions, ...userOptions };
 
-  return (...args) => {
+  return (...args: any []) => {
     if (typeof args[0] === 'string') {
-      return deprecate((storyFn: StoryFn<unknown>, { kind }: Parameters) => {
+      return deprecate((storyFn: StoryFn<any>, { kind }: Parameters) => {
         emitAddTests({ kind, story: storyFn, testFiles: (args as any) as string[], options });
 
         return storyFn();


### PR DESCRIPTION
Issue: #8058

## What I did
Update index.ts of jest addon to make withTests type generic

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
