### PR TITLE
Core: Add globalArgs/globalArgTypes `preview.js` exports

### DIFF
--- a/examples/official-storybook/preview.js
+++ b/examples/official-storybook/preview.js
@@ -57,7 +57,10 @@ addParameters({
 
 export const parameters = {
   exportedParameter: 'exportedParameter',
+  args: { invalid1: 'will warn' },
 };
+
+export const args = { invalid2: 'will warn' };
 
 export const globalArgs = {
   foo: 'fooValue',

--- a/examples/official-storybook/preview.js
+++ b/examples/official-storybook/preview.js
@@ -58,3 +58,12 @@ addParameters({
 export const parameters = {
   exportedParameter: 'exportedParameter',
 };
+
+export const globalArgs = {
+  foo: 'fooValue',
+};
+
+export const globalArgTypes = {
+  foo: { defaultValue: 'fooDefaultValue' },
+  bar: { defaultValue: 'barDefaultValue' },
+};

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -216,6 +216,26 @@ describe('preview.story_store', () => {
       });
     });
 
+    it('is initialized to the default values stored in parameters.globalArgsTypes on the first story', () => {
+      const store = new StoryStore({ channel });
+      addStoryToStore(store, 'a', '1', () => 0, {
+        globalArgs: {
+          arg1: 'arg1',
+          arg2: 2,
+        },
+        globalArgTypes: {
+          arg2: { defaultValue: 'arg2' },
+          arg3: { defaultValue: { complex: { object: ['type'] } } },
+        },
+      });
+      store.finishConfiguring();
+      expect(store.getRawStory('a', '1').globalArgs).toEqual({
+        arg1: 'arg1',
+        arg2: 2,
+        arg3: { complex: { object: ['type'] } },
+      });
+    });
+
     it('on HMR it sensibly re-initializes with memory', () => {
       const store = new StoryStore({ channel });
       addons.setChannel(channel);

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -57,9 +57,10 @@ const checkGlobalArgs = (parameters: Parameters) => {
   const { globalArgs, globalArgTypes } = parameters;
   if (globalArgs || globalArgTypes) {
     throw new Error(
-      `Global args/argTypes can only be set globally: ${JSON.stringify(
-        globalArgs
-      )} ${JSON.stringify(globalArgTypes)}`
+      `Global args/argTypes can only be set globally: ${JSON.stringify({
+        globalArgs,
+        globalArgTypes,
+      })}`
     );
   }
 };
@@ -181,7 +182,10 @@ export default class StoryStore {
     if (parameters) {
       const { args, argTypes } = parameters;
       if (args || argTypes)
-        logger.warn('Found args/argTypes in global parameters.', JSON.stringify(args || argTypes));
+        logger.warn(
+          'Found args/argTypes in global parameters.',
+          JSON.stringify({ args, argTypes })
+        );
     }
     const globalParameters = this._globalMetadata.parameters;
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -138,8 +138,18 @@ export default class StoryStore {
     const storyIds = Object.keys(this._stories);
     if (storyIds.length) {
       const {
-        parameters: { globalArgs },
+        parameters: { globalArgs: initialGlobalArgs, globalArgTypes },
       } = this.fromId(storyIds[0]);
+
+      const defaultGlobalArgs: Args = globalArgTypes
+        ? Object.entries(globalArgTypes as Record<string, { defaultValue: any }>).reduce(
+            (acc, [arg, { defaultValue }]) => {
+              if (defaultValue) acc[arg] = defaultValue;
+              return acc;
+            },
+            {} as Args
+          )
+        : {};
 
       // To deal with HMR, we consider the previous value of global args, and:
       //   1. Remove any keys that are not in the new parameter
@@ -151,7 +161,7 @@ export default class StoryStore {
 
           return acc;
         },
-        globalArgs
+        { ...defaultGlobalArgs, ...initialGlobalArgs }
       );
     }
   }

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -54,11 +54,13 @@ export default ({
       const configFilename = match[1];
       virtualModuleMapping[entryFilename] = `
         import { addDecorator, addParameters, addParameterEnhancer } from '@storybook/client-api';
+        import { logger } from '@storybook/client-logger';
 
-        const { decorators, parameters, parameterEnhancers, globalArgs, globalArgTypes } = require(${JSON.stringify(
+        const { decorators, parameters, parameterEnhancers, globalArgs, globalArgTypes, args, argTypes } = require(${JSON.stringify(
           configFilename
         )});
-        
+
+        if(args || argTypes) logger.warn('Invalid args/argTypes in config, ignoring.', JSON.stringify(args || argTypes))
         if (decorators) decorators.forEach(decorator => addDecorator(decorator));
         if (parameters || globalArgs || globalArgTypes) addParameters({ ...parameters, globalArgs, globalArgTypes });
         if (parameterEnhancers) parameterEnhancers.forEach(enhancer => addParameterEnhancer(enhancer));

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -60,7 +60,7 @@ export default ({
           configFilename
         )});
 
-        if(args || argTypes) logger.warn('Invalid args/argTypes in config, ignoring.', JSON.stringify(args || argTypes))
+        if(args || argTypes) logger.warn('Invalid args/argTypes in config, ignoring.', JSON.stringify({ args, argTypes }));
         if (decorators) decorators.forEach(decorator => addDecorator(decorator));
         if (parameters || globalArgs || globalArgTypes) addParameters({ ...parameters, globalArgs, globalArgTypes });
         if (parameterEnhancers) parameterEnhancers.forEach(enhancer => addParameterEnhancer(enhancer));

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -55,12 +55,12 @@ export default ({
       virtualModuleMapping[entryFilename] = `
         import { addDecorator, addParameters, addParameterEnhancer } from '@storybook/client-api';
 
-        const { decorators, parameters,parameterEnhancers } = require(${JSON.stringify(
+        const { decorators, parameters, parameterEnhancers, globalArgs, globalArgTypes } = require(${JSON.stringify(
           configFilename
         )});
         
         if (decorators) decorators.forEach(decorator => addDecorator(decorator));
-        if (parameters) addParameters(parameters);
+        if (parameters || globalArgs || globalArgTypes) addParameters({ ...parameters, globalArgs, globalArgTypes });
         if (parameterEnhancers) parameterEnhancers.forEach(enhancer => addParameterEnhancer(enhancer));
       `;
     }


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Added globalArgs/globalArgTypes support for preview.js
- [x] Added test/example
- [ ] documentation?
- [ ] store globalArgTypes and make it accessible?

## How to test

See attached tests and Global Args stories in `official-storybook`