### PR TITLE
CHANGE the compilation target for RN - it was compiled for old browsers

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -73,6 +73,11 @@ module.exports = {
       },
     },
     {
+      test: './app/react-native',
+      presets: ['module:metro-react-native-babel-preset'],
+      plugins: ['babel-plugin-macros', ['emotion', { sourceMap: true, autoLabel: true }]],
+    },
+    {
       test: [
         './lib/node-logger',
         './lib/codemod',


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8371

RN app is compiled for old browsers

## What I did
I added an override for `app/react-native` in the `.babelrc.js`