### PR TITLE
Support for quotes in title of MDX Meta

### DIFF
--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -133,7 +133,7 @@ function genMeta(ast) {
   let id = getAttr(ast.openingElement, 'id');
   let parameters = getAttr(ast.openingElement, 'parameters');
   let decorators = getAttr(ast.openingElement, 'decorators');
-  title = title && `'${title.value}'`;
+  title = title && `'${jsStringEscape(title.value)}'`;
   id = id && `'${id.value}'`;
   if (parameters && parameters.expression) {
     const { code: params } = generate(parameters.expression, {});

--- a/examples/official-storybook/stories/addon-docs/meta-title-quotes.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/meta-title-quotes.stories.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta
+  title="Addons/Docs/what's in a title?"
+/>
+
+# Quotes in the title


### PR DESCRIPTION
Issue: #9062

## What I did
* change to the mdx-compiler
* added story to official storybook
 ```
<Meta
  title="Addons/Docs/what's in a title?"
/>
```
