### PR TITLE
📝 Fix typos on Ember guide 

### DIFF
--- a/docs/src/pages/guides/guide-ember/index.md
+++ b/docs/src/pages/guides/guide-ember/index.md
@@ -35,7 +35,7 @@ If you don't have `package.json` in your project, you'll need to init it first:
 npm init
 ```
 
-Then add the following NPM script to your package json in order to start the storybook later in this guide:
+Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
 
 > In order for your storybook to run properly be sure to be either run `ember serve` or `ember build` before running any storybook commands. Running `ember serve` before storybook will enable live reloading.
 
@@ -105,7 +105,7 @@ export const component = () => {
 };
 ```
 
-> If you are using an older version of ember <= 3.1 please use this story style
+> If you are using an older version of Ember <= 3.1 please use this story style
 
 ```js
 import { compile } from 'ember-source/dist/ember-template-compiler';


### PR DESCRIPTION
Issue: Typos on Ember guide 

## What I did
Add capital letter on Ember and add backquote for syntax highlight to `package.json`

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
