### PR TITLE
Fix import statement in mdx example

### DIFF
--- a/addons/docs/angular/README.md
+++ b/addons/docs/angular/README.md
@@ -104,7 +104,7 @@ configure(require.context('../src/stories', true, /\.stories\.(ts|mdx)$/), modul
 Finally, you can create MDX files like this:
 
 ```md
-import { Meta, Story, Props } from '@storybook/docs/blocks';
+import { Meta, Story, Props } from '@storybook/addon-docs/blocks';
 import { AppComponent } from './app.component';
 
 <Meta title='App Component' component={AppComponent} />


### PR DESCRIPTION
`addon-` was missing in `import { Meta, Story, Props } from '@storybook/addon-docs/blocks';`
