### PR TITLE
Addon-docs: Make source resilient to bad story ID's

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -39,7 +39,7 @@ export const getSourceProps = (
     source = targetIds
       .map(sourceId => {
         const data = storyStore.fromId(sourceId);
-        return data.parameters.docs?.source?.code || '';
+        return data?.parameters?.docs?.source?.code || '';
       })
       .join('\n\n');
   }


### PR DESCRIPTION
Issue: #7479 

## What I did

When users type `<Story id="some-random">` the source addon currently crashes ungracefully. With this fix, it shows "no source found" instead.

## How to test

See the MDX stories in `official-storybook`, which are currently broken on `next`.