### PR TITLE
Distribute src for `jsnext:main`

### DIFF
--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "files": [
+    "src/**/*",
     "dist/**/*",
     "docs/**/*",
     "README.md",

--- a/app/ember/package.json
+++ b/app/ember/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "files": [
+    "src/**/*",
     "bin/**/*",
     "dist/**/*",
     "README.md",

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -16,6 +16,7 @@
   },
   "license": "MIT",
   "files": [
+    "src/**/*",
     "dist/**/*",
     "README.md",
     "*.js",

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "files": [
+    "src/**/*",
     "dist/**/*",
     "README.md",
     "*.js",


### PR DESCRIPTION
Issue: #8324 

## What I did

We are referring to `src/**` in `jsnext:main` so I added that to the distribution. Alternatively we could remove the `jsnext:main` field.

cc @Hypnosphi @ndelangen 

## How to test

Don't know?
