### PR TITLE
Addon-docs: Fix React.forwardedRef/memo props

### DIFF
--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -27,11 +27,13 @@ export const getPropsTableProps = (
     const params = parameters || {};
     const { component, framework = null } = params;
 
-    const target = of === CURRENT_SELECTION ? component : of;
+    let target = of === CURRENT_SELECTION ? component : of;
     if (!target) {
       throw new Error(PropsTableError.NO_COMPONENT);
     }
-
+    if (target.render) {
+      target = target.render().type;
+    }
     const { getPropDefs = inferPropDefs(framework) } = params.docs || {};
     if (!getPropDefs) {
       throw new Error(PropsTableError.PROPS_UNSUPPORTED);

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -27,12 +27,9 @@ export const getPropsTableProps = (
     const params = parameters || {};
     const { component, framework = null } = params;
 
-    let target = of === CURRENT_SELECTION ? component : of;
+    const target = of === CURRENT_SELECTION ? component : of;
     if (!target) {
       throw new Error(PropsTableError.NO_COMPONENT);
-    }
-    if (target.render) {
-      target = target.render().type;
     }
     const { getPropDefs = inferPropDefs(framework) } = params.docs || {};
     if (!getPropDefs) {

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -31,6 +31,7 @@ export const getPropsTableProps = (
     if (!target) {
       throw new Error(PropsTableError.NO_COMPONENT);
     }
+
     const { getPropDefs = inferPropDefs(framework) } = params.docs || {};
     if (!getPropDefs) {
       throw new Error(PropsTableError.PROPS_UNSUPPORTED);

--- a/addons/docs/src/lib/getPropDefs.ts
+++ b/addons/docs/src/lib/getPropDefs.ts
@@ -84,5 +84,9 @@ const propsFromPropTypes: PropDefGetter = type => {
   return Object.values(props);
 };
 
-export const getPropDefs: PropDefGetter = type =>
-  hasDocgen(type.__docgenInfo) ? propsFromDocgen(type) : propsFromPropTypes(type);
+export const getPropDefs: PropDefGetter = type => {
+  const processedType = type.render ? type.render().type : type;
+  return hasDocgen(processedType.__docgenInfo)
+    ? propsFromDocgen(processedType)
+    : propsFromPropTypes(processedType);
+};

--- a/addons/docs/src/lib/getPropDefs.ts
+++ b/addons/docs/src/lib/getPropDefs.ts
@@ -85,7 +85,13 @@ const propsFromPropTypes: PropDefGetter = type => {
 };
 
 export const getPropDefs: PropDefGetter = type => {
-  const processedType = type.render ? type.render().type : type;
+  let processedType = type;
+  if (type.render) {
+    processedType = type.render().type;
+  }
+  if (typeof type.type === 'function') {
+    processedType = type.type().type;
+  }
   return hasDocgen(processedType.__docgenInfo)
     ? propsFromDocgen(processedType)
     : propsFromPropTypes(processedType);

--- a/examples/official-storybook/stories/addon-docs/forward-ref.stories.js
+++ b/examples/official-storybook/stories/addon-docs/forward-ref.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button } from '@storybook/react/demo';
+import DocgenButton from '../../components/DocgenButton';
 
-const ForwardedButton = React.forwardRef((props, ref) => <Button ref={ref} {...props} />);
+const ForwardedButton = React.forwardRef((props, ref) => <DocgenButton ref={ref} {...props} />);
 
 export default {
   title: 'Addons|Docs/ForwardRef',

--- a/examples/official-storybook/stories/addon-docs/forward-ref.stories.js
+++ b/examples/official-storybook/stories/addon-docs/forward-ref.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Button } from '@storybook/react/demo';
+
+const ForwardedButton = React.forwardRef((props, ref) => <Button ref={ref} {...props} />);
+
+export default {
+  title: 'Addons|Docs/ForwardRef',
+  component: ForwardedButton,
+};
+
+export const displaysCorrectly = () => <ForwardedButton>Hello World!</ForwardedButton>;
+displaysCorrectly.story = { name: 'Displays forwarded ref components correctly' };

--- a/examples/official-storybook/stories/addon-docs/react-memo.stories.js
+++ b/examples/official-storybook/stories/addon-docs/react-memo.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import DocgenButton from '../../components/DocgenButton';
+
+const ButtonWithMemo = React.memo(props => <DocgenButton {...props} />);
+
+export default {
+  title: 'Addons|Docs/ButtonWithMemo',
+  component: ButtonWithMemo,
+};
+
+export const displaysCorrectly = () => <ButtonWithMemo>Hello World!</ButtonWithMemo>;
+displaysCorrectly.story = { name: 'Displays components with memo correctly' };


### PR DESCRIPTION
Issue: #7933 

## What I did
Fix Props block rendering issue when using `React.forwardRef` by checking whether the target should be calling `render()` first to get the list of `propTypes` or not.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
