### PR TITLE
Docs: add detail to addon-contexts per-story settings

### DIFF
--- a/addons/contexts/README.md
+++ b/addons/contexts/README.md
@@ -78,16 +78,35 @@ export default {
 };
 ```
 
-Finally, you may want to modify the default setups at per story level. Here is how you can do this:
+Finally, you may want to create new contextual environments or disable default setups at the story level. To create a new contextual environment at the story level:
+
+```js
+export const defaultView = () => <div />; // sample story in CSF format
+defaultView.story = {
+  parameters: {
+    contexts: [{ /* contextual environment defined using the API below */ }]
+  }
+};
+```
+
+To disable a default setup at the story level:
 
 ```js
 export const defaultView = () => <div />;
 defaultView.story = {
   parameters: {
-    contexts: [{}]
+    contexts: [
+      {
+         title: '[title of contextual environment defined in contexts.js]'
+         options: { disable: true }
+      }
+    ]
   }
 };
 ```
+
+To override the default option for a default setup at the story level, see [this suggestion](https://discordapp.com/channels/486522875931656193/501692020226654208/687359410577604732).
+
 
 ## ⚙️ Setups
 


### PR DESCRIPTION
Issue:

The addon-contexts readme currently says, "...you may want to modify the default setups at per story level". But there's no example provided, and it appears that "modifying" is a stretch. You can create per-story contextual environments, and you can disable default setups, but there doesn't seem to be a way to actually modify a setup defined in context.js at the story level.

## What I did
Clarified that you can create per-story contexts or disable default (global) contexts defined in contexts.js, and provided sample code for the latter. I also linked to my explanation on Discord of how I went about "modifying" a default setup at the story level, which involved disabling the default setup and creating a new, nearly identical setup with a different default option. Not a lovely solution (and maybe only relevant until addon-toolbars is released), which is why I didn't include the code here in the readme itself.

## How to test

- Is this testable with Jest or Chromatic screenshots? **No.**
- Does this need a new example in the kitchen sink apps? **No.**
- Does this need an update to the documentation? **No -- it is an update to the documentation.**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
