### PR TITLE
docs(addon-backgrounds): fix usage typos in addon-backgrounds documentation

### DIFF
--- a/addons/backgrounds/README.md
+++ b/addons/backgrounds/README.md
@@ -73,7 +73,7 @@ export const defaultView = () => (
 );
 defaultView.story = {
   parameters: {
-    background: [
+    backgrounds: [
       { name: 'red', value: 'rgba(255, 0, 0)' },
     ],
   },
@@ -94,7 +94,7 @@ export const noBackgrounds = () => (
 );
 noBackgrounds.story = {
   parameters: {
-    background: [],
+    backgrounds: [],
   },
 };
 
@@ -103,7 +103,7 @@ export const disabledBackgrounds = () => (
 );
 disabledBackgrounds.story = {
   parameters: {
-    background: { disabled: true },
+    backgrounds: { disabled: true },
   },
 };
 ```


### PR DESCRIPTION
Issue: The examples in the `addon-backgrounds` documentation for story-specific usage includes a typo that, if followed, will not allow the addon to work properly.

## What I did

Fixed the typo by changing the incorrect `background` to the correct `backgrounds`.

## How to test

No testing required. Documentation change only.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
