### PR TITLE
Fix broken link to repo in empty knobs panel

### DIFF
--- a/addons/knobs/src/components/Panel.tsx
+++ b/addons/knobs/src/components/Panel.tsx
@@ -252,6 +252,7 @@ export default class KnobPanel extends PureComponent<KnobPanelProps> {
               href="https://github.com/storybookjs/storybook/tree/master/addons/knobs"
               target="_blank"
               withArrow
+              cancel={false}
             >
               dynamically interact with components
             </Link>


### PR DESCRIPTION
## What I did
The link to repo in empty knobs panel couldn't be triggered. The problem was with missing `cancel={false}` prop, because `Link` component has a `cancel={true}` by default.

## How to test
1. Go to Knobs addon panel
2. Check if no knobs are found
3. Click on the link to repo

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No