### PR TITLE
Typescript: add types for react demo

### DIFF
--- a/app/react/demo.d.ts
+++ b/app/react/demo.d.ts
@@ -16,7 +16,7 @@ declare const Welcome: {
 
 declare const Button: {
     ({ children, onClick, }: {
-        children: React.ReactChildren;
+        children: React.ReactNode;
         onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     }): JSX.Element;
     displayName: string;

--- a/app/react/demo.d.ts
+++ b/app/react/demo.d.ts
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+declare const Welcome: {
+    ({ showApp }: {
+        showApp: () => void;
+    }): JSX.Element;
+    displayName: string;
+    propTypes: {
+        showApp: PropTypes.Requireable<(...args: any[]) => any>;
+    };
+    defaultProps: {
+        showApp: any;
+    };
+};
+
+declare const Button: {
+    ({ children, onClick, }: {
+        children: React.ReactChildren;
+        onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+    }): JSX.Element;
+    displayName: string;
+    propTypes: {
+        children: PropTypes.Validator<PropTypes.ReactNodeLike>;
+        onClick: PropTypes.Requireable<(...args: any[]) => any>;
+    };
+    defaultProps: {
+        onClick: () => void;
+    };
+};
+
+export { Welcome, Button };


### PR DESCRIPTION
Issue:
When I use the demo story files generated by the cli, and change the file name from `.stories.js` to `.stories.tsx`, the two demo components provided in the `react` package causes the following error.

```
import {Welcome} from '@storybook/react/demo'; // Could not find a declaration file for module '@storybook/react/demo'. 
```

This is because the generated typings for the demo components are not included in the root folder of `react`, `@storybook/react/demo`

## What I did

Added `d.ts` file for demo components in root directory of react.

## How to test

Adding `d.ts` file in the root directory of react made the error go away, and the auto completion properly worked as expected.

`files` property in `package.json` includes `*.d.ts`, so this `d.ts` file will be included when user installs the `@storybook/react` package.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
