### PR TITLE
Add svelte-loader to docs for Svelte guide

### DIFF
--- a/docs/src/pages/guides/guide-svelte/index.md
+++ b/docs/src/pages/guides/guide-svelte/index.md
@@ -36,6 +36,15 @@ Make sure that you have `@babel/core`, and `babel-loader` in your dependencies a
 npm install babel-loader @babel/core --save-dev 
 ```
 
+### svelte-loader
+
+You'll also need to install `svelte-loader` if you haven't already.
+
+```sh
+
+npm install svelte-loader --save-dev
+```
+
 ## Step 2: Add a npm script
 
 Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:


### PR DESCRIPTION
Issue: no issue

## What I did

I was running Storybook in an open-source Svelte component that I was building with Rollup. Given that I'm not using `webpack` (but Storybook is), the documentation assumed that [`svelte-loader`](https://github.com/sveltejs/svelte-loader) was already installed.

I added an additional step to the Svelte guide to install `svelte-loader`.

## How to test

- Create a component ([using this template](https://github.com/sveltejs/component-template)).
- Add Storybook, with the manual steps from the Storybook Svelte Guide [here](https://github.com/storybookjs/storybook/blob/master/docs/src/pages/guides/guide-svelte/index.md).
- Existing documentation does not indicate that you need `svelte-loader`, but when you actually run `npm run storybook` it will fail because it can't find `svelte-loader`.
- Add `svelte-loader` and everything works.
