### PR TITLE
Core: Preserve kind load order on HMR when no sortFn is provided

### DIFF
--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -507,6 +507,44 @@ describe('preview.client_api', () => {
       expect(stories[1]).toHaveBeenCalled();
       expect(logger.warn).not.toHaveBeenCalled();
     });
+
+    it('should maintain kind order when the module reloads', async () => {
+      const {
+        clientApi: { storiesOf, getStorybook },
+        channel,
+      } = getContext(undefined);
+      const module1 = new MockModule();
+      const module2 = new MockModule();
+      channel.emit = jest.fn();
+
+      const stories = [jest.fn(), jest.fn()];
+
+      expect(getStorybook()).toEqual([]);
+
+      storiesOf('kind1', module1).add('story1', jest.fn());
+      storiesOf('kind2', module2).add('story2', jest.fn());
+
+      // storyStore debounces so we need to wait for the next tick
+      await new Promise(r => setTimeout(r, 0));
+      let [event, storiesHash] = channel.emit.mock.calls[0];
+      expect(event).toEqual('setStories');
+      expect(Object.values(storiesHash.stories).map(v => v.kind)).toEqual(['kind1', 'kind2']);
+
+      expect(getStorybook().map(story => story.kind)).toEqual(['kind1', 'kind2']);
+
+      channel.emit.mockClear();
+
+      module1.hot.reload();
+      storiesOf('kind1', module1).add('story1', jest.fn());
+
+      await new Promise(r => setTimeout(r, 0));
+      // eslint-disable-next-line prefer-destructuring
+      [event, storiesHash] = channel.emit.mock.calls[0];
+      expect(event).toEqual('setStories');
+      expect(Object.values(storiesHash.stories).map(v => v.kind)).toEqual(['kind1', 'kind2']);
+
+      expect(getStorybook().map(story => story.kind)).toEqual(['kind1', 'kind2']);
+    });
   });
 
   describe('parameters', () => {

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -1,5 +1,6 @@
 import { logger } from '@storybook/client-logger';
 import addons, { mockChannel } from '@storybook/addons';
+import Events from '@storybook/core-events';
 import ClientApi from './client_api';
 import ConfigApi from './config_api';
 import StoryStore from './story_store';
@@ -517,8 +518,6 @@ describe('preview.client_api', () => {
       const module2 = new MockModule();
       channel.emit = jest.fn();
 
-      const stories = [jest.fn(), jest.fn()];
-
       expect(getStorybook()).toEqual([]);
 
       storiesOf('kind1', module1).add('story1', jest.fn());
@@ -526,23 +525,25 @@ describe('preview.client_api', () => {
 
       // storyStore debounces so we need to wait for the next tick
       await new Promise(r => setTimeout(r, 0));
-      let [event, storiesHash] = channel.emit.mock.calls[0];
-      expect(event).toEqual('setStories');
-      expect(Object.values(storiesHash.stories).map(v => v.kind)).toEqual(['kind1', 'kind2']);
 
+      let [event, storiesHash] = channel.emit.mock.calls[0];
+      expect(event).toEqual(Events.SET_STORIES);
+      expect(Object.values(storiesHash.stories).map(v => v.kind)).toEqual(['kind1', 'kind2']);
       expect(getStorybook().map(story => story.kind)).toEqual(['kind1', 'kind2']);
 
       channel.emit.mockClear();
 
+      // simulate an HMR of kind1, which would cause it to go to the end
+      // if the original order is not maintainaed
       module1.hot.reload();
       storiesOf('kind1', module1).add('story1', jest.fn());
 
       await new Promise(r => setTimeout(r, 0));
       // eslint-disable-next-line prefer-destructuring
       [event, storiesHash] = channel.emit.mock.calls[0];
-      expect(event).toEqual('setStories');
-      expect(Object.values(storiesHash.stories).map(v => v.kind)).toEqual(['kind1', 'kind2']);
 
+      expect(event).toEqual(Events.SET_STORIES);
+      expect(Object.values(storiesHash.stories).map(v => v.kind)).toEqual(['kind1', 'kind2']);
       expect(getStorybook().map(story => story.kind)).toEqual(['kind1', 'kind2']);
     });
   });

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -131,6 +131,17 @@ export default class StoryStore extends EventEmitter {
       if (index && this._data[index].parameters.options.storySort) {
         const sortFn = this._data[index].parameters.options.storySort;
         stable.inplace(stories, sortFn);
+      } else {
+        // NOTE: here we are using _legacydata to preserve the original kind loading
+        // order if there is no sort function, which is totally weird.
+        const kindOrder = Object.keys(this._legacydata).reduce(
+          (acc: Record<string, number>, kind: string, idx: number) => {
+            acc[kind] = idx;
+            return acc;
+          },
+          {}
+        );
+        stable.inplace(stories, (s1, s2) => kindOrder[s1[1].kind] - kindOrder[s2[1].kind]);
       }
     }
     // removes function values from all stories so they are safe to transport over the channel

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -132,8 +132,10 @@ export default class StoryStore extends EventEmitter {
         const sortFn = this._data[index].parameters.options.storySort;
         stable.inplace(stories, sortFn);
       } else {
-        // NOTE: here we are using _legacydata to preserve the original kind loading
-        // order if there is no sort function, which is totally weird.
+        // NOTE: when kinds are HMR'ed they get temporarily removed from the `_data` array
+        // and thus lose order. However in `_legacydata` they just get zeroed out, meaning
+        // that the order is preserved. Here we can use this to preserve the load
+        // order if there is no sort function, although it's a hack.
         const kindOrder = Object.keys(this._legacydata).reduce(
           (acc: Record<string, number>, kind: string, idx: number) => {
             acc[kind] = idx;


### PR DESCRIPTION
Issue: #9419 

## What I did

Preserve kind order when stories are edited.

## How to test

See attached test case. Also edit stories that are not last in the list in a project where no sort order is specified.
