### PR TITLE
Addon-docs: Remove hard-coded lineHeight in Typeset block

### DIFF
--- a/lib/components/src/blocks/Typeset.tsx
+++ b/lib/components/src/blocks/Typeset.tsx
@@ -15,7 +15,6 @@ const Label = styled.div<{}>(({ theme }) => ({
 }));
 
 const Sample = styled.div({
-  lineHeight: 1,
   overflow: 'hidden',
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',


### PR DESCRIPTION
Issue: #8926 

## What I did

With lineHeight set to set 1, the bottom of the letters like 'p' gets truncated for most fonts.

This is to fix issue 

Removed lineHeight:1

if someone wants it, he can put it in a parent's div.

## How to test

Put something like

```
<Typeset fontFamily="Open Sans" fontSizes={["9px","12px","14px","18px","24px"]} fontWeight={600} sampleText="This is the title font : probably "/>
```

Inside a story and notice that you can see the full letter 'p' and 'y'.


