### PR TITLE
Addon-docs: Generalize Description doc block

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 - [Migration](#migration)
   - [From version 5.2.x to 5.3.x](#from-version-52x-to-53x)
     - [Create React App preset](#create-react-app-preset)
+    - [Description docs block](#description-docs-block)
   - [From version 5.1.x to 5.2.x](#from-version-51x-to-52x)
     - [Source-loader](#source-loader)
     - [Default viewports](#default-viewports)
@@ -76,6 +77,14 @@
 You can now move to the new preset for [Create React App](https://create-react-app.dev/). The in-built preset for Create React App will be disabled in Storybook 6.0.
 
 Simply install [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app) and it will be used automatically.
+
+### Description doc block
+
+In 5.3 we've changed `addon-docs`'s `Description` doc block's default behavior. Technically this is a breaking change, but MDX was not officially released in 5.2 and we reserved the right to make small breaking changes. The behavior of `DocsPage`, which was officially released, remains unchanged.
+
+The old behavior of `<Description of={Component} />` was to concatenate the info parameter or notes parameter, if available, with the docgen information loaded from source comments. If you depend on the old behavior, it's still available with `<Description of={Component} type='legacy-5.2' />`. This description type will be removed in Storybook 6.0.
+
+The new default behavior is to use the framework-specific description extractor, which for React/Vue is still docgen, but may come from other places (e.g. a JSON file) for other frameworks.
 
 ## From version 5.1.x to 5.2.x
 

--- a/addons/docs/docs/multiframework.md
+++ b/addons/docs/docs/multiframework.md
@@ -4,6 +4,7 @@ Storybook Docs [provides basic support for all non-RN Storybook view layers](../
 
 - [Adding a preset](#adding-a-preset)
 - [Props tables](#props-tables)
+- [Component descriptions](#component-descriptions)
 - [Inline story rendering](#inline-story-rendering)
 
 ## Adding a preset
@@ -76,6 +77,12 @@ So far, in React and Vue, the implementation of this extraction is as follows:
 - The view-layer specific `extractProps` function translates that metadata into `PropsTableProps`
 
 However, for your framework you may want to implement this in some other way. There is also an effort to load data from static JSON files for performance [#7942](https://github.com/storybookjs/storybook/issues/7942).
+
+## Component descriptions
+
+Component descriptions are enabled by the `docs.extractComponentDescription` parameter, which extract's a component description (usually from source code comments) into a markdown string.
+
+It follows the pattern of [Props tables](#props-tables) above, only it's even simpler because the function output is simply a string (or null if there no description).
 
 ## Inline story rendering
 

--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -4,7 +4,7 @@ import { parseKind } from '@storybook/router';
 import { DocsPage as PureDocsPage, PropsTable, PropsTableProps } from '@storybook/components';
 import { H2, H3 } from '@storybook/components/html';
 import { DocsContext } from './DocsContext';
-import { Description, getDocgen } from './Description';
+import { Description } from './Description';
 import { Story } from './Story';
 import { Preview } from './Preview';
 import { Anchor } from './Anchor';
@@ -64,8 +64,13 @@ const defaultSubtitleSlot: StringSlot = ({ parameters }) =>
 
 const defaultPropsSlot: PropsSlot = context => getPropsTableProps({ of: '.' }, context);
 
-const defaultDescriptionSlot: StringSlot = ({ parameters }) =>
-  parameters && getDocgen(parameters.component);
+const defaultDescriptionSlot: StringSlot = ({ parameters: { component, docs } }) => {
+  if (!component) {
+    return null;
+  }
+  const { extractComponentDescription } = docs || {};
+  return extractComponentDescription && extractComponentDescription(component);
+};
 
 const defaultPrimarySlot: StorySlot = stories => stories && stories[0];
 const defaultStoriesSlot: StoriesSlot = stories => {

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -3,7 +3,7 @@ import { PropsTable, PropsTableError, PropsTableProps } from '@storybook/compone
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { Component, CURRENT_SELECTION } from './shared';
 
-import { PropsExtractor } from '../lib/propsUtils';
+import { PropsExtractor } from '../lib/docgenUtils';
 import { extractProps as reactExtractProps } from '../frameworks/react/extractProps';
 import { extractProps as vueExtractProps } from '../frameworks/vue/extractProps';
 

--- a/addons/docs/src/frameworks/common/index.ts
+++ b/addons/docs/src/frameworks/common/index.ts
@@ -1,1 +1,1 @@
-export * from '../../lib/propsUtils';
+export * from '../../lib/docgenUtils';

--- a/addons/docs/src/frameworks/react/config.js
+++ b/addons/docs/src/frameworks/react/config.js
@@ -2,6 +2,7 @@
 import { addParameters } from '@storybook/react';
 import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 import { extractProps } from './extractProps';
+import { extractComponentDescription } from '../../lib/docgenUtils';
 
 addParameters({
   docs: {
@@ -11,5 +12,6 @@ addParameters({
     // NOTE: that the result is a react element. Hooks support is provided by the outer code.
     prepareForInline: storyFn => storyFn(),
     extractProps,
+    extractComponentDescription,
   },
 });

--- a/addons/docs/src/frameworks/react/extractProps.ts
+++ b/addons/docs/src/frameworks/react/extractProps.ts
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 import { isForwardRef, isMemo } from 'react-is';
 import { PropDef } from '@storybook/components';
-import { PropDefGetter, PropsExtractor, propsFromDocgen, hasDocgen } from '../../lib/propsUtils';
+import { PropDefGetter, PropsExtractor, propsFromDocgen, hasDocgen } from '../../lib/docgenUtils';
 
 export interface PropDefMap {
   [p: string]: PropDef;

--- a/addons/docs/src/frameworks/vue/config.js
+++ b/addons/docs/src/frameworks/vue/config.js
@@ -4,6 +4,7 @@ import toReact from '@egoist/vue-to-react';
 import { addParameters } from '@storybook/vue';
 import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 import { extractProps } from './extractProps';
+import { extractComponentDescription } from '../../lib/docgenUtils';
 
 addParameters({
   docs: {
@@ -14,5 +15,6 @@ addParameters({
       return <Story />;
     },
     extractProps,
+    extractComponentDescription,
   },
 });

--- a/addons/docs/src/frameworks/vue/extractProps.ts
+++ b/addons/docs/src/frameworks/vue/extractProps.ts
@@ -1,5 +1,5 @@
 import { PropDef } from '@storybook/components';
-import { PropsExtractor, propsFromDocgen, hasDocgen } from '../../lib/propsUtils';
+import { PropsExtractor, propsFromDocgen, hasDocgen } from '../../lib/docgenUtils';
 
 const SECTIONS = ['props', 'events', 'slots'];
 

--- a/addons/docs/src/lib/docgenUtils.ts
+++ b/addons/docs/src/lib/docgenUtils.ts
@@ -6,6 +6,16 @@ export type PropsExtractor = (component: Component) => PropsTableProps | null;
 
 export type PropDefGetter = (type: Component, section: string) => PropDef[] | null;
 
+export const str = (o: any) => {
+  if (!o) {
+    return '';
+  }
+  if (typeof o === 'string') {
+    return o as string;
+  }
+  throw new Error(`Description: expected string, got: ${JSON.stringify(o)}`);
+};
+
 export const hasDocgen = (obj: any) => !!obj.__docgenInfo;
 
 export const hasDocgenSection = (obj: any, section: string) =>
@@ -36,3 +46,6 @@ export const propsFromDocgen: PropDefGetter = (type, section) => {
 
   return Object.values(props);
 };
+
+export const extractComponentDescription = (component?: Component) =>
+  component && component.__docgenInfo && str(component.__docgenInfo.description);

--- a/examples/official-storybook/stories/addon-docs/addon-docs.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/addon-docs.stories.mdx
@@ -112,7 +112,7 @@ export const nonStory2 = () => <Button>Not a story</Button>; // another one
 
 <Description markdown="this is _markdown_" />
 
-<Description of={Button} />
+<Description of={DocgenButton} />
 
 ## Props
 

--- a/examples/official-storybook/stories/addon-info/react-docgen.stories.js
+++ b/examples/official-storybook/stories/addon-info/react-docgen.stories.js
@@ -9,6 +9,7 @@ import { NamedExportButton } from '../../components/NamedExportButton';
 
 export default {
   title: 'Addons|Info/React Docgen',
+  component: DocgenButton,
   decorators: [withInfo],
 };
 


### PR DESCRIPTION
Issue: #8586 

## What I did

- [x] Introduced an `docs.extractComponentDescription` parameter
- [x] Implemented for React & Vue
- [x] Changed `Description` doc block default behavior & documented in `MIGRATION.md`
- [x] Added to Docs "first-class framework support" checklist

## How to test

- official-storybook
- vue-kitchen-sink
- etc.
