### PR TITLE
Addon-knobs: Allow `text` and `number` to take undefined values

### DIFF
--- a/addons/knobs/src/components/types/Number.tsx
+++ b/addons/knobs/src/components/types/Number.tsx
@@ -14,11 +14,8 @@ export interface NumberTypeKnobOptions {
   step?: number;
 }
 
-export interface NumberTypeKnob
-  extends KnobControlConfig<NumberTypeKnobValue>,
-    NumberTypeKnobOptions {
-  value: NumberTypeKnobValue;
-}
+export type NumberTypeKnob = KnobControlConfig<NumberTypeKnobValue> &
+  NumberTypeKnobOptions & { value?: NumberTypeKnobValue };
 
 interface NumberTypeProps extends KnobControlProps<NumberTypeKnobValue | null> {
   knob: NumberTypeKnob;

--- a/addons/knobs/src/components/types/Text.tsx
+++ b/addons/knobs/src/components/types/Text.tsx
@@ -5,7 +5,7 @@ import { Form } from '@storybook/components';
 import { KnobControlConfig, KnobControlProps } from './types';
 
 type TextTypeKnobValue = string;
-export type TextTypeKnob = KnobControlConfig<TextTypeKnobValue>;
+export type TextTypeKnob = KnobControlConfig<TextTypeKnobValue> & { value?: TextTypeKnobValue };
 type TextTypeProps = KnobControlProps<TextTypeKnobValue>;
 
 export default class TextType extends Component<TextTypeProps> {


### PR DESCRIPTION
> This allows developers to pass optional props to text and number knobs
> in storybook. A common pattern for this is when a React component has
> an optional string or number prop.

Issue:

`text()` and `number()` knobs do not allow undefined values, which become many optional props when writing React components with typescript.

## What I did
Update the types for each of these props to allow the value to be optional. I first tried changing `value` to optional inside `KnobControlConfig` (`src/components/types/types.ts`), but this threw errors in the `Date` knob, and I didn't want to dive into that.

## How to test

This already works in knobs today when using typescript - if you pass undefined to a `text()` or `number()` knob, you will see a typescript warning, however, if you add a `//@ts-ignore`, you will notice that the knobs functions as expected with no value provided.

Here is a very simple code example:

This component (`SimpleText`) takes an optional value prop, which can be a string or a number. To represent this in knobs, you can pass `undefined` as the value (or you may omit it as I have done in the number example). However, `value` is a required property for both the `number` and `text` functions, which will generally throw typescript errors during compilation. 

```
import React from 'react'
import { text, number } from '@storybook/addon-knobs'

interface Value {
  value?: string | number;
}

const SimpleText: React.FC<Value> = ({ value }) => <div>{value}</div>

export const emptyDiv = () => (
  <SimpleText />
)

export const textDiv = () => (
  <SimpleText value={text('Text for div: ', undefined)} />
)

export const numberDiv = () => (
  <SimpleText value={number('Number for div: ')} />
)

export default {
  component: SimpleText,
  title: 'Example|TextDiv'
}
```



<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
