### PR TITLE
Presets: Fix register.js addons entry

### DIFF
--- a/lib/core/src/server/presets.js
+++ b/lib/core/src/server/presets.js
@@ -61,7 +61,8 @@ export const resolveAddonName = name => {
   if (path) {
     return {
       name,
-      type: path.match(/register$/) ? 'managerEntries' : 'presets',
+      // Accept `register`, `register.js`, `require.resolve('foo/register') cases
+      type: path.match(/register(.js)?$/) ? 'managerEntries' : 'presets',
     };
   }
 

--- a/lib/core/src/server/presets.test.js
+++ b/lib/core/src/server/presets.test.js
@@ -385,7 +385,11 @@ describe('splitAddons', () => {
   const { splitAddons } = require.requireActual('./presets');
 
   it('should split managerEntries that end in register', () => {
-    const addons = ['@storybook/addon-actions/register', 'storybook-addon-readme/register'];
+    const addons = [
+      '@storybook/addon-actions/register',
+      'storybook-addon-readme/register',
+      'addon-foo/register.js',
+    ];
     expect(splitAddons(addons)).toEqual({
       managerEntries: addons,
       presets: [],
@@ -393,7 +397,11 @@ describe('splitAddons', () => {
   });
 
   it('should split preset packages and package entries', () => {
-    const addons = ['@storybook/addon-essentials', '@storybook/addon-docs/presets'];
+    const addons = [
+      '@storybook/addon-essentials',
+      '@storybook/addon-docs/presets',
+      'addon-bar/presets.js',
+    ];
     expect(splitAddons(addons)).toEqual({
       managerEntries: [],
       presets: addons,


### PR DESCRIPTION
Issue: #9343 

## What I did

- [x] Handle `register`, `register.js`, `require.resolve('foo/register') in addons

## How to test

See updated test case
