### PR TITLE
Core: Fix source-map strategy for production

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -80,7 +80,7 @@ export default ({
   return {
     mode: isProd ? 'production' : 'development',
     bail: isProd,
-    devtool: '#cheap-module-source-map',
+    devtool: isProd ? 'inline-source-map' : '#cheap-module-source-map',
     entry: entries,
     output: {
       path: path.resolve(process.cwd(), outputDir),


### PR DESCRIPTION
Issue: #9901

## What I did

## How to test

- start in devmode (source-maps should work)
- make a static build, host static build (source-maps should work)