### PR TITLE
Addon-docs: Check if component propTypes exists before unwrapping

### DIFF
--- a/addons/docs/src/frameworks/react/extractProps.ts
+++ b/addons/docs/src/frameworks/react/extractProps.ts
@@ -61,7 +61,7 @@ const propsFromPropTypes: PropDefGetter = (type, section) => {
 
 export const getPropDefs: PropDefGetter = (type, section) => {
   let processedType = type;
-  if (!hasDocgen(type)) {
+  if (!hasDocgen(type) && !type.propTypes) {
     if (isForwardRef(type) || type.render) {
       processedType = type.render().type;
     }


### PR DESCRIPTION
Issue: Fixes #8664

## What I did

Check if propTypes exists in supplied type before trying to unwrap when extracting props for docs.

The function should be able to extract the props for the following type of component

```jsx
const Component = forwardRef((props, ref) => (/* ... */);

Component.propTypes = {
  /* some prop types */
}
```

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

I'm not sure if there are already existing tests for this functionality. I'd be glad to add more test cases if there are.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
