### PR TITLE
fix(a11y): fix highlight of selected blindness color filter

### DIFF
--- a/addons/a11y/src/components/ColorBlindness.tsx
+++ b/addons/a11y/src/components/ColorBlindness.tsx
@@ -87,9 +87,7 @@ export const ColorBlindness: FunctionComponent = () => {
 
     if (iframe) {
       iframe.style.filter = getFilter(activeState);
-      setActiveState({
-        active: activeState,
-      });
+      setActiveState(activeState);
     } else {
       logger.error('Cannot find Storybook iframe');
     }


### PR DESCRIPTION
## What I did

Fix highlight of selected blindness color filter.

## How to test

 - Open a story
 - Select a blindness color filter 
 - Open the menu of blindness color filters
 - The previously selected filter should be highlighted

After the fix:
![Dec-18-2019 08-11-53](https://user-images.githubusercontent.com/4112568/71064037-630ae900-216e-11ea-9ea5-11f652b0cd63.gif)
