### PR TITLE
Fix: Remove usage of a vulnerable version of serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,9 @@
     ]
   },
   "browserslist": "defaults",
+  "resolutions": {
+    "serialize-javascript": "2.1.2"
+  },
   "devDependencies": {
     "@angular/common": "^8.2.8",
     "@angular/compiler": "^8.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26819,12 +26819,7 @@ send@0.17.1, send@latest:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.4.0, serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
-serialize-javascript@^2.1.2:
+serialize-javascript@2.1.2, serialize-javascript@^1.4.0, serialize-javascript@^1.7.0, serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==


### PR DESCRIPTION
Issue: 

## What I did
I fixed the issue #9173, by just forcing the resolution of the dependency `serialize-javascript` to version 2, in which they fixed the XSS vulnerability.

According to their [release notes](https://github.com/yahoo/serialize-javascript/releases/tag/v2.0.0), their major change is basically allowing `undefined` values to be serialized, which shouldn't affect Storybook.

## How to test

As Storybook transitively depends on this dependency through `terser-webpack-plugin`, I'd recommend trying to run storybook and build the project. If everything goes well, then there shouldn't be any problem.

- `@storybook/react > @storybook/core > corejs-upgrade-webpack-plugin > webpack > terser-webpack-plugin > serialize-javascript`
- `@storybook/react > @storybook/core > webpack > terser-webpack-plugin > serialize-javascript`
- `@storybook/react > webpack > terser-webpack-plugin > serialize-javascript`
- `@storybook/react > @storybook/core > terser-webpack-plugin > serialize-javascript`
