### PR TITLE
Added docs to show how to override SB block when using MDX

### DIFF
--- a/addons/docs/docs/theming.md
+++ b/addons/docs/docs/theming.md
@@ -65,12 +65,12 @@ You can even override a Storybook *block* component.
 Here's how you might insert a custom `<Preview />` block:
 
 ```js
-import { PreviewBlock } from './PreviewBlock';
+import { MyPreview } from './MyPreview';
 
 addParameters({
   docs: {
     components: {
-      Preview: PreviewBlock,
+      Preview: MyPreview,
     },
   },
 });

--- a/addons/docs/docs/theming.md
+++ b/addons/docs/docs/theming.md
@@ -60,6 +60,22 @@ addParameters({
 });
 ```
 
+You can even override a Storybook *block* component.
+
+Here's how you might insert a custom `<Preview />` block:
+
+```js
+import { PreviewBlock } from './PreviewBlock';
+
+addParameters({
+  docs: {
+    components: {
+      Preview: PreviewBlock,
+    },
+  },
+});
+```
+
 ## More resources
 
 Want to learn more? Here are some more articles on Storybook Docs:


### PR DESCRIPTION
Issue:

## What I did

- Added docs to show how to override the Preview block with MDX

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
