### PR TITLE
Fix 'path is required in .pageview()' in GA addon

### DIFF
--- a/addons/google-analytics/src/register.ts
+++ b/addons/google-analytics/src/register.ts
@@ -8,8 +8,8 @@ addons.register('storybook/google-analytics', api => {
   ReactGA.initialize(window.STORYBOOK_GA_ID);
 
   api.on(STORY_CHANGED, () => {
-    const { url } = api.getUrlState();
-    ReactGA.pageview(url);
+    const { path } = api.getUrlState();
+    ReactGA.pageview(path);
   });
   api.on(STORY_ERRORED, ({ description }: { description: string }) => {
     ReactGA.exception({


### PR DESCRIPTION
See https://github.com/storybookjs/storybook/issues/6012

This uses the fix in https://github.com/thundermiracle/storybook-loader/pull/19/files. Not tested - I don't have Typescript running locally.