### PR TITLE
Fix missing tab in vue setup guide

### DIFF
--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -43,7 +43,7 @@ Then add the following NPM script to your `package.json` in order to start the s
 {
   "scripts": {
     "storybook": "start-storybook"
-  }
+    }
 }
 ```
 


### PR DESCRIPTION
Add missing tab.
See issue live: https://storybook.js.org/docs/guides/guide-vue/#step-2-add-an-npm-script

Issue:

## What I did

Add missing tab.

## How to test

No tests. Just documentation.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
