### PR TITLE
Addon-docs: Inline rendering for web-components as default

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -14,15 +14,16 @@ Just like Storybook, Docs supports every major view layer including React, Vue, 
 
 Read on to learn more:
 
-- [DocsPage](#docspage)
-- [MDX](#mdx)
-- [Framework support](#framework-support)
-- [Installation](#installation)
-  - [Be sure to check framework specific installation needs](#be-sure-to-check-framework-specific-installation-needs)
-- [Preset options](#preset-options)
-- [Manual configuration](#manual-configuration)
-- [TypeScript configuration](#typescript-configuration)
-- [More resources](#more-resources)
+- [Storybook Docs](#storybook-docs)
+  - [DocsPage](#docspage)
+  - [MDX](#mdx)
+  - [Framework support](#framework-support)
+  - [Installation](#installation)
+    - [Be sure to check framework specific installation needs](#be-sure-to-check-framework-specific-installation-needs)
+  - [Preset options](#preset-options)
+  - [Manual configuration](#manual-configuration)
+  - [TypeScript configuration](#typescript-configuration)
+  - [More resources](#more-resources)
 
 ## DocsPage
 
@@ -76,16 +77,16 @@ For more information on `MDX`, see the [`MDX` reference](./docs/mdx.md).
 
 Storybook Docs supports all view layers that Storybook supports except for React Native (currently). There are some framework-specific features as well, such as props tables and inline story rendering. This chart captures the current state of support:
 
-|                   | React | Vue | Angular | HTML | [Web Components](./web-components) | Svelte | Polymer | Marko | Mithril | Riot | Ember | Preact |
-| ----------------- | :---: | :-: | :-----: | :--: | :--------------------------------: | :----: | :-----: | :---: | :-----: | :--: | :---: | :----: |
-| MDX stories       |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
-| CSF stories       |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
-| StoriesOf stories |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
-| Source            |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
-| Notes / Info      |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
-| Props table       |   +   |  +  |    #    |      |                 +                  |        |         |       |         |      |       |        |
-| Description       |   +   |  +  |    #    |      |                 +                  |        |         |       |         |      |       |        |
-| Inline stories    |   +   |  +  |         |      |                                    |        |         |       |         |      |       |        |
+|                   | React |  Vue  | Angular | HTML  | [Web Components](./web-components) | Svelte | Polymer | Marko | Mithril | Riot  | Ember | Preact |
+| ----------------- | :---: | :---: | :-----: | :---: | :--------------------------------: | :----: | :-----: | :---: | :-----: | :---: | :---: | :----: |
+| MDX stories       |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
+| CSF stories       |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
+| StoriesOf stories |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
+| Source            |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
+| Notes / Info      |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
+| Props table       |   +   |   +   |    #    |       |                 +                  |        |         |       |         |       |       |        |
+| Description       |   +   |   +   |    #    |       |                 +                  |        |         |       |         |       |       |        |
+| Inline stories    |   +   |   +   |         |       |                 +                  |        |         |       |         |       |       |        |
 
 **Note:** `#` = WIP support
 

--- a/addons/docs/src/frameworks/web-components/config.js
+++ b/addons/docs/src/frameworks/web-components/config.js
@@ -2,6 +2,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { addParameters } from '@storybook/client-api';
 import { getCustomElements, isValidComponent, isValidMetaData } from '@storybook/web-components';
+import React from 'react';
+import { render } from 'lit-html';
 
 function mapData(data) {
   return data.map(item => ({
@@ -56,6 +58,25 @@ addParameters({
         }
       }
       return false;
+    },
+    inlineStories: true,
+    prepareForInline: storyFn => {
+      class Story extends React.Component {
+        constructor(props) {
+          super(props);
+          this.wrapperRef = React.createRef();
+        }
+
+        componentDidMount() {
+          render(storyFn(), this.wrapperRef.current);
+        }
+
+        render() {
+          return React.createElement('div', { ref: this.wrapperRef });
+        }
+      }
+
+      return React.createElement(Story);
     },
   },
 });

--- a/addons/docs/web-components/README.md
+++ b/addons/docs/web-components/README.md
@@ -61,3 +61,25 @@ It basically looks like this:
 ```
 
 For a full example see the [web-components-kitchen-sink/custom-elements.json](../../../examples/web-components-kitchen-sink/custom-elements.json).
+
+## Stories not inline
+
+By default stories are rendered inline.
+For web components that is usually fine as they are style encapsulated via shadow dom.
+However when you have a style tag in you template it might be best to show them in an iframe.
+
+To always use iframes you can set
+
+```js
+addParameters({
+  docs: {
+    inlineStories: false,
+  },
+});
+```
+
+or add it to individual stories.
+
+```js
+<Story inline={false} />
+```

--- a/examples/web-components-kitchen-sink/stories/addon-docs.stories.mdx
+++ b/examples/web-components-kitchen-sink/stories/addon-docs.stories.mdx
@@ -55,5 +55,38 @@ You can also wrap your live demos in a nice little wrapper.
 You can also reference an existing story from within your MDX file.
 
 <Preview withToolbar>
-  <Story id="welcome--welcome" height="500px" />
+  <Story id="welcome--welcome" height="500px" inline={false} />
+</Preview>
+
+## Stories not inline
+
+By default stories are rendered inline.
+For web components that is usually fine as they are style encapsulated via shadow dom.
+However when you have a style tag in you template it might be best to show them in an iframe.
+
+To always use iframes you can set
+
+```js
+addParameters({
+  docs: {
+    inlineStories: false,
+  },
+});
+```
+
+or add it to individual stories.
+
+```
+<Story inline={false} />
+```
+
+<Preview withToolbar>
+  <Story name="notInline" height="220px">
+    {html`
+    <style>
+      p { color: red; }
+    </style>
+    <p>Makes all p tags red... so best to not render inline</pd>
+  `}
+  </Story>
 </Preview>


### PR DESCRIPTION
Issue:

## What I did

- Allow rendering web-components inline in docs mode.
- Enable it by default

## How to test

Open docs mode page on kitchen sink for web components.

I am not really a react pro so I am not sure if that is the best way to do it... but it works really nice and seems quite simple. 🤗 

feedback welcome 🙏 