### PR TITLE
Misc: Add missing dependencies

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@babel/generator": "^7.8.4",
     "@babel/parser": "^7.8.4",
+    "@babel/preset-env": "^7.8.4",
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "@egoist/vue-to-react": "^1.1.0",
     "@jest/transform": "^25.1.0",
@@ -53,6 +54,7 @@
     "@storybook/core-events": "6.0.0-alpha.20",
     "@storybook/csf": "0.0.1",
     "@storybook/postinstall": "6.0.0-alpha.20",
+    "@storybook/node-logger": "6.0.0-alpha.20",
     "@storybook/source-loader": "6.0.0-alpha.20",
     "@storybook/theming": "6.0.0-alpha.20",
     "acorn": "^7.1.0",
@@ -76,6 +78,10 @@
     "vue-docgen-loader": "^1.4.0"
   },
   "devDependencies": {
+    "@angular/core": "^8.2.8",
+    "@emotion/styled": "^10.0.17",
+    "@emotion/core": "^10.0.20",
+    "@babel/core": "^7.8.4",
     "@storybook/react": "6.0.0-alpha.20",
     "@storybook/web-components": "6.0.0-alpha.20",
     "@types/doctrine": "^0.0.3",
@@ -83,21 +89,42 @@
     "@types/jest": "^25.1.1",
     "@types/prop-types": "^15.5.9",
     "@types/util-deprecate": "^1.0.0",
+    "babel-loader": "^8.0.6",
     "babel-plugin-react-docgen": "^4.1.0",
     "cross-spawn": "^7.0.1",
+    "fs-extra": "^8.1.0",
+    "jest": "^25.1.0",
     "jest-specific-snapshot": "^2.0.0",
+    "lit-element": "^2.2.1",
     "lit-html": "^1.0.0",
+    "prettier": "^1.18.2",
     "require-from-string": "^2.0.2",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3",
+    "react-is": "^16.12.0",
+    "rxjs": "^6.5.4",
     "styled-components": "^5.0.1",
     "tmp": "^0.1.0",
-    "web-component-analyzer": "^1.0.3"
+    "web-component-analyzer": "^1.0.3",
+    "webpack": "^4.33.0",
+    "zone.js": "^0.10.2"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",
     "babel-loader": "^8.0.0",
-    "react": "^16.9.0",
+    "react": ">=16.3.0",
     "react-dom": "*",
-    "react-is": "^16.8.0"
+    "react-is": "^16.8.0",
+    "vue": "^2.6.10",
+    "webpack": ">=4"
+  },
+  "peerDependenciesMeta": {
+    "vue": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/docs/postinstall/presets.js
+++ b/addons/docs/postinstall/presets.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import { presetsAddPreset, getFrameworks } from '@storybook/postinstall';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { logger } from '@storybook/node-logger';
 
 export default function transformer(file, api) {

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -43,6 +43,7 @@
     "@types/util-deprecate": "^1.0.0"
   },
   "peerDependencies": {
+    "react": "*",
     "react-dom": "*"
   },
   "publishConfig": {

--- a/lib/addons/src/index.ts
+++ b/lib/addons/src/index.ts
@@ -1,5 +1,4 @@
 import global from 'global';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ReactElement } from 'react';
 import { Channel } from '@storybook/channels';
 import { API } from '@storybook/api';

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -50,7 +50,9 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.149",
-    "@types/semver": "^6.0.0"
+    "@types/semver": "^6.0.0",
+    "flush-promises": "^1.0.2",
+    "qs": "^6.6.0"
   },
   "peerDependencies": {
     "react-dom": "*"

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -47,6 +47,7 @@
     "util-deprecate": "^1.0.2"
   },
   "peerDependencies": {
+    "react": "*",
     "react-dom": "*"
   },
   "publishConfig": {

--- a/lib/postinstall/package.json
+++ b/lib/postinstall/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@hypnosphi/jscodeshift": "^0.6.4",
+    "jest": "^25.1.0",
     "jest-specific-snapshot": "^2.0.0"
   },
   "publishConfig": {

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -40,6 +40,7 @@
     "regenerator-runtime": "^0.13.3"
   },
   "peerDependencies": {
+    "react": "*",
     "react-dom": "*"
   },
   "publishConfig": {

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -64,11 +64,16 @@
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.8.4",
     "@storybook/addon-actions": "6.0.0-alpha.20",
     "@storybook/addon-knobs": "6.0.0-alpha.20",
     "@storybook/react": "6.0.0-alpha.20",
+    "@testing-library/react": "^9.2.0",
+    "babel-loader": "^8.0.6",
     "corejs-upgrade-webpack-plugin": "^3.0.1",
+    "enzyme": "^3.11.0",
     "flush-promises": "^1.0.2",
+    "storybook-chromatic": "^3.5.0",
     "terser-webpack-plugin": "^2.3.4",
     "webpack": "^4.33.0"
   },


### PR DESCRIPTION
Follows https://github.com/storybookjs/storybook/pull/9916

## What I did

As Yarn 2 is much stricter than Yarn 1 or NPM about missing `dependencies` or `peerDependencies` I used `npx @yarnpkg/doctor` (details [here](https://yarnpkg.com/advanced/migration#run-the-doctor)) to fix some of them. Added them with version range already used in the workspace to avoid downloading new deps (that's why yarn.lock is not modified)