### PR TITLE
Addon-a11y: Move react to peer dependency

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -44,7 +44,6 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
-    "react": "^16.8.3",
     "react-redux": "^7.0.2",
     "react-sizeme": "^2.5.2",
     "redux": "^4.0.1",
@@ -58,6 +57,7 @@
     "enzyme": "^3.11.0"
   },
   "peerDependencies": {
+    "react": "*",
     "react-dom": "*"
   },
   "publishConfig": {


### PR DESCRIPTION
Issue: #9953 

## What I did
Moved `react` to peer dependencies.

## How to test
It doesn't appear that this change requires and tests. Rebuilt everything and ran `yarn test`  to all green. I don't have all the context on this add-on though, so open to discussing if there's anything else that needs to be checked.

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
