### PR TITLE
Fix typo compponent to component

### DIFF
--- a/lib/codemod/src/transforms/csf-to-mdx.js
+++ b/lib/codemod/src/transforms/csf-to-mdx.js
@@ -37,7 +37,7 @@ function parseIncludeExclude(prop) {
 }
 
 /**
- * Convert a compponent's module story file into an MDX file
+ * Convert a component's module story file into an MDX file
  *
  * For example:
  *

--- a/lib/codemod/src/transforms/mdx-to-csf.js
+++ b/lib/codemod/src/transforms/mdx-to-csf.js
@@ -4,7 +4,7 @@ import prettier from 'prettier';
 import { sanitizeName } from '../lib/utils';
 
 /**
- * Convert a compponent's MDX file into module story format
+ * Convert a component's MDX file into module story format
  */
 export default function transformer(file, api) {
   const j = api.jscodeshift;


### PR DESCRIPTION
## What I did
Fixed a typo from `compponent` to `component`