### PR TITLE
feat: allow upercase path names in url query param

### DIFF
--- a/lib/router/src/utils.ts
+++ b/lib/router/src/utils.ts
@@ -46,7 +46,11 @@ export const parsePath: (path?: string) => StoryData = memoize(1000)(
     };
 
     if (path) {
-      const [, viewMode, storyId] = path.match(splitPathRegex) || [undefined, undefined, undefined];
+      const [, viewMode, storyId] = path.toLowerCase().match(splitPathRegex) || [
+        undefined,
+        undefined,
+        undefined,
+      ];
       if (viewMode) {
         Object.assign(result, {
           viewMode,


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8500

## What I did

allow the path-query param to be case insensitive

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? yes --> e.g. if you go to https://monorepo-git-fork-panter-f-make-path-case-insensitive.storybook.now.sh/angular-cli/?path=/story/Custom-Pipes--simple you wont get redirected to the first story
- Does this need an update to the documentation? no


