### PR TITLE
Generate custom-elements.json from Stencil

### DIFF
--- a/addons/docs/web-components/README.md
+++ b/addons/docs/web-components/README.md
@@ -35,6 +35,15 @@ Known analyzers that output `custom-elements.json`:
 - [stenciljs](https://stenciljs.com/)
   - Supports Stencil (but does not have all metadata)
 
+To generate this file with Stencil, 
+add `docs-vscode` to outputTargets in the stencil.config.ts
+```
+{
+  type: 'docs-vscode',
+  file: 'custom-elements.json'
+},
+```
+
 It basically looks like this:
 
 ```json

--- a/addons/docs/web-components/README.md
+++ b/addons/docs/web-components/README.md
@@ -35,8 +35,8 @@ Known analyzers that output `custom-elements.json`:
 - [stenciljs](https://stenciljs.com/)
   - Supports Stencil (but does not have all metadata)
 
-To generate this file with Stencil, 
-add `docs-vscode` to outputTargets in the stencil.config.ts
+To generate this file with Stencil, add `docs-vscode` to outputTargets in `stencil.config.ts`:
+
 ```
 {
   type: 'docs-vscode',
@@ -44,7 +44,7 @@ add `docs-vscode` to outputTargets in the stencil.config.ts
 },
 ```
 
-It basically looks like this:
+The file looks somewthing like this:
 
 ```json
 {


### PR DESCRIPTION


Issue: #9848 

## What I did
Added more informations about how to generate a valid custom-elements.json from Stencil

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
