### PR TITLE
feat(addon-docs): named colors with ColorPalette

### DIFF
--- a/lib/components/src/blocks/ColorPalette.stories.tsx
+++ b/lib/components/src/blocks/ColorPalette.stories.tsx
@@ -27,3 +27,29 @@ export const defaultStyle = () => (
     />
   </ColorPalette>
 );
+
+export const NamedColors = () => (
+  <ColorPalette>
+    <ColorItem
+      title="theme.color.greyscale"
+      subtitle="Some of the greys"
+      colors={{ White: '#FFFFFF', Alabaster: '#F8F8F8', Concrete: '#F3F3F3' }}
+    />
+    <ColorItem
+      title="theme.color.primary"
+      subtitle="Coral"
+      colors={{ WildWatermelon: '#FF4785' }}
+    />
+    <ColorItem title="theme.color.secondary" subtitle="Ocean" colors={{ DodgerBlue: '#1EA7FD' }} />
+    <ColorItem
+      title="theme.color.positive"
+      subtitle="Green"
+      colors={{
+        Apple: 'rgba(102,191,60,1)',
+        Apple80: 'rgba(102,191,60,.8)',
+        Apple60: 'rgba(102,191,60,.6)',
+        Apple30: 'rgba(102,191,60,.3)',
+      }}
+    />
+  </ColorPalette>
+);

--- a/lib/components/src/blocks/ColorPalette.tsx
+++ b/lib/components/src/blocks/ColorPalette.tsx
@@ -137,19 +137,19 @@ function renderSwatchLabel(color: string, colorDescription?: string) {
 function renderSwatchSpecimen(colors: Colors) {
   if (Array.isArray(colors)) {
     return (
-      <>
+      <SwatchSpecimen>
         <SwatchColors>{colors.map(color => renderSwatch(color))}</SwatchColors>
         <SwatchLabels>{colors.map(color => renderSwatchLabel(color))}</SwatchLabels>
-      </>
+      </SwatchSpecimen>
     );
   }
   return (
-    <>
+    <SwatchSpecimen>
       <SwatchColors>{Object.values(colors).map(color => renderSwatch(color))}</SwatchColors>
       <SwatchLabels>
         {Object.keys(colors).map(color => renderSwatchLabel(color, colors[color]))}
       </SwatchLabels>
-    </>
+    </SwatchSpecimen>
   );
 }
 
@@ -164,9 +164,7 @@ export const ColorItem: FunctionComponent<ColorProps> = ({ title, subtitle, colo
         <ItemTitle>{title}</ItemTitle>
         <ItemSubtitle>{subtitle}</ItemSubtitle>
       </ItemDescription>
-      <Swatches>
-        <SwatchSpecimen>{renderSwatchSpecimen(colors)}</SwatchSpecimen>
-      </Swatches>
+      <Swatches>{renderSwatchSpecimen(colors)}</Swatches>
     </Item>
   );
 };

--- a/lib/components/src/blocks/ColorPalette.tsx
+++ b/lib/components/src/blocks/ColorPalette.tsx
@@ -35,10 +35,8 @@ const SwatchLabel = styled.div(({ theme }) => ({
       ? transparentize(0.4, theme.color.defaultText)
       : transparentize(0.6, theme.color.defaultText),
 
-  '> div': {
-    display: 'inline-block',
-    overflow: 'hidden',
-    maxWidth: '100%',
+  small: {
+    display: 'block',
   },
 }));
 
@@ -107,10 +105,52 @@ const List = styled.div(({ theme }) => ({
   flexDirection: 'column',
 }));
 
+type Colors = string[] | { [key: string]: string };
+
 interface ColorProps {
   title: string;
   subtitle: string;
-  colors: string[];
+  colors: Colors;
+}
+
+function renderSwatch(color: string) {
+  return (
+    <Swatch
+      key={color}
+      title={color}
+      style={{
+        backgroundColor: color,
+      }}
+    />
+  );
+}
+
+function renderSwatchLabel(color: string, colorDescription?: string) {
+  return (
+    <SwatchLabel key={color} title={color}>
+      {color}
+      {colorDescription && <small>{colorDescription}</small>}
+    </SwatchLabel>
+  );
+}
+
+function renderSwatchSpecimen(colors: Colors) {
+  if (Array.isArray(colors)) {
+    return (
+      <>
+        <SwatchColors>{colors.map(color => renderSwatch(color))}</SwatchColors>
+        <SwatchLabels>{colors.map(color => renderSwatchLabel(color))}</SwatchLabels>
+      </>
+    );
+  }
+  return (
+    <>
+      <SwatchColors>{Object.values(colors).map(color => renderSwatch(color))}</SwatchColors>
+      <SwatchLabels>
+        {Object.keys(colors).map(color => renderSwatchLabel(color, colors[color]))}
+      </SwatchLabels>
+    </>
+  );
 }
 
 /**
@@ -124,28 +164,8 @@ export const ColorItem: FunctionComponent<ColorProps> = ({ title, subtitle, colo
         <ItemTitle>{title}</ItemTitle>
         <ItemSubtitle>{subtitle}</ItemSubtitle>
       </ItemDescription>
-
       <Swatches>
-        <SwatchSpecimen>
-          <SwatchColors>
-            {colors.map(color => (
-              <Swatch
-                key={color}
-                title={color}
-                style={{
-                  backgroundColor: color,
-                }}
-              />
-            ))}
-          </SwatchColors>
-          <SwatchLabels>
-            {colors.map(color => (
-              <SwatchLabel key={color} title={color}>
-                <div>{color}</div>
-              </SwatchLabel>
-            ))}
-          </SwatchLabels>
-        </SwatchSpecimen>
+        <SwatchSpecimen>{renderSwatchSpecimen(colors)}</SwatchSpecimen>
       </Swatches>
     </Item>
   );


### PR DESCRIPTION
Issue:
Cannot display design token names using ColorPalette docs component

## What I did
Be able to pass an object for colors in addition to a simple array.
![image](https://user-images.githubusercontent.com/18534166/72391237-e51a0d80-372c-11ea-9450-52fb589786bf.png)

## How to test

`NamedColors` story has been added.

<!--

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.


Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
