### PR TITLE
Examples: Change main.js to main.ts to show it's possible

### DIFF
--- a/examples/cra-ts-kitchen-sink/.storybook/main.ts
+++ b/examples/cra-ts-kitchen-sink/.storybook/main.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 const path = require('path');
 
 module.exports = {
@@ -9,7 +10,7 @@ module.exports = {
         tsDocgenLoaderOptions: {
           tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
           shouldExtractLiteralValuesFromEnum: true,
-          propFilter: prop => {
+          propFilter: (prop: any) => {
             // Currently not working, prop.parent is always null.
             if (prop.parent) {
               return !prop.parent.fileName.includes('node_modules/@types/react/');

--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -43,6 +43,7 @@
     "@storybook/preset-create-react-app": "^1.5.0",
     "@storybook/react": "6.0.0-alpha.6",
     "@types/enzyme": "^3.9.0",
+    "@types/node": "13.5.3",
     "@types/react": "^16.8.14",
     "@types/react-dom": "^16.8.2",
     "enzyme": "^3.9.0",
@@ -54,6 +55,7 @@
     "react-scripts": "^3.0.1",
     "tslint": "^6.0.0",
     "tslint-config-airbnb": "^5.11.1",
+    "ts-node": "~7.0.0",
     "typescript": "^3.4.0"
   }
 }

--- a/examples/cra-ts-kitchen-sink/tsconfig.json
+++ b/examples/cra-ts-kitchen-sink/tsconfig.json
@@ -14,6 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react"

--- a/examples/cra-ts-kitchen-sink/tsconfig.json
+++ b/examples/cra-ts-kitchen-sink/tsconfig.json
@@ -14,12 +14,12 @@
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react"
   },
   "include": [
-    "src"
+    "src/**/*",
+    ".storybook/**/*"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,7 +8147,7 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
-buffer-from@1.x, buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -10968,6 +10968,11 @@ diff-sequences@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.1.0.tgz#fd29a46f1c913fd66c22645dc75bffbe43051f32"
   integrity sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==
+
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -29193,6 +29198,20 @@ ts-map@^1.0.3:
   resolved "https://registry.yarnpkg.com/ts-map/-/ts-map-1.0.3.tgz#1c4d218dec813d2103b7e04e4bcf348e1471c1ff"
   integrity sha512-vDWbsl26LIcPGmDpoVzjEP6+hvHZkBkLW7JpvwbCv/5IYPJlsbzCVXY3wsCeAxAUeTclNOUZxnLdGh3VBD/J6w==
 
+ts-node@~7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
+  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
+  dependencies:
+    arrify "^1.0.0"
+    buffer-from "^1.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.6"
+    yn "^2.0.0"
+
 ts-node@~8.6.2:
   version "8.6.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
@@ -31944,6 +31963,11 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
+  integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
 
 yui@^3.18.1:
   version "3.18.1"


### PR DESCRIPTION
Issue: #9765
Hi all =)

The issue claims it's not possible to use `main.ts` inside .storybook dir while it's actually possible since it's required with `serverRequire`. 

## What I did
renamed `main.js` to `main.ts` in `cra-ts-kitchen-sink` and changed a bit tsconfig. 
`tsignore` there is because of the `"isolatedModules": true,` attribute that prevents using 
 commonjs. 

TBD: gonna add this to docs soon.
