### PR TITLE
feat(Number): add optional range slider values showing for react-native

### DIFF
--- a/addons/ondevice-knobs/README.md
+++ b/addons/ondevice-knobs/README.md
@@ -30,3 +30,11 @@ import './rn-addons';
 ```
 
 See [@storybook/addon-knobs](https://github.com/storybookjs/storybook/blob/master/addons/knobs) to learn how to write stories with knobs and the [crna-kitchen-sink app](../../examples-native/crna-kitchen-sink) for more examples.
+
+Knob of type number with prop range can have prop ShowValues, to display current values below the slider.
+
+```
+{
+    showValues: true,
+}
+```

--- a/addons/ondevice-knobs/README.md
+++ b/addons/ondevice-knobs/README.md
@@ -29,12 +29,16 @@ Then import `rn-addons.js` next to your `getStorybookUI` call.
 import './rn-addons';
 ```
 
+## Usage
+
 See [@storybook/addon-knobs](https://github.com/storybookjs/storybook/blob/master/addons/knobs) to learn how to write stories with knobs and the [crna-kitchen-sink app](../../examples-native/crna-kitchen-sink) for more examples.
 
-Knob of type number with prop range can have prop ShowValues, to display current values below the slider.
+Knob of type number with prop range can have prop showValues, to display current values below the slider.
 
 ```
 {
+    ...
     showValues: true,
+    ...
 }
 ```

--- a/addons/ondevice-knobs/src/types/Number.js
+++ b/addons/ondevice-knobs/src/types/Number.js
@@ -12,6 +12,10 @@ const Input = styled.TextInput(({ theme }) => ({
   color: theme.labelColor,
 }));
 
+const ValueText = styled.Text(() => ({
+  fontSize: 10,
+}));
+
 class NumberType extends React.Component {
   constructor(props) {
     super(props);
@@ -54,13 +58,24 @@ class NumberType extends React.Component {
     const { knob, onChange } = this.props;
 
     return (
-      <Slider
-        value={knob.value}
-        minimumValue={knob.min}
-        maximumValue={knob.max}
-        step={knob.step}
-        onSlidingComplete={val => onChange(parseFloat(val))}
-      />
+      <>
+        <Slider
+          value={knob.value}
+          minimumValue={knob.min}
+          maximumValue={knob.max}
+          step={knob.step}
+          onSlidingComplete={val => onChange(parseFloat(val))}
+        />
+
+        {knob.showValues && (
+          <View>
+            <ValueText>Min: {knob.min}</ValueText>
+            <ValueText>Max: {knob.max}</ValueText>
+            <ValueText>Step: {knob.step}</ValueText>
+            <ValueText>Value: {knob.value}</ValueText>
+          </View>
+        )}
+      </>
     );
   }
 
@@ -86,6 +101,7 @@ NumberType.propTypes = {
     min: PropTypes.number,
     max: PropTypes.number,
     range: PropTypes.bool,
+    showValues: PropTypes.bool,
   }),
   onChange: PropTypes.func,
 };

--- a/examples-native/crna-kitchen-sink/storybook/stories/Knobs/index.js
+++ b/examples-native/crna-kitchen-sink/storybook/stories/Knobs/index.js
@@ -15,7 +15,7 @@ import {
 
 export default () => {
   const name = text('Name', 'Storyteller');
-  const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 });
+  const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5, showValues: true });
   const fruits = {
     Apple: 'apple',
     Banana: 'banana',


### PR DESCRIPTION
Issue: 
no visible values for range slider

## What I did
added min, max, step, value text fields with current values below slider

## How to test

- no test for on device type number
- for kitchen sink needs to be updated prop: showValues. Added.
- For on device knob version it needs to mention prop showValues. Added.

If your answer is yes to any of these, please make sure to include it in your PR.
