### PR TITLE
Core: Remove legacy data from Story Store

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 - [Migration](#migration)
   - [From version 5.3.x to 6.0.x](#from-version-53x-to-60x)
     - [New addon presets](#new-addon-presets)
+    - [Removed legacy story APIs](#removed-legacy-story-apis)
   - [From version 5.2.x to 5.3.x](#from-version-52x-to-53x)
     - [To main.js configuration](#to-mainjs-configuration)
     - [Create React App preset](#create-react-app-preset)
@@ -124,6 +125,14 @@ MyNonCheckedStory.story = {
   },
 };
 ```
+
+### Removed Legacy Story APIs
+
+In 6.0 we removed a set of APIs from the underlying `StoryStore` (which wasn't publicly accessible):
+
+- `getStories`, `getStoryFileName`, `getStoryAndParameters`, `getStory`, `getStoryWithContext`, `hasStoryKind`, `hasStory`, `dumpStoryBook`, `size`, `clean`
+
+Although these were private APIs, if you were using them, you could probably use the newer APIs (which are still private): `getStoriesForKind`, `getRawStory`, `removeStoryKind`, `remove`.
 
 ## From version 5.2.x to 5.3.x
 

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -652,7 +652,7 @@ describe('preview.client_api', () => {
           expect(entry.stories).toHaveLength(1);
           expect(entry.stories[0].name).toBe('story');
 
-          expect(entry.stories[0].render).toBe(stories[0]);
+          expect(entry.stories[0].render()).toBe('story1');
         }
 
         storiesOf('kind', module).add('story', stories[1]);
@@ -669,7 +669,7 @@ describe('preview.client_api', () => {
           expect(entry.stories).toHaveLength(1);
           expect(entry.stories[0].name).toBe('story');
 
-          expect(entry.stories[0].render).toBe(stories[1]);
+          expect(entry.stories[0].render()).toBe('story2');
         }
       });
     });

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -652,12 +652,7 @@ describe('preview.client_api', () => {
           expect(entry.stories).toHaveLength(1);
           expect(entry.stories[0].name).toBe('story');
 
-          // v3 returns the same function we passed in
-          if (jest.isMockFunction(entry.stories[0].render)) {
-            expect(entry.stories[0].render).toBe(stories[0]);
-          } else {
-            expect(entry.stories[0].render()).toBe('story1');
-          }
+          expect(entry.stories[0].render).toBe(stories[0]);
         }
 
         storiesOf('kind', module).add('story', stories[1]);
@@ -674,12 +669,7 @@ describe('preview.client_api', () => {
           expect(entry.stories).toHaveLength(1);
           expect(entry.stories[0].name).toBe('story');
 
-          // v3 returns the same function we passed in
-          if (jest.isMockFunction(entry.stories[0].render)) {
-            expect(entry.stories[0].render).toBe(stories[0]);
-          } else {
-            expect(entry.stories[0].render()).toBe('story2');
-          }
+          expect(entry.stories[0].render).toBe(stories[1]);
         }
       });
     });

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -274,18 +274,7 @@ This is probably not what you intended. Read more here: https://github.com/story
     return api;
   };
 
-  // legacy
-  getStorybook = () =>
-    this._storyStore.getStoryKinds().map(kind => {
-      const fileName = this._storyStore.getStoryFileName(kind);
-
-      const stories = this._storyStore.getStories(kind).map(name => {
-        const render = this._storyStore.getStoryWithContext(kind, name);
-        return { name, render };
-      });
-
-      return { kind, fileName, stories };
-    });
+  getStorybook = () => this._storyStore.getStorybook();
 
   raw = () => this._storyStore.raw();
 

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -223,59 +223,12 @@ describe('preview.story_store', () => {
     });
   });
 
-  describe('dumpStoryBook/getStoriesForManager', () => {
-    it('should return nothing when empty', () => {
-      const store = new StoryStore({ channel });
-      expect(store.dumpStoryBook()).toEqual([]);
-      expect(Object.keys(store.getStoriesForManager())).toEqual([]);
-    });
-
-    it('should return storybook with stories', () => {
-      const store = new StoryStore({ channel });
-
-      store.addStory(...make('kind-1', 'story-1.1', () => 0));
-      store.addStory(...make('kind-1', 'story-1.2', () => 0));
-      store.addStory(...make('kind-2', 'story-2.1', () => 0));
-      store.addStory(...make('kind-2', 'story-2.2', () => 0));
-
-      expect(store.dumpStoryBook()).toEqual([
-        {
-          kind: 'kind-1',
-          stories: ['story-1.1', 'story-1.2'],
-        },
-        {
-          kind: 'kind-2',
-          stories: ['story-2.1', 'story-2.2'],
-        },
-      ]);
-
-      expect(Object.keys(store.getStoriesForManager())).toEqual([
-        'kind-1--story-1-1',
-        'kind-1--story-1-2',
-        'kind-2--story-2-1',
-        'kind-2--story-2-2',
-      ]);
-    });
-  });
-
-  describe('getStoryFileName', () => {
-    it('should return the filename of the first story passed for the kind', () => {
-      const store = new StoryStore({ channel });
-      store.addStory(...make('kind-1', 'story-1.1', () => 0, { fileName: 'foo.js' }));
-      store.addStory(...make('kind-1', 'story-1.2', () => 0, { fileName: 'foo-2.js' }));
-      store.addStory(...make('kind-2', 'story-2.1', () => 0, { fileName: 'bar.js' }));
-
-      expect(store.getStoryFileName('kind-1')).toBe('foo.js');
-      expect(store.getStoryFileName('kind-2')).toBe('bar.js');
-    });
-  });
-
   describe('removeStoryKind', () => {
     it('should not error even if there is no kind', () => {
       const store = new StoryStore({ channel });
       store.removeStoryKind('kind');
     });
-    it('should remove the kind in both modern and legacy APIs', () => {
+    it('should remove the kind', () => {
       const store = new StoryStore({ channel });
       addons.setChannel(channel);
       store.addStory(...make('kind-1', 'story-1.1', () => 0));
@@ -285,10 +238,6 @@ describe('preview.story_store', () => {
 
       store.removeStoryKind('kind-1');
 
-      // _legacydata
-      expect(store.hasStory('kind-1', 'story-1.1')).toBeFalsy();
-      expect(store.hasStory('kind-2', 'story-2.1')).toBeTruthy();
-
       // _data
       expect(store.fromId(toId('kind-1', 'story-1.1'))).toBeFalsy();
       expect(store.fromId(toId('kind-2', 'story-2.1'))).toBeTruthy();
@@ -296,7 +245,7 @@ describe('preview.story_store', () => {
   });
 
   describe('remove', () => {
-    it('should remove the kind in both modern and legacy APIs', () => {
+    it('should remove the story', () => {
       const store = new StoryStore({ channel });
       addons.setChannel(channel);
       store.addStory(...make('kind-1', 'story-1.1', () => 0));
@@ -304,51 +253,9 @@ describe('preview.story_store', () => {
 
       store.remove(toId('kind-1', 'story-1.1'));
 
-      // _legacydata
-      expect(store.hasStory('kind-1', 'story-1.1')).toBeFalsy();
-      expect(store.hasStory('kind-1', 'story-1.2')).toBeTruthy();
-
       // _data
       expect(store.fromId(toId('kind-1', 'story-1.1'))).toBeFalsy();
       expect(store.fromId(toId('kind-1', 'story-1.2'))).toBeTruthy();
-    });
-  });
-
-  describe('getStoryAndParameters', () => {
-    it('should return parameters that we passed in', () => {
-      const store = new StoryStore({ channel });
-      const story = jest.fn();
-      const parameters = {
-        fileName: 'foo.js',
-        parameter: 'value',
-      };
-      store.addStory(...make('kind', 'name', story, parameters));
-
-      expect(store.getStoryAndParameters('kind', 'name').parameters).toEqual(parameters);
-    });
-  });
-
-  describe('getStoryWithContext', () => {
-    it('should return a function that calls the story with the context', () => {
-      const store = new StoryStore({ channel });
-      const storyFn = jest.fn();
-      const parameters = {
-        fileName: 'foo.js',
-        parameter: 'value',
-      };
-      store.addStory(...make('kind', 'name', storyFn, parameters));
-
-      const storyWithContext = store.getStoryWithContext('kind', 'name');
-      storyWithContext();
-      const { hooks } = store.fromId(toId('kind', 'name'));
-      expect(storyFn).toHaveBeenCalledWith({
-        id: 'kind--name',
-        name: 'name',
-        kind: 'kind',
-        story: 'name',
-        parameters,
-        hooks,
-      });
     });
   });
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -287,10 +287,9 @@ export default class StoryStore extends EventEmitter {
 
   removeStoryKind(kind: string) {
     this.cleanHooksForKind(kind);
-    this._data = Object.entries(this._data).reduce((acc, [id, story]) => {
-      if (story.kind !== kind) {
-        Object.assign(acc, { [id]: story });
-      }
+    this._data = Object.entries(this._data).reduce((acc: StoreData, [id, story]) => {
+      if (story.kind !== kind) acc[id] = story;
+
       return acc;
     }, {});
     this.pushToManager();
@@ -312,7 +311,8 @@ export default class StoryStore extends EventEmitter {
           parameters: { fileName },
         } = story;
 
-        if (!kinds[kind]) Object.assign(kinds, { [kind]: { kind, fileName, stories: [] } });
+        // eslint-disable-next-line no-param-reassign
+        if (!kinds[kind]) kinds[kind] = { kind, fileName, stories: [] };
 
         kinds[kind].stories.push({ name, render: storyFn });
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -4,6 +4,7 @@ import memoize from 'memoizerific';
 import debounce from 'lodash/debounce';
 import dedent from 'ts-dedent';
 import stable from 'stable';
+import deprecate from 'util-deprecate';
 
 import { Channel } from '@storybook/channels';
 import Events from '@storybook/core-events';
@@ -11,12 +12,11 @@ import { logger } from '@storybook/client-logger';
 import { Comparator, Parameters, StoryFn } from '@storybook/addons';
 import {
   DecoratorFunction,
-  LegacyData,
-  LegacyItem,
   StoreData,
   AddStoryArgs,
   StoreItem,
   ErrorLike,
+  GetStorybookKind,
 } from './types';
 import { HooksContext } from './hooks';
 import storySort from './storySort';
@@ -76,10 +76,6 @@ export default class StoryStore extends EventEmitter {
 
   _data: StoreData;
 
-  _legacyData?: LegacyData;
-
-  _legacydata: LegacyData;
-
   _revision: number;
 
   _selection: Selection;
@@ -89,7 +85,6 @@ export default class StoryStore extends EventEmitter {
   constructor(params: { channel: Channel }) {
     super();
 
-    this._legacydata = {} as any;
     this._data = {} as any;
     this._revision = 0;
     this._selection = {} as any;
@@ -191,14 +186,7 @@ export default class StoryStore extends EventEmitter {
     const story = _data[id];
     delete _data[id];
 
-    if (story) {
-      story.hooks.clean();
-      const { kind, name } = story;
-      const kindData = this._legacydata[toKey(kind)];
-      if (kindData) {
-        delete kindData.stories[toKey(name)];
-      }
-    }
+    if (story) story.hooks.clean();
   };
 
   addStory(
@@ -258,13 +246,6 @@ export default class StoryStore extends EventEmitter {
       parameters,
     };
 
-    // Don't store docs-only stories in legacy data because
-    // existing clients (at the time?!), e.g. storyshots/chromatic
-    // are not necessarily equipped to process them
-    if (!isStoryDocsOnly(parameters)) {
-      this.addLegacyStory({ kind, name, storyFn, parameters });
-    }
-
     // Store 1-based order of kind loading to preserve sorting on HMR
     if (!this._kindOrder[kind]) {
       this._kindOrder[kind] = 1 + Object.keys(this._kindOrder).length;
@@ -287,9 +268,9 @@ export default class StoryStore extends EventEmitter {
     }
   }, 0);
 
-  // Unlike a bunch of deprecated APIs below, these lookup functions
-  // use the `_data` member, which is the new data structure. They should
-  // be the preferred way of looking up stories in the future.
+  getStoryKinds() {
+    return Array.from(new Set(this.raw().map(s => s.kind)));
+  }
 
   getStoriesForKind(kind: string) {
     return this.raw().filter(story => story.kind === kind);
@@ -299,148 +280,12 @@ export default class StoryStore extends EventEmitter {
     return this.getStoriesForKind(kind).find(s => s.name === name);
   }
 
-  // OLD apis
   getRevision() {
     return this._revision;
   }
 
   incrementRevision() {
     this._revision += 1;
-  }
-
-  addLegacyStory({
-    kind,
-    name,
-    storyFn,
-    parameters,
-  }: {
-    kind: string;
-    name: string;
-    storyFn: StoryFn;
-    parameters: Parameters;
-  }) {
-    const k = toKey(kind);
-    if (!this._legacydata[k as string]) {
-      this._legacydata[k as string] = {
-        kind,
-        fileName: parameters.fileName,
-        index: getId(),
-        stories: {},
-      };
-    }
-
-    this._legacydata[k as string].stories[toKey(name)] = {
-      name,
-      // kind,
-      index: getId(),
-      story: storyFn,
-      parameters,
-    };
-  }
-
-  getStoryKinds() {
-    return Object.values(this._legacydata)
-      .filter((kind: LegacyItem) => Object.keys(kind.stories).length > 0)
-      .sort((info1: LegacyItem, info2: LegacyItem) => info1.index - info2.index)
-      .map((info: LegacyItem) => info.kind);
-  }
-
-  getStories(kind: string) {
-    const key = toKey(kind);
-
-    if (!this._legacydata[key as string]) {
-      return [];
-    }
-
-    return Object.keys(this._legacydata[key as string].stories)
-      .map(name => this._legacydata[key as string].stories[name])
-      .sort((info1, info2) => info1.index - info2.index)
-      .map(info => info.name);
-  }
-
-  getStoryFileName(kind: string) {
-    const key = toKey(kind);
-    const storiesKind = this._legacydata[key as string];
-    if (!storiesKind) {
-      return null;
-    }
-
-    return storiesKind.fileName;
-  }
-
-  getStoryAndParameters(kind: string, name: string) {
-    if (!kind || !name) {
-      return null;
-    }
-
-    const storiesKind = this._legacydata[toKey(kind) as string];
-    if (!storiesKind) {
-      return null;
-    }
-
-    const storyInfo = storiesKind.stories[toKey(name)];
-    if (!storyInfo) {
-      return null;
-    }
-
-    const { story, parameters } = storyInfo;
-    return {
-      story,
-      parameters,
-    };
-  }
-
-  getStory(kind: string, name: string) {
-    const data = this.getStoryAndParameters(kind, name);
-    return data && data.story;
-  }
-
-  getStoryWithContext(kind: string, name: string) {
-    const data = this.getStoryAndParameters(kind, name);
-    if (!data) {
-      return null;
-    }
-    const { story } = data;
-    return story;
-  }
-
-  removeStoryKind(kind: string) {
-    if (this.hasStoryKind(kind)) {
-      this._legacydata[toKey(kind)].stories = {};
-      this.cleanHooksForKind(kind);
-      this._data = Object.entries(this._data).reduce((acc, [id, story]) => {
-        if (story.kind !== kind) {
-          Object.assign(acc, { [id]: story });
-        }
-        return acc;
-      }, {});
-      this.pushToManager();
-    }
-  }
-
-  hasStoryKind(kind: string) {
-    return Boolean(this._legacydata[toKey(kind) as string]);
-  }
-
-  hasStory(kind: string, name: string) {
-    return Boolean(this.getStory(kind, name));
-  }
-
-  dumpStoryBook() {
-    const data = this.getStoryKinds().map(kind => ({
-      kind,
-      stories: this.getStories(kind),
-    }));
-
-    return data;
-  }
-
-  size() {
-    return Object.keys(this._legacydata).length;
-  }
-
-  clean() {
-    this.getStoryKinds().forEach(kind => delete this._legacydata[toKey(kind) as string]);
   }
 
   cleanHooks(id: string) {
@@ -451,5 +296,41 @@ export default class StoryStore extends EventEmitter {
 
   cleanHooksForKind(kind: string) {
     this.getStoriesForKind(kind).map(story => this.cleanHooks(story.id));
+  }
+
+  removeStoryKind(kind: string) {
+    this.cleanHooksForKind(kind);
+    this._data = Object.entries(this._data).reduce((acc, [id, story]) => {
+      if (story.kind !== kind) {
+        Object.assign(acc, { [id]: story });
+      }
+      return acc;
+    }, {});
+    this.pushToManager();
+  }
+
+  // This API is a reimplementation of Storybook's original getStorybook() API.
+  // As such it may not behave *exactly* the same, but aims to. Some notes:
+  //  - It is *NOT* sorted by the user's sort function, but remains sorted in "insertion order"
+  //  - It does not include docs-only stories
+  getStorybook(): GetStorybookKind[] {
+    return Object.values(
+      this.raw().reduce((kinds: { [kind: string]: GetStorybookKind }, story) => {
+        if (!includeStory(story)) return kinds;
+
+        const {
+          kind,
+          name,
+          getOriginal,
+          parameters: { fileName },
+        } = story;
+
+        if (!kinds[kind]) Object.assign(kinds, { [kind]: { kind, fileName, stories: [] } });
+
+        kinds[kind].stories.push({ name, render: getOriginal() });
+
+        return kinds;
+      }, {})
+    ).sort((s1, s2) => this._kindOrder[s1.kind] - this._kindOrder[s2.kind]);
   }
 }

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -20,18 +20,6 @@ import {
 import { HooksContext } from './hooks';
 import storySort from './storySort';
 
-// TODO: these are copies from components/nav/lib
-// refactor to DRY
-const toKey = (input: string) =>
-  input.replace(/[^a-z0-9]+([a-z0-9])/gi, (...params) => params[1].toUpperCase());
-
-let count = 0;
-
-const getId = (): number => {
-  count += 1;
-  return count;
-};
-
 const toExtracted = <T>(obj: T) =>
   Object.entries(obj).reduce((acc, [key, value]) => {
     if (typeof value === 'function') {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -4,7 +4,6 @@ import memoize from 'memoizerific';
 import debounce from 'lodash/debounce';
 import dedent from 'ts-dedent';
 import stable from 'stable';
-import deprecate from 'util-deprecate';
 
 import { Channel } from '@storybook/channels';
 import Events from '@storybook/core-events';
@@ -321,13 +320,13 @@ export default class StoryStore extends EventEmitter {
         const {
           kind,
           name,
-          getOriginal,
+          storyFn,
           parameters: { fileName },
         } = story;
 
         if (!kinds[kind]) Object.assign(kinds, { [kind]: { kind, fileName, stories: [] } });
 
-        kinds[kind].stories.push({ name, render: getOriginal() });
+        kinds[kind].stories.push({ name, render: storyFn });
 
         return kinds;
       }, {})

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -35,15 +35,6 @@ export type ClientApiReturnFn<StoryFnReturnType> = (...args: any[]) => StoryApi<
 
 export { StoryApi, DecoratorFunction };
 
-export interface LegacyItem {
-  fileName: string;
-  index: number;
-  kind: string;
-  stories: { [key: string]: any };
-  revision?: number;
-  selection?: { storyId: string };
-}
-
 export interface AddStoryArgs {
   id: string;
   kind: string;
@@ -52,14 +43,21 @@ export interface AddStoryArgs {
   parameters: Parameters;
 }
 
-export interface LegacyData {
-  [K: string]: LegacyItem;
-}
-
 export interface ClientApiAddon<StoryFnReturnType = unknown> extends Addon {
   apply: (a: StoryApi<StoryFnReturnType>, b: any[]) => any;
 }
 
 export interface ClientApiAddons<StoryFnReturnType> {
   [key: string]: ClientApiAddon<StoryFnReturnType>;
+}
+
+export interface GetStorybookStory {
+  name: string;
+  render: StoryFn;
+}
+
+export interface GetStorybookKind {
+  kind: string;
+  fileName: string;
+  stories: Array<GetStorybookStory>;
 }

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -59,5 +59,5 @@ export interface GetStorybookStory {
 export interface GetStorybookKind {
   kind: string;
   fileName: string;
-  stories: Array<GetStorybookStory>;
+  stories: GetStorybookStory[];
 }


### PR DESCRIPTION
Issue: #9507

## What I did

 - Removed legacy data and APIs from story store.

 - Updated `getStorybook` to use `_data` (hopefully works the same)

 - Added migration notes

## How to test

See tests. Try some example storybooks.