### PR TITLE
Official-storybook: Prop table example for multiple named exports

### DIFF
--- a/examples/official-storybook/components/ButtonGroup.js
+++ b/examples/official-storybook/components/ButtonGroup.js
@@ -12,6 +12,25 @@ ButtonGroup.defaultProps = {
 };
 
 ButtonGroup.propTypes = {
+  /**
+   * Background color for the group
+   */
+  background: PropTypes.string,
+  children: PropTypes.arrayOf(PropTypes.element),
+};
+
+/** SubGroup component description from docgen */
+export const SubGroup = ({ background, children }) => <div style={{ background }}>{children}</div>;
+
+SubGroup.defaultProps = {
+  background: '#0f0',
+  children: null,
+};
+
+SubGroup.propTypes = {
+  /**
+   * Background color for the sub-group
+   */
   background: PropTypes.string,
   children: PropTypes.arrayOf(PropTypes.element),
 };

--- a/examples/official-storybook/stories/addon-docs/addon-docs-blocks.stories.js
+++ b/examples/official-storybook/stories/addon-docs/addon-docs-blocks.stories.js
@@ -9,7 +9,7 @@ import {
 } from '@storybook/addon-docs/blocks';
 import { DocgenButton } from '../../components/DocgenButton';
 import BaseButton from '../../components/BaseButton';
-import { ButtonGroup } from '../../components/ButtonGroup';
+import { ButtonGroup, SubGroup } from '../../components/ButtonGroup';
 
 export default {
   title: 'Addons/Docs/stories docs blocks',
@@ -131,6 +131,7 @@ multipleComponents.story = {
   parameters: {
     component: ButtonGroup,
     subcomponents: {
+      SubGroup,
       'Docgen Button': DocgenButton,
       'Base Button': BaseButton,
     },


### PR DESCRIPTION
Issue: N/A

## What I did

Simple proof of concept example for named exports

![subcomponents](https://user-images.githubusercontent.com/488689/72039001-63fee880-32de-11ea-8bb9-4bd124951994.gif)

## How to test

See `official-storybook` 