### PR TITLE
Source-loader: Disable linting altogether

### DIFF
--- a/lib/source-loader/src/server/build.js
+++ b/lib/source-loader/src/server/build.js
@@ -56,7 +56,6 @@ var __MODULE_DEPENDENCIES__ = ${JSON.stringify(dependencies)};
 var __LOCAL_DEPENDENCIES__ = ${JSON.stringify(localDependencies)};
 // @ts-ignore
 var __IDS_TO_FRAMEWORKS__ = ${JSON.stringify(idsToFrameworks)};
-/* eslint-enable */
         `;
         return insertAfterImports(this, preamble, source);
         // return `${preamble}${source}`;


### PR DESCRIPTION
Issue: #9407 #9423 

## What I did

More aggressive than #9410 - just disable linting entirely in these synthetic files. Since this happens at load time, it shouldn't affect users' linting in general.

## How to test

Didn't test
