### PR TITLE
Centered: remove `typesVersions` attribute 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 *.sw*
 npm-shrinkwrap.json
 dist
+ts3.5
 .tern-port
 *.DS_Store
 .cache

--- a/addons/centered/package.json
+++ b/addons/centered/package.json
@@ -46,12 +46,5 @@
     "react-dom": "*",
     "regenerator-runtime": "*"
   },
-  "gitHead": "4b9d901add9452525135caae98ae5f78dd8da9ff",
-  "typesVersions": {
-    "<=3.5": {
-      "*": [
-        "ts3.5/*"
-      ]
-    }
-  }
+  "gitHead": "4b9d901add9452525135caae98ae5f78dd8da9ff"
 }

--- a/scripts/reset.js
+++ b/scripts/reset.js
@@ -28,6 +28,7 @@ cleaningProcess.stdout.on('data', data => {
           if (
             uri.match(/node_modules/) ||
             uri.match(/dist/) ||
+            uri.match(/ts3\.5/) ||
             uri.match(/\.cache/) ||
             uri.match(/dll/)
           ) {


### PR DESCRIPTION
## Issue
After testing https://github.com/storybookjs/storybook/pull/9847 on a real angular project I faced the following error: 
```sh
TS2307: Cannot find module '@storybook/addon-centered/angular'.
```

After 🔍 it looks like it's due to the fact that this addon is exporting handwritten types from the addon rrot dir but TS was looking for types inside `dist` or `ts3.5/dist` folder.

## What I did

Removes `typesVersions` attribute because this addon exports handwritten types from base dir and so we should still let TS uses them instead of the one from `dist` or `ts3.5/dist` folder.

⚠️ Be careful when writing types by hand, they should be compatible with TS3.5

