### PR TITLE
Server: Simplify server addons

### DIFF
--- a/app/server/src/lib/compiler/__testfixtures__/a11y.json
+++ b/app/server/src/lib/compiler/__testfixtures__/a11y.json
@@ -1,6 +1,5 @@
 {
   "title": "Addons/a11y",
-  "addons": ["a11y"],
   "parameters": {
     "options": { "selectedPanel": "storybook/a11y/panel" }
   },

--- a/app/server/src/lib/compiler/__testfixtures__/a11y.snapshot
+++ b/app/server/src/lib/compiler/__testfixtures__/a11y.snapshot
@@ -1,13 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`json-to-csf-compiler a11y.json 1`] = `
-"import { withA11y } from '@storybook/addon-a11y';
-
+"
 export default {
   title: 'Addons/a11y',
-  decorators: [
-    withA11y
-  ],
   parameters: {
     options: {
       selectedPanel: 'storybook/a11y/panel'

--- a/app/server/src/lib/compiler/__testfixtures__/kitchen_sink.json
+++ b/app/server/src/lib/compiler/__testfixtures__/kitchen_sink.json
@@ -1,6 +1,6 @@
 {
   "title": "Kitchen Sink",
-  "addons": ["a11y", "knobs", "actions", "links"],
+  "addons": ["knobs", "actions"],
   "parameters": {
     "backgrounds": [
       { "name": "light", "value": "#eeeeee" },

--- a/app/server/src/lib/compiler/__testfixtures__/kitchen_sink.snapshot
+++ b/app/server/src/lib/compiler/__testfixtures__/kitchen_sink.snapshot
@@ -1,16 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`json-to-csf-compiler kitchen_sink.json 1`] = `
-"import { withA11y } from '@storybook/addon-a11y';
-import { withLinks } from '@storybook/addon-links';
-import { array, boolean, color, date, number, object, select, text, withKnobs } from '@storybook/addon-knobs';
+"import { array, boolean, color, date, number, object, select, text, withKnobs } from '@storybook/addon-knobs';
 import { withActions } from '@storybook/addon-actions';
 
 export default {
   title: 'Kitchen Sink',
   decorators: [
-    withA11y,
-    withLinks,
     withKnobs
   ],
   parameters: {

--- a/app/server/src/lib/compiler/__testfixtures__/links.json
+++ b/app/server/src/lib/compiler/__testfixtures__/links.json
@@ -1,6 +1,5 @@
 {
   "title": "Welcome",
-  "addons": ["links"],
   "stories": [
     {
       "name": "Welcome",

--- a/app/server/src/lib/compiler/__testfixtures__/links.snapshot
+++ b/app/server/src/lib/compiler/__testfixtures__/links.snapshot
@@ -1,13 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`json-to-csf-compiler links.json 1`] = `
-"import { withLinks } from '@storybook/addon-links';
-
+"
 export default {
   title: 'Welcome',
-  decorators: [
-    withLinks
-  ],
 };
 
 export const Welcome = () => {};

--- a/app/server/src/lib/compiler/decorators/index.ts
+++ b/app/server/src/lib/compiler/decorators/index.ts
@@ -1,15 +1,8 @@
 import { StorybookSection, Decorator } from '../types';
-import { decorateSimpleAddon } from './utils';
 import { knobsDecorator } from './knobs';
 import { actionsDecorator } from './actions';
 
-function createSimpleDecorator(addon: string) {
-  return (section: StorybookSection): StorybookSection => decorateSimpleAddon(section, addon);
-}
-
 const allDecorators: Record<string, Decorator> = {
-  a11y: createSimpleDecorator('a11y'),
-  links: createSimpleDecorator('links'),
   knobs: knobsDecorator,
   actions: actionsDecorator,
 };

--- a/examples/server-kitchen-sink/.storybook/preview.js
+++ b/examples/server-kitchen-sink/.storybook/preview.js
@@ -1,7 +1,7 @@
 import { addParameters, addDecorator } from '@storybook/server';
-import { withA11y } from '@storybook/addon-a11y';
+import { withLinks } from '@storybook/addon-links';
 
-addDecorator(withA11y);
+addDecorator(withLinks);
 
 const port = process.env.SERVER_PORT || 1337;
 

--- a/examples/server-kitchen-sink/stories/addon-a11y.stories.json
+++ b/examples/server-kitchen-sink/stories/addon-a11y.stories.json
@@ -1,6 +1,5 @@
 {
   "title": "Addons/a11y",
-  "addons": ["a11y"],
   "parameters": {
     "options": { "selectedPanel": "storybook/a11y/panel" }
   },

--- a/examples/server-kitchen-sink/stories/kitchen_sink.stories.json
+++ b/examples/server-kitchen-sink/stories/kitchen_sink.stories.json
@@ -1,6 +1,6 @@
 {
   "title": "Kitchen Sink",
-  "addons": ["a11y", "knobs", "actions", "links"],
+  "addons": ["knobs", "actions"],
   "parameters": {
     "backgrounds": [
       { "name": "light", "value": "#eeeeee" },

--- a/examples/server-kitchen-sink/stories/welcome.stories.json
+++ b/examples/server-kitchen-sink/stories/welcome.stories.json
@@ -1,6 +1,5 @@
 {
   "title": "Welcome",
-  "addons": ["links"],
   "stories": [
     {
       "name": "Welcome",


### PR DESCRIPTION
Issue: #9741

## What I did

links and a11y addons don't need to be declared in stories.json
This works out of the box. However, to make links work the decorator is needed in preview.js. a11y doesn't need the decorator and I'm not clear why the addons behave differently.




