### PR TITLE
Add missing dependencies or peerDependencies

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -54,7 +54,8 @@
   },
   "devDependencies": {
     "@types/react-redux": "^7.0.6",
-    "@types/webpack-env": "^1.15.1"
+    "@types/webpack-env": "^1.15.1",
+    "enzyme": "^3.11.0"
   },
   "peerDependencies": {
     "react-dom": "*"

--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -48,6 +48,7 @@
     "react-redux": "^7.0.2",
     "react-sizeme": "^2.5.2",
     "redux": "^4.0.1",
+    "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1",
     "util-deprecate": "^1.0.2"
   },
@@ -56,8 +57,7 @@
     "@types/webpack-env": "^1.15.1"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -41,6 +41,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.3",
     "react-inspector": "^4.0.0",
+    "regenerator-runtime": "^0.13.3",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
@@ -49,8 +50,7 @@
     "@types/webpack-env": "^1.15.1"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -41,6 +41,7 @@
     "core-js": "^3.0.1",
     "memoizerific": "^1.11.3",
     "react": "^16.8.3",
+    "regenerator-runtime": "^0.13.3",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
@@ -48,8 +49,7 @@
     "@types/webpack-env": "^1.15.1"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/centered/package.json
+++ b/addons/centered/package.json
@@ -41,10 +41,34 @@
     "@types/webpack-env": "^1.15.1",
     "mithril": "*",
     "preact": "*",
+    "rax": "*",
+    "rax-view": "*",
     "react": "*"
   },
   "peerDependencies": {
+    "mithril": "*",
+    "preact": "*",
+    "rax": "*",
+    "rax-view": "*",
+    "react": "*",
     "react-dom": "*"
+  },
+  "peerDependenciesMeta": {
+    "mithril": {
+      "optional": true
+    },
+    "preact": {
+      "optional": true
+    },
+    "rax": {
+      "optional": true
+    },
+    "rax-view": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
   },
   "gitHead": "4b9d901add9452525135caae98ae5f78dd8da9ff",
   "typesVersions": {

--- a/addons/centered/package.json
+++ b/addons/centered/package.json
@@ -33,7 +33,8 @@
     "@storybook/addons": "6.0.0-alpha.15",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "util-deprecate": "^1.0.2"
+    "util-deprecate": "^1.0.2",
+    "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {
     "@types/mithril": "^1.1.16",
@@ -43,8 +44,7 @@
     "react": "*"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "gitHead": "4b9d901add9452525135caae98ae5f78dd8da9ff",
   "typesVersions": {

--- a/addons/centered/src/mithril.tsx
+++ b/addons/centered/src/mithril.tsx
@@ -1,5 +1,4 @@
 /** @jsx m */
-/* eslint-disable import/no-extraneous-dependencies */
 import m, { ComponentTypes } from 'mithril';
 import { makeDecorator } from '@storybook/addons';
 import parameters from './parameters';

--- a/addons/centered/src/preact.tsx
+++ b/addons/centered/src/preact.tsx
@@ -1,5 +1,4 @@
 /** @jsx h */
-/* eslint-disable import/no-extraneous-dependencies */
 import { Component, h } from 'preact';
 import { makeDecorator } from '@storybook/addons';
 import parameters from './parameters';

--- a/addons/centered/src/rax.js
+++ b/addons/centered/src/rax.js
@@ -1,5 +1,4 @@
 /** @jsx createElement */
-/* eslint-disable import/no-extraneous-dependencies */
 import { createElement } from 'rax';
 import View from 'rax-view';
 import { makeDecorator } from '@storybook/addons';

--- a/addons/centered/src/react.tsx
+++ b/addons/centered/src/react.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React, { ReactNode } from 'react';
 import { makeDecorator, StoryFn } from '@storybook/addons';
 import parameters from './parameters';

--- a/addons/contexts/package.json
+++ b/addons/contexts/package.json
@@ -37,6 +37,10 @@
     "qs": "^6.6.0",
     "regenerator-runtime": "^0.13.3"
   },
+  "devDependencies": {
+    "@types/enzyme": "^3.10.5",
+    "enzyme": "^3.11.0"
+  },
   "peerDependencies": {
     "global": "*",
     "preact": "*",

--- a/addons/contexts/package.json
+++ b/addons/contexts/package.json
@@ -34,7 +34,8 @@
     "@storybook/core-events": "6.0.0-alpha.15",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "qs": "^6.6.0"
+    "qs": "^6.6.0",
+    "regenerator-runtime": "^0.13.3"
   },
   "peerDependencies": {
     "global": "*",
@@ -43,7 +44,6 @@
     "rax": "*",
     "react": "*",
     "react-dom": "*",
-    "regenerator-runtime": "*",
     "vue": "*"
   },
   "peerDependenciesMeta": {

--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -43,7 +43,10 @@
     "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.1"
+    "@types/webpack-env": "^1.15.1",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.2",
+    "react-dom": "^16.12.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -39,15 +39,15 @@
     "@storybook/theming": "6.0.0-alpha.15",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "react": "^16.8.3"
+    "react": "^16.8.3",
+    "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.15.1"
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/design-assets/package.json
+++ b/addons/design-assets/package.json
@@ -43,12 +43,12 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "react": "^16.8.3",
+    "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1",
     "use-image": "^1.0.3"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -48,6 +48,7 @@
     "@mdx-js/react": "^1.5.1",
     "@storybook/addons": "6.0.0-alpha.15",
     "@storybook/api": "6.0.0-alpha.15",
+    "@storybook/client-api": "6.0.0-alpha.15",
     "@storybook/components": "6.0.0-alpha.15",
     "@storybook/core-events": "6.0.0-alpha.15",
     "@storybook/csf": "0.0.1",

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -66,6 +66,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react-element-to-jsx-string": "^14.1.0",
+    "regenerator-runtime": "^0.13.3",
     "remark-external-links": "^5.0.0",
     "remark-slug": "^5.1.2",
     "ts-dedent": "^1.1.1",
@@ -95,8 +96,7 @@
     "babel-loader": "^8.0.0",
     "react": "^16.9.0",
     "react-dom": "*",
-    "react-is": "^16.8.0",
-    "regenerator-runtime": "*"
+    "react-is": "^16.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { addParameters } from '@storybook/client-api';
 import { extractProps, extractComponentDescription } from './compodoc';
 

--- a/addons/docs/src/frameworks/common/config.ts
+++ b/addons/docs/src/frameworks/common/config.ts
@@ -1,5 +1,5 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { addParameters } from '@storybook/client-api';
+/* eslint-disable-next-line import/no-extraneous-dependencies */
 import { DocsPage, DocsContainer } from '@storybook/addon-docs/blocks';
 
 addParameters({

--- a/addons/docs/src/frameworks/ember/config.js
+++ b/addons/docs/src/frameworks/ember/config.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { addParameters } from '@storybook/client-api';
 import { extractProps, extractComponentDescription } from './jsondoc';
 

--- a/addons/docs/src/frameworks/react/config.ts
+++ b/addons/docs/src/frameworks/react/config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { addParameters } from '@storybook/client-api';
 import { StoryFn } from '@storybook/addons';
 import { extractProps } from './extractProps';

--- a/addons/docs/src/frameworks/vue/config.tsx
+++ b/addons/docs/src/frameworks/vue/config.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import toReact from '@egoist/vue-to-react';
 import { StoryFn } from '@storybook/addons';

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -33,6 +33,8 @@
     "@storybook/addons": "6.0.0-alpha.15",
     "@storybook/api": "6.0.0-alpha.15",
     "@storybook/node-logger": "6.0.0-alpha.15",
+    "core-js": "^3.0.1",
+    "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1"
   },
   "devDependencies": {
@@ -42,8 +44,7 @@
     "babel-loader": "^8.0.0",
     "react": "^16.8.0",
     "react-dom": "*",
-    "react-is": "^16.8.0",
-    "regenerator-runtime": "*"
+    "react-is": "^16.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -43,6 +43,7 @@
     "react": "^16.8.3",
     "react-lifecycles-compat": "^3.0.4",
     "react-textarea-autosize": "^7.0.4",
+    "regenerator-runtime": "^0.13.3",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
@@ -50,8 +51,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/google-analytics/package.json
+++ b/addons/google-analytics/package.json
@@ -24,11 +24,11 @@
     "@storybook/core-events": "6.0.0-alpha.15",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "react-ga": "^2.5.7"
+    "react-ga": "^2.5.7",
+    "regenerator-runtime": "^0.13.3"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/google-analytics/package.json
+++ b/addons/google-analytics/package.json
@@ -28,7 +28,9 @@
     "regenerator-runtime": "^0.13.3"
   },
   "peerDependencies": {
-    "react-dom": "*"
+    "react-dom": "*",
+    "react": "^15.6.2 || ^16.0",
+    "prop-types": "^15.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -35,12 +35,12 @@
     "global": "^4.3.2",
     "graphiql": "^0.17.5",
     "graphql": "^14.6.0",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "regenerator-runtime": "^0.13.3"
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/jest/package.json
+++ b/addons/jest/package.json
@@ -44,6 +44,7 @@
     "global": "^4.3.2",
     "react": "^16.8.3",
     "react-sizeme": "^2.5.2",
+    "regenerator-runtime": "^0.13.3",
     "upath": "^1.1.0",
     "util-deprecate": "^1.0.2"
   },
@@ -52,8 +53,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -32,6 +32,7 @@
     "@storybook/addons": "6.0.0-alpha.15",
     "@storybook/api": "6.0.0-alpha.15",
     "@storybook/client-api": "6.0.0-alpha.15",
+    "@storybook/channels": "6.0.0-alpha.15",
     "@storybook/components": "6.0.0-alpha.15",
     "@storybook/core-events": "6.0.0-alpha.15",
     "@storybook/theming": "6.0.0-alpha.15",
@@ -53,7 +54,9 @@
     "@types/escape-html": "0.0.20",
     "@types/react-lifecycles-compat": "^3.0.1",
     "@types/react-select": "^2.0.19",
-    "@types/webpack-env": "^1.15.1"
+    "@types/webpack-env": "^1.15.1",
+    "@types/enzyme": "^3.10.5",
+    "enzyme": "^3.11.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -46,7 +46,8 @@
     "qs": "^6.6.0",
     "react-color": "^2.17.0",
     "react-lifecycles-compat": "^3.0.4",
-    "react-select": "^3.0.8"
+    "react-select": "^3.0.8",
+    "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {
     "@types/escape-html": "0.0.20",
@@ -56,8 +57,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/knobs/src/KnobManager.ts
+++ b/addons/knobs/src/KnobManager.ts
@@ -3,7 +3,6 @@
 import { navigator } from 'global';
 import escape from 'escape-html';
 import { getQueryParams } from '@storybook/client-api';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Channel } from '@storybook/channels';
 
 import KnobStore, { KnobStoreKnob } from './KnobStore';

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -43,7 +43,8 @@
     "ts-dedent": "^1.1.1"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.1"
+    "@types/webpack-env": "^1.15.1",
+    "enzyme": "^3.11.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -39,6 +39,7 @@
     "global": "^4.3.2",
     "prop-types": "^15.7.2",
     "qs": "^6.6.0",
+    "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1"
   },
   "devDependencies": {
@@ -46,8 +47,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/options/package.json
+++ b/addons/options/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@storybook/addons": "6.0.0-alpha.15",
     "core-js": "^3.0.1",
+    "regenerator-runtime": "^0.13.3",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
@@ -38,8 +39,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/queryparams/package.json
+++ b/addons/queryparams/package.json
@@ -40,14 +40,14 @@
     "global": "^4.3.2",
     "qs": "^6.6.0",
     "react": "^16.8.3",
+    "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.15.1"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -58,8 +58,7 @@
     "react": "^16.8.3"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -53,6 +53,7 @@
     "@storybook/addon-docs": "6.0.0-alpha.15",
     "@storybook/react": "6.0.0-alpha.15",
     "babel-loader": "^8.0.6",
+    "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.4.1",
     "jest-emotion": "^10.0.17",
     "react": "^16.8.3"

--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -39,6 +39,7 @@
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
     "prop-types": "^15.7.2",
+    "regenerator-runtime": "^0.13.3",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
@@ -46,8 +47,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/app/marionette/package.json
+++ b/app/marionette/package.json
@@ -30,7 +30,7 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "html-loader": "^0.5.5",
-    "regenerator-runtime": "^0.12.1"
+    "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {
     "backbone.marionette": "*"

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -35,6 +35,7 @@
     "@storybook/router": "6.0.0-alpha.15",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
+    "regenerator-runtime": "^0.13.3",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
@@ -42,8 +43,7 @@
     "@types/util-deprecate": "^1.0.0"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -41,6 +41,7 @@
     "lodash": "^4.17.15",
     "memoizerific": "^1.11.3",
     "react": "^16.8.3",
+    "regenerator-runtime": "^0.13.3",
     "semver": "^6.0.0",
     "store2": "^2.7.1",
     "telejson": "^3.2.0",
@@ -52,8 +53,7 @@
     "@types/semver": "^6.0.0"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -47,8 +47,7 @@
     "util-deprecate": "^1.0.2"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/node-logger/package.json
+++ b/lib/node-logger/package.json
@@ -32,8 +32,7 @@
     "chalk": "^3.0.0",
     "core-js": "^3.0.1",
     "npmlog": "^4.1.2",
-    "pretty-hrtime": "^1.0.3",
-    "regenerator-runtime": "^0.13.3"
+    "pretty-hrtime": "^1.0.3"
   },
   "devDependencies": {
     "@types/pretty-hrtime": "^1.0.0"

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -40,8 +40,7 @@
     "regenerator-runtime": "^0.13.3"
   },
   "peerDependencies": {
-    "react-dom": "*",
-    "regenerator-runtime": "*"
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -56,7 +56,7 @@
     "react-helmet-async": "^1.0.2",
     "react-hotkeys": "2.0.0",
     "react-sizeme": "^2.6.7",
-    "regenerator-runtime": "^0.13.2",
+    "regenerator-runtime": "^0.13.3",
     "resolve-from": "^5.0.0",
     "semver": "^6.0.0",
     "store2": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25293,11 +25293,6 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
-  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
-
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3940,7 +3940,7 @@
   resolved "https://registry.yarnpkg.com/@types/doctrine/-/doctrine-0.0.3.tgz#e892d293c92c9c1d3f9af72c15a554fbc7e0895a"
   integrity sha1-6JLSk8ksnB0/mvcsFaVU+8fgiVo=
 
-"@types/enzyme@^3.10.3", "@types/enzyme@^3.9.0":
+"@types/enzyme@^3.10.3", "@types/enzyme@^3.10.5", "@types/enzyme@^3.9.0":
   version "3.10.5"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.5.tgz#fe7eeba3550369eed20e7fb565bfb74eec44f1f0"
   integrity sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==
@@ -11789,7 +11789,7 @@ envinfo@^7.3.1, envinfo@^7.5.0:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.5.0.tgz#91410bb6db262fb4f1409bd506e9ff57e91023f4"
   integrity sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ==
 
-enzyme-adapter-react-16@^1.9.1:
+enzyme-adapter-react-16@^1.15.2, enzyme-adapter-react-16@^1.9.1:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.2.tgz#b16db2f0ea424d58a808f9df86ab6212895a4501"
   integrity sha512-SkvDrb8xU3lSxID8Qic9rB8pvevDbLybxPK6D/vW7PrT0s2Cl/zJYuXvsd1EBTz0q4o3iqG3FJhpYz3nUNpM2Q==
@@ -11840,7 +11840,7 @@ enzyme-to-json@^3.3.0, enzyme-to-json@^3.4.1:
     lodash "^4.17.15"
     react-is "^16.12.0"
 
-enzyme@^3.9.0:
+enzyme@^3.11.0, enzyme@^3.9.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.11.0.tgz#71d680c580fe9349f6f5ac6c775bc3e6b7a79c28"
   integrity sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==
@@ -24340,7 +24340,7 @@ rax-text@^1.0.1, rax-text@^1.1.2:
   dependencies:
     universal-env "^3.0.0"
 
-rax-view@^1.0.0:
+rax-view@*, rax-view@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/rax-view/-/rax-view-1.1.0.tgz#4ff95bcadb6c5355d342753b7f4e364e219c3411"
   integrity sha512-AaBkFaks49Igs8tHU3HmYoa+PoXitMbddAQ8BlfJabYTT6/gfcMdj7ejDB/23MGtB/cuJthmuiQMlkr8/JVUuA==
@@ -24348,7 +24348,7 @@ rax-view@^1.0.0:
     classnames "^2.2.6"
     universal-env "^1.0.0"
 
-rax@^1.1.0:
+rax@*, rax@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/rax/-/rax-1.1.1.tgz#f8a8b51913bdcbf343d8ad8f50c742d555eb5e45"
   integrity sha512-sk34VJ/D4lMgT6z6PLTF5xK3Nvk2QMkdhvm45a3f4TZq3Uy18dDf5+b7oUqrHBZZNT5E0Se8RHSa/WodhMAV0g==
@@ -24501,7 +24501,7 @@ react-dom@^15.4.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-dom@^16.10.2, react-dom@^16.11.0, react-dom@^16.8.3, react-dom@^16.8.4:
+react-dom@^16.10.2, react-dom@^16.11.0, react-dom@^16.12.0, react-dom@^16.8.3, react-dom@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
   integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==


### PR DESCRIPTION
## What I did

As Yarn 2 is must stricter than Yarn 1 or NPM about missing `dependencies` or `peerDependencies` I used `npx @yarnpkg/doctor` (details [here](https://yarnpkg.com/advanced/migration#run-the-doctor)) to fix some of them. 

There are still a lot more, I will fix them step by step. 

--

Specific case of `regenerator-runtime`: as discussed with @ndelangen `regenerator-runtime` is used as polyfill to backport async/await and generator to old browser (like core-js). Any package that uses async/await or generator will require `regenerator-runtime` at runtime without any import in the source (it's added by babel during transpilation). To avoid any issue in the future `regenerator-runtime` is added to almost all packages, as it has been done for `core-js`

## How to test

 - All check should be green 

