### PR TITLE
Addon-actions: Style ActionLogger to preserve whitespace

### DIFF
--- a/addons/actions/src/components/ActionLogger/style.tsx
+++ b/addons/actions/src/components/ActionLogger/style.tsx
@@ -8,6 +8,7 @@ export const Action = styled.div({
   borderBottom: '1px solid transparent',
   transition: 'all 0.1s',
   alignItems: 'flex-start',
+  whiteSpace: 'pre',
 });
 
 export const Counter = styled.div<{}>(({ theme }) => ({


### PR DESCRIPTION
Issue: #9499 

## What I did

Fixed issue referred on #9499 by adding the css white-space property with value "pre" in the ActionLogger style to preserve whitespaces.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation?  No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
