### PR TITLE
CLI: fix React Scripts  csf-ts story templates

### DIFF
--- a/lib/cli/.babelrc.json
+++ b/lib/cli/.babelrc.json
@@ -14,6 +14,7 @@
   "ignore": [
     "./src/generators/**/template",
     "./src/generators/**/template-csf",
+    "./src/generators/**/template-csf-ts",
     "./src/generators/**/template-mdx"
   ]
 }


### PR DESCRIPTION
## What I did

Added the template folder that has been forgotten in https://github.com/storybookjs/storybook/commit/3dd714d3532687d958c41e093187b84ffca603ee

I tried to use a Glob pattern instead of listing all the different folder however it is not entirely supported by Babel: https://github.com/babel/babel/issues/9680 😞 