### PR TITLE
Core: Fix `configFilename` containing backticks

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -55,7 +55,7 @@ export default ({
       virtualModuleMapping[entryFilename] = `
         import { addDecorator, addParameters } from '@storybook/client-api';
 
-        const { decorators, parameters } = require('${configFilename}');
+        const { decorators, parameters } = require(${JSON.stringify(configFilename)});
         
         if (decorators) decorators.forEach(decorator => addDecorator(decorator));
         if (parameters) addParameters(parameters);


### PR DESCRIPTION
Issue: #9937 

In windows the path sep is `\` which will lead to weird stuff like: https://github.com/chromaui/learnstorybook.com/issues/284
