### PR TITLE
Fix configurations/overview header & add glob info

### DIFF
--- a/docs/src/pages/configurations/overview/index.md
+++ b/docs/src/pages/configurations/overview/index.md
@@ -1,4 +1,3 @@
-
 ---
 id: 'overview'
 title: 'Configuration overview'
@@ -8,13 +7,13 @@ For CLI options see: [here](/docs/cli-options).
 
 > migration guide: This page documents the method to configure storybook introduced recently in 5.3.0, consult the [migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md) if you want to migrate to this format of configuring storybook.
 
-## main configuration
+## Main configuration
 
 Storybook has a few files it uses for configuration, and they are grouped together into a directory (default: `.storybook`).
 
 The most import file is the `main.js` file. This is where general config is declared.
 
-Here's an minimal example of a that file:
+Here's an minimal example of that file:
 
 ```js
 module.exports = {
@@ -25,17 +24,24 @@ module.exports = {
 };
 ```
 
-The addons field can refer to traditional [addons](docs/addons/introduction), but it can also include [presets](/docs/presets/introduction/) extending the config further.
+`stories` is a list of [glob](https://www.npmjs.com/package/glob) patterns that tells where your stories are located, relative to the configuration file.
 
-## manager & preview
+The `addons` field can refer to traditional [addons](docs/addons/introduction), but it can also include [presets](/docs/presets/introduction/), which are able to extend the config further.
 
-Storybook works by being split into 2 applications, which communicate with each other over a postmessage channel; called the "manager" and "preview".
+### `main.js` is a  Preset
+The `main.js` file is actually a preset! So if you know how to configure storybook, then you know how to write a preset, and vice-versa!
+So the `main.js` API is equal to [that of presets](/docs/presets/writing-presets/#presets-api).
 
-The preview application is essentially just your stories with a framework agnostic 'router'. Making it so when the manager application tells it so, it renders the correct story.
+
+## Manager & preview
+
+Storybook works by being split into 2 applications ("manager" and "preview"), which communicate with each other over a postMessage channel.
+
+The preview application is essentially just your stories with a framework-agnostic 'router'. It renders whichever story the  manager application tells it to render.
 
 The manager application renders the UI of [addons](docs/addons/introduction), the navigator and [toolbar](/docs/basics/toolbar-guide/).
 
-There are 2 extra config files, for doing some special runtime configs for each of those 2 applications.
+There are two extra config files, if you need to configure the runtime of Manager or Preview.
 
 In `preview.js` you can add global [decorators](../../basics/writing-stories/#decorators) and [parameters](../../basics/writing-stories/#parameters):
 
@@ -57,23 +63,6 @@ import { addons } from '@storybook/addons';
 addons.setConfig({
   theme: themes.dark,
 });
-```
-
-## entire main.js config
-
-The `main.js` file is actually a preset! so if you know how to configure storybook, you know how to write a preset, and vice-versa!
-So the API of `main.js` is equal to [that of presets](/docs/presets/writing-presets/#presets-api).
-
-Here's an overview of the important configuration properties in `main.js`:
-
-```js
-module.exports = {
-  // and array of glob patterns
-  stories: ['../src/components/**/*.stories.js'],
-
-  // an array of addons & presets
-  addons: ['@storybook/addon-essentials'],
-};
 ```
 
 ## webpack


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/10153

## What I did

This is a documentation change.
1) From https://github.com/storybookjs/storybook/issues/10153, I added wording about `glob`.
2) The configurations/overview page was not being rendered on the site. I removed a leading space above the file header. Hopefully that fixes the issue.

I went over the document and tried to improve the wording as much as I could. If you consider any of these changes to be regressions, then feel free to revert. 

I decided to move the bottom section (about the relationship of main.js to Presets) to the top, because there was starting to be two sections for the same thing --- explaining main.js properties. And I chose to put this at the top, because people probably want to see that information most of the time.

## How to test

Not sure --- how do you test these documentation changes?
