### PR TITLE
Examples: Add "debug" script for storybook-official

### DIFF
--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build-storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true build-storybook -c ./",
+    "debug": "cross-env NODE_OPTIONS=--inspect-brk STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./ --no-dll",
     "do-image-snapshots": "../../node_modules/.bin/jest --projects=./image-snapshots",
     "generate-addon-jest-testresults": "jest --config=tests/addon-jest.config.json --json --outputFile=stories/addon-jest.testresults.json",
     "graphql": "node ./graphql-server/index.js",


### PR DESCRIPTION
Issue:

Ability to debug storybook build process without editing `https://github.com/storybooks/storybook/blob/2f53feb64af7f468322bde4bbea6c2444f80412c/app/react/bin/index.js`

## What I did
added a `debug`script to the official-storybook/package.json`

```
"debug": "cross-env NODE_OPTIONS=--inspect-brk STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./ --no-dll",
```
## How to test

in storybook-official
`yarn debug`