### PR TITLE
React-native: Fix layout in RN61 so addons no longer initially displayed

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.tsx
@@ -5,6 +5,7 @@ import {
   Platform,
   Animated,
   TouchableOpacityProps,
+  Dimensions,
 } from 'react-native';
 import styled from '@emotion/native';
 import addons from '@storybook/addons';
@@ -49,10 +50,10 @@ const Preview = styled.TouchableOpacity<TouchableOpacityProps>(
     flex: 1,
   },
   ({ disabled, theme }) => ({
-    borderLeftWidth: disabled ? '0' : '1',
-    borderTopWidth: disabled ? '0' : '1',
-    borderRightWidth: disabled ? '0' : '1',
-    borderBottomWidth: disabled ? '0' : '1',
+    borderLeftWidth: disabled ? 0 : 1,
+    borderTopWidth: disabled ? 0 : 1,
+    borderRightWidth: disabled ? 0 : 1,
+    borderBottomWidth: disabled ? 0 : 1,
     borderColor: disabled ? 'transparent' : theme.previewBorderColor,
   })
 );
@@ -61,11 +62,12 @@ export default class OnDeviceUI extends PureComponent<OnDeviceUIProps, OnDeviceU
   constructor(props: OnDeviceUIProps) {
     super(props);
     const tabOpen = props.tabOpen || PREVIEW;
+
     this.state = {
       tabOpen,
       slideBetweenAnimation: false,
-      previewWidth: 0,
-      previewHeight: 0,
+      previewWidth: Dimensions.get('window').width,
+      previewHeight: Dimensions.get('window').height,
     };
     this.animatedValue = new Animated.Value(tabOpen);
     this.channel = addons.getChannel();

--- a/app/react-native/src/preview/components/OnDeviceUI/navigation/visibility-button.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/navigation/visibility-button.tsx
@@ -8,8 +8,8 @@ interface Props {
 const Touchable = styled.TouchableOpacity({
   backgroundColor: 'transparent',
   position: 'absolute',
-  right: '8',
-  bottom: '12',
+  right: 8,
+  bottom: 12,
   zIndex: 100,
 });
 

--- a/app/react-native/src/preview/components/StoryListView/index.tsx
+++ b/app/react-native/src/preview/components/StoryListView/index.tsx
@@ -72,8 +72,8 @@ interface State {
 }
 
 const List = styled.SectionList({
-  flex: '1',
-  marginBottom: '40',
+  flex: 1,
+  marginBottom: 40,
 });
 
 export default class StoryListView extends Component<Props, State> {


### PR DESCRIPTION
Issue: #8613, #8274

## What I did

Fixed the layout