### PR TITLE
[addon-docs] Add check for multiple stories before rendering Stories component

### DIFF
--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -21,6 +21,6 @@ export const DocsPage: FunctionComponent<DocsPageProps> = ({
     <Description slot={descriptionSlot} />
     <Primary slot={primarySlot} />
     <Props slot={propsSlot} />
-    <Stories slot={storiesSlot} />
+    {storiesSlot && <Stories slot={storiesSlot} />}
   </>
 );


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/9269

## What I did
Added a check for multiple stories before rendering the the Stories component in the DocsPage. Without this check, unnecessary rendering of the Stories component headline would occur. 
## How to test
Go to the examples HTML storybook app and check out a component that only has one story. For example, '/docs/addons-centered--story-1'. You will see that there is a headline at the bottom that reads "Stories". This headline is not needed. This happens in react/angular ETC ETC too. Just using the HTML one as an example to help explain the problem.
- Is this testable with Jest or Chromatic screenshots?
not sure
- Does this need a new example in the kitchen sink apps?
Can see this using the Centered story in the HTML kitchen sink app.
- Does this need an update to the documentation?
No
If your answer is yes to any of these, please make sure to include it in your PR.

This is current in SB HTML. You can see the unneeded "Stories" heading.
![Screen Shot 2019-12-30 at 10 57 35 AM](https://user-images.githubusercontent.com/2117593/71590458-8af73680-2af6-11ea-8739-427c6d738f75.png)

This is with my PR. The heading is removed because there is only one story.
![Screen Shot 2019-12-30 at 11 15 32 AM](https://user-images.githubusercontent.com/2117593/71590466-9b0f1600-2af6-11ea-805f-03693e9b529a.png)


