### PR TITLE
Addon-docs: Fix props table in no props case

### DIFF
--- a/lib/components/src/blocks/PropsTable/PropsTable.tsx
+++ b/lib/components/src/blocks/PropsTable/PropsTable.tsx
@@ -165,15 +165,15 @@ const PropsTable: FC<PropsTableProps> = props => {
     return <EmptyBlock>{error}</EmptyBlock>;
   }
 
-  let allRows: any[];
+  let allRows: any[] = [];
   const { sections } = props as PropsTableSectionsProps;
+  const { rows } = props as PropsTableRowsProps;
   if (sections) {
-    allRows = [];
     Object.keys(sections).forEach(section => {
-      const rows = sections[section];
-      if (rows && rows.length > 0) {
+      const sectionRows = sections[section];
+      if (sectionRows && sectionRows.length > 0) {
         allRows.push({ key: section, value: { section } });
-        rows.forEach(row => {
+        sectionRows.forEach(row => {
           allRows.push({
             key: `${section}_${row.name}`,
             value: { row },
@@ -181,8 +181,7 @@ const PropsTable: FC<PropsTableProps> = props => {
         });
       }
     });
-  } else {
-    const { rows } = props as PropsTableRowsProps;
+  } else if (rows) {
     allRows = rows.map(row => ({
       key: row.name,
       value: { row },


### PR DESCRIPTION
Issue: #8123 

## What I did

Fix a bug in generalized props table handling where no rows are provided.

## How to test

See `Docs` tab for the story `Brand > Storybook Logo` which is broken before this fix. (NOTE: we need a better way of testing docs tab?!)
