### PR TITLE
import react-syntax-highlighter/create-element from cjs

### DIFF
--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -12,7 +12,7 @@ import typescript from 'react-syntax-highlighter/dist/cjs/languages/prism/typesc
 
 import { PrismLight as ReactSyntaxHighlighter } from 'react-syntax-highlighter';
 // @ts-ignore
-import createElement from 'react-syntax-highlighter/dist/esm/create-element';
+import createElement from 'react-syntax-highlighter/dist/cjs/create-element';
 import { ActionBar } from '../ActionBar/ActionBar';
 import { ScrollArea } from '../ScrollArea/ScrollArea';
 


### PR DESCRIPTION
Issue: #9279

This pr is the copy of https://github.com/storybookjs/storybook/pull/9780
Looks like create-element should also be imported from cjs

What I did
This is a splited task from #9292

Changed imports from ESModules to CommonJS modules for react-syntax-highlighter.



How to test
Nothing to test