### PR TITLE
add a text knob to the mdx story in the angular cli project

### DIFF
--- a/examples/angular-cli/src/stories/addon-docs.stories.mdx
+++ b/examples/angular-cli/src/stories/addon-docs.stories.mdx
@@ -2,6 +2,7 @@ import { moduleMetadata } from '@storybook/angular';
 import { Story, Meta } from '@storybook/addon-docs/blocks';
 import { Welcome, Button } from '@storybook/angular/demo';
 import { linkTo } from '@storybook/addon-links';
+import { text, withKnobs } from '@storybook/addon-knobs';
 
 # Storybook Docs for Angular
 
@@ -19,7 +20,7 @@ How you like them apples?!
 
 Just like in React, we first declare our component.
 
-<Meta title="Addon/Docs" decorators={[moduleMetadata({ declarations: [Button] })]} />
+<Meta title="Addon/Docs" decorators={[withKnobs, moduleMetadata({ declarations: [Button] })]} />
 
 This declaration doesn't show up in the MDX output.
 
@@ -53,7 +54,7 @@ Similarly, here's how we do it in the Docs MDX format. We've already added the d
   {{
     template: `<storybook-button-component [text]="text" (onClick)="onClick($event)"></storybook-button-component>`,
     props: {
-      text: 'Hello Button',
+      text: text('Button text', 'Hello Button'),
       onClick: () => {},
     },
   }}


### PR DESCRIPTION
Issue:
In the Angular CLI, the Knob panel isnt showing knobs when adding a knob to the props object in the mdx file.

## What I did

Added an example of the bug:
```
<Story name="with text">
  {{
    template: `<storybook-button-component [text]="text" (onClick)="onClick($event)"></storybook-button-component>`,
    props: {
      text: text('Button text', 'Hello Button'),
      onClick: () => {},
    },
  }}
</Story>
```

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
