### PR TITLE
CSF: Use `__namedExportsOrder` array in loader if provided

### DIFF
--- a/examples/official-storybook/stories/core/named-export-order.stories.js
+++ b/examples/official-storybook/stories/core/named-export-order.stories.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default {
+  title: 'Core/Named Export Order',
+};
+
+export const Story1 = () => 'story1';
+export const Story2 = () => 'story2';
+
+// eslint-disable-next-line no-underscore-dangle
+export const __namedExportsOrder = ['Story2', 'Story1'];

--- a/lib/core/src/client/preview/start.js
+++ b/lib/core/src/client/preview/start.js
@@ -379,10 +379,21 @@ export default function start(render, { decorateStory } = {}) {
         );
       }
 
-      const { default: meta, __orderedExports, ...namedExports } = fileExports;
-      // prefer a user/loader provided `__orderedExports` object if supplied as es module exports
-      // are ordered alphabetically - see https://github.com/storybookjs/storybook/issues/9136
-      const exports = __orderedExports || namedExports;
+      const { default: meta, __namedExportsOrder, ...namedExports } = fileExports;
+      let exports = namedExports;
+
+      // prefer a user/loader provided `__namedExportsOrder` array if supplied
+      // we do this as es module exports are always ordered alphabetically
+      // see https://github.com/storybookjs/storybook/issues/9136
+      if (Array.isArray(__namedExportsOrder)) {
+        exports = {};
+        __namedExportsOrder.forEach(name => {
+          if (namedExports[name]) {
+            exports[name] = namedExports[name];
+          }
+        });
+      }
+
       const {
         title: kindName,
         id: componentId,


### PR DESCRIPTION
closes #9136
follow up of https://github.com/storybookjs/storybook/pull/9181

## What I did

As discussed in https://github.com/storybookjs/storybook/pull/9181 there have been 2 solutions to guarantee a story order if loaded via es modules. I went for the object. However, I have been missing the use case of rexports

```js
const myStory = () => html`Foo`;
export { myStory as notMyStory };
```

which currently produces the following `export const __orderedExports = { notMyStory };` which fails as `notMyStory` is not a local variable.

Therefore we should go with the previously discussed array of strings.

This Pull Request changes how loaders can guarantee the order of stories

Before:
```js
export const __orderedExports = { notMyStory };
```

After:
```js
export const __namedExportsOrder = ['notMyStory'];
```

## How to test

- use storybook without webpack and provide this export

## Notes

Related PR where we found the issue
https://github.com/open-wc/open-wc/pull/1171
