### PR TITLE
Update README about @storybook/react typescript part

### DIFF
--- a/app/react/README.md
+++ b/app/react/README.md
@@ -35,7 +35,9 @@ This preset enables support for all Create React App features, including Sass/SC
 
 ## Typescript
 
-If you are using Typescript, make sure you have the type definitions installed via `yarn add @types/node @types/react @types/storybook__react --dev`.
+`@storybook/react` is now exporting its own types to use with Typescript.
+You don't need to have `@types/storybook__react` installed anymore if it was your case.
+But you probably also need to use types from `@types/node @types/react`.
 
 ## Docs
 


### PR DESCRIPTION
## What I did
Update documentation about `@storybook/react` types usage with Typescript since:
![Screenshot 2019-12-23 at 16 00 49](https://user-images.githubusercontent.com/10224453/71365481-6c95b600-259f-11ea-8657-eb139dbbe039.png)

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? Yes

If you think the phrasing is wrong or can be better, I can change :)
