### PR TITLE
Core: Fix StoryInput parameters typings

### DIFF
--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -47,7 +47,7 @@ export interface Story {
   isRoot: false;
   isLeaf: true;
   parameters?: {
-    filename: string;
+    fileName: string;
     options: {
       hierarchyRootSeparator?: RegExp;
       hierarchySeparator?: RegExp;
@@ -65,7 +65,7 @@ export interface StoryInput {
   kind: string;
   children: string[];
   parameters: {
-    filename: string;
+    fileName: string;
     options: {
       hierarchyRootSeparator: RegExp;
       hierarchySeparator: RegExp;


### PR DESCRIPTION
Issue:

Story parameters properties doesn't match with declared types for `StoryInput`. In type declaration used parameter name `filename` but in implementation [here](https://github.com/storybookjs/storybook/blob/next/lib/core/src/client/preview/makeConfigure.ts#L105) and [here](https://github.com/storybookjs/storybook/blob/next/lib/client-api/src/client_api.ts#L183) parameter named as `fileName`.

## What I did

Update types to be more consistent.
