### PR TITLE
check if docsOnly is set to hide the addon panels

### DIFF
--- a/lib/ui/src/components/layout/desktop.js
+++ b/lib/ui/src/components/layout/desktop.js
@@ -43,7 +43,7 @@ const Desktop = React.memo(
                   <Preview id="main" debug={previewProps} />
                 </S.Preview>
 
-                <S.Panel {...panelProps} hidden={viewMode !== 'story'}>
+                <S.Panel {...panelProps} hidden={viewMode !== 'story' || docsOnly}>
                   <Panel debug={panelProps} />
                 </S.Panel>
 


### PR DESCRIPTION
Issue: #9684

## What I did
added additional check for docsOnly for hiding addon panels
the use case is what user goes to a 'story' path out of a mdx page

## How to test
the flow of this code is really complicated, I have the use cases in official-storybook but comes also that depending on the setup it can get even more complicated. 
At some point, you might decide to not set 'story' by default if user navigates to the main age - and show addons/toolbars only after the first story was loaded, so we know if its a documentation only story. There will be a slight delay to displaying the addon panel if its actually a canvas story, but long term will avoid UI complications