### PR TITLE
fix storySort docs: rename 'sort' to 'order'

### DIFF
--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -95,7 +95,9 @@ addParameters({
 
 ### Sorting stories
 
-Import and use `addParameters` with the `options` key in your `preview.js` file.
+By default, stories are sorted in the order in which they were imported. This can be overridden by adding `storySort` to the `options` parameters in your `preview.js` file.
+
+The most powerful method of sorting is to provide a function to `storySort`. Any custom sorting can be achieved with this method.
 
 ```js
 import { addParameters } from '@storybook/react';
@@ -107,6 +109,62 @@ addParameters({
   },
 });
 ```
+
+The `storySort` can also accept a configuration object.
+
+```js
+import { addParameters, configure } from '@storybook/react';
+
+addParameters({
+  options: {
+    storySort: {
+      method: 'alphabetical', // Optional, defaults to 'configure'.
+      order: ['Intro', 'Components'], // Optional, defaults to [].
+      locales: 'en-US', // Optional, defaults to system locale.
+    },
+  },
+});
+```
+
+To sort your stories alphabetically, set `method` to `'alphabetical'` and optionally set the `locales` string. To sort your stories using a custom list, use the `sort` array; stories that don't match an item in the `sort` list will appear after the items in the list. 2nd
+
+The `sort` array can accept a nested array in order to sort 2nd-level story kinds. For example:
+
+```js
+import { addParameters, configure } from '@storybook/react';
+
+addParameters({
+  options: {
+    storySort: {
+      order: [
+        'Intro',
+        'Pages',
+        [
+          'Home',
+          'Login',
+          'Admin',
+        ],
+        'Components',
+      ],
+    },
+  },
+});
+```
+
+Which would result in this story ordering:
+
+1. `Intro` and then `Intro/*` stories
+2. `Pages` story
+3. `Pages/Home` and `Pages/Home/*` stories
+4. `Pages/Login` and `Pages/Login/*` stories
+5. `Pages/Admin` and `Pages/Admin/*` stories
+6. `Pages/*` stories
+7. `Components` and `Components/*` stories
+8. All other stories
+
+Note that the `order` option is independent of the `method` option; stories are sorted first by the `order` array and then by either the `method: 'alphabetical'` or the default `configure()` import order.
+
+### Theming
 
 For more information on configuring the `theme`, see [theming](../theming/).
 

--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -60,17 +60,17 @@ addons.setConfig({
    */
   theme: undefined,
 
-  /**	
-   * id to select an addon panel	
-   * @type {String}	
-   */	
+  /**
+   * id to select an addon panel
+   * @type {String}
+   */
   selectedPanel: undefined,
 
-  /**	
+  /**
    * Select the default active tab on Mobile.
    * 'sidebar' | 'canvas' | 'addons'
    * @type {('sidebar'|'canvas'|'addons')}
-   */	
+   */
   initialActive: 'sidebar',
 });
 ```
@@ -126,9 +126,9 @@ addParameters({
 });
 ```
 
-To sort your stories alphabetically, set `method` to `'alphabetical'` and optionally set the `locales` string. To sort your stories using a custom list, use the `sort` array; stories that don't match an item in the `sort` list will appear after the items in the list. 2nd
+To sort your stories alphabetically, set `method` to `'alphabetical'` and optionally set the `locales` string. To sort your stories using a custom list, use the `order` array; stories that don't match an item in the `order` list will appear after the items in the list.
 
-The `sort` array can accept a nested array in order to sort 2nd-level story kinds. For example:
+The `order` array can accept a nested array in order to sort 2nd-level story kinds. For example:
 
 ```js
 import { addParameters, configure } from '@storybook/react';
@@ -136,16 +136,7 @@ import { addParameters, configure } from '@storybook/react';
 addParameters({
   options: {
     storySort: {
-      order: [
-        'Intro',
-        'Pages',
-        [
-          'Home',
-          'Login',
-          'Admin',
-        ],
-        'Components',
-      ],
+      order: ['Intro', 'Pages', ['Home', 'Login', 'Admin'], 'Components'],
     },
   },
 });


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/pull/9188#discussion_r397987445

Hi @ndelangen!

I wanted to fix that little mistake in John's commit, but although it was present in git history, the change seemed to be lost in a merge conflict. I cherry-picked it 🤷 and changed `sort` to `order` to reflect what's happening in the [code](https://github.com/JohnAlbin/storybook/blob/9ef9e55ad1afe50efbe75d0cb2531a63132c9fe2/lib/client-api/src/storySort.ts#L38-L49).
