### PR TITLE
Documentation of writing add-on: replace 'withFoo' with the name of addon used in sample below 'withMyAddon'

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -132,7 +132,7 @@ Now we need to create two files, `register.js` and `index.js,`. `register.js` wi
 
 ## Creating a decorator
 
-Let's add the following content to the `index.js`. It will expose a decorator called `withFoo` which we use the `.addDecorator()` API to decorate all our stories.
+Let's add the following content to the `index.js`. It will expose a decorator called `withMyAddon` which we use the `.addDecorator()` API to decorate all our stories.
 
 The `@storybook/addons` package contains a `makeDecorator` function which we can use to create such a decorator:
 


### PR DESCRIPTION
Issue:
Documentation has inconsistant add-on name in sample vs description.

## What I did
changed 'withFoo' to 'withMyAddon'
## How to test
No test needed, simple text change in doc
- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
