### PR TITLE
Update the PropRow component to Replace line breaks for <br />

### DIFF
--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -33,6 +33,7 @@
     "@types/react-textarea-autosize": "^4.3.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
+    "lodash": "^4.17.15",
     "markdown-to-jsx": "^6.9.1",
     "memoizerific": "^1.11.3",
     "polished": "^3.3.1",

--- a/lib/components/src/blocks/PropsTable/PropRow.stories.tsx
+++ b/lib/components/src/blocks/PropsTable/PropRow.stories.tsx
@@ -36,6 +36,11 @@ export const longDescDef = {
   description: 'really long description that takes up a lot of space. sometimes this happens.',
 };
 
+export const multilineDescDef = {
+  ...stringDef,
+  description: 'really long description\non multiple lines.\nsometimes this\nhappens\ntoo.',
+};
+
 export const numberDef = {
   name: 'someNumber',
   type: { name: 'number' },
@@ -107,6 +112,7 @@ export const complexDef = {
 export const string = () => <PropRow row={stringDef} />;
 export const longName = () => <PropRow row={longNameDef} />;
 export const longDesc = () => <PropRow row={longDescDef} />;
+export const multilineDesc = () => <PropRow row={multilineDescDef} />;
 export const number = () => <PropRow row={numberDef} />;
 export const objectOf = () => <PropRow row={objectDef} />;
 export const arrayOf = () => <PropRow row={arrayDef} />;

--- a/lib/components/src/blocks/PropsTable/PropRow.tsx
+++ b/lib/components/src/blocks/PropsTable/PropRow.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Markdown from 'markdown-to-jsx';
 import { styled } from '@storybook/theming';
 import { transparentize } from 'polished';
+import { isNil } from 'lodash';
 import { PropDef } from './PropDef';
 
 enum PropType {
@@ -90,10 +91,16 @@ export const PropRow: FC<PropRowProps> = ({
   <tr>
     <td>
       <Name>{name}</Name>
-      {required ? <Required title="Required">*</Required> : null}
+      {required ? (
+        <Required title="Required" className="sbdocs-required">
+          *
+        </Required>
+      ) : null}
     </td>
     <td>
-      <Markdown>{description || ''}</Markdown>
+      <Markdown>
+        {!isNil(description) ? description.replace(/(?:\r\n|\r|\n)/g, '<br>') : ''}
+      </Markdown>
       <StyledPropDef>
         <PrettyPropType type={type} />
       </StyledPropDef>


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8533

## What I did

I updated the PropRow component to replace the line breaks caracters of the description for <br /> elements

Before:

![before](https://user-images.githubusercontent.com/794579/68148102-5bb6b580-ff09-11e9-8213-15443d34bc6c.PNG)

After:

![after](https://user-images.githubusercontent.com/794579/68148115-5eb1a600-ff09-11e9-850f-f290eac09b04.PNG)

ALSO:

I cheated a little bit and added a CSS escape hatch `sbdocs-required` for the required indicator of a prop row.

## How to test

- II added a story called `multilineDescDef` to the officiel storybook PropRow stories.
