### PR TITLE
fix: adjust web component name in cli

### DIFF
--- a/app/web-components/README.md
+++ b/app/web-components/README.md
@@ -14,7 +14,7 @@ So you can develop UI components in isolation without worrying about app specifi
 
 ```sh
 cd my-app
-npx -p @storybook/cli sb init -t web-components
+npx -p @storybook/cli sb init -t web_components
 ```
 
 For more information visit: [storybook.js.org](https://storybook.js.org)


### PR DESCRIPTION
The CLI uses an underscore