### PR TITLE
Update index.md

### DIFF
--- a/docs/src/pages/formats/storiesof-api/index.md
+++ b/docs/src/pages/formats/storiesof-api/index.md
@@ -40,7 +40,7 @@ Each `.add` call takes a story name, a story function that returns a renderable 
 
 [Decorators](../../basics/writing-stories/#decorators) and [parameters](../../basics/writing-stories/#parameters) can be specified globally, at the component level, or locally at the story level.
 
-Global decorators are parameters are specified in the Storybook config:
+Global decorators and parameters are specified in the Storybook config:
 
 ```js
 addDecorator(storyFn => <blink>{storyFn()}</blink>);


### PR DESCRIPTION
Fixed a typo / wrong word.

Issue:

## What I did
The word 'are' was repeated twice and should have been 'and' the first time.
## How to test
Nothing to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
