### PR TITLE
Merge pull request #9280 from weyert/bugfixes/fix-simplify-issue

### DIFF
--- a/lib/core/src/server/common/babel.js
+++ b/lib/core/src/server/common/babel.js
@@ -5,6 +5,7 @@ function createProdPresets() {
       {
         builtIns: false,
         mangle: false,
+        simplify: false
       },
     ],
   ];


### PR DESCRIPTION
Issue: #9261

A small fix to disable the simplify-feature of the babel's minify plugin as it stops the compilation of the storybook static build.

## What I did
I have added the `simplify: false`-configuration to the `babel.js`-file

## How to test
- Is this testable with Jest or Chromatic screenshots?
No
- Does this need a new example in the kitchen sink apps?
No
- Does this need an update to the documentation?
I am not sure