### PR TITLE
Downgrade TypeScript to ~3.6.0

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/src/axeTest.ts
+++ b/addons/storyshots/storyshots-puppeteer/src/axeTest.ts
@@ -17,7 +17,8 @@ export const axeTest = (customConfig: Partial<CommonConfig> = {}) =>
     ...customConfig,
     async testBody(page, options) {
       const parameters = options.context.parameters.a11y;
-      const include = parameters?.element ?? '#root';
+      const element = (parameters === null || parameters === undefined) ? undefined : parameters.element;
+      const include = (element === null || element === undefined) ? '#root' : element;
       await expect(page).toPassAxeTests({ ...parameters, include });
     },
   });

--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -33,6 +33,8 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
+    "@angular/compiler-cli": "^8.2.8",
+    "@angular-devkit/build-angular": "~0.803.6",
     "@storybook/addons": "6.0.0-alpha.10",
     "@storybook/core": "6.0.0-alpha.10",
     "@storybook/node-logger": "6.0.0-alpha.10",

--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -161,7 +161,7 @@ export function applyAngularCliWebpackConfig(baseConfig: any, cliWebpackConfigOp
   // todo add type for acc
   const entry = [
     ...baseConfig.entry,
-    ...Object.values(cliStyleConfig.entry).reduce((acc: any, item) => acc.concat(item), []),
+    ...Object.values<any>(cliStyleConfig.entry).reduce((acc: any, item) => acc.concat(item), []),
   ];
 
   const module = {

--- a/lib/ui/src/components/sidebar/treeview/treeview.tsx
+++ b/lib/ui/src/components/sidebar/treeview/treeview.tsx
@@ -49,6 +49,7 @@ const linked = (
   }: { onClick: Function; onKeyUp: Function; Link: ComponentType; prefix: string }
 ) => {
   const Linked = React.memo(p => (
+    // @ts-ignore
     <L
       prefix={prefix}
       {...p}

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "trash": "^6.1.1",
     "ts-dedent": "^1.1.1",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.4.0",
+    "typescript": "~3.6.0",
     "wait-on": "^4.0.0"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -29353,6 +29353,11 @@ typescript@^2.4.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
+typescript@~3.6.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
+  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
+
 ua-parser-js@^0.7.18:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"


### PR DESCRIPTION
**Possibly closing in favor of #9847**

---

Issue: Fixes #9463 

Storybook version 5.3.x should be on TypeScript 3.6 and not on 3.7.

The "minor" bump in TS versions caused a breaking change. A class of type declarations generated with TS3.7 would not be compatible with TS3.6 and below. This causes users of Storybook 5.3 to either upgrade TS to 3.7 or stay on an older version of Storybook.

For library maintainers, if they upgrade TS to 3.7, they would force their consumers to do so as well to avoid this issue. Given that the leap from TS 3.6 to 3.7 is technically a breaking change, it would make sense for the Storybook 5.3 version line to just hold at `~3.6.0` and wait to upgrade to 3.7 when Storybook 6 gets released (or held until future major versions). This PR does that.

## What I did
I specified the workspace `package.json` dependency to `"typescript": '~3.6.0'`. This generates declaration files using `tsc` using 3.6.5 and should play nice with Storybook consumers still using TypeScript 3.6 and below.

A few other changes were made to accommodate this and I've notated it as comments in the file diffs themselves.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
