### PR TITLE
update readme for clarity

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -108,6 +108,14 @@ Docs has peer dependencies on `react`, `react-is`, and `babel-loader`. If you wa
 yarn add -D react react-is babel-loader
 ```
 
+If using Create React App, enable [this preset](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app). Otherwise
+
+```sh
+yarn add -D babel-plugin-react-docgen
+```
+
+and add `react-docgen` to babelrc.
+
 Then add the following to your `.storybook/main.js`:
 
 ```js


### PR DESCRIPTION
Issue: As documented in [this issue](https://github.com/storybookjs/storybook/issues/9120) the docs fail to mention prereq docgen for addon-docs

## What I did
Include language in README to guide developer in the right direction

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
