### PR TITLE
Update addon storyshot puppeteer doc

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,6 +9,7 @@
     - [Deprecate displayName parameter](#deprecate-displayname-parameter)
     - [Unified docs preset](#unified-docs-preset)
     - [Simplified hierarchy separators](#simplified-hierarchy-separators)
+    - [Addon StoryShots Puppeteer uses external puppeteer](#addon-storyshots-puppeteer-uses-external-puppeteer)
   - [From version 5.1.x to 5.2.x](#from-version-51x-to-52x)
     - [Source-loader](#source-loader)
     - [Default viewports](#default-viewports)
@@ -219,6 +220,17 @@ addParameters({
 ```
 
 NOTE: it is no longer possible to have some stories with roots and others without. If you want to keep the old behavior, simply add a root called "Others" to all your previously unrooted stories.
+
+### Addon StoryShots Puppeteer uses external puppeteer
+
+To give you more control on the Chrome version used when running StoryShots Puppeteer, `puppeteer` is no more included in the addon dependencies. So you can now pick the version of `puppeteer` you want and set it in your project.
+ 
+If you want the latest version available just run:
+```sh
+yarn add puppeteer --dev
+OR
+npm install puppeteer --save-dev
+``` 
 
 ## From version 5.1.x to 5.2.x
 

--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -8,9 +8,11 @@ Add the following modules into your app.
 npm install @storybook/addon-storyshots-puppeteer puppeteer --save-dev
 ```
 
+⚠️ As of Storybook 5.3 `puppeteer` is no more included in addon dependencies and must be added to your project directly.
+
 ## Configure Storyshots for Puppeteeer tests
 
-/\*\ **React-native** is **not supported** by this test function.
+⚠️ **React-native** is **not supported** by this test function.
 
 When willing to run Puppeteer tests for your stories, you have two options:
 


### PR DESCRIPTION
Issue: #9517 

`puppeteer` was moved to optional peer dependency in https://github.com/storybookjs/storybook/pull/8925 but the documentation wasn't updated accordingly.


## What I did

Update docs:
 - add a section about external `puppeteer` in MIGRATION.md
 - add a warning to emphasize the fact that as of SB 5.3 `puppeteer` must be added to the project dep directly
