### PR TITLE
React-native-server: Changed default port to number in CLI options

### DIFF
--- a/app/react-native-server/src/server/cli.js
+++ b/app/react-native-server/src/server/cli.js
@@ -8,7 +8,7 @@ export function parseList(str) {
 function getCli() {
   program
     .option('-h, --host <host>', 'host to listen on', 'localhost')
-    .option('-p, --port <port>', 'port to listen on', str => parseInt(str, 10), '7007')
+    .option('-p, --port <port>', 'port to listen on', str => parseInt(str, 10), 7007)
     .option('-e, --environment [environment]', 'DEVELOPMENT/PRODUCTION environment for webpack')
     .option('-i, --manual-id', 'allow multiple users to work with same storybook')
     .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')


### PR DESCRIPTION
Issue: related to #8487
While fixing the above issue in #8491 I accidentally introduces same bug for default port. This PR is a fix for that

## What I did
Changed default port from string to number 
