### PR TITLE
Source-loader: Support function declaration story exports

### DIFF
--- a/__mocks__/inject-decorator.ts.csf.txt
+++ b/__mocks__/inject-decorator.ts.csf.txt
@@ -17,3 +17,13 @@ export const emoji = () => (
     </span>
   </Button>
 );
+
+export function emojiFn() {
+  return (
+    <Button onClick={action("clicked")}>
+      <span role="img" aria-label="so cool">
+        😀 😎 👍 💯
+      </span>
+    </Button>
+  )
+};

--- a/lib/source-loader/src/server/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
+++ b/lib/source-loader/src/server/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
@@ -5,7 +5,7 @@ exports[`inject-decorator positive - ts - csf includes storySource parameter in 
 import { action } from \\"@storybook/addon-actions\\";
 import { Button } from \\"@storybook/react/demo\\";
 
-export default {parameters: {\\"storySource\\":{\\"source\\":\\"import React from \\\\\\"react\\\\\\";\\\\nimport { action } from \\\\\\"@storybook/addon-actions\\\\\\";\\\\nimport { Button } from \\\\\\"@storybook/react/demo\\\\\\";\\\\n\\\\nexport default {\\\\n  title: \\\\\\"Button\\\\\\"\\\\n};\\\\n\\\\nexport const text = () => (\\\\n  <Button onClick={action(\\\\\\"clicked\\\\\\")}>Hello Button</Button>\\\\n);\\\\n\\\\nexport const emoji = () => (\\\\n  <Button onClick={action(\\\\\\"clicked\\\\\\")}>\\\\n    <span role=\\\\\\"img\\\\\\" aria-label=\\\\\\"so cool\\\\\\">\\\\n      😀 😎 👍 💯\\\\n    </span>\\\\n  </Button>\\\\n);\\\\n\\",\\"locationsMap\\":{\\"button--text\\":{\\"startLoc\\":{\\"col\\":20,\\"line\\":9},\\"endLoc\\":{\\"col\\":1,\\"line\\":11},\\"startBody\\":{\\"col\\":20,\\"line\\":9},\\"endBody\\":{\\"col\\":1,\\"line\\":11}},\\"button--emoji\\":{\\"startLoc\\":{\\"col\\":21,\\"line\\":13},\\"endLoc\\":{\\"col\\":1,\\"line\\":19},\\"startBody\\":{\\"col\\":21,\\"line\\":13},\\"endBody\\":{\\"col\\":1,\\"line\\":19}}}},},
+export default {parameters: {\\"storySource\\":{\\"source\\":\\"import React from \\\\\\"react\\\\\\";\\\\nimport { action } from \\\\\\"@storybook/addon-actions\\\\\\";\\\\nimport { Button } from \\\\\\"@storybook/react/demo\\\\\\";\\\\n\\\\nexport default {\\\\n  title: \\\\\\"Button\\\\\\"\\\\n};\\\\n\\\\nexport const text = () => (\\\\n  <Button onClick={action(\\\\\\"clicked\\\\\\")}>Hello Button</Button>\\\\n);\\\\n\\\\nexport const emoji = () => (\\\\n  <Button onClick={action(\\\\\\"clicked\\\\\\")}>\\\\n    <span role=\\\\\\"img\\\\\\" aria-label=\\\\\\"so cool\\\\\\">\\\\n      😀 😎 👍 💯\\\\n    </span>\\\\n  </Button>\\\\n);\\\\n\\\\nexport function emojiFn() {\\\\n  return (\\\\n    <Button onClick={action(\\\\\\"clicked\\\\\\")}>\\\\n      <span role=\\\\\\"img\\\\\\" aria-label=\\\\\\"so cool\\\\\\">\\\\n        😀 😎 👍 💯\\\\n      </span>\\\\n    </Button>\\\\n  )\\\\n};\\\\n\\",\\"locationsMap\\":{\\"button--text\\":{\\"startLoc\\":{\\"col\\":20,\\"line\\":9},\\"endLoc\\":{\\"col\\":1,\\"line\\":11},\\"startBody\\":{\\"col\\":20,\\"line\\":9},\\"endBody\\":{\\"col\\":1,\\"line\\":11}},\\"button--emoji\\":{\\"startLoc\\":{\\"col\\":21,\\"line\\":13},\\"endLoc\\":{\\"col\\":1,\\"line\\":19},\\"startBody\\":{\\"col\\":21,\\"line\\":13},\\"endBody\\":{\\"col\\":1,\\"line\\":19}},\\"button--emoji-fn\\":{\\"startLoc\\":{\\"col\\":7,\\"line\\":21},\\"endLoc\\":{\\"col\\":1,\\"line\\":29},\\"startBody\\":{\\"col\\":7,\\"line\\":21},\\"endBody\\":{\\"col\\":1,\\"line\\":29}}}},},
   title: \\"Button\\"
 };
 
@@ -19,6 +19,16 @@ export const emoji = addSourceDecorator(() => (
       😀 😎 👍 💯
     </span>
   </Button>
-), {__STORY__, __ADDS_MAP__,__MAIN_FILE_LOCATION__,__MODULE_DEPENDENCIES__,__LOCAL_DEPENDENCIES__,__SOURCE_PREFIX__,__IDS_TO_FRAMEWORKS__});
+), {__STORY__, __ADDS_MAP__,__MAIN_FILE_LOCATION__,__MODULE_DEPENDENCIES__,__LOCAL_DEPENDENCIES__,__SOURCE_PREFIX__,__IDS_TO_FRAMEWORKS__});;
+
+export const emojiFn = addSourceDecorator(function emojiFn() {
+  return (
+    <Button onClick={action(\\"clicked\\")}>
+      <span role=\\"img\\" aria-label=\\"so cool\\">
+        😀 😎 👍 💯
+      </span>
+    </Button>
+  )
+}, {__STORY__, __ADDS_MAP__,__MAIN_FILE_LOCATION__,__MODULE_DEPENDENCIES__,__LOCAL_DEPENDENCIES__,__SOURCE_PREFIX__,__IDS_TO_FRAMEWORKS__});
 "
 `;

--- a/lib/source-loader/src/server/abstract-syntax-tree/generate-helpers.js
+++ b/lib/source-loader/src/server/abstract-syntax-tree/generate-helpers.js
@@ -68,7 +68,9 @@ const STORY_DECORATOR_STATEMENT =
 const ADD_PARAMETERS_STATEMENT =
   '.addParameters({ storySource: { source: __STORY__, locationsMap: __ADDS_MAP__ } })';
 const applyExportDecoratorStatement = part =>
-  ` addSourceDecorator(${part}, {__STORY__, __ADDS_MAP__,__MAIN_FILE_LOCATION__,__MODULE_DEPENDENCIES__,__LOCAL_DEPENDENCIES__,__SOURCE_PREFIX__,__IDS_TO_FRAMEWORKS__});`;
+  part.declaration.isVariableDeclaration
+    ? ` addSourceDecorator(${part.source}, {__STORY__, __ADDS_MAP__,__MAIN_FILE_LOCATION__,__MODULE_DEPENDENCIES__,__LOCAL_DEPENDENCIES__,__SOURCE_PREFIX__,__IDS_TO_FRAMEWORKS__});`
+    : ` const ${part.declaration.ident} = addSourceDecorator(${part.source}, {__STORY__, __ADDS_MAP__,__MAIN_FILE_LOCATION__,__MODULE_DEPENDENCIES__,__LOCAL_DEPENDENCIES__,__SOURCE_PREFIX__,__IDS_TO_FRAMEWORKS__});`;
 
 export function generateSourceWithDecorators(source, ast, withParameters) {
   const { comments = [] } = ast;
@@ -91,7 +93,7 @@ export function generateSourceWithDecorators(source, ast, withParameters) {
   const partsUsingExports = splitExports(ast, source);
 
   const newSource = partsUsingExports
-    .map((part, i) => (i % 2 === 0 ? part : applyExportDecoratorStatement(part)))
+    .map((part, i) => (i % 2 === 0 ? part.source : applyExportDecoratorStatement(part)))
     .join('');
 
   return {

--- a/lib/source-loader/src/server/abstract-syntax-tree/traverse-helpers.js
+++ b/lib/source-loader/src/server/abstract-syntax-tree/traverse-helpers.js
@@ -28,9 +28,11 @@ export function splitExports(ast, source) {
     fallback: 'iteration',
     enter: node => {
       patchNode(node);
-      if (
-        node.type === 'ExportNamedDeclaration' &&
-        node.declaration &&
+
+      const isNamedExport = node.type === 'ExportNamedDeclaration' && node.declaration;
+
+      const isFunctionVariableExport =
+        isNamedExport &&
         node.declaration.declarations &&
         node.declaration.declarations.length === 1 &&
         node.declaration.declarations[0].type === 'VariableDeclarator' &&
@@ -39,17 +41,36 @@ export function splitExports(ast, source) {
         node.declaration.declarations[0].init &&
         ['CallExpression', 'ArrowFunctionExpression', 'FunctionExpression'].includes(
           node.declaration.declarations[0].init.type
-        )
-      ) {
-        const functionNode = node.declaration.declarations[0].init;
-        parts.push(source.substring(lastIndex, functionNode.start - 1));
-        parts.push(source.substring(functionNode.start, functionNode.end));
+        );
+
+      const isFunctionDeclarationExport =
+        isNamedExport &&
+        node.declaration.type === 'FunctionDeclaration' &&
+        node.declaration.id &&
+        node.declaration.id.name;
+
+      if (isFunctionDeclarationExport || isFunctionVariableExport) {
+        const functionNode = isFunctionVariableExport
+          ? node.declaration.declarations[0].init
+          : node.declaration;
+        parts.push({
+          source: source.substring(lastIndex, functionNode.start - 1),
+        });
+        parts.push({
+          source: source.substring(functionNode.start, functionNode.end),
+          declaration: {
+            isVariableDeclaration: isFunctionVariableExport,
+            ident: isFunctionVariableExport
+              ? node.declaration.declarations[0].id.name
+              : functionNode.id.name,
+          },
+        });
         lastIndex = functionNode.end;
       }
     },
   });
 
-  if (source.length > lastIndex + 1) parts.push(source.substring(lastIndex + 1));
+  if (source.length > lastIndex + 1) parts.push({ source: source.substring(lastIndex + 1) });
   if (parts.length === 1) return [source];
   return parts;
 }
@@ -110,9 +131,11 @@ export function findExportsMap(ast) {
       fallback: 'iteration',
       enter: node => {
         patchNode(node);
-        if (
-          node.type === 'ExportNamedDeclaration' &&
-          node.declaration &&
+
+        const isNamedExport = node.type === 'ExportNamedDeclaration' && node.declaration;
+
+        const isFunctionVariableExport =
+          isNamedExport &&
           node.declaration.declarations &&
           node.declaration.declarations.length === 1 &&
           node.declaration.declarations[0].type === 'VariableDeclarator' &&
@@ -121,10 +144,24 @@ export function findExportsMap(ast) {
           node.declaration.declarations[0].init &&
           ['CallExpression', 'ArrowFunctionExpression', 'FunctionExpression'].includes(
             node.declaration.declarations[0].init.type
-          )
-        ) {
-          const storyName = storyNameFromExport(node.declaration.declarations[0].id.name);
-          const toAdd = handleExportedName(title, storyName, node.declaration.declarations[0].init);
+          );
+
+        const isFunctionDeclarationExport =
+          isNamedExport &&
+          node.declaration.type === 'FunctionDeclaration' &&
+          node.declaration.id &&
+          node.declaration.id.name;
+
+        if (isFunctionDeclarationExport || isFunctionVariableExport) {
+          const exportDeclaration = isFunctionVariableExport
+            ? node.declaration.declarations[0]
+            : node.declaration;
+          const storyName = storyNameFromExport(exportDeclaration.id.name);
+          const toAdd = handleExportedName(
+            title,
+            storyName,
+            exportDeclaration.init || exportDeclaration
+          );
           Object.assign(addsMap, toAdd);
         }
       },


### PR DESCRIPTION
Issue: fix #8401 

## What I did

Added support for `export function story() {}` style stories in source-loader.

## How to test

- Is this testable with Jest or Chromatic screenshots? ... perhaps
- Does this need a new example in the kitchen sink apps? ... maybe, but I don't know where to add the example
- Does this need an update to the documentation? ... no

I added the test fixture in `__mocks__/inject-decorator.ts.csf.txt`.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
