### PR TITLE
Fixes incorrect link

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -7,7 +7,7 @@ This is a central reference for using Storybook with TypeScript.
 
 ## Typescript configuration presets
 
-The easiest way to write and configure your stories in TypeScript is by using [Storybook presets](../../presets/introduction/index.md).
+The easiest way to write and configure your stories in TypeScript is by using [Storybook presets](../../presets/introduction).
 
 If you're using Create React App (CRA) and have configured it to work with TS, you should use the [CRA preset](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app), which configures Storybook to reuse CRA's TS handling.
 


### PR DESCRIPTION
Issue: Pointed to markdown file instead of the actual page.

## What I did

Fixed URL

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
