### PR TITLE
Addon-storysource: Add preset

### DIFF
--- a/addons/storysource/README.md
+++ b/addons/storysource/README.md
@@ -14,7 +14,7 @@ First, install the addon
 yarn add @storybook/addon-storysource @storybook/source-loader --dev
 ```
 
-You can add configuration for this addon using by using a preset or by using the addon config with webpack
+You can add configuration for this addon by using a preset or by using the addon config with webpack
 
 ### Install using preset
 

--- a/addons/storysource/README.md
+++ b/addons/storysource/README.md
@@ -11,27 +11,36 @@ This addon is used to show stories source in the addon panel.
 First, install the addon
 
 ```sh
-yarn add @storybook/addon-storysource --dev
+yarn add @storybook/addon-storysource @storybook/source-loader --dev
 ```
 
-Add this line to your `addons.js` file
+You can add configuration for this addon using by using a preset or by using the addon config with webpack
+
+### Install using preset
+
+Add the following to your `.storybook/presets.js` exports:
 
 ```js
-import '@storybook/addon-storysource/register';
+module.exports = ['@storybook/addon-storysource/preset'];
 ```
 
-Use this hook to a custom webpack.config. This will generate a decorator call in every story:
+You can pass configurations into the addon-storysource loader in your `.storybook/presets.js` file, e.g.:
 
-```js
-module.exports = function({ config }) {
-  config.module.rules.push({
-    test: /\.stories\.jsx?$/,
-    loaders: [require.resolve('@storybook/source-loader')],
-    enforce: 'pre',
-  });
-
-  return config;
-};
+```javascript
+module.exports = [
+  {
+    name: '@storybook/addon-storysource/preset',
+    options: {
+      rule: {
+        // test: [/\.stories\.jsx?$/], This is default
+        include: [path.resolve(__dirname, '../src')], // You can specify directories
+      },
+      loaderOptions: {
+        prettierConfig: { printWidth: 80, singleQuote: false },
+      },
+    },
+  },
+];
 ```
 
 ## Loader Options
@@ -166,5 +175,6 @@ module.exports = function({ config }) {
 ```
 
 ## Theming
+
 Storysource will automatically use the light or dark syntax theme based on your storybook theme. See [Theming Storybook](https://storybook.js.org/docs/configurations/theming/) for more information.
 ![Storysource Light/Dark Themes](./docs/theming-light-dark.png)

--- a/addons/storysource/README.md
+++ b/addons/storysource/README.md
@@ -11,7 +11,7 @@ This addon is used to show stories source in the addon panel.
 First, install the addon
 
 ```sh
-yarn add @storybook/addon-storysource @storybook/source-loader --dev
+yarn add @storybook/addon-storysource --dev
 ```
 
 You can add configuration for this addon by using a preset or by using the addon config with webpack

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -1,52 +1,52 @@
 {
-	"name": "@storybook/addon-storysource",
-	"version": "5.3.0-alpha.20",
-	"description": "Stories addon for storybook",
-	"keywords": [
-		"addon",
-		"storybook"
-	],
-	"homepage": "https://github.com/storybookjs/storybook/tree/master/addons/storysource",
-	"bugs": {
-		"url": "https://github.com/storybookjs/storybook/issues"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/storybookjs/storybook.git",
-		"directory": "addons/storysource"
-	},
-	"license": "MIT",
-	"files": [
-		"dist/**/*",
-		"docs/**/*",
-		"README.md",
-		"*.js",
-		"*.d.ts"
-	],
-	"main": "dist/index.js",
-	"scripts": {
-		"prepare": "node ../../scripts/prepare.js"
-	},
-	"dependencies": {
-		"@storybook/addons": "5.3.0-alpha.20",
-		"@storybook/components": "5.3.0-alpha.20",
-		"@storybook/router": "5.3.0-alpha.20",
-		"@storybook/source-loader": "5.3.0-alpha.20",
-		"@storybook/theming": "5.3.0-alpha.20",
-		"core-js": "^3.0.1",
-		"estraverse": "^4.2.0",
-		"loader-utils": "^1.2.3",
-		"prettier": "^1.16.4",
-		"prop-types": "^15.7.2",
-		"react-syntax-highlighter": "^11.0.2",
-		"regenerator-runtime": "^0.13.3",
-		"util-deprecate": "^1.0.2"
-	},
-	"peerDependencies": {
-		"@storybook/source-loader": "*",
-		"react": "*"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "@storybook/addon-storysource",
+  "version": "5.3.0-alpha.20",
+  "description": "Stories addon for storybook",
+  "keywords": [
+    "addon",
+    "storybook"
+  ],
+  "homepage": "https://github.com/storybookjs/storybook/tree/master/addons/storysource",
+  "bugs": {
+    "url": "https://github.com/storybookjs/storybook/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storybookjs/storybook.git",
+    "directory": "addons/storysource"
+  },
+  "license": "MIT",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts"
+  ],
+  "main": "dist/index.js",
+  "scripts": {
+    "prepare": "node ../../scripts/prepare.js"
+  },
+  "dependencies": {
+    "@storybook/addons": "5.3.0-alpha.20",
+    "@storybook/components": "5.3.0-alpha.20",
+    "@storybook/router": "5.3.0-alpha.20",
+    "@storybook/source-loader": "5.3.0-alpha.20",
+    "@storybook/theming": "5.3.0-alpha.20",
+    "core-js": "^3.0.1",
+    "estraverse": "^4.2.0",
+    "loader-utils": "^1.2.3",
+    "prettier": "^1.16.4",
+    "prop-types": "^15.7.2",
+    "react-syntax-highlighter": "^11.0.2",
+    "regenerator-runtime": "^0.13.3",
+    "util-deprecate": "^1.0.2"
+  },
+  "peerDependencies": {
+    "@storybook/source-loader": "*",
+    "react": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -1,51 +1,52 @@
 {
-  "name": "@storybook/addon-storysource",
-  "version": "5.3.0-alpha.20",
-  "description": "Stories addon for storybook",
-  "keywords": [
-    "addon",
-    "storybook"
-  ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/master/addons/storysource",
-  "bugs": {
-    "url": "https://github.com/storybookjs/storybook/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
-    "directory": "addons/storysource"
-  },
-  "license": "MIT",
-  "files": [
-    "dist/**/*",
-    "docs/**/*",
-    "README.md",
-    "*.js",
-    "*.d.ts"
-  ],
-  "main": "dist/index.js",
-  "scripts": {
-    "prepare": "node ../../scripts/prepare.js"
-  },
-  "dependencies": {
-    "@storybook/addons": "5.3.0-alpha.20",
-    "@storybook/components": "5.3.0-alpha.20",
-    "@storybook/router": "5.3.0-alpha.20",
-    "@storybook/source-loader": "5.3.0-alpha.20",
-    "@storybook/theming": "5.3.0-alpha.20",
-    "core-js": "^3.0.1",
-    "estraverse": "^4.2.0",
-    "loader-utils": "^1.2.3",
-    "prettier": "^1.16.4",
-    "prop-types": "^15.7.2",
-    "react-syntax-highlighter": "^11.0.2",
-    "regenerator-runtime": "^0.13.3",
-    "util-deprecate": "^1.0.2"
-  },
-  "peerDependencies": {
-    "react": "*"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@storybook/addon-storysource",
+	"version": "5.3.0-alpha.20",
+	"description": "Stories addon for storybook",
+	"keywords": [
+		"addon",
+		"storybook"
+	],
+	"homepage": "https://github.com/storybookjs/storybook/tree/master/addons/storysource",
+	"bugs": {
+		"url": "https://github.com/storybookjs/storybook/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/storybookjs/storybook.git",
+		"directory": "addons/storysource"
+	},
+	"license": "MIT",
+	"files": [
+		"dist/**/*",
+		"docs/**/*",
+		"README.md",
+		"*.js",
+		"*.d.ts"
+	],
+	"main": "dist/index.js",
+	"scripts": {
+		"prepare": "node ../../scripts/prepare.js"
+	},
+	"dependencies": {
+		"@storybook/addons": "5.3.0-alpha.20",
+		"@storybook/components": "5.3.0-alpha.20",
+		"@storybook/router": "5.3.0-alpha.20",
+		"@storybook/source-loader": "5.3.0-alpha.20",
+		"@storybook/theming": "5.3.0-alpha.20",
+		"core-js": "^3.0.1",
+		"estraverse": "^4.2.0",
+		"loader-utils": "^1.2.3",
+		"prettier": "^1.16.4",
+		"prop-types": "^15.7.2",
+		"react-syntax-highlighter": "^11.0.2",
+		"regenerator-runtime": "^0.13.3",
+		"util-deprecate": "^1.0.2"
+	},
+	"peerDependencies": {
+		"@storybook/source-loader": "*",
+		"react": "*"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/addons/storysource/preset.js
+++ b/addons/storysource/preset.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/preset');

--- a/addons/storysource/src/preset.js
+++ b/addons/storysource/src/preset.js
@@ -1,0 +1,31 @@
+function webpack(webpackConfig = {}, options = {}) {
+  const { module = {} } = webpackConfig;
+  const { loaderOptions, rule = {} } = options;
+
+  return {
+    ...webpackConfig,
+    module: {
+      ...module,
+      rules: [
+        ...(module.rules || []),
+        {
+          test: [/\.stories\.(jsx?$|tsx?$)/],
+          ...rule,
+          enforce: 'pre',
+          use: [
+            {
+              loader: require.resolve('@storybook/source-loader'),
+              options: loaderOptions,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function addons(entry = []) {
+  return [...entry, require.resolve('@storybook/addon-storysource/register')];
+}
+
+module.exports = { webpack, addons };


### PR DESCRIPTION
Adding preset for Storysource addon as mentioned by @shilman  in this [PR](https://github.com/storybookjs/presets/pull/43)

## What I did
Under the storysource folder created a `preset.js` that exports from `./dist/preset` which gets compiled from `./src/preset.js`. This preset has `webpack` and `addons` which accepts `loaderOptions` and `rules` as options which can be mentioned by the user in their `presets.js`

README was also updated to include presets as an option for installation.


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
