### PR TITLE
Addon-docs: MDX Octicon anchors should not be tabbable

### DIFF
--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -150,6 +150,7 @@ const HeaderWithOcticonAnchor: FC<HeaderWithOcticonAnchorProps> = ({
       <OcticonAnchor
         aria-hidden="true"
         href={generateHrefWithHash(id)}
+        tabIndex={-1}
         onClick={() => {
           const element = document.getElementById(id);
           if (!isNil(element)) {


### PR DESCRIPTION
![anchor_tabbable](https://user-images.githubusercontent.com/794579/70178279-fb529980-16a9-11ea-997a-24622ed255ab.png)

## What I did

- Added a tabindex of -1 to the Octicon anchors.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
