### PR TITLE
Addon-notes: Add key to render function

### DIFF
--- a/addons/notes/src/register.tsx
+++ b/addons/notes/src/register.tsx
@@ -13,7 +13,7 @@ export default function register(type: types) {
       title: 'Notes',
       route: ({ storyId }) => `/info/${storyId}`, // todo add type
       match: ({ viewMode }) => viewMode === 'info', // todo add type
-      render: ({ active }) => <Panel api={api} active={active} />,
+      render: ({ active, key }) => <Panel api={api} active={active} key={key} />,
       paramKey: PARAM_KEY,
     });
   });


### PR DESCRIPTION
Issue: #7005 

![image](https://user-images.githubusercontent.com/35371660/67832602-85489900-fb25-11e9-9c10-49ef314b8e12.png)

## What I did

* add key to addon-notes register 

## How to test

- Is this testable with Jest or Chromatic screenshots? 
- Does this need a new example in the kitchen sink apps? NO
- Does this need an update to the documentation? NO

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
