### PR TITLE
Add build-storybook script during setup as well

### DIFF
--- a/docs/src/pages/guides/guide-angular/index.md
+++ b/docs/src/pages/guides/guide-angular/index.md
@@ -31,17 +31,18 @@ npm install @storybook/angular --save-dev
 Make sure that you have `@babel/core`, and `babel-loader` in your dependencies as well because we list these as a peer dependencies:
 
 ```sh
-npm install babel-loader @babel/core --save-dev 
+npm install babel-loader @babel/core --save-dev
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-ember/index.md
+++ b/docs/src/pages/guides/guide-ember/index.md
@@ -35,15 +35,15 @@ If you don't have `package.json` in your project, you'll need to init it first:
 npm init
 ```
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following npm scripts to your `package.json` in order to start the storybook later in this guide:
 
 > In order for your storybook to run properly be sure to be either run `ember serve` or `ember build` before running any storybook commands. Running `ember serve` before storybook will enable live reloading.
 
 ```json
 {
   "scripts": {
-    "build-storybook": "ember build && build-storybook -s dist",
-    "storybook": "ember serve & start-storybook -p 9001 -s dist"
+    "storybook": "ember serve & start-storybook -p 9001 -s dist",
+    "build-storybook": "ember build && build-storybook -s dist"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-html/index.md
+++ b/docs/src/pages/guides/guide-html/index.md
@@ -39,17 +39,18 @@ npm install @storybook/html --save-dev
 Make sure that you have `@babel/core`, and `babel-loader` in your dependencies as well because we list these as a peer dependencies:
 
 ```sh
-npm install babel-loader @babel/core --save-dev 
+npm install babel-loader @babel/core --save-dev
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-marko/index.md
+++ b/docs/src/pages/guides/guide-marko/index.md
@@ -31,17 +31,18 @@ npm install @storybook/marko --save-dev
 Make sure that you have `marko`, `@babel/core`, and `babel-loader` in your dependencies as well because we list these as a peer dependencies:
 
 ```sh
-npm install babel-loader @babel/core --save-dev 
+npm install babel-loader @babel/core --save-dev
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-mithril/index.md
+++ b/docs/src/pages/guides/guide-mithril/index.md
@@ -32,17 +32,18 @@ Make sure that you have `mithril`, `@babel/core`, and `babel-loader` in your dep
 
 ```sh
 npm install mithril --save
-npm install babel-loader @babel/core --save-dev 
+npm install babel-loader @babel/core --save-dev
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-preact/index.md
+++ b/docs/src/pages/guides/guide-preact/index.md
@@ -32,17 +32,18 @@ Make sure that you have `preact`, `@babel/core`, and `babel-loader` in your depe
 
 ```sh
 npm install preact --save
-npm install babel-loader @babel/core --save-dev 
+npm install babel-loader @babel/core --save-dev
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-rax/index.md
+++ b/docs/src/pages/guides/guide-rax/index.md
@@ -35,14 +35,15 @@ npm install rax --save
 npm install babel-loader @babel/core --save-dev
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-react/index.md
+++ b/docs/src/pages/guides/guide-react/index.md
@@ -53,14 +53,15 @@ npm install react react-dom --save
 npm install babel-loader @babel/core --save-dev
 ```
 
-## Step 2: Add an npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-riot/index.md
+++ b/docs/src/pages/guides/guide-riot/index.md
@@ -34,14 +34,15 @@ Make sure that you have `riot`, `@babel/core`, and `babel-loader` in your depend
 npm install riot babel-loader @babel/core --save-dev
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-svelte/index.md
+++ b/docs/src/pages/guides/guide-svelte/index.md
@@ -45,14 +45,15 @@ You'll also need to install `svelte-loader` if you haven't already.
 npm install svelte-loader --save-dev
 ```
 
-## Step 2: Add a npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```

--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -35,14 +35,15 @@ npm install vue --save
 npm install vue-loader vue-template-compiler @babel/core babel-loader babel-preset-vue --save-dev
 ```
 
-## Step 2: Add an npm script
+## Step 2: Add npm scripts
 
-Then add the following NPM script to your `package.json` in order to start the storybook later in this guide:
+Then add the following scripts to your `package.json` in order to start the storybook later in this guide:
 
 ```json
 {
   "scripts": {
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   }
 }
 ```


### PR DESCRIPTION
This updates the manual getting started guides for each framework to also include the `"build-storybook": "build-storybook"` script in the snippet to copy-paste into `package.json`.