### PR TITLE
CLI: Add component meta to framework templates

### DIFF
--- a/lib/cli/generators/ANGULAR/template-csf/src/stories/0-Welcome.stories.ts
+++ b/lib/cli/generators/ANGULAR/template-csf/src/stories/0-Welcome.stories.ts
@@ -2,6 +2,7 @@ import { Welcome } from '@storybook/angular/demo';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => ({

--- a/lib/cli/generators/ANGULAR/template-csf/src/stories/1-Button.stories.ts
+++ b/lib/cli/generators/ANGULAR/template-csf/src/stories/1-Button.stories.ts
@@ -5,6 +5,7 @@ import { Button } from '@storybook/angular/demo';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => ({

--- a/lib/cli/generators/ANGULAR/template-mdx/src/stories/0-Welcome.stories.mdx
+++ b/lib/cli/generators/ANGULAR/template-mdx/src/stories/0-Welcome.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { Welcome } from '@storybook/angular/demo';
 
-<Meta title="Welcome" />
+<Meta title="Welcome" component={Welcome} />
 
 # Welcome
 

--- a/lib/cli/generators/ANGULAR/template-mdx/src/stories/1-Button.stories.mdx
+++ b/lib/cli/generators/ANGULAR/template-mdx/src/stories/1-Button.stories.mdx
@@ -4,7 +4,7 @@ import { linkTo } from '@storybook/addon-links';
 
 import { Button } from '@storybook/angular/demo';
 
-<Meta title="Button" />
+<Meta title="Button" component={Button} />
 
 # Button
 

--- a/lib/cli/generators/MARKO/template-csf/stories/index.stories.js
+++ b/lib/cli/generators/MARKO/template-csf/stories/index.stories.js
@@ -2,6 +2,7 @@ import Welcome from './components/welcome/index.marko';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const welcome = () => ({ component: Welcome });

--- a/lib/cli/generators/METEOR/template-csf/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/METEOR/template-csf/stories/0-Welcome.stories.js
@@ -4,6 +4,7 @@ import { Welcome } from '@storybook/react/demo';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => <Welcome showApp={linkTo('Button')} />;

--- a/lib/cli/generators/METEOR/template-csf/stories/1-Button.stories.js
+++ b/lib/cli/generators/METEOR/template-csf/stories/1-Button.stories.js
@@ -4,6 +4,7 @@ import { Button } from '@storybook/react/demo';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => <Button onClick={action('clicked')}>Hello Button</Button>;

--- a/lib/cli/generators/MITHRIL/template-csf/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/MITHRIL/template-csf/stories/0-Welcome.stories.js
@@ -4,6 +4,7 @@ import Welcome from './Welcome';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => ({

--- a/lib/cli/generators/MITHRIL/template-csf/stories/1-Button.stories.js
+++ b/lib/cli/generators/MITHRIL/template-csf/stories/1-Button.stories.js
@@ -4,6 +4,7 @@ import Button from './Button';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => ({

--- a/lib/cli/generators/PREACT/template-csf/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/PREACT/template-csf/stories/0-Welcome.stories.js
@@ -6,6 +6,7 @@ import Welcome from './Welcome';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => <Welcome showApp={linkTo('Button')} />;

--- a/lib/cli/generators/PREACT/template-csf/stories/1-Button.stories.js
+++ b/lib/cli/generators/PREACT/template-csf/stories/1-Button.stories.js
@@ -6,6 +6,7 @@ import Button from './Button';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => <Button onClick={action('clicked')}>Hello Button</Button>;

--- a/lib/cli/generators/RAX/template-csf/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/RAX/template-csf/stories/0-Welcome.stories.js
@@ -5,6 +5,7 @@ import Welcome from './Welcome';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => <Welcome showApp={linkTo('Button', 'with text')} />;

--- a/lib/cli/generators/REACT/template-csf/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/REACT/template-csf/stories/0-Welcome.stories.js
@@ -4,6 +4,7 @@ import { Welcome } from '@storybook/react/demo';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => <Welcome showApp={linkTo('Button')} />;

--- a/lib/cli/generators/REACT/template-csf/stories/1-Button.stories.js
+++ b/lib/cli/generators/REACT/template-csf/stories/1-Button.stories.js
@@ -4,6 +4,7 @@ import { Button } from '@storybook/react/demo';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => <Button onClick={action('clicked')}>Hello Button</Button>;

--- a/lib/cli/generators/REACT/template-mdx/stories/0-Welcome.stories.mdx
+++ b/lib/cli/generators/REACT/template-mdx/stories/0-Welcome.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { linkTo } from '@storybook/addon-links';
 import { Welcome } from '@storybook/react/demo';
 
-<Meta title="Welcome" />
+<Meta title="Welcome" component={Welcome} />
 
 # Welcome
 

--- a/lib/cli/generators/REACT/template-mdx/stories/1-Button.stories.mdx
+++ b/lib/cli/generators/REACT/template-mdx/stories/1-Button.stories.mdx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { Button } from '@storybook/react/demo';
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Button" />
+<Meta title="Button" component={Button} />
 
 # Button
 

--- a/lib/cli/generators/REACT_SCRIPTS/template-csf-ts/src/stories/0-Welcome.stories.tsx
+++ b/lib/cli/generators/REACT_SCRIPTS/template-csf-ts/src/stories/0-Welcome.stories.tsx
@@ -4,6 +4,7 @@ import { Welcome } from '@storybook/react/demo';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => <Welcome showApp={linkTo('Button')} />;

--- a/lib/cli/generators/REACT_SCRIPTS/template-csf-ts/src/stories/1-Button.stories.tsx
+++ b/lib/cli/generators/REACT_SCRIPTS/template-csf-ts/src/stories/1-Button.stories.tsx
@@ -4,6 +4,7 @@ import { Button } from '@storybook/react/demo';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => <Button onClick={action('clicked')}>Hello Button</Button>;

--- a/lib/cli/generators/REACT_SCRIPTS/template-csf/src/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/REACT_SCRIPTS/template-csf/src/stories/0-Welcome.stories.js
@@ -4,6 +4,7 @@ import { Welcome } from '@storybook/react/demo';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => <Welcome showApp={linkTo('Button')} />;

--- a/lib/cli/generators/REACT_SCRIPTS/template-csf/src/stories/1-Button.stories.js
+++ b/lib/cli/generators/REACT_SCRIPTS/template-csf/src/stories/1-Button.stories.js
@@ -4,6 +4,7 @@ import { Button } from '@storybook/react/demo';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => <Button onClick={action('clicked')}>Hello Button</Button>;

--- a/lib/cli/generators/REACT_SCRIPTS/template-mdx/src/stories/0-Welcome.stories.mdx
+++ b/lib/cli/generators/REACT_SCRIPTS/template-mdx/src/stories/0-Welcome.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { linkTo } from '@storybook/addon-links';
 import { Welcome } from '@storybook/react/demo';
 
-<Meta title="Welcome" />
+<Meta title="Welcome" component={Welcome} />
 
 # Welcome
 

--- a/lib/cli/generators/REACT_SCRIPTS/template-mdx/src/stories/1-Button.stories.mdx
+++ b/lib/cli/generators/REACT_SCRIPTS/template-mdx/src/stories/1-Button.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
 import { Button } from '@storybook/react/demo';
 
-<Meta title="Button" />
+<Meta title="Button" component={Button} />
 
 # Button
 

--- a/lib/cli/generators/SFC_VUE/template-csf/src/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/SFC_VUE/template-csf/src/stories/0-Welcome.stories.js
@@ -4,6 +4,7 @@ import Welcome from './Welcome.vue';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => ({

--- a/lib/cli/generators/SFC_VUE/template-csf/src/stories/1-Button.stories.js
+++ b/lib/cli/generators/SFC_VUE/template-csf/src/stories/1-Button.stories.js
@@ -5,6 +5,7 @@ import MyButton from './MyButton.vue';
 
 export default {
   title: 'Button',
+  component: MyButton,
 };
 
 export const text = () => ({

--- a/lib/cli/generators/SFC_VUE/template-mdx/src/stories/0-Welcome.stories.mdx
+++ b/lib/cli/generators/SFC_VUE/template-mdx/src/stories/0-Welcome.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { linkTo } from '@storybook/addon-links';
 import Welcome from './Welcome.vue';
 
-<Meta title="Welcome" />
+<Meta title="Welcome" component={Welcome} />
 
 # Welcome
 

--- a/lib/cli/generators/SFC_VUE/template-mdx/src/stories/1-Button.stories.mdx
+++ b/lib/cli/generators/SFC_VUE/template-mdx/src/stories/1-Button.stories.mdx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 import MyButton from './MyButton.vue';
 
-<Meta title="Button" />
+<Meta title="Button" component={MyButton} />
 
 # Button
 

--- a/lib/cli/generators/SVELTE/template-csf/stories/index.stories.js
+++ b/lib/cli/generators/SVELTE/template-csf/stories/index.stories.js
@@ -4,6 +4,7 @@ import Button from './button.svelte';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => ({

--- a/lib/cli/generators/VUE/template-csf/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/VUE/template-csf/stories/0-Welcome.stories.js
@@ -4,6 +4,7 @@ import Welcome from './Welcome';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => ({

--- a/lib/cli/generators/VUE/template-csf/stories/1-Button.stories.js
+++ b/lib/cli/generators/VUE/template-csf/stories/1-Button.stories.js
@@ -5,6 +5,7 @@ import MyButton from './MyButton';
 
 export default {
   title: 'Button',
+  component: MyButton,
 };
 
 export const text = () => ({

--- a/lib/cli/generators/VUE/template-mdx/stories/0-Welcome.stories.mdx
+++ b/lib/cli/generators/VUE/template-mdx/stories/0-Welcome.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { linkTo } from '@storybook/addon-links';
 import Welcome from './Welcome';
 
-<Meta title="Welcome" />
+<Meta title="Welcome" component={Welcome} />
 
 # Welcome
 

--- a/lib/cli/generators/VUE/template-mdx/stories/1-Button.stories.mdx
+++ b/lib/cli/generators/VUE/template-mdx/stories/1-Button.stories.mdx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 import MyButton from './MyButton';
 
-<Meta title="Button" />
+<Meta title="Button" component={MyButton} />
 
 # Button
 

--- a/lib/cli/generators/WEBPACK_REACT/template-csf/stories/0-Welcome.stories.js
+++ b/lib/cli/generators/WEBPACK_REACT/template-csf/stories/0-Welcome.stories.js
@@ -4,6 +4,7 @@ import { Welcome } from '@storybook/react/demo';
 
 export default {
   title: 'Welcome',
+  component: Welcome,
 };
 
 export const toStorybook = () => <Welcome showApp={linkTo('Button')} />;

--- a/lib/cli/generators/WEBPACK_REACT/template-csf/stories/1-Button.stories.js
+++ b/lib/cli/generators/WEBPACK_REACT/template-csf/stories/1-Button.stories.js
@@ -5,6 +5,7 @@ import { Button } from '@storybook/react/demo';
 
 export default {
   title: 'Button',
+  component: Button,
 };
 
 export const text = () => <Button onClick={action('clicked')}>Hello Button</Button>;

--- a/lib/cli/generators/WEBPACK_REACT/template-mdx/stories/0-Welcome.stories.mdx
+++ b/lib/cli/generators/WEBPACK_REACT/template-mdx/stories/0-Welcome.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { linkTo } from '@storybook/addon-links';
 import { Welcome } from '@storybook/react/demo';
 
-<Meta title="Welcome" />
+<Meta title="Welcome" component={Welcome} />
 
 # Welcome
 

--- a/lib/cli/generators/WEBPACK_REACT/template-mdx/stories/1-Button.stories.mdx
+++ b/lib/cli/generators/WEBPACK_REACT/template-mdx/stories/1-Button.stories.mdx
@@ -1,8 +1,8 @@
+import { Meta, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
 import { Button } from '@storybook/react/demo';
-import { Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Button" />
+<Meta title="Button" component={Button} />
 
 # Button
 


### PR DESCRIPTION
Issue: #7543 

## What I did

Added `export default { component: XXX }` to all templates where there is a clear component used. Currently this is only useful for React and Vue, but eventually it will be used to auto generate prop tables for all frameworks.

## How to test

```
cd lib/cli
yarn test
```
