### PR TITLE
Fix 8074 invisible hr styles in typography components

### DIFF
--- a/examples/official-storybook/stories/addon-notes.stories.js
+++ b/examples/official-storybook/stories/addon-notes.stories.js
@@ -40,6 +40,8 @@ export class FromComponent {
 }
 ~~~
 
+---
+
 ### html with special formatting
 ~~~html
 <foo-outer property-a="value"

--- a/examples/official-storybook/stories/notes/notes.md
+++ b/examples/official-storybook/stories/notes/notes.md
@@ -2,6 +2,8 @@
 
 #### It is imported and compiled using a webpack markdown loader
 
+---
+
 Supports code snippets too:
 
 ```jsx

--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -113,7 +113,7 @@ export const A = styled.a<{}>(withReset, ({ theme }) => ({
 
 export const HR = styled.hr<{}>(({ theme }) => ({
   border: '0 none',
-  color: theme.appBorderColor,
+  borderTop: `1px solid ${theme.appBorderColor}`,
   height: '4px',
   padding: '0',
 }));

--- a/lib/components/src/typography/DocumentFormattingSample.md
+++ b/lib/components/src/typography/DocumentFormattingSample.md
@@ -95,6 +95,10 @@ var foo = function(bar) {
 console.log(foo(5));
 ```
 
+## Horizontal Rule
+
+---
+
 ## Tables
 
 | Option | Description                                                               |

--- a/lib/components/src/typography/DocumentWrapper.stories.tsx
+++ b/lib/components/src/typography/DocumentWrapper.stories.tsx
@@ -114,6 +114,8 @@ export const withDOM = () => (
       <li>foo</li>
       <li>bar</li>
     </ol>
+    <h2>Horizontal Rule</h2>
+    <hr />
     <h2>Tables</h2>
     <table>
       <thead>

--- a/lib/components/src/typography/DocumentWrapper.tsx
+++ b/lib/components/src/typography/DocumentWrapper.tsx
@@ -179,7 +179,7 @@ export const DocumentWrapper = styled.div(
 
     hr {
       border: 0 none;
-      color: ${theme.appBorderColor};
+      border-top: 1px solid ${theme.appBorderColor};
       height: 4px;
       padding: 0;
     }


### PR DESCRIPTION
Issue: #8074 

Horizontal rule styling from Markdown was rendering invisible in DocumentWrapper and DocumentFormatting, and especially impacted the notes addon.

## What I did
Added horizontal rule to markdown examples in Notes and DocumentFormatting in examples/official-storybook.

Updated hr css styles in DocumentWrapper and DocumentFormatting to use border-top, consistent with global theming in https://github.com/storybookjs/storybook/blob/master/lib/theming/src/global.ts#L109

## How to test
View DocumentFormatting at https://monorepo-58rd0r0xx.now.sh/official-storybook/?path=/story/basics-documentformatting--with-markdown
View Notes at https://monorepo-58rd0r0xx.now.sh/official-storybook/?path=/info/addons-notes--addon-notes-rendering-imported-markdown

- Is this testable with Jest or Chromatic screenshots? Unsure, image snapshots were not running for me. I kept getting this error:
> Error when generating image snapshot for test Addons|Storyshots - Block : It seems the headless browser is not running.
- Does this need a new example in the kitchen sink apps? Already added
- Does this need an update to the documentation? No

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
