### PR TITLE
Publish: Remove docs to reduce package size

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -17,7 +17,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -21,7 +21,6 @@
   "author": "jbaxleyiii",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -21,7 +21,6 @@
   "author": "nm123github",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/design-assets/package.json
+++ b/addons/design-assets/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "angular/**/*",
     "common/**/*",
     "ember/**/*",

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -20,7 +20,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/info/package.json
+++ b/addons/info/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/jest/package.json
+++ b/addons/jest/package.json
@@ -24,7 +24,6 @@
   "author": "Renaud Tertrais <renaud.tertrais@gmail.com> (https://github.com/renaudtertrais)",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/notes/package.json
+++ b/addons/notes/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/options/package.json
+++ b/addons/options/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/queryparams/package.json
+++ b/addons/queryparams/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
-    "docs/**/*",
     "README.md",
     "*.js",
     "*.d.ts"

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -20,7 +20,6 @@
   "author": "Storybook Team",
   "files": [
     "bin/**/*",
-    "docs/**/*",
     "generators/**/*",
     "lib/**/*",
     "README.md",


### PR DESCRIPTION
Issue: N/A

## What I did

Remove docs from package, since images can increase the node_modules size from a few Kb to 3M (addon-docs) and 6M (addon-cssresources). 

## How to test

N/A