### PR TITLE
Addon-links: Fix return type of linkTo and examples

### DIFF
--- a/addons/links/src/preview.ts
+++ b/addons/links/src/preview.ts
@@ -36,7 +36,7 @@ const valueOrCall = (args: string[]) => (value: string | ((...args: string[]) =>
 export const linkTo = (
   idOrKindInput: string,
   storyInput?: string | ((...args: any[]) => string)
-) => (...args: string[]) => {
+) => (...args: any[]) => {
   const resolver = valueOrCall(args);
   const { storyId } = storyStore.getSelection();
   const current = storyStore.fromId(storyId) || {};

--- a/examples/official-storybook/stories/addon-links/button.stories.tsx
+++ b/examples/official-storybook/stories/addon-links/button.stories.tsx
@@ -6,13 +6,13 @@ export default {
 };
 
 export const First = () => (
-  <button type="button" onClick={linkTo('Addons|Links.Button', 'Second')}>
+  <button type="button" onClick={linkTo('Addons/Links/Button', 'Second')}>
     Go to "Second"
   </button>
 );
 
 export const Second = () => (
-  <button type="button" onClick={linkTo('Addons|Links.Button', 'First')}>
+  <button type="button" onClick={linkTo('Addons/Links/Button', 'First')}>
     Go to "First"
   </button>
 );


### PR DESCRIPTION
Issue: #8958 

## What I did
* fixed return type of linkTo
* changes Buttons link stories to `.tsx` (`official-storybook/stories/addon-links/button.stories.tsx`)
* fixed issues with `official-storybook/stories/addon-links/button.stories.tsx`  stories (the separators PR broke those stories)

## How to test
Check the add-on-links button stories in official-storybook
