### PR TITLE
fix: Disables html-webpack-plugin's option to remove script tag types

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -101,6 +101,14 @@ export default ({
           dlls: [],
           bodyHtmlSnippet: getPreviewBodyHtml(configDir, process.env),
         }),
+        minify: {
+          collapseWhitespace: true,
+          removeComments: true,
+          removeRedundantAttributes: true,
+          removeScriptTypeAttributes: false,
+          removeStyleLinkTypeAttributes: true,
+          useShortDoctype: true,
+        },
         template: require.resolve(`../templates/index.ejs`),
       }),
       new DefinePlugin({


### PR DESCRIPTION
Issue: #9900 

## What I did
Disabled html-webpack-plugin's option to remove script tag types

## How to test
Build a static storybook that uses a preview-head.html that includes a script tag with the `type` attribute is set to equal "module".