### PR TITLE
Addon-docs: Publish web-components preset

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -25,6 +25,7 @@
     "html/**/*",
     "react/**/*",
     "vue/**/*",
+    "web-components/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/lib/cli/generators/WEB-COMPONENTS/index.js
+++ b/lib/cli/generators/WEB-COMPONENTS/index.js
@@ -10,7 +10,7 @@ import {
 } from '../../lib/helpers';
 
 export default async npmOptions => {
-  const storybookVersion = await getVersion(npmOptions, '@storybook/html');
+  const storybookVersion = await getVersion(npmOptions, '@storybook/web-components');
   fse.copySync(path.resolve(__dirname, 'template/'), '.', { overwrite: true });
 
   let packageJson = getPackageJson();
@@ -30,5 +30,8 @@ export default async npmOptions => {
 
   const babelDependencies = await getBabelDependencies(npmOptions, packageJson);
 
-  installDependencies(npmOptions, [`@storybook/html@${storybookVersion}`, ...babelDependencies]);
+  installDependencies(npmOptions, [
+    `@storybook/web-components@${storybookVersion}`,
+    ...babelDependencies,
+  ]);
 };


### PR DESCRIPTION
Issue:

docs preset for web-components is on git but not in the npm artifact
https://unpkg.com/browse/@storybook/addon-docs@5.3.0-alpha.27/

I forgot to add it to the npm files 🙈 

this fixes it 👍 

Side fix: actually install web-components app in the generator