### PR TITLE
📝 add example for Ember on addon-notes

### DIFF
--- a/addons/notes/README.md
+++ b/addons/notes/README.md
@@ -79,6 +79,33 @@ storiesOf('Button', module).add(
 );
 ```
 
+### With Ember
+
+```js
+import hbs from 'htmlbars-inline-precompile';
+
+export const button = () => {
+  return {
+    template: hbs`
+      <button>
+         <h4>title</h4>
+      </button>
+    `,
+  };
+};
+
+button.story = {
+  parameters: {
+    notes: {
+      markdown: `
+      ##Component usage with block 
+      The component is call as any other example but with a block instead of a title param 
+    `,
+    },
+  },
+};
+```
+
 ### Upgrading to CSF Format
 
 Add `notes` to the `parameters` object:


### PR DESCRIPTION
Issue: no example for ember on this [readme](https://github.com/storybookjs/storybook/tree/next/addons/notes)

## What I did
Just added a example for Ember :) 🐹 
## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
