### PR TITLE
Changes import of options/optionsKnob

### DIFF
--- a/addons/knobs/README.md
+++ b/addons/knobs/README.md
@@ -396,7 +396,7 @@ const value = radios(label, options, defaultValue, groupId);
 Configurable UI for selecting a value from a set of options. 
 
 ```js
-import { optionsKnob as options } from '@storybook/addon-knobs';
+import { optionsKnob } from '@storybook/addon-knobs';
 
 const label = 'Fruits';
 const valuesObj = {
@@ -409,6 +409,15 @@ const optionsObj = {
   display: 'inline-radio'
 };
 const groupId = 'GROUP-ID1';
+
+const value = optionsKnob(label, valuesObj, defaultValue, optionsObj, groupId);
+```
+
+Alternatively you can use this import:
+```
+import { optionsKnob as options } from '@storybook/addon-knobs';
+
+...
 
 const value = options(label, valuesObj, defaultValue, optionsObj, groupId);
 ```


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/7116

## What I did
The import, which is different from all other imports, is easy to overlook. Therefore I have adapted the import to the other button types and added a note for an alternative import that corresponds to the naming of the other button types (without the suffix `Knob`).

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
