### PR TITLE
Feature add data-tags attribute to sidebar items

### DIFF
--- a/docs/src/pages/basics/writing-stories/index.md
+++ b/docs/src/pages/basics/writing-stories/index.md
@@ -384,3 +384,55 @@ Baz.story = {
 ```
 
 Storybook will prioritize the `id` over the title for ID generation, if provided, and will prioritize the `story.name` over the export key for display.
+
+## Adding tags to story links in the sidebar
+
+Components are rendered in the sidebar as links that include a `data-tags` attribute which defaults to `data-tags="none"`
+Users can add tags to components and stories so they will show up in the `data-tags` atribute
+
+These tags can be used to show or hide stories based on plain css selectors:
+for instance users can add a rule to hide all stories with `data-tags="hidden"`:
+```css
+[data-tags=hidden] {
+  display: none;
+}
+```
+or more complex to hide all stories that do not have a certain TAG so only the stories that belong to that TAG will show:
+```css
+[data-tags]:not([data-tags~=TAG] {
+  display: none;
+}
+```
+> NOTE: - these css options are not included in the code, the user must add these themselves, depending on the solution they are looking for.
+
+to add the tags to the stories you only need to add it to the default like so:
+```js
+export default {
+  title: 'Welcome',
+  tags: 'hidden',
+};
+```
+or to a specific story like this:
+```js
+Button.story = {
+  tags: 'hidden'
+}
+```
+
+Users can specify multiple tags using the pipe symbol `|` e.g. `tags: 'web|app'` to specify that the component or story belongs to the `web` and to the `app`
+if a user would add `tags: 'web|app'` to default and then add `tags: 'web'` to a story and `tags: 'app'` to another, one could show and hide different stories based on a selected TAG
+if components are created under the same branch, the branch will receive the tags from all component and pipe `|` them together e.g. if one storyfile has 
+```js
+export default {
+  title: 'Components/Category/Headings',
+  tags: 'web'
+}
+```
+and another storyfile has
+```js
+export default {
+  title: 'Components/Category/Buttons',
+  tags: 'app'
+}
+```
+the resulting link in the sidebar to `Category` will have `data-tags="web|app"`

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -18,6 +18,7 @@ export function isSupportedType(type: Types): boolean {
 
 export type StoryId = string;
 export type StoryKind = string;
+export type StoryTags = string;
 export type StoryName = string;
 export type ViewMode = 'story' | 'docs';
 
@@ -54,6 +55,8 @@ export interface StoryIdentifier {
 
 export type StoryContext = StoryIdentifier & {
   [key: string]: any;
+  componentTags?: StoryTags;
+  storyTags?: StoryTags;
   parameters: Parameters;
   args: Args;
   globalArgs: Args;
@@ -124,7 +127,9 @@ export interface StoryApi<StoryFnReturnType = unknown> {
   add: (
     storyName: StoryName,
     storyFn: StoryFn<StoryFnReturnType>,
-    parameters?: Parameters
+    parameters?: Parameters,
+    componentTags?: StoryTags,
+    storyTags?: StoryTags
   ) => StoryApi<StoryFnReturnType>;
   addDecorator: (decorator: DecoratorFunction<StoryFnReturnType>) => StoryApi<StoryFnReturnType>;
   addParameters: (parameters: Parameters) => StoryApi<StoryFnReturnType>;

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -15,6 +15,7 @@ export interface Root {
   depth: 0;
   name: string;
   refId?: string;
+  componentTags?: string;
   children: StoryId[];
   isComponent: false;
   isRoot: true;
@@ -30,6 +31,7 @@ export interface Group {
   id: StoryId;
   depth: number;
   name: string;
+  componentTags?: string;
   children: StoryId[];
   refId?: string;
   parent?: StoryId;
@@ -51,6 +53,8 @@ export interface Story {
   name: string;
   kind: StoryKind;
   refId?: string;
+  componentTags?: string;
+  storyTags?: string;
   children?: StoryId[];
   isComponent: boolean;
   isRoot: false;
@@ -74,7 +78,9 @@ export interface StoryInput {
   id: StoryId;
   name: string;
   refId?: string;
-  kind: StoryKind;
+  kind: string;
+  componentTags?: string;
+  storyTags?: string;
   children: string[];
   parameters: {
     fileName: string;

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -169,7 +169,9 @@ export default class ClientApi {
     api.add = (
       storyName: string,
       storyFn: StoryFn<StoryFnReturnType>,
-      parameters: Parameters = {}
+      parameters: Parameters = {},
+      componentTags,
+      storyTags
     ) => {
       hasAdded = true;
 
@@ -196,6 +198,8 @@ export default class ClientApi {
           id,
           kind,
           name: storyName,
+          componentTags,
+          storyTags,
           storyFn,
           parameters: { fileName, ...storyParameters },
           decorators,

--- a/lib/client-api/src/decorators.ts
+++ b/lib/client-api/src/decorators.ts
@@ -9,6 +9,8 @@ const defaultContext: StoryContext = {
   id: 'unspecified',
   name: 'unspecified',
   kind: 'unspecified',
+  componentTags: 'unspecified',
+  storyTags: 'unspecified',
   parameters: {},
   args: {},
   globalArgs: {},

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -248,6 +248,8 @@ export default class StoryStore {
       id,
       kind,
       name,
+      componentTags,
+      storyTags,
       storyFn: original,
       parameters: storyParameters = {},
       decorators: storyDecorators = [],
@@ -284,6 +286,8 @@ export default class StoryStore {
       id,
       kind,
       name,
+      componentTags,
+      storyTags,
       story: name, // legacy
     };
 

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -1,6 +1,7 @@
 import {
   Addon,
   StoryIdentifier,
+  StoryTags,
   StoryFn,
   Parameters,
   Args,
@@ -26,12 +27,16 @@ export interface StoryMetadata {
 export type ArgTypesEnhancer = (context: StoryContext) => ArgTypes;
 
 export type AddStoryArgs = StoryIdentifier & {
+  componentTags?: StoryTags;
+  storyTags?: StoryTags;
   storyFn: StoryFn<any>;
   parameters?: Parameters;
   decorators?: DecoratorFunction[];
 };
 
 export type StoreItem = StoryIdentifier & {
+  componentTags?: StoryTags;
+  storyTags?: StoryTags;
   parameters: Parameters;
   getDecorated: () => StoryFn<any>;
   getOriginal: () => StoryFn<any>;

--- a/lib/core/src/client/preview/loadCsf.test.ts
+++ b/lib/core/src/client/preview/loadCsf.test.ts
@@ -65,6 +65,7 @@ describe('core.preview.loadCsf', () => {
       a: {
         default: {
           title: 'a',
+          tags: 'a',
         },
         1: () => 0,
         2: () => 0,
@@ -72,9 +73,10 @@ describe('core.preview.loadCsf', () => {
       b: {
         default: {
           title: 'b',
+          tags: 'b',
         },
         1: () => 0,
-        2: Object.assign(() => 0, { story: { name: 'two' } }),
+        2: Object.assign(() => 0, { story: { name: 'two', tags: 'two' } }),
       },
     };
     configure(makeRequireContext(input), mod, 'react');
@@ -82,13 +84,13 @@ describe('core.preview.loadCsf', () => {
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     expect(mockedStoriesOf).toHaveBeenCalledWith('a', true);
     const aApi = mockedStoriesOf.mock.results[0].value;
-    expect(aApi.add).toHaveBeenCalledWith('1', input.a[1], { __id: 'a--1' });
-    expect(aApi.add).toHaveBeenCalledWith('2', input.a[2], { __id: 'a--2' });
+    expect(aApi.add).toHaveBeenCalledWith('1', input.a[1], { __id: 'a--1' }, 'a', undefined);
+    expect(aApi.add).toHaveBeenCalledWith('2', input.a[2], { __id: 'a--2' }, 'a', undefined);
 
     expect(mockedStoriesOf).toHaveBeenCalledWith('b', true);
     const bApi = mockedStoriesOf.mock.results[1].value;
-    expect(bApi.add).toHaveBeenCalledWith('1', input.b[1], { __id: 'b--1' });
-    expect(bApi.add).toHaveBeenCalledWith('two', input.b[2], { __id: 'b--2' });
+    expect(bApi.add).toHaveBeenCalledWith('1', input.b[1], { __id: 'b--1' }, 'b', undefined);
+    expect(bApi.add).toHaveBeenCalledWith('two', input.b[2], { __id: 'b--2' }, 'b', 'two');
   });
 
   it('adds stories in the right order if __namedExportsOrder is supplied', () => {
@@ -175,7 +177,13 @@ describe('core.preview.loadCsf', () => {
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
-    expect(aApi.add).toHaveBeenCalledWith('X', input.a.x, { __id: 'random--x' });
+    expect(aApi.add).toHaveBeenCalledWith(
+      'X',
+      input.a.x,
+      { __id: 'random--x' },
+      undefined,
+      undefined
+    );
   });
 
   it('sets various parameters on components', () => {
@@ -251,13 +259,19 @@ describe('core.preview.loadCsf', () => {
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
-    expect(aApi.add).toHaveBeenCalledWith('X', input.a.x, {
-      x: 'y',
-      decorators: [decorator],
-      __id: 'a--x',
-      args: { b: 1 },
-      argTypes: { b: 'string' },
-    });
+    expect(aApi.add).toHaveBeenCalledWith(
+      'X',
+      input.a.x,
+      {
+        x: 'y',
+        decorators: [decorator],
+        __id: 'a--x',
+        args: { b: 1 },
+        argTypes: { b: 'string' },
+      },
+      undefined,
+      undefined
+    );
   });
 
   it('handles HMR correctly when adding stories', () => {

--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -87,6 +87,7 @@ const loadStories = (
     const {
       title: kindName,
       id: componentId,
+      tags: componentTags,
       parameters: kindParameters,
       decorators: kindDecorators,
       component,
@@ -126,7 +127,8 @@ const loadStories = (
     storyExports.forEach((key) => {
       if (isExportStory(key, meta)) {
         const storyFn = exports[key];
-        const { name, parameters, decorators, args, argTypes } = storyFn.story || {};
+        const { name, tags: storyTags, parameters, decorators, args, argTypes } =
+          storyFn.story || {};
         const decoratorParams = decorators ? { decorators } : null;
         const exportName = storyNameFromExport(key);
         const idParams = { __id: toId(componentId || kindName, exportName) };
@@ -138,7 +140,7 @@ const loadStories = (
           args,
           argTypes,
         };
-        kind.add(name || exportName, storyFn, storyParams);
+        kind.add(name || exportName, storyFn, storyParams, componentTags, storyTags);
       }
     });
   });

--- a/lib/ui/src/components/sidebar/RefBlocks.tsx
+++ b/lib/ui/src/components/sidebar/RefBlocks.tsx
@@ -286,10 +286,11 @@ export const ContentBlock: FunctionComponent<{
     <Spaced row={1.5}>
       {others.length ? (
         <Section data-title="categorized" key="categorized">
-          {others.map(({ id }) => (
+          {others.map(({ id, componentTags }) => (
             <Tree
               key={id}
               depth={0}
+              tags={componentTags}
               dataset={dataSet}
               selected={selectedSet}
               expanded={expandedSet}
@@ -300,13 +301,14 @@ export const ContentBlock: FunctionComponent<{
         </Section>
       ) : null}
 
-      {roots.map(({ id, name, children }) => (
+      {roots.map(({ id, name, componentTags, children }) => (
         <Section data-title={name} key={id}>
           <RootHeading className="sidebar-subheading">{name}</RootHeading>
           {children.map((child) => (
             <Tree
               key={child}
               depth={0}
+              tags={componentTags}
               dataset={dataSet}
               selected={selectedSet}
               expanded={expandedSet}

--- a/lib/ui/src/components/sidebar/Tree/ListItem.tsx
+++ b/lib/ui/src/components/sidebar/Tree/ListItem.tsx
@@ -116,6 +116,7 @@ export type ListItemProps = ComponentProps<typeof Item> & {
   name: string;
   kind: string;
   refId?: string;
+  tags?: string;
   depth: number;
   parameters: Record<string, any>;
 };
@@ -125,6 +126,7 @@ export const ListItem: FunctionComponent<ListItemProps> = ({
   id,
   kind,
   refId,
+  tags,
   isComponent = false,
   isLeaf = false,
   isExpanded = false,
@@ -150,7 +152,14 @@ export const ListItem: FunctionComponent<ListItemProps> = ({
   );
 
   return (
-    <Item isSelected={isSelected} depth={depth} {...props} className={classes} id={id}>
+    <Item
+      isSelected={isSelected}
+      depth={depth}
+      data-tags={tags}
+      {...props}
+      className={classes}
+      id={id}
+    >
       {!isLeaf ? (
         <Expander className="sidebar-expander" depth={depth} isExpanded={isExpanded} />
       ) : null}

--- a/lib/ui/src/components/sidebar/Tree/Tree.tsx
+++ b/lib/ui/src/components/sidebar/Tree/Tree.tsx
@@ -1,8 +1,11 @@
 import React, { ComponentType, FunctionComponent } from 'react';
 
+import { Story } from '@storybook/api';
 import { Dataset, ExpandedSet, SelectedSet } from './utils';
 
 import { DefaultList, DefaultLeaf, DefaultHead } from './components';
+
+const noTags = 'none';
 
 const branchOrLeaf = (
   {
@@ -24,7 +27,7 @@ const branchOrLeaf = (
     depth,
   }: { root: string; dataset: Dataset; expanded: ExpandedSet; selected: SelectedSet; depth: number }
 ) => {
-  const node = dataset[root];
+  const node = dataset[root] as Story;
 
   if (!node) {
     return null;
@@ -33,6 +36,7 @@ const branchOrLeaf = (
   return node.children ? (
     <Branch
       key={node.id}
+      tags={node.componentTags || noTags}
       {...{
         Branch,
         Leaf,
@@ -46,13 +50,20 @@ const branchOrLeaf = (
       }}
     />
   ) : (
-    <Leaf key={node.id} {...node} depth={depth} isSelected={selected[node.id]} />
+    <Leaf
+      key={node.id}
+      tags={node.storyTags || node.componentTags || noTags}
+      {...node}
+      depth={depth}
+      isSelected={selected[node.id]}
+    />
   );
 };
 
 const Tree: FunctionComponent<{
   root: string;
   depth: number;
+  tags: string;
   dataset: Dataset;
   expanded: ExpandedSet;
   selected: SelectedSet;
@@ -64,6 +75,7 @@ const Tree: FunctionComponent<{
   const {
     root,
     depth,
+    tags = noTags,
     dataset,
     expanded,
     selected,
@@ -93,6 +105,7 @@ const Tree: FunctionComponent<{
         <>
           <Head
             {...node}
+            tags={tags}
             depth={depth}
             isExpanded={expanded[node.id]}
             isSelected={selected[node.id]}
@@ -106,7 +119,9 @@ const Tree: FunctionComponent<{
       return <List>{children.map(mapNode)}</List>;
     }
     case node.isLeaf: {
-      return <Leaf key={node.id} {...node} depth={depth} isSelected={selected[node.id]} />;
+      return (
+        <Leaf key={node.id} tags={tags} {...node} depth={depth} isSelected={selected[node.id]} />
+      );
     }
     default: {
       return null;

--- a/lib/ui/src/components/sidebar/Tree/components.tsx
+++ b/lib/ui/src/components/sidebar/Tree/components.tsx
@@ -35,22 +35,25 @@ export const LeafStyle = styled.div<{ depth: number; isSelected: boolean }>(
   })
 );
 
-export const DefaultLeaf: FunctionComponent<
-  { name: ReactNode; depth: number } & Record<string, any>
-> = ({ name, isSelected, depth, ...rest }) => (
-  <LeafStyle isSelected={isSelected} depth={depth} {...rest}>
+export const DefaultLeaf: FunctionComponent<{
+  name: ReactNode;
+  tags: string;
+  depth: number;
+} & Record<string, any>> = ({ name, tags, isSelected, depth, ...rest }) => (
+  <LeafStyle isSelected={isSelected} depth={depth} data-tags={tags} {...rest}>
     {name}
   </LeafStyle>
 );
 
 export const DefaultHead: FunctionComponent<{
   name: ReactNode;
+  tags: string;
   depth: number;
   isExpanded?: boolean;
   isSelected?: boolean;
   isComponent?: boolean;
-}> = ({ name, depth, isExpanded = false, isSelected = false, isComponent = false }) => (
-  <LeafStyle isSelected={isSelected} depth={depth}>
+}> = ({ name, tags, depth, isExpanded = false, isSelected = false, isComponent = false }) => (
+  <LeafStyle isSelected={isSelected} depth={depth} data-tags={tags}>
     <span>
       {isExpanded ? '-' : '+'}
       {isComponent ? '!' : ''}
@@ -64,10 +67,16 @@ export const DefaultRootTitle = styled.h4({});
 export const DefaultLink: FunctionComponent<{
   id: string;
   prefix: string;
+  tags: string;
   children: string[];
   onClick: Function;
-}> = ({ id, prefix, children, ...rest }) => (
-  <A href={`#!${prefix}${id}`} {...rest} onClick={(e) => prevent(e) || rest.onClick(e)}>
+}> = ({ id, prefix, tags, children, ...rest }) => (
+  <A
+    href={`#!${prefix}${id}`}
+    data-tags={tags}
+    {...rest}
+    onClick={e => prevent(e) || rest.onClick(e)}
+  >
     {children}
   </A>
 );


### PR DESCRIPTION
Issue: [9209](https://github.com/storybookjs/storybook/issues/9209) Add an option to hide a story from the sidebar

## What I did
I made an adjustment to how stories are written out to the sidebar to include a `data-tags` attribute which defaults to `data-tags="none"` 

the tags can then be used to show or hide stories based on plain css selectors:
for instance one could add a rule to hide all stories with `data-tags="hidden"`:
```
[data-tags=hidden] {
  display: none;
}
```
or more complex to hide all stories that do not have a certain TAG so you could show just the stories that belong to that TAG:
```
[data-tags]:not([data-tags~=TAG] {
  display: none;
}
```
> NOTE: - these css options are not included in the PR one must add these depending on the solution they are looking for.

to add the tags to the stories you only need to add it to the default like so:
```
export default {
  title: 'Welcome',
  tags: 'hidden',
};
```
or to a specific story like this:
```
Button.story = {
  tags: 'hidden'
}
```

you can specify multiple tags using the pipe symbol `|` e.g. `tags: 'web|app'` to specify that the component or story belongs to the `web` and to the `app`
if you would add `tags: 'web|app'` to default and then add `tags: 'web'` to a story and `tags: 'app'` to another, one could show and hide different stories based on a selected TAG
if components are created under the same branch, the branch will receive the tags from all component and pipe `|` them together e.g. if one storyfile has 
```
export default {
  title: 'Components/Category/Headings',
  tags: 'web'
}
```
and another storyfile has
```
export default {
  title: 'Components/Category/Buttons',
  tags: 'app'
}
```
the resulting link in the sidebar to `Category` will have `data-tags="web|app"`

## How to test

1. start one of the example apps
2. add `tags: 'hidden'` to one of the stories files like described above
3. refresh page and inspect the stories in the sidebar with the devtools
4. see that the links in the sidebar contain `data-tags` attibutes

- Is this testable with Jest or Chromatic screenshots? NO
- Does this need a new example in the kitchen sink apps? probably NOT
- Does this need an update to the documentation? YES included

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
