### PR TITLE
Storyshots: Fix support for jsx/tsx config files

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -14,10 +14,14 @@ function __setMockFiles(newMockFiles) {
 // file list set via __setMockFiles
 const readFileSync = (filePath = '') => mockFiles[filePath];
 const existsSync = filePath => !!mockFiles[filePath];
+const lstatSync = filePath => ({
+  isFile: () => !!mockFiles[filePath],
+});
 
 // eslint-disable-next-line no-underscore-dangle
 fs.__setMockFiles = __setMockFiles;
 fs.readFileSync = readFileSync;
 fs.existsSync = existsSync;
+fs.lstatSync = lstatSync;
 
 module.exports = fs;

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.test.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.test.ts
@@ -1,4 +1,4 @@
-import { getPreviewFile } from './configure';
+import { getPreviewFile, getMainFile } from './configure';
 
 // eslint-disable-next-line global-require, jest/no-mocks-import
 jest.mock('fs', () => require('../../../../../__mocks__/fs'));
@@ -7,20 +7,42 @@ const setupFiles = (files: Record<string, string>) => {
   require('fs').__setMockFiles(files);
 };
 
-it.each`
-  filepath
-  ${'preview.ts'}
-  ${'preview.tsx'}
-  ${'preview.js'}
-  ${'preview.jsx'}
-`('resolves a valid preview file from $filepath', ({ filepath }) => {
-  setupFiles({ [`test/${filepath}`]: 'true' });
+describe('preview files', () => {
+  it.each`
+    filepath
+    ${'preview.ts'}
+    ${'preview.tsx'}
+    ${'preview.js'}
+    ${'preview.jsx'}
+  `('resolves a valid preview file from $filepath', ({ filepath }) => {
+    setupFiles({ [`test/${filepath}`]: 'true' });
 
-  expect(getPreviewFile('test/')).toEqual(`test/${filepath}`);
+    expect(getPreviewFile('test/')).toEqual(`test/${filepath}`);
+  });
+
+  it('returns false when none of the paths exist', () => {
+    setupFiles(Object.create(null));
+
+    expect(getPreviewFile('test/')).toEqual(false);
+  });
 });
 
-it('returns false when none of the paths exist', () => {
-  setupFiles(Object.create(null));
+describe('main files', () => {
+  it.each`
+    filepath
+    ${'main.ts'}
+    ${'main.tsx'}
+    ${'main.js'}
+    ${'main.jsx'}
+  `('resolves a valid main file path from $filepath', ({ filepath }) => {
+    setupFiles({ [`test/${filepath}`]: 'true' });
 
-  expect(getPreviewFile('test/')).toEqual(false);
+    expect(getMainFile('test/')).toEqual(`test/${filepath}`);
+  });
+
+  it('returns false when none of the paths exist', () => {
+    setupFiles(Object.create(null));
+
+    expect(getPreviewFile('test/')).toEqual(false);
+  });
 });

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.test.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.test.ts
@@ -1,0 +1,26 @@
+import { getPreviewFile } from './configure';
+
+// eslint-disable-next-line global-require, jest/no-mocks-import
+jest.mock('fs', () => require('../../../../../__mocks__/fs'));
+const setupFiles = (files: Record<string, string>) => {
+  // eslint-disable-next-line no-underscore-dangle, global-require
+  require('fs').__setMockFiles(files);
+};
+
+it.each`
+  filepath
+  ${'preview.ts'}
+  ${'preview.tsx'}
+  ${'preview.js'}
+  ${'preview.jsx'}
+`('resolves a valid preview file from $filepath', ({ filepath }) => {
+  setupFiles({ [`test/${filepath}`]: 'true' });
+
+  expect(getPreviewFile('test/')).toEqual(`test/${filepath}`);
+});
+
+it('returns false when none of the paths exist', () => {
+  setupFiles(Object.create(null));
+
+  expect(getPreviewFile('test/')).toEqual(false);
+});

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.test.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.test.ts
@@ -14,6 +14,10 @@ describe('preview files', () => {
     ${'preview.tsx'}
     ${'preview.js'}
     ${'preview.jsx'}
+    ${'config.ts'}
+    ${'config.tsx'}
+    ${'config.js'}
+    ${'config.jsx'}
   `('resolves a valid preview file from $filepath', ({ filepath }) => {
     setupFiles({ [`test/${filepath}`]: 'true' });
 

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -23,23 +23,16 @@ interface Output {
 
 const supportedExtensions = ['ts', 'tsx', 'js', 'jsx'];
 
-export const getPreviewFile = (configDir: string): string | false => {
-  const supportedFilenames = ['preview', 'config'];
-  const allFilenames = supportedFilenames
+const resolveFile = (configDir: string, supportedFilenames: string[]) =>
+  supportedFilenames
     .flatMap(filename => supportedExtensions.map(ext => `${filename}.${ext}`))
-    .map(filename => path.join(configDir, filename));
+    .map(filename => path.join(configDir, filename))
+    .find(isFile) || false;
 
-  return allFilenames.find(isFile) || false;
-};
+export const getPreviewFile = (configDir: string): string | false =>
+  resolveFile(configDir, ['preview', 'config']);
 
-export const getMainFile = (configDir: string): string | false => {
-  const supportedFilenames = ['main'];
-  const allFilenames = supportedFilenames
-    .flatMap(filename => supportedExtensions.map(ext => `${filename}.${ext}`))
-    .map(filename => path.join(configDir, filename));
-
-  return allFilenames.find(isFile) || false;
-};
+export const getMainFile = (configDir: string): string | false => resolveFile(configDir, ['main']);
 
 function getConfigPathParts(input: string): Output {
   const configDir = path.resolve(input);

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -25,8 +25,7 @@ const supportedExtensions = ['ts', 'tsx', 'js', 'jsx'];
 
 const resolveFile = (configDir: string, supportedFilenames: string[]) =>
   supportedFilenames
-    .flatMap(filename => supportedExtensions.map(ext => `${filename}.${ext}`))
-    .map(filename => path.join(configDir, filename))
+    .flatMap(filename => supportedExtensions.map(ext => path.join(configDir, `${filename}.${ext}`)))
     .find(isFile) || false;
 
 export const getPreviewFile = (configDir: string): string | false =>

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -22,9 +22,9 @@ interface Output {
 }
 
 const supportedExtensions = ['ts', 'tsx', 'js', 'jsx'];
-const supportedFilenames = ['preview', 'config'];
 
 export const getPreviewFile = (configDir: string): string | false => {
+  const supportedFilenames = ['preview', 'config'];
   const allFilenames = supportedFilenames
     .flatMap(filename => supportedExtensions.map(ext => `${filename}.${ext}`))
     .map(filename => path.join(configDir, filename));
@@ -32,14 +32,13 @@ export const getPreviewFile = (configDir: string): string | false => {
   return allFilenames.find(isFile) || false;
 };
 
-const getMainFile = (configDir: string): string | false => {
-  const main = path.join(configDir, 'main.js');
+export const getMainFile = (configDir: string): string | false => {
+  const supportedFilenames = ['main'];
+  const allFilenames = supportedFilenames
+    .flatMap(filename => supportedExtensions.map(ext => `${filename}.${ext}`))
+    .map(filename => path.join(configDir, filename));
 
-  if (isFile(main)) {
-    return main;
-  }
-
-  return false;
+  return allFilenames.find(isFile) || false;
 };
 
 function getConfigPathParts(input: string): Output {

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -21,26 +21,15 @@ interface Output {
   files: string[];
 }
 
-const getPreviewFile = (configDir: string): string | false => {
-  const preview = path.join(configDir, 'preview.js');
-  const previewTS = path.join(configDir, 'preview.ts');
-  const config = path.join(configDir, 'config.js');
-  const configTS = path.join(configDir, 'config.ts');
+const supportedExtensions = ['ts', 'tsx', 'js', 'jsx'];
+const supportedFilenames = ['preview', 'config'];
 
-  if (isFile(previewTS)) {
-    return previewTS;
-  }
-  if (isFile(preview)) {
-    return preview;
-  }
-  if (isFile(configTS)) {
-    return configTS;
-  }
-  if (isFile(config)) {
-    return config;
-  }
+export const getPreviewFile = (configDir: string): string | false => {
+  const allFilenames = supportedFilenames
+    .flatMap(filename => supportedExtensions.map(ext => `${filename}.${ext}`))
+    .map(filename => path.join(configDir, filename));
 
-  return false;
+  return allFilenames.find(isFile) || false;
 };
 
 const getMainFile = (configDir: string): string | false => {


### PR DESCRIPTION
Issue: #9771 

## What I did
Implemented support for *.jsx and *.tsx preview files.

## How to test

- Added a Jest unit test for the new behavior.
- Verified in the minimal repro repository (in the linked issue) that these changes fix the original issue.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
