### PR TITLE
Increase TooltipLinkList max-height to accommodate more links

### DIFF
--- a/lib/components/src/tooltip/TooltipLinkList.tsx
+++ b/lib/components/src/tooltip/TooltipLinkList.tsx
@@ -8,7 +8,7 @@ const List = styled.div<{}>(
     minWidth: 180,
     overflow: 'hidden',
     overflowY: 'auto',
-    maxHeight: 10.5 * 32, // 10.5 items
+    maxHeight: 20.5 * 32, // 20.5 items
   },
   ({ theme }) => ({
     borderRadius: theme.appBorderRadius * 2,


### PR DESCRIPTION
Issue: #8509 

## What I did
Increase the max-height value to accommodate up to 20 items

## How to test

```shell
cd examples/official-storybook
yarn storybook
```

## Note
The same hard limit also exists in docs/src/new-components/basics/tooltip/TooltipLinkList.js but it doesn't seem to be used (at least with a fast search in source code) so I didn't touch it
