### PR TITLE
8793 do not use old separators in docs

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -47,7 +47,7 @@ Here's an example file:
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { Checkbox } from './Checkbox';
 
-<Meta title="MDX|Checkbox" component={Checkbox} />
+<Meta title="MDX/Checkbox" component={Checkbox} />
 
 # Checkbox
 
@@ -77,16 +77,16 @@ For more information on `MDX`, see the [`MDX` reference](./docs/mdx.md).
 
 Storybook Docs supports all view layers that Storybook supports except for React Native (currently). There are some framework-specific features as well, such as props tables and inline story rendering. This chart captures the current state of support:
 
-|                   | React |  Vue  | Angular | HTML  | [Web Components](./web-components) | Svelte | Polymer | Marko | Mithril | Riot  | Ember | Preact |
-| ----------------- | :---: | :---: | :-----: | :---: | :--------------------------------: | :----: | :-----: | :---: | :-----: | :---: | :---: | :----: |
-| MDX stories       |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
-| CSF stories       |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
-| StoriesOf stories |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
-| Source            |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
-| Notes / Info      |   +   |   +   |    +    |   +   |                 +                  |   +    |    +    |   +   |    +    |   +   |   +   |   +    |
-| Props table       |   +   |   +   |    #    |       |                 +                  |        |         |       |         |       |       |        |
-| Description       |   +   |   +   |    #    |       |                 +                  |        |         |       |         |       |       |        |
-| Inline stories    |   +   |   +   |         |       |                 +                  |        |         |       |         |       |       |        |
+|                   | React | Vue | Angular | HTML | [Web Components](./web-components) | Svelte | Polymer | Marko | Mithril | Riot | Ember | Preact |
+| ----------------- | :---: | :-: | :-----: | :--: | :--------------------------------: | :----: | :-----: | :---: | :-----: | :--: | :---: | :----: |
+| MDX stories       |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
+| CSF stories       |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
+| StoriesOf stories |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
+| Source            |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
+| Notes / Info      |   +   |  +  |    +    |  +   |                 +                  |   +    |    +    |   +   |    +    |  +   |   +   |   +    |
+| Props table       |   +   |  +  |    #    |      |                 +                  |        |         |       |         |      |       |        |
+| Description       |   +   |  +  |    #    |      |                 +                  |        |         |       |         |      |       |        |
+| Inline stories    |   +   |  +  |         |      |                 +                  |        |         |       |         |      |       |        |
 
 **Note:** `#` = WIP support
 

--- a/addons/docs/docs/mdx.md
+++ b/addons/docs/docs/mdx.md
@@ -25,7 +25,7 @@ Let's get started with an example that combines markdown with a single story:
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { Checkbox } from './Checkbox';
 
-<Meta title="MDX|Checkbox" component={Checkbox} />
+<Meta title="MDX/Checkbox" component={Checkbox} />
 
 # Checkbox
 
@@ -64,7 +64,7 @@ For example, here's the story from `Checkbox` example above, rewritten in CSF:
 ```js
 import React from 'react';
 import { Checkbox } from './Checkbox';
-export default { title: "MDX|Checkbox" component: Checkbox };
+export default { title: "MDX/Checkbox" component: Checkbox };
 export const allCheckboxes = () => (
   <form>
     <Checkbox id="Unchecked" label="Unchecked" />
@@ -86,7 +86,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { Badge } from './Badge';
 import { Icon } from './Icon';
 
-<Meta title="MDX|Badge" component={Badge} />
+<Meta title="MDX/Badge" component={Badge} />
 
 # Badge
 

--- a/docs/src/pages/basics/writing-stories/index.md
+++ b/docs/src/pages/basics/writing-stories/index.md
@@ -312,7 +312,7 @@ import base from 'paths.macro';
 import BaseButton from '../components/BaseButton';
 
 export default {
-  title: `Other|${base}/Dirname Example`,
+  title: `Other/${base}/Dirname Example`,
 };
 export const story1 = () => <BaseButton label="Story 1" />;
 export const story2 = () => <BaseButton label="Story 2" />;

--- a/docs/src/pages/formats/component-story-format/index.md
+++ b/docs/src/pages/formats/component-story-format/index.md
@@ -17,7 +17,7 @@ The default export defines metadata about your component, including the `compone
 import MyComponent from './MyComponent';
 
 export default {
-  title: 'Path|To/MyComponent',
+  title: 'Path/To/MyComponent',
   component: MyComponent,
   decorators: [ ... ],
   parameters: { ... }

--- a/lib/ui/src/components/sidebar/Sidebar.stories.mdx
+++ b/lib/ui/src/components/sidebar/Sidebar.stories.mdx
@@ -4,7 +4,7 @@ import Sidebar from './Sidebar';
 import { standardData } from './SidebarHeading.stories';
 import { withRootData } from './SidebarStories.stories';
 
-<Meta component="Sidebar" title="Addons|Docs/Sidebar" />
+<Meta component="Sidebar" title="Addons/Docs/Sidebar" />
 
 # Sidebar
 


### PR DESCRIPTION
Issue: We were still using `|` as a separator in a couple of doc files