### PR TITLE
Addon-docs: Upgrade vue-docgen-api

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -68,7 +68,7 @@
     "remark-slug": "^5.1.2",
     "ts-dedent": "^1.1.0",
     "util-deprecate": "^1.0.2",
-    "vue-docgen-api": "^3.26.0",
+    "vue-docgen-api": "^4.1.0",
     "vue-docgen-loader": "^1.0.1"
   },
   "devDependencies": {

--- a/addons/docs/src/lib/docgen/extractDocgenProps.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.ts
@@ -31,13 +31,16 @@ const getTypeSystem = (docgenInfo: DocgenInfo): TypeSystem => {
   return TypeSystem.UNKNOWN;
 };
 
-export const extractComponentProps: ExtractProps = (component, section) => {
-  const docgenSection = getDocgenSection(component, section);
+export const extractComponentSectionArray = (docgenSection: any) => {
+  const typeSystem = getTypeSystem(docgenSection[0]);
+  const createPropDef = getPropDefFactory(typeSystem);
 
-  if (!isValidDocgenSection(docgenSection)) {
-    return [];
-  }
+  return docgenSection
+    .map((item: any) => extractProp(item.name, item, typeSystem, createPropDef))
+    .filter(Boolean);
+};
 
+export const extractComponentSectionObject = (docgenSection: any) => {
   const docgenPropsKeys = Object.keys(docgenSection);
   const typeSystem = getTypeSystem(docgenSection[docgenPropsKeys[0]]);
   const createPropDef = getPropDefFactory(typeSystem);
@@ -50,7 +53,20 @@ export const extractComponentProps: ExtractProps = (component, section) => {
         ? extractProp(propName, docgenInfo, typeSystem, createPropDef)
         : null;
     })
-    .filter(x => x);
+    .filter(Boolean);
+};
+
+export const extractComponentProps: ExtractProps = (component, section) => {
+  const docgenSection = getDocgenSection(component, section);
+
+  if (!isValidDocgenSection(docgenSection)) {
+    return [];
+  }
+
+  // vue-docgen-api has diverged from react-docgen and returns an array
+  return Array.isArray(docgenSection)
+    ? extractComponentSectionArray(docgenSection)
+    : extractComponentSectionObject(docgenSection);
 };
 
 function extractProp(

--- a/yarn.lock
+++ b/yarn.lock
@@ -30457,7 +30457,7 @@ typescript@3.5.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@3.7.2, typescript@^3.2.2, typescript@^3.4.0:
+typescript@3.7.2, typescript@^3.4.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
@@ -31388,10 +31388,10 @@ vue-class-component@^7.0.1:
   resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.1.0.tgz#b33efcb10e17236d684f70b1e96f1946ec793e87"
   integrity sha512-G9152NzUkz0i0xTfhk0Afc8vzdXxDR1pfN4dTwE72cskkgJtdXfrKBkMfGvDuxUh35U500g5Ve4xL8PEGdWeHg==
 
-vue-docgen-api@^3.26.0:
-  version "3.26.0"
-  resolved "https://registry.yarnpkg.com/vue-docgen-api/-/vue-docgen-api-3.26.0.tgz#2afc6a39e72862fbbc60ceb8510c681749f05460"
-  integrity sha512-ujdg4i5ZI/wE46RZQMFzKnDGyhEuPCu+fMA86CAd9EIek/6+OqraSVBm5ZkLrbEd5f8xxdnqMU4yiSGHHeao/Q==
+vue-docgen-api@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vue-docgen-api/-/vue-docgen-api-4.1.0.tgz#46e8df9f37c815d32165c883dac6d667430b5d4f"
+  integrity sha512-Oop5CqQbglFA5kJRY9e/QqsVMo/2zh2Gxnh7HnJI8hrjilZxfD+YvSfmZtq+HCTBota+F012qi5QJiBctUKUzA==
   dependencies:
     "@babel/parser" "^7.2.3"
     "@babel/types" "^7.0.0"
@@ -31401,7 +31401,6 @@ vue-docgen-api@^3.26.0:
     pug "^2.0.3"
     recast "^0.17.3"
     ts-map "^1.0.3"
-    typescript "^3.2.2"
     vue-template-compiler "^2.0.0"
 
 vue-docgen-loader@^1.0.1:


### PR DESCRIPTION
Issue: N/A

## What I did

Upgrade vue-docgen-api to 4.1 to get props tables for multiple components per file

NOTE: this will also require a change to `vue-docgen-loader` to get multiple prop tables. @Aaron-Pool is on it!

## How to test

- `vue-kitchen-sink` example project
- `cra-ts-kitchen-sink` to make sure we didn't regress on react


