### PR TITLE
Addon-docs: Added dark theme option to source component

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -5,6 +5,7 @@ import { CURRENT_SELECTION } from './shared';
 
 interface CommonProps {
   language?: string;
+  dark?: boolean;
 }
 
 type SingleSourceProps = {
@@ -76,7 +77,7 @@ export const getSourceProps = (
       .join('\n\n');
   }
   return source
-    ? { code: source, language: props.language || 'jsx' }
+    ? { code: source, language: props.language || 'jsx', dark: props.dark || false }
     : { error: SourceError.SOURCE_UNAVAILABLE };
 };
 


### PR DESCRIPTION
Issue: [#8709](https://github.com/storybookjs/storybook/issues/8709)

## What I did

I add `dark` prop to docs `<Souce />` compnent.

No we can set dark theme for source code in .mdx file:

```
<Source
  code={`<a href="#" rel="Some rel text" target="_blank">
    <Button>Link text</Button>
  </a>`}
  language="jsx"
  dark={true}
/>
```
![Zrzut ekranu 2019-11-6 o 08 53 20](https://user-images.githubusercontent.com/6291752/68279057-ee269880-0072-11ea-9e01-42a9b7565b9a.png)


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
