### PR TITLE
fix: webpack config when excute 'yarn workspace vue-example dev'

### DIFF
--- a/examples/vue-kitchen-sink/package.json
+++ b/examples/vue-kitchen-sink/package.json
@@ -36,6 +36,7 @@
     "prop-types": "^15.7.2",
     "svg-url-loader": "^3.0.2",
     "vue-loader": "^15.7.0",
+    "vue-style-loader": "^4.1.2",
     "webpack": "^4.33.0",
     "webpack-dev-server": "^3.8.2"
   }

--- a/examples/vue-kitchen-sink/webpack.config.js
+++ b/examples/vue-kitchen-sink/webpack.config.js
@@ -27,10 +27,15 @@ module.exports = {
       },
       {
         test: /\.(png|jpg|gif)$/,
-        loader: 'file-loader',
-        options: {
-          name: '[name].[ext]?[hash]',
-        },
+        use: [
+          {
+            loader: 'url-loader',
+            options: {
+              esModule: false,
+              fallback: 'file-loader',
+            },
+          },
+        ],
       },
       {
         test: /\.svg$/,
@@ -44,6 +49,21 @@ module.exports = {
         loader: require.resolve('@storybook/source-loader'),
         include: [path.resolve(__dirname, '../stories')],
         enforce: 'pre',
+      },
+      {
+        test: /\.css$/,
+        use: [
+          'vue-style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              // enable CSS Modules
+              modules: true,
+              // customize generated class names
+              localIdentName: '[local]_[hash:base64:8]',
+            },
+          },
+        ],
       },
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -29049,7 +29049,7 @@ vue-property-decorator@8.2.2:
   dependencies:
     vue-class-component "^7.0.1"
 
-vue-style-loader@^4.1.0:
+vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"
   integrity sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==


### PR DESCRIPTION
Issue: when excute 
```yarn workspace vue-example dev```
there are css and image loader bug in webpack

## What I did
I add css-loader and fix file-loader to url-loader in wepback.config.js 
and also add css-loader npm package to package.json

## How to test
no need to test or update document. just 
```yarn workspace vue-example dev```

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
