### PR TITLE
Addon-A11y: Show errors, reset config properly

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -56,7 +56,6 @@ import { withA11y } from '@storybook/addon-a11y';
 addDecorator(withA11y)
 addParameters({
   a11y: {
-    // ... axe options
     element: '#root', // optional selector which element to inspect
     config: {}, // axe-core configurationOptions (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#parameters-1)
     options: {} // axe-core optionsParameter (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter)

--- a/addons/a11y/src/components/A11YPanel.test.js
+++ b/addons/a11y/src/components/A11YPanel.test.js
@@ -63,7 +63,7 @@ function ThemedA11YPanel(props) {
 }
 
 describe('A11YPanel', () => {
-  it('should register STORY_RENDERED and RESULT updater on mount', () => {
+  it('should register STORY_RENDERED, RESULT and ERROR updater on mount', () => {
     // given
     const api = createApi();
     expect(api.on).not.toHaveBeenCalled();
@@ -72,9 +72,10 @@ describe('A11YPanel', () => {
     mount(<ThemedA11YPanel api={api} />);
 
     // then
-    expect(api.on.mock.calls.length).toBe(2);
+    expect(api.on.mock.calls.length).toBe(3);
     expect(api.on.mock.calls[0][0]).toBe(STORY_RENDERED);
     expect(api.on.mock.calls[1][0]).toBe(EVENTS.RESULT);
+    expect(api.on.mock.calls[2][0]).toBe(EVENTS.ERROR);
   });
 
   it('should request a run on tab activation', () => {
@@ -93,7 +94,7 @@ describe('A11YPanel', () => {
     expect(wrapper.find(ScrollArea).length).toBe(0);
   });
 
-  it('should deregister STORY_RENDERED and RESULT updater on unmount', () => {
+  it('should deregister STORY_RENDERED, RESULT and ERROR updater on unmount', () => {
     // given
     const api = createApi();
     const wrapper = mount(<ThemedA11YPanel api={api} />);
@@ -103,9 +104,10 @@ describe('A11YPanel', () => {
     wrapper.unmount();
 
     // then
-    expect(api.off.mock.calls.length).toBe(2);
+    expect(api.off.mock.calls.length).toBe(3);
     expect(api.off.mock.calls[0][0]).toBe(STORY_RENDERED);
     expect(api.off.mock.calls[1][0]).toBe(EVENTS.RESULT);
+    expect(api.off.mock.calls[2][0]).toBe(EVENTS.ERROR);
   });
 
   it('should update run result', () => {

--- a/addons/a11y/src/components/__snapshots__/A11YPanel.test.js.snap
+++ b/addons/a11y/src/components/__snapshots__/A11YPanel.test.js.snap
@@ -177,8 +177,16 @@ exports[`A11YPanel should render report 1`] = `
             "storybook/a11y/result",
             [Function],
           ],
+          Array [
+            "storybook/a11y/error",
+            [Function],
+          ],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,

--- a/addons/a11y/src/constants.ts
+++ b/addons/a11y/src/constants.ts
@@ -6,5 +6,6 @@ export const ADD_ELEMENT = 'ADD_ELEMENT';
 export const CLEAR_ELEMENTS = 'CLEAR_ELEMENTS';
 const RESULT = `${ADDON_ID}/result`;
 const REQUEST = `${ADDON_ID}/request`;
+const ERROR = `${ADDON_ID}/error`;
 
-export const EVENTS = { RESULT, REQUEST };
+export const EVENTS = { RESULT, REQUEST, ERROR };

--- a/addons/a11y/src/index.ts
+++ b/addons/a11y/src/index.ts
@@ -48,18 +48,20 @@ if (module && module.hot && module.hot.decline) {
   module.hot.decline();
 }
 
-let storedSetup: Setup | null = null;
+let storedDefaultSetup: Setup | null = null;
 
 export const withA11y = makeDecorator({
   name: 'withA11Y',
   parameterName: PARAM_KEY,
   wrapper: (getStory, context, { parameters }) => {
     if (parameters) {
-      storedSetup = setup;
-      setup = parameters as Setup;
-    } else if (storedSetup) {
-      setup = storedSetup;
-      storedSetup = null;
+      if (storedDefaultSetup === null) {
+        storedDefaultSetup = { ...setup };
+      }
+      Object.assign(setup, parameters as Setup);
+    } else if (storedDefaultSetup !== null) {
+      Object.assign(setup, storedDefaultSetup);
+      storedDefaultSetup = null;
     }
     addons.getChannel().on(EVENTS.REQUEST, () => run(setup.element, setup.config, setup.options));
 

--- a/addons/a11y/src/index.ts
+++ b/addons/a11y/src/index.ts
@@ -39,7 +39,8 @@ const run = (element: ElementContext, config: Spec, options: RunOptions) => {
             restoreScroll: true,
           } as RunOptions) // cast to RunOptions is necessary because axe types are not up to date
       )
-      .then(report);
+      .then(report)
+      .catch(error => addons.getChannel().emit(EVENTS.ERROR, String(error)));
   });
 };
 
@@ -47,12 +48,18 @@ if (module && module.hot && module.hot.decline) {
   module.hot.decline();
 }
 
+let storedSetup: Setup | null = null;
+
 export const withA11y = makeDecorator({
   name: 'withA11Y',
   parameterName: PARAM_KEY,
   wrapper: (getStory, context, { parameters }) => {
     if (parameters) {
+      storedSetup = setup;
       setup = parameters as Setup;
+    } else if (storedSetup) {
+      setup = storedSetup;
+      storedSetup = null;
     }
     addons.getChannel().on(EVENTS.REQUEST, () => run(setup.element, setup.config, setup.options));
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8126

## What I did

1. Added proper error state.
2. Reset configs properly and apply them partially.
3. Removed `// ... axe options` comment in the README. It was ambiguous as it implied there were some "axe options" which could be spread into the configuration alongside `element`/ `config`/`options`.

![image](https://user-images.githubusercontent.com/1152805/68566869-d7f45000-0457-11ea-9acf-d7e94739254d.png)

## How to test

This change fixes this demo: https://github.com/donaldpipowitch/storybook-bug-demo-a11y-at-story-level

---

## Questions

1. I needed to add `// eslint-disable-next-line react/destructuring-assignment`. If you don't like that change, I'd need to wrap `A11YPanelState` in another object, because descruturing doesn't work well with tagged union types in that case. Any preference?

2. Is there a way to run  `$ yarn prepare` in a `--watch` mode? That would help while debugging.

3. Can I **partially** override a11y configs on a story level? The README implied it as far as I understood, but it isn't really written down literally. At least I always assumed it, but the code behaved like it would need the whole config even on a story level.