### PR TITLE
Fix typo in addon-contexts docs

### DIFF
--- a/addons/contexts/README.md
+++ b/addons/contexts/README.md
@@ -84,7 +84,7 @@ Finally, you may want to modify the default setups at per story level. Here is h
 export const defaultView = () => <div />;
 defaultView.story = {
   parameters: {
-    context: [{}]
+    contexts: [{}]
   }
 };
 ```


### PR DESCRIPTION
Issue: I know addon-contexts will be deprecated in favor of addon-toolbars, but in the meantime others might benefit from a minor typo correction: the sample code for setting per-story context settings uses the key `context`, when it should be `contexts` (presumably to match the addon's `parameterName`?).

## What I did

Changed the key `context` to `contexts`.

## How to test

- Is this testable with Jest or Chromatic screenshots? **Don't know**
- Does this need a new example in the kitchen sink apps? **Don't think so**
- Does this need an update to the documentation? **Err, not beyond the change itself**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
