### PR TITLE
Addon-docs: Improve basic support for Flow props

### DIFF
--- a/addons/docs/src/frameworks/react/propTypes/createDefaultValue.ts
+++ b/addons/docs/src/frameworks/react/propTypes/createDefaultValue.ts
@@ -1,6 +1,6 @@
 import { isNil } from 'lodash';
 // @ts-ignore
-import { PropDefaultValue, PropSummaryValue } from '@storybook/components';
+import { PropDefaultValue } from '@storybook/components';
 import { inspectValue } from '../inspection/inspectValue';
 import { OBJECT_CAPTION, FUNCTION_CAPTION, ELEMENT_CAPTION, ARRAY_CAPTION } from './captions';
 import { generateCode } from './generateCode';
@@ -11,12 +11,7 @@ import {
   InspectionElement,
 } from '../inspection/types';
 import { isHtmlTag } from './isHtmlTag';
-
-const MAX_SUMMARY_LENGTH = 50;
-
-function isTooLongForSummary(value: string): boolean {
-  return value.length > MAX_SUMMARY_LENGTH;
-}
+import { createSummaryValue, isTooLongForDefaultValueSummary } from '../../../lib';
 
 // TODO: Fix this any type.
 function getPrettyIdentifier(inferedType: any): string {
@@ -32,10 +27,6 @@ function getPrettyIdentifier(inferedType: any): string {
   }
 }
 
-function createSummaryValue(summary: string, detail?: string): PropSummaryValue {
-  return { summary, detail };
-}
-
 function generateObject({ ast }: InspectionResult): PropDefaultValue {
   let prettyCaption = generateCode(ast, true);
 
@@ -45,7 +36,7 @@ function generateObject({ ast }: InspectionResult): PropDefaultValue {
     prettyCaption = `${prettyCaption.slice(0, -1)} }`;
   }
 
-  return !isTooLongForSummary(prettyCaption)
+  return !isTooLongForDefaultValueSummary(prettyCaption)
     ? createSummaryValue(prettyCaption)
     : createSummaryValue(OBJECT_CAPTION, generateCode(ast));
 }
@@ -59,7 +50,7 @@ function generateFunc({ inferedType, ast }: InspectionResult): PropDefaultValue 
 
   const prettyCaption = generateCode(ast, true);
 
-  return !isTooLongForSummary(prettyCaption)
+  return !isTooLongForDefaultValueSummary(prettyCaption)
     ? createSummaryValue(prettyCaption)
     : createSummaryValue(FUNCTION_CAPTION, generateCode(ast));
 }
@@ -84,7 +75,7 @@ function generateElement(
     }
   }
 
-  return !isTooLongForSummary(defaultValue)
+  return !isTooLongForDefaultValueSummary(defaultValue)
     ? createSummaryValue(defaultValue)
     : createSummaryValue(ELEMENT_CAPTION, defaultValue);
 }
@@ -92,7 +83,7 @@ function generateElement(
 function generateArray({ ast }: InspectionResult): PropDefaultValue {
   const prettyCaption = generateCode(ast, true);
 
-  return !isTooLongForSummary(prettyCaption)
+  return !isTooLongForDefaultValueSummary(prettyCaption)
     ? createSummaryValue(prettyCaption)
     : createSummaryValue(ARRAY_CAPTION, generateCode(ast));
 }

--- a/addons/docs/src/frameworks/react/propTypes/createType.ts
+++ b/addons/docs/src/frameworks/react/propTypes/createType.ts
@@ -1,5 +1,6 @@
 import { isNil } from 'lodash';
 import { PropSummaryValue, PropType } from '@storybook/components';
+import { createSummaryValue, isTooLongForTypeSummary } from '../../../lib';
 import { ExtractedProp, DocgenPropType } from '../../../lib/docgen';
 import { inspectValue } from '../inspection/inspectValue';
 import { generateCode } from './generateCode';
@@ -14,8 +15,6 @@ import {
 } from './captions';
 import { InspectionType } from '../inspection/types';
 import { isHtmlTag } from './isHtmlTag';
-
-const MAX_SUMMARY_LENGTH = 35;
 
 enum PropTypesType {
   CUSTOM = 'custom',
@@ -90,15 +89,11 @@ function getCaptionFromInspectionType(type: InspectionType): string {
   }
 }
 
-function isTooLongForSummary(value: string): boolean {
-  return value.length > MAX_SUMMARY_LENGTH;
-}
-
 function generateValuesForObjectAst(ast: any): [string, string] {
   let summary = prettyObject(ast, true);
   let detail;
 
-  if (!isTooLongForSummary(summary)) {
+  if (!isTooLongForTypeSummary(summary)) {
     detail = summary;
   } else {
     summary = OBJECT_CAPTION;
@@ -188,7 +183,7 @@ function generateObjectOf(type: DocgenPropType, extractedProp: ExtractedProp): T
   let { summary, detail } = value;
 
   if (name === PropTypesType.SHAPE) {
-    if (!isTooLongForSummary(detail)) {
+    if (!isTooLongForTypeSummary(detail)) {
       summary = detail;
     }
   }
@@ -350,15 +345,12 @@ export function createType(extractedProp: ExtractedProp): PropType {
     case PropTypesType.ARRAYOF: {
       const { summary, detail } = generateType(type, extractedProp).value;
 
-      return {
-        summary,
-        detail: summary !== detail ? detail : undefined,
-      };
+      return createSummaryValue(summary, summary !== detail ? detail : undefined);
     }
     case PropTypesType.FUNC: {
       const { detail } = generateType(type, extractedProp).value;
 
-      return { summary: detail };
+      return createSummaryValue(detail);
     }
     default:
       return null;

--- a/addons/docs/src/lib/docgen/createDefaultValue.ts
+++ b/addons/docs/src/lib/docgen/createDefaultValue.ts
@@ -1,6 +1,7 @@
 import { isNil } from 'lodash';
 import { PropDefaultValue } from '@storybook/components';
 import { DocgenPropDefaultValue } from './types';
+import { createSummaryValue } from '../utils';
 
 const BLACKLIST = ['null', 'undefined'];
 
@@ -13,9 +14,7 @@ export function createDefaultValue(defaultValue: DocgenPropDefaultValue): PropDe
     const { value } = defaultValue;
 
     if (!isDefaultValueBlacklisted(value)) {
-      return {
-        summary: value,
-      };
+      return createSummaryValue(value);
     }
   }
 

--- a/addons/docs/src/lib/docgen/extractDocgenProps.test.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.test.ts
@@ -14,6 +14,7 @@ interface TypeSystemDef {
 const TypeSystems: TypeSystemDef[] = [
   { name: 'javascript', typeProperty: 'type' },
   { name: 'typescript', typeProperty: 'tsType' },
+  { name: 'flow', typeProperty: 'flowType' },
 ];
 
 function createType(typeName: string, others: Record<string, any> = {}): Record<string, string> {

--- a/addons/docs/src/lib/docgen/flow/createDefaultValue.ts
+++ b/addons/docs/src/lib/docgen/flow/createDefaultValue.ts
@@ -1,0 +1,19 @@
+import { PropDefaultValue } from '@storybook/components';
+import { isNil } from 'lodash';
+import { DocgenPropDefaultValue, DocgenPropType } from '../types';
+import { createSummaryValue, isTooLongForDefaultValueSummary } from '../../utils';
+
+export function createDefaultValue(
+  defaultValue: DocgenPropDefaultValue,
+  type: DocgenPropType
+): PropDefaultValue {
+  if (!isNil(defaultValue)) {
+    const { value } = defaultValue;
+
+    return !isTooLongForDefaultValueSummary(value)
+      ? createSummaryValue(value)
+      : createSummaryValue(type.name, value);
+  }
+
+  return null;
+}

--- a/addons/docs/src/lib/docgen/flow/createPropDef.test.ts
+++ b/addons/docs/src/lib/docgen/flow/createPropDef.test.ts
@@ -1,0 +1,242 @@
+import { isNil } from 'lodash';
+import { createFlowPropDef } from './createPropDef';
+import { DocgenInfo, DocgenFlowType } from '../types';
+
+const PROP_NAME = 'propName';
+
+function createDocgenInfo({
+  type,
+  defaultValue,
+  ...rest
+}: {
+  type: DocgenFlowType;
+  defaultValue?: string;
+}): DocgenInfo {
+  return {
+    flowType: type,
+    defaultValue: !isNil(defaultValue) ? { value: defaultValue } : undefined,
+    required: false,
+    ...rest,
+  };
+}
+
+describe('type', () => {
+  ['string', 'number', 'boolean', 'any', 'void', 'Object', 'String', 'MyClass', 'literal'].forEach(
+    x => {
+      it(`should support ${x}`, () => {
+        const docgenInfo = createDocgenInfo({
+          type: { name: x },
+        });
+
+        const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+        expect(type.summary).toBe(x);
+        expect(type.detail).toBeUndefined();
+      });
+    }
+  );
+
+  ['Array', 'Class', 'MyClass'].forEach(x => {
+    it(`should support untyped ${x}`, () => {
+      const docgenInfo = createDocgenInfo({
+        type: { name: x },
+      });
+
+      const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+      expect(type.summary).toBe(x);
+      expect(type.detail).toBeUndefined();
+    });
+
+    it(`should support typed ${x}`, () => {
+      const docgenInfo = createDocgenInfo({
+        type: {
+          name: x,
+          elements: [
+            {
+              name: 'any',
+            },
+          ],
+          raw: `${x}<any>`,
+        },
+      });
+
+      const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+      expect(type.summary).toBe(`${x}<any>`);
+      expect(type.detail).toBeUndefined();
+    });
+  });
+
+  it('should support short object signature', () => {
+    const docgenInfo = createDocgenInfo({
+      type: {
+        name: 'signature',
+        type: 'object',
+        raw: '{ foo: string, bar?: mixed }',
+        signature: {
+          properties: [
+            {
+              key: 'foo',
+              value: {
+                name: 'string',
+                required: true,
+              },
+            },
+            {
+              key: 'bar',
+              value: {
+                name: 'mixed',
+                required: false,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('{ foo: string, bar?: mixed }');
+    expect(type.detail).toBeUndefined();
+  });
+
+  it('should support long object signature', () => {
+    const docgenInfo = createDocgenInfo({
+      type: {
+        name: 'signature',
+        type: 'object',
+        raw: '{ (x: string): void, prop: string }',
+        signature: {
+          properties: [
+            {
+              key: 'prop',
+              value: {
+                name: 'string',
+                required: true,
+              },
+            },
+          ],
+          constructor: {
+            name: 'signature',
+            type: 'function',
+            raw: '(x: string): void',
+            signature: {
+              arguments: [
+                {
+                  name: 'x',
+                  type: {
+                    name: 'string',
+                  },
+                },
+              ],
+              return: {
+                name: 'void',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('object');
+    expect(type.detail).toBe('{ (x: string): void, prop: string }');
+  });
+
+  it('should support func signature', () => {
+    const docgenInfo = createDocgenInfo({
+      type: {
+        name: 'signature',
+        type: 'function',
+        raw: '(x: string) => void',
+        signature: {
+          arguments: [
+            {
+              name: 'x',
+              type: {
+                name: 'string',
+              },
+            },
+          ],
+          return: {
+            name: 'void',
+          },
+        },
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('(x: string) => void');
+    expect(type.detail).toBeUndefined();
+  });
+
+  it('should support tuple', () => {
+    const docgenInfo = createDocgenInfo({
+      type: {
+        name: 'tuple',
+        raw: '[foo, "value", number]',
+        elements: [
+          {
+            name: 'foo',
+          },
+          {
+            name: 'literal',
+            value: '"value"',
+          },
+          {
+            name: 'number',
+          },
+        ],
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('[foo, "value", number]');
+  });
+
+  it('should support union', () => {
+    const docgenInfo = createDocgenInfo({
+      type: {
+        name: 'union',
+        raw: 'number | string',
+        elements: [
+          {
+            name: 'number',
+          },
+          {
+            name: 'string',
+          },
+        ],
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('number | string');
+  });
+
+  it('should support intersection', () => {
+    const docgenInfo = createDocgenInfo({
+      type: {
+        name: 'intersection',
+        raw: 'number & string',
+        elements: [
+          {
+            name: 'number',
+          },
+          {
+            name: 'string',
+          },
+        ],
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('number & string');
+  });
+});

--- a/addons/docs/src/lib/docgen/flow/createPropDef.ts
+++ b/addons/docs/src/lib/docgen/flow/createPropDef.ts
@@ -1,0 +1,15 @@
+import { PropDefFactory } from '../createPropDef';
+import { createType } from './createType';
+import { createDefaultValue } from './createDefaultValue';
+
+export const createFlowPropDef: PropDefFactory = (propName, docgenInfo) => {
+  const { flowType, description, required, defaultValue } = docgenInfo;
+
+  return {
+    name: propName,
+    type: createType(flowType),
+    required,
+    description,
+    defaultValue: createDefaultValue(defaultValue, flowType),
+  };
+};

--- a/addons/docs/src/lib/docgen/flow/createType.ts
+++ b/addons/docs/src/lib/docgen/flow/createType.ts
@@ -1,0 +1,55 @@
+import { PropType, PropSummaryValue } from '@storybook/components';
+import { isNil } from 'lodash';
+import { DocgenPropType } from '../types';
+import { createSummaryValue } from '../../utils';
+
+enum FlowTypesType {
+  UNION = 'union',
+  ARRAY = 'Array',
+  SIGNATURE = 'signature',
+}
+
+interface DocgenFlowUnionType extends DocgenPropType {
+  elements: { name: string; value: string }[];
+}
+
+function generateUnion(type: DocgenFlowUnionType): PropSummaryValue {
+  if (!isNil(type.raw)) {
+    return createSummaryValue(type.raw);
+  }
+
+  if (!isNil(type.elements)) {
+    return createSummaryValue(type.elements.map(x => x.value).join(' | '));
+  }
+
+  return createSummaryValue(type.name);
+}
+
+function generateArray(type: DocgenPropType): PropSummaryValue {
+  if (!isNil(type.raw)) {
+    return createSummaryValue(type.raw);
+  }
+
+  return createSummaryValue(type.name);
+}
+
+function generateSignature(type: DocgenPropType): PropSummaryValue {
+  if (!isNil(type.raw)) {
+    return createSummaryValue(type.raw);
+  }
+
+  return createSummaryValue(type.name);
+}
+
+export function createType(type: DocgenPropType): PropType {
+  switch (type.name) {
+    case FlowTypesType.UNION:
+      return generateUnion(type as DocgenFlowUnionType);
+    case FlowTypesType.ARRAY:
+      return generateArray(type);
+    case FlowTypesType.SIGNATURE:
+      return generateSignature(type);
+    default:
+      return createSummaryValue(type.name);
+  }
+}

--- a/addons/docs/src/lib/docgen/types.ts
+++ b/addons/docs/src/lib/docgen/types.ts
@@ -15,8 +15,12 @@ export interface DocgenPropType extends DocgenBaseType {
   computed?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface DocgenFlowType extends DocgenBaseType {}
+export interface DocgenFlowType extends DocgenBaseType {
+  type?: string;
+  raw?: string;
+  signature?: any;
+  elements?: any[];
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DocgenTypeScriptType extends DocgenBaseType {}

--- a/addons/docs/src/lib/index.ts
+++ b/addons/docs/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/addons/docs/src/lib/utils.ts
+++ b/addons/docs/src/lib/utils.ts
@@ -1,0 +1,16 @@
+import { PropSummaryValue } from '@storybook/components';
+
+export const MAX_TYPE_SUMMARY_LENGTH = 30;
+export const MAX_DEFALUT_VALUE_SUMMARY_LENGTH = 50;
+
+export function isTooLongForTypeSummary(value: string): boolean {
+  return value.length > MAX_TYPE_SUMMARY_LENGTH;
+}
+
+export function isTooLongForDefaultValueSummary(value: string): boolean {
+  return value.length > MAX_DEFALUT_VALUE_SUMMARY_LENGTH;
+}
+
+export function createSummaryValue(summary: string, detail?: string): PropSummaryValue {
+  return { summary, detail };
+}

--- a/examples/cra-ts-kitchen-sink/.storybook/presets.js
+++ b/examples/cra-ts-kitchen-sink/.storybook/presets.js
@@ -8,6 +8,7 @@ module.exports = [
         tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
         shouldExtractLiteralValuesFromEnum: true,
         propFilter: prop => {
+          // Currently not working, prop.parent is always null.
           if (prop.parent) {
             return !prop.parent.fileName.includes('node_modules/@types/react/');
           }


### PR DESCRIPTION
Issue:

## What I did

Improved the basic support for Flow.

Before the improvement for PropTypes the support for Flow was better than it is now. This PR fix that.

This is also a first step to generalize some concepts of PropTypes to other type systems.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

To test with Jest run: `yarn jest --testPathPattern=createPropDef`

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
