### PR TITLE
Enabling HMR logging in browser console

### DIFF
--- a/lib/core/src/server/preview/preview-preset.js
+++ b/lib/core/src/server/preview/preview-preset.js
@@ -12,7 +12,7 @@ export const entries = async (_, options) => {
 
   if (options.configType === 'DEVELOPMENT') {
     result = result.concat(
-      `${require.resolve('webpack-hot-middleware/client')}?reload=true&quiet=true`
+      `${require.resolve('webpack-hot-middleware/client')}?reload=true&quiet=false`
     );
   }
 


### PR DESCRIPTION
## What I did

- Addresses issue #8308 to re-enable HMR console logging, disabled after Storybook 5.2