### PR TITLE
Addon-docs: Fix prop table default value for web-components

### DIFF
--- a/addons/docs/src/frameworks/web-components/config.js
+++ b/addons/docs/src/frameworks/web-components/config.js
@@ -11,7 +11,7 @@ function mapData(data) {
     type: { summary: item.type },
     required: '',
     description: item.description,
-    defaultValue: { summary: item.default },
+    defaultValue: { summary: item.defaultValue }
   }));
 }
 


### PR DESCRIPTION
Issue:

The work in progress specification for custom-elements.json uses the `defaultValue` key rather than `default`. Currently, the default value is not displayed in the props table because this is mapped incorrectly.

https://github.com/webcomponents/custom-elements-json/pull/8/files

## What I did

I updated the mapping.