### PR TITLE
documentation - remove extra word in addons/info readme

### DIFF
--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -39,7 +39,7 @@ storiesOf('Component', module)
 ```
 
 Then, you can use the `info` parameter to either pass certain options or specific documentation text to your stories.
-A complete list of possible configurations can be found at [in a later section](#setting-global-options).
+A complete list of possible configurations can be found [in a later section](#setting-global-options).
 This can be done per book of stories:
 
 ```js


### PR DESCRIPTION
Issue: extra word in addons/info readme

## What I did

s/can be found at in a later section./can be found in a later section.


## How to test

View the addons/info readme.