### PR TITLE
Misc: Add some missing dependencies 

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -85,6 +85,9 @@
     "@storybook/vue": "6.0.0-alpha.21",
     "@storybook/web-components": "6.0.0-alpha.21"
   },
+  "peerDependencies": {
+    "jest": "*"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -34,12 +34,15 @@
     "core-js": "^3.0.1",
     "cross-spawn": "^7.0.0",
     "globby": "^11.0.0",
-    "jest-specific-snapshot": "^2.0.0",
     "jscodeshift": "^0.7.0",
     "lodash": "^4.17.15",
     "prettier": "^1.16.4",
     "recast": "^0.16.1",
     "regenerator-runtime": "^0.13.3"
+  },
+  "devDependencies": {
+    "jest": "^25.1.0",
+    "jest-specific-snapshot": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Issue:
- `@storybook/cli@npm:6.0.0-alpha.20 doesn't provide jest@* requested by @storybook/codemod@npm:6.0.0-alpha.20`
- `@storybook/codemod@npm:6.0.0-alpha.20 doesn't provide jest@* requested by jest-specific-snapshot@npm:2.0.0`


## What I did
Added the missing peerDependencies to their relevant package.