### PR TITLE
UI: viewMode proptypes changed to any string

### DIFF
--- a/lib/ui/src/app.js
+++ b/lib/ui/src/app.js
@@ -74,7 +74,7 @@ const App = React.memo(({ viewMode, layout, panelCount, size: { width, height } 
   );
 });
 App.propTypes = {
-  viewMode: PropTypes.oneOf(['story', 'info', 'docs', 'settings']),
+  viewMode: PropTypes.string,
   panelCount: PropTypes.number.isRequired,
   layout: PropTypes.shape({}).isRequired,
   size: PropTypes.shape({

--- a/lib/ui/src/components/layout/container.js
+++ b/lib/ui/src/components/layout/container.js
@@ -553,7 +553,7 @@ Layout.propTypes = {
     panelPosition: PropTypes.string.isRequired,
     isToolshown: PropTypes.bool.isRequired,
   }).isRequired,
-  viewMode: PropTypes.oneOf(['story', 'info', 'docs', 'settings']),
+  viewMode: PropTypes.string,
   theme: PropTypes.shape({ layoutMargin: PropTypes.number }).isRequired,
 };
 Layout.defaultProps = {

--- a/lib/ui/src/components/layout/desktop.js
+++ b/lib/ui/src/components/layout/desktop.js
@@ -71,7 +71,7 @@ Desktop.propTypes = {
     panelPosition: PropTypes.string.isRequired,
     isToolshown: PropTypes.bool.isRequired,
   }).isRequired,
-  viewMode: PropTypes.oneOf(['story', 'info', 'docs', 'settings']),
+  viewMode: PropTypes.string,
 };
 Desktop.defaultProps = {
   viewMode: undefined,

--- a/lib/ui/src/components/layout/mobile.js
+++ b/lib/ui/src/components/layout/mobile.js
@@ -201,7 +201,7 @@ Mobile.propTypes = {
       render: PropTypes.func.isRequired,
     })
   ).isRequired,
-  viewMode: PropTypes.oneOf(['story', 'info', 'docs', 'settings']),
+  viewMode: PropTypes.string,
   options: PropTypes.shape({
     initialActive: PropTypes.number,
     isToolshown: PropTypes.bool,

--- a/lib/ui/src/components/preview/preview.js
+++ b/lib/ui/src/components/preview/preview.js
@@ -313,7 +313,7 @@ Preview.propTypes = {
   }).isRequired,
   storyId: PropTypes.string,
   path: PropTypes.string,
-  viewMode: PropTypes.oneOf(['story', 'info', 'docs', 'settings']),
+  viewMode: PropTypes.string,
   location: PropTypes.shape({}).isRequired,
   getElements: PropTypes.func.isRequired,
   queryParams: PropTypes.shape({}).isRequired,


### PR DESCRIPTION
Issue: #8790 

## What I did
Changed all viewMode occurrences to PropTypes.string to avoid console warnings for new `TAB` addons

