### PR TITLE
Addon-Docs: Handle leaf/non-leaf mixture in docs-mode navigation

### DIFF
--- a/examples/official-storybook/stories/addon-docs/mixed-leaves-component.stories.js
+++ b/examples/official-storybook/stories/addon-docs/mixed-leaves-component.stories.js
@@ -5,7 +5,7 @@
 // See also ./mixed-leaves-folder.stories.js
 
 export default {
-  title: 'Addons/Docs/MixedLeaves/Component',
+  title: 'Addons/Docs/Mixed Leaves/Component',
   parameters: { chromatic: { disable: true } },
 };
 

--- a/examples/official-storybook/stories/addon-docs/mixed-leaves-component.stories.js
+++ b/examples/official-storybook/stories/addon-docs/mixed-leaves-component.stories.js
@@ -1,0 +1,13 @@
+// This example exists solely to demonstrate nav hierarchy
+// in --docs mode when a folder contains both a component and
+// individual stories
+//
+// See also ./mixed-leaves-folder.stories.js
+
+export default {
+  title: 'Addons/Docs/MixedLeaves/Component',
+  parameters: { chromatic: { disable: true } },
+};
+
+export const B = () => 'b';
+export const C = () => 'c';

--- a/examples/official-storybook/stories/addon-docs/mixed-leaves-folder.stories.js
+++ b/examples/official-storybook/stories/addon-docs/mixed-leaves-folder.stories.js
@@ -5,7 +5,7 @@
 // See also ./mixed-leaves-component.stories.js
 
 export default {
-  title: 'Addons/Docs/MixedLeaves',
+  title: 'Addons/Docs/Mixed Leaves',
   parameters: { chromatic: { disable: true } },
 };
 

--- a/examples/official-storybook/stories/addon-docs/mixed-leaves-folder.stories.js
+++ b/examples/official-storybook/stories/addon-docs/mixed-leaves-folder.stories.js
@@ -1,0 +1,12 @@
+// This example exists solely to demonstrate nav hierarchy
+// in --docs mode when a folder contains both a component and
+// individual stories
+//
+// See also ./mixed-leaves-component.stories.js
+
+export default {
+  title: 'Addons/Docs/MixedLeaves',
+  parameters: { chromatic: { disable: true } },
+};
+
+export const A = () => 'a';

--- a/examples/official-storybook/stories/core/named-export-order.stories.js
+++ b/examples/official-storybook/stories/core/named-export-order.stories.js
@@ -1,7 +1,6 @@
-import React from 'react';
-
 export default {
   title: 'Core/Named Export Order',
+  parameters: { chromatic: { disable: true } },
 };
 
 export const Story1 = () => 'story1';

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -4,7 +4,6 @@ import memoize from 'memoizerific';
 
 import { Badge } from '@storybook/components';
 import { Consumer } from '@storybook/api';
-import { logger } from '@storybook/client-logger';
 
 import { shortcutToHumanString } from '../libs/shortcut';
 

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -121,6 +121,8 @@ export const collapseAllStories = stories => {
   // 2) make all components leaves and rewrite their ID's to the first leaf child
   const componentsFlattened = leavesRemoved.map(item => {
     const { id, isComponent, children, ...rest } = item;
+
+    // this is a folder, so just leave it alone
     if (!isComponent) {
       return item;
     }
@@ -137,10 +139,8 @@ export const collapseAllStories = stories => {
     const component = { ...rest, id: leafId, isLeaf: true, isComponent: true };
     componentIdToLeafId[id] = leafId;
 
-    if (
-      (!isComponent && nonLeafChildren.length === 0) ||
-      (isComponent && nonLeafChildren.length !== 0)
-    ) {
+    // this is a component, so it should not have any non-leaf children
+    if (nonLeafChildren.length !== 0) {
       throw new Error(
         `Unexpected '${item.id}': ${JSON.stringify({ isComponent, nonLeafChildren })}`
       );

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -131,18 +131,17 @@ export const collapseAllStories = stories => {
     const component = { ...rest, id: leafId, isLeaf: true, isComponent: true };
     componentIdToLeafId[id] = leafId;
 
-    if (
-      (isComponent && nonLeafChildren.length > 0) ||
-      (!isComponent && nonLeafChildren.length === 0)
-    ) {
+    if (!isComponent && nonLeafChildren.length === 0) {
       throw new Error(
         `Unexpected '${item.id}': ${JSON.stringify({ isComponent, nonLeafChildren })}`
       );
     }
 
     if (nonLeafChildren.length > 0) {
+      const nodeType = isComponent ? 'Component' : 'Folder';
+
       logger.error(
-        `Node ${item.id} contains non-leaf nodes that are getting removed: ${nonLeafChildren}!`
+        `${nodeType} '${item.id}' contains non-leaf nodes that are removed: '${nonLeafChildren}'!`
       );
     }
 

--- a/lib/ui/src/containers/nav.js
+++ b/lib/ui/src/containers/nav.js
@@ -114,11 +114,17 @@ export const collapseAllStories = stories => {
   const componentIdToLeafId = {};
 
   // 1) remove all leaves
-  const leavesRemoved = Object.values(stories).filter(item => !item.isLeaf);
+  const leavesRemoved = Object.values(stories).filter(
+    item => !(item.isLeaf && stories[item.parent].isComponent)
+  );
 
   // 2) make all components leaves and rewrite their ID's to the first leaf child
   const componentsFlattened = leavesRemoved.map(item => {
     const { id, isComponent, children, ...rest } = item;
+    if (!isComponent) {
+      return item;
+    }
+
     const nonLeafChildren = [];
     const leafChildren = [];
     children.forEach(child => (stories[child].isLeaf ? leafChildren : nonLeafChildren).push(child));
@@ -131,17 +137,12 @@ export const collapseAllStories = stories => {
     const component = { ...rest, id: leafId, isLeaf: true, isComponent: true };
     componentIdToLeafId[id] = leafId;
 
-    if (!isComponent && nonLeafChildren.length === 0) {
+    if (
+      (!isComponent && nonLeafChildren.length === 0) ||
+      (isComponent && nonLeafChildren.length !== 0)
+    ) {
       throw new Error(
         `Unexpected '${item.id}': ${JSON.stringify({ isComponent, nonLeafChildren })}`
-      );
-    }
-
-    if (nonLeafChildren.length > 0) {
-      const nodeType = isComponent ? 'Component' : 'Folder';
-
-      logger.error(
-        `${nodeType} '${item.id}' contains non-leaf nodes that are removed: '${nonLeafChildren}'!`
       );
     }
 

--- a/lib/ui/src/containers/nav.test.js
+++ b/lib/ui/src/containers/nav.test.js
@@ -66,27 +66,25 @@ describe('collapse all stories', () => {
       parent: 'root',
     });
   });
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('collapses mixtures of leaf and non-leaf children', () => {
-    const mixedRoot = { id: 'mixedRoot', parent: false, children: ['a', 'b1'] };
-    const mixed = { mixedRoot, a, a1, b1 };
+  it('collapses mixtures of leaf and non-leaf children', () => {
+    const mixedRoot = { id: 'root', parent: false, children: ['a', 'b1'] };
+    const mixed = { root: mixedRoot, a, a1, b1: { ...b1, parent: 'root' } };
     const collapsed = collapseAllStories(mixed);
     expect(collapsed).toEqual({
       a1: {
         id: 'a1',
         isComponent: true,
         isLeaf: true,
-        parent: 'mixedRoot',
+        parent: 'root',
       },
       b1: {
         id: 'b1',
-        isComponent: true,
         isLeaf: true,
-        parent: 'mixedRoot',
+        parent: 'root',
       },
-      mixed: {
+      root: {
         children: ['a1', 'b1'],
-        id: 'mixedRoot',
+        id: 'root',
         parent: false,
       },
     });

--- a/lib/ui/src/containers/nav.test.js
+++ b/lib/ui/src/containers/nav.test.js
@@ -58,12 +58,37 @@ describe('collapse all stories', () => {
       ...stories,
       a1: { ...a1, ...docsOnly },
     };
-    const filtered = collapseAllStories(hasDocsOnly);
-    expect(filtered.a1).toEqual({
+    const collapsed = collapseAllStories(hasDocsOnly);
+    expect(collapsed.a1).toEqual({
       id: 'a1',
       isComponent: true,
       isLeaf: true,
       parent: 'root',
+    });
+  });
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('collapses mixtures of leaf and non-leaf children', () => {
+    const mixedRoot = { id: 'mixedRoot', parent: false, children: ['a', 'b1'] };
+    const mixed = { mixedRoot, a, a1, b1 };
+    const collapsed = collapseAllStories(mixed);
+    expect(collapsed).toEqual({
+      a1: {
+        id: 'a1',
+        isComponent: true,
+        isLeaf: true,
+        parent: 'mixedRoot',
+      },
+      b1: {
+        id: 'b1',
+        isComponent: true,
+        isLeaf: true,
+        parent: 'mixedRoot',
+      },
+      mixed: {
+        children: ['a1', 'b1'],
+        id: 'mixedRoot',
+        parent: false,
+      },
     });
   });
 });


### PR DESCRIPTION
Issue: #9314 

## What I did

When a navigation node contains both stories AND folders/components, don't collapse it in `--docs` mode.

It currently throws an error. This version doesn't error and doesn't lose data -- users can fix it by re-grouping their stories.

## How to test

- See updated unit test
- See `Addons/Docs/Mixed Leaves` in `official-storybook`
