### PR TITLE
Fix react native style

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/addons/index.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/addons/index.tsx
@@ -14,7 +14,7 @@ const NoAddonContainer = styled.View({
 
 const Container = styled.View(({ theme }) => ({
   flex: 1,
-  background: theme.backgroundColor,
+  backgroundColor: theme.backgroundColor,
 }));
 
 export default class Addons extends PureComponent<{}, { addonSelected: string }> {

--- a/app/react-native/src/preview/components/OnDeviceUI/navigation/bar.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/navigation/bar.tsx
@@ -6,7 +6,7 @@ import { NAVIGATOR, PREVIEW, ADDONS } from './constants';
 const Container = styled.View(({ theme }) => ({
   flexDirection: 'row',
   paddingHorizontal: 8,
-  background: theme.backgroundColor,
+  backgroundColor: theme.backgroundColor,
   borderTopWidth: 1,
   borderBottomWidth: 1,
   borderColor: theme.borderColor,

--- a/app/react-native/src/preview/components/OnDeviceUI/navigation/button.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/navigation/button.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity } from 'react-native';
 import styled from '@emotion/native';
 
 const ActiveBorder = styled.View<{ active: boolean }>(({ active, theme }) => ({
-  background: active ? theme.borderColor : 'transparent',
+  backgroundColor: active ? theme.borderColor : 'transparent',
   height: 3,
 }));
 

--- a/app/react-native/src/preview/components/OnDeviceUI/navigation/visibility-button.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/navigation/visibility-button.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const Touchable = styled.TouchableOpacity({
-  background: 'transparent',
+  backgroundColor: 'transparent',
   position: 'absolute',
   right: '8',
   bottom: '12',

--- a/app/react-native/src/preview/components/OnDeviceUI/panel.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/panel.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Animated } from 'react-native';
 import styled from '@emotion/native';
 
 const Container = styled(Animated.View)(({ theme }) => ({
-  background: theme.backgroundColor,
+  backgroundColor: theme.backgroundColor,
 }));
 
 interface Props {

--- a/app/react-native/src/preview/components/StoryListView/index.tsx
+++ b/app/react-native/src/preview/components/StoryListView/index.tsx
@@ -18,7 +18,7 @@ const SearchBar = styled.TextInput(
     paddingVertical: 5,
   },
   ({ theme }) => ({
-    background: theme.borderColor,
+    backgroundColor: theme.borderColor,
     color: theme.buttonActiveTextColor,
   })
 );

--- a/app/react-native/src/preview/components/StoryListView/index.tsx
+++ b/app/react-native/src/preview/components/StoryListView/index.tsx
@@ -24,7 +24,7 @@ const SearchBar = styled.TextInput(
 );
 
 const HeaderContainer = styled.View({
-  paddingCertical: 5,
+  paddingVertical: 5,
 });
 
 interface SectionProps {


### PR DESCRIPTION
Issue: warning in crna-kitchen-sink app: 
```Warning: Failed prop type: Invalid props.style key `background` supplied to `TextInput`.```

There is no `background` style property for View components, it should be `backgroundColor` instead.

## What I did

Replaced `background` style prop with `backgroundColor`.
Fixed typo in `paddingCertical` style prop.

Before and after screenshots:
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/1106887/67138311-60257200-f26b-11e9-89d4-24a2a8df5bba.png">


## How to test

- I think it should be type error for these cases

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
