### PR TITLE
CLI: Support js / jsx / ts / tsx stories in React CSF template

### DIFF
--- a/lib/cli/src/generators/REACT/template-csf/.storybook/main.js
+++ b/lib/cli/src/generators/REACT/template-csf/.storybook/main.js
@@ -1,4 +1,4 @@
 module.exports = {
-  stories: ['../stories/**/*.stories.js'],
+  stories: ['../stories/**/*.stories.(ts|tsx|js|jsx)'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 };


### PR DESCRIPTION
Updated Regex to accommodate both Js and JSX or ts and TSX.

Issue:

What I did
Update default template generation in storybook cli to add jsx/ts/tsx file.

Issue:
When Using cli tool to initialise storybook inside a project it only take .js files and not jsx/ts/tsx.