### PR TITLE
fix prettier warning

### DIFF
--- a/lib/core/src/server/common/babel.js
+++ b/lib/core/src/server/common/babel.js
@@ -5,7 +5,7 @@ function createProdPresets() {
       {
         builtIns: false,
         mangle: false,
-        simplify: false
+        simplify: false,
       },
     ],
   ];


### PR DESCRIPTION

## What I did
When you do `storybook/lib/core/src/server/common/babel.js 8:24  warning  Insert `,`  prettier/prettier`  `yarn lint` .

fixed prettier.