### PR TITLE
Remove autoprefixer as peer dependency.

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -59,7 +59,6 @@
     "@angular/forms": ">=6.0.0",
     "@angular/platform-browser": ">=6.0.0",
     "@angular/platform-browser-dynamic": ">=6.0.0",
-    "autoprefixer": "^8.1.0",
     "babel-loader": "^7.0.0 || ^8.0.0",
     "rxjs": "^6.0.0",
     "typescript": "^3.4.0",


### PR DESCRIPTION
Issue:

`autoprefixer` is already a dependency from `@storybook/core` which is a dependency from this  **@storybook/angular** package.

The versions mismatch, causing a:

`npm WARN @storybook/angular@5.3.1 requires a peer of autoprefixer@^8.1.0 but none is installed. You must install peer dependencies yourself.`

`$ npm ls autoprefixer
`
<img width="211" alt="Screenshot 2020-01-13 at 13 20 24" src="https://user-images.githubusercontent.com/875432/72259135-9d4d9600-3607-11ea-8055-67efa3e34ad7.png">


## What I did

Removed `autoprefixer` as peer dependency.
Alternative would be to keep `autoprefixer` version matching with the one from `@storybook/core` ...
