### PR TITLE
CLI: Make template `stories` glob more permissive

### DIFF
--- a/lib/cli/generators/ANGULAR/template-csf/.storybook/main.js
+++ b/lib/cli/generators/ANGULAR/template-csf/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../src/stories/**/*.stories.ts'],
+  stories: ['../src/**/*.stories.ts'],
   addons: [
     '@storybook/addon-actions/register',
     '@storybook/addon-links/register',

--- a/lib/cli/generators/ANGULAR/template-mdx/.storybook/main.js
+++ b/lib/cli/generators/ANGULAR/template-mdx/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../src/stories/**/*.stories.(ts|mdx)'],
+  stories: ['../src/**/*.stories.(ts|mdx)'],
   addons: [
     '@storybook/addon-actions/register',
     '@storybook/addon-links/register',

--- a/lib/cli/generators/POLYMER/template-csf/.storybook/main.js
+++ b/lib/cli/generators/POLYMER/template-csf/.storybook/main.js
@@ -1,3 +1,3 @@
 module.exports = {
-  stories: ['../src/stories/**/*.stories.js'],
+  stories: ['../src/**/*.stories.js'],
 };

--- a/lib/cli/generators/REACT_SCRIPTS/template-csf-ts/.storybook/main.js
+++ b/lib/cli/generators/REACT_SCRIPTS/template-csf-ts/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../src/stories/**/*.stories.(ts|tsx|js|jsx)'],
+  stories: ['../src/**/*.stories.(ts|tsx|js|jsx)'],
   addons: ['@storybook/addon-actions/register', '@storybook/addon-links/register'],
   presets: ['@storybook/preset-create-react-app'],
 };

--- a/lib/cli/generators/REACT_SCRIPTS/template-csf/.storybook/main.js
+++ b/lib/cli/generators/REACT_SCRIPTS/template-csf/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../src/stories/**/*.stories.js'],
+  stories: ['../src/**/*.stories.js'],
   addons: ['@storybook/addon-actions/register', '@storybook/addon-links/register'],
   presets: ['@storybook/preset-create-react-app'],
 };

--- a/lib/cli/generators/REACT_SCRIPTS/template-mdx/.storybook/main.js
+++ b/lib/cli/generators/REACT_SCRIPTS/template-mdx/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../src/stories/**/*.stories.(js|mdx)'],
+  stories: ['../src/**/*.stories.(js|mdx)'],
   addons: ['@storybook/addon-actions/register', '@storybook/addon-links/register'],
   presets: [
     '@storybook/preset-create-react-app',

--- a/lib/cli/generators/SFC_VUE/template-csf/.storybook/main.js
+++ b/lib/cli/generators/SFC_VUE/template-csf/.storybook/main.js
@@ -1,4 +1,4 @@
 module.exports = {
-  stories: ['../src/stories/**/*.stories.js'],
+  stories: ['../src/**/*.stories.js'],
   addons: ['@storybook/addon-actions/register', '@storybook/addon-links/register'],
 };

--- a/lib/cli/generators/SFC_VUE/template-mdx/.storybook/main.js
+++ b/lib/cli/generators/SFC_VUE/template-mdx/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../src/stories/**/*.stories.(js|mdx)'],
+  stories: ['../src/**/*.stories.(js|mdx)'],
   addons: ['@storybook/addon-actions/register', '@storybook/addon-links/register'],
   presets: ['@storybook/addon-docs/preset'],
 };


### PR DESCRIPTION
Issue: N/A

## What I did

In Storybook we recommend users to colocate their stories with their components. However, in our CLI templates, we generate a stories glob which points to `src/stories` directory. As soon as users start adding stories next to their components, those stories won't show up, as their components are probably not in the `src/stories` directory. This PR updates the glob in all the templates to help minimize user confusion (with a hopefully small perf cost, unless they are working in a massive repo).

This is in response to a Slack support request from a user who had exactly this problem.

## How to test

Verify CLI test run passes in CI