### PR TITLE
Addon-docs: Increase docs content wrapper max-width to 1000px

### DIFF
--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -51,6 +51,7 @@
     "enzyme-to-json": "^3.4.1",
     "fork-ts-checker-webpack-plugin": "^3.0.1",
     "react-docgen-typescript-loader": "^3.3.0",
+    "react-moment-proptypes": "^1.7.0",
     "react-scripts": "^3.0.1",
     "tslint": "^5.14.0",
     "tslint-config-airbnb": "^5.11.1",

--- a/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/types/prop-types.js
+++ b/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/types/prop-types.js
@@ -2,6 +2,7 @@
 import React from 'react';
 // @ts-ignore
 import PropTypes, { string, shape } from 'prop-types';
+import momentPropTypes from 'react-moment-proptypes';
 import { PRESET_SHAPE, SOME_PROP_TYPES } from './ext';
 
 const NAMED_OBJECT = {
@@ -33,6 +34,14 @@ class ClassComponent extends React.PureComponent {
 function concat(a, b) {
   return a + b;
 }
+
+function customPropType() {
+  return null;
+}
+
+const nestedCustomPropType = {
+  custom: customPropType,
+};
 
 const SOME_INLINE_PROP_TYPES = {
   /**
@@ -140,6 +149,9 @@ PropTypesProps.propTypes = {
   obj: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   symbol: PropTypes.symbol,
   node: PropTypes.node,
+  useCustomPropType: customPropType,
+  useNestedCustomPropType: nestedCustomPropType.custom,
+  externalMomentPropType: momentPropTypes.momentObj,
   functionalElement: PropTypes.element,
   functionalElementInline: PropTypes.element,
   functionalElementNamedInline: PropTypes.element,

--- a/lib/components/src/blocks/DocsPage.tsx
+++ b/lib/components/src/blocks/DocsPage.tsx
@@ -44,7 +44,7 @@ export const Subtitle = styled.h2<{}>(withReset, ({ theme }: { theme: Theme }) =
 }));
 
 export const DocsContent = styled.div({
-  maxWidth: 800,
+  maxWidth: 1000,
   width: '100%',
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20989,7 +20989,7 @@ module-deps@^6.0.0:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment@2.24.0, moment@^2.10.6, moment@^2.18.1:
+moment@2.24.0, moment@>=1.6.0, moment@^2.10.6, moment@^2.18.1:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -25352,6 +25352,13 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-moment-proptypes@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz#89881479840a76c13574a86e3bb214c4ba564e7a"
+  integrity sha512-ZbOn/P4u469WEGAw5hgkS/E+g1YZqdves2BjYsLluJobzUZCtManhjHiZKjniBVT7MSHM6D/iKtRVzlXVv3ikA==
+  dependencies:
+    moment ">=1.6.0"
 
 react-native-animatable@1.3.3:
   version "1.3.3"


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8947

## What I did

- Increased the docs content wrapper max-width to 1000px
- Added new test cases in the cra-ts-kitchen-sink for custom prop type

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
