### PR TITLE
Addon-google-analytics: Add gaOption config

### DIFF
--- a/addons/google-analytics/README.md
+++ b/addons/google-analytics/README.md
@@ -22,4 +22,5 @@ Then, set an environment variable
 
 ```
 window.STORYBOOK_GA_ID = UA-000000-01
+window.STORYBOOK_REACT_GA_OPTIONS = {}
 ```

--- a/addons/google-analytics/src/register.ts
+++ b/addons/google-analytics/src/register.ts
@@ -5,7 +5,7 @@ import { STORY_CHANGED, STORY_ERRORED, STORY_MISSING } from '@storybook/core-eve
 import ReactGA from 'react-ga';
 
 addons.register('storybook/google-analytics', api => {
-  ReactGA.initialize(window.STORYBOOK_GA_ID);
+  ReactGA.initialize(window.STORYBOOK_GA_ID, window.STORYBOOK_REACT_GA_OPTIONS);
 
   api.on(STORY_CHANGED, () => {
     const { url } = api.getUrlState();


### PR DESCRIPTION
## What I did
- Set the second argument of [ReactGA.initialize](https://github.com/react-ga/react-ga/blob/master/types/index.d.ts#L89)

## How to test

-  set an environment variable `window.STORYBOOK_REACT_GA_OPTIONS = {gaOptions: { 'cookieDomain' ：'none' }}`
