### PR TITLE
React-native: Make menu bar have its own position instead of absolute

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/navigation/index.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/navigation/index.tsx
@@ -10,15 +10,6 @@ const SWIPE_CONFIG = {
   directionalOffsetThreshold: 80,
 };
 
-const style = StyleSheet.create({
-  wrapper: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
-});
-
 interface Props {
   initialUiVisible?: boolean;
   tabOpen: number;
@@ -55,7 +46,7 @@ export default class Navigation extends PureComponent<Props> {
     const { isUIVisible } = this.state;
 
     return (
-      <View style={style.wrapper}>
+      <View>
         <SafeAreaView>
           {isUIVisible && (
             <GestureRecognizer

--- a/app/react-native/src/preview/components/OnDeviceUI/navigation/index.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/navigation/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
 import React, { PureComponent } from 'react';
-import { View, SafeAreaView, StyleSheet } from 'react-native';
+import { View, SafeAreaView } from 'react-native';
 import GestureRecognizer from 'react-native-swipe-gestures';
 import Bar from './bar';
 import VisibilityButton from './visibility-button';


### PR DESCRIPTION
Issue: N/A.

Currently navigation bar is positioned absolutely and it is displayed on top of components. I saw some issue in github where someone asked to make it static, but I can't find it.