### PR TITLE
Missing equal sign from code snippet

### DIFF
--- a/docs/src/pages/guides/guide-html/index.md
+++ b/docs/src/pages/guides/guide-html/index.md
@@ -61,7 +61,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```


### PR DESCRIPTION
For those of us who were copy pasting the code snippet but ran into syntax errors. 😋

Issue:
Missing equal sign on the code snippet

## What I did
Added the missing equal sign

## How to test
Just a simple text config to correct the syntax on the code snippet example

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
