### PR TITLE
Core: Fix default story sort

### DIFF
--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -127,10 +127,11 @@ describe('preview.story_store', () => {
     });
   });
 
-  describe('dumpStoryBook', () => {
+  describe('dumpStoryBook/getStoriesForManager', () => {
     it('should return nothing when empty', () => {
       const store = new StoryStore({ channel });
       expect(store.dumpStoryBook()).toEqual([]);
+      expect(Object.keys(store.getStoriesForManager())).toEqual([]);
     });
 
     it('should return storybook with stories', () => {
@@ -150,6 +151,13 @@ describe('preview.story_store', () => {
           kind: 'kind-2',
           stories: ['story-2.1', 'story-2.2'],
         },
+      ]);
+
+      expect(Object.keys(store.getStoriesForManager())).toEqual([
+        'kind-1--story-1-1',
+        'kind-1--story-1-2',
+        'kind-2--story-2-1',
+        'kind-2--story-2-2',
       ]);
     });
   });

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -136,8 +136,8 @@ export default class StoryStore extends EventEmitter {
         // and thus lose order. However in `_legacydata` they just get zeroed out, meaning
         // that the order is preserved. Here we can use this to preserve the load
         // order if there is no sort function, although it's a hack.
-        const kindOrder = Object.keys(this._legacydata).reduce(
-          (acc: Record<string, number>, kind: string, idx: number) => {
+        const kindOrder = Object.values(this._legacydata).reduce(
+          (acc: Record<string, number>, { kind }: any, idx: number) => {
             acc[kind] = idx;
             return acc;
           },
@@ -261,9 +261,13 @@ export default class StoryStore extends EventEmitter {
     this.pushToManager();
   }
 
+  getStoriesForManager = () => {
+    return this.extract({ includeDocsOnly: true });
+  };
+
   pushToManager = debounce(() => {
     if (this._channel) {
-      const stories = this.extract({ includeDocsOnly: true });
+      const stories = this.getStoriesForManager();
 
       // send to the parent frame.
       this._channel.emit(Events.SET_STORIES, { stories });


### PR DESCRIPTION
Issue: #9477 

## What I did

Fix the story sorting logic, which I broke in #9424 

## How to test

See updated test cases.

@tmeasday NOTE: there were no other `dumpStorybook()` tests in `story_store.test.ts`. there are a bunch of `getStorybook()` tests in `client_api.test.ts` but it's pretty messy to update those tests. i propose we add tests to `story_store` if needed.
