### PR TITLE
CLI: Fix `sb init` to use spawn.sync if creating package.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,22 @@
     "skipFiles": [
       "<node_internals>/**"
     ]
-  },
+  }, {
+    "type": "node",
+    "request": "launch",
+    "name": "cli html",
+    "cwd": "${workspaceFolder}/lib/cli/stories",
+    "runtimeArgs": [
+      "--inspect-brk",
+      "${workspaceFolder}/lib/cli/bin/index.js",
+      "init",
+      "--type",
+      "html"
+    ],
+    "port": 9229,
+    "skipFiles": [
+      "<node_internals>/**"
+    ]
+  }
   ]
 }

--- a/lib/cli/lib/helpers.js
+++ b/lib/cli/lib/helpers.js
@@ -65,8 +65,15 @@ export function getPackageJson() {
 
 export async function retrievePackageJson() {
   const existing = getPackageJson();
+  if (existing) {
+    return existing;
+  }
 
-  return existing || npmInit();
+  // npmInit will create a new package.json file
+  npmInit();
+
+  // read the newly created packafe,json file
+  return getPackageJson() || {};
 }
 
 export function getBowerJson() {

--- a/lib/cli/lib/npm_init.js
+++ b/lib/cli/lib/npm_init.js
@@ -4,17 +4,16 @@ import hasYarn from './has_yarn';
 const packageManager = hasYarn() ? 'yarn' : 'npm';
 
 export default function npmInit() {
-  return new Promise((resolve, reject) => {
-    const command = spawn(packageManager, ['init', '-y'], {
+  const { status, signal, output, pid, stdout, stderr, error, ...rest } = spawn.sync(
+    packageManager,
+    ['init', '-y'],
+    {
       cwd: process.cwd(),
       env: process.env,
       stdio: 'pipe',
       encoding: 'utf-8',
       silent: true,
-    });
-
-    command.stdout.on('data', resolve);
-
-    command.stderr.on('data', reject);
-  });
+    }
+  );
+  return rest;
 }

--- a/lib/cli/lib/npm_init.js
+++ b/lib/cli/lib/npm_init.js
@@ -4,16 +4,12 @@ import hasYarn from './has_yarn';
 const packageManager = hasYarn() ? 'yarn' : 'npm';
 
 export default function npmInit() {
-  const { status, signal, output, pid, stdout, stderr, error, ...rest } = spawn.sync(
-    packageManager,
-    ['init', '-y'],
-    {
-      cwd: process.cwd(),
-      env: process.env,
-      stdio: 'pipe',
-      encoding: 'utf-8',
-      silent: true,
-    }
-  );
-  return rest;
+  const results = spawn.sync(packageManager, ['init', '-y'], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'pipe',
+    encoding: 'utf-8',
+    silent: true,
+  });
+  return results.stdout;
 }


### PR DESCRIPTION
Issue: #9358

## What I did
Not familiar with it, but seems the cross-spawn has changed? 

I moved to use the sync method and also there were multiple unneeded parameters being returned

## How to test
like in the issue, `sb init --type html` or other storybook types