### PR TITLE
 UI: Fix edge case where only one legacy separator is defined

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -129,6 +129,38 @@ const initStoriesApi = ({
     return undefined;
   };
 
+  const jumpToComponent = (direction: Direction) => {
+    const state = store.getState();
+    const { storiesHash, viewMode, storyId } = state;
+
+    // cannot navigate when there's no current selection
+    if (!storyId || !storiesHash[storyId]) {
+      return;
+    }
+
+    const lookupList = Object.entries(storiesHash).reduce((acc, i) => {
+      const value = i[1];
+      if (value.isComponent) {
+        acc.push([...i[1].children]);
+      }
+      return acc;
+    }, []);
+
+    const index = lookupList.findIndex(i => i.includes(storyId));
+
+    // cannot navigate beyond fist or last
+    if (index === lookupList.length - 1 && direction > 0) {
+      return;
+    }
+    if (index === 0 && direction < 0) {
+      return;
+    }
+
+    const result = lookupList[index + direction][0];
+
+    navigate(`/${viewMode || 'story'}/${result}`);
+  };
+
   const jumpToStory = (direction: Direction) => {
     const { storiesHash, viewMode, storyId } = store.getState();
 
@@ -160,38 +192,6 @@ const initStoriesApi = ({
     if (viewMode && result) {
       navigate(`/${viewMode}/${result}`);
     }
-  };
-
-  const jumpToComponent = (direction: Direction) => {
-    const state = store.getState();
-    const { storiesHash, viewMode, storyId } = state;
-
-    // cannot navigate when there's no current selection
-    if (!storyId || !storiesHash[storyId]) {
-      return;
-    }
-
-    const lookupList = Object.entries(storiesHash).reduce((acc, i) => {
-      const value = i[1];
-      if (value.isComponent) {
-        acc.push([...i[1].children]);
-      }
-      return acc;
-    }, []);
-
-    const index = lookupList.findIndex(i => i.includes(storyId));
-
-    // cannot navigate beyond fist or last
-    if (index === lookupList.length - 1 && direction > 0) {
-      return;
-    }
-    if (index === 0 && direction < 0) {
-      return;
-    }
-
-    const result = lookupList[index + direction][0];
-
-    navigate(`/${viewMode || 'story'}/${result}`);
   };
 
   const toKey = (input: string) =>

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -238,7 +238,10 @@ const initStoriesApi = ({
       if (typeof rootSeparator !== 'undefined' || typeof groupSeparator !== 'undefined') {
         warnRemovingHierarchySeparators();
         if (usingShowRoots) warnUsingHierarchySeparatorsAndShowRoots();
-        ({ root, groups } = parseKind(kind, { rootSeparator, groupSeparator }));
+        ({ root, groups } = parseKind(kind, {
+          rootSeparator: rootSeparator || '|',
+          groupSeparator: groupSeparator || /\/|\./,
+        }));
 
         // 2. If the user hasn't passed separators, but is using | or . in kinds, use the old behaviour but warn
       } else if (anyKindMatchesOldHierarchySeparators && !usingShowRoots) {


### PR DESCRIPTION
Issue: #9420

## What I did

Fill in default values if either legacy separator is specified by the user.

NOTE: There are a bunch more diffs in this file, because I had to reorder the function definition to pass linting. The actual changes are just a few lines at the end.

## How to test

Test by hand in `official-storybook`. Didn't add tests since this code will be removed in 6.0.