### PR TITLE
Add CSF upgrade example

### DIFF
--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -79,6 +79,18 @@ storiesOf('Button', module).add(
 );
 ```
 
+### Upgrading to CSF Format
+
+Add `notes` to the `parameters` object:
+
+```js
+export default {
+  parameters: {
+    notes: 'My notes',
+  }
+}
+```
+
 ## Using Markdown
 
 Using Markdown in your notes is supported, Storybook will load Markdown as raw by default.


### PR DESCRIPTION
Figured this should be included in the docs since CSF is being promoted as best practice moving forward. 

Thanks for the solution go to the comments in this thread:

https://github.com/storybookjs/storybook/issues/8746#issuecomment-551054492

Issue: Usage of notes in CSF is not yet documented
