### PR TITLE
Addon-info: Fix "The prop 'children' is marked as required in 'Td'"

### DIFF
--- a/addons/info/src/components/PropTable/components/Td.js
+++ b/addons/info/src/components/PropTable/components/Td.js
@@ -12,12 +12,13 @@ Td.propTypes = {
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.arrayOf(PropTypes.element),
-  ]).isRequired,
+  ]),
   isMonospace: PropTypes.bool,
 };
 
 Td.defaultProps = {
   isMonospace: false,
+  children: null,
 };
 
 export default Td;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/7195

## What I did
Make `children` prop in the `Td` component as optional and added it to the `defaultProps`
