### PR TITLE
Core: Use `stable` package to ensure story sorting is stable

### DIFF
--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -40,6 +40,7 @@
     "lodash": "^4.17.15",
     "memoizerific": "^1.11.3",
     "qs": "^6.6.0",
+    "stable": "^0.1.8",
     "ts-dedent": "^1.1.0",
     "util-deprecate": "^1.0.2"
   },

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'eventemitter3';
 import memoize from 'memoizerific';
 import debounce from 'lodash/debounce';
 import dedent from 'ts-dedent';
+import stable from 'stable';
 
 import { Channel } from '@storybook/channels';
 import Events from '@storybook/core-events';
@@ -129,7 +130,7 @@ export default class StoryStore extends EventEmitter {
       );
       if (index && this._data[index].parameters.options.storySort) {
         const sortFn = this._data[index].parameters.options.storySort;
-        stories.sort(sortFn);
+        stable.inplace(stories, sortFn);
       }
     }
     // removes function values from all stories so they are safe to transport over the channel


### PR DESCRIPTION
Fixes #8792

Issue: `stories.sort()` was not guaranteed to be stable so if the compare function sometimes returned `0`, the order was not defined.

## What I did

Use a guaranteed stable sorting algorithm. This way the ordering will fall back to the original ordering (the order the stories were added).

## How to test

- Is this testable with Jest or Chromatic screenshots?

Check the library page of chromatic -- see this comment: https://github.com/storybookjs/storybook/issues/8792#issue-521217259