### PR TITLE
docs: ✏️changed deployment command for zeit now

### DIFF
--- a/docs/src/pages/basics/exporting-storybook/index.md
+++ b/docs/src/pages/basics/exporting-storybook/index.md
@@ -50,7 +50,7 @@ npm i -g now
 - Configure your `build` script:
 
 ```
-`"build": "build-storybook -c .storybook -o public"`
+`"build": "build-storybook -c .storybook -o build"`
 ```
 
 - Execute `now` on your terminal.


### PR DESCRIPTION
Issue:

## What I did
With the existing command when we deploy using `now` command it fails with the below error.
<img width="1002" alt="Screenshot 2019-12-19 at 6 16 22 PM" src="https://user-images.githubusercontent.com/5508780/71175535-d0616b80-228d-11ea-9b2f-93ef4ec31219.png">

`Error: No output directory named "build" found.`
On changing the command. The deployment happened successfully.
## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
