### PR TITLE
UI: Escape hatch CSS on for "active" tablist buttons

### DIFF
--- a/lib/components/src/tabs/tabs.tsx
+++ b/lib/components/src/tabs/tabs.tsx
@@ -164,6 +164,7 @@ export const Tabs: FunctionComponent<TabsProps> = memo(
                   actions.onSelect(id);
                 }}
                 role="tab"
+                className={`tabbutton ${active ? 'tabbutton-active' : ''}`}
               >
                 {typeof title === 'function' ? title() : title}
               </TabButton>


### PR DESCRIPTION
Issue:
There is no way to theme a tablist button, nothing differentiate them between active and non active.

## What I did
I added a class of tabbutton-active when a tab is active.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No