### PR TITLE
Addon-docs / web-components: Rename 'props' to 'properties' in props table

### DIFF
--- a/addons/docs/src/frameworks/web-components/config.js
+++ b/addons/docs/src/frameworks/web-components/config.js
@@ -32,7 +32,7 @@ addParameters({
           sections.attributes = mapData(metaData.attributes);
         }
         if (metaData.properties) {
-          sections.props = mapData(metaData.properties);
+          sections.properties = mapData(metaData.properties);
         }
         if (metaData.events) {
           sections.events = mapData(metaData.events);


### PR DESCRIPTION
Update 'props' section title to 'properties'

Issue: Generated docs have a section 'Props'. 'Properties' is more appropriate for web component projects.

## What I did
Updated wording

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

Updated docs page:
<img width="1151" alt="Screen Shot 2020-01-08 at 5 56 16 PM" src="https://user-images.githubusercontent.com/7429891/72031165-67dc2d80-3240-11ea-9e61-fb3613e2a6c7.png">
