### PR TITLE
getSnapshotFileName is not a function

### DIFF
--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -636,13 +636,15 @@ This is a class that generates snapshot's name based on the story (kind, story &
 Let's say we wanted to create a test function for shallow && multi-file snapshots:
 
 ```js
-import initStoryshots, { getSnapshotFileName } from '@storybook/addon-storyshots';
+import initStoryshots, { Stories2SnapsConverter } from '@storybook/addon-storyshots';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
+const converter = new Stories2SnapsConverter();
+
 initStoryshots({
   test: ({ story, context }) => {
-    const snapshotFileName = getSnapshotFileName(context);
+    const snapshotFileName = converter.getSnapshotFileName(context);
     const storyElement = story.render();
     const shallowTree = shallow(storyElement);
 


### PR DESCRIPTION
I tried to run the example under `Stories2SnapsConverter` section but I was getting an error that `getSnapshotFileName` is not a function and I couldn't import it.

I played around and this seems to be working.

Issue:

## What I did
Updated README example

## How to test

- Is this testable with Jest or Chromatic screenshots? NO
- Does this need a new example in the kitchen sink apps? NO
- Does this need an update to the documentation? YES

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
