### PR TITLE
Source-loader: Warn if applied to non-stories file

### DIFF
--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@storybook/addons": "5.3.0-alpha.42",
-    "@storybook/node-logger": "5.3.0-alpha.42",
+    "@storybook/client-logger": "5.3.0-alpha.42",
     "@storybook/router": "5.3.0-alpha.42",
     "core-js": "^3.0.1",
     "estraverse": "^4.2.0",

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@storybook/addons": "5.3.0-alpha.42",
+    "@storybook/node-logger": "5.3.0-alpha.42",
     "@storybook/router": "5.3.0-alpha.42",
     "core-js": "^3.0.1",
     "estraverse": "^4.2.0",

--- a/lib/source-loader/src/client/preview.js
+++ b/lib/source-loader/src/client/preview.js
@@ -1,4 +1,5 @@
 import addons from '@storybook/addons';
+import { logger } from '@storybook/node-logger';
 import { STORY_EVENT_ID } from './events';
 
 const getLocation = (context, locationsMap) => locationsMap[context.id];
@@ -14,10 +15,10 @@ function sendEvent(
   idsToFrameworks
 ) {
   if (!context || !context.id || !context.kind || !context.story) {
-    console.warn(
+    logger.warn(
       '@storybook/source-loader was applied to a file which does not contain a story. Please check your webpack configuration and make sure to apply @storybook/source-loader only to files containg stories. Related file:'
     );
-    console.warn(source);
+    logger.warn(source);
     return;
   }
 

--- a/lib/source-loader/src/client/preview.js
+++ b/lib/source-loader/src/client/preview.js
@@ -1,5 +1,5 @@
 import addons from '@storybook/addons';
-import { logger } from '@storybook/node-logger';
+import { logger } from '@storybook/client-logger';
 import { STORY_EVENT_ID } from './events';
 
 const getLocation = (context, locationsMap) => locationsMap[context.id];

--- a/lib/source-loader/src/client/preview.js
+++ b/lib/source-loader/src/client/preview.js
@@ -13,6 +13,14 @@ function sendEvent(
   prefix,
   idsToFrameworks
 ) {
+  if (!context || !context.id || !context.kind || !context.story) {
+    console.warn(
+      '@storybook/source-loader was applied to a file which does not contain a story. Please check your webpack configuration and make sure to apply @storybook/source-loader only to files containg stories. Related file:'
+    );
+    console.warn(source);
+    return;
+  }
+
   const channel = addons.getChannel();
   const currentLocation = getLocation(context, locationsMap);
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8294

## What I did

I added a warning for people like me who misconfigured the `@storybook/source-loader`. If I understand correctly, it should only be used for files containing stories. In my webpack config it was applied to all source code files.

## How to test

Checkout my PR, `cd lib/source-loader && yarn prepare && yarn link`. After that `$ git clone git@github.com:donaldpipowitch/storybook-bug-demo-source-loader-context-null.git && cd storybook-bug-demo-source-loader-context-null && yarn && yarn link "@storybook/source-loader" && yarn storybook`. You should see the warning.

![image](https://user-images.githubusercontent.com/1152805/68529620-d2d0bd00-0300-11ea-93e8-87c35c8bd158.png)
