### PR TITLE
#8297 Fix "storybook/source-loader/set" event parameters in "addon-storysource"

### DIFF
--- a/addons/storysource/src/preview.js
+++ b/addons/storysource/src/preview.js
@@ -7,9 +7,11 @@ function setStorySource(context, source, locationsMap) {
   const currentLocation = getLocation(context, locationsMap);
 
   addons.getChannel().emit(EVENT_ID, {
-    source,
-    currentLocation,
-    locationsMap,
+    edition: { source },
+    location: {
+      currentLocation,
+      locationsMap
+    }
   });
 }
 


### PR DESCRIPTION
Fixes the "storybook/source-loader/set" event parameters  in the "addon-storysource" addon, introduced by the following changes:

    https://github.com/storybookjs/storybook/pull/7272/files#diff-904dad7f92c7bbfac64aca74960bbf33

Referenced in the following issue:

Issue: https://github.com/storybookjs/storybook/issues/8297

## What I did

## How to test

1) add `.addDecorator(withStorySource('test'))` to stories, or:

    `addons.getChannel().emit('storybook/source-loader/set', {
        edition: { source: 'source' },
        location: {currentLocation: undefined, locationsMap: {}}
    });`

2) add the following to the .storybook/webpack.config.js file:

    `{
        loader: require.resolve('@storybook/source-loader'),
        options: { injectDecorator: false }
      }`

Then the code should be loaded successfully in the "Story" Panel. if the Injector is not disabled, the stories decorator code is overwritten by the loader.
