### PR TITLE
CLI: Add Yarn workspaces support for init command

### DIFF
--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -23,7 +23,7 @@ See the command-line help with `-h` for details.
 
 ## [Yarn](https://github.com/yarnpkg/yarn) support
 
-The CLI supports yarn. If you have installed yarn in your system, it'll detect it and use `yarn` instead of `npm`.
+The CLI supports yarn. If you have installed yarn in your system and your project has `yarn.lock` file, it'll detect it and use `yarn` instead of `npm`.
 
 If you don't want to use `yarn` always you can use the `--use-npm` option like this:
 

--- a/lib/cli/lib/has_yarn.js
+++ b/lib/cli/lib/has_yarn.js
@@ -1,13 +1,40 @@
 import { sync as spawnSync } from 'cross-spawn';
 import path from 'path';
 import fs from 'fs';
+import finder from 'find-package-json';
 
 export default function hasYarn() {
   const yarnAvailable = spawnSync('yarn', ['--version'], { silent: true });
   const npmAvailable = spawnSync('npm', ['--version'], { silent: true });
-  const yarnLockPath = path.resolve('yarn.lock');
-  if ((fs.existsSync(yarnLockPath) || npmAvailable.status !== 0) && yarnAvailable.status === 0) {
+
+  if (yarnAvailable.status === 0 && (hasLockFile() || npmAvailable.status !== 0)) {
     return true;
   }
+  return false;
+}
+
+/**
+ * Lookup yarn.lock in the current directory and its ancestor directories,
+ * return true if it exists.
+ */
+function hasLockFile() {
+  const f = finder();
+
+  const found = f.next();
+  while (!found.done) {
+    const dir = path.dirname(found.filename);
+
+    if (fs.existsSync(path.resolve(dir, 'yarn.lock'))) {
+      return true;
+    }
+
+    // We can assume that current directory isn't inside Yarn workspace
+    if (fs.existsSync(path.resolve(dir, 'package-lock.json'))) {
+      return false;
+    }
+
+    found.next();
+  }
+
   return false;
 }

--- a/lib/cli/lib/has_yarn.js
+++ b/lib/cli/lib/has_yarn.js
@@ -1,40 +1,16 @@
 import { sync as spawnSync } from 'cross-spawn';
 import path from 'path';
-import fs from 'fs';
-import finder from 'find-package-json';
+import findUp from 'find-up';
 
 export default function hasYarn() {
   const yarnAvailable = spawnSync('yarn', ['--version'], { silent: true });
   const npmAvailable = spawnSync('npm', ['--version'], { silent: true });
 
-  if (yarnAvailable.status === 0 && (hasLockFile() || npmAvailable.status !== 0)) {
+  const lockFile = findUp.sync(['yarn.lock', 'package-lock.json']);
+  const hasYarnLock = lockFile && path.basename(lockFile) === 'yarn.lock';
+
+  if (yarnAvailable.status === 0 && (hasYarnLock || npmAvailable.status !== 0)) {
     return true;
   }
-  return false;
-}
-
-/**
- * Lookup yarn.lock in the current directory and its ancestor directories,
- * return true if it exists.
- */
-function hasLockFile() {
-  const f = finder();
-
-  const found = f.next();
-  while (!found.done) {
-    const dir = path.dirname(found.filename);
-
-    if (fs.existsSync(path.resolve(dir, 'yarn.lock'))) {
-      return true;
-    }
-
-    // We can assume that current directory isn't inside Yarn workspace
-    if (fs.existsSync(path.resolve(dir, 'package-lock.json'))) {
-      return false;
-    }
-
-    found.next();
-  }
-
   return false;
 }

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -46,7 +46,7 @@
     "didyoumean": "^1.2.1",
     "envinfo": "^7.5.0",
     "esm": "3.2.25",
-    "find-package-json": "^1.2.0",
+    "find-up": "^4.1.0",
     "fs-extra": "^8.0.1",
     "inquirer": "^7.0.0",
     "jscodeshift": "^0.6.3",

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -46,6 +46,7 @@
     "didyoumean": "^1.2.1",
     "envinfo": "^7.5.0",
     "esm": "3.2.25",
+    "find-package-json": "^1.2.0",
     "fs-extra": "^8.0.1",
     "inquirer": "^7.0.0",
     "jscodeshift": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13997,6 +13997,11 @@ find-npm-prefix@^1.0.2:
   resolved "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
   integrity sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==
 
+find-package-json@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-package-json/-/find-package-json-1.2.0.tgz#4057d1b943f82d8445fe52dc9cf456f6b8b58083"
+  integrity sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==
+
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13997,11 +13997,6 @@ find-npm-prefix@^1.0.2:
   resolved "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
   integrity sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==
 
-find-package-json@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/find-package-json/-/find-package-json-1.2.0.tgz#4057d1b943f82d8445fe52dc9cf456f6b8b58083"
-  integrity sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==
-
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"


### PR DESCRIPTION
Issue: close #9045 

## What I did

Add support Yarn workspaces support for init command.

I changed `@storybook/cli init` command to lookup `yarn.lock` in ancestor directories, in addition to the current directory.

```
# Run `@storybook/cli init` on subdir

## use npm
.
├── package.json
├── package-lock.json
└── subdir/

.
├── package.json
├── package-lock.json
└── subdir/
    ├── package.json
    └── package-lock.json

.
├── package.json
├── yarn.lock
└── subdir/
    ├── package.json
    └── package-lock.json

## use yarn
.
├── package.json
├── yarn.lock
└── subdir/

.
├── package.json
├── package-lock.json
└── subdir/
    ├── package.json
    └── yarn.lock.json
```

I believe this commit doesn't break normal use-cases, but it surely adds complexity.
Should I implement `--use-yarn` flag instead?

## How to test

- Is this testable with Jest or Chromatic screenshots? ... no
- Does this need a new example in the kitchen sink apps? ... no
- Does this need an update to the documentation? ... Updated README

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
