### PR TITLE
React: Add support for CRA without overrides

### DIFF
--- a/app/react/src/server/framework-preset-cra.ts
+++ b/app/react/src/server/framework-preset-cra.ts
@@ -7,14 +7,12 @@ type Preset = string | { name: string };
 
 // Disable the built-in preset if the new preset is detected.
 const checkForNewPreset = (presetsList: Preset[]) => {
-  try {
-    const hasNewPreset = presetsList.some((preset: Preset) => {
-      const presetName = typeof preset === 'string' ? preset : preset.name;
-      return presetName === '@storybook/preset-create-react-app';
-    });
+  const hasNewPreset = presetsList.some((preset: Preset) => {
+    const presetName = typeof preset === 'string' ? preset : preset.name;
+    return presetName === '@storybook/preset-create-react-app';
+  });
 
-    return hasNewPreset;
-  } catch (e) {
+  if (!hasNewPreset) {
     logger.warn('Storybook support for Create React App is now a separate preset.');
     logger.warn(
       'To get started with the new preset, simply add `@storybook/preset-create-react-app` to your project.'
@@ -22,6 +20,8 @@ const checkForNewPreset = (presetsList: Preset[]) => {
     logger.warn('The built-in preset will be disabled in Storybook 6.0.');
     return false;
   }
+
+  return true;
 };
 
 export function webpackFinal(

--- a/lib/core/src/server/preview/base-webpack.config.js
+++ b/lib/core/src/server/preview/base-webpack.config.js
@@ -3,7 +3,11 @@ import findUp from 'find-up';
 import path from 'path';
 import { logger } from '@storybook/node-logger';
 
-export async function createDefaultWebpackConfig(storybookBaseConfig) {
+export async function createDefaultWebpackConfig(storybookBaseConfig, options) {
+  if (options.presetsList.some(({ name }) => name === '@storybook/preset-create-react-app')) {
+    return storybookBaseConfig;
+  }
+
   const postcssConfigFiles = [
     '.postcssrc',
     '.postcssrc.json',

--- a/lib/core/src/server/preview/custom-webpack-preset.js
+++ b/lib/core/src/server/preview/custom-webpack-preset.js
@@ -6,7 +6,7 @@ import mergeConfigs from '../utils/merge-webpack-config';
 import { createDefaultWebpackConfig } from './base-webpack.config';
 
 async function createFinalDefaultConfig(presets, config, options) {
-  const defaultConfig = await createDefaultWebpackConfig(config);
+  const defaultConfig = await createDefaultWebpackConfig(config, options);
   return presets.apply('webpackFinal', defaultConfig, options);
 }
 


### PR DESCRIPTION
## What I did

This update ensures that no additional config is inserted after the CRA preset is loaded. 

## How to test

Run this alongside the new CRA preset, and the config should be returned without additional loaders.

Related PR for the preset: https://github.com/storybookjs/presets/pull/77.