### PR TITLE
Addon-viewport: Allow viewports config to be optional

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -24,8 +24,8 @@ within `.storybook/main.js`:
 
 ```js
 module.exports = {
-  addons: ['@storybook/addon-viewport/register']
-}
+  addons: ['@storybook/addon-viewport/register'],
+};
 ```
 
 You should now be able to see the viewport addon icon in the the toolbar at the top of the screen.
@@ -157,11 +157,14 @@ addParameters({
 
 ### Add New Device
 
-This will add both `Kindle Fire 2` and `Kindle Fire HD` to the list of devices. This is achieved by making use of the exported [`INITIAL_VIEWPORTS`](src/defaults.ts) property, by merging it with the new viewports and pass the result as `viewports` to `configureViewport` function
+This will add both `Kindle Fire 2` and `Kindle Fire HD` to the list of devices. This is achieved by making use of the exported [`INITIAL_VIEWPORTS`](src/defaults.ts) or [`MINIMAL_VIEWPORTS`](src/defaults.ts) property, by merging it with the new viewports and pass the result as `viewports` to `configureViewport` function
 
 ```js
 import { addParameters } from '@storybook/react';
-import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import {
+  INITIAL_VIEWPORTS,
+  // or MINIMAL_VIEWPORTS,
+} from '@storybook/addon-viewport';
 
 const customViewports = {
   kindleFire2: {
@@ -184,6 +187,7 @@ addParameters({
   viewport: {
     viewports: {
       ...INITIAL_VIEWPORTS,
+      // or ...MINIMAL_VIEWPORTS,
       ...customViewports,
     },
   },

--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -124,13 +124,11 @@ const getStyles = (
 
 export const ViewportTool: FunctionComponent = memo(
   withTheme(({ theme }: { theme: Theme }) => {
-    const { viewports, defaultViewport, disable } = useParameter<ViewportAddonParameter>(
-      PARAM_KEY,
-      {
-        viewports: MINIMAL_VIEWPORTS,
-        defaultViewport: responsiveViewport.id,
-      }
-    );
+    const {
+      viewports = MINIMAL_VIEWPORTS,
+      defaultViewport = responsiveViewport.id,
+      disable,
+    } = useParameter<ViewportAddonParameter>(PARAM_KEY, {});
     const [state, setState] = useAddonState<ViewportToolState>(ADDON_ID, {
       selected: defaultViewport || responsiveViewport.id,
       isRotated: false,

--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -135,6 +135,12 @@ export const ViewportTool: FunctionComponent = memo(
     });
     const list = toList(viewports);
 
+    if (!list.find(i => i.id === defaultViewport)) {
+      console.warn(
+        `Cannot find "defaultViewport" of "${defaultViewport}" in addon-viewport configs, please check the "viewports" setting in the configuration.`
+      );
+    }
+
     useEffect(() => {
       setState({
         selected:

--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -130,7 +130,7 @@ export const ViewportTool: FunctionComponent = memo(
       disable,
     } = useParameter<ViewportAddonParameter>(PARAM_KEY, {});
     const [state, setState] = useAddonState<ViewportToolState>(ADDON_ID, {
-      selected: defaultViewport || responsiveViewport.id,
+      selected: defaultViewport,
       isRotated: false,
     });
     const list = toList(viewports);

--- a/addons/viewport/src/legacy_preview/index.ts
+++ b/addons/viewport/src/legacy_preview/index.ts
@@ -1,6 +1,6 @@
 import deprecate from 'util-deprecate';
 
-export { INITIAL_VIEWPORTS, DEFAULT_VIEWPORT } from '../defaults';
+export { INITIAL_VIEWPORTS, DEFAULT_VIEWPORT, MINIMAL_VIEWPORTS } from '../defaults';
 
 export const configureViewport = deprecate(() => {},
 'configureViewport is no longer supported, use .addParameters({ viewport }) instead');

--- a/addons/viewport/src/models/ViewportAddonParameter.ts
+++ b/addons/viewport/src/models/ViewportAddonParameter.ts
@@ -3,7 +3,7 @@ import { ViewportMap } from './Viewport';
 export interface ViewportAddonParameter {
   disable?: boolean;
   defaultViewport?: string;
-  viewports: ViewportMap;
+  viewports?: ViewportMap;
   /*
    * @deprecated
    * The viewport parameter `onViewportChange` is no longer supported

--- a/addons/viewport/src/preview.ts
+++ b/addons/viewport/src/preview.ts
@@ -1,1 +1,6 @@
-export { configureViewport, DEFAULT_VIEWPORT, INITIAL_VIEWPORTS } from './legacy_preview';
+export {
+  configureViewport,
+  DEFAULT_VIEWPORT,
+  INITIAL_VIEWPORTS,
+  MINIMAL_VIEWPORTS,
+} from './legacy_preview';


### PR DESCRIPTION
Issue: fix #9129 

## What I did

- Allow `viewports` option to be optional
- Export `MINIMAL_VIEWPORTS`
- Update doc
- Add warning about `defaultViewport` doesn't exists in `viewports` config
<img width="646" alt="Screen Shot 2019-12-12 at 5 43 56 PM" src="https://user-images.githubusercontent.com/7753001/70701575-8fa2a900-1d07-11ea-900d-945f552d70c6.png">

## How to test

Is there any recommended way to test addons? I couldn't find any :(. So I instead just tweak the configs in `official-storybook` to test it locally.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
