### PR TITLE
Addon-contexts: Fix 'cannot read property h of undefined' in preact

### DIFF
--- a/addons/contexts/src/preview/frameworks/preact.ts
+++ b/addons/contexts/src/preview/frameworks/preact.ts
@@ -1,4 +1,4 @@
-import Preact from 'preact';
+import { h, VNode } from 'preact';
 import { createAddonDecorator, Render } from '../../index';
 import { ContextsPreviewAPI } from '../ContextsPreviewAPI';
 
@@ -6,9 +6,9 @@ import { ContextsPreviewAPI } from '../ContextsPreviewAPI';
  * This is the framework specific bindings for Preact.
  * '@storybook/preact' expects the returning object from a decorator to be a 'Preact vNode'.
  */
-export const renderPreact: Render<Preact.VNode> = (contextNodes, propsMap, getStoryVNode) => {
+export const renderPreact: Render<VNode> = (contextNodes, propsMap, getStoryVNode) => {
   const { getRendererFrom } = ContextsPreviewAPI();
-  return getRendererFrom(Preact.h)(contextNodes, propsMap, getStoryVNode);
+  return getRendererFrom(h)(contextNodes, propsMap, getStoryVNode);
 };
 
 export const withContexts = createAddonDecorator(renderPreact);


### PR DESCRIPTION
When trying to setup `addon-contexts` with Preact, I encountered the following error:

```
Cannot read property 'h' of undefined
TypeError: Cannot read property 'h' of undefined
    at renderPreact (http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:202:45)
    at wrapper (http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:36:12)
    at http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:2318:14
    at http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:2342:46
    at http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:1849:21
    at http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:3151:14
    at http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:3152:16
    at wrapper (http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:1432:12)
    at http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:2318:14
    at http://localhost:50903/vendors~main.61fc4c3beec8040aebff.bundle.js:2332:26
```

This is due to the fact that preact is imported with a synthetic default import. This forces the user to enable `allowJs` and `allowSyntheticDefaultImports` in `tsconfig.json` which conflicts with `declaration`.

# What I did

Changed the import to a proper destructuring import (same as for React):

https://github.com/storybookjs/storybook/blob/47868b01f8230f6525148874cbdc2d8cdc4489e9/addons/contexts/src/preview/frameworks/react.ts#L1
