### PR TITLE
Fix @storybook/addon-storyshots not being able to read config from main.ts

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -45,7 +45,11 @@ const getPreviewFile = (configDir: string): string | false => {
 
 const getMainFile = (configDir: string): string | false => {
   const main = path.join(configDir, 'main.js');
+  const mainTS = path.join(configDir, 'main.ts');
 
+  if (isFile(mainTS)) {
+    return mainTS;
+  }
   if (isFile(main)) {
     return main;
   }


### PR DESCRIPTION
Issue:

`@storybook/addon-storyshots` cannot read the new declarative configuration introduced in 5.3  from a TS file, but only a JS file.
## What I did

This PR enables `main.ts` as well as `main.js` in the same style as as the `preview` and `config` files are loaded.

This fixes https://github.com/storybookjs/storybook/issues/9576

## How to test

I'm new to contributing to storybook, and couldn't see any tests for this feature. I didn't add any either, but if you require I can also add tests.