### PR TITLE
Addon-docs: Add fontFamily prop to Typeset component

### DIFF
--- a/lib/components/src/blocks/Typeset.stories.tsx
+++ b/lib/components/src/blocks/Typeset.stories.tsx
@@ -8,9 +8,11 @@ export default {
 
 const fontSizes = ['12px', '14px', '16px', '20px', '24px', '32px', '40px', '48px'];
 const fontWeight = 900;
+const fontFamily = 'monospace';
 
 export const withFontSizes = () => <Typeset fontSizes={fontSizes} />;
 export const withFontWeight = () => <Typeset fontSizes={fontSizes} fontWeight={fontWeight} />;
+export const withFontFamily = () => <Typeset fontSizes={fontSizes} fontFamily={fontFamily} />;
 export const withWeightText = () => (
   <Typeset fontSizes={fontSizes} fontWeight={fontWeight} sampleText="Heading" />
 );

--- a/lib/components/src/blocks/Typeset.tsx
+++ b/lib/components/src/blocks/Typeset.tsx
@@ -35,6 +35,7 @@ const Wrapper = styled.div<{}>(withReset, ({ theme }) => ({
 }));
 
 export interface TypesetProps {
+  fontFamily?: string;
   fontSizes: string[];
   fontWeight?: number;
   sampleText?: string;
@@ -45,6 +46,7 @@ export interface TypesetProps {
  * with different sizes and weights and configurable sample text.
  */
 export const Typeset: FunctionComponent<TypesetProps> = ({
+  fontFamily,
   fontSizes,
   fontWeight,
   sampleText,
@@ -56,6 +58,7 @@ export const Typeset: FunctionComponent<TypesetProps> = ({
         <Label>{size}</Label>
         <Sample
           style={{
+            fontFamily,
             fontSize: size,
             fontWeight,
           }}


### PR DESCRIPTION
Issue: #8161

## What I did

![image](https://user-images.githubusercontent.com/8302959/70870282-62e8ce80-1f5f-11ea-97f8-d7d1ba1addaa.png)

- Added `fontFamily` prop to Typeset component that allows you to set the font family on the type sample
- Added a story for `Typeset` illustrating the use of the `fontFamily` prop

## How to test

1. `cd examples/official-storybook && yarn storybook`
1. Search for `font family`
1. Verify that the font family story renders the type sample using a monospace font

- Is this testable with Jest or Chromatic screenshots? **yes (not sure how to set that up though)**
- Does this need a new example in the kitchen sink apps? **not sure**
- Does this need an update to the documentation? **not sure**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

