### PR TITLE
Core: Fix HMR for global decorators in main.js config

### DIFF
--- a/lib/client-api/src/config_api.ts
+++ b/lib/client-api/src/config_api.ts
@@ -76,9 +76,12 @@ export default class ConfigApi {
 
     if (module.hot) {
       module.hot.accept();
-      module.hot.dispose(() => {
-        this._clearDecorators();
-      });
+      // @ts-ignore
+      if (!module._StorybookPreserveDecorators) {
+        module.hot.dispose(() => {
+          this._clearDecorators();
+        });
+      }
     }
 
     if (this._channel) {

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -51,6 +51,7 @@ export default ({
       stories && stories.length
         ? new VirtualModulePlugin({
             [path.resolve(path.join(configDir, `generated-entry.js`))]: `
+              module._StorybookPreserveDecorators = true;
               import { configure, addDecorator, addParameters } from '@storybook/${framework}';
 
               configure([${stories.map(toRequireContextString).join(',')}


### PR DESCRIPTION
Issue: #9192 

## What I did

Adding a _StorybookPreserveDecorators unto the module for flagging when to preserve global decorators

## How to test

- open the official storybook in dev mode
- change a story, it should HMR correctly without erros
  /?path=/story/basics-syntaxhighlighter--bash uses the global theme from a global decorator so it's a good reproduction
- change preview.js file, it should reload the iframe, not the manager