### PR TITLE
CLI: Add Yarn 2 compatibility

### DIFF
--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -1,6 +1,6 @@
 name: CLI tests
 
-on: 
+on:
   push
   # push:
 # disabled for now:
@@ -33,6 +33,30 @@ jobs:
     - name: cli
       run: |
         yarn test --cli
+  cli-yarn-2:
+    name: CLI Fixtures with Yarn 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - uses: actions/checkout@v1
+    - name: Cache node modules
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.OS }}-build-${{ env.cache-name }}-
+          ${{ runner.OS }}-build-
+          ${{ runner.OS }}-
+    - name: install, bootstrap
+      run: |
+        yarn bootstrap --core
+    - name: cli with Yarn 2
+      run: |
+        cd lib/cli
+        yarn test-yarn-2
   latest-cra:
     name: Latest CRA
     runs-on: ubuntu-latest

--- a/app/ember/package.json
+++ b/app/ember/package.json
@@ -41,6 +41,7 @@
     "@babel/core": "*",
     "babel-loader": "^7.0.0 || ^8.0.0",
     "babel-plugin-ember-modules-api-polyfill": "^2.12.0",
+    "babel-plugin-htmlbars-inline-precompile": "2 || 3",
     "ember-source": "^3.16.0",
     "react": "*",
     "react-dom": "*"

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -32,7 +32,8 @@
   "scripts": {
     "prepare": "node ../../scripts/prepare.js",
     "test": "cd test && ./run_tests.sh",
-    "test-latest-cra": "cd test && ./test_latest_cra.sh"
+    "test-latest-cra": "cd test && ./test_latest_cra.sh",
+    "test-yarn-2": "cd test && ./run_tests_yarn_2.sh"
   },
   "dependencies": {
     "@babel/core": "^7.8.4",

--- a/lib/cli/src/generators/EMBER/index.js
+++ b/lib/cli/src/generators/EMBER/index.js
@@ -8,9 +8,20 @@ import {
 } from '../../helpers';
 
 export default async (npmOptions, { storyFormat = 'csf' }) => {
-  const [storybookVersion, linksVersion, actionsVersion, addonsVersion] = await getVersions(
+  const [
+    storybookVersion,
+    babelPluginEmberModulePolyfillVersion,
+    babelPluginHtmlBarsInlinePrecompileVersion,
+    linksVersion,
+    actionsVersion,
+    addonsVersion,
+  ] = await getVersions(
     npmOptions,
     '@storybook/ember',
+    // babel-plugin-ember-modules-api-polyfill is a peerDep of @storybook/ember
+    'babel-plugin-ember-modules-api-polyfill',
+    // babel-plugin-htmlbars-inline-precompile is a peerDep of @storybook/ember
+    'babel-plugin-htmlbars-inline-precompile',
     '@storybook/addon-links',
     '@storybook/addon-actions',
     '@storybook/addons'
@@ -40,6 +51,8 @@ export default async (npmOptions, { storyFormat = 'csf' }) => {
     `@storybook/addon-actions@${actionsVersion}`,
     `@storybook/addon-links@${linksVersion}`,
     `@storybook/addons@${addonsVersion}`,
+    `babel-plugin-ember-modules-api-polyfill@${babelPluginEmberModulePolyfillVersion}`,
+    `babel-plugin-htmlbars-inline-precompile@${babelPluginHtmlBarsInlinePrecompileVersion}`,
     ...babelDependencies,
   ]);
 };

--- a/lib/cli/src/generators/METEOR/index.js
+++ b/lib/cli/src/generators/METEOR/index.js
@@ -14,6 +14,7 @@ export default async (npmOptions, { storyFormat = 'csf' }) => {
     storybookVersion,
     actionsVersion,
     linksVersion,
+    knobsVersion,
     addonsVersion,
     reactVersion,
     reactDomVersion,
@@ -24,6 +25,7 @@ export default async (npmOptions, { storyFormat = 'csf' }) => {
     '@storybook/react',
     '@storybook/addon-actions',
     '@storybook/addon-links',
+    '@storybook/addon-knobs',
     '@storybook/addons',
     'react',
     'react-dom',
@@ -43,6 +45,7 @@ export default async (npmOptions, { storyFormat = 'csf' }) => {
     `@storybook/react@${storybookVersion}`,
     `@storybook/addon-actions@${actionsVersion}`,
     `@storybook/addon-links@${linksVersion}`,
+    `@storybook/addon-knobs@${knobsVersion}`,
     `@storybook/addons@${addonsVersion}`,
   ];
 

--- a/lib/cli/src/generators/MITHRIL/index.js
+++ b/lib/cli/src/generators/MITHRIL/index.js
@@ -8,11 +8,18 @@ import {
 } from '../../helpers';
 
 export default async (npmOptions, { storyFormat = 'csf' }) => {
-  const [storybookVersion, actionsVersion, linksVersion, addonsVersion] = await getVersions(
+  const [
+    storybookVersion,
+    actionsVersion,
+    linksVersion,
+    knobsVersion,
+    addonsVersion,
+  ] = await getVersions(
     npmOptions,
     '@storybook/mithril',
     '@storybook/addon-actions',
     '@storybook/addon-links',
+    '@storybook/addon-knobs',
     '@storybook/addons'
   );
 
@@ -35,6 +42,7 @@ export default async (npmOptions, { storyFormat = 'csf' }) => {
     `@storybook/mithril@${storybookVersion}`,
     `@storybook/addon-actions@${actionsVersion}`,
     `@storybook/addon-links@${linksVersion}`,
+    `@storybook/addon-knobs@${knobsVersion}`,
     `@storybook/addons@${addonsVersion}`,
     ...babelDependencies,
   ]);

--- a/lib/cli/src/generators/REACT_SCRIPTS/index.js
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs';
-import semver from 'semver';
 import {
   retrievePackageJson,
   getVersionedPackages,
@@ -44,14 +43,7 @@ export default async (npmOptions, { storyFormat = 'csf' }) => {
 
   writePackageJson(packageJson);
 
-  // When working with `create-react-app@>=2.0.0`, we know `babel-loader` is installed.
-  let babelDependencies = [];
-  const reactScriptsDep =
-    packageJson.dependencies['react-scripts'] || packageJson.devDependencies['react-scripts'];
-
-  if (reactScriptsDep && semver.gtr('2.0.0', reactScriptsDep)) {
-    babelDependencies = await getBabelDependencies(npmOptions, packageJson);
-  }
+  const babelDependencies = await getBabelDependencies(npmOptions, packageJson);
 
   installDependencies({ ...npmOptions, packageJson }, [...versionedPackages, ...babelDependencies]);
 };

--- a/lib/cli/src/latest_version.js
+++ b/lib/cli/src/latest_version.js
@@ -1,11 +1,38 @@
 import { spawn } from 'cross-spawn';
 import { satisfies } from 'semver';
 
+/**
+ * Get latest version of the package available on npmjs.com.
+ * If constraint is set then it returns a version satisfying it, otherwise the latest version available is returned.
+ *
+ * @param {Object} npmOptions Object containing a `useYarn: boolean` attribute
+ * @param {string} packageName Name of the package
+ * @param {Object} constraint Version range to use to constraint the returned version
+ * @return {Promise<string>} Promise resolved with a version
+ */
 export function latestVersion(npmOptions, packageName, constraint) {
-  const packageManager = npmOptions.useYarn ? 'yarn' : 'npm';
+  const getPackageVersions = npmOptions.useYarn
+    ? spawnVersionsWithYarn(packageName, constraint)
+    : spawnVersionsWithNpm(packageName, constraint);
+
+  return getPackageVersions.then(versions => {
+    if (!constraint) return versions;
+
+    return versions.reverse().find(version => satisfies(version, constraint));
+  });
+}
+
+/**
+ *  Get latest version(s) of the package available on npmjs.com using NPM
+ *
+ * @param {string} packageName Name of the package
+ * @param {Object} constraint Version range to use to constraint the returned version
+ * @returns {Promise<string|Array<string>>} versions  Promise resolved with a version or an array of versions
+ */
+function spawnVersionsWithNpm(packageName, constraint) {
   return new Promise((resolve, reject) => {
     const command = spawn(
-      packageManager,
+      'npm',
       ['info', packageName, constraint ? 'versions' : 'version', '--json', '--silent'],
       {
         cwd: process.cwd(),
@@ -16,39 +43,57 @@ export function latestVersion(npmOptions, packageName, constraint) {
       }
     );
 
-    const processResult = result => {
-      if (!constraint) return result;
-
-      return result.reverse().find(version => satisfies(version, constraint));
-    };
-
     command.stdout.on('data', data => {
       try {
         const info = JSON.parse(data);
         if (info.error) {
-          // npm error
           reject(new Error(info.error.summary));
-        } else if (info.type === 'inspect') {
-          // yarn success
-          resolve(processResult(info.data));
         } else {
-          // npm success
-          resolve(processResult(info));
+          resolve(info);
         }
       } catch (e) {
-        // yarn info output
+        reject(new Error(`Unable to find versions of ${packageName} using npm`));
+      }
+    });
+  });
+}
+
+/**
+ *  Get latest version(s) of the package available on npmjs.com using Yarn
+ *
+ * @param {string} packageName Name of the package
+ * @param {Object} constraint Version range to use to constraint the returned version
+ * @returns {Promise<string|Array<string>>} versions  Promise resolved with a version or an array of versions
+ */
+function spawnVersionsWithYarn(packageName, constraint) {
+  return new Promise((resolve, reject) => {
+    const command = spawn(
+      'yarn',
+      ['info', packageName, constraint ? 'versions' : 'version', '--json', '--silent'],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+        stdio: 'pipe',
+        encoding: 'utf-8',
+        silent: true,
+      }
+    );
+
+    command.stdout.on('data', data => {
+      try {
+        const info = JSON.parse(data);
+        if (info.type === 'inspect') {
+          resolve(info.data);
+        }
+      } catch (e) {
+        reject(new Error(`Unable to find versions of ${packageName} using yarn`));
       }
     });
 
     command.stderr.on('data', data => {
-      try {
-        // yarn error
-        const info = JSON.parse(data);
-        if (info.type === 'error') {
-          reject(new Error(info.data));
-        }
-      } catch (e) {
-        // package manager unstructured info/warnings output
+      const info = JSON.parse(data);
+      if (info.type === 'error') {
+        reject(new Error(info.data));
       }
     });
   });

--- a/lib/cli/src/latest_version.js
+++ b/lib/cli/src/latest_version.js
@@ -1,4 +1,4 @@
-import { spawn } from 'cross-spawn';
+import { spawn, sync } from 'cross-spawn';
 import { satisfies } from 'semver';
 
 /**
@@ -11,9 +11,25 @@ import { satisfies } from 'semver';
  * @return {Promise<string>} Promise resolved with a version
  */
 export function latestVersion(npmOptions, packageName, constraint) {
-  const getPackageVersions = npmOptions.useYarn
-    ? spawnVersionsWithYarn(packageName, constraint)
-    : spawnVersionsWithNpm(packageName, constraint);
+  let getPackageVersions;
+
+  // TODO: Refactor things to hide the package manager details:
+  // Create a `PackageManager` interface that expose some functions like `version`, `add` etc
+  // and then create classes that handle the npm/yarn/yarn2 specific behavior
+  if (npmOptions.useYarn) {
+    const yarnVersion = sync('yarn', ['--version'], { silent: true })
+      .output.toString('utf8')
+      .replace(/,/g, '')
+      .replace(/"/g, '');
+
+    if (/^1\.+/.test(yarnVersion)) {
+      getPackageVersions = spawnVersionsWithYarn(packageName, constraint);
+    } else {
+      getPackageVersions = spawnVersionsWithYarn2(packageName, constraint);
+    }
+  } else {
+    getPackageVersions = spawnVersionsWithNpm(packageName, constraint);
+  }
 
   return getPackageVersions.then(versions => {
     if (!constraint) return versions;
@@ -95,6 +111,40 @@ function spawnVersionsWithYarn(packageName, constraint) {
       if (info.type === 'error') {
         reject(new Error(info.data));
       }
+    });
+  });
+}
+
+/**
+ *  Get latest version(s) of the package available on npmjs.com using Yarn 2 a.k.a Berry
+ *
+ * @param {string} packageName Name of the package
+ * @param {Object} constraint Version range to use to constraint the returned version
+ * @returns {Promise<string|Array<string>>} versions  Promise resolved with a version or an array of versions
+ */
+function spawnVersionsWithYarn2(packageName, constraint) {
+  const field = constraint ? 'versions' : 'version';
+  return new Promise((resolve, reject) => {
+    const command = spawn('yarn', ['npm', 'info', packageName, '--fields', field, '--json'], {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: 'pipe',
+      encoding: 'utf-8',
+      silent: true,
+    });
+
+    command.stdout.on('data', data => {
+      try {
+        const info = JSON.parse(data);
+        resolve(info[field]);
+      } catch (e) {
+        reject(new Error(`Unable to find versions of ${packageName} using yarn 2`));
+      }
+    });
+
+    command.stderr.on('data', data => {
+      const info = JSON.parse(data);
+      reject(new Error(info));
     });
   });
 }

--- a/lib/cli/test/.gitignore
+++ b/lib/cli/test/.gitignore
@@ -1,2 +1,3 @@
 cra-fixtures
 run
+run-yarn-2

--- a/lib/cli/test/berryfy_package_json.js
+++ b/lib/cli/test/berryfy_package_json.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+// Map between SB packages names and their folders inside this monorepo
+const sbRootDir = '../../../../..';
+const sbPackagesResolutionsMap = {
+  '@storybook/addons': `portal:${sbRootDir}/lib/addons`,
+  '@storybook/api': `portal:${sbRootDir}/lib/api`,
+  '@storybook/channel-postmessage': `portal:${sbRootDir}/lib/channel-postmessage`,
+  '@storybook/channel-websocket': `portal:${sbRootDir}/lib/channel-websocket`,
+  '@storybook/channels': `portal:${sbRootDir}/lib/channels`,
+  '@storybook/cli': `portal:${sbRootDir}/lib/cli`,
+  '@storybook/core': `portal:${sbRootDir}/lib/core`,
+  '@storybook/source-loader': `portal:${sbRootDir}/lib/source-loader`,
+  '@storybook/router': `portal:${sbRootDir}/lib/router`,
+  '@storybook/theming': `portal:${sbRootDir}/lib/theming`,
+  '@storybook/ui': `portal:${sbRootDir}/lib/ui`,
+  '@storybook/ember': `portal:${sbRootDir}/app/ember`,
+  '@storybook/html': `portal:${sbRootDir}/app/html`,
+  '@storybook/marionette': `portal:${sbRootDir}/app/marionette`,
+  '@storybook/marko': `portal:${sbRootDir}/app/marko`,
+  '@storybook/mithril': `portal:${sbRootDir}/app/mithril`,
+  '@storybook/preact': `portal:${sbRootDir}/app/preact`,
+  '@storybook/rax': `portal:${sbRootDir}/app/rax`,
+  '@storybook/react': `portal:${sbRootDir}/app/react`,
+  '@storybook/riot': `portal:${sbRootDir}/app/riot`,
+  '@storybook/server': `portal:${sbRootDir}/app/server`,
+  '@storybook/svelte': `portal:${sbRootDir}/app/svelte`,
+  '@storybook/vue': `portal:${sbRootDir}/app/vue`,
+  '@storybook/web-components': `portal:${sbRootDir}/app/web-components`,
+  '@storybook/addon-actions': `portal:${sbRootDir}/addons/actions`,
+  '@storybook/addon-links': `portal:${sbRootDir}/addons/links`,
+  '@storybook/addon-knobs': `portal:${sbRootDir}/addons/knobs`,
+};
+
+const fs = require('fs');
+
+const args = process.argv.slice(2);
+
+if (args.length !== 1) {
+  throw Error('This script must be ran with 1 argument: the path of the package.json to update');
+}
+
+const packageJsonPath = args[0];
+const packageJson = require(packageJsonPath);
+
+// Add `@storybook/cli` as dev dependency to be able to do `yarn sb init` with Yarn 2
+packageJson.devDependencies = {
+  ...packageJson.devDependencies,
+  '@storybook/cli': 'next',
+};
+
+// Link `@storybook/xxx` package to local one by filling `resolutions` attribute using "portal" protocol (https://yarnpkg.com/features/protocols)
+// We have to do it like this for now because we can not used Yarn v1 workspace.
+// This can be rework when the whole monorepo will be migrated to Yarn 2
+packageJson.resolutions = {
+  ...packageJson.resolutions,
+  ...sbPackagesResolutionsMap,
+};
+
+// Get a string representing updated `package.json` and write it
+const prettyUpdatedPackageJson = JSON.stringify(packageJson, null, 2);
+fs.writeFileSync(packageJsonPath, prettyUpdatedPackageJson);

--- a/lib/cli/test/fixtures/riot/package.json
+++ b/lib/cli/test/fixtures/riot/package.json
@@ -19,6 +19,7 @@
     "raw-loader": "^1.0.0",
     "riot-compiler": "^3.6.0",
     "riot-hot-reload": "^1.0.0",
+    "riot-tmpl": "^3.0.8",
     "style-loader": "^0.23.1",
     "webpack": "^4.33.0",
     "webpack-bundle-analyzer": "^3.3.2",

--- a/lib/cli/test/run_tests_yarn_2.sh
+++ b/lib/cli/test/run_tests_yarn_2.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# exit on error
+set -e
+
+declare test_root=$PWD
+
+test_folder='run-yarn-2'
+fixtures_dir='fixtures'
+story_format='csf'
+
+# remove run directory before exit to prevent yarn.lock spoiling
+function cleanup {
+  rm -rfd ${test_root}/$test_folder
+}
+trap cleanup EXIT
+
+# parse command-line options
+# '-s' sets story format to use
+while getopts ":s:" opt; do
+  case $opt in
+    s)
+      story_format=$OPTARG
+      ;;
+  esac
+done
+
+rm -rfd $test_folder
+mkdir $test_folder
+# copy some files from fixtures directory, the goal is to test that CLI is running well with Yarn 2 not to have all framework covered (especially because some are not compatible with Yarn 2 yet)
+cp -r $fixtures_dir/react $test_folder/react
+cp -r $fixtures_dir/react_babelrc_js $test_folder/react_babelrc_js
+cp -r $fixtures_dir/react_scripts_ts $test_folder/react_scripts_ts
+cp -r $fixtures_dir/react_scripts_v2 $test_folder/react_scripts_v2
+cp -r $fixtures_dir/webpack_react $test_folder/webpack_react
+cd $test_folder
+
+for dir in *
+do
+  cd $dir
+  echo "Set Yarn 2 in $dir"
+  # First command is for Yarn <=1.21, second for Yarn 1.22
+  yarn policies set-version berry || yarn set version berry
+
+  # Do some magic to make Yarn 2 work inside a Yarn 1 monorepo
+  unset YARN_WRAP_OUTPUT
+  touch yarn.lock
+
+  # Use a global cache to avoid fetching the same dep multiple times across all fixtures
+  echo "enableGlobalCache: true" >> .yarnrc.yml
+
+  # Transform `package.json`:
+  #   - add `@storybook/cli` dep to be able to do `yarn sb init` with Yarn 2
+  #   - fill `resolutions` attribute with link to local `@storybook` packages because we can not use Yarn v1 workspace
+  #   directly, this can be rework when the whole monorepo will be migrated to Yarn 2
+  ../../berryfy_package_json.js $PWD/package.json
+
+  echo "Installing dependencies in $dir"
+  # Need to do `yarn install` first to have `@storybook/cli` correctly linked
+  yarn install
+
+  echo "Running storybook-cli in $dir"
+  case $story_format in
+  csf)
+    yarn sb init --skip-install --yes
+    ;;
+  mdx)
+    if [[ $dir =~ (react_native*|angular-cli-v6|ember-cli|marko|meteor|mithril|riot|react_babel_6) ]]
+    then
+      yarn sb init --skip-install --yes
+    else
+      yarn sb init --skip-install --yes --story-format mdx
+    fi
+    ;;
+  csf-ts)
+    if [[ $dir =~ (react_scripts_ts) ]]
+    then
+      yarn sb init --skip-install --yes --story-format csf-ts
+    else
+      yarn sb init --skip-install --yes
+    fi
+    ;;
+  esac
+
+  # Need to do a new `yarn install` to have all `@storybook/xxx` packages correctly linked to local ones
+  yarn install
+
+  echo "Running smoke test in $dir"
+  failed=0
+  yarn storybook --smoke-test --quiet || failed=1
+
+  if [ $failed -eq 1 ]
+  then
+    exit 1
+  fi
+
+  cd ..
+done


### PR DESCRIPTION
Issue:
Part of #9527 

## What I did
 - Make SB CLI compatible with Yarn 2 by handling command used to fetch package versions on NPM registry. => Will need a refactoring, much easier to do if I migrate the package to TS first.
 - Add tests to check CLI and Yarn 2 compatibility: These tests mimic the ones done to test SB CLI with "classic" yarn. However, some magic setup and `package.json` customization are needed in order to make Yarn 2 works inside a Yarn v1 workspace.

⚠️ CLI is working with Yarn 2 but it does not mean that running `yarn sb init` will not fails because all frameworks or the SB integration are currently not compatible with Yarn 2. Especially projects using:
 - Angular as Angular is not working with Yarn 2
 - Marko => ` Cause: Error: Unable to load tag ([.yarn/berry/cache/marko-npm-4.18.46-d693c4c719-2.zip/node_modules/marko/src/core-tags/cache/marko.json → <cached-fragment>])`
 - React Static => `Error: Couldn't find preset "./babel-preset.js" relative to directory ".yarn/berry/cache/react-static-npm-5.9.12-e804e3b66e-2.zip/node_modules/react-static"`
 - Vue => https://github.com/nickmessing/babel-plugin-jsx-event-modifiers is not compatible with Yarn 2, it is deprecated too, so we will need to do something about it

## How to test

I add a new GitHub Actions workflow running tests related to SB CLI with Yarn 2. 
It should be 🟢.