### PR TITLE
Addon-docs: Fix "Cannot read property 'props'"

### DIFF
--- a/addons/docs/src/lib/docgenUtils.ts
+++ b/addons/docs/src/lib/docgenUtils.ts
@@ -27,11 +27,8 @@ export const hasDocgenSection = (obj: any, section: string) =>
 export const extractPropsFromDocgen: PropDefGetter = (type, section) => {
   const props: Record<string, PropDef> = {};
 
-  const docgenInfoProps = type.__docgenInfo[section];
-  if (!docgenInfoProps) {
-    return [];
-  }
-
+  const docgenInfo = type.__docgenInfo;
+  const docgenInfoProps = (docgenInfo && docgenInfo[section]) || {};
   const propKeys = Object.keys(docgenInfoProps);
   if (propKeys.length === 0) {
     return [];

--- a/addons/docs/src/lib/docgenUtils.ts
+++ b/addons/docs/src/lib/docgenUtils.ts
@@ -5,7 +5,7 @@ import { getTypeSystemHandler, getPropTypeSystem } from './type-system-handlers'
 
 export type PropsExtractor = (component: Component) => PropsTableProps | null;
 
-export type PropDefGetter = (type: Component, section: string) => PropDef[];
+export type PropDefGetter = (component: Component, section: string) => PropDef[];
 
 export const str = (o: any) => {
   if (!o) {
@@ -17,24 +17,24 @@ export const str = (o: any) => {
   throw new Error(`Description: expected string, got: ${JSON.stringify(o)}`);
 };
 
-export const hasDocgen = (obj: any) => !!obj.__docgenInfo;
+export const hasDocgen = (component: Component) => !!component.__docgenInfo;
 
-export const hasDocgenSection = (obj: any, section: string) =>
-  obj.__docgenInfo &&
-  obj.__docgenInfo[section] &&
-  Object.keys(obj.__docgenInfo[section]).length > 0;
+export const hasDocgenSection = (component: Component, section: string) =>
+  component &&
+  component.__docgenInfo &&
+  component.__docgenInfo[section] &&
+  Object.keys(component.__docgenInfo[section]).length > 0;
 
-export const extractPropsFromDocgen: PropDefGetter = (type, section) => {
-  const props: Record<string, PropDef> = {};
-
-  const docgenInfo = type.__docgenInfo;
-  const docgenInfoProps = (docgenInfo && docgenInfo[section]) || {};
-  const propKeys = Object.keys(docgenInfoProps);
-  if (propKeys.length === 0) {
+export const extractPropsFromDocgen: PropDefGetter = (component, section) => {
+  if (!hasDocgenSection(component, section)) {
     return [];
   }
 
-  // Assuming the props for a given type will all have the same type system.
+  const props: Record<string, PropDef> = {};
+  const docgenInfoProps = component.__docgenInfo[section];
+  const propKeys = Object.keys(docgenInfoProps);
+
+  // Assuming the props for a given component will all have the same type system.
   const typeSystem = getPropTypeSystem(docgenInfoProps[propKeys[0]]);
   const typeSystemHandler = getTypeSystemHandler(typeSystem);
 


### PR DESCRIPTION
Issue: #8729 

## What I did

Add extra check to make sure we have docgen info after stripping away HOCs