### PR TITLE
Addon-docs: Add `react-docgen-typescript-loader` to docs preset

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -223,8 +223,23 @@ addParameters({
 
 SB Docs for React uses `babel-plugin-react-docgen` to extract Docgen comments from your code automatically. However, if you're using TypeScript, some extra configuration maybe required to get this information included in your docs.
 
-1. You can add [react-docgen-typescript-loader](https://www.npmjs.com/package/react-docgen-typescript-loader) to your project by following the instructions there.
-2. You can use [@storybook/preset-typescript](https://www.npmjs.com/package/@storybook/preset-typescript) which includes `react-docgen-typescript-loader`.
+1. Add [react-docgen-typescript-loader](https://www.npmjs.com/package/react-docgen-typescript-loader) to your project.
+2. Configure the loader options manually or in the docs preset with `tsDocgenLoaderOptions`, e.g.
+
+```js
+module.exports = {
+  presets: [
+    {
+      name: '@storybook/addon-docs/preset',
+      options: {
+        tsDocgenLoaderOptions: {
+          tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
+        },
+      },
+    },
+  ],
+};
+```
 
 Install the preset with care. If you've already configured Typescript manually, that configuration may conflict with the preset. You can [debug your final webpack configuration with `--debug-webpack`](https://storybook.js.org/docs/configurations/custom-webpack-config/#debug-the-default-webpack-config).
 

--- a/addons/docs/src/frameworks/react/preset.ts
+++ b/addons/docs/src/frameworks/react/preset.ts
@@ -1,0 +1,15 @@
+export function webpack(webpackConfig: any = {}, options: any = {}) {
+  const { tsDocgenLoaderOptions } = options;
+  if (tsDocgenLoaderOptions) {
+    webpackConfig.module.rules.push({
+      test: /\.tsx$/,
+      use: [
+        {
+          loader: require.resolve('react-docgen-typescript-loader'),
+          options: tsDocgenLoaderOptions,
+        },
+      ],
+    });
+  }
+  return webpackConfig;
+}


### PR DESCRIPTION
Issue: #8337 

## What I did

Add typescript preset to docs and make it opt-in

@patricklafrance can you take this PR and run with it?

1) use it in one of the example apps to test it
2) add whatever config you wanted to add

## How to test

WIP
