### PR TITLE
DocsPage: Fix title with new path separator scheme

### DIFF
--- a/addons/docs/src/blocks/DocsPage.test.ts
+++ b/addons/docs/src/blocks/DocsPage.test.ts
@@ -15,4 +15,10 @@ describe('defaultTitleSlot', () => {
     expect(defaultTitleSlot({ selectedKind: 'a|b', parameters })).toBe('b');
     expect(defaultTitleSlot({ selectedKind: 'a/b/c.d', parameters })).toBe('d');
   });
+  it('empty options', () => {
+    const parameters = { options: {} };
+    expect(defaultTitleSlot({ selectedKind: 'a/b/c', parameters })).toBe('c');
+    expect(defaultTitleSlot({ selectedKind: 'a|b', parameters })).toBe('b');
+    expect(defaultTitleSlot({ selectedKind: 'a/b/c.d', parameters })).toBe('d');
+  });
 });

--- a/addons/docs/src/blocks/Title.tsx
+++ b/addons/docs/src/blocks/Title.tsx
@@ -11,13 +11,9 @@ interface TitleProps {
 export const defaultTitleSlot: StringSlot = ({ selectedKind, parameters }) => {
   const {
     showRoots,
-    hierarchyRootSeparator: rootSeparator,
-    hierarchySeparator: groupSeparator,
-  } = (parameters && parameters.options) || {
-    showRoots: undefined,
-    hierarchyRootSeparator: '|',
-    hierarchySeparator: /\/|\./,
-  };
+    hierarchyRootSeparator: rootSeparator = '|',
+    hierarchySeparator: groupSeparator = /\/|\./,
+  } = (parameters && parameters.options) || {};
 
   let groups;
   if (typeof showRoots !== 'undefined') {


### PR DESCRIPTION
Issue: #8907 

## What I did

Fix case where user has some options set & add test case

## How to test

See updated unit test
