### PR TITLE
Add react-scripts automatic setup to docs

### DIFF
--- a/docs/src/pages/guides/guide-react/index.md
+++ b/docs/src/pages/guides/guide-react/index.md
@@ -5,6 +5,12 @@ title: 'Storybook for React'
 
 ## Automatic setup
 
+Before trying the below commands, you should try the following command. In most cases, Storybook will detect that you're using `react` or `react-scripts`, and install the appropriate packages.
+
+```sh
+npx -p @storybook/cli sb init
+```
+
 You may have tried to use our quick start guide to setup your project for Storybook.
 If it failed because it couldn't detect you're using React, you could try forcing it to use React:
 
@@ -12,7 +18,13 @@ If it failed because it couldn't detect you're using React, you could try forcin
 npx -p @storybook/cli sb init --type react
 ```
 
-Note: be sure you have a `package.json` in your project or the above command will fail.
+If you're using [Create React App](https://create-react-app.dev/) (or a fork of `react-scrips`), you should use this command instead:
+
+```sh
+npx -p @storybook/cli sb init --type react_scripts
+```
+
+Note: You must have a `package.json` in your project or the above commands will fail.
 
 ## Manual setup
 


### PR DESCRIPTION
Issue: #5183

## What I did
Users are short on time (as we all are) and often skip over the docs to the React section, without first trying automatic setup. 

As a result, `react-scripts` users install with `--type react`  - but they should pass `--type react_scripts`.

## How to test
N/A