### PR TITLE
Node-logger: Move `@types/npmlog` to dependencies 

### DIFF
--- a/lib/node-logger/package.json
+++ b/lib/node-logger/package.json
@@ -27,6 +27,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
+    "@types/npmlog": "^4.1.2",
     "chalk": "^3.0.0",
     "core-js": "^3.0.1",
     "npmlog": "^4.1.2",
@@ -34,7 +35,6 @@
     "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {
-    "@types/npmlog": "^4.1.1",
     "@types/pretty-hrtime": "^1.0.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4333,7 +4333,7 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
-"@types/npmlog@^4.1.1":
+"@types/npmlog@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.2.tgz#d070fe6a6b78755d1092a3dc492d34c3d8f871c4"
   integrity sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA==


### PR DESCRIPTION
Issue: #7855

## What I did

As `npmlog` is exported [here](https://github.com/storybookjs/storybook/blob/28fed37f0d7d6a3c1276d0e54060205858f54c29/lib/node-logger/src/index.ts#L29) --`export { npmLog as instance };`, TS users of this lib need to have `npmlog` types too, so `@types/npmlog` have to be in `dependencies` and not in `devDependencies`.

