### PR TITLE
Addon-docs: Fix Description block when no component provided

### DIFF
--- a/addons/docs/src/lib/docgen/extractDocgenProps.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.ts
@@ -76,6 +76,6 @@ function extractProp(
   return null;
 }
 
-export function extractComponentDescription(component: Component): string {
-  return getDocgenDescription(component);
+export function extractComponentDescription(component?: Component): string {
+  return !isNil(component) && getDocgenDescription(component);
 }


### PR DESCRIPTION
Issue:

## What I did

Fix the Description block for Vue

![image](https://user-images.githubusercontent.com/794579/69302273-1a035b80-0be7-11ea-89b5-ed822264083a.png)


## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
