### PR TITLE
ViewportAddon: Add EVENT_VIEWPORT_CHANGED event

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -193,3 +193,52 @@ addParameters({
   },
 });
 ```
+
+### Handle viewport change event
+
+If you are addon-developer you may need to react on viewport change.
+For these purposes, you can use `EVENT_VIEWPORT_CHANGED`:
+```js
+import React from 'react';
+import { addons, types } from '@storybook/addons';
+import { EVENT_VIEWPORT_CHANGED } from '@storybook/addon-viewport';
+
+addons.register('MY_ADDON', () => {
+  addons.add('MY_ADDON_TOOL', {
+    title: 'My Addon',
+    type: types.TOOL,
+    match: ({ viewMode }) => viewMode === 'story',
+    render: () => <MyComponent />,
+  });
+});
+
+class MyComponent extends React.Component {
+  state = {
+    currentViewportTitle: undefined,
+  };
+
+  componentDidMount() {
+    const channel = addons.getChannel();
+    channel.on(EVENT_VIEWPORT_CHANGED, data => {
+      console.log('VIEWPORT_DATA', {
+        item: {
+          id: data.item.id,
+          title: data.item.title,
+          styles: data.item.style,
+          type: data.item.type,
+          default: data.item.default,
+        },
+        isRotated: data.isRotated,
+      });
+      this.setState({
+        currentViewportTitle: data.item.title,
+      });
+    });
+  }
+
+  render() {
+    const { currentViewportTitle } = this.state;
+    return <span>{currentViewportTitle || 'no viewport'}</span>;
+  }
+}
+```

--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -23,8 +23,8 @@
     "*.js",
     "*.d.ts"
   ],
-  "main": "dist/preview.js",
-  "types": "dist/preview.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"
   },

--- a/addons/viewport/src/components/Tool.tsx
+++ b/addons/viewport/src/components/Tool.tsx
@@ -6,10 +6,11 @@ import { styled, Global, Theme, withTheme } from '@storybook/theming';
 
 import { Icons, IconButton, WithTooltip, TooltipLinkList } from '@storybook/components';
 
-import { useParameter, useAddonState } from '@storybook/api';
-import { PARAM_KEY, ADDON_ID } from './constants';
-import { MINIMAL_VIEWPORTS } from './defaults';
-import { ViewportAddonParameter, ViewportMap, ViewportStyles, Styles } from './models';
+import { useParameter, useAddonState, API } from '@storybook/api';
+import { PARAM_KEY, ADDON_ID, EVENT_VIEWPORT_CHANGED } from '../constants';
+import { MINIMAL_VIEWPORTS } from '../defaults';
+import { ViewportAddonParameter, ViewportMap, ViewportStyles, Styles } from '../models';
+import { ViewportChangedEventProps } from '../models/ViewportAddonEvents';
 
 interface ViewportItem {
   id: string;
@@ -122,8 +123,13 @@ const getStyles = (
   return isRotated ? flip(result) : result;
 };
 
-export const ViewportTool: FunctionComponent = memo(
-  withTheme(({ theme }: { theme: Theme }) => {
+type Props = {
+  theme: Theme;
+  api: API;
+};
+
+export const ViewportTool: FunctionComponent<Omit<Props, 'theme'>> = memo(
+  withTheme(({ theme, api }: Props) => {
     const {
       viewports = MINIMAL_VIEWPORTS,
       defaultViewport = responsiveViewport.id,
@@ -155,6 +161,11 @@ export const ViewportTool: FunctionComponent = memo(
       list.find(i => i.id === defaultViewport) ||
       list.find(i => i.default) ||
       responsiveViewport;
+
+    useEffect(() => {
+      const eventProps: ViewportChangedEventProps = { item, isRotated };
+      api.emit(EVENT_VIEWPORT_CHANGED, eventProps);
+    }, [item, isRotated]);
 
     const ref = useRef<ViewportStyles>();
 

--- a/addons/viewport/src/components/Tool.tsx
+++ b/addons/viewport/src/components/Tool.tsx
@@ -128,131 +128,131 @@ type Props = {
   api: API;
 };
 
-export const ViewportTool: FunctionComponent<Omit<Props, 'theme'>> = memo(
-  withTheme(({ theme, api }: Props) => {
-    const {
-      viewports = MINIMAL_VIEWPORTS,
-      defaultViewport = responsiveViewport.id,
-      disable,
-    } = useParameter<ViewportAddonParameter>(PARAM_KEY, {});
-    const [state, setState] = useAddonState<ViewportToolState>(ADDON_ID, {
-      selected: defaultViewport,
-      isRotated: false,
+export const ViewportToolComponent: FunctionComponent<Props> = ({ theme, api }) => {
+  const {
+    viewports = MINIMAL_VIEWPORTS,
+    defaultViewport = responsiveViewport.id,
+    disable,
+  } = useParameter<ViewportAddonParameter>(PARAM_KEY, {});
+  const [state, setState] = useAddonState<ViewportToolState>(ADDON_ID, {
+    selected: defaultViewport,
+    isRotated: false,
+  });
+  const list = toList(viewports);
+
+  if (!list.find(i => i.id === defaultViewport)) {
+    console.warn(
+      `Cannot find "defaultViewport" of "${defaultViewport}" in addon-viewport configs, please check the "viewports" setting in the configuration.`
+    );
+  }
+
+  useEffect(() => {
+    setState({
+      selected:
+        defaultViewport || (viewports[state.selected] ? state.selected : responsiveViewport.id),
+      isRotated: state.isRotated,
     });
-    const list = toList(viewports);
+  }, [defaultViewport]);
 
-    if (!list.find(i => i.id === defaultViewport)) {
-      console.warn(
-        `Cannot find "defaultViewport" of "${defaultViewport}" in addon-viewport configs, please check the "viewports" setting in the configuration.`
-      );
-    }
+  const { selected, isRotated } = state;
+  const item =
+    list.find(i => i.id === selected) ||
+    list.find(i => i.id === defaultViewport) ||
+    list.find(i => i.default) ||
+    responsiveViewport;
 
-    useEffect(() => {
-      setState({
-        selected:
-          defaultViewport || (viewports[state.selected] ? state.selected : responsiveViewport.id),
-        isRotated: state.isRotated,
-      });
-    }, [defaultViewport]);
+  useEffect(() => {
+    const eventProps: ViewportChangedEventProps = { item, isRotated };
+    api.emit(EVENT_VIEWPORT_CHANGED, eventProps);
+  }, [item, isRotated]);
 
-    const { selected, isRotated } = state;
-    const item =
-      list.find(i => i.id === selected) ||
-      list.find(i => i.id === defaultViewport) ||
-      list.find(i => i.default) ||
-      responsiveViewport;
+  const ref = useRef<ViewportStyles>();
 
-    useEffect(() => {
-      const eventProps: ViewportChangedEventProps = { item, isRotated };
-      api.emit(EVENT_VIEWPORT_CHANGED, eventProps);
-    }, [item, isRotated]);
+  const styles = getStyles(ref.current, item.styles, isRotated);
 
-    const ref = useRef<ViewportStyles>();
+  useEffect(() => {
+    ref.current = styles;
+  }, [item]);
 
-    const styles = getStyles(ref.current, item.styles, isRotated);
+  if (disable || Object.entries(viewports).length === 0) {
+    return null;
+  }
 
-    useEffect(() => {
-      ref.current = styles;
-    }, [item]);
-
-    if (disable || Object.entries(viewports).length === 0) {
-      return null;
-    }
-
-    return (
-      <Fragment>
-        <WithTooltip
-          placement="top"
-          trigger="click"
-          tooltip={({ onHide }) => (
-            <TooltipLinkList links={toLinks(list, item, setState, state, onHide)} />
-          )}
-          closeOnClick
+  return (
+    <Fragment>
+      <WithTooltip
+        placement="top"
+        trigger="click"
+        tooltip={({ onHide }) => (
+          <TooltipLinkList links={toLinks(list, item, setState, state, onHide)} />
+        )}
+        closeOnClick
+      >
+        <IconButtonWithLabel
+          key="viewport"
+          title="Change the size of the preview"
+          active={!!styles}
+          onDoubleClick={() => {
+            setState({ ...state, selected: responsiveViewport.id });
+          }}
         >
-          <IconButtonWithLabel
-            key="viewport"
-            title="Change the size of the preview"
-            active={!!styles}
-            onDoubleClick={() => {
-              setState({ ...state, selected: responsiveViewport.id });
+          <Icons icon="grow" />
+          {styles ? (
+            <IconButtonLabel>
+              {isRotated ? `${item.title} (L)` : `${item.title} (P)`}
+            </IconButtonLabel>
+          ) : null}
+        </IconButtonWithLabel>
+      </WithTooltip>
+
+      {styles ? (
+        <ActiveViewportSize>
+          <Global
+            styles={{
+              [`#${iframeId}`]: {
+                margin: `auto`,
+                transition: 'width .3s, height .3s',
+                position: 'relative',
+                border: `${theme.layoutMargin}px solid black`,
+                borderRadius: theme.appBorderRadius,
+                boxShadow:
+                  '0 0 100px 1000px rgba(0,0,0,0.5), 0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08)',
+
+                ...styles,
+              },
+              [`#${wrapperId}`]: {
+                padding: theme.layoutMargin,
+                alignContent: 'center',
+                alignItems: 'center',
+                justifyContent: 'center',
+                justifyItems: 'center',
+                overflow: 'auto',
+
+                display: 'grid',
+                gridTemplateColumns: '100%',
+                gridTemplateRows: '100%',
+              },
+            }}
+          />
+          <ActiveViewportLabel title="Viewport width">
+            {styles.width.replace('px', '')}
+          </ActiveViewportLabel>
+          <IconButton
+            key="viewport-rotate"
+            title="Rotate viewport"
+            onClick={() => {
+              setState({ ...state, isRotated: !isRotated });
             }}
           >
-            <Icons icon="grow" />
-            {styles ? (
-              <IconButtonLabel>
-                {isRotated ? `${item.title} (L)` : `${item.title} (P)`}
-              </IconButtonLabel>
-            ) : null}
-          </IconButtonWithLabel>
-        </WithTooltip>
+            <Icons icon="transfer" />
+          </IconButton>
+          <ActiveViewportLabel title="Viewport height">
+            {styles.height.replace('px', '')}
+          </ActiveViewportLabel>
+        </ActiveViewportSize>
+      ) : null}
+    </Fragment>
+  );
+};
 
-        {styles ? (
-          <ActiveViewportSize>
-            <Global
-              styles={{
-                [`#${iframeId}`]: {
-                  margin: `auto`,
-                  transition: 'width .3s, height .3s',
-                  position: 'relative',
-                  border: `${theme.layoutMargin}px solid black`,
-                  borderRadius: theme.appBorderRadius,
-                  boxShadow:
-                    '0 0 100px 1000px rgba(0,0,0,0.5), 0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08)',
-
-                  ...styles,
-                },
-                [`#${wrapperId}`]: {
-                  padding: theme.layoutMargin,
-                  alignContent: 'center',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  justifyItems: 'center',
-                  overflow: 'auto',
-
-                  display: 'grid',
-                  gridTemplateColumns: '100%',
-                  gridTemplateRows: '100%',
-                },
-              }}
-            />
-            <ActiveViewportLabel title="Viewport width">
-              {styles.width.replace('px', '')}
-            </ActiveViewportLabel>
-            <IconButton
-              key="viewport-rotate"
-              title="Rotate viewport"
-              onClick={() => {
-                setState({ ...state, isRotated: !isRotated });
-              }}
-            >
-              <Icons icon="transfer" />
-            </IconButton>
-            <ActiveViewportLabel title="Viewport height">
-              {styles.height.replace('px', '')}
-            </ActiveViewportLabel>
-          </ActiveViewportSize>
-        ) : null}
-      </Fragment>
-    );
-  })
-);
+export const ViewportTool = withTheme(memo(ViewportToolComponent));

--- a/addons/viewport/src/components/types.ts
+++ b/addons/viewport/src/components/types.ts
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+import { Styles, ViewportStyles, ViewportType } from '../models';
+
+export interface ViewportItem {
+  id: string;
+  title: string;
+  styles: Styles;
+  type: ViewportType;
+  default?: boolean;
+}
+
+export interface LinkBase {
+  id: string;
+  title: string;
+  right?: ReactNode;
+  type: 'desktop' | 'mobile' | 'tablet' | 'other';
+  styles: ViewportStyles | ((s: ViewportStyles) => ViewportStyles) | null;
+}
+
+export interface Link extends LinkBase {
+  onClick: () => void;
+}

--- a/addons/viewport/src/constants.ts
+++ b/addons/viewport/src/constants.ts
@@ -1,7 +1,8 @@
 export const ADDON_ID = 'storybook/viewport';
 export const PARAM_KEY = 'viewport';
 
-export const UPDATE = `${ADDON_ID}/update`;
-export const CONFIGURE = `${ADDON_ID}/configure`;
-export const SET = `${ADDON_ID}/setStoryDefaultViewport`;
-export const CHANGED = `${ADDON_ID}/viewportChanged`;
+// Do not use string concatenation in event constants for better typescript support
+export const PREVIEW_IFRAME_ID = 'storybook-preview-iframe';
+export const PREVIEW_WRAPPER_ID = 'storybook-preview-wrapper';
+
+export const EVENT_VIEWPORT_CHANGED = 'storybook/viewport/viewportChanged';

--- a/addons/viewport/src/index.ts
+++ b/addons/viewport/src/index.ts
@@ -1,6 +1,7 @@
 import deprecate from 'util-deprecate';
 
-export { INITIAL_VIEWPORTS, DEFAULT_VIEWPORT, MINIMAL_VIEWPORTS } from '../defaults';
+export { INITIAL_VIEWPORTS, DEFAULT_VIEWPORT, MINIMAL_VIEWPORTS } from './defaults';
+export { EVENT_VIEWPORT_CHANGED } from './constants';
 
 export const configureViewport = deprecate(() => {},
 'configureViewport is no longer supported, use .addParameters({ viewport }) instead');

--- a/addons/viewport/src/models/Viewport.ts
+++ b/addons/viewport/src/models/Viewport.ts
@@ -1,14 +1,20 @@
 export type Styles = ViewportStyles | ((s: ViewportStyles) => ViewportStyles) | null;
 
+export type ViewportType = 'desktop' | 'mobile' | 'tablet' | 'other';
+
 export interface Viewport {
   name: string;
   styles: Styles;
-  type: 'desktop' | 'mobile' | 'tablet' | 'other';
+  type: ViewportType;
   /*
    * @deprecated
    * Deprecated option?
    */
   default?: boolean;
+}
+
+export interface ComputedViewport extends Viewport {
+  styles: ViewportStyles;
 }
 
 export interface ViewportStyles {

--- a/addons/viewport/src/models/ViewportAddonEvents.ts
+++ b/addons/viewport/src/models/ViewportAddonEvents.ts
@@ -1,0 +1,3 @@
+import { ViewportItem } from '../components/types';
+
+export type ViewportChangedEventProps = { item: ViewportItem; isRotated: boolean };

--- a/addons/viewport/src/preview.ts
+++ b/addons/viewport/src/preview.ts
@@ -1,6 +1,0 @@
-export {
-  configureViewport,
-  DEFAULT_VIEWPORT,
-  INITIAL_VIEWPORTS,
-  MINIMAL_VIEWPORTS,
-} from './legacy_preview';

--- a/addons/viewport/src/register.tsx
+++ b/addons/viewport/src/register.tsx
@@ -3,13 +3,13 @@ import addons, { types } from '@storybook/addons';
 
 import { ADDON_ID } from './constants';
 
-import { ViewportTool } from './Tool';
+import { ViewportTool } from './components/Tool';
 
-addons.register(ADDON_ID, () => {
+addons.register(ADDON_ID, api => {
   addons.add(ADDON_ID, {
     title: 'viewport / media-queries',
     type: types.TOOL,
     match: ({ viewMode }) => viewMode === 'story',
-    render: () => <ViewportTool />,
+    render: () => <ViewportTool api={api} />,
   });
 });


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8230

## What I did
I provide a new event `EVENT_VIEWPORT_CHANGED` that you can use to react to viewport change.

## How to test
You can test this with example from documentation

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
