### PR TITLE
React: Check CRA is installed before showing warning

### DIFF
--- a/app/react/src/server/framework-preset-cra.ts
+++ b/app/react/src/server/framework-preset-cra.ts
@@ -7,9 +7,6 @@ type Preset = string | { name: string };
 
 // Disable the built-in preset if the new preset is detected.
 const checkForNewPreset = (presetsList: Preset[]) => {
-  if (!isReactScriptsInstalled()) {
-    return false;
-  }
   const hasNewPreset = presetsList.some((preset: Preset) => {
     const presetName = typeof preset === 'string' ? preset : preset.name;
     return presetName === '@storybook/preset-create-react-app';
@@ -31,11 +28,12 @@ export function webpackFinal(
   config: Configuration,
   { presetsList, configDir }: { presetsList: Preset[]; configDir: string }
 ) {
-  if (checkForNewPreset(presetsList)) {
-    return config;
-  }
   if (!isReactScriptsInstalled()) {
     logger.info('=> Using base config because react-scripts is not installed.');
+    return config;
+  }
+
+  if (checkForNewPreset(presetsList)) {
     return config;
   }
 

--- a/app/react/src/server/framework-preset-cra.ts
+++ b/app/react/src/server/framework-preset-cra.ts
@@ -7,6 +7,9 @@ type Preset = string | { name: string };
 
 // Disable the built-in preset if the new preset is detected.
 const checkForNewPreset = (presetsList: Preset[]) => {
+  if (!isReactScriptsInstalled()) {
+    return false;
+  }
   const hasNewPreset = presetsList.some((preset: Preset) => {
     const presetName = typeof preset === 'string' ? preset : preset.name;
     return presetName === '@storybook/preset-create-react-app';


### PR DESCRIPTION
Issue: #9345

```
WARN Storybook support for Create React App is now a separate preset.
WARN To get started with the new preset, simply add `@storybook/preset-create-react-app` to your project.
WARN The built-in preset will be disabled in Storybook 6.0.
```

## What I did
added check is CRA is installed at all before showing the warning

## How to test

launch official-storybook, it should not show the warning