### PR TITLE
Storyshots: update render w/ React.createElement

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/react/renderShallowTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/react/renderShallowTree.ts
@@ -1,8 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import shallow from 'react-test-renderer/shallow';
 
 function getRenderedTree(story: any, context: any, { renderer, serializer }: any) {
-  const storyElement = story.render();
+  const storyElement = React.createElement(story.render);
   const shallowRenderer = renderer || shallow.createRenderer();
   const tree = shallowRenderer.render(storyElement);
   return serializer ? serializer(tree) : tree;

--- a/addons/storyshots/storyshots-core/src/frameworks/react/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/react/renderTree.ts
@@ -1,8 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import reactTestRenderer from 'react-test-renderer';
 
 function getRenderedTree(story: any, context: any, { renderer, ...rendererOptions }: any) {
-  const storyElement = story.render();
+  const storyElement = React.createElement(story.render);
   const currentRenderer = renderer || reactTestRenderer.create;
   const tree = currentRenderer(storyElement, rendererOptions);
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8177

## What I did

Wrapped the `story.render()` calls with `React.createElement` for storyshots.

This allows you to use hooks in CSF without wrapping components in a thunk-like function.

## How to test

- Is this testable with Jest or Chromatic screenshots?
Jest

- Does this need a new example in the kitchen sink apps?
Nope

- Does this need an update to the documentation?
Nope

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
