### PR TITLE
Addon-docs: Add linear gradient support to ColorPalette block

### DIFF
--- a/lib/components/src/blocks/ColorPalette.stories.tsx
+++ b/lib/components/src/blocks/ColorPalette.stories.tsx
@@ -25,6 +25,11 @@ export const defaultStyle = () => (
         'rgba(102,191,60,.3)',
       ]}
     />
+    <ColorItem
+      title="gradient"
+      subtitle="Grayscale"
+      colors={['linear-gradient(to right,white,black)']}
+    />
   </ColorPalette>
 );
 
@@ -49,6 +54,13 @@ export const NamedColors = () => (
         Apple80: 'rgba(102,191,60,.8)',
         Apple60: 'rgba(102,191,60,.6)',
         Apple30: 'rgba(102,191,60,.3)',
+      }}
+    />
+    <ColorItem
+      title="gradient"
+      subtitle="Grayscale"
+      colors={{
+        Gradient: 'linear-gradient(to right,white,black)',
       }}
     />
   </ColorPalette>

--- a/lib/components/src/blocks/ColorPalette.tsx
+++ b/lib/components/src/blocks/ColorPalette.tsx
@@ -39,6 +39,7 @@ const SwatchLabel = styled.div(({ theme }) => ({
     display: 'inline-block',
     overflow: 'hidden',
     maxWidth: '100%',
+    textOverflow: 'ellipsis',
   },
 
   span: {
@@ -126,7 +127,7 @@ function renderSwatch(color: string) {
       key={color}
       title={color}
       style={{
-        backgroundColor: color,
+        background: color,
       }}
     />
   );


### PR DESCRIPTION
Issue: #10232

## What I did

changed `backgroundColor` to `background` in the `ColorItem` component so that we can set things like `linear-gradient` instead of only colors.

`background` continues to work for colors when specifed

Screenshot:

![image](https://user-images.githubusercontent.com/6325237/77785825-1f5c3100-7033-11ea-8986-8bd8ecbb87b0.png)

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
