### PR TITLE
Addon-docs: Don't error in React when there's no `prepareForInline`

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -44,7 +44,6 @@
     "@mdx-js/react": "^1.0.27",
     "@storybook/addons": "5.3.0-alpha.18",
     "@storybook/api": "5.3.0-alpha.18",
-    "@storybook/client-logger": "5.3.0-alpha.18",
     "@storybook/components": "5.3.0-alpha.18",
     "@storybook/router": "5.3.0-alpha.18",
     "@storybook/source-loader": "5.3.0-alpha.18",

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -44,6 +44,7 @@
     "@mdx-js/react": "^1.0.27",
     "@storybook/addons": "5.3.0-alpha.18",
     "@storybook/api": "5.3.0-alpha.18",
+    "@storybook/client-logger": "5.3.0-alpha.18",
     "@storybook/components": "5.3.0-alpha.18",
     "@storybook/router": "5.3.0-alpha.18",
     "@storybook/source-loader": "5.3.0-alpha.18",

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
-import { logger } from '@storybook/client-logger';
 import { components as docsComponents } from '@storybook/components/html';
 import { Story, StoryProps as PureStoryProps } from '@storybook/components';
 import { CURRENT_SELECTION } from './shared';
@@ -67,8 +66,8 @@ export const getStoryProps = (
   const { storyFn = undefined, name: storyName = undefined } = data || {};
 
   const storyIsInline = typeof inline === 'boolean' ? inline : inlineStories;
-  if (storyIsInline && !prepareForInline) {
-    logger.warn(
+  if (storyIsInline && !prepareForInline && framework !== 'react') {
+    throw new Error(
       `Story '${storyName}' is set to render inline, but no 'prepareForInline' function is implemented in your docs configuration!`
     );
   }

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
+import { logger } from '@storybook/client-logger';
 import { components as docsComponents } from '@storybook/components/html';
 import { Story, StoryProps as PureStoryProps } from '@storybook/components';
 import { CURRENT_SELECTION } from './shared';
@@ -67,7 +68,7 @@ export const getStoryProps = (
 
   const storyIsInline = typeof inline === 'boolean' ? inline : inlineStories;
   if (storyIsInline && !prepareForInline) {
-    throw new Error(
+    logger.warn(
       `Story '${storyName}' is set to render inline, but no 'prepareForInline' function is implemented in your docs configuration!`
     );
   }

--- a/addons/docs/src/frameworks/react/config.js
+++ b/addons/docs/src/frameworks/react/config.js
@@ -7,6 +7,6 @@ addParameters({
     container: DocsContainer,
     page: DocsPage,
     // react is Storybook's "native" framework, so it's stories are inherently prepared to be rendered inline
-    prepareForInline: storyFn => storyFn(),
+    prepareForInline: storyFn => storyFn,
   },
 });


### PR DESCRIPTION
Issue: #6706 

## What I did

The inline rendering contributed in #7929 was actually a breaking change for users who had manually configured their docs setup.

Also removed the storyFn call in React default prepareForInline, which can have implications to React hooks. (Should this be a separate PR?)

## How to test

Manually configure an app without `prepareForInline` with and without the change