### PR TITLE
Addon-docs: Fix MDX component permalinking

### DIFF
--- a/addons/docs/src/mdx/__testfixtures__/component-id.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/component-id.output.snapshot
@@ -39,7 +39,7 @@ componentNotes.story.parameters = { mdxSource: '<Button>Component notes</Button>
 
 const componentMeta = { title: 'Button', id: 'button-id', includeStories: ['componentNotes'] };
 
-const mdxStoryNameToId = { 'component notes': 'button--component-notes' };
+const mdxStoryNameToId = { 'component notes': 'button-id--component-notes' };
 
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -298,11 +298,11 @@ function extractExports(node, options) {
   }
   metaExport.includeStories = JSON.stringify(includeStories);
 
-  const { title } = metaExport;
+  const { title, id: componentId } = metaExport;
   const mdxStoryNameToId = Object.entries(context.storyNameToKey).reduce(
     (acc, [storyName, storyKey]) => {
       if (title) {
-        acc[storyName] = toId(title, storyNameFromExport(storyKey));
+        acc[storyName] = toId(componentId || title, storyNameFromExport(storyKey));
       }
       return acc;
     },


### PR DESCRIPTION
Issue: #8507 (follow-up)

## What I did

Fix compiler in case of component-id metadata

## How to test

See updated snapshots, also this story in `official-storybook` that exposed the bug:

```
<Meta
  title="Addons/Docs/mdx"
  id="addons-docs-mdx-id"
  ...