### PR TITLE
fix(cli): capture unknown arguments the native way

### DIFF
--- a/lib/cli/src/generate.js
+++ b/lib/cli/src/generate.js
@@ -73,7 +73,8 @@ if (process.argv[1].includes('getstorybook')) {
       });
     });
 
-  program.command('*', { noHelp: true }).action(invalidCmd => {
+  program.command('*', { noHelp: true }).action(() => {
+    const [, , invalidCmd] = process.argv;
     logger.error(
       ' Invalid command: %s.\n See --help for a list of available commands.',
       invalidCmd


### PR DESCRIPTION
closes #9887

It seems `commander.js` fails to capture the exact unknown command passed in. A solution would be to pick it up from the native `process.argv`.