### PR TITLE
Addon-docs: Support subcomponents as a top-level default export

### DIFF
--- a/examples/official-storybook/stories/addon-docs/subcomponents.stories.js
+++ b/examples/official-storybook/stories/addon-docs/subcomponents.stories.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { DocgenButton } from '../../components/DocgenButton';
+import { ButtonGroup } from '../../components/ButtonGroup';
+
+export default {
+  title: 'Addons/Docs/ButtonGroup',
+  component: ButtonGroup,
+  subcomponents: { DocgenButton },
+};
+
+export const basic = () => (
+  <ButtonGroup>
+    <DocgenButton label="foo" />
+    <DocgenButton label="bar" />
+  </ButtonGroup>
+);

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -402,6 +402,7 @@ export default function start(render, { decorateStory } = {}) {
         parameters: params,
         decorators: decos,
         component,
+        subcomponents,
       } = meta;
       // We pass true here to avoid the warning about HMR. It's cool clientApi, we got this
       const kind = clientApi.storiesOf(kindName, true);
@@ -410,6 +411,7 @@ export default function start(render, { decorateStory } = {}) {
       kind.addParameters({
         framework,
         component,
+        subcomponents,
         fileName: currentExports.get(fileExports),
         ...params,
       });


### PR DESCRIPTION
Issue: #7811 

## What I did

Support `export default { title, component, subcomponents }` in addition to `export default { title, component, parameters: { subcomponents }}` to match the documentation. Also added a test case.
