### PR TITLE
docs(migration): fix syntax for main.js step

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -130,11 +130,13 @@ module.exports = {
       rules: [
         ...config.module.rules,
         {
+          test: /\.tsx?$/,
           loader: require.resolve('react-docgen-typescript-loader'),
           options: {}, // your options here
         },
+      ]
     }
-  }
+  })
 }
 ```
 


### PR DESCRIPTION
Issue: syntax is incorrect in migration step. Fix is basically adding the closing brackets/parenthesis to the configuration.