### PR TITLE
docs(README): add ts to module.exports

### DIFF
--- a/addons/docs/angular/README.md
+++ b/addons/docs/angular/README.md
@@ -101,7 +101,7 @@ Then update your `.storybook/main.js` to make sure you load MDX files:
 
 ```ts
 module.exports = {
-  stories: ['../src/stories/**/*.stories.(js|mdx)'],
+  stories: ['../src/stories/**/*.stories.(js|ts|mdx)'],
 };
 ```
 


### PR DESCRIPTION
Issue:
In angular we work with typescript files, but this part was missing in the `main.js`file

## What I did
Fixing the README file

## How to test

No it is just documentation