### PR TITLE
Added example of a decorator in Storybook config

### DIFF
--- a/docs/src/pages/addons/introduction/index.md
+++ b/docs/src/pages/addons/introduction/index.md
@@ -94,7 +94,18 @@ storiesOf('Button', module)
   ));
 ```
 
-> You can call `addDecorator()` inside the story definition file as shown above. But adding it to the Storybook config file is a much better option.
+You can call `addDecorator()` inside the story definition file as shown above, but **adding it to the Storybook config file is a much better option**. That would look like this in `config.js`:
+
+```js
+import React from 'react'
+import { addDecorator } from '@storybook/react';
+
+const styles = {
+  textAlign: 'center',
+};
+const CenterDecorator = storyFn => <div style={styles}>{storyFn()}</div>;
+addDecorator(CenterDecorator);
+```
 
 ## 2. Native Addons
 


### PR DESCRIPTION
There was previously text on this page that recommends adding decorators to the Storybook config, but doesn't show how to do that. I was confused about this at first, so when I figured it out I decided to add it to the docs.

Issue:

## What I did
Added an example to the docs

## How to test
N/A
- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
