### PR TITLE
docs: change "tsConfigPath" to "configFile"

### DIFF
--- a/docs/src/pages/presets/introduction/index.md
+++ b/docs/src/pages/presets/introduction/index.md
@@ -41,7 +41,7 @@ module.exports = {
       name: '@storybook/preset-typescript',
       options: {
         tsLoaderOptions: {
-          tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
+          configFile: path.resolve(__dirname, '../tsconfig.json'),
         },
         include: [path.resolve(__dirname)],
       },


### PR DESCRIPTION
## What I did
While updating the docs in #10063, I forgot to change "tsConfigPath" to "configFile" as well [as shown here](https://github.com/storybookjs/presets/tree/master/packages/preset-typescript#advanced-usage). The docs should now be correct.
