### PR TITLE
React-native: Fix event listening for story navigation

### DIFF
--- a/addons/ondevice-actions/src/containers/ActionLogger/index.tsx
+++ b/addons/ondevice-actions/src/containers/ActionLogger/index.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import deepEqual from 'fast-deep-equal';
 
 import { addons } from '@storybook/addons';
-import { STORY_RENDERED } from '@storybook/core-events';
+import { SELECT_STORY } from '@storybook/core-events';
 import { ActionDisplay, EVENT_ID } from '@storybook/addon-actions';
 
 import { ActionLogger as ActionLoggerComponent } from '../../components/ActionLogger';
@@ -34,11 +34,11 @@ export default class ActionLogger extends Component<ActionLoggerProps, ActionLog
 
   componentDidMount() {
     this.channel.addListener(EVENT_ID, this.addAction);
-    this.channel.addListener(STORY_RENDERED, this.handleStoryChange);
+    this.channel.addListener(SELECT_STORY, this.handleStoryChange);
   }
 
   componentWillUnmount() {
-    this.channel.removeListener(STORY_RENDERED, this.handleStoryChange);
+    this.channel.removeListener(SELECT_STORY, this.handleStoryChange);
     this.channel.removeListener(EVENT_ID, this.addAction);
   }
 
@@ -50,6 +50,8 @@ export default class ActionLogger extends Component<ActionLoggerProps, ActionLog
   };
 
   addAction = (action: ActionDisplay) => {
+    console.warn('called!!');
+
     this.setState((prevState: ActionLoggerState) => {
       const actions = [...prevState.actions];
       const previous = actions.length && actions[0];

--- a/addons/ondevice-actions/src/containers/ActionLogger/index.tsx
+++ b/addons/ondevice-actions/src/containers/ActionLogger/index.tsx
@@ -50,8 +50,6 @@ export default class ActionLogger extends Component<ActionLoggerProps, ActionLog
   };
 
   addAction = (action: ActionDisplay) => {
-    console.warn('called!!');
-
     this.setState((prevState: ActionLoggerState) => {
       const actions = [...prevState.actions];
       const previous = actions.length && actions[0];


### PR DESCRIPTION

Issue: #6471

## What I did

Addons-ondevice-actions was completely broken (never showing any actions), so I changed the event to proper one. The issue #6471 still persists, but at least we can avoid it by not passing react events to it directy by doing.
```javascript
<Button onPress={() => action('Button pressed')}>
```