### PR TITLE
docs: ✏️Changed deployment command for zeit now cloud deployments

### DIFF
--- a/docs/src/pages/basics/exporting-storybook/index.md
+++ b/docs/src/pages/basics/exporting-storybook/index.md
@@ -47,7 +47,7 @@ Or, you can simply export your storybook into the docs directory and use it as t
 
 - Configure your `build` script:
 
-  `"build": "build-storybook -c .storybook -o public"`
+  `"build": "build-storybook -c .storybook -o build"`
 
 - Execute `now` on your terminal.
 


### PR DESCRIPTION
With the existing command when we deploy using `now` command it fails with the below error.
<img width="1002" alt="Screenshot 2019-12-19 at 6 16 22 PM" src="https://user-images.githubusercontent.com/5508780/71174720-deae8800-228b-11ea-8da8-cf1960f48aa7.png">

`Error: No output directory named "build" found.`
On changing the command. The deployment happened successfully.

Issue:

## What I did
Updates documentation with a new command for Zeit now deployments
## How to test
- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
