### PR TITLE
Dev: Add vscode launch.json for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ node_modules
 *.log
 .idea
 *.iml
-.vscode
+.vscode/*
+!.vscode/launch.json
 *.sw*
 npm-shrinkwrap.json
 dist

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [{
+    "type": "node",
+    "request": "launch",
+    "name": "official-storybook",
+    "runtimeExecutable": "npm",
+    "cwd": "${workspaceFolder}/examples/official-storybook",
+    "runtimeArgs": [
+      "run-script",
+      "debug"
+    ],
+    "port": 9229,
+    "skipFiles": [
+      "<node_internals>/**"
+    ]
+  },
+  ]
+}


### PR DESCRIPTION
Issue:
Out of the box ability to debug the launch/build process of official-storybook example

## What I did
Updated `.gitignore` to allow checking in the launch.json file from VScode, no other VSCode files make sense to check-in for now.

## How to test

In VSCode, set a breakpoint in one of the `dist` folders (ie `@storybook/core`) and start debugging session. In the debug console should say 'debugger attached'.