### PR TITLE
MDX: Handle quotes / template literals in title

### DIFF
--- a/addons/docs/src/mdx/__testfixtures__/meta-quotes-in-title.mdx
+++ b/addons/docs/src/mdx/__testfixtures__/meta-quotes-in-title.mdx
@@ -1,0 +1,5 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta
+  title="Addons/Docs/what's in a title?"
+/>

--- a/addons/docs/src/mdx/__testfixtures__/meta-quotes-in-title.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/meta-quotes-in-title.output.snapshot
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`docs-mdx-compiler-plugin meta-quotes-in-title.mdx 1`] = `
+"/* @jsx mdx */
+import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+
+import { Meta } from '@storybook/addon-docs/blocks';
+
+const makeShortcode = name =>
+  function MDXDefaultShortcode(props) {
+    console.warn(
+      'Component ' +
+        name +
+        ' was not imported, exported, or provided by MDXProvider as global scope'
+    );
+    return <div {...props} />;
+  };
+
+const layoutProps = {};
+const MDXLayout = 'wrapper';
+function MDXContent({ components, ...props }) {
+  return (
+    <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
+      <Meta title=\\"Addons/Docs/what's in a title?\\" mdxType=\\"Meta\\" />
+    </MDXLayout>
+  );
+}
+
+MDXContent.isMDXComponent = true;
+
+export const __page = () => {
+  throw new Error('Docs-only story');
+};
+
+__page.story = { parameters: { docsOnly: true } };
+
+const componentMeta = { title: \\"Addons/Docs/what's in a title?\\", includeStories: ['__page'] };
+
+const mdxStoryNameToId = {};
+
+componentMeta.parameters = componentMeta.parameters || {};
+componentMeta.parameters.docs = {
+  ...(componentMeta.parameters.docs || {}),
+  page: () => (
+    <AddContext mdxStoryNameToId={mdxStoryNameToId}>
+      <MDXContent />
+    </AddContext>
+  ),
+};
+
+export default componentMeta;
+"
+`;

--- a/addons/docs/src/mdx/__testfixtures__/title-template-string.mdx
+++ b/addons/docs/src/mdx/__testfixtures__/title-template-string.mdx
@@ -1,0 +1,4 @@
+import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { titleFunction } from '../title-generators';
+
+<Meta title={`${titleFunction('template')}`} />

--- a/addons/docs/src/mdx/__testfixtures__/title-template-string.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/title-template-string.output.snapshot
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`docs-mdx-compiler-plugin title-template-string.mdx 1`] = `
+"/* @jsx mdx */
+import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+
+import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { titleFunction } from '../title-generators';
+
+const makeShortcode = name =>
+  function MDXDefaultShortcode(props) {
+    console.warn(
+      'Component ' +
+        name +
+        ' was not imported, exported, or provided by MDXProvider as global scope'
+    );
+    return <div {...props} />;
+  };
+
+const layoutProps = {};
+const MDXLayout = 'wrapper';
+function MDXContent({ components, ...props }) {
+  return (
+    <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
+      <Meta title={\`\${titleFunction('template')}\`} mdxType=\\"Meta\\" />
+    </MDXLayout>
+  );
+}
+
+MDXContent.isMDXComponent = true;
+
+export const __page = () => {
+  throw new Error('Docs-only story');
+};
+
+__page.story = { parameters: { docsOnly: true } };
+
+const componentMeta = { title: \`\${titleFunction('template')}\`, includeStories: ['__page'] };
+
+const mdxStoryNameToId = {};
+
+componentMeta.parameters = componentMeta.parameters || {};
+componentMeta.parameters.docs = {
+  ...(componentMeta.parameters.docs || {}),
+  page: () => (
+    <AddContext mdxStoryNameToId={mdxStoryNameToId}>
+      <MDXContent />
+    </AddContext>
+  ),
+};
+
+export default componentMeta;
+"
+`;

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -140,12 +140,12 @@ function genMeta(ast, options) {
       try {
         // generate code, so the expression is evaluated by the CSF compiler
         const { code } = generate(title, {});
-        // remove the curly brackes at start and end of code
+        // remove the curly brackets at start and end of code
         title = code.replace(/^\{(.+)\}$/, '$1');
       } catch (e) {
         // eat exception if title parsing didn't go well
         // eslint-disable-next-line no-console
-        console.warn('Invalid title', title);
+        console.warn('Invalid title:', options.filepath);
         title = undefined;
       }
     }

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -128,7 +128,7 @@ function genPreviewExports(ast, context) {
   return previewExports;
 }
 
-function genMeta(ast) {
+function genMeta(ast, options) {
   let title = getAttr(ast.openingElement, 'title');
   let id = getAttr(ast.openingElement, 'id');
   let parameters = getAttr(ast.openingElement, 'parameters');
@@ -145,7 +145,7 @@ function genMeta(ast) {
       } catch (e) {
         // eat exception if title parsing didnt go well
         // eslint-disable-next-line no-console
-        console.warn('Invalid title found');
+        console.warn(`Invalid title: ${options.filepath}`);
         title = undefined;
       }
     }
@@ -167,7 +167,7 @@ function genMeta(ast) {
   };
 }
 
-function getExports(node, counter) {
+function getExports(node, counter, options) {
   const { value, type } = node;
   if (type === 'jsx') {
     if (STORY_REGEX.exec(value)) {
@@ -184,7 +184,7 @@ function getExports(node, counter) {
     if (META_REGEX.exec(value)) {
       // Preview, possibly containing multiple stories
       const ast = parser.parseExpression(value, { plugins: ['jsx'] });
-      return { meta: genMeta(ast) };
+      return { meta: genMeta(ast, options) };
     }
   }
   return null;
@@ -286,7 +286,7 @@ function extractExports(node, options) {
     storyNameToKey: {},
   };
   node.children.forEach(n => {
-    const exports = getExports(n, context);
+    const exports = getExports(n, context, options);
     if (exports) {
       const { stories, meta } = exports;
       if (stories) {

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -133,7 +133,20 @@ function genMeta(ast) {
   let id = getAttr(ast.openingElement, 'id');
   let parameters = getAttr(ast.openingElement, 'parameters');
   let decorators = getAttr(ast.openingElement, 'decorators');
-  title = title && `'${title.value}'`;
+  if (title) {
+    if (title.type === 'StringLiteral') {
+      title = "'".concat(title.value, "'");
+    } else {
+      try {
+        // generate code, so the expression is evaluated by the CSF compiler
+        const { code } = generate(title, {});
+        // remove the curly brackes at start and end of code
+        title = code.replace(/^\{(.+)\}$/, '$1');
+      } catch (e) {
+        // eat exception if title parsing didnt go well
+      }
+    }
+  }
   id = id && `'${id.value}'`;
   if (parameters && parameters.expression) {
     const { code: params } = generate(parameters.expression, {});

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -145,7 +145,7 @@ function genMeta(ast) {
       } catch (e) {
         // eat exception if title parsing didnt go well
         // eslint-disable-next-line no-console
-        console.warn('Invalid title found');
+        console.warn('Invalid title', title);
         title = undefined;
       }
     }

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -135,7 +135,7 @@ function genMeta(ast) {
   let decorators = getAttr(ast.openingElement, 'decorators');
   if (title) {
     if (title.type === 'StringLiteral') {
-      title = "'".concat(title.value, "'");
+      title = "'".concat(jsStringEscape(title.value), "'");
     } else {
       try {
         // generate code, so the expression is evaluated by the CSF compiler
@@ -144,6 +144,9 @@ function genMeta(ast) {
         title = code.replace(/^\{(.+)\}$/, '$1');
       } catch (e) {
         // eat exception if title parsing didnt go well
+        // eslint-disable-next-line no-console
+        console.warn('Invalid title found');
+        title = undefined;
       }
     }
   }

--- a/addons/docs/src/mdx/title-generators.js
+++ b/addons/docs/src/mdx/title-generators.js
@@ -1,0 +1,1 @@
+export const titleFunction = title => `Addons/Docs/${title}`;

--- a/examples/official-storybook/stories/addon-docs/meta-string-template.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/meta-string-template.stories.mdx
@@ -1,0 +1,7 @@
+import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { titleFunction } from '@storybook/addon-docs/dist/mdx/title-generators';
+
+<Meta title={`${titleFunction('template')}`} />
+
+# Meta title from a string template
+

--- a/examples/official-storybook/stories/addon-docs/meta-title-quotes.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/meta-title-quotes.stories.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta
+  title="Addons/Docs/what's in a title?"
+/>
+
+# Quotes in the title


### PR DESCRIPTION
Issue: ability to have string templates and expressions in Meta title

## What I did
* in mdx-compiler, if node is not StringLiteral, generate code for the title and leave it to CSF compiler to evaluate

## How to test

Added story to official-storybook and added snapshot testing
