### PR TITLE
Storyshots: Escape Windows fileNames

### DIFF
--- a/addons/storyshots/storyshots-core/injectFileName.js
+++ b/addons/storyshots/storyshots-core/injectFileName.js
@@ -16,7 +16,7 @@ module.exports = {
     return `${code};
 if(exports.default != null) {
   exports.default.parameters = exports.default.parameters || {};
-  exports.default.parameters.fileName = '${fileName}';
+  exports.default.parameters.fileName = '${fileName.replace(/\\/g, '\\\\')}';
 }
 `;
   },


### PR DESCRIPTION
Issue: `multisnapshotWithOptions` + CSF doesn't work on Windows
