### PR TITLE
Addon-docs: Fix story scroll-to heuristics

### DIFF
--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -54,9 +54,14 @@ export const DocsContainer: FunctionComponent<DocsContainerProps> = ({ context, 
       element = document.getElementById(storyBlockIdFromId(storyId));
     }
     if (element) {
+      const allStories = element.parentElement.querySelectorAll('[id|="anchor-"]');
+      let block = 'start';
+      if (allStories && allStories[0] === element) {
+        block = 'end'; // first story should be shown with the intro content above
+      }
       element.scrollIntoView({
         behavior: 'smooth',
-        block: 'end',
+        block,
         inline: 'nearest',
       });
     }

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -270,7 +270,7 @@ export default function start(render, { decorateStory } = {}) {
     previousViewMode = viewMode;
     previousId = id;
 
-    if (!forceRender) {
+    if (!forceRender && viewMode !== 'docs') {
       document.documentElement.scrollTop = 0;
     }
   };


### PR DESCRIPTION
Issue: #8286

## What I did

In Docs mode:
- When selecting a story in the left menu scrolling was always starting from top.
- Now it goes from story to story. 
- First story get's scrolled to "end" to show intro above. 
- Otherwise, scroll to "start".

## How to test

Open [web components kitchen sink](https://monorepo-2693dpw9q.now.sh/web-components-kitchen-sink/?path=/docs/demo-card--front) and click on multiple stories in docs mode

## Preview
left old - right new

![Kapture 2019-10-29 at 23 48 05](https://user-images.githubusercontent.com/24378/67815542-7c18e700-faa7-11e9-9df8-424879714cdd.gif)
