### PR TITLE
Update Writing-Addon doc

### DIFF
--- a/docs/src/pages/addons/writing-addons/index.md
+++ b/docs/src/pages/addons/writing-addons/index.md
@@ -74,8 +74,8 @@ const PANEL_ID = `${ADDON_ID}/panel`;
 
 const MyPanel = () => {
   const value = useParameter(PARAM_KEY, null);
-  
-  return <div>{value}</div>;
+  const item = value ? value.data : "";
+  return <div>{item}</div>;
 }
 
 addons.register(ADDON_ID, api => {


### PR DESCRIPTION
(two line change)
Update Writing-Addon doc to fix error in reading parameter data.  As currently written this causes an exception due to the object returned not being a string. Two ways to fix this, change the data passed by param to just a bare string in the story code above, or change how the addon handles the parameter data. The second is preferable since this is the more likely scenario, and a more useful showcase of passing parameter data.   This is the path I've chosen to changed.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
