### PR TITLE
Web-components: Use framework id 'web-components'

### DIFF
--- a/app/web-components/src/client/preview/index.ts
+++ b/app/web-components/src/client/preview/index.ts
@@ -6,7 +6,7 @@ import './globals';
 import render from './render';
 import { StoryFnHtmlReturnType, IStorybookSection } from './types';
 
-const framework = 'html';
+const framework = 'web-components';
 
 interface ClientApi extends ClientStoryApi<StoryFnHtmlReturnType> {
   setAddon(addon: any): void;


### PR DESCRIPTION
Issue: N/A

## What I did

Use `web-components` framework identifier. `html` is already used by `@storybook/html` cc @daKmoR 