### PR TITLE
addons/docs/vue README: fix path in presets.js

### DIFF
--- a/addons/docs/vue/README.md
+++ b/addons/docs/vue/README.md
@@ -25,7 +25,7 @@ yarn add -D @storybook/addon-docs@next
 Then add the following to your `.storybook/presets.js` exports:
 
 ```js
-module.exports = ['@storybook/addon-docs/preset'];
+module.exports = ['@storybook/addon-docs/vue/preset'];
 ```
 
 ## DocsPage


### PR DESCRIPTION
`@storybook/addon-docs/preset` does not exist and we are trying to use
vue presets - so this looks like the logical thing to do.

This is a documentation change.