### PR TITLE
Replace lodash named imports with specific imports

### DIFF
--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent, useContext } from 'react';
-import { isNil } from 'lodash';
 
 import {
   PropsTable,
@@ -60,7 +59,7 @@ export const getComponentProps = (
       throw new Error(PropsTableError.PROPS_UNSUPPORTED);
     }
     let props = extractProps(component);
-    if (!isNil(exclude)) {
+    if (exclude != null) {
       const { rows } = props as PropsTableRowsProps;
       const { sections } = props as PropsTableSectionsProps;
       if (rows) {

--- a/addons/docs/src/frameworks/react/lib/defaultValues/createDefaultValue.ts
+++ b/addons/docs/src/frameworks/react/lib/defaultValues/createDefaultValue.ts
@@ -1,4 +1,3 @@
-import { isNil } from 'lodash';
 import { PropDefaultValue } from '@storybook/components';
 import { FUNCTION_CAPTION, ELEMENT_CAPTION } from '../captions';
 import {
@@ -19,7 +18,7 @@ import { getPrettyIdentifier } from './prettyIdentifier';
 function generateFunc({ inferedType, ast }: InspectionResult): PropDefaultValue {
   const { identifier } = inferedType as InspectionFunction;
 
-  if (!isNil(identifier)) {
+  if (identifier != null) {
     return createSummaryValue(
       getPrettyIdentifier(inferedType as InspectionIdentifiableInferedType),
       generateCode(ast)
@@ -42,7 +41,7 @@ function generateElement(
   const { inferedType } = inspectionResult;
   const { identifier } = inferedType as InspectionElement;
 
-  if (!isNil(identifier)) {
+  if (identifier != null) {
     if (!isHtmlTag(identifier)) {
       const prettyIdentifier = getPrettyIdentifier(
         inferedType as InspectionIdentifiableInferedType

--- a/addons/docs/src/frameworks/react/lib/defaultValues/createFromRawDefaultProp.ts
+++ b/addons/docs/src/frameworks/react/lib/defaultValues/createFromRawDefaultProp.ts
@@ -1,5 +1,7 @@
 import { PropDefaultValue, PropDef } from '@storybook/components';
-import { isNil, isPlainObject, isArray, isFunction, isString } from 'lodash';
+import isPlainObject from 'lodash/isPlainObject';
+import isFunction from 'lodash/isFunction';
+import isString from 'lodash/isString';
 // @ts-ignore
 import reactElementToJSXString from 'react-element-to-jsx-string';
 import { createSummaryValue, isTooLongForDefaultValueSummary } from '../../../../lib';
@@ -20,7 +22,7 @@ export interface TypeResolvers {
 }
 
 function isReactElement(element: any): boolean {
-  return !isNil(element.$$typeof);
+  return element.$$typeof != null;
 }
 
 export function extractFunctionName(func: Function, propName: string): string {
@@ -44,7 +46,7 @@ function generateReactObject(rawDefaultProp: any) {
 
   const jsx = reactElementToJSXString(rawDefaultProp);
 
-  if (!isNil(displayName)) {
+  if (displayName != null) {
     const prettyIdentifier = getPrettyElementIdentifier(displayName);
 
     return createSummaryValue(prettyIdentifier, prettyIdentifier !== jsx ? jsx : undefined);
@@ -66,7 +68,7 @@ function generateReactObject(rawDefaultProp: any) {
 }
 
 const objectResolver: TypeResolver = rawDefaultProp => {
-  if (isReactElement(rawDefaultProp) && !isNil(rawDefaultProp.type)) {
+  if (isReactElement(rawDefaultProp) && rawDefaultProp.type != null) {
     return generateReactObject(rawDefaultProp);
   }
 
@@ -76,7 +78,7 @@ const objectResolver: TypeResolver = rawDefaultProp => {
     return generateObject(inspectionResult);
   }
 
-  if (isArray(rawDefaultProp)) {
+  if (Array.isArray(rawDefaultProp)) {
     const inspectionResult = inspectValue(JSON.stringify(rawDefaultProp));
 
     return generateArray(inspectionResult);
@@ -92,7 +94,7 @@ const functionResolver: TypeResolver = (rawDefaultProp, propDef) => {
   // Try to display the name of the component. The body of the component is ommited since the code has been transpiled.
   if (isFunction(rawDefaultProp.render)) {
     isElement = true;
-  } else if (!isNil(rawDefaultProp.prototype) && isFunction(rawDefaultProp.prototype.render)) {
+  } else if (rawDefaultProp.prototype != null && isFunction(rawDefaultProp.prototype.render)) {
     isElement = true;
   } else {
     let innerElement;
@@ -110,7 +112,7 @@ const functionResolver: TypeResolver = (rawDefaultProp, propDef) => {
         innerElement = rawDefaultProp();
       }
 
-      if (!isNil(innerElement)) {
+      if (innerElement != null) {
         if (isReactElement(innerElement)) {
           isElement = true;
         }
@@ -121,12 +123,12 @@ const functionResolver: TypeResolver = (rawDefaultProp, propDef) => {
   }
 
   const funcName = extractFunctionName(rawDefaultProp, propDef.name);
-  if (!isNil(funcName)) {
+  if (funcName != null) {
     if (isElement) {
       return createSummaryValue(getPrettyElementIdentifier(funcName));
     }
 
-    if (!isNil(inspectionResult)) {
+    if (inspectionResult != null) {
       inspectionResult = inspectValue(rawDefaultProp.toString());
     }
 
@@ -169,7 +171,7 @@ export function createDefaultValueFromRawDefaultProp(
   try {
     // Keep the extra () otherwise it will fail for functions.
     // eslint-disable-next-line prettier/prettier
-    switch (typeof (rawDefaultProp)) {
+    switch (typeof rawDefaultProp) {
       case 'string':
         return typeResolvers.string(rawDefaultProp, propDef);
       case 'object':

--- a/addons/docs/src/frameworks/react/lib/defaultValues/createFromRawDefaultProp.ts
+++ b/addons/docs/src/frameworks/react/lib/defaultValues/createFromRawDefaultProp.ts
@@ -170,7 +170,6 @@ export function createDefaultValueFromRawDefaultProp(
 ): PropDefaultValue {
   try {
     // Keep the extra () otherwise it will fail for functions.
-    // eslint-disable-next-line prettier/prettier
     switch (typeof rawDefaultProp) {
       case 'string':
         return typeResolvers.string(rawDefaultProp, propDef);

--- a/addons/docs/src/frameworks/react/lib/inspection/acornParser.ts
+++ b/addons/docs/src/frameworks/react/lib/inspection/acornParser.ts
@@ -1,7 +1,6 @@
 import { Parser } from 'acorn';
 // @ts-ignore
 import jsx from 'acorn-jsx';
-import { isNil } from 'lodash';
 import estree from 'estree';
 // @ts-ignore
 import * as acornWalk from 'acorn-walk';
@@ -32,7 +31,7 @@ const acornParser = Parser.extend(jsx());
 
 // Cannot use "estree.Identifier" type because this function also support "JSXIdentifier".
 function extractIdentifierName(identifierNode: any) {
-  return !isNil(identifierNode) ? identifierNode.name : null;
+  return identifierNode != null ? identifierNode.name : null;
 }
 
 function filterAncestors(ancestors: estree.Node[]): estree.Node[] {
@@ -91,7 +90,7 @@ function parseFunction(
     ACORN_WALK_VISITORS
   );
 
-  const isJsx = !isNil(innerJsxElementNode);
+  const isJsx = innerJsxElementNode != null;
 
   const inferedType: InspectionFunction | InspectionElement = {
     type: isJsx ? InspectionType.ELEMENT : InspectionType.FUNCTION,
@@ -100,7 +99,7 @@ function parseFunction(
   };
 
   const identifierName = extractIdentifierName((funcNode as estree.FunctionExpression).id);
-  if (!isNil(identifierName)) {
+  if (identifierName != null) {
     inferedType.identifier = identifierName;
   }
 
@@ -127,7 +126,7 @@ function parseClass(
   );
 
   const inferedType: any = {
-    type: !isNil(innerJsxElementNode) ? InspectionType.ELEMENT : InspectionType.CLASS,
+    type: innerJsxElementNode != null ? InspectionType.ELEMENT : InspectionType.CLASS,
     identifier: extractIdentifierName(classNode.id),
   };
 
@@ -143,7 +142,7 @@ function parseJsxElement(jsxElementNode: any): ParsingResult<InspectionElement> 
   };
 
   const identifierName = extractIdentifierName(jsxElementNode.openingElement.name);
-  if (!isNil(identifierName)) {
+  if (identifierName != null) {
     inferedType.identifier = identifierName;
   }
 
@@ -212,13 +211,13 @@ export function parse(value: string): ParsingResult<InspectionInferedType> {
     ast,
   };
 
-  if (!isNil(ast.body[0])) {
+  if (ast.body[0] != null) {
     const rootNode = ast.body[0];
 
     switch (rootNode.type) {
       case 'ExpressionStatement': {
         const expressionResult = parseExpression(rootNode.expression);
-        if (!isNil(expressionResult)) {
+        if (expressionResult != null) {
           parsingResult = expressionResult as any;
         }
         break;

--- a/addons/docs/src/frameworks/react/propTypes/createType.ts
+++ b/addons/docs/src/frameworks/react/propTypes/createType.ts
@@ -1,4 +1,3 @@
-import { isNil } from 'lodash';
 import { PropType } from '@storybook/components';
 import { createSummaryValue, isTooLongForTypeSummary } from '../../../lib';
 import { ExtractedProp, DocgenPropType } from '../../../lib/docgen';
@@ -74,7 +73,7 @@ function createTypeDef({
     name,
     short,
     compact,
-    full: !isNil(full) ? full : short,
+    full: full != null ? full : short,
     inferedType,
   };
 }
@@ -137,7 +136,7 @@ function generateTypeFromString(value: string, originalTypeName: string): TypeDe
     case InspectionType.ELEMENT: {
       const { identifier } = inferedType as InspectionElement;
 
-      short = !isNil(identifier) && !isHtmlTag(identifier) ? identifier : ELEMENT_CAPTION;
+      short = identifier != null && !isHtmlTag(identifier) ? identifier : ELEMENT_CAPTION;
       compact = splitIntoLines(value).length === 1 ? value : null;
       full = value;
       break;
@@ -167,7 +166,7 @@ function generateTypeFromString(value: string, originalTypeName: string): TypeDe
 }
 
 function generateCustom({ raw }: DocgenPropType): TypeDef {
-  if (!isNil(raw)) {
+  if (raw != null) {
     return generateTypeFromString(raw, PropTypesType.CUSTOM);
   }
 
@@ -181,8 +180,8 @@ function generateCustom({ raw }: DocgenPropType): TypeDef {
 function generateFunc(extractedProp: ExtractedProp): TypeDef {
   const { jsDocTags } = extractedProp;
 
-  if (!isNil(jsDocTags)) {
-    if (!isNil(jsDocTags.params) || !isNil(jsDocTags.returns)) {
+  if (jsDocTags != null) {
+    if (jsDocTags.params != null || jsDocTags.returns != null) {
       return createTypeDef({
         name: PropTypesType.FUNC,
         short: generateShortFuncSignature(jsDocTags.params, jsDocTags.returns),
@@ -225,7 +224,7 @@ function generateObjectOf(type: DocgenPropType, extractedProp: ExtractedProp): T
   return createTypeDef({
     name: PropTypesType.OBJECTOF,
     short: objectOf(short),
-    compact: !isNil(compact) ? objectOf(compact) : null,
+    compact: compact != null ? objectOf(compact) : null,
     full: objectOf(full),
   });
 }
@@ -248,7 +247,7 @@ function generateUnion(type: DocgenPropType, extractedProp: ExtractedProp): Type
     return createTypeDef({
       name: PropTypesType.UNION,
       short: values.short.join(' | '),
-      compact: values.compact.every((x: string) => !isNil(x)) ? values.compact.join(' | ') : null,
+      compact: values.compact.every((x: string) => x != null) ? values.compact.join(' | ') : null,
       full: values.full.join(' | '),
     });
   }
@@ -280,7 +279,7 @@ function generateEnum(type: DocgenPropType): TypeDef {
     return createTypeDef({
       name: PropTypesType.ENUM,
       short: values.short.join(' | '),
-      compact: values.compact.every((x: string) => !isNil(x)) ? values.compact.join(' | ') : null,
+      compact: values.compact.every((x: string) => x != null) ? values.compact.join(' | ') : null,
       full: values.full.join(' | '),
     });
   }
@@ -300,7 +299,7 @@ function createArrayOfObjectTypeDef(short: string, compact: string, full: string
   return createTypeDef({
     name: PropTypesType.ARRAYOF,
     short: braceAfter(short),
-    compact: !isNil(compact) ? braceAround(compact) : null,
+    compact: compact != null ? braceAround(compact) : null,
     full: braceAround(full),
   });
 }
@@ -361,7 +360,7 @@ export function createType(extractedProp: ExtractedProp): PropType {
   const { type } = extractedProp.docgenInfo;
 
   // A type could be null if a defaultProp has been provided without a type definition.
-  if (isNil(type)) {
+  if (type == null) {
     return null;
   }
 
@@ -376,7 +375,7 @@ export function createType(extractedProp: ExtractedProp): PropType {
       case PropTypesType.ARRAYOF: {
         const { short, compact, full } = generateType(type, extractedProp);
 
-        if (!isNil(compact)) {
+        if (compact != null) {
           if (!isTooLongForTypeSummary(compact)) {
             return createSummaryValue(compact);
           }

--- a/addons/docs/src/frameworks/react/propTypes/generateFuncSignature.ts
+++ b/addons/docs/src/frameworks/react/propTypes/generateFuncSignature.ts
@@ -1,12 +1,11 @@
-import { isNil } from 'lodash';
 import { ExtractedJsDocParam, ExtractedJsDocReturns } from '../../../lib/jsdocParser';
 
 export function generateFuncSignature(
   params: ExtractedJsDocParam[],
   returns: ExtractedJsDocReturns
 ): string {
-  const hasParams = !isNil(params);
-  const hasReturns = !isNil(returns);
+  const hasParams = params != null;
+  const hasReturns = returns != null;
 
   if (!hasParams && !hasReturns) {
     return '';
@@ -19,7 +18,7 @@ export function generateFuncSignature(
       const prettyName = x.getPrettyName();
       const typeName = x.getTypeName();
 
-      if (!isNil(typeName)) {
+      if (typeName != null) {
         return `${prettyName}: ${typeName}`;
       }
 
@@ -42,8 +41,8 @@ export function generateShortFuncSignature(
   params: ExtractedJsDocParam[],
   returns: ExtractedJsDocReturns
 ): string {
-  const hasParams = !isNil(params);
-  const hasReturns = !isNil(returns);
+  const hasParams = params != null;
+  const hasReturns = returns != null;
 
   if (!hasParams && !hasReturns) {
     return '';

--- a/addons/docs/src/frameworks/react/propTypes/handleProp.ts
+++ b/addons/docs/src/frameworks/react/propTypes/handleProp.ts
@@ -1,4 +1,3 @@
-import { isNil } from 'lodash';
 import { PropDef } from '@storybook/components';
 import { ExtractedProp } from '../../../lib/docgen';
 import { createType } from './createType';
@@ -11,25 +10,25 @@ export function enhancePropTypesProp(extractedProp: ExtractedProp, rawDefaultPro
   const { propDef } = extractedProp;
 
   const newtype = createType(extractedProp);
-  if (!isNil(newtype)) {
+  if (newtype != null) {
     propDef.type = newtype;
   }
 
   const { defaultValue } = extractedProp.docgenInfo;
-  if (!isNil(defaultValue) && !isNil(defaultValue.value)) {
+  if (defaultValue != null && defaultValue.value != null) {
     const newDefaultValue = createDefaultValue(defaultValue.value);
 
-    if (!isNil(newDefaultValue)) {
+    if (newDefaultValue != null) {
       propDef.defaultValue = newDefaultValue;
     }
-  } else if (!isNil(rawDefaultProp)) {
+  } else if (rawDefaultProp != null) {
     const newDefaultValue = createDefaultValueFromRawDefaultProp(
       rawDefaultProp,
       propDef,
       rawDefaultPropTypeResolvers
     );
 
-    if (!isNil(newDefaultValue)) {
+    if (newDefaultValue != null) {
       propDef.defaultValue = newDefaultValue;
     }
   }
@@ -41,7 +40,7 @@ export function enhancePropTypesProps(
   extractedProps: ExtractedProp[],
   component: Component
 ): PropDef[] {
-  const rawDefaultProps = !isNil(component.defaultProps) ? component.defaultProps : {};
+  const rawDefaultProps = component.defaultProps != null ? component.defaultProps : {};
   const enhancedProps = extractedProps.map(x =>
     enhancePropTypesProp(x, rawDefaultProps[x.propDef.name])
   );

--- a/addons/docs/src/frameworks/react/propTypes/rawDefaultPropResolvers.ts
+++ b/addons/docs/src/frameworks/react/propTypes/rawDefaultPropResolvers.ts
@@ -1,4 +1,3 @@
-import { isNil } from 'lodash';
 import { TypeResolver, extractFunctionName, createTypeResolvers } from '../lib/defaultValues';
 import { createSummaryValue } from '../../../lib';
 import { FUNCTION_CAPTION, ELEMENT_CAPTION } from '../lib';
@@ -12,7 +11,7 @@ const funcResolver: TypeResolver = (rawDefaultProp, { name, type }) => {
   const isElement = type.summary === 'element' || type.summary === 'elementType';
 
   const funcName = extractFunctionName(rawDefaultProp, name);
-  if (!isNil(funcName)) {
+  if (funcName != null) {
     // Try to display the name of the component. The body of the component is ommited since the code has been transpiled.
     if (isElement) {
       return createSummaryValue(getPrettyElementIdentifier(funcName));

--- a/addons/docs/src/frameworks/react/propTypes/sortProps.ts
+++ b/addons/docs/src/frameworks/react/propTypes/sortProps.ts
@@ -1,5 +1,4 @@
 import { PropDef } from '@storybook/components';
-import { isNil } from 'lodash';
 import { Component } from '../../../blocks/shared';
 
 // react-docgen doesn't returned the props in the order they were defined in the "propTypes" object of the component.
@@ -11,7 +10,7 @@ export function keepOriginalDefinitionOrder(
   // eslint-disable-next-line react/forbid-foreign-prop-types
   const { propTypes } = component;
 
-  if (!isNil(propTypes)) {
+  if (propTypes != null) {
     return Object.keys(propTypes)
       .map(x => extractedProps.find(y => y.name === x))
       .filter(x => x);

--- a/addons/docs/src/frameworks/react/typeScript/handleProp.ts
+++ b/addons/docs/src/frameworks/react/typeScript/handleProp.ts
@@ -1,4 +1,3 @@
-import { isNil } from 'lodash';
 import { PropDef } from '@storybook/components';
 import { ExtractedProp } from '../../../lib/docgen';
 import { createDefaultValue, createDefaultValueFromRawDefaultProp } from '../lib/defaultValues';
@@ -7,15 +6,15 @@ export function enhanceTypeScriptProp(extractedProp: ExtractedProp, rawDefaultPr
   const { propDef } = extractedProp;
 
   const { defaultValue } = extractedProp.docgenInfo;
-  if (!isNil(defaultValue) && !isNil(defaultValue.value)) {
+  if (defaultValue != null && defaultValue.value != null) {
     const newDefaultValue = createDefaultValue(defaultValue.value);
-    if (!isNil(newDefaultValue)) {
+    if (newDefaultValue != null) {
       propDef.defaultValue = newDefaultValue;
     }
-  } else if (!isNil(rawDefaultProp)) {
+  } else if (rawDefaultProp != null) {
     const newDefaultValue = createDefaultValueFromRawDefaultProp(rawDefaultProp, propDef);
 
-    if (!isNil(newDefaultValue)) {
+    if (newDefaultValue != null) {
       propDef.defaultValue = newDefaultValue;
     }
   }

--- a/addons/docs/src/lib/docgen/createPropDef.ts
+++ b/addons/docs/src/lib/docgen/createPropDef.ts
@@ -1,4 +1,3 @@
-import { isNil } from 'lodash';
 import { PropDef, PropDefaultValue } from '@storybook/components';
 import { TypeSystem, DocgenInfo, DocgenType, DocgenPropDefaultValue } from './types';
 import { JsDocParsingResult } from '../jsdocParser';
@@ -15,11 +14,11 @@ export type PropDefFactory = (
 
 function createType(type: DocgenType) {
   // A type could be null if a defaultProp has been provided without a type definition.
-  return !isNil(type) ? createSummaryValue(type.name) : null;
+  return type != null ? createSummaryValue(type.name) : null;
 }
 
 function createDefaultValue(defaultValue: DocgenPropDefaultValue): PropDefaultValue {
-  if (!isNil(defaultValue)) {
+  if (defaultValue != null) {
     const { value } = defaultValue;
 
     if (!isDefaultValueBlacklisted(value)) {
@@ -46,13 +45,13 @@ function applyJsDocResult(propDef: PropDef, jsDocParsingResult: JsDocParsingResu
   if (jsDocParsingResult.includesJsDoc) {
     const { description, extractedTags } = jsDocParsingResult;
 
-    if (!isNil(description)) {
+    if (description != null) {
       // eslint-disable-next-line no-param-reassign
       propDef.description = jsDocParsingResult.description;
     }
 
-    const hasParams = !isNil(extractedTags.params);
-    const hasReturns = !isNil(extractedTags.returns) && !isNil(extractedTags.returns.type);
+    const hasParams = extractedTags.params != null;
+    const hasReturns = extractedTags.returns != null && extractedTags.returns.type != null;
 
     if (hasParams || hasReturns) {
       // eslint-disable-next-line no-param-reassign

--- a/addons/docs/src/lib/docgen/extractDocgenProps.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.ts
@@ -1,4 +1,3 @@
-import { isNil } from 'lodash';
 import { PropDef } from '@storybook/components';
 import { Component } from '../../blocks/shared';
 import { ExtractedJsDoc, parseJsDoc } from '../jsdocParser';
@@ -16,15 +15,15 @@ export interface ExtractedProp {
 export type ExtractProps = (component: Component, section: string) => ExtractedProp[];
 
 const getTypeSystem = (docgenInfo: DocgenInfo): TypeSystem => {
-  if (!isNil(docgenInfo.type)) {
+  if (docgenInfo.type != null) {
     return TypeSystem.JAVASCRIPT;
   }
 
-  if (!isNil(docgenInfo.flowType)) {
+  if (docgenInfo.flowType != null) {
     return TypeSystem.FLOW;
   }
 
-  if (!isNil(docgenInfo.tsType)) {
+  if (docgenInfo.tsType != null) {
     return TypeSystem.TYPESCRIPT;
   }
 
@@ -49,7 +48,7 @@ export const extractComponentSectionObject = (docgenSection: any) => {
     .map(propName => {
       const docgenInfo = docgenSection[propName];
 
-      return !isNil(docgenInfo)
+      return docgenInfo != null
         ? extractProp(propName, docgenInfo, typeSystem, createPropDef)
         : null;
     })
@@ -93,5 +92,5 @@ function extractProp(
 }
 
 export function extractComponentDescription(component?: Component): string {
-  return !isNil(component) && getDocgenDescription(component);
+  return component != null && getDocgenDescription(component);
 }

--- a/addons/docs/src/lib/docgen/flow/createDefaultValue.ts
+++ b/addons/docs/src/lib/docgen/flow/createDefaultValue.ts
@@ -1,5 +1,4 @@
 import { PropDefaultValue } from '@storybook/components';
-import { isNil } from 'lodash';
 import { DocgenPropDefaultValue, DocgenPropType } from '../types';
 import { createSummaryValue, isTooLongForDefaultValueSummary } from '../../utils';
 import { isDefaultValueBlacklisted } from '../utils/defaultValue';
@@ -8,7 +7,7 @@ export function createDefaultValue(
   defaultValue: DocgenPropDefaultValue,
   type: DocgenPropType
 ): PropDefaultValue {
-  if (!isNil(defaultValue)) {
+  if (defaultValue != null) {
     const { value } = defaultValue;
 
     if (!isDefaultValueBlacklisted(value)) {

--- a/addons/docs/src/lib/docgen/flow/createType.ts
+++ b/addons/docs/src/lib/docgen/flow/createType.ts
@@ -1,5 +1,4 @@
 import { PropType } from '@storybook/components';
-import { isNil } from 'lodash';
 import { DocgenFlowType } from '../types';
 import { createSummaryValue, isTooLongForTypeSummary } from '../../utils';
 
@@ -13,11 +12,11 @@ interface DocgenFlowUnionType extends DocgenFlowType {
 }
 
 function generateUnion({ name, raw, elements }: DocgenFlowUnionType): PropType {
-  if (!isNil(raw)) {
+  if (raw != null) {
     return createSummaryValue(raw);
   }
 
-  if (!isNil(elements)) {
+  if (elements != null) {
     return createSummaryValue(elements.map(x => x.value).join(' | '));
   }
 
@@ -25,7 +24,7 @@ function generateUnion({ name, raw, elements }: DocgenFlowUnionType): PropType {
 }
 
 function generateFuncSignature({ type, raw }: DocgenFlowType): PropType {
-  if (!isNil(raw)) {
+  if (raw != null) {
     return createSummaryValue(raw);
   }
 
@@ -33,7 +32,7 @@ function generateFuncSignature({ type, raw }: DocgenFlowType): PropType {
 }
 
 function generateObjectSignature({ type, raw }: DocgenFlowType): PropType {
-  if (!isNil(raw)) {
+  if (raw != null) {
     return !isTooLongForTypeSummary(raw) ? createSummaryValue(raw) : createSummaryValue(type, raw);
   }
 
@@ -47,7 +46,7 @@ function generateSignature(flowType: DocgenFlowType): PropType {
 }
 
 function generateDefault({ name, raw }: DocgenFlowType): PropType {
-  if (!isNil(raw)) {
+  if (raw != null) {
     return !isTooLongForTypeSummary(raw) ? createSummaryValue(raw) : createSummaryValue(name, raw);
   }
 
@@ -56,7 +55,7 @@ function generateDefault({ name, raw }: DocgenFlowType): PropType {
 
 export function createType(type: DocgenFlowType): PropType {
   // A type could be null if a defaultProp has been provided without a type definition.
-  if (isNil(type)) {
+  if (type == null) {
     return null;
   }
 

--- a/addons/docs/src/lib/docgen/typeScript/createDefaultValue.ts
+++ b/addons/docs/src/lib/docgen/typeScript/createDefaultValue.ts
@@ -1,11 +1,10 @@
 import { PropDefaultValue } from '@storybook/components';
-import { isNil } from 'lodash';
 import { DocgenInfo } from '../types';
 import { createSummaryValue } from '../../utils';
 import { isDefaultValueBlacklisted } from '../utils/defaultValue';
 
 export function createDefaultValue({ defaultValue }: DocgenInfo): PropDefaultValue {
-  if (!isNil(defaultValue)) {
+  if (defaultValue != null) {
     const { value } = defaultValue;
 
     if (!isDefaultValueBlacklisted(value)) {

--- a/addons/docs/src/lib/docgen/typeScript/createType.ts
+++ b/addons/docs/src/lib/docgen/typeScript/createType.ts
@@ -1,11 +1,10 @@
 import { PropType } from '@storybook/components';
-import { isNil } from 'lodash';
 import { DocgenInfo } from '../types';
 import { createSummaryValue } from '../../utils';
 
 export function createType({ tsType, required }: DocgenInfo): PropType {
   // A type could be null if a defaultProp has been provided without a type definition.
-  if (isNil(tsType)) {
+  if (tsType == null) {
     return null;
   }
 

--- a/addons/docs/src/lib/docgen/utils/docgenInfo.ts
+++ b/addons/docs/src/lib/docgen/utils/docgenInfo.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 
-import { isNil } from 'lodash';
 import { Component } from '../../../blocks/shared';
 import { str } from './string';
 
@@ -9,7 +8,7 @@ export function hasDocgen(component: Component): boolean {
 }
 
 export function isValidDocgenSection(docgenSection: any) {
-  return !isNil(docgenSection) && Object.keys(docgenSection).length > 0;
+  return docgenSection != null && Object.keys(docgenSection).length > 0;
 }
 
 export function getDocgenSection(component: Component, section: string): any {

--- a/addons/docs/src/lib/jsdocParser.ts
+++ b/addons/docs/src/lib/jsdocParser.ts
@@ -1,5 +1,4 @@
 import doctrine, { Annotation } from 'doctrine';
-import { isNil } from 'lodash';
 
 export interface ExtractedJsDocParam {
   name: string;
@@ -35,7 +34,7 @@ export interface JsDocParsingResult {
 export type ParseJsDoc = (value?: string, options?: JsDocParsingOptions) => JsDocParsingResult;
 
 function containsJsDoc(value?: string): boolean {
-  return !isNil(value) && value.includes('@');
+  return value != null && value.includes('@');
 }
 
 function parse(content: string, tags: string[]): Annotation {
@@ -112,8 +111,8 @@ function extractJsDocTags(ast: doctrine.Annotation): ExtractedJsDoc {
         case 'arg':
         case 'argument': {
           const paramTag = extractParam(tag);
-          if (!isNil(paramTag)) {
-            if (isNil(extractedTags.params)) {
+          if (paramTag != null) {
+            if (extractedTags.params == null) {
               extractedTags.params = [];
             }
             extractedTags.params.push(paramTag);
@@ -122,7 +121,7 @@ function extractJsDocTags(ast: doctrine.Annotation): ExtractedJsDoc {
         }
         case 'returns': {
           const returnsTag = extractReturns(tag);
-          if (!isNil(returnsTag)) {
+          if (returnsTag != null) {
             extractedTags.returns = returnsTag;
           }
           break;
@@ -140,7 +139,7 @@ function extractParam(tag: doctrine.Tag): ExtractedJsDocParam {
   const paramName = tag.name;
 
   // When the @param doesn't have a name but have a type and a description, "null-null" is returned.
-  if (!isNil(paramName) && paramName !== 'null-null') {
+  if (paramName != null && paramName !== 'null-null') {
     return {
       name: tag.name,
       type: tag.type,
@@ -156,7 +155,7 @@ function extractParam(tag: doctrine.Tag): ExtractedJsDocParam {
         return tag.name;
       },
       getTypeName: () => {
-        return !isNil(tag.type) ? extractTypeName(tag.type) : null;
+        return tag.type != null ? extractTypeName(tag.type) : null;
       },
     };
   }
@@ -165,7 +164,7 @@ function extractParam(tag: doctrine.Tag): ExtractedJsDocParam {
 }
 
 function extractReturns(tag: doctrine.Tag): ExtractedJsDocReturns {
-  if (!isNil(tag.type)) {
+  if (tag.type != null) {
     return {
       type: tag.type,
       description: tag.description,
@@ -185,7 +184,7 @@ function extractTypeName(type: doctrine.Type): string {
 
   if (type.type === 'RecordType') {
     const recordFields = type.fields.map((field: doctrine.type.FieldType) => {
-      if (!isNil(field.value)) {
+      if (field.value != null) {
         const valueTypeName = extractTypeName(field.value);
 
         return `${field.key}: ${valueTypeName}`;
@@ -209,7 +208,7 @@ function extractTypeName(type: doctrine.Type): string {
   }
 
   if (type.type === 'TypeApplication') {
-    if (!isNil(type.expression)) {
+    if (type.expression != null) {
       if ((type.expression as doctrine.type.NameExpression).name === 'Array') {
         const arrayType = extractTypeName(type.applications[0]);
 

--- a/docs/src/pages/examples/index.jsx
+++ b/docs/src/pages/examples/index.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { values } from 'lodash';
 
 import Examples from '../../components/Grid/Examples';
 import examples from './_examples.yml';
 
-const examplesArray = values(examples).map(example => ({
+const examplesArray = Object.values(examples).map(example => ({
   ...example,
   // eslint-disable-next-line import/no-dynamic-require, global-require
   thumbnailSrc: require(`./thumbnails/${example.thumbnail}`),

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { values } from 'lodash';
 import Homepage from '../components/Homepage';
 import users from './_users.yml';
 
-const usersArray = values(users).map(user => ({
+const usersArray = Object.values(users).map(user => ({
   ...user,
   // eslint-disable-next-line import/no-dynamic-require, global-require
   logoSrc: require(`./logos/${user.logo}`),

--- a/docs/src/stories/implementations.js
+++ b/docs/src/stories/implementations.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { values } from 'lodash';
 
 import Homepage from '../components/Homepage';
 import Header from '../components/Header';
@@ -24,7 +23,7 @@ import exampleData from './_examples.yml';
 
 export default {
   'Homepage.page': (
-    <Homepage featuredStorybooks={docsData.featuredStorybooks} users={values(users)} />
+    <Homepage featuredStorybooks={docsData.featuredStorybooks} users={Object.values(users)} />
   ),
   'Homepage.header': <Header />,
   'Homepage.heading': <Heading />,
@@ -32,7 +31,7 @@ export default {
   'Homepage.built-for': <Platforms />,
   'Homepage.main-links': <MainLinks />,
   'Homepage.featured-storybooks': <Featured featuredStorybooks={docsData.featuredStorybooks} />,
-  'Homepage.used-by': <UsedBy users={values(users)} />,
+  'Homepage.used-by': <UsedBy users={Object.values(users)} />,
   'Homepage.footer': <Footer />,
   'Docs.page': (
     <Docs
@@ -60,7 +59,7 @@ export default {
       selectedItem={docsData.selectedItem.id}
     />
   ),
-  'Grid.grid-item': <GridItem {...values(exampleData)[0]} />,
-  'Grid.grid': <Grid items={values(exampleData)} columnWidth={300} />,
-  'Grid.examples': <Examples items={values(exampleData)} />,
+  'Grid.grid-item': <GridItem {...Object.values(exampleData)[0]} />,
+  'Grid.grid': <Grid items={Object.values(exampleData)} columnWidth={300} />,
+  'Grid.examples': <Examples items={Object.values(exampleData)} />,
 };

--- a/lib/components/src/blocks/PropsTable/PropJsDoc.tsx
+++ b/lib/components/src/blocks/PropsTable/PropJsDoc.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 import { styled } from '@storybook/theming';
-import { isNil } from 'lodash';
 import { JsDocTags } from './PropDef';
 import { codeCommon } from '../../typography/shared';
 
@@ -65,7 +64,7 @@ export const Table = styled.table(({ theme }) => ({
 export const PropJsDoc: FC<PropJsDocProps> = ({ tags }) => {
   const params = (tags.params || []).filter(x => x.description);
   const hasDisplayableParams = params.length !== 0;
-  const hasDisplayableReturns = !isNil(tags.returns) && !isNil(tags.returns.description);
+  const hasDisplayableReturns = tags.returns != null && tags.returns.description != null;
 
   if (!hasDisplayableParams && !hasDisplayableReturns) {
     return null;

--- a/lib/components/src/blocks/PropsTable/PropRow.tsx
+++ b/lib/components/src/blocks/PropsTable/PropRow.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 import Markdown from 'markdown-to-jsx';
-import { isNil } from 'lodash';
 import { transparentize } from 'polished';
 import { styled } from '@storybook/theming';
 import { PropDef } from './PropDef';
@@ -55,7 +54,7 @@ const TypeWithJsDoc = styled.div<{ hasDescription: boolean }>(({ theme, hasDescr
 export const PropRow: FC<PropRowProps> = ({
   row: { name, type, required, description, defaultValue, jsDocTags },
 }) => {
-  const hasDescription = !isNil(description) && description !== '';
+  const hasDescription = description != null && description !== '';
 
   return (
     <tr>
@@ -69,7 +68,7 @@ export const PropRow: FC<PropRowProps> = ({
             <Markdown>{description}</Markdown>
           </Description>
         )}
-        {!isNil(jsDocTags) ? (
+        {jsDocTags != null ? (
           <>
             <TypeWithJsDoc hasDescription={hasDescription}>
               <PropValue value={type} />

--- a/lib/components/src/blocks/PropsTable/PropValue.tsx
+++ b/lib/components/src/blocks/PropsTable/PropValue.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useState } from 'react';
-import { isNil } from 'lodash';
 import { styled } from '@storybook/theming';
 import memoize from 'memoizerific';
 import { PropSummaryValue } from './PropDef';
@@ -81,7 +80,7 @@ const PropSummary: FC<PropSummaryProps> = ({ value }) => {
     summary !== undefined && summary !== null && typeof summary.toString === 'function'
       ? summary.toString()
       : summary;
-  if (isNil(detail)) {
+  if (detail == null) {
     return <PropText text={summaryAsString} />;
   }
 
@@ -111,5 +110,5 @@ const PropSummary: FC<PropSummaryProps> = ({ value }) => {
 };
 
 export const PropValue: FC<PropValueProps> = ({ value }) => {
-  return isNil(value) ? <EmptyProp /> : <PropSummary value={value} />;
+  return value == null ? <EmptyProp /> : <PropSummary value={value} />;
 };


### PR DESCRIPTION
fix: replace the use of isNill to the double eq comparison against null.

Issue: fix #9778
 
## What I did

- Replace named imports for lodash to specific imports.
- Replace imports for `lodash/isNil` with non-strict null comparison. Is what `isNil` have btw.
- Replace some `lodash/values` with `Object.values` (what is also being used in the rest of the codebase).

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

Thank you!