### PR TITLE
Fix module.export syntax error in 'Storybook for HTML' README

### DIFF
--- a/docs/src/pages/guides/guide-html/index.md
+++ b/docs/src/pages/guides/guide-html/index.md
@@ -61,7 +61,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```


### PR DESCRIPTION
Issue:

## What I did
There is a small syntax error in the `Storybook for HTML` README. 

The example js should be `module.exports = { ...` rather than `module.exports { ...`