### PR TITLE
WC-kitchen-sink: Add babel-loader dependency

### DIFF
--- a/examples/web-components-kitchen-sink/package.json
+++ b/examples/web-components-kitchen-sink/package.json
@@ -32,6 +32,7 @@
     "@storybook/core-events": "5.3.0-alpha.29",
     "@storybook/source-loader": "5.3.0-alpha.29",
     "@storybook/web-components": "5.3.0-alpha.29",
+    "babel-loader": "^8.0.5",
     "eventemitter3": "^4.0.0",
     "format-json": "^1.0.3",
     "global": "^4.3.2",


### PR DESCRIPTION
Issue: N/A

## What I did

Addded missing dependency to allow `web-components-kitchen-sink` to run outside of the repo cc @daKmoR 

## How to test

```
cp -r examples/web-components-kitchen-sink /tmp
cd /tmp/web-components-kitchen-sink
yarn && yarn storybook
```

