### PR TITLE
Addon-docs: Add back Props "exclude" support

### DIFF
--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -1,7 +1,13 @@
 import React, { FunctionComponent, useContext } from 'react';
 import { isNil } from 'lodash';
 
-import { PropsTable, PropsTableError, PropsTableProps, TabsState } from '@storybook/components';
+import {
+  PropsTable,
+  PropsTableError,
+  PropsTableProps,
+  PropDef,
+  TabsState,
+} from '@storybook/components';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { Component, PropsSlot, CURRENT_SELECTION } from './shared';
 import { getComponentName } from './utils';
@@ -47,7 +53,7 @@ export const getComponentProps = (
     if (!extractProps) {
       throw new Error(PropsTableError.PROPS_UNSUPPORTED);
     }
-    let { rows } = extractProps(target);
+    let { rows } = extractProps(component);
     if (!isNil(exclude)) {
       rows = rows.filter((row: PropDef) => !exclude.includes(row.name));
     }

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react';
-import { PropsTable, PropsTableError, PropsTableProps } from '@storybook/components';
+import { PropsTable, PropsTableError, PropsTableProps, PropDef } from '@storybook/components';
+import { isNil } from 'lodash';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { Component, CURRENT_SELECTION } from './shared';
-
 import { PropsExtractor } from '../lib/docgen/types';
 import { extractProps as reactExtractProps } from '../frameworks/react/extractProps';
 import { extractProps as vueExtractProps } from '../frameworks/vue/extractProps';
@@ -41,7 +41,13 @@ export const getPropsTableProps = (
     if (!extractProps) {
       throw new Error(PropsTableError.PROPS_UNSUPPORTED);
     }
-    return extractProps(target, { exclude });
+
+    let { rows } = extractProps(target);
+    if (!isNil(exclude)) {
+      rows = rows.filter((row: PropDef) => !exclude.includes(row.name));
+    }
+
+    return { rows };
   } catch (err) {
     return { error: err.message };
   }

--- a/examples/cra-ts-kitchen-sink/src/stories/props-sort.stories.mdx
+++ b/examples/cra-ts-kitchen-sink/src/stories/props-sort.stories.mdx
@@ -4,3 +4,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 <Meta title="PropsSort" />
 
 <Props of={PropsSort} />
+<Props of={PropsSort} exclude={["foo"]} />


### PR DESCRIPTION
## What I did

Added back the code to support `exclude` with the `Props` component 

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps? Yes
- Does this need an update to the documentation?

cra-ts-kichen-sink: `?path=/docs/propssort--page`

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
