### PR TITLE
Fix default value for web components prop table docs

### DIFF
--- a/addons/docs/src/frameworks/web-components/config.js
+++ b/addons/docs/src/frameworks/web-components/config.js
@@ -11,7 +11,7 @@ function mapData(data) {
     type: { summary: item.type },
     required: '',
     description: item.description,
-    defaultValue: { summary: item.defaultValue },
+    defaultValue: { summary: item.default !== undefined ? item.default : item.defaultValue },
   }));
 }
 


### PR DESCRIPTION
Issue: #9642 

## What I did
As `custom-elements.json` format changed we have to support `default` to get the default value for the prop table.
This change still keeps compatibility with `defaultValue`.

For more information you can see the issue #9642 .