### PR TITLE
docs: remove unused line in writing addons documentation

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -62,7 +62,6 @@ We write an addon that responds to a change in story selection like so:
 // register.js
 
 import React from 'react';
-import { STORY_RENDERED } from '@storybook/core-events';
 import { addons, types } from '@storybook/addons';
 import { useParameter } from '@storybook/api';
 import { AddonPanel } from '@storybook/components';


### PR DESCRIPTION
Issue:

## What I did
I removed an unused line from the example `register.js` in `writing addons` page.

## How to test

- Is this testable with Jest or Chromatic screenshots? NO
- Does this need a new example in the kitchen sink apps? NO
- Does this need an update to the documentation? NO

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
