### PR TITLE
Core: Fix default sorting of docs-only stories

### DIFF
--- a/examples/official-storybook/intro.stories.mdx
+++ b/examples/official-storybook/intro.stories.mdx
@@ -1,0 +1,5 @@
+<Meta title="About/Intro" />
+
+# Official-storybook
+
+Welcome to `official-storybook`, a collection of test cases and demos for `@storybook/react` and all its addons.

--- a/examples/official-storybook/main.js
+++ b/examples/official-storybook/main.js
@@ -1,6 +1,6 @@
 module.exports = {
   stories: [
-    './intro.stories.mdx',
+    // FIXME: Breaks e2e tests './intro.stories.mdx',
     '../../lib/ui/src/**/*.stories.(js|tsx|mdx)',
     '../../lib/components/src/**/*.stories.(js|tsx|mdx)',
     './stories/**/*.stories.(js|tsx|mdx)',

--- a/examples/official-storybook/main.js
+++ b/examples/official-storybook/main.js
@@ -1,5 +1,6 @@
 module.exports = {
   stories: [
+    './intro.stories.mdx',
     '../../lib/ui/src/**/*.stories.(js|tsx|mdx)',
     '../../lib/components/src/**/*.stories.(js|tsx|mdx)',
     './stories/**/*.stories.(js|tsx|mdx)',

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -514,21 +514,23 @@ describe('preview.client_api', () => {
         clientApi: { storiesOf, getStorybook },
         channel,
       } = getContext(undefined);
+      const module0 = new MockModule();
       const module1 = new MockModule();
       const module2 = new MockModule();
       channel.emit = jest.fn();
 
       expect(getStorybook()).toEqual([]);
 
+      storiesOf('kind0', module0).add('story0-docs-only', jest.fn(), { docsOnly: true });
       storiesOf('kind1', module1).add('story1', jest.fn());
       storiesOf('kind2', module2).add('story2', jest.fn());
 
       // storyStore debounces so we need to wait for the next tick
       await new Promise(r => setTimeout(r, 0));
 
-      let [event, storiesHash] = channel.emit.mock.calls[0];
+      let [event, args] = channel.emit.mock.calls[0];
       expect(event).toEqual(Events.SET_STORIES);
-      expect(Object.values(storiesHash.stories).map(v => v.kind)).toEqual(['kind1', 'kind2']);
+      expect(Object.values(args.stories).map(v => v.kind)).toEqual(['kind0', 'kind1', 'kind2']);
       expect(getStorybook().map(story => story.kind)).toEqual(['kind1', 'kind2']);
 
       channel.emit.mockClear();
@@ -540,10 +542,10 @@ describe('preview.client_api', () => {
 
       await new Promise(r => setTimeout(r, 0));
       // eslint-disable-next-line prefer-destructuring
-      [event, storiesHash] = channel.emit.mock.calls[0];
+      [event, args] = channel.emit.mock.calls[0];
 
       expect(event).toEqual(Events.SET_STORIES);
-      expect(Object.values(storiesHash.stories).map(v => v.kind)).toEqual(['kind1', 'kind2']);
+      expect(Object.values(args.stories).map(v => v.kind)).toEqual(['kind0', 'kind1', 'kind2']);
       expect(getStorybook().map(story => story.kind)).toEqual(['kind1', 'kind2']);
     });
   });


### PR DESCRIPTION
Issue: #9481 

## What I did

Fix sort logic: it was using `_legacydata` which doesn't contain docs-only stories for some legacy-ish reason.

## How to test

See updated unit tests! 🥇 

Also E2E test in `official-storybook` if you disable some stories, etc. Doesn't really work as is, because `storiesOf` stories always get loaded before CSF/MDX.
