### PR TITLE
Fix CSF in MDX example code

### DIFF
--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -66,7 +66,7 @@ import { SomeComponent } from 'path/to/SomeComponent';
 
 I can define a story with the function imported from CSF:
 
-<Story name="basic">{stories.basic}</Story>
+<Story name="basic">{stories.basic()}</Story>
 
 And I can also embed arbitrary markdown & JSX in this file.
 


### PR DESCRIPTION
Issue:

The updated line produces the warning below:
> Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.

## What I did

I've fixed the line.
