### PR TITLE
Angular: Emit decorator metadata by default

### DIFF
--- a/app/angular/src/server/__tests__/ts_config.test.ts
+++ b/app/angular/src/server/__tests__/ts_config.test.ts
@@ -20,6 +20,9 @@ describe('ts_config', () => {
 
     expect(config).toEqual({
       transpileOnly: true,
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+      },
       configFile: 'tsconfig.json',
     });
   });
@@ -31,6 +34,9 @@ describe('ts_config', () => {
 
     expect(config).toEqual({
       transpileOnly: true,
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+      },
     });
   });
 });

--- a/app/angular/src/server/ts_config.ts
+++ b/app/angular/src/server/ts_config.ts
@@ -14,6 +14,9 @@ export default function(configDir: string) {
   const configFilePath = resolveTsConfig(path.resolve(configDir, 'tsconfig.json'));
   return {
     transpileOnly: true,
+    compilerOptions: {
+      emitDecoratorMetadata: true,
+    },
     configFile: configFilePath || undefined,
   };
 }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/7544

## What I did

I added `emitDecoratorMetadata: true` as default value to the ts compiler options. Angular dependency injection does not work correctly without it


## How to test

- `ng new test-app`
- `sb init`
- create demo component with
```typescript
@Component({
  selector: 'app-test',
  template: 'test.component.html'
})

export class TestComponent implements OnInit {
  constructor(private elementRef: ElementRef) {
    console.log(elementRef);
  }

  ngOnInit() {
  }
}
```
- add this component to a story
- It should fail now.
- modify ts_config.js in `node_modules/@storybook/angular/server/ts_config.js`
```
function default_1(configDir) {
    var configFilePath = resolveTsConfig(path_1.default.resolve(configDir, 'tsconfig.json'));
    return {
        transpileOnly: true,
        compilerOptions: {
          emitDecoratorMetadata: true
        },
        configFile: configFilePath || undefined,
    };
}
```

- it should work now