### PR TITLE
Addon-docs: Add tests for prop types default value

### DIFF
--- a/addons/docs/src/frameworks/react/propTypes/createDefaultValue.ts
+++ b/addons/docs/src/frameworks/react/propTypes/createDefaultValue.ts
@@ -65,7 +65,7 @@ function generateFunc({ inferedType, ast }: InspectionResult): PropDefaultValue 
 }
 
 // All elements are JSX elements.
-// JSX elements cannot are not supported by escodegen.
+// JSX elements are not supported by escodegen.
 function generateElement(
   defaultValue: string,
   inspectionResult: InspectionResult

--- a/addons/docs/src/frameworks/react/propTypes/handleProp.test.ts
+++ b/addons/docs/src/frameworks/react/propTypes/handleProp.test.ts
@@ -47,15 +47,15 @@ function extractPropDef(component: Component): PropDef {
 }
 
 describe('enhancePropTypesProp', () => {
-  function createTestComponent(docgenInfo: Partial<DocgenInfo>): Component {
-    return createComponent({
-      docgenInfo: {
-        ...createDocgenProp({ name: 'prop', ...docgenInfo }),
-      },
-    });
-  }
-
   describe('type', () => {
+    function createTestComponent(docgenInfo: Partial<DocgenInfo>): Component {
+      return createComponent({
+        docgenInfo: {
+          ...createDocgenProp({ name: 'prop', ...docgenInfo }),
+        },
+      });
+    }
+
     describe('custom', () => {
       describe('when raw value is available', () => {
         it('should support literal', () => {
@@ -82,9 +82,7 @@ describe('enhancePropTypesProp', () => {
 
           const { type } = extractPropDef(component);
 
-          const expectedSummary = `{
-            text: string
-          }`;
+          const expectedSummary = '{ text: string }';
 
           expect(type.summary.replace(/\s/g, '')).toBe(expectedSummary.replace(/\s/g, ''));
           expect(type.detail).toBeUndefined();
@@ -705,6 +703,181 @@ describe('enhancePropTypesProp', () => {
 
         expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
       });
+    });
+  });
+
+  describe('defaultValue', () => {
+    function createTestComponent(defaultValue: string): Component {
+      return createComponent({
+        docgenInfo: {
+          ...createDocgenProp({
+            name: 'prop',
+            type: { name: 'custom' },
+            defaultValue: { value: defaultValue },
+          }),
+        },
+      });
+    }
+
+    it('should support short object', () => {
+      const component = createTestComponent("{ foo: 'foo', bar: 'bar' }");
+
+      const { defaultValue } = extractPropDef(component);
+
+      const expectedSummary = "{ foo: 'foo', bar: 'bar' }";
+
+      expect(defaultValue.summary.replace(/\s/g, '')).toBe(expectedSummary.replace(/\s/g, ''));
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long object', () => {
+      const component = createTestComponent("{ foo: 'foo', bar: 'bar', another: 'another' }");
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('object');
+
+      const expectedDetail = `{
+        foo: 'foo',
+        bar: 'bar',
+        another: 'another'
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should support short function', () => {
+      const component = createTestComponent('() => {}');
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('() => {}');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long function', () => {
+      const component = createTestComponent(
+        '(foo, bar) => {\n  const concat = foo + bar;\n  const append = concat + " hey!";\n  \n  return append;\n}'
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('func');
+
+      const expectedDetail = `(foo, bar) => {
+        const concat = foo + bar;
+        const append = concat + ' hey!';
+        return append
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should use the name of function when available and indicate that args are present', () => {
+      const component = createTestComponent('function concat(a, b) {\n  return a + b;\n}');
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('concat( ... )');
+
+      const expectedDetail = `function concat(a, b) {
+        return a + b
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should use the name of function when available', () => {
+      const component = createTestComponent('function hello() {\n  return "hello";\n}');
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('hello()');
+
+      const expectedDetail = `function hello() {
+        return 'hello'
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should support short element', () => {
+      const component = createTestComponent('<div>Hey!</div>');
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('<div>Hey!</div>');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long element', () => {
+      const component = createTestComponent(
+        '() => {\n  return <div>Inlined FunctionnalComponent!</div>;\n}'
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('element');
+
+      const expectedDetail = `() => {
+        return <div>Inlined FunctionnalComponent!</div>;
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it("should use the name of the React component when it's available", () => {
+      const component = createTestComponent(
+        'function InlinedFunctionalComponent() {\n  return <div>Inlined FunctionnalComponent!</div>;\n}'
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('<InlinedFunctionalComponent />');
+
+      const expectedDetail = `function InlinedFunctionalComponent() {
+        return <div>Inlined FunctionnalComponent!</div>;
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should not use the name of an HTML element', () => {
+      const component = createTestComponent('<div>Hey!</div>');
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).not.toBe('<div />');
+    });
+
+    it('should support short array', () => {
+      const component = createTestComponent('[1]');
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('[1]');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long array', () => {
+      const component = createTestComponent(
+        '[\n  {\n    thing: {\n      id: 2,\n      func: () => {},\n      arr: [],\n    },\n  },\n]'
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('array');
+
+      const expectedDetail = `[{
+          thing: {
+            id: 2,
+            func: () => {
+            },
+            arr: []
+          }
+        }]`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
     });
   });
 });

--- a/addons/docs/src/frameworks/react/propTypes/sortProps.ts
+++ b/addons/docs/src/frameworks/react/propTypes/sortProps.ts
@@ -2,7 +2,7 @@ import { PropDef } from '@storybook/components';
 import { isNil } from 'lodash';
 import { Component } from '../../../blocks/shared';
 
-// react-docgen doesn't returned the props in the order they were defined in the "propTypes" of the component.
+// react-docgen doesn't returned the props in the order they were defined in the "propTypes" object of the component.
 // This function re-order them by their original definition order.
 export function keepOriginalDefinitionOrder(
   extractedProps: PropDef[],


### PR DESCRIPTION
Issue:

## What I did

Added test coverage for prop types default value

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
