### PR TITLE
Addon-docs: Add preset options for vue-docgen-api

### DIFF
--- a/addons/docs/src/frameworks/vue/preset.ts
+++ b/addons/docs/src/frameworks/vue/preset.ts
@@ -1,8 +1,14 @@
-export function webpack(webpackConfig: any = {}, options: any = {}) {
+export function webpackFinal(webpackConfig: any = {}, options: any = {}) {
   webpackConfig.module.rules.push({
     test: /\.vue$/,
     loader: 'vue-docgen-loader',
     enforce: 'post',
+    options: {
+      docgenOptions: {
+        alias: webpackConfig.resolve.alias,
+        ...options.vueDocgenOptions,
+      },
+    },
   });
   return webpackConfig;
 }

--- a/addons/docs/vue/README.md
+++ b/addons/docs/vue/README.md
@@ -32,11 +32,36 @@ module.exports = {
 };
 ```
 
+## Preset options
+
+The `addon-docs` preset for Vue has a configuration option that can be used to configure [`vue-docgen-api`](https://github.com/vue-styleguidist/vue-styleguidist/tree/dev/packages/vue-docgen-api), a tool which extracts information from Vue components. Here's an example of how to use the preset with options for Vue app:
+
+```js
+const path = require('path');
+
+module.exports = {
+  addons: [
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        vueDocgenOptions: {
+          alias: {
+            '@': path.resolve(__dirname, '../'),
+          },
+        },
+      },
+    },
+  ],
+};
+```
+
+The `vueDocgenOptions` is an object for configuring `vue-docgen-api`. See [`vue-docgen-api`'s docs](https://github.com/vue-styleguidist/vue-styleguidist/tree/dev/packages/vue-docgen-api#options-docgenoptions) for available configuration options.
+
 ## DocsPage
 
 When you [install docs](#installation) you should get basic [DocsPage](../docs/docspage.md) documentation automagically for all your stories, available in the `Docs` tab of the Storybook UI.
 
-Props tables for your components requires a few more steps. Docs for Vue relies on [Addon-vue-info](https://github.com/pocka/storybook-addon-vue-info)'s loader. It supports `props`, `events`, and `slots` as first class prop types.
+Props tables for your components requires a few more steps. Docs for Vue relies on [`vue-docgen-loader`](https://github.com/pocka/vue-docgen-loader). It supports `props`, `events`, and `slots` as first class prop types.
 
 Finally, be sure to fill in the `component` field in your story metadata:
 


### PR DESCRIPTION
Issue: close #9615 , close #9695 

## What I did

Added `vueDocgenOptions` to the `addon-docs`' preset option.

```js
// main.js
module.exports = {
  addons: [
    {
      name: '@storybook/addon-docs',
      options: {
        vueDocgenOptions: {/* options for vue-docgen-api */}
      }
  ]
}
```

## How to test

- Is this testable with Jest or Chromatic screenshots? ... no
- Does this need a new example in the kitchen sink apps? ... no
- Does this need an update to the documentation? ... yes

If your answer is yes to any of these, please make sure to include it in your PR. ... updated `addons/docs/vue/README.md`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
