### PR TITLE
Fix docs configuration file typos

### DIFF
--- a/docs/src/pages/guides/guide-ember/index.md
+++ b/docs/src/pages/guides/guide-ember/index.md
@@ -59,7 +59,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```

--- a/docs/src/pages/guides/guide-marko/index.md
+++ b/docs/src/pages/guides/guide-marko/index.md
@@ -53,7 +53,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```

--- a/docs/src/pages/guides/guide-mithril/index.md
+++ b/docs/src/pages/guides/guide-mithril/index.md
@@ -54,7 +54,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```

--- a/docs/src/pages/guides/guide-preact/index.md
+++ b/docs/src/pages/guides/guide-preact/index.md
@@ -54,7 +54,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```

--- a/docs/src/pages/guides/guide-rax/index.md
+++ b/docs/src/pages/guides/guide-rax/index.md
@@ -54,7 +54,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```

--- a/docs/src/pages/guides/guide-riot/index.md
+++ b/docs/src/pages/guides/guide-riot/index.md
@@ -53,7 +53,7 @@ For a basic Storybook configuration, the only thing you need to do is tell Story
 To do that, create a file at `.storybook/main.js` with the following content:
 
 ```js
-module.exports {
+module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
 };
 ```


### PR DESCRIPTION
Issue:

I was running into a `SyntaxError: Unexpected token '{'` error when firing up `npm start storybook` in the tutorials.

## What I did

I fixed the typos.

## How to test

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? It is an update to the documentation.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
