### PR TITLE
Addon-knobs: Fix null knob values in select

### DIFF
--- a/addons/knobs/src/components/types/Select.tsx
+++ b/addons/knobs/src/components/types/Select.tsx
@@ -32,7 +32,7 @@ const SelectType: FunctionComponent<SelectTypeProps> & {
   const { options } = knob;
 
   const callbackReduceArrayOptions = (acc: any, option: any, i: number) => {
-    if (typeof option !== 'object') return { ...acc, [option]: option };
+    if (typeof option !== 'object' || option === null) return { ...acc, [option]: option };
     const label = option.label || option.key || i;
     return { ...acc, [label]: option };
   };

--- a/examples/official-storybook/stories/addon-knobs/with-knobs.stories.js
+++ b/examples/official-storybook/stories/addon-knobs/with-knobs.stories.js
@@ -45,6 +45,12 @@ export default {
   decorators: [withKnobs],
 };
 
+export const selectKnob = () => {
+  const value = select('value', [1, 2, 3, undefined, null], 1);
+
+  return <div>{JSON.stringify({ value: String(value) }, null, 2)}</div>;
+};
+
 export const TweaksStaticValues = () => {
   const name = text('Name', 'Storyteller');
   const age = number('Age', 70, { range: true, min: 0, max: 90, step: 5 });


### PR DESCRIPTION
Issue: #9405

## What I did

ADD a story to test
FIX the bug by adding a `=== null` check