### PR TITLE
addon-notes: Fix Giphy docs

### DIFF
--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -95,7 +95,7 @@ storiesOf('Component', module).add('With Markdown', () => <Component />, {
 
 ## Giphy
 
-When using Markdown, you can also embed gifs from Giphy into your Markdown. Currently, the value `gif` of the gif prop is used to search and return the first result returned by Giphy.
+When using Markdown, you can also embed gifs from Giphy into your Markdown. Currently, the value `cheese` of the query prop is used to search and return the first result returned by Giphy.
 
 ```md
 # Title

--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -100,7 +100,7 @@ When using Markdown, you can also embed gifs from Giphy into your Markdown. Curr
 ```md
 # Title
 
-<Giphy gif='cheese' />
+<Giphy query='cheese' />
 ```
 
 ## Multiple Notes Sections


### PR DESCRIPTION
Issue:
The docs for addon-notes Giphy is referencing an incorrect prop.

## What I did
Changed the documentation to reflect the actual prop.

## How to test
Put a <Giphy /> component into a notes page and change the query prop.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
