### PR TITLE
Correct usage of getchannel

### DIFF
--- a/addons/backgrounds/README.md
+++ b/addons/backgrounds/README.md
@@ -91,7 +91,9 @@ storiesOf('Button', module)
 If you want to react to a background change—for instance to implement some custom logic in your Storybook—you can subscribe to the `storybook/background/update` event. It will be emitted when the user changes the background.
 
 ```js
-addonAPI.getChannel().on('storybook/background/update', (bg) => {
+import { addons } from '@storybook/addons';
+
+addons.getChannel().on('storybook/background/update', (bg) => {
   console.log('Background color', bg.selected);
   console.log('Background name', bg.name);
 });


### PR DESCRIPTION
Issue:
The README is outdated
https://storybook.js.org/docs/addons/api/#addonsgetchannel

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots? (Just a Readme change)
- Does this need a new example in the kitchen sink apps? (Just a Readme change)
- Does this need an update to the documentation? (Just a Readme change)
