### PR TITLE
Addon-essentials: Remove actions, links, knobs

### DIFF
--- a/addons/essentials/README.md
+++ b/addons/essentials/README.md
@@ -8,10 +8,7 @@ Each addon is documented and maintained by the core team and will be upgraded al
 
 Storybook essentials includes the following addons. Addons can be disabled and re-configured as [described below](#configuration):
 
-- [Actions](https://github.com/storybookjs/storybook/tree/next/addons/actions)
 - [Backgrounds](https://github.com/storybookjs/storybook/tree/next/addons/backgrounds)
-- [Knobs](https://github.com/storybookjs/storybook/tree/next/addons/knobs)
-- [Links](https://github.com/storybookjs/storybook/tree/next/addons/links)
 - [Viewport](https://github.com/storybookjs/storybook/tree/next/addons/viewport)
 
 ## Installation
@@ -51,4 +48,4 @@ module.exports = {
 };
 ```
 
-Valid addon keys include: `actions`, `backgrounds`, `knobs`, `links`, `viewport`
+Valid addon keys include: `backgrounds`, `viewport`

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -27,10 +27,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
-    "@storybook/addon-actions": "5.3.0-beta.31",
     "@storybook/addon-backgrounds": "5.3.0-beta.31",
-    "@storybook/addon-knobs": "5.3.0-beta.31",
-    "@storybook/addon-links": "5.3.0-beta.31",
     "@storybook/addon-viewport": "5.3.0-beta.31",
     "@storybook/addons": "5.3.0-beta.31",
     "@storybook/api": "5.3.0-beta.31",

--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -2,10 +2,7 @@ import fs from 'fs';
 import { logger } from '@storybook/node-logger';
 
 type PresetOptions = {
-  actions?: any;
   backgrounds?: any;
-  knobs?: any;
-  links?: any;
   viewport?: any;
 };
 
@@ -25,17 +22,8 @@ const isInstalled = (addon: string) => {
 
 const makeAddon = (key: string) => `@storybook/addon-${key}`;
 
-export function presets(options: PresetOptions = {}) {
-  const presetAddons = ['knobs']
-    .filter(key => (options as any)[key] !== false)
-    .map(key => makeAddon(key))
-    .filter(addon => !isInstalled(addon))
-    .map(addon => `${addon}/preset`);
-  return presetAddons;
-}
-
 export function addons(entry: any[] = [], options: PresetOptions = {}) {
-  const registerAddons = ['actions', 'backgrounds', 'links', 'viewport']
+  const registerAddons = ['backgrounds', 'viewport']
     .filter(key => (options as any)[key] !== false)
     .map(key => makeAddon(key))
     .filter(addon => !isInstalled(addon))

--- a/examples/cra-ts-essentials/package.json
+++ b/examples/cra-ts-essentials/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@storybook/addon-essentials": "5.3.0-beta.31",
     "@storybook/addons": "5.3.0-beta.31",
-    "@storybook/preset-create-react-app": "^1.2.0",
+    "@storybook/preset-create-react-app": "^1.5.0",
     "@storybook/react": "5.3.0-beta.31"
   }
 }

--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -41,7 +41,7 @@
     "@storybook/addon-links": "5.3.0-beta.31",
     "@storybook/addon-options": "5.3.0-beta.31",
     "@storybook/addons": "5.3.0-beta.31",
-    "@storybook/preset-create-react-app": "^1.3.1",
+    "@storybook/preset-create-react-app": "^1.5.0",
     "@storybook/react": "5.3.0-beta.31",
     "@types/enzyme": "^3.9.0",
     "@types/react": "^16.8.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3618,10 +3618,10 @@
     remark-lint "^6.0.4"
     remark-preset-lint-recommended "^3.0.2"
 
-"@storybook/node-logger@^5.2.6":
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-5.2.6.tgz#e353aff14375bef9e922c217a0afb50f93e2ceb1"
-  integrity sha512-Z3mn9CUSiG7kR2OBoz4lNeoeBS094h5d9wufZSp5S+M47L6KEXmTgNcuePKj+t8Z8KT/Ph8B63bjChseKp3DNw==
+"@storybook/node-logger@^5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-5.2.8.tgz#4a3df21d731014d54b9ca53d5b9a72dd350bb075"
+  integrity sha512-3TK5mx6VWbfJO+WUrqwPhTbTQ4qESTnwJY/02xPzOhvuC6tIG1QOxzi+Rq6rFlwxTpUuWh6iyDYnGIqFFQywkA==
   dependencies:
     chalk "^2.4.2"
     core-js "^3.0.1"
@@ -3629,14 +3629,15 @@
     pretty-hrtime "^1.0.3"
     regenerator-runtime "^0.12.1"
 
-"@storybook/preset-create-react-app@^1.2.0", "@storybook/preset-create-react-app@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@storybook/preset-create-react-app/-/preset-create-react-app-1.3.1.tgz#1a7cb7d58b64a2254c566f9907eab8340a531506"
-  integrity sha512-atJ4Jbq5QYXRa+8wscfN1kCnDk3/Dn8RZy/xm1OVrozptjlRz2CuiJEDqfmKeIEi81fBuUs41Uc3M+VWocSklg==
+"@storybook/preset-create-react-app@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@storybook/preset-create-react-app/-/preset-create-react-app-1.5.0.tgz#214c023790545a36bb6b551d317a8dacbb7bc1a1"
+  integrity sha512-HkVmduGBPiCdtpq+rNZDzjJXEt7+KxszePDkCvnXfQMKKe+OusvmiuHwNB1A7apB7fGXPysbAgST/1G96sn61Q==
   dependencies:
-    "@storybook/node-logger" "^5.2.6"
-    "@types/webpack" "^4.39.8"
-    react-docgen-typescript-loader "^3.3.0"
+    "@storybook/node-logger" "^5.2.8"
+    "@types/webpack" "^4.41.0"
+    react-docgen-typescript-loader "^3.6.0"
+    semver "7.0.0"
 
 "@stroncium/procfs@^1.0.0":
   version "1.0.0"
@@ -4377,7 +4378,7 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@*", "@types/webpack@^4.39.8", "@types/webpack@^4.41.0":
+"@types/webpack@*", "@types/webpack@^4.41.0":
   version "4.41.0"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.0.tgz#b813a044d8b0dec7dfcd7622fdbe327bde06eb9a"
   integrity sha512-tWkdf9nO0zFgAY/EumUKwrDUhraHKDqCPhwfFR/R8l0qnPdgb9le0Gzhvb7uzVpouuDGBgiE//ZdY+5jcZy2TA==
@@ -25543,7 +25544,7 @@ react-devtools-core@^3.4.2, react-devtools-core@^3.6.0:
     shell-quote "^1.6.1"
     ws "^3.3.1"
 
-react-docgen-typescript-loader@^3.3.0:
+react-docgen-typescript-loader@^3.3.0, react-docgen-typescript-loader@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.6.0.tgz#5515f03f869e66d49e287c5f1e7ec10f2084f7bb"
   integrity sha512-+uEsM3VYCdlcBGxF3tBqI5XWL1phvrh8dkiIfdpciKlM1BDHW+d82kKJI9hX6zk9H8TL+3Th/j/JAEaKb5FFNw==
@@ -28051,6 +28052,11 @@ semver@6.3.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
+  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
Issue: #5731 

## What I did

Adding a new constraint to essentials (for now). An essential addon must provide value out of the box with zero config/programming from users. Currently only `viewport`/`backgrounds` satisfy this constraint.

## How to test

See `examples/cra-ts-essentials`