### PR TITLE
Source-loader: Bypass if file has no exports

### DIFF
--- a/examples/official-storybook/stories/core/reexport-source-loader.stories.js
+++ b/examples/official-storybook/stories/core/reexport-source-loader.stories.js
@@ -1,0 +1,8 @@
+export default {
+  title: 'Core/Re-export source loader',
+};
+
+const Story1 = () => 'story1';
+const Story2 = () => 'story2';
+
+export { Story1, Story2 };

--- a/lib/source-loader/src/server/build.js
+++ b/lib/source-loader/src/server/build.js
@@ -3,7 +3,16 @@ import { getRidOfUselessFilePrefixes } from './dependencies-lookup/getRidOfUsele
 
 export function transform(inputSource) {
   return readStory(this, inputSource)
-    .then(getRidOfUselessFilePrefixes)
+    .then(sourceObject => {
+      // if source-loader had trouble parsing the story exports, return the original story
+      // example is
+      // const myStory = () => xxx
+      // export { myStory }
+      if (!sourceObject.source || sourceObject.source.length === 0) {
+        return { source: inputSource };
+      }
+      return getRidOfUselessFilePrefixes(sourceObject);
+    })
     .then(
       ({
         prefix,
@@ -15,7 +24,8 @@ export function transform(inputSource) {
         localDependencies,
         idsToFrameworks,
       }) => {
-        const preamble = `
+        const preamble = prefix
+          ? `
 /* eslint-disable */
 // @ts-nocheck
 // @ts-ignore
@@ -36,7 +46,8 @@ var __MODULE_DEPENDENCIES__ = ${JSON.stringify(dependencies)};
 var __LOCAL_DEPENDENCIES__ = ${JSON.stringify(localDependencies)};
 // @ts-ignore
 var __IDS_TO_FRAMEWORKS__ = ${JSON.stringify(idsToFrameworks)};
-        `;
+        `
+          : '';
         return `${preamble}\n${source}`;
       }
     );


### PR DESCRIPTION
Issue: #9457 #9412

## What I did
source-loader does not handle named exports that are separate from the story definitions. 
This PR bypasses the source-loader when it is unable to parse a file, so the stories will appear in the sidebar. However the source code will not available to see in docs mode. 

## How to test

added a story`Core/Re-export source loader` to demonstrate the issue


const Story1 = () => 'story1';
const Story2 = () => 'story2';

export { Story1, Story2 };