### PR TITLE
fix(addon-storyshots): Remove excess slashes from jest transform warning

### DIFF
--- a/addons/storyshots/storyshots-core/src/Stories2SnapsConverter.ts
+++ b/addons/storyshots/storyshots-core/src/Stories2SnapsConverter.ts
@@ -43,7 +43,7 @@ export class Stories2SnapsConverter {
           To fix it, add following to your jest.config.js:
               transform: {
                 // should be above any other js transform like babel-jest
-                '^.+\\\\.stories\\\\.js$': '@storybook/addon-storyshots/injectFileName',
+                '^.+\\.stories\\.js$': '@storybook/addon-storyshots/injectFileName',
               }
         `
       );


### PR DESCRIPTION
It's printing all of them, so I copied all of them, and that didn't work!

before:

![image](https://user-images.githubusercontent.com/472830/73002233-9985f480-3dfb-11ea-8019-b8e783adcf52.png)

## What I did

## How to test

Testable by running storyshots tests with this config:

```
import initStoryshots, { multiSnapshotWithOptions } from '@storybook/addon-storyshots';

initStoryshots({
  test: multiSnapshotWithOptions()
});
```

Then if you're using CSFs, the warning will be thrown.

The example in the docs is already correct.

