### PR TITLE
UI: Store layout state in sessionStorage

### DIFF
--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -157,86 +157,107 @@ let hasSetOptions = false;
 export default function({ store, provider }: { store: Store; provider: Provider }) {
   const api = {
     toggleFullscreen(toggled?: boolean) {
-      return store.setState((state: State) => {
-        const value = typeof toggled === 'boolean' ? toggled : !state.layout.isFullscreen;
+      return store.setState(
+        (state: State) => {
+          const value = typeof toggled === 'boolean' ? toggled : !state.layout.isFullscreen;
 
-        return {
-          layout: {
-            ...state.layout,
-            isFullscreen: value,
-          },
-        };
-      });
+          return {
+            layout: {
+              ...state.layout,
+              isFullscreen: value,
+            },
+          };
+        },
+        { persistence: 'session' }
+      );
     },
 
     togglePanel(toggled?: boolean) {
-      return store.setState((state: State) => {
-        const value = typeof toggled !== 'undefined' ? toggled : !state.layout.showPanel;
+      return store.setState(
+        (state: State) => {
+          const value = typeof toggled !== 'undefined' ? toggled : !state.layout.showPanel;
 
-        return {
-          layout: {
-            ...state.layout,
-            showPanel: value,
-          },
-        };
-      });
+          return {
+            layout: {
+              ...state.layout,
+              showPanel: value,
+            },
+          };
+        },
+        { persistence: 'session' }
+      );
     },
 
     togglePanelPosition(position?: 'bottom' | 'right') {
       if (typeof position !== 'undefined') {
-        return store.setState((state: State) => ({
-          layout: {
-            ...state.layout,
-            panelPosition: position,
-          },
-        }));
+        return store.setState(
+          (state: State) => ({
+            layout: {
+              ...state.layout,
+              panelPosition: position,
+            },
+          }),
+          { persistence: 'session' }
+        );
       }
 
-      return store.setState((state: State) => ({
-        layout: {
-          ...state.layout,
-          panelPosition: state.layout.panelPosition === 'right' ? 'bottom' : 'right',
-        },
-      }));
+      return store.setState(
+        (state: State) => ({
+          layout: {
+            ...state.layout,
+            panelPosition: state.layout.panelPosition === 'right' ? 'bottom' : 'right',
+          },
+        }),
+        { persistence: 'session' }
+      );
     },
 
     toggleNav(toggled?: boolean) {
-      return store.setState((state: State) => {
-        const value = typeof toggled !== 'undefined' ? toggled : !state.layout.showNav;
+      return store.setState(
+        (state: State) => {
+          const value = typeof toggled !== 'undefined' ? toggled : !state.layout.showNav;
 
-        return {
-          layout: {
-            ...state.layout,
-            showNav: value,
-          },
-        };
-      });
+          return {
+            layout: {
+              ...state.layout,
+              showNav: value,
+            },
+          };
+        },
+        { persistence: 'session' }
+      );
     },
 
     toggleToolbar(toggled?: boolean) {
-      return store.setState((state: State) => {
-        const value = typeof toggled !== 'undefined' ? toggled : !state.layout.isToolshown;
+      return store.setState(
+        (state: State) => {
+          const value = typeof toggled !== 'undefined' ? toggled : !state.layout.isToolshown;
 
-        return {
-          layout: {
-            ...state.layout,
-            isToolshown: value,
-          },
-        };
-      });
+          return {
+            layout: {
+              ...state.layout,
+              isToolshown: value,
+            },
+          };
+        },
+        { persistence: 'session' }
+      );
     },
 
     resetLayout() {
-      return store.setState((state: State) => {
-        return {
-          layout: {
-            ...state.layout,
-            showNav: false,
-            showPanel: false,
-            isFullscreen: false,
-          },
-        };
-      });
+      return store.setState(
+        (state: State) => {
+          return {
+            layout: {
+              ...state.layout,
+              showNav: false,
+              showPanel: false,
+              isFullscreen: false,
+            },
+          };
+        },
+        { persistence: 'session' }
+      );
     },
 
     focusOnUIElement(elementId?: string) {


### PR DESCRIPTION
## What I did

This adds `{ persistence: 'session' }` to all `store.setState` calls in `layout.ts`. This will make sure panel visibility and other layout settings are retained between page reloads.

## How to test

Toggle one of the layout settings (fullscreen, nav, addons, toolbar) and reload the page. Notice your settings will be retained.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
