### PR TITLE
Document showRoots for 5.3 by parameters

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -143,7 +143,6 @@ const theme = create({
 });
 
 addons.setConfig({
-  showRoots: true,
   panelPosition: 'bottom',
   theme,
 });
@@ -210,7 +209,11 @@ yarn sb migrate upgrade-hierarchy-separators --glob="*.stories.js"
 If you were using `|` and wish to keep the "root" behavior, use the `showRoots: true` option to re-enable roots:
 
 ```js
-addParameters({ options: { showRoots: true } });
+addParameters({ 
+  options: {
+    showRoots: true,
+  },
+});
 ```
 
 NOTE: it is no longer possible to have some stories with roots and others without. If you want to keep the old behavior, simply add a root called "Others" to all your previously unrooted stories.

--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -38,12 +38,6 @@ addons.setConfig({
   panelPosition: 'bottom',
 
   /**
-   * display the top-level grouping as a "root" in the sidebar
-   * @type {Boolean}
-   */
-  showRoots: false,
-
-  /**
    * sidebar tree animations
    * @type {Boolean}
    */
@@ -74,12 +68,30 @@ addons.setConfig({
 });
 ```
 
+### showRoots
+
+Import and use `addParameters` with the `options` key in your `preview.js` file.
+
+```js
+import { addParameters } from '@storybook/react';
+
+addParameters({
+  options: {
+    /**
+     * display the top-level grouping as a "root" in the sidebar
+     * @type {Boolean}
+     */
+    showRoots: false,
+  },
+};
+```
+
 ### Sorting stories
 
 Import and use `addParameters` with the `options` key in your `preview.js` file.
 
 ```js
-import { addParameters, configure } from '@storybook/react';
+import { addParameters } from '@storybook/react';
 
 addParameters({
   options: {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/pull/9323

## What I did
corrected the documentation so it's clear to users that for now they should configure showRoots in parameters