### PR TITLE
Update ADDONS_SUPPORT.md

### DIFF
--- a/ADDONS_SUPPORT.md
+++ b/ADDONS_SUPPORT.md
@@ -12,7 +12,7 @@
 |[graphql](addons/graphql)                   |+| | | | | | | | | | | |
 |[google-analytics](addons/google-analytics) |+|+|+|+|+|+|+|+|+|+|+|+|
 |[info](addons/info)                         |+| | | | | | | | | | | |
-|[jest](addons/jest)                         |+| | |+| | |+| | | | | |
+|[jest](addons/jest)                         |+| |+|+| | |+| | | | | |
 |[knobs](addons/knobs)                       |+|+*|+|+|+|+|+|+|+|+|+|+|
 |[links](addons/links)                       |+|+|+|+|+|+|+| |+|+|+|+|
 |[notes](addons/notes)                       |+|+*|+|+|+|+|+| |+|+|+|+|

--- a/ADDONS_SUPPORT.md
+++ b/ADDONS_SUPPORT.md
@@ -12,7 +12,7 @@
 |[graphql](addons/graphql)                   |+| | | | | | | | | | | |
 |[google-analytics](addons/google-analytics) |+|+|+|+|+|+|+|+|+|+|+|+|
 |[info](addons/info)                         |+| | | | | | | | | | | |
-|[jest](addons/jest)                         |+| |+|+| | |+| | | | | |
+|[jest](addons/jest)                         |+|+|+|+|+|+|+|+|+|+|+|+|
 |[knobs](addons/knobs)                       |+|+*|+|+|+|+|+|+|+|+|+|+|
 |[links](addons/links)                       |+|+|+|+|+|+|+| |+|+|+|+|
 |[notes](addons/notes)                       |+|+*|+|+|+|+|+| |+|+|+|+|


### PR DESCRIPTION
Issue:
The documentation states that `addon-jest` doesn't work with VueJS, but it does seem to work in my Vue project with no problems, after all, the addon only needs the test results and a matching component name, I don't see why it wouldn't be compatible with all the frameworks, but I only tested it in Vue, so in this change I only added the check mark for Vue.

## What I did
Updated the docs for jest addon to show VueJs as supported since it already works.

## How to test
- In a project with VueCli v3, Vue 2.6.10, add Storybook 5.2.5, and @storybook/addon-jest v5.2.5, follow documentation instructions and voila, it shows the "Tests" tab with the related tests.

