### PR TITLE
docs: Update preset-typescript documentation

### DIFF
--- a/docs/src/pages/presets/introduction/index.md
+++ b/docs/src/pages/presets/introduction/index.md
@@ -40,7 +40,7 @@ module.exports = {
     {
       name: '@storybook/preset-typescript',
       options: {
-        tsDocgenLoaderOptions: {
+        tsLoaderOptions: {
           tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
         },
         include: [path.resolve(__dirname)],
@@ -50,7 +50,7 @@ module.exports = {
 };
 ```
 
-This configures the typescript docgen loader using the app's `tsconfig.json` and also tells the typescript loaders to only be applied to the current directory.
+This configures the typescript loader using the app's `tsconfig.json` and also tells the typescript loader to only be applied to the current directory.
 
 Each preset has its own option and those options should be documented in the preset's README.
 


### PR DESCRIPTION
Issue:
With the changes in https://github.com/storybookjs/presets/pull/68, `tsDocgenLoaderOptions` no longer exists on `@storybook/preset-typescript`. 

## What I did
`tsDocgenLoaderOptions` has been replaced with `tsLoaderOptions` instead as shown [here](https://github.com/storybookjs/presets/tree/master/packages/preset-typescript#advanced-usage). I have updated the docs to reflect these changes.