### PR TITLE
Addon-docs: Fix regression to @ignore in Props

### DIFF
--- a/addons/docs/src/frameworks/react/propTypes/handleProp.test.ts
+++ b/addons/docs/src/frameworks/react/propTypes/handleProp.test.ts
@@ -710,7 +710,7 @@ describe('enhancePropTypesProp', () => {
 });
 
 describe('enhancePropTypesProps', () => {
-  it('keep the original definition order', () => {
+  it('should keep the original definition order', () => {
     const component = createComponent({
       propTypes: {
         foo: PropTypes.string,
@@ -750,5 +750,33 @@ describe('enhancePropTypesProps', () => {
     expect(props[1].name).toBe('middleWithDefaultValue');
     expect(props[2].name).toBe('bar');
     expect(props[3].name).toBe('endWithDefaultValue');
+  });
+
+  it('should not include @ignore props', () => {
+    const component = createComponent({
+      propTypes: {
+        foo: PropTypes.string,
+        bar: PropTypes.string,
+      },
+      docgenInfo: {
+        ...createDocgenProp({
+          name: 'foo',
+          type: { name: 'string' },
+        }),
+        ...createDocgenProp({
+          name: 'bar',
+          type: { name: 'string' },
+          description: '@ignore',
+        }),
+      },
+    });
+
+    const props = enhancePropTypesProps(
+      extractPropsFromDocgen(component, DOCGEN_SECTION),
+      component
+    );
+
+    expect(props.length).toBe(1);
+    expect(props[0].name).toBe('foo');
   });
 });

--- a/addons/docs/src/frameworks/react/propTypes/sortProps.ts
+++ b/addons/docs/src/frameworks/react/propTypes/sortProps.ts
@@ -12,7 +12,9 @@ export function keepOriginalDefinitionOrder(
   const { propTypes } = component;
 
   if (!isNil(propTypes)) {
-    return Object.keys(propTypes).map(x => extractedProps.find(y => y.name === x));
+    return Object.keys(propTypes)
+      .map(x => extractedProps.find(y => y.name === x))
+      .filter(x => x);
   }
 
   return extractedProps;


### PR DESCRIPTION
Issue: #8539 

https://github.com/storybookjs/storybook/pull/8857 introduced a regression with @ignore. The ignored prop were returned an undefined.

## What I did

Fixed the issue and added a test.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
