### PR TITLE
Adding missing '=' for Svelte config

### DIFF
--- a/docs/src/pages/guides/guide-svelte/index.md
+++ b/docs/src/pages/guides/guide-svelte/index.md
@@ -64,7 +64,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```


### PR DESCRIPTION
Issue:

The documentation for Svelte was missing an '=' when defining the configuration.

## What I did

Added the missing '='

## How to test

N/A
