### PR TITLE
Addon-docs: Include ember files in addon-docs publish

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -22,6 +22,7 @@
     "docs/**/*",
     "angular/**/*",
     "common/**/*",
+    "ember/**/*",
     "html/**/*",
     "postinstall/**/*",
     "react/**/*",


### PR DESCRIPTION
Issue:
Testing out ember's new props table integration locally, I ran into this error: `Can't resolve '@storybook/addon-docs/ember'`. This was my first time running it from registry-installed packages, previously I'd only used `yarn link`.

## What I did
I found that the relevant files weren't included in [`files` in `package.json`](https://github.com/storybookjs/storybook/blob/ca22a87fbf6afc280decbfe94cd78a7ee67c3c95/addons/docs/package.json#L20-L33), so I added them.

## How to test
I tested this locally with the local registry script and a local ember app.

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
