### PR TITLE
Correct the Example for Merging Custom Webpack Configs

### DIFF
--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -262,6 +262,6 @@ const path = require('path');
 const custom = require('../webpack.config.js');
 
 module.exports = async ({ config, mode }) => {
-  return { ...config, module: { ...config.module, rules: custom.module.rules } };
+  return { ...config, module: { ...config.module, rules: [...config.module.rules, ...custom.module.rules] } };
 };
 ```


### PR DESCRIPTION
Issue:
In my company's React project with a customized webpack config. Following your [example](https://storybook.js.org/docs/configurations/custom-webpack-config/#using-your-existing-config) in documentation FAILED to build storybook

## What I did
I run `yarn storybook --debug-webpack` and found inside the storybook's webpack config there are `config.module.rules` as well and I merged it with our custom config rules by using spread operator and it works.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
