### PR TITLE
Add a README about client-api, specifically about args

### DIFF
--- a/lib/client-api/README.md
+++ b/lib/client-api/README.md
@@ -25,5 +25,63 @@ Parameters are inheritable -- you can set global parameters via `addParameters` 
 
 Some notable parameters:
 
-- `fileName` - the file that the story was defined in, when available
-- `properties` - type information about properties (see below)
+- `parameters.fileName` - the file that the story was defined in, when available
+- `parameters.argsTypes` - type information about args (see below)
+
+### Parameter enhancement
+
+Ideally all parameters should be set _at build time_ of the Storybook, either directly by the user, or via the use of a webpack loader. (For an example of this, see `addon-storysource`, which writes to the `parameters.storysource` parameter with a set of static information about the story file).
+
+However, in some cases it is necessary to set parameters at _load time_ when the Storybook first loads. This should be avoided if at all possible as it is cost that must be paid each time a Storybook loads, rather than just once when the Storybook is built.
+
+To add a parameter enhancer, call `store.addParameterEnhancer(enhancer)` _before_ any stories are loaded (in addon registration or in `preview.js`). As each story is loaded, the enhancer will be called with the full story `context` -- the return value should be an object that will be patched into the Story's parameters.
+Alm
+
+## Args
+
+Args are "inputs" to stories.
+
+You can think of them equivalently to React props, Angular inputs and outputs, etc.
+
+Changing the args cause the story to be re-rendered with the new set of args.
+
+### Using args in a story
+
+By default, args are passed to a story in the context; like parameters, they are available as `context.args`.
+
+```js
+const YourStory = ({ args: { x, y }}) => /* render your story using `x` and `y` */
+```
+
+If you set the `parameters.options.passArgsFirst` option on a story, then the args will be passed to the story as first argument and the context as second:
+
+```js
+const YourStory = ({ x, y } /*, context*/) => /* render your story using `x` and `y` */
+```
+
+### Using args in an addon
+
+Args values are automatically syncronized (via the `changeStoryArgs` and `storyArgsChanged` events) between the preview and manager; APIs exist in `lib/api` to read and set properties in the manager.
+
+Args need to be serializable -- so currently cannot include callbacks (this may change in a future version).
+
+Note that arg values are passed directly to a story -- you should only store the actual value that the story needs to render in the property. If you need more complex information supporting that, use parameters or addon state.
+
+### Default values
+
+The initial value of an arg is driven by the `parameters.argTypes` field. For each key in that field, if a `defaultValue` exists, then the arg will be initialized to that value.
+
+For instance, for this story:
+
+```js
+export MyStory = ....
+MyStory.story = { parameters: {
+  argTypes: {
+    primary: { defaultValue: true },
+    size: { defaultValue: 'large' },
+    color: { /* other things */ },
+  },
+}}
+```
+
+Then `context.args` will default to `{ primary: true, size: large }`

--- a/lib/client-api/README.md
+++ b/lib/client-api/README.md
@@ -1,0 +1,29 @@
+# `@storybook/client-api` -- APIs that control the rendering of stories in the preview iframe.
+
+## Story store
+
+The story store contains the list of stories loaded in a Storybook.
+
+Each story is loaded via the `.add()` API and contains the follow attributes, which are available on the `context` (which is passed to the story's render function and decorators):
+
+- `kind` - the grouping of the story, typically corresponds to a single component. Also known as the `title` in CSF.
+- `name` - the name of the specific story.
+- `id` - an unique, URL sanitized identifier for the story, created from the `kind` and `name`.
+- `parameters` - static data about the story, see below.
+- `properties` - dynamic inputs to the story, see blow.
+- `hooks` - listeners that will rerun when the story changes or is unmounted, see `@storybook/addons`.
+
+## Parameters
+
+The story parameters is a static, serializable object of data that provides details about the story. Those details can be used by addons or Storybook itself to render UI or provide defaults about the story rendering.
+
+Parameters _cannot change_ and are syncronized to the manager once when the story is loaded (note over the lifetime of a development Storybook a story can be loaded several times due to hot module reload, so the parameters technically can change for that reason).
+
+Usually addons will read from a single key of `parameters` namespaced by the name of that addon. For instance the configuration of the `backgrounds` addon is driven by the `parameters.backgrounds` namespace.
+
+Parameters are inheritable -- you can set global parameters via `addParameters` (exported by `client_api` and each framework), at the component level by the `parameters` key of the component (default) export in CSF (or in `.storiesOf`), and on a single story via the `parameters` key on the story data, or the third argument to `.add()`.
+
+Some notable parameters:
+
+- `fileName` - the file that the story was defined in, when available
+- `properties` - type information about properties (see below)


### PR DESCRIPTION
"Args" (aka state/controls) are a new concept that replaces story state. They'll be used for future versions of knobs, context, actions and more.

Args are intended to be used in the implementation of the story (see README) if that story is parameterized.

This is a README that outlines a first phase of development of args, intended to start down the above road and support the new addon-controls (a successor to knobs).

The plan at the highest level:
  1. The user can define `argTypes` parameters if they want
  2. `addon-docs` uses an `parameterEnhancer` to  add extra `argTypes` parameters from auto detected arg type. [This replaces the "smart controls" concept]
  3. The store is initialized with `argValues` based on the `argTypes.$.defaultValue` in parameters.
  4. The story is passed the values via `context.args`
  4. Controls can use the `argValues` APIs to change them and re-render the story.

Interested in people's thoughts in general.

@atanasster in particular I wanted to discuss (based on your earlier comments):

A. The "reset" event -- I don't currently have this or an event to reset an individual arg. I think we can add this in a near-term iteration.

B. "on click" event -- I'm not sure I entirely understand the use case you have for this (perhaps you can tell me more?), but there's a larger issue around other functional args (in particular for **actions**) that we need to mull on a bit more. For now, we expect users will not use args for functional props.

C. You requested to keep the control (/arg) values alongside the type information. I can see the benefit but it is much simpler this way; the use of a parameter to control arg types maps really well to the prop table and other related things. It doesn't seem that hard to look both in `context.parameters.argTypes` and `context.args` to get the full picture. Is there something I am missing here?

D. Continuing on that -- do you think that setting the initial value for arg `X` based on `parameters.argTypes[X].defaultValue` is going to be sufficient? It seems very simple as a starting point, but I wonder if we've missed something.