### PR TITLE
Added missing = in angular guide

### DIFF
--- a/docs/src/pages/guides/guide-angular/index.md
+++ b/docs/src/pages/guides/guide-angular/index.md
@@ -53,7 +53,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```


### PR DESCRIPTION
L56 was missing an `=`, breaking `npm run storybook`

This is just a documentation update for https://storybook.js.org/docs/guides/guide-angular/