### PR TITLE
Correct the file path for the Button story

### DIFF
--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.enzyme.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.enzyme.test.js.snap
@@ -246,7 +246,7 @@ exports[`Storyshots Welcome MDX to Storybook 1`] = `
               }
             }
           >
-            src/stories/index.js
+            src/stories/1-Button.stories.js
           </code>
         </InlineCode>
         .)
@@ -450,7 +450,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
               }
             }
           >
-            src/stories/index.js
+            src/stories/1-Button.stories.js
           </code>
         </InlineCode>
         .)

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.shallow.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.shallow.test.js.snap
@@ -139,7 +139,7 @@ exports[`Storyshots Welcome MDX to Storybook 1`] = `
     </InlineCode>
      stories located at 
     <InlineCode>
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </InlineCode>
     .)
   </p>
@@ -213,7 +213,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
     </InlineCode>
      stories located at 
     <InlineCode>
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </InlineCode>
     .)
   </p>

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.shallowWithOptions.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.shallowWithOptions.test.js.snap
@@ -139,7 +139,7 @@ exports[`Storyshots Welcome MDX to Storybook 1`] = `
     </InlineCode>
      stories located at 
     <InlineCode>
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </InlineCode>
     .)
   </p>
@@ -213,7 +213,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
     </InlineCode>
      stories located at 
     <InlineCode>
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </InlineCode>
     .)
   </p>

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.snapshotWithOptionsFunction.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.snapshotWithOptionsFunction.test.js.snap
@@ -213,7 +213,7 @@ exports[`Storyshots Welcome MDX to Storybook 1`] = `
         }
       }
     >
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </code>
     .)
   </p>
@@ -387,7 +387,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
         }
       }
     >
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </code>
     .)
   </p>

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.foo
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.foo
@@ -117,7 +117,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
         }
       }
     >
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </code>
     .)
   </p>

--- a/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.storyshot
+++ b/addons/storyshots/storyshots-core/stories/required_with_context/__snapshots__/Welcome.stories.storyshot
@@ -117,7 +117,7 @@ exports[`Storyshots Welcome MDX to Storybook 1`] = `
         }
       }
     >
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </code>
     .)
   </p>
@@ -291,7 +291,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
         }
       }
     >
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </code>
     .)
   </p>

--- a/app/react/src/demo/Welcome.tsx
+++ b/app/react/src/demo/Welcome.tsx
@@ -151,7 +151,7 @@ const Welcome: FunctionComponent<WelcomeProps> = ({ showApp }) => (
       You can also edit those components and see changes right away.
       <br />
       (Try editing the <InlineCode>Button</InlineCode> stories located at&nbsp;
-      <InlineCode>src/stories/index.js</InlineCode>
+      <InlineCode>src/stories/0-Welcome.stories.js</InlineCode>
       .)
     </p>
     <p>

--- a/app/react/src/demo/Welcome.tsx
+++ b/app/react/src/demo/Welcome.tsx
@@ -151,7 +151,7 @@ const Welcome: FunctionComponent<WelcomeProps> = ({ showApp }) => (
       You can also edit those components and see changes right away.
       <br />
       (Try editing the <InlineCode>Button</InlineCode> stories located at&nbsp;
-      <InlineCode>src/stories/0-Welcome.stories.js</InlineCode>
+      <InlineCode>src/stories/1-Button.stories.js</InlineCode>
       .)
     </p>
     <p>

--- a/examples/mithril-kitchen-sink/src/Welcome.js
+++ b/examples/mithril-kitchen-sink/src/Welcome.js
@@ -109,7 +109,7 @@ const Welcome = {
         You can also edit those components and see changes right away.
         <br />
         (Try editing the <InlineCode>Button</InlineCode> stories located at&nbsp;
-        <InlineCode>src/stories/index.js</InlineCode>
+        <InlineCode>src/stories/1-Button.stories.js</InlineCode>
         .)
       </p>
       <p>

--- a/examples/preact-kitchen-sink/src/Welcome.js
+++ b/examples/preact-kitchen-sink/src/Welcome.js
@@ -112,7 +112,7 @@ const Welcome = ({ showApp }) => (
       You can also edit those components and see changes right away.
       <br />
       (Try editing the <InlineCode>Button</InlineCode> stories located at&nbsp;
-      <InlineCode>src/stories/index.js</InlineCode>
+      <InlineCode>src/stories/1-Button.stories.js</InlineCode>
       .)
     </p>
     <p>

--- a/examples/preact-kitchen-sink/src/stories/__snapshots__/welcome.stories.storyshot
+++ b/examples/preact-kitchen-sink/src/stories/__snapshots__/welcome.stories.storyshot
@@ -128,7 +128,7 @@ exports[`Storyshots Welcome to Storybook 1`] = `
         }
       }
     >
-      src/stories/index.js
+      src/stories/1-Button.stories.js
     </code>
     .)
   </p>

--- a/lib/cli/generators/MITHRIL/template-csf/stories/Welcome.js
+++ b/lib/cli/generators/MITHRIL/template-csf/stories/Welcome.js
@@ -150,7 +150,7 @@ const Welcome = {
         You can also edit those components and see changes right away.
         <br />
         (Try editing the <InlineCode>Button</InlineCode> stories located at&nbsp;
-        <InlineCode>src/stories/index.js</InlineCode>
+        <InlineCode>src/stories/1-Button.stories.js</InlineCode>
         .)
       </p>
       <p>

--- a/lib/cli/generators/PREACT/template-csf/stories/Welcome.js
+++ b/lib/cli/generators/PREACT/template-csf/stories/Welcome.js
@@ -101,7 +101,7 @@ const Welcome = ({ showApp }) => (
       You can also edit those components and see changes right away.
       <br />
       (Try editing the <InlineCode>Button</InlineCode> stories located at&nbsp;
-      <InlineCode>src/stories/index.js</InlineCode>
+      <InlineCode>src/stories/1-Button.stories.js</InlineCode>
       .)
     </p>
     <p>

--- a/lib/cli/generators/RAX/template-csf/stories/Welcome.js
+++ b/lib/cli/generators/RAX/template-csf/stories/Welcome.js
@@ -92,7 +92,7 @@ const Welcome = ({ showApp }) => (
     <P>
       Just like that, you can add your own components as stories. You can also edit those components
       and see changes right away. (Try editing the <InlineCode>Button</InlineCode> stories located
-      at <InlineCode>src/stories/index.js</InlineCode>
+      at <InlineCode>src/stories/1-Button.stories.js</InlineCode>
       .)
     </P>
     <P>


### PR DESCRIPTION
Issue: I happened to notice that the file path for the Button story was incorrect when looking at [Storybook for React tutorial](https://www.learnstorybook.com/intro-to-storybook/react/en/get-started/).

## What I did

Corrected the file path for the Button story.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
