### PR TITLE
Fix wrong path in readme

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -111,7 +111,7 @@ Then add the following to your `.storybook/main.js`:
 ```js
 module.exports = {
   presets: ['@storybook/addon-docs/preset'],
-  stories: ['../src/**/*/stories.(js|mdx)'],
+  stories: ['../src/**/*.stories.(js|mdx)'],
 };
 ```
 


### PR DESCRIPTION
Issue: The readme stories path is wrong, the story files should be called `example.stories.mdx`

