### PR TITLE
Addon-docs: Update MDX compiler to fix knobs

### DIFF
--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -7,8 +7,13 @@ import { styled } from '@storybook/theming';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { scrollToElement } from './utils';
 
-// Hacky utility for dealing with functions or values in MDX Story elements
-export const makeStoryFn = (val: any) => (typeof val === 'function' ? val : () => val);
+// Hacky utility for asserting identifiers in MDX Story elements
+export const assertIsFn = (val: any) => {
+  if (typeof val !== 'function') {
+    throw new Error(`Expected story function, got: ${val}`);
+  }
+  return val;
+};
 
 // Hacky utilty for adding mdxStoryToId to the default context
 export const AddContext: FC<DocsContextProps> = props => {

--- a/addons/docs/src/mdx/__testfixtures__/component-id.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/component-id.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin component-id.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/decorators.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/decorators.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin decorators.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/docs-only.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/docs-only.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin docs-only.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Meta } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/meta-quotes-in-title.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/meta-quotes-in-title.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin meta-quotes-in-title.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Meta } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/non-story-exports.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/non-story-exports.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin non-story-exports.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/parameters.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/parameters.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin parameters.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/previews.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/previews.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin previews.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Button } from '@storybook/react/demo';
 import { Preview, Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/story-current.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-current.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin story-current.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Story } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/story-def-text-only.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-def-text-only.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin story-def-text-only.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Story, Meta } from '@storybook/addon-docs/blocks';
 
@@ -32,7 +32,7 @@ function MDXContent({ components, ...props }) {
 
 MDXContent.isMDXComponent = true;
 
-export const text = makeStoryFn('Plain text');
+export const text = () => 'Plain text';
 text.story = {};
 text.story.name = 'text';
 text.story.parameters = { mdxSource: \\"'Plain text'\\" };

--- a/addons/docs/src/mdx/__testfixtures__/story-definitions.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-definitions.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin story-definitions.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/story-function-var.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-function-var.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin story-function-var.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 export const basicFn = () => <Button mdxType=\\"Button\\" />;
@@ -36,7 +36,7 @@ function MDXContent({ components, ...props }) {
 
 MDXContent.isMDXComponent = true;
 
-export const basic = makeStoryFn(basicFn);
+export const basic = assertIsFn(basicFn);
 basic.story = {};
 basic.story.name = 'basic';
 basic.story.parameters = { mdxSource: 'basicFn' };

--- a/addons/docs/src/mdx/__testfixtures__/story-function.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-function.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin story-function.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 const makeShortcode = name =>
   function MDXDefaultShortcode(props) {
@@ -33,12 +33,12 @@ function MDXContent({ components, ...props }) {
 
 MDXContent.isMDXComponent = true;
 
-export const functionStory = makeStoryFn(() => {
+export const functionStory = () => {
   const btn = document.createElement('button');
   btn.innerHTML = 'Hello Button';
   btn.addEventListener('click', action('Click'));
   return btn;
-});
+};
 functionStory.story = {};
 functionStory.story.name = 'function';
 functionStory.story.parameters = {

--- a/addons/docs/src/mdx/__testfixtures__/story-object.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-object.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin story-object.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Story, Meta } from '@storybook/addon-docs/blocks';
 import { Welcome, Button } from '@storybook/angular/demo';
@@ -42,7 +42,7 @@ function MDXContent({ components, ...props }) {
 
 MDXContent.isMDXComponent = true;
 
-export const toStorybook = makeStoryFn({
+export const toStorybook = () => ({
   template: \`<storybook-welcome-component (showApp)=\\"showApp()\\"></storybook-welcome-component>\`,
   props: {
     showApp: linkTo('Button'),

--- a/addons/docs/src/mdx/__testfixtures__/story-references.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-references.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin story-references.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Story } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/title-template-string.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/title-template-string.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin title-template-string.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 import { titleFunction } from '../title-generators';

--- a/addons/docs/src/mdx/__testfixtures__/vanilla.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/vanilla.output.snapshot
@@ -2,7 +2,7 @@
 
 exports[`docs-mdx-compiler-plugin vanilla.mdx 1`] = `
 "/* @jsx mdx */
-import { makeStoryFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Button } from '@storybook/react/demo';
 

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -55,7 +55,7 @@ function genStoryExport(ast, context) {
 
   let body = ast.children.find(n => n.type !== 'JSXText');
   let storyCode = null;
-  let isJsx = false;
+
   if (!body) {
     // plain text node
     const { code } = generate(ast.children[0], {});
@@ -64,21 +64,29 @@ function genStoryExport(ast, context) {
     if (body.type === 'JSXExpressionContainer') {
       // FIXME: handle fragments
       body = body.expression;
-    } else {
-      isJsx = true;
     }
     const { code } = generate(body, {});
     storyCode = code;
   }
-  if (isJsx) {
-    statements.push(
-      `export const ${storyKey} = () => (
+
+  let storyVal = null;
+  switch (body && body.type) {
+    // We don't know what type the identifier is, but this code
+    // assumes it's a function from CSF. Let's see who complains!
+    case 'Identifier':
+      storyVal = `assertIsFn(${storyCode})`;
+      break;
+    case 'ArrowFunctionExpression':
+      storyVal = `(${storyCode})`;
+      break;
+    default:
+      storyVal = `() => (
         ${storyCode}
-      );`
-    );
-  } else {
-    statements.push(`export const ${storyKey} = makeStoryFn(${storyCode});`);
+      )`;
+      break;
   }
+
+  statements.push(`export const ${storyKey} = ${storyVal};`);
   statements.push(`${storyKey}.story = {};`);
 
   // always preserve the name, since CSF exports can get modified by displayName
@@ -326,7 +334,7 @@ function extractExports(node, options) {
   );
 
   const fullJsx = [
-    'import { makeStoryFn, AddContext } from "@storybook/addon-docs/blocks";',
+    'import { assertIsFn, AddContext } from "@storybook/addon-docs/blocks";',
     defaultJsx,
     ...storyExports,
     `const componentMeta = ${stringifyMeta(metaExport)};`,

--- a/examples/angular-cli/src/stories/addon-docs.stories.mdx
+++ b/examples/angular-cli/src/stories/addon-docs.stories.mdx
@@ -2,6 +2,7 @@ import { moduleMetadata } from '@storybook/angular';
 import { Story, Meta } from '@storybook/addon-docs/blocks';
 import { Welcome, Button } from '@storybook/angular/demo';
 import { linkTo } from '@storybook/addon-links';
+import { text, withKnobs } from '@storybook/addon-knobs';
 
 # Storybook Docs for Angular
 
@@ -19,7 +20,7 @@ How you like them apples?!
 
 Just like in React, we first declare our component.
 
-<Meta title="Addon/Docs" decorators={[moduleMetadata({ declarations: [Button] })]} />
+<Meta title="Addon/Docs" decorators={[withKnobs, moduleMetadata({ declarations: [Button] })]} />
 
 This declaration doesn't show up in the MDX output.
 
@@ -53,7 +54,7 @@ Similarly, here's how we do it in the Docs MDX format. We've already added the d
   {{
     template: `<storybook-button-component [text]="text" (onClick)="onClick($event)"></storybook-button-component>`,
     props: {
-      text: 'Hello Button',
+      text: text('Button text', 'Hello Button'),
       onClick: () => {},
     },
   }}


### PR DESCRIPTION
Issue: N/A

MDX stories don't work with knobs. This is due to an issue with `makeStoryFn`, an internal function used at runtime by the MDX compiler-generated code that somehow interacts badly with the knobs code or with Storybook's preview hooks.

## What I did

- [x] Update MDX compiler to be a little smarter about story definitions so that we no longer need `makeStoryFn`
- [x] Change the behavior slightly so that MDX assumes that variable identifiers are always functions (and throw a runtime error if they're not)
- [x] Add test case to Angular MDX (as reported in #8974)

## How to test

Test the `angular-cli` example "Docs > with text" story