### PR TITLE
Framework-specific presets are deprecated

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -109,10 +109,8 @@ yarn add -D react react-is babel-loader
 Then add the following to your `.storybook/presets.js` exports:
 
 ```js
-module.exports = ['@storybook/addon-docs/react/preset'];
+module.exports = ['@storybook/addon-docs/preset'];
 ```
-
-If you're not using `react`, replace it with your framework of choice corresponding to the Storybook package name, e.g. `angular` for `@storybook/angular` etc.
 
 **Configure.** If you're migrating from an earlier version of Storybook and want to use `MDX`, you need to upgrade your Storybook config:
 


### PR DESCRIPTION
The Readme told me to use `@storybook/addon-docs/react/preset`, but Storybook told me to use `@storybook/addon-docs/preset`. I think this correctly brings the docs up to date.