### PR TITLE
Bugfix - Addons relative path

### DIFF
--- a/lib/core/src/server/presets.js
+++ b/lib/core/src/server/presets.js
@@ -1,5 +1,6 @@
 import dedent from 'ts-dedent';
 import { join } from 'path';
+import { existsSync } from 'fs'
 import { logger } from '@storybook/node-logger';
 import { resolveFile } from './utils/resolve-file';
 
@@ -17,6 +18,17 @@ function parsePackageName(input) {
   const matched = input.charAt(0) === '@' ? input.match(RE_SCOPED) : input.match(RE_NORMAL);
 
   if (!matched) {
+
+    const packageFromLocalPath = existsSync(input)
+
+    if (packageFromLocalPath) {
+      return {
+        name: input,
+        path: input,
+        version: '',
+      }
+    }
+
     throw new Error(`[parse-package-name] "${input}" is not a valid string`);
   }
 
@@ -72,7 +84,7 @@ export const resolveAddonName = name => {
       type: 'presets',
     };
     // eslint-disable-next-line no-empty
-  } catch (err) {}
+  } catch (err) { }
 
   try {
     return {
@@ -80,7 +92,7 @@ export const resolveAddonName = name => {
       type: 'managerEntries',
     };
     // eslint-disable-next-line no-empty
-  } catch (err) {}
+  } catch (err) { }
 
   return { name, type: 'presets' };
 };

--- a/lib/core/src/server/presets.js
+++ b/lib/core/src/server/presets.js
@@ -84,7 +84,7 @@ export const resolveAddonName = name => {
       type: 'presets',
     };
     // eslint-disable-next-line no-empty
-  } catch (err) { }
+  } catch (err) {}
 
   try {
     return {
@@ -92,7 +92,7 @@ export const resolveAddonName = name => {
       type: 'managerEntries',
     };
     // eslint-disable-next-line no-empty
-  } catch (err) { }
+  } catch (err) {}
 
   return { name, type: 'presets' };
 };

--- a/lib/core/src/server/presets.test.js
+++ b/lib/core/src/server/presets.test.js
@@ -1,3 +1,11 @@
+jest.mock('fs', () => ({
+  existsSync: jest.fn(file => {
+    const realFakeFile = ['/local/path/@org/name/preset', '/local/path/@org/name/register'];
+    const isRealFakeFile = realFakeFile.indexOf(file) !== -1;
+    return isRealFakeFile;
+  }),
+}));
+
 function wrapPreset(basePresets) {
   return {
     babel: async (config, args) => basePresets.apply('babel', config, args),
@@ -333,6 +341,24 @@ describe('presets', () => {
 
 describe('resolveAddonName', () => {
   const { resolveAddonName } = require.requireActual('./presets');
+
+  it('should resolve preset given with absolute path', () => {
+    expect(resolveAddonName('/local/path/@org/name/preset')).toEqual({
+      name: '/local/path/@org/name/preset',
+      type: 'presets',
+    });
+  });
+
+  it('should resolve managerEntries given with absolute path', () => {
+    expect(resolveAddonName('/local/path/@org/name/register')).toEqual({
+      name: '/local/path/@org/name/register',
+      type: 'managerEntries',
+    });
+  });
+
+  it('should throw an error if absolute path doesnt exist', () => {
+    expect(() => resolveAddonName('/wrong/local/path/@org/name/register')).toThrowError();
+  });
 
   it('should resolve packages with metadata (relative path)', () => {
     expect(resolveAddonName('@storybook/addon-docs')).toEqual({


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/9343

## What I did
Editing the presets function to allow local addons to be included in main.js

## How to test
Current function is not tested in existing unit tests as the function is only indirectly exposed.
Test the functionality by adding an addon to main.js like the following:
```
require.resolve('../packages/node_modules/@my/addon/dist/register')
```