### PR TITLE
Addon-docs: Hide stories block when there are no stories

### DIFF
--- a/addons/docs/src/blocks/Stories.tsx
+++ b/addons/docs/src/blocks/Stories.tsx
@@ -17,7 +17,7 @@ export const Stories: FunctionComponent<StoriesProps> = ({ slot, title }) => {
   const stories: DocsStoryProps[] = slot
     ? slot(componentStories, context)
     : componentStories && componentStories.slice(1);
-  if (!stories) {
+  if (!stories || stories.length === 0) {
     return null;
   }
   return (


### PR DESCRIPTION
Issue: #9269 

## What I did

Hide the `Stories` block, esp the heading per #9269 

## How to test

See any example where there's only a single story, e.g. `official-storybook`: http://localhost:9011/?path=/docs/addons-actions-deprecated--decorated-action

