### PR TITLE
Addon-docs: Fix code style inside LI

### DIFF
--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -304,6 +304,7 @@ export const LI = styled.li<{}>(withReset, ({ theme }) => ({
     marginTop: '.25em',
     marginBottom: 0,
   },
+  '& code': codeCommon({ theme }),
 }));
 
 export const UL = styled.ul<{}>(withReset, withMargin, listCommon, {});


### PR DESCRIPTION
Issue: [#8651](https://github.com/storybookjs/storybook/issues/8651)

## What I did
I add 'code' styles to the list.

```
export const LI = styled.li<{}>(withReset, ({ theme }) => ({
  fontSize: theme.typography.size.s2,
  color: theme.color.defaultText,
  lineHeight: '24px',
  '& + li': {
    marginTop: '.25em',
  },
  '& ul, & ol': {
    marginTop: '.25em',
    marginBottom: 0,
  },
  '& code': codeCommon({ theme }),
}));
```

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
