### PR TITLE
fix(addon-docs): ColorPalette style

### DIFF
--- a/lib/components/src/blocks/ColorPalette.tsx
+++ b/lib/components/src/blocks/ColorPalette.tsx
@@ -35,8 +35,9 @@ const SwatchLabel = styled.div(({ theme }) => ({
       ? transparentize(0.4, theme.color.defaultText)
       : transparentize(0.6, theme.color.defaultText),
 
-  small: {
+  span: {
     display: 'block',
+    marginTop: 2,
   },
 }));
 
@@ -129,7 +130,7 @@ function renderSwatchLabel(color: string, colorDescription?: string) {
   return (
     <SwatchLabel key={color} title={color}>
       {color}
-      {colorDescription && <small>{colorDescription}</small>}
+      {colorDescription && <span>{colorDescription}</span>}
     </SwatchLabel>
   );
 }

--- a/lib/components/src/blocks/ColorPalette.tsx
+++ b/lib/components/src/blocks/ColorPalette.tsx
@@ -35,6 +35,12 @@ const SwatchLabel = styled.div(({ theme }) => ({
       ? transparentize(0.4, theme.color.defaultText)
       : transparentize(0.6, theme.color.defaultText),
 
+  '> div': {
+    display: 'inline-block',
+    overflow: 'hidden',
+    maxWidth: '100%',
+  },
+
   span: {
     display: 'block',
     marginTop: 2,

--- a/lib/components/src/blocks/ColorPalette.tsx
+++ b/lib/components/src/blocks/ColorPalette.tsx
@@ -129,8 +129,10 @@ function renderSwatch(color: string) {
 function renderSwatchLabel(color: string, colorDescription?: string) {
   return (
     <SwatchLabel key={color} title={color}>
-      {color}
-      {colorDescription && <span>{colorDescription}</span>}
+      <div>
+        {color}
+        {colorDescription && <span>{colorDescription}</span>}
+      </div>
     </SwatchLabel>
   );
 }


### PR DESCRIPTION
Issue:
ColorPalette style is not convenient when design tokens are there.

## What I did
@domyen [asked for some style changes](https://github.com/storybookjs/storybook/pull/9453#issuecomment-577890749) in #9453 after it was merged, so here is another PR to fix them.

## How to test

See demo
