### PR TITLE
Addon-docs: Prop table support for Angular directives

### DIFF
--- a/addons/docs/docs/multiframework.md
+++ b/addons/docs/docs/multiframework.md
@@ -49,7 +49,7 @@ addParameters({
 });
 ```
 
-The `extractProps`function receives a component as an argument, and returns an object of type [`PropsTableProps`](https://github.com/storybookjs/storybook/blob/next/lib/components/src/blocks/PropsTable/PropsTable.tsx#L147), which can either be a array of `PropDef` rows (React), or a mapping of section name to an array of `PropDef` rows (e.g. `Props`/`Events`/`Slots` in Vue).
+The `extractProps`function receives a component as an argument, and returns an object of type [`PropsTableProps`](https://github.com/storybookjs/storybook/blob/next/lib/components/src/blocks/PropsTable/PropsTable.tsx#L147), which can either be an array of `PropDef` rows (React), or a mapping of section name to an array of `PropDef` rows (e.g. `Props`/`Events`/`Slots` in Vue).
 
 ```ts
 export interface PropDef {

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -18,7 +18,7 @@ export const setCompodocJson = (compodocJson: CompodocJson) => {
 // @ts-ignore
 export const getCompdocJson = (): CompodocJson => window.__STORYBOOK_COMPODOC_JSON__;
 
-export const checkValidComponent = (component: Component | Directive) => {
+export const checkValidComponentOrDirective = (component: Component | Directive) => {
   if (!component.name) {
     throw new Error(`Invalid component ${JSON.stringify(component)}`);
   }
@@ -75,7 +75,7 @@ const getComponentData = (component: Component | Directive) => {
   if (!component) {
     return null;
   }
-  checkValidComponent(component);
+  checkValidComponentOrDirective(component);
   const compodocJson = getCompdocJson();
   checkValidCompodocJson(compodocJson);
   const { name } = component;

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -2,7 +2,7 @@
 /* global window */
 
 import { PropDef } from '@storybook/components';
-import { Argument, CompodocJson, Component, Method, Property } from './types';
+import { Argument, CompodocJson, Component, Method, Property, Directive } from './types';
 
 type Sections = Record<string, PropDef[]>;
 
@@ -18,7 +18,7 @@ export const setCompodocJson = (compodocJson: CompodocJson) => {
 // @ts-ignore
 export const getCompdocJson = (): CompodocJson => window.__STORYBOOK_COMPODOC_JSON__;
 
-export const checkValidComponent = (component: Component) => {
+export const checkValidComponent = (component: Component | Directive) => {
   if (!component.name) {
     throw new Error(`Invalid component ${JSON.stringify(component)}`);
   }
@@ -71,7 +71,7 @@ const mapItemToSection = (key: string, item: Method | Property): string => {
   }
 };
 
-const getComponentData = (component: Component) => {
+const getComponentData = (component: Component | Directive) => {
   if (!component) {
     return null;
   }
@@ -79,7 +79,10 @@ const getComponentData = (component: Component) => {
   const compodocJson = getCompdocJson();
   checkValidCompodocJson(compodocJson);
   const { name } = component;
-  return compodocJson.components.find((c: Component) => c.name === name);
+  return (
+    compodocJson.components.find((c: Component) => c.name === name) ||
+    compodocJson.directives.find((c: Directive) => c.name === name)
+  );
 };
 
 const displaySignature = (item: Method): string => {
@@ -89,7 +92,7 @@ const displaySignature = (item: Method): string => {
   return `(${args.join(', ')}) => ${item.returnType}`;
 };
 
-export const extractProps = (component: Component) => {
+export const extractProps = (component: Component | Directive) => {
   const componentData = getComponentData(component);
   if (!componentData) {
     return null;
@@ -140,7 +143,7 @@ export const extractProps = (component: Component) => {
   return isEmpty(sections) ? null : { sections };
 };
 
-export const extractComponentDescription = (component: Component) => {
+export const extractComponentDescription = (component: Component | Directive) => {
   const componentData = getComponentData(component);
   if (!componentData) {
     return null;

--- a/addons/docs/src/frameworks/angular/types.ts
+++ b/addons/docs/src/frameworks/angular/types.ts
@@ -24,6 +24,15 @@ export interface Component {
   rawdescription: string;
 }
 
+export interface Directive {
+  name: string;
+  propertiesClass: Property[];
+  inputsClass: Property[];
+  outputsClass: Property[];
+  methodsClass: Method[];
+  rawdescription: string;
+}
+
 export interface Argument {
   name: string;
   type: string;
@@ -35,5 +44,6 @@ export interface Decorator {
 }
 
 export interface CompodocJson {
+  directives: Directive[];
   components: Component[];
 }

--- a/addons/docs/src/frameworks/angular/types.ts
+++ b/addons/docs/src/frameworks/angular/types.ts
@@ -15,15 +15,6 @@ export interface Property {
   description?: string;
 }
 
-export interface Component {
-  name: string;
-  propertiesClass: Property[];
-  inputsClass: Property[];
-  outputsClass: Property[];
-  methodsClass: Method[];
-  rawdescription: string;
-}
-
 export interface Directive {
   name: string;
   propertiesClass: Property[];
@@ -32,6 +23,8 @@ export interface Directive {
   methodsClass: Method[];
   rawdescription: string;
 }
+
+export type Component = Directive;
 
 export interface Argument {
   name: string;

--- a/examples/angular-cli/src/stories/doc-directive/__snapshots__/doc-directive.stories.storyshot
+++ b/examples/angular-cli/src/stories/doc-directive/__snapshots__/doc-directive.stories.storyshot
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots DocDirective Basic 1`] = `
+<storybook-dynamic-app-root
+  cfr={[Function CodegenComponentFactoryResolver]}
+  data={[Function Object]}
+  target={[Function ViewContainerRef_]}
+>
+  <ng-component>
+    <div
+      docdirective=""
+      ng-reflect-has-gray-background="true"
+      style="background-color: lightgray;"
+    >
+      <h1>
+        DocDirective
+      </h1>
+    </div>
+  </ng-component>
+</storybook-dynamic-app-root>
+`;

--- a/examples/angular-cli/src/stories/doc-directive/doc-directive.directive.ts
+++ b/examples/angular-cli/src/stories/doc-directive/doc-directive.directive.ts
@@ -1,0 +1,25 @@
+/* eslint-disable no-useless-constructor */
+import { Directive, ElementRef, AfterViewInit, Input } from '@angular/core';
+
+/**
+ * This is an Angular Directive
+ * example that has a Prop Table.
+ */
+@Directive({
+  selector: '[docDirective]',
+})
+export class DocDirective implements AfterViewInit {
+  constructor(private ref: ElementRef) {}
+
+  /**
+   * Will apply gray background color
+   * if set to true.
+   */
+  @Input() hasGrayBackground = false;
+
+  ngAfterViewInit(): void {
+    if (this.hasGrayBackground) {
+      this.ref.nativeElement.style = 'background-color: lightgray';
+    }
+  }
+}

--- a/examples/angular-cli/src/stories/doc-directive/doc-directive.stories.ts
+++ b/examples/angular-cli/src/stories/doc-directive/doc-directive.stories.ts
@@ -1,0 +1,16 @@
+import { DocDirective } from './doc-directive.directive';
+
+export default {
+  title: 'DocDirective',
+  component: DocDirective,
+  parameters: { docs: { iframeHeight: 120 } },
+};
+
+const modules = {
+  declarations: [DocDirective],
+};
+
+export const Basic = () => ({
+  moduleMetadata: modules,
+  template: '<div docDirective [hasGrayBackground]="true"><h1>DocDirective</h1></div>',
+});


### PR DESCRIPTION
Issue: #8920

## Note
Hey all! I'm new here, first PR. Please let me know of any feedback. I opened this as a possible solution to this issue - there could be better ones.

## What I did
I added a "Directive" interface in frameworks/angular/types.ts that is the same as the interface for components. I then specified that the component param inside the getComponentData function could be of type Component or of type Directive. The function that will return the data for the component or the directive. Before it only searched through the compodoc JSON data for components. I added a doc-directive.ts and a story for it. 

## How to test

- Is this testable with Jest or Chromatic screenshots?
 Would want to check that the prop table shows up.
- Does this need a new example in the kitchen sink apps?
I made a new story and example in the angular-cli example app.
- Does this need an update to the documentation?
I'm not sure, looking for help on this.
