### PR TITLE
Addon-docs: Restore IE11 compat by transpiling acorn-jsx

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -45,6 +45,18 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
       rules: [
         ...(module.rules || []),
         {
+          test: /\.js$/,
+          include: /node_modules\/acorn-jsx/,
+          use: [
+            {
+              loader: 'babel-loader',
+              options: {
+                presets: [[require.resolve('@babel/preset-env'), { modules: 'commonjs' }]],
+              },
+            },
+          ],
+        },
+        {
           test: /\.(stories|story).mdx$/,
           use: [
             {


### PR DESCRIPTION
Issue: #8884

## What I did

I added a new Webpack rule for the `acorn-jsx` dependency - that's used by `addon-docs` - with `babel-loader` to transpile it. Since `acorn-jsx` uses ES6 classes, it wasn't working on IE 11.

## How to test

`yarn storybook` on any `kitchen-sink` that's using `addon-docs` and browser with Internet Explorer 11.
