### PR TITLE
Ensure visibility of links within PropRow descriptions

### DIFF
--- a/lib/components/src/blocks/PropsTable/PropRow.tsx
+++ b/lib/components/src/blocks/PropsTable/PropRow.tsx
@@ -24,6 +24,14 @@ const Description = styled.div(({ theme }) => ({
     p: {
       margin: '0 0 10px 0',
     },
+
+    a: {
+      textDecoration: 'underline',
+
+      '&:hover': {
+        textDecoration: 'none',
+      },
+    },
   },
 
   code: codeCommon({ theme }),


### PR DESCRIPTION
Issue: Links within prop descriptions are not visible.

## What I did

I changed the style of links within prop descriptions so they can be differentiated from regular text.

Before:

![invisible-link](https://user-images.githubusercontent.com/793344/77540416-57346e80-6ea3-11ea-9956-e786c706a1e0.png)

After:

![visible-link](https://user-images.githubusercontent.com/793344/77540423-5996c880-6ea3-11ea-9c39-afaae2e64d3e.png)

## How to test

- Is this testable with Jest or Chromatic screenshots? Not sure
- Does this need a new example in the kitchen sink apps? Not sure
- Does this need an update to the documentation? No

---

I’m not sure if this MR needs anything else, could you please let me know and I'll add whatever is required 😊 