### PR TITLE
CSF: Use `__orderedExports` in loader if provided 

### DIFF
--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -379,7 +379,10 @@ export default function start(render, { decorateStory } = {}) {
         );
       }
 
-      const { default: meta, ...exports } = fileExports;
+      const { default: meta, __orderedExports, ...namedExports } = fileExports;
+      // prefer a user/loader provided `__orderedExports` object if supplied as es module exports
+      // are ordered alphabetically - see https://github.com/storybookjs/storybook/issues/9136
+      const exports = __orderedExports || namedExports;
       const {
         title: kindName,
         id: componentId,


### PR DESCRIPTION
closes: https://github.com/storybookjs/storybook/issues/9136

## What I did

prefer a user/loader provided `__orderedExports` object if supplied as es module exports are ordered alphabetically

This will have 0 effects if that export is not used/provided.

And you should only provide it you are using native es modules (which have alphabetically ordered exports vs webpack source code ordered exports)

## How to test

- use storybook without webpack and provide this export
