### PR TITLE
Changes links to absolute URLs

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -1,5 +1,5 @@
 <center>
-  <img src="docs/media/hero.png" width="100%" />
+  <img src="https://raw.githubusercontent.com/storybookjs/storybook/master/addons/docs/docs/media/hero.png" width="100%" />
 </center>
 
 # Storybook Docs
@@ -30,7 +30,7 @@ When you [install Docs](#installation), every story gets a `DocsPage`. `DocsPage
 Click on the `Docs` tab to see it:
 
 <center>
-  <img src="docs/media/docs-tab.png" width="100%" />
+  <img src="https://raw.githubusercontent.com/storybookjs/storybook/master/addons/docs/docs/media/docs-tab.png" width="100%" />
 </center>
 
 For more information on how it works, see the [`DocsPage` reference](./docs/docspage.md).
@@ -66,7 +66,7 @@ markdown documentation.
 And here's how that's rendered in Storybook:
 
 <center>
-  <img src="docs/media/mdx-simple.png" width="100%" />
+  <img src="https://raw.githubusercontent.com/storybookjs/storybook/master/addons/docs/docs/media/mdx-simple.png" width="100%" />
 </center>
 
 For more information on `MDX`, see the [`MDX` reference](./docs/mdx.md).


### PR DESCRIPTION
Relative links break when README file is viewed at https://www.npmjs.com/package/@storybook/addon-docs.

Issue: Images break when viewing at https://www.npmjs.com/package/@storybook/addon-docs

## What I did

Changed image `src` to absolute URL and not relative URL (which breaks on other domains).

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No