### PR TITLE
Update Custom Body Documentation

### DIFF
--- a/docs/src/pages/configurations/add-custom-body/index.md
+++ b/docs/src/pages/configurations/add-custom-body/index.md
@@ -11,7 +11,7 @@ You can accomplish this by creating a file called `preview-body.html` inside the
 <div id="custom-root"></div>
 ```
 
-If using relative sizing in your project (like `rems` or `ems`), you may update the base `font-size` by adding a `style` tag to `preview-body.html`:
+If using relative sizing in your project (like `rem` or `em`), you may update the base `font-size` by adding a `style` tag to `preview-body.html`:
 
 ```html
 <style>

--- a/docs/src/pages/configurations/add-custom-body/index.md
+++ b/docs/src/pages/configurations/add-custom-body/index.md
@@ -11,6 +11,16 @@ You can accomplish this by creating a file called `preview-body.html` inside the
 <div id="custom-root"></div>
 ```
 
+If using relative sizing in your project (like `rems` or `ems`), you may update the base `font-size` by adding a `style` tag to `preview-body.html`:
+
+```html
+<style>
+  body {
+    font-size: 15px;
+  }
+</style>
+```
+
 That's it. Storybook will inject these tags to html body.
 
 > **Important**


### PR DESCRIPTION
I'm using Storybook to document and build a design system. The design system uses relative sizing, but it is based on a `15px` base font-size rather than the `16px` font-size in the storybook preview. 

## What I did

I referred to the Storybook docs to try and solve my problem, but there was no explicit documentation for how to change the base font-size in the preview. It took me a bit to figure out, but ended up being an easy fix. I updated the Storybook documentation to explain how to update the base font-size in the preview window because I imagine a lot, lot, lot of people are using Storybook just how I am - to build a relatively-sized design system. 😄 

## How to test

Not much to test here, just an addition to the docs 🎉