### PR TITLE
Patch 3 - typo fix by copy rewrite

### DIFF
--- a/docs/src/pages/presets/introduction/index.md
+++ b/docs/src/pages/presets/introduction/index.md
@@ -29,7 +29,7 @@ That's it. When Storybook starts up, it will configure itself for typescript wit
 
 ## Preset configuration
 
-Presets can also take optional parameters. Sometimes these used by the preset itself, and another common case is to pass them through to configure webpack loaders that are used by the presets.
+Presets can also take optional parameters. These can be used by the preset itself, or passed through to configure the webpack loaders that are used by the preset.
 
 Consider this example:
 

--- a/docs/src/pages/presets/introduction/index.md
+++ b/docs/src/pages/presets/introduction/index.md
@@ -29,7 +29,7 @@ That's it. When Storybook starts up, it will configure itself for typescript wit
 
 ## Preset configuration
 
-Presets can also take optional parameters. These can be used by the preset itself, or passed through to configure the webpack loaders that are used by the preset.
+Presets can also take optional parameters. These can be used by the preset itself or passed through to configure the webpack loaders that are used by the preset.
 
 Consider this example:
 


### PR DESCRIPTION
If reviewers don't agree that my proposed copy rewrite is an improvement, let's at least add the missing 'are': so, "Sometimes these are used..." instead of "Sometimes these used..."

Issue:

## What I did
Fixed typo (missing word) and unclear sentence by rewriting in a more direct voice.

## How to test
Documentation only.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
