### PR TITLE
Fix localeCompare() examples. Fixes #9193

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -256,7 +256,7 @@ For example, here's how to sort by story ID using `storySort`:
 addParameters({
   options: {
     storySort: (a, b) =>
-      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
+      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
   },
 });
 ```

--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -84,7 +84,7 @@ import { addParameters, configure } from '@storybook/react';
 addParameters({
   options: {
     storySort: (a, b) =>
-      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
+      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
   },
 };
 ```

--- a/examples/cra-kitchen-sink/.storybook/preview.js
+++ b/examples/cra-kitchen-sink/.storybook/preview.js
@@ -5,6 +5,6 @@ addDecorator(withA11y);
 addParameters({
   options: {
     storySort: (a, b) =>
-      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
+      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
   },
 });

--- a/examples/official-storybook/preview.js
+++ b/examples/official-storybook/preview.js
@@ -48,7 +48,7 @@ addParameters({
     showRoots: true,
     theme: themes.light, // { base: 'dark', brandTitle: 'Storybook!' },
     storySort: (a, b) =>
-      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, { numeric: true }),
+      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
   },
   backgrounds: [
     { name: 'storybook app', value: themes.light.appBg, default: true },

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -40,7 +40,7 @@ describe('preview.story_store', () => {
 
       const extracted = store.extract();
 
-      // We need exact key ordering, even if in theory JS doesns't guarantee it
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
       expect(Object.keys(extracted)).toEqual(['a--1', 'a--2', 'b--1']);
 
       // content of item should be correct
@@ -50,6 +50,40 @@ describe('preview.story_store', () => {
         name: '1',
         parameters: expect.any(Object),
       });
+    });
+  });
+
+  describe('storySort', () => {
+    it('sorts stories using given function', () => {
+      const parameters = {
+        options: {
+          // Test function does alphabetical ordering.
+          storySort: (a: any, b: any): number =>
+            a[1].kind === b[1].kind
+              ? 0
+              : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
+        },
+      };
+      const store = new StoryStore({ channel });
+      store.addStory(...make('a/a', '1', () => 0, parameters));
+      store.addStory(...make('a/a', '2', () => 0, parameters));
+      store.addStory(...make('a/b', '1', () => 0, parameters));
+      store.addStory(...make('b/b1', '1', () => 0, parameters));
+      store.addStory(...make('b/b10', '1', () => 0, parameters));
+      store.addStory(...make('b/b9', '1', () => 0, parameters));
+      store.addStory(...make('c', '1', () => 0, parameters));
+
+      const extracted = store.extract();
+
+      expect(Object.keys(extracted)).toEqual([
+        'a-a--1',
+        'a-a--2',
+        'a-b--1',
+        'b-b1--1',
+        'b-b9--1',
+        'b-b10--1',
+        'c--1',
+      ]);
     });
   });
 


### PR DESCRIPTION
Issue: #9193 

## What I did

- Fixes docs where localeCompare() is used incorrectly.
- Adds test for `storySort` option that uses a custom function where localeCompare() is used correctly.

## How to test

In this PR, you'll see a test that currently passes. If you want to see how the current docs don't work, you can delete the `undefined,` parameter from the `localeCompare()` in the new test and watch it fail to sort  "b-b10--1" after "b-b9--1".
