### PR TITLE
CSF: Warn when CSF and `storiesOf` mixed in one file

### DIFF
--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -156,6 +156,16 @@ export default class ClientApi {
       );
     }
 
+    if (m) {
+      const proto = Object.getPrototypeOf(m);
+      if (proto.exports && proto.exports.default) {
+        // FIXME: throw an error in SB6.0
+        logger.error(
+          `Illegal mix of CSF default export and storiesOf calls in a single file: ${proto.i}`
+        );
+      }
+    }
+
     if (m && m.hot && m.hot.dispose) {
       m.hot.dispose(() => {
         const { _storyStore } = this;


### PR DESCRIPTION
Issue: #8306 

## What I did

Show an error when a calls `storiesOf` from a file with a default export.

Should we throw an error instead? (This is a breaking change, but maybe a good one?)

## How to test

Add a `storiesOf` call from a CSF file in `official-storybook`