### PR TITLE
Addon-docs: Fix scroll behavior on page navigation

### DIFF
--- a/addons/docs/src/blocks/Meta.tsx
+++ b/addons/docs/src/blocks/Meta.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useContext } from 'react';
+import { document } from 'global';
 import { Anchor } from './Anchor';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { getDocsStories } from './utils';
@@ -18,14 +19,21 @@ function getFirstStoryId(docsContext: DocsContextProps): string {
   return stories.length > 0 ? stories[0].id : null;
 }
 
-/**
- * This component is used to declare component metadata in docs
- * and gets transformed into a default export underneath the hood.
- */
-export const Meta: FC<MetaProps> = () => {
+function renderAnchor() {
   const context = useContext(DocsContext);
   // eslint-disable-next-line react/destructuring-assignment
   const anchorId = getFirstStoryId(context) || context.id;
 
   return <Anchor storyId={anchorId} />;
+}
+
+/**
+ * This component is used to declare component metadata in docs
+ * and gets transformed into a default export underneath the hood.
+ */
+export const Meta: FC<MetaProps> = () => {
+  const params = new URL(document.location).searchParams;
+  const isDocs = params.get('viewMode') === 'docs';
+
+  return isDocs ? renderAnchor() : null;
 };

--- a/addons/docs/src/blocks/Meta.tsx
+++ b/addons/docs/src/blocks/Meta.tsx
@@ -1,4 +1,7 @@
-import { FunctionComponent } from 'react';
+import React, { FC, useContext } from 'react';
+import { Anchor } from './Anchor';
+import { DocsContext, DocsContextProps } from './DocsContext';
+import { getDocsStories } from './utils';
 
 type Decorator = (...args: any) => any;
 
@@ -9,9 +12,20 @@ interface MetaProps {
   parameters?: any;
 }
 
+function getFirstStoryId(docsContext: DocsContextProps): string {
+  const stories = getDocsStories(docsContext);
+
+  return stories.length > 0 ? stories[0].id : null;
+}
+
 /**
  * This component is used to declare component metadata in docs
  * and gets transformed into a default export underneath the hood.
- * It doesn't actually render anything.
  */
-export const Meta: FunctionComponent<MetaProps> = props => null;
+export const Meta: FC<MetaProps> = () => {
+  const context = useContext(DocsContext);
+  // eslint-disable-next-line react/destructuring-assignment
+  const anchorId = getFirstStoryId(context) || context.id;
+
+  return <Anchor storyId={anchorId} />;
+};

--- a/addons/docs/src/blocks/utils.ts
+++ b/addons/docs/src/blocks/utils.ts
@@ -4,6 +4,11 @@ import { StoryData, Component } from './shared';
 
 export const getDocsStories = (context: DocsContextProps): StoryData[] => {
   const { storyStore, selectedKind } = context;
+
+  if (!storyStore) {
+    return [];
+  }
+
   return storyStore
     .getStoriesForKind(selectedKind)
     .filter((s: any) => !(s.parameters && s.parameters.docs && s.parameters.docs.disable));

--- a/examples/official-storybook/stories/addon-docs/addon-docs-blocks.stories.js
+++ b/examples/official-storybook/stories/addon-docs/addon-docs-blocks.stories.js
@@ -12,7 +12,7 @@ import BaseButton from '../../components/BaseButton';
 import { ButtonGroup } from '../../components/ButtonGroup';
 
 export default {
-  title: 'Addons/Docs/stories docs bocks',
+  title: 'Addons/Docs/stories docs blocks',
   component: DocgenButton,
   parameters: {
     docs: {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8914

## What I did

- The meta component renders an anchor with the id of the stories if the page contains any story, otherwise if it's a docs only page, it renders the docs page id.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No, it can be tested with the current addon-docs stories of official-storybook.
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
