### PR TITLE
fix(storybook/angular): add default value to the budgets property

### DIFF
--- a/app/angular/src/server/__tests__/angular-cli_config.test.ts
+++ b/app/angular/src/server/__tests__/angular-cli_config.test.ts
@@ -70,4 +70,13 @@ describe('angular-cli_config', () => {
     expect(projectConfig).toBe(null);
     expect(config).toBe(baseConfig);
   });
+
+  it('should return empty `buildOptions.budgets` by default', () => {
+    const config = getAngularCliWebpackConfigOptions(__dirname as Path);
+    expect(config).toMatchObject({
+      buildOptions: {
+        budgets: [],
+      },
+    });
+  });
 });

--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -89,6 +89,7 @@ export function getAngularCliWebpackConfigOptions(dirToSearch: Path) {
   const projectRoot = path.resolve(dirToSearch, project.root);
   const tsConfigPath = path.resolve(dirToSearch, projectOptions.tsConfig) as Path;
   const tsConfig = getTsConfigOptions(tsConfigPath);
+  const budgets = projectOptions.budgets || [];
 
   return {
     root: dirToSearch,
@@ -101,6 +102,7 @@ export function getAngularCliWebpackConfigOptions(dirToSearch: Path) {
       optimization: {},
       ...projectOptions,
       assets: normalizedAssets,
+      budgets
     },
   };
 }


### PR DESCRIPTION
Issue: Closes #9206

## What I did
Added default value to the budgets property.

## How to test

- Is this testable with Jest or Chromatic screenshots? -Yes
- Does this need a new example in the kitchen sink apps? -No
- Does this need an update to the documentation? -No

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
