### PR TITLE
cssresources-addon: Do not use SyntaxHighlighter with the very long code-content.

### DIFF
--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -36,6 +36,7 @@
     "@storybook/api": "5.3.0-rc.12",
     "@storybook/components": "5.3.0-rc.12",
     "@storybook/core-events": "5.3.0-rc.12",
+    "@storybook/theming": "5.3.0-rc.12",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "react": "^16.8.3"

--- a/addons/cssresources/src/css-resource-panel.tsx
+++ b/addons/cssresources/src/css-resource-panel.tsx
@@ -1,7 +1,8 @@
 import React, { Component, Fragment } from 'react';
-import { SyntaxHighlighter } from '@storybook/components';
+import { SyntaxHighlighter, Placeholder, Spaced, Icons } from '@storybook/components';
 import { STORY_RENDERED } from '@storybook/core-events';
 import { API } from '@storybook/api';
+import { styled } from '@storybook/theming';
 
 import { EVENTS, PARAM_KEY } from './constants';
 import { CssResource } from './CssResource';
@@ -19,6 +20,27 @@ interface State {
 interface CssResourceLookup {
   [key: string]: CssResource;
 }
+
+const maxLimitToUseSyntaxHighlighter = 100000;
+
+const PlainCode = styled.pre({
+  textAlign: 'left',
+  fontWeight: 'normal',
+});
+
+const Warning = styled.div({
+  display: 'flex',
+  padding: '10px',
+  justifyContent: 'center',
+  alignItems: 'center',
+  background: '#fff3cd',
+  fontSize: 12,
+  '& svg': {
+    marginRight: 10,
+    width: 24,
+    height: 24,
+  },
+});
 
 export class CssResourcePanel extends Component<Props, State> {
   constructor(props: Props) {
@@ -96,7 +118,20 @@ export class CssResourcePanel extends Component<Props, State> {
                 <input type="checkbox" checked={picked} onChange={this.onChange} id={id} />
                 <span>#{id}</span>
               </label>
-              {code ? <SyntaxHighlighter language="html">{code}</SyntaxHighlighter> : null}
+              {code && code.length < maxLimitToUseSyntaxHighlighter && (
+                <SyntaxHighlighter language="html">{code}</SyntaxHighlighter>
+              )}
+              {code && code.length >= maxLimitToUseSyntaxHighlighter && (
+                <Placeholder>
+                  <Spaced row={1}>
+                    <PlainCode>{code.substring(0, maxLimitToUseSyntaxHighlighter)} ...</PlainCode>
+                    <Warning>
+                      <Icons icon="alert" />
+                      Rest of the content cannot be displayed
+                    </Warning>
+                  </Spaced>
+                </Placeholder>
+              )}
             </div>
           ))}
       </div>


### PR DESCRIPTION
Issue:

## What I did

Adds support to use very long css content with **cssresources-addon**. The current implementation tries to render (forever) all the content with SyntaxHighlighter. This PR will restrict the use of SyntaxHighligher with content length up to 100k. In case the SyntaxHighligher is not used, the first 100k of the content will be rendered within plain pre-tag and warning of partly missing content is added to the end of it.

## How to test

This is example with less-files.

webpack.config.js
```
...
// do not include style-loader to inject css content manually
config.module.rules.push({
    test: /\.less?$/,
    loaders: [require.resolve('css-loader'), require.resolve('less-loader')], 
  })
...
```

config.js
```
...
import globalStyles from '../styles/index.less'

cssresources: [
    {
      id: `Global toggleable styles`,
      code: `<style>${globalStyles}</style>`,
      picked: true,
    },
  ],
...
```

## Screenshot

![image](https://user-images.githubusercontent.com/1045401/72051695-6bb59180-32cc-11ea-8019-1d9318a57804.png)

