### PR TITLE
Typescript: Use native package types now available

### DIFF
--- a/addons/knobs/src/typings.d.ts
+++ b/addons/knobs/src/typings.d.ts
@@ -1,2 +1,1 @@
 declare module 'global';
-declare module '@storybook/client-api';

--- a/lib/addons/src/typings.d.ts
+++ b/lib/addons/src/typings.d.ts
@@ -1,3 +1,1 @@
 declare module 'global';
-declare module '@storybook/client-logger';
-declare module '@storybook/addons';

--- a/lib/ui/src/settings/typings.d.ts
+++ b/lib/ui/src/settings/typings.d.ts
@@ -1,3 +1,2 @@
 declare module 'global';
-declare module '@storybook/client-logger';
 declare module '@storybook/components/src/treeview/utils';


### PR DESCRIPTION
minor cleanup, these packages have types now, and so putting them in the typings.d.ts removes types