### PR TITLE
Addon-docs: Reset styles in Preview component 

### DIFF
--- a/addons/docs/src/blocks/Preview.tsx
+++ b/addons/docs/src/blocks/Preview.tsx
@@ -1,8 +1,22 @@
-import React, { FunctionComponent, ReactElement, ReactNode, ReactNodeArray } from 'react';
+import React, {
+  createElement,
+  ElementType,
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  ReactNodeArray,
+} from 'react';
+import { MDXProvider } from '@mdx-js/react';
 import { toId, storyNameFromExport } from '@storybook/csf';
+import { components as docsComponents } from '@storybook/components/html';
 import { Preview as PurePreview, PreviewProps as PurePreviewProps } from '@storybook/components';
 import { getSourceProps } from './Source';
 import { DocsContext, DocsContextProps } from './DocsContext';
+
+const resetComponents: Record<string, ElementType> = {};
+Object.keys(docsComponents).forEach(key => {
+  resetComponents[key] = (props: any) => createElement(key, props);
+});
 
 export enum SourceState {
   OPEN = 'open',
@@ -13,6 +27,7 @@ export enum SourceState {
 type PreviewProps = PurePreviewProps & {
   withSource?: SourceState;
   mdxSource?: string;
+  resetStyles?: boolean;
 };
 
 const getPreviewProps = (
@@ -38,7 +53,7 @@ const getPreviewProps = (
     (c: ReactElement) => c.props && (c.props.id || c.props.name)
   ) as ReactElement[];
   const targetIds = stories.map(
-    (s) =>
+    s =>
       s.props.id ||
       toId(
         mdxComponentMeta.id || mdxComponentMeta.title,
@@ -53,11 +68,15 @@ const getPreviewProps = (
   };
 };
 
-export const Preview: FunctionComponent<PreviewProps> = (props) => (
+export const Preview: FunctionComponent<PreviewProps> = props => (
   <DocsContext.Consumer>
-    {(context) => {
+    {context => {
       const previewProps = getPreviewProps(props, context);
-      return <PurePreview {...previewProps}>{props.children}</PurePreview>;
+      return (
+        <MDXProvider components={props.resetStyles ? resetComponents : docsComponents}>
+          <PurePreview {...previewProps}>{props.children}</PurePreview>
+        </MDXProvider>
+      );
     }}
   </DocsContext.Consumer>
 );

--- a/addons/docs/src/blocks/Preview.tsx
+++ b/addons/docs/src/blocks/Preview.tsx
@@ -1,22 +1,10 @@
-import React, {
-  createElement,
-  ElementType,
-  FunctionComponent,
-  ReactElement,
-  ReactNode,
-  ReactNodeArray,
-} from 'react';
+import React, { FunctionComponent, ReactElement, ReactNode, ReactNodeArray } from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { toId, storyNameFromExport } from '@storybook/csf';
-import { components as docsComponents } from '@storybook/components/html';
+import { resetComponents } from '@storybook/components/html';
 import { Preview as PurePreview, PreviewProps as PurePreviewProps } from '@storybook/components';
 import { getSourceProps } from './Source';
 import { DocsContext, DocsContextProps } from './DocsContext';
-
-const resetComponents: Record<string, ElementType> = {};
-Object.keys(docsComponents).forEach(key => {
-  resetComponents[key] = (props: any) => createElement(key, props);
-});
 
 export enum SourceState {
   OPEN = 'open',
@@ -27,7 +15,6 @@ export enum SourceState {
 type PreviewProps = PurePreviewProps & {
   withSource?: SourceState;
   mdxSource?: string;
-  resetStyles?: boolean;
 };
 
 const getPreviewProps = (
@@ -53,7 +40,7 @@ const getPreviewProps = (
     (c: ReactElement) => c.props && (c.props.id || c.props.name)
   ) as ReactElement[];
   const targetIds = stories.map(
-    s =>
+    (s) =>
       s.props.id ||
       toId(
         mdxComponentMeta.id || mdxComponentMeta.title,
@@ -68,12 +55,12 @@ const getPreviewProps = (
   };
 };
 
-export const Preview: FunctionComponent<PreviewProps> = props => (
+export const Preview: FunctionComponent<PreviewProps> = (props) => (
   <DocsContext.Consumer>
-    {context => {
+    {(context) => {
       const previewProps = getPreviewProps(props, context);
       return (
-        <MDXProvider components={props.resetStyles ? resetComponents : docsComponents}>
+        <MDXProvider components={resetComponents}>
           <PurePreview {...previewProps}>{props.children}</PurePreview>
         </MDXProvider>
       );

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -1,6 +1,6 @@
-import React, { createElement, ElementType, FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import { MDXProvider } from '@mdx-js/react';
-import { components as docsComponents } from '@storybook/components/html';
+import { resetComponents } from '@storybook/components/html';
 import { Story as PureStory, StoryProps as PureStoryProps } from '@storybook/components';
 import { toId, storyNameFromExport } from '@storybook/csf';
 import { CURRENT_SELECTION } from './types';
@@ -8,11 +8,6 @@ import { CURRENT_SELECTION } from './types';
 import { DocsContext, DocsContextProps } from './DocsContext';
 
 export const storyBlockIdFromId = (storyId: string) => `story--${storyId}`;
-
-const resetComponents: Record<string, ElementType> = {};
-Object.keys(docsComponents).forEach((key) => {
-  resetComponents[key] = (props: any) => createElement(key, props);
-});
 
 interface CommonProps {
   height?: string;

--- a/examples/official-storybook/stories/addon-docs/docs-only.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/docs-only.stories.mdx
@@ -1,6 +1,6 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta, Preview } from '@storybook/addon-docs/blocks';
 
-<Meta title="Addons/Docs/docs-only" parameters={{ previewTabs: { 'canvas': { hidden: true }}}} />
+<Meta title="Addons/Docs/docs-only" parameters={{ previewTabs: { canvas: { hidden: true } } }} />
 
 # Documentation-only MDX
 
@@ -8,8 +8,56 @@ This file is a documentation-only MDX file, i.e. it doesn't contain any `<Story>
 
 Therefore, it shows up in the navigation UI as a document icon.
 
-<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
-<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
+It can, however, still contain a `<Preview>` definition:
+
+<Preview>
+  <div>
+    <h3>This is a preview block within a documentation-only MDX file</h3>
+    <p>
+      You may need to wrap certain documentation in a `Preview` in order to reset the styles for use
+      cases such as documenting a design system.
+    </p>
+  </div>
+</Preview>
+
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
 
 ## Bottom
 

--- a/lib/components/src/html.tsx
+++ b/lib/components/src/html.tsx
@@ -1,5 +1,15 @@
+import { createElement, ElementType } from 'react';
+
 import { components as rawComponents } from './typography/DocumentFormatting';
 
 export * from './typography/DocumentFormatting';
 
 export { rawComponents as components };
+
+const resetComponents: Record<string, ElementType> = {};
+
+Object.keys(rawComponents).forEach((key) => {
+  resetComponents[key] = (props: any) => createElement(key, props);
+});
+
+export { resetComponents };


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/10273

## What I did

- Moved `resetComponents` out of `Story.tsx` and into `@storybook/components/html`
- Wrapped `Preview.tsx` with an `MDXProvider`
- Applied the newly exported `resetComponents` to the `MDXProvider` in `Story.tsx` and `Preview.tsx` 
- Added docs to the MDX only example story with the reset `Preview`

## How to test

Create a documentation-only mdx file that contains a `<Preview>` block and ensure the styles have been reset for the contents or check out the MDX only story in the official example.


---

<img width="1440" alt="Screen Shot 2020-04-20 at 3 22 48 PM" src="https://user-images.githubusercontent.com/12575994/79791181-e30eae80-831a-11ea-93ec-ff912e399d5c.png">
