### PR TITLE
Addon-viewport: Fix Galaxy S9's viewport size

### DIFF
--- a/addons/viewport/src/defaults.ts
+++ b/addons/viewport/src/defaults.ts
@@ -92,8 +92,8 @@ export const INITIAL_VIEWPORTS: ViewportMap = {
   galaxys9: {
     name: 'Galaxy S9',
     styles: {
-      height: '1480px',
-      width: '720px',
+      height: '740px',
+      width: '360px',
     },
     type: 'mobile',
   },


### PR DESCRIPTION
Galaxy S9's viewport size is 740x360. See https://yesviz.com/devices/s9/.

Issue:

## What I did

Fixed Galaxy S9 viewport size in the viewport addon's defaults.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
