### PR TITLE
Addon-viewports: Fix missing TypeScript types

### DIFF
--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -23,7 +23,8 @@
     "*.js",
     "*.d.ts"
   ],
-  "main": "preview.js",
+  "main": "dist/preview.js",
+  "types": "dist/preview.d.ts",
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"
   },

--- a/addons/viewport/preview.js
+++ b/addons/viewport/preview.js
@@ -1,5 +1,0 @@
-const preview = require('./dist/legacy_preview/index');
-
-exports.configureViewport = preview.configureViewport;
-exports.DEFAULT_VIEWPORT = preview.DEFAULT_VIEWPORT;
-exports.INITIAL_VIEWPORTS = preview.INITIAL_VIEWPORTS;

--- a/addons/viewport/src/preview.ts
+++ b/addons/viewport/src/preview.ts
@@ -1,0 +1,1 @@
+export { configureViewport, DEFAULT_VIEWPORT, INITIAL_VIEWPORTS } from './legacy_preview';


### PR DESCRIPTION
Issue: #8611

## What I did

- Migrate `preview.js` to TypeScript and move it to `src`
- Update `main` field and add `types` field to `package.json`