### PR TITLE
Props: Fix typescript unspecified default value

### DIFF
--- a/addons/docs/src/frameworks/react/__testfixtures__/8143-ts-imported-types/properties.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8143-ts-imported-types/properties.snapshot
@@ -4,10 +4,7 @@ exports[`react component properties 8143-ts-imported-types 1`] = `
 Object {
   "rows": Array [
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "0",
-      },
+      "defaultValue": null,
       "description": "",
       "name": "bar",
       "required": true,

--- a/addons/docs/src/frameworks/react/__testfixtures__/9493-ts-display-name/properties.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9493-ts-display-name/properties.snapshot
@@ -17,10 +17,7 @@ Object {
       },
     },
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "1",
-      },
+      "defaultValue": null,
       "description": "A message alerting about Empire activities.",
       "name": "message",
       "required": true,

--- a/addons/docs/src/frameworks/react/__testfixtures__/9591-ts-import-types/properties.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9591-ts-import-types/properties.snapshot
@@ -4,10 +4,7 @@ exports[`react component properties 9591-ts-import-types 1`] = `
 Object {
   "rows": Array [
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "0",
-      },
+      "defaultValue": null,
       "description": "",
       "name": "other",
       "required": false,

--- a/addons/docs/src/frameworks/react/__testfixtures__/9592-ts-styled-props/properties.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9592-ts-styled-props/properties.snapshot
@@ -4,10 +4,7 @@ exports[`react component properties 9592-ts-styled-props 1`] = `
 Object {
   "rows": Array [
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "0",
-      },
+      "defaultValue": null,
       "description": "",
       "name": "title",
       "required": true,

--- a/addons/docs/src/frameworks/react/__testfixtures__/9721-ts-deprecated-jsdoc/properties.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9721-ts-deprecated-jsdoc/properties.snapshot
@@ -4,10 +4,7 @@ exports[`react component properties 9721-ts-deprecated-jsdoc 1`] = `
 Object {
   "rows": Array [
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "0",
-      },
+      "defaultValue": null,
       "description": "",
       "name": "width",
       "required": true,
@@ -17,10 +14,7 @@ Object {
       },
     },
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "1",
-      },
+      "defaultValue": null,
       "description": "The size (replaces width)",
       "name": "size",
       "required": true,

--- a/addons/docs/src/frameworks/react/__testfixtures__/9764-ts-extend-props/properties.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9764-ts-extend-props/properties.snapshot
@@ -4,10 +4,7 @@ exports[`react component properties 9764-ts-extend-props 1`] = `
 Object {
   "rows": Array [
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "0",
-      },
+      "defaultValue": null,
       "description": "The input content value",
       "name": "value",
       "required": false,
@@ -17,10 +14,7 @@ Object {
       },
     },
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "1",
-      },
+      "defaultValue": null,
       "description": "",
       "name": "defaultChecked",
       "required": false,
@@ -30,10 +24,7 @@ Object {
       },
     },
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "2",
-      },
+      "defaultValue": null,
       "description": "",
       "name": "checked",
       "required": false,

--- a/addons/docs/src/frameworks/react/__testfixtures__/9827-ts-default-values/properties.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9827-ts-default-values/properties.snapshot
@@ -17,10 +17,7 @@ Object {
       },
     },
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "1",
-      },
+      "defaultValue": null,
       "description": "",
       "name": "foo",
       "required": true,
@@ -30,10 +27,7 @@ Object {
       },
     },
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "2",
-      },
+      "defaultValue": null,
       "description": "",
       "name": "bar",
       "required": false,

--- a/addons/docs/src/frameworks/react/__testfixtures__/ts-function-component/properties.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/ts-function-component/properties.snapshot
@@ -30,10 +30,7 @@ Object {
       },
     },
     Object {
-      "defaultValue": Object {
-        "detail": undefined,
-        "summary": "2",
-      },
+      "defaultValue": null,
       "description": "Simple click handler",
       "name": "onClick",
       "required": false,

--- a/addons/docs/src/frameworks/react/typeScript/handleProp.ts
+++ b/addons/docs/src/frameworks/react/typeScript/handleProp.ts
@@ -23,5 +23,5 @@ export function enhanceTypeScriptProp(extractedProp: ExtractedProp, rawDefaultPr
 }
 
 export function enhanceTypeScriptProps(extractedProps: ExtractedProp[]): PropDef[] {
-  return extractedProps.map(enhanceTypeScriptProp);
+  return extractedProps.map(prop => enhanceTypeScriptProp(prop));
 }


### PR DESCRIPTION
Issue: #9827 

## What I did

Mapping a function that takes two arguments passes the index as the second argument. Fixed & tested!

## How to test

See updated snapshots & chromatic changes