### PR TITLE
Incorrect minimal required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "typescript": "^3.4.0"
   },
   "engines": {
-    "node": ">=8.6.0",
+    "node": ">=8.10.0",
     "yarn": ">=1.3.2"
   },
   "collective": {


### PR DESCRIPTION
Issue: minimal required node in the `package.json` is not correct

## What I did
I've installed dependencies
```bash
 storybook $ node -v
v8.9.4

 storybook $ yarn bootstrap
yarn run v1.19.0
$ node ./scripts/bootstrap.js
? Select the bootstrap activities Core, Dll & Examples (core)
storybook info bootstrap Install dependencies (install)
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
error @typescript-eslint/eslint-plugin@2.3.2: The engine "node" is incompatible with this module. Expected version "^8.10.0 || ^10.13.0 || >=11.10.1". Got "8.9.4"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? Maybe, it seems no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
