### PR TITLE
React-native-server: Convert port to number in CLI options

### DIFF
--- a/app/react-native-server/src/server/cli.js
+++ b/app/react-native-server/src/server/cli.js
@@ -8,7 +8,7 @@ export function parseList(str) {
 function getCli() {
   program
     .option('-h, --host <host>', 'host to listen on', 'localhost')
-    .option('-p, --port <port>', 'port to listen on', 7007)
+    .option('-p, --port <port>', 'port to listen on', str => parseInt(str, 10), '7007')
     .option('-e, --environment [environment]', 'DEVELOPMENT/PRODUCTION environment for webpack')
     .option('-i, --manual-id', 'allow multiple users to work with same storybook')
     .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')


### PR DESCRIPTION
Issue: #8487 
The issue is caused by comparison operation between string and number ie: port specified via CLI and available port

## What I did
Converting port type to number in CLI options parser

## How to test
This will fix the above-mentioned issue
