### PR TITLE
Fix typo on AsyncStorage section

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -236,14 +236,14 @@ To avoid that now you have to manually pass asyncStorage to React Native Storybo
 
 Solution:
 
-- Use `require('@react-native-community/async-storage').AsyncStorage` for React Native v0.59 and above.
+- Use `require('@react-native-community/async-storage').default` for React Native v0.59 and above.
 - Use `require('react-native').AsyncStorage` for React Native v0.58 or below.
 - Use `null` to disable Async Storage completely.
 
 ```javascript
 getStorybookUI({
   ...
-  asyncStorage: require('@react-native-community/async-storage').AsyncStorage || require('react-native').AsyncStorage || null
+  asyncStorage: require('@react-native-community/async-storage').default || require('react-native').AsyncStorage || null
 });
 ```
 


### PR DESCRIPTION
Issue: In the `AsyncStorage` section of the docs, there is a typo on the `require` causing the `AsyncStorage` from `react-native-community` to be never used.

## What I did
Fix that typo. 

## How to test

- ✖️Is this testable with Jest or Chromatic screenshots?
- ✖️Does this need a new example in the kitchen sink apps?
- ✅Does this need an update to the documentation?

Despite it's just a change in the docs, it can be tested by checking there is no warning when using the `AsyncStorage` from `react-native-community`
```js
const StorybookUIRoot = getStorybookUI({
  asyncStorage: require('@react-native-community/async-storage').default,
})
```
Versus following the previous doc, which will cause a warning
```js
const StorybookUIRoot = getStorybookUI({
  asyncStorage: require('@react-native-community/async-storage').AsyncStorage,
})
```

Note: I can't set a `documentation` label as suggested