### PR TITLE
CHANGE docs & examples to prefer webpackFinal over webpack property

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -176,7 +176,7 @@ Then configure Storybook's webpack loader in `.storybook/main.js` to understand 
 const createCompiler = require('@storybook/addon-docs/mdx-compiler-plugin');
 
 module.exports = {
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: /\.(stories|story)\.mdx$/,
       use: [

--- a/app/web-components/README.md
+++ b/app/web-components/README.md
@@ -60,7 +60,7 @@ For example if you have a library called `my-library` which is in es7 then you c
 // .storybook/main.js
 
 module.exports = { 
-  webpack: async config => {
+  webpackFinal: async config => {
     // find web-components rule for extra transpilation
     const webComponentsRule = config.module.rules.find(
       rule => rule.use && rule.use.options && rule.use.options.babelrc === false

--- a/docs/src/pages/basics/faq/index.md
+++ b/docs/src/pages/basics/faq/index.md
@@ -26,7 +26,7 @@ You can generally reuse webpack rules by placing them in a file that is `require
 
 ```js
 module.exports = {
-  webpack: async (baseConfig) => {
+  webpackFinal: async (baseConfig) => {
     const nextConfig = require('/path/to/next.config.js');
 
     // merge whatever from nextConfig into the webpack config storybook will use

--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -157,7 +157,7 @@ The webpack config [is configurable](/configurations/custom-webpack-config#webpa
 - Edit its contents:
   ```js
   module.exports = {
-    webpack: (config) => console.dir(config, { depth: null }) || config,
+    webpackFinal: (config) => console.dir(config, { depth: null }) || config,
   };
   ```
 - Then run storybook:
@@ -178,7 +178,7 @@ const path = require('path');
 
 // Export a function. Accept the base config as the only param.
 module.exports = {
-  webpack: async (config, { configType }) => {
+  webpackFinal: async (config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
     // You can change the configuration based on that.
     // 'PRODUCTION' is used when building the static version of storybook.
@@ -207,7 +207,7 @@ Furthermore, `config` requires the `HtmlWebpackplugin` to generate the preview p
 
 ```js
 module.exports = {
-  webpack: (config) => {
+  webpackFinal: (config) => {
     config.plugins.push(...);
     return config;
   },
@@ -234,7 +234,7 @@ const path = require('path');
 const custom = require('../webpack.config.js');
 
 module.exports = {
-  webpack: (config) => {
+  webpackFinal: (config) => {
     return { ...config, module: { ...config.module, rules: custom.module.rules } };
   },
 };

--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -36,7 +36,7 @@ We [configure storybook's webpack](/configurations/custom-webpack-config/#full-c
 
 ```js
 module.exports = {
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: /\.(ts|tsx)$/,
       use: [
@@ -106,7 +106,7 @@ We will create a [custom Webpack config](/configurations/custom-webpack-config/)
 ```js
 module.exports = {
   stories: ['../src/**/*.stories.tsx'],
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: /\.(ts|tsx)$/,
       loader: require.resolve('babel-loader'),

--- a/docs/src/pages/presets/writing-presets/index.md
+++ b/docs/src/pages/presets/writing-presets/index.md
@@ -121,7 +121,8 @@ module.exports = {
     // update config here
     return config;
   },
-  webpack: async (config, options) => {
+  webpackFinal: async (config, options) => {
+    // change webpack config
     return config;
   },
   babel: async (config, options) => {
@@ -155,7 +156,7 @@ module.exports = {
     // update config here
     return config;
   },
-  webpack: async (config, options) => {
+  webpackFinal: async (config, options) => {
     return config;
   },
   babel: async (config, options) => {

--- a/examples/ember-cli/.storybook/main.js
+++ b/examples/ember-cli/.storybook/main.js
@@ -14,7 +14,7 @@ module.exports = {
     '@storybook/addon-backgrounds',
   ],
   stories: ['../stories/**/*.stories.js'],
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: [/\.stories\.js$/, /index\.js$/],
       loaders: [require.resolve('@storybook/source-loader')],

--- a/examples/marko-cli/.storybook/main.js
+++ b/examples/marko-cli/.storybook/main.js
@@ -9,7 +9,7 @@ module.exports = {
     '@storybook/addon-options',
     '@storybook/addon-a11y',
   ],
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: [/\.stories\.js$/],
       loaders: [require.resolve('@storybook/source-loader')],

--- a/examples/mithril-kitchen-sink/.storybook/main.js
+++ b/examples/mithril-kitchen-sink/.storybook/main.js
@@ -13,7 +13,7 @@ module.exports = {
     '@storybook/addon-backgrounds',
     '@storybook/addon-a11y',
   ],
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: [/\.stories\.js$/],
       loaders: [require.resolve('@storybook/source-loader')],

--- a/examples/official-storybook/main.js
+++ b/examples/official-storybook/main.js
@@ -22,7 +22,7 @@ module.exports = {
     '@storybook/addon-graphql',
     '@storybook/addon-contexts',
   ],
-  webpack: async (config, { configType }) => ({
+  webpackFinal: async (config, { configType }) => ({
     ...config,
     module: {
       ...config.module,

--- a/examples/polymer-cli/.storybook/main.js
+++ b/examples/polymer-cli/.storybook/main.js
@@ -14,7 +14,7 @@ module.exports = {
     '@storybook/addon-options',
     '@storybook/addon-a11y',
   ],
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: [/\.stories\.js$/, /index\.js$/],
       loaders: [require.resolve('@storybook/source-loader')],

--- a/examples/preact-kitchen-sink/.storybook/main.js
+++ b/examples/preact-kitchen-sink/.storybook/main.js
@@ -14,7 +14,7 @@ module.exports = {
     '@storybook/addon-contexts',
     '@storybook/addon-a11y',
   ],
-  webpack: config => {
+  webpackFinal: config => {
     config.module.rules.push({
       test: [/\.stories\.js$/],
       loaders: [require.resolve('@storybook/source-loader')],

--- a/examples/rax-kitchen-sink/.storybook/main.js
+++ b/examples/rax-kitchen-sink/.storybook/main.js
@@ -14,7 +14,7 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-jest',
   ],
-  webpack: async config => ({
+  webpackFinal: async config => ({
     ...config,
     module: {
       ...config.module,

--- a/examples/riot-kitchen-sink/.storybook/main.js
+++ b/examples/riot-kitchen-sink/.storybook/main.js
@@ -13,7 +13,7 @@ module.exports = {
     '@storybook/addon-backgrounds',
     '@storybook/addon-a11y',
   ],
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: [/\.stories\.js$/, /index\.js$/],
       loaders: [require.resolve('@storybook/source-loader')],

--- a/examples/svelte-kitchen-sink/.storybook/main.js
+++ b/examples/svelte-kitchen-sink/.storybook/main.js
@@ -13,7 +13,7 @@ module.exports = {
     '@storybook/addon-options',
     '@storybook/addon-a11y',
   ],
-  webpack: async config => {
+  webpackFinal: async config => {
     config.module.rules.push({
       test: [/\.stories\.js$/, /index\.js$/],
       loaders: [require.resolve('@storybook/source-loader')],

--- a/lib/cli/generators/WEBPACK_REACT/template-csf/.storybook/main.js
+++ b/lib/cli/generators/WEBPACK_REACT/template-csf/.storybook/main.js
@@ -1,7 +1,7 @@
 module.exports = {
   stories: ['../stories/**/*.stories.js'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
-  webpack: async config => {
+  webpackFinal: async config => {
     // do mutation to the config
 
     return config;

--- a/lib/cli/generators/WEBPACK_REACT/template-mdx/.storybook/main.js
+++ b/lib/cli/generators/WEBPACK_REACT/template-mdx/.storybook/main.js
@@ -8,7 +8,7 @@ module.exports = {
       options: { configureJSX: true },
     },
   ],
-  webpack: async config => {
+  webpackFinal: async config => {
     // do mutation to the config
 
     return config;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/9396

## What I did
I changed to docs & examples to refer to webpackFinal.

@shilman and I tested and this seems to resolve the issue.
@mrmckeb you might pitch in if this will influence the cra-preset?