### PR TITLE
Addon-docs: Preserve Source indentation by default

### DIFF
--- a/lib/components/src/blocks/Source.tsx
+++ b/lib/components/src/blocks/Source.tsx
@@ -69,4 +69,7 @@ const Source: FunctionComponent<SourceProps> = props => {
   return <ThemeProvider theme={convert(overrideTheme)}>{syntaxHighlighter}</ThemeProvider>;
 };
 
+Source.defaultProps = {
+  format: false,
+};
 export { Source };

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -80,7 +80,6 @@ const Code = styled.code({
   flex: 1,
   paddingRight: 0,
   opacity: 1,
-  whiteSpace: 'pre',
 });
 
 export interface SyntaxHighlighterProps {

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -105,7 +105,7 @@ export const SyntaxHighlighter: FunctionComponent<Props> = ({
   copyable = false,
   bordered = false,
   padded = false,
-  format = false,
+  format = true,
   className = null,
   ...rest
 }) => {

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -80,6 +80,7 @@ const Code = styled.code({
   flex: 1,
   paddingRight: 0,
   opacity: 1,
+  whiteSpace: 'pre',
 });
 
 export interface SyntaxHighlighterProps {
@@ -104,7 +105,7 @@ export const SyntaxHighlighter: FunctionComponent<Props> = ({
   copyable = false,
   bordered = false,
   padded = false,
-  format = true,
+  format = false,
   className = null,
   ...rest
 }) => {


### PR DESCRIPTION
Issue: #8078

## What I did

- Removed default decent (remove template strings spacing) 
- code styling prevent white space wrapping style

## How to test

I didn't get much stories to try with, so mostly tested indentation. 
Possibly find stories that are using template strings? 