### PR TITLE
Correct Demo url for react-native-web

### DIFF
--- a/app/react/README.md
+++ b/app/react/README.md
@@ -25,7 +25,7 @@ You can also build a [static version](https://storybook.js.org/basics/exporting-
 Here are some featured storybooks that you can reference to see how Storybook works:
 
 - [Demo of React Dates](http://airbnb.io/react-dates/) - [source](https://github.com/airbnb/react-dates)
-- [Demo of React Native Web](http://necolas.github.io/react-native-web/storybook/) - [source](https://github.com/necolas/react-native-web)
+- [Demo of React Native Web](https://necolas.github.io/react-native-web/docs/) - [source](https://github.com/necolas/react-native-web)
 
 ## Create React App
 

--- a/docs/src/pages/basics/exporting-storybook/index.md
+++ b/docs/src/pages/basics/exporting-storybook/index.md
@@ -6,7 +6,7 @@ title: 'Exporting Storybook as a Static App'
 Storybook gives a great developer experience with its dev time features, like instant change updates via Webpack's HMR.
 
 But Storybook is also a tool you can use to showcase your components to others.
-Demos of [React Native Web](http://necolas.github.io/react-native-web/storybook/) and [React Dates](http://airbnb.io/react-dates/) are a good example for that.
+Demos of [React Native Web](https://necolas.github.io/react-native-web/docs/) and [React Dates](http://airbnb.io/react-dates/) are a good example for that.
 
 For that, Storybook comes with a tool to export your storybook into a static web app. Then you can deploy it to GitHub pages or any static hosting service.
 

--- a/docs/src/pages/basics/introduction/index.md
+++ b/docs/src/pages/basics/introduction/index.md
@@ -16,6 +16,6 @@ A [Static version](/basics/exporting-storybook) of Storybook can also be built a
 Here are some featured Storybooks to see how it works:
 
 - [Demo of React Dates](http://airbnb.io/react-dates/) - [source](https://github.com/airbnb/react-dates)
-- [Demo of React Native Web](http://necolas.github.io/react-native-web/storybook/) - [source](https://github.com/necolas/react-native-web)
+- [Demo of React Native Web](https://necolas.github.io/react-native-web/docs/) - [source](https://github.com/necolas/react-native-web)
 
 Read the Learn Storybook [tutorial](https://www.learnstorybook.com) for a step by step guide to building an app with Storybook and to see how building components in isolation can supercharge your app development workflow.

--- a/docs/src/pages/examples/_examples.yml
+++ b/docs/src/pages/examples/_examples.yml
@@ -69,7 +69,7 @@ necolas:
   title: React Native Web
   description: Storybook demo for React Native Web.
   source: https://github.com/necolas/react-native-web
-  demo: https://necolas.github.io/react-native-web/storybook/
+  demo: https://necolas.github.io/react-native-web/docs/
 griddle:
   thumbnail: griddle.jpg
   title: Griddle

--- a/docs/src/stories/data.js
+++ b/docs/src/stories/data.js
@@ -82,7 +82,7 @@ storiesOf('Toggle', module)
       owner: 'https://avatars3.githubusercontent.com/u/239676?v=3&s=460',
       storybook: {
         name: 'React Native Web',
-        link: 'https://necolas.github.io/react-native-web/storybook',
+        link: 'https://necolas.github.io/react-native-web/docs/',
       },
       source: 'https://github.com/necolas/react-native-web',
     },


### PR DESCRIPTION
React Native for Web seems to have changed it's documentation style and url.
Old url results 404 error, so this update points to right place.
Fixed in all places in codebase where link seems to be active..

Issue:

## What I did
Searched whole codebase to change old url http://necolas.github.io/react-native-web/storybook/ into new working url https://necolas.github.io/react-native-web/docs/

## How to test
Click the links.