### PR TITLE
Fix source link for carbon in Examples page

### DIFF
--- a/docs/src/pages/examples/_examples.yml
+++ b/docs/src/pages/examples/_examples.yml
@@ -20,7 +20,7 @@ carbon:
   thumbnail: carbon.png
   title: Carbon Components
   description: IBM's Carbon Design System implemented in React.
-  source: https://github.com/carbon-design-system/carbon-components-react
+  source: https://github.com/carbon-design-system/carbon/tree/master/packages/react
   demo: http://react.carbondesignsystem.com
   site: http://carbondesignsystem.com
 lonelyplanet:


### PR DESCRIPTION
Issue: The current link (https://github.com/carbon-design-system/carbon-components-react) says the project has been moved to a mono-repo. This PR updates it.

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
No
- Does this need a new example in the kitchen sink apps?
No
- Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
