### PR TITLE
Angular: Fix missing architect properties

### DIFF
--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -108,6 +108,9 @@ export function getAngularCliWebpackConfigOptions(dirToSearch: Path) {
   const tsConfigPath = path.resolve(dirToSearch, projectOptions.tsConfig) as Path;
   const tsConfig = getTsConfigOptions(tsConfigPath);
   const budgets = projectOptions.budgets || [];
+  const scripts = projectOptions.scripts || [];
+  const outputPath = projectOptions.outputPath || 'dist/storybook-angular';
+  const styles = projectOptions.styles || [];
 
   return {
     root: dirToSearch,
@@ -121,6 +124,9 @@ export function getAngularCliWebpackConfigOptions(dirToSearch: Path) {
       ...projectOptions,
       assets: normalizedAssets,
       budgets,
+      scripts,
+      styles,
+      outputPath,
     },
   };
 }

--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -50,6 +50,7 @@ export function getAngularCliConfig(dirToSearch: string) {
   const fname = path.join(dirToSearch, 'angular.json');
 
   if (!fs.existsSync(fname)) {
+    logger.error(`Could not find angular.json using ${fname}`);
     return undefined;
   }
 
@@ -67,9 +68,26 @@ export function getLeadingAngularCliProject(ngCliConfig: any) {
     throw new Error('angular.json must have projects entry.');
   }
 
-  const fallbackProject = defaultProject && projects[defaultProject];
-  const firstProject = projects[Object.keys(projects)[0]];
-  return projects.storybook || fallbackProject || firstProject;
+  let projectName;
+  const firstProjectName = Object.keys(projects)[0];
+  if (projects.storybook) {
+    projectName = 'storybook';
+  } else if (defaultProject && projects[defaultProject]) {
+    projectName = defaultProject;
+  } else if (projects[firstProjectName]) {
+    projectName = firstProjectName;
+  }
+
+  const project = projects[projectName];
+  if (!project) {
+    logger.error(`Could not find angular project '${projectName}' in angular.json.`);
+  } else {
+    logger.info(`=> Using angular project '${projectName}' for configuring Storybook.`);
+  }
+  if (!project.architect.build) {
+    logger.error(`architect.build is not defined for project '${projectName}'.`);
+  }
+  return project;
 }
 
 export function getAngularCliWebpackConfigOptions(dirToSearch: Path) {
@@ -102,7 +120,7 @@ export function getAngularCliWebpackConfigOptions(dirToSearch: Path) {
       optimization: {},
       ...projectOptions,
       assets: normalizedAssets,
-      budgets
+      budgets,
     },
   };
 }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/9319

## What I did


### Improving dev-server logger outuputs
I added additional log outputs during the dev-server start. This should hopefully improve bug reports.

Starting storybook now looks like this:

```
info @storybook/angular v5.2.8
info
info => Loading presets
info => Loading presets
info => Loading custom addons config.
info => Found custom tsconfig.json
info => Loading custom Webpack config (full-control mode).
info => Using angular project 'my-awesome-project' for configuring Storybook. <----- this is new
info => Loading angular-cli config.
Browserslist: caniuse-lite is outdated. Please run next command `npm update`
info => Get angular-cli webpack config.
Starting type checking service...
Using 1 worker with 2048MB memory limit
webpack built 4a8afdd8c6e25eeeb15f in 20870ms
...
```

There are also new log outputs for errors.

### Added missing architect.buildOptions 

This fixes the referenced issue. Angular internally needs them and don't has default values for it so we must provide them.

## How to test

- Create angular project
- Remove "styles", "scripts" or "outputPath" 
- Storybook should still start without any errors
