### PR TITLE
Nav UI: Nodes are components only if they contain ALL leaf nodes

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -280,7 +280,7 @@ Did you create a path that uses the separator char accidentally, such as 'Vue <d
             parent,
             depth: index,
             children: [],
-            isComponent: index === original.length - 1,
+            isComponent: false,
             isLeaf: false,
             isRoot: !!root && index === 0,
           };
@@ -312,7 +312,9 @@ Did you create a path that uses the separator char accidentally, such as 'Vue <d
         acc[item.id] = item;
         const { children } = item;
         if (children) {
-          children.forEach(id => addItem(acc, storiesHashOutOfOrder[id]));
+          const childNodes = children.map(id => storiesHashOutOfOrder[id]);
+          acc[item.id].isComponent = childNodes.every(childNode => childNode.isLeaf);
+          childNodes.forEach(childNode => addItem(acc, childNode));
         }
       }
       return acc;

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -403,7 +403,7 @@ describe('stories API', () => {
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
 
-    it('navigates to the first leaf story if a story exsits but it is not a leaf story(1)', () => {
+    it('navigates to the first leaf story if a story exists but it is not a leaf story(1)', () => {
       const navigate = jest.fn();
       const store = {
         getState: () => ({ viewMode: 'story', storyId: 'b' }),
@@ -418,7 +418,7 @@ describe('stories API', () => {
       expect(navigate).toHaveBeenCalledWith('/story/b-c--1');
     });
 
-    it('navigates to the first leaf story if a story exsits but it is not a leaf story(2)', () => {
+    it('navigates to the first leaf story if a story exists but it is not a leaf story(2)', () => {
       const navigate = jest.fn();
       const store = {
         getState: () => ({ viewMode: 'story', storyId: 'b-d' }),


### PR DESCRIPTION
Issue: #9314 

## What I did

**Before:** nodes with mixed leaf/non-leaf children would either show up as folders or components depending on load order

**After:** nodes with mixed leaf/non-leaf children always show up as folders regardless of load order

## How to test

1. Disable story sorting in `official-storybook`
2. Revert change and see `Addons/Docs/Mixed Leaves` stories
3. Re-apply change and see above
