### PR TITLE
Fixed Angular button example story

### DIFF
--- a/lib/cli/generators/ANGULAR/template-csf/src/stories/1-Button.stories.ts
+++ b/lib/cli/generators/ANGULAR/template-csf/src/stories/1-Button.stories.ts
@@ -11,14 +11,14 @@ export default {
 export const Text = () => ({
   component: Button,
   props: {
-    Text: 'Hello Button',
+    text: 'Hello Button',
   },
 });
 
 export const Emoji = () => ({
   component: Button,
   props: {
-    Text: '😀 😎 👍 💯',
+    text: '😀 😎 👍 💯',
   },
 });
 
@@ -29,7 +29,7 @@ Emoji.story = {
 export const WithSomeEmojiAndAction = () => ({
   component: Button,
   props: {
-    Text: '😀 😎 👍 💯',
+    text: '😀 😎 👍 💯',
     onClick: action('This was clicked OMG'),
   },
 });
@@ -42,7 +42,7 @@ WithSomeEmojiAndAction.story = {
 export const ButtonWithLinkToAnotherStory = () => ({
   component: Button,
   props: {
-    Text: 'Go to Welcome Story',
+    text: 'Go to Welcome Story',
     onClick: linkTo('Welcome'),
   },
 });


### PR DESCRIPTION
Issue:
The button example story in Angular is broken. The text isn't displayed since the property name was renamed in 24ec9d3674fe8a2b151144803c1443c6d0a389ab.

## What I did
Made the property name lowercase.

## How to test

- Is this testable with Jest or Chromatic screenshots? Idk.
- Does this need a new example in the kitchen sink apps? Idk.
- Does this need an update to the documentation? No

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
