### PR TITLE
Addon-docs: Modify Typeset doc block to accept units

### DIFF
--- a/lib/components/src/blocks/Typeset.stories.tsx
+++ b/lib/components/src/blocks/Typeset.stories.tsx
@@ -6,7 +6,7 @@ export default {
   component: Typeset,
 };
 
-const fontSizes = [12, 14, 16, 20, 24, 32, 40, 48];
+const fontSizes = ['12px', '14px', '16px', '20px', '24px', '32px', '40px', '48px'];
 const fontWeight = 900;
 
 export const withFontSizes = () => <Typeset fontSizes={fontSizes} />;

--- a/lib/components/src/blocks/Typeset.tsx
+++ b/lib/components/src/blocks/Typeset.tsx
@@ -35,7 +35,7 @@ const Wrapper = styled.div<{}>(withReset, ({ theme }) => ({
 }));
 
 export interface TypesetProps {
-  fontSizes: number[];
+  fontSizes: string[];
   fontWeight?: number;
   sampleText?: string;
 }
@@ -51,12 +51,12 @@ export const Typeset: FunctionComponent<TypesetProps> = ({
   ...props
 }) => (
   <Wrapper {...props} className="docblock-typeset">
-    {fontSizes.map(num => (
-      <TypeSpecimen key={num}>
-        <Label>{num}px</Label>
+    {fontSizes.map(size => (
+      <TypeSpecimen key={size}>
+        <Label>{size}</Label>
         <Sample
           style={{
-            fontSize: num,
+            fontSize: size,
             fontWeight,
           }}
         >


### PR DESCRIPTION
Issue: #8568

## What I did
- Changed `fontSizes` property of Typeset component to accept array of strings (size with units) instead of numbers
- Added units to font sizes in Typesets.stories.tsx

## How to test

Change Typeset.stories.tsx so that it will have rems or ems instead of px. Also example with px still should work

- Is this testable with Jest or Chromatic screenshots? yes (no changes needed)
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? not sure

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
