### PR TITLE
fix documentation typo: add missing = in react config example

### DIFF
--- a/docs/src/pages/guides/guide-react/index.md
+++ b/docs/src/pages/guides/guide-react/index.md
@@ -66,7 +66,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```


### PR DESCRIPTION
## What I did
I tried to copy & paste this example config, and noticed the missing equal sign

## How to test

not really testable

