### PR TITLE
Improve Typescript Configuration documentation page

### DIFF
--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -7,13 +7,15 @@ This is a central reference for using Storybook with TypeScript.
 
 ## Typescript configuration presets
 
-The easiest way to write and configure your stories in TypeScript is by using [Storybook presets](../../presets/introduction).
+The fatest and easiest way to write and configure your stories in TypeScript is by using a Storybook preset.
 
-If you're using Create React App (CRA) and have configured it to work with TS, you should use the [CRA preset](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app), which configures Storybook to reuse CRA's TS handling.
+If you're using Create React App (CRA) and have configured it to work with TS, you should use [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app), which configures Storybook to reuse CRA's TS handling.
 
-If you're not using CRA, the next best thing is to use the [Typescript preset](https://github.com/storybookjs/presets/tree/master/packages/preset-typescript), which configures `ts-loader` under the hood.
+If you are not using CRA or have other requirements, then the next best option is [`@storybook/preset-typescript`](https://github.com/storybookjs/presets/tree/master/packages/preset-typescript), which configures `ts-loader` under the hood.
 
-If you need more control than the TypeScript preset offers, read on for manual configuration instructions.
+If you need more control than these presets offer, read on for manual configuration instructions.
+
+You can learn more about Storybook presets [over here](../../presets/introduction).
 
 > If using TypeScript, some addons require features available in TS version 3.4+.
 

--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -9,9 +9,9 @@ This is a central reference for using Storybook with TypeScript.
 
 The fatest and easiest way to write and configure your stories in TypeScript is by using a Storybook preset.
 
-If you're using Create React App (CRA) and have configured it to work with TS, you should use [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app), which configures Storybook to reuse CRA's TS handling.
+* If you're using Create React App (CRA) and have configured it to work with TS, you should use [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app), which configures Storybook to reuse CRA's TS handling.
 
-If you are not using CRA or have other requirements, then the next best option is [`@storybook/preset-typescript`](https://github.com/storybookjs/presets/tree/master/packages/preset-typescript), which configures `ts-loader` under the hood.
+* If you are not using CRA or have other requirements, then the next best option is [`@storybook/preset-typescript`](https://github.com/storybookjs/presets/tree/master/packages/preset-typescript), which configures `ts-loader` under the hood.
 
 If you need more control than these presets offer, read on for manual configuration instructions.
 

--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -7,7 +7,7 @@ This is a central reference for using Storybook with TypeScript.
 
 ## Typescript configuration presets
 
-The fatest and easiest way to write and configure your stories in TypeScript is by using a Storybook preset.
+The fastest and easiest way to write and configure your stories in TypeScript is by using a Storybook preset.
 
 * If you're using Create React App (CRA) and have configured it to work with TS, you should use [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app), which configures Storybook to reuse CRA's TS handling.
 


### PR DESCRIPTION
Issue: n/a

## What I did

When I used the Typescript Configuration page recently, I thought that it didn't even mention the preset but as it turned out it was just mentioned in a single line near the top which I missed.

Some others that I know and have pointed to this page have also missed this line and link - which then leads you into all the details further down the page and makes Typescript + Storybook seem like a configuration nightmare (which its really not 😄)

This PR is an attempt to make the preset options more predominate on the Typescript Configuration page, so that people are less likely to skip over them when trying to get Storybook set up.

## How to test

n/a docs only