### PR TITLE
Web-components: Clean up example `custom-elements.json` and expose `defaultValue`

### DIFF
--- a/examples/web-components-kitchen-sink/custom-elements.json
+++ b/examples/web-components-kitchen-sink/custom-elements.json
@@ -1,27 +1,25 @@
 {
-  "version": 2,
+  "version": 1.2,
   "tags": [
     {
       "name": "demo-wc-card",
       "description": "This is a container looking like a card with a back and front side you can switch",
-      "jsDoc": "/**\n * This is a container looking like a card with a back and front side you can switch\n *\n * @slot - This is an unnamed slot (the default slot)\n * @fires side-changed - Fires whenever it switches between front/back\n * @cssprop --demo-wc-card-header-font-size - Header font size\n * @cssprop --demo-wc-card-front-color - Font color for front\n * @cssprop --demo-wc-card-back-color - Font color for back\n */",
       "attributes": [
         {
           "name": "back-side",
           "description": "Indicates that the back of the card is shown",
-          "jsDoc": "/**\n     * Indicates that the back of the card is shown\n     */",
-          "type": "boolean"
+          "type": "boolean",
+          "defaultValue": false
         },
         {
           "name": "header",
           "description": "Header message",
-          "jsDoc": "/**\n     * Header message\n     */",
-          "type": "string"
+          "type": "string",
+          "defaultValue": "Your message"
         },
         {
           "name": "rows",
           "description": "Data rows",
-          "jsDoc": "/**\n     * Data rows\n     */",
           "type": "never[]"
         }
       ],
@@ -29,19 +27,16 @@
         {
           "name": "backSide",
           "description": "Indicates that the back of the card is shown",
-          "jsDoc": "/**\n     * Indicates that the back of the card is shown\n     */",
           "type": "boolean"
         },
         {
           "name": "header",
           "description": "Header message",
-          "jsDoc": "/**\n     * Header message\n     */",
           "type": "string"
         },
         {
           "name": "rows",
           "description": "Data rows",
-          "jsDoc": "/**\n     * Data rows\n     */",
           "type": "never[]"
         }
       ],


### PR DESCRIPTION
Issue:

The web components kitchen sink has a `custom-elements.json` that wasn't up to date.

I added the missing `defaultValue` so that it is properly rendered in the PropTable in the docs page.

This is a follow-up to update the example in conjunction with this PR https://github.com/storybookjs/storybook/pull/9086