### PR TITLE
Add default value for active to avoid error in Mobile layout

### DIFF
--- a/lib/ui/src/components/layout/mobile.js
+++ b/lib/ui/src/components/layout/mobile.js
@@ -128,7 +128,7 @@ class Mobile extends Component {
 
     const { options } = props;
     this.state = {
-      active: options.initialActive,
+      active: options.initialActive || 0,
     };
   }
 


### PR DESCRIPTION
Issue: #5910 

## What I did
Not sure if this is the right approach, but I added a default value for the `active` value in Mobile component to silence the error.