### PR TITLE
Addon-docs Props: Convert default prop value to string

### DIFF
--- a/examples/cra-ts-kitchen-sink/src/stories/Button.tsx
+++ b/examples/cra-ts-kitchen-sink/src/stories/Button.tsx
@@ -5,6 +5,11 @@ interface ButtonProps {
    * Simple click handler
    */
   onClick?: () => void;
+
+  /**
+   * Is primary?
+   */
+  primary: boolean;
 }
 
 /**
@@ -15,3 +20,7 @@ export const Button: FC<ButtonProps> = ({ children, onClick }) => (
     {children}
   </button>
 );
+
+Button.defaultProps = {
+  primary: true,
+};

--- a/lib/components/src/blocks/PropsTable/PropValue.tsx
+++ b/lib/components/src/blocks/PropsTable/PropValue.tsx
@@ -78,7 +78,8 @@ const PropSummary: FC<PropSummaryProps> = ({ value }) => {
 
   // summary is used for the default value
   // below check fixes not displaying default values for boolean typescript vars
-  const summaryAsString = typeof summary.toString === 'function' ? summary.toString() : summary;
+  const summaryAsString =
+    summary && typeof summary.toString === 'function' ? summary.toString() : summary;
   if (isNil(detail)) {
     return <PropText text={summaryAsString} />;
   }

--- a/lib/components/src/blocks/PropsTable/PropValue.tsx
+++ b/lib/components/src/blocks/PropsTable/PropValue.tsx
@@ -76,8 +76,11 @@ const PropSummary: FC<PropSummaryProps> = ({ value }) => {
 
   const [isOpen, setIsOpen] = useState(false);
 
+  // summary is used for the default value
+  // below check fixes not displaying default values for boolean typescript vars
+  const summaryAsString = typeof summary.toString === 'function' ? summary.toString() : summary;
   if (isNil(detail)) {
-    return <PropText text={summary} />;
+    return <PropText text={summaryAsString} />;
   }
 
   return (
@@ -98,7 +101,7 @@ const PropSummary: FC<PropSummaryProps> = ({ value }) => {
       }
     >
       <Expandable className="sbdocs-expandable">
-        <span>{summary}</span>
+        <span>{summaryAsString}</span>
         <ArrowIcon icon={isOpen ? 'arrowup' : 'arrowdown'} />
       </Expandable>
     </WithTooltipPure>


### PR DESCRIPTION
Issue: #9394

## What I did
- check if the "summary" prop (used for default value) has a toString method and use it to convert to string. 
- added a boolean prop with default value to Button.tsx in cra-ts-kitchen-sink

## How to test

use cra-ts-kitchen-sink