### PR TITLE
update popover max-height to be calculated based on correct number of items

### DIFF
--- a/docs/src/new-components/basics/tooltip/TooltipLinkList.js
+++ b/docs/src/new-components/basics/tooltip/TooltipLinkList.js
@@ -7,7 +7,7 @@ const List = styled.div`
   min-width: 180px;
   overflow: hidden;
   overflow-y: auto;
-  maxheight: ${10.5 * 32 /* 10.5 items */};
+  maxheight: ${11.5 * 32 /* 11.5 items */};
 `;
 
 function TooltipLinkList({ links, LinkWrapper }) {

--- a/lib/components/src/tooltip/TooltipLinkList.tsx
+++ b/lib/components/src/tooltip/TooltipLinkList.tsx
@@ -8,7 +8,7 @@ const List = styled.div<{}>(
     minWidth: 180,
     overflow: 'hidden',
     overflowY: 'auto',
-    maxHeight: 20.5 * 32, // 20.5 items
+    maxHeight: 11.5 * 32, // 11.5 items
   },
   ({ theme }) => ({
     borderRadius: theme.appBorderRadius * 2,


### PR DESCRIPTION
… items

Issue: 3 dot menu popup was scrolling unneccesarily

## What I did

Updated Popup max Height calculation to calculate off 11.5 items rather than 10.5

## How to test

Open in browser
