### PR TITLE
Addon-docs: Fix the props table detail tooltip to prevent cutting the end of the content.

### DIFF
--- a/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/types/prop-types.js
+++ b/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/types/prop-types.js
@@ -65,6 +65,7 @@ PropTypesProps.propTypes = {
   classElementInline: PropTypes.element,
   functionalElementType: PropTypes.elementType,
   classElementType: PropTypes.elementType,
+  elementWithProps: PropTypes.elementType,
   /**
    * `instanceOf` is also supported and the custom type will be shown instead of `instanceOf`
    */
@@ -298,6 +299,7 @@ PropTypesProps.defaultProps = {
   },
   functionalElementType: FunctionalComponent,
   classElementType: ClassComponent,
+  elementWithProps: <ClassComponent className="w8 h8 fill-marine-500" />,
   instanceOf: new Set(),
   oneOfString: 'News',
   oneOfNumeric: 1,

--- a/lib/components/src/blocks/PropsTable/PropValue.tsx
+++ b/lib/components/src/blocks/PropsTable/PropValue.tsx
@@ -38,6 +38,22 @@ const Expandable = styled.div<{}>(codeCommon, ({ theme }) => ({
   alignItems: 'center',
 }));
 
+const Detail = styled.div<{ width: string }>(({ theme, width }) => ({
+  width,
+  minWidth: '200px',
+  maxWidth: '800px',
+  padding: '15px',
+  // Dont remove the mono fontFamily here even if it seem useless, this is used by the browser to calculate the length of a "ch" unit.
+  fontFamily: theme.typography.fonts.mono,
+  fontSize: theme.typography.size.s2 - 1,
+  // Most custom stylesheet will reset the box-sizing to "border-box" and will break the tooltip.
+  boxSizing: 'content-box',
+
+  '& code': {
+    padding: '0 !important',
+  },
+}));
+
 const ArrowIcon = styled(Icons)({
   height: 10,
   width: 10,
@@ -45,16 +61,6 @@ const ArrowIcon = styled(Icons)({
   marginLeft: '4px',
   marginTop: `-${DIRTY_PADDING_TOP_IN_PX}px`,
 });
-
-const StyledSyntaxHighlighter = styled(SyntaxHighlighter)(({ theme, width }) => ({
-  width,
-  minWidth: '200px',
-  maxWith: '800px',
-  padding: '15px',
-  // Dont remove the mono fontFamily here even if it seem useless, this is used by the browser to calculate the length of a "ch" unit.
-  fontFamily: theme.typography.fonts.mono,
-  fontSize: theme.typography.size.s2 - 1,
-}));
 
 const EmptyProp = () => {
   return <span>-</span>;
@@ -89,9 +95,11 @@ const PropSummary: FC<PropSummaryProps> = ({ value }) => {
         setIsOpen(isVisible);
       }}
       tooltip={
-        <StyledSyntaxHighlighter width={calculateDetailWidth(detail)} language="jsx" format={false}>
-          {detail}
-        </StyledSyntaxHighlighter>
+        <Detail width={calculateDetailWidth(detail)}>
+          <SyntaxHighlighter language="jsx" format={false}>
+            {detail}
+          </SyntaxHighlighter>
+        </Detail>
       }
     >
       <Expandable className="sbdocs-expandable">


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8919

## What I did

- Forced box-sizing to "content-box"
- Fix maxWidth typo
- Reset the padding of a `<code>` element under the syntax highlighter to remove the padding right and stop displaying an horizontal scrollbar when hovering the tooltip

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? Yes, cra-ts-kitchen-sink
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
