### PR TITLE
Yarn 2: rework imports in webpack preview virtual module to fix compatibility

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -52,9 +52,21 @@ export default ({
     const match = entryFilename.match(/(.*)-generated-(config|other)-entry.js$/);
     if (match) {
       const configFilename = match[1];
+
+      // Check on Yarn Pnp is mandatory to avoid error during webpack build in CRA example (non PnP case):
+      // Module not found: Error: You attempted to import /tmp/storybook/lib/client-api/dist/index.js which falls outside of the project src/ directory. Relative imports outside of src/ are not supported.
+      // as soon as scripted E2E tests with a local NPM registry will be implemented we can remove it.
+      const isUsingYarnPnp = typeof process.versions.pnp !== 'undefined';
+      const clientApi = isUsingYarnPnp
+        ? `${require.resolve('@storybook/client-api')}`
+        : '@storybook/client-api';
+      const clientLogger = isUsingYarnPnp
+        ? `${require.resolve('@storybook/client-logger')}`
+        : '@storybook/client-logger';
+
       virtualModuleMapping[entryFilename] = `
-        import { addDecorator, addParameters, addParameterEnhancer } from '@storybook/client-api';
-        import { logger } from '@storybook/client-logger';
+        const { addDecorator, addParameters, addParameterEnhancer } = require("${clientApi}")
+        const { logger } = require("${clientLogger}")
 
         const { decorators, parameters, parameterEnhancers, globalArgs, globalArgTypes, args, argTypes } = require(${JSON.stringify(
           configFilename


### PR DESCRIPTION
Issue: #10094 
Also related to https://github.com/storybookjs/storybook/issues/9527
## What I did

Using ES6 import directly in `preview.js-generated-config-entry.js` module definition is causing the following error when using Yarn 2:
```sh
ERROR in ./.storybook/preview.js-generated-config-entry.js
Module not found: Error: Something that got detected as your top-level application (because it doesn't seem to belong to any package) tried to access a package that is not declared in your dependencies

Required package: @storybook/client-api (via "@storybook/client-api")
Required by: /Users/dev/project/.storybook/preview.js-generated-config-entry.js
```

This is because the code of the virtual module is importing `@storybook/client-api` and `@storybook/client-logger`. When the code is executed these packages are required in the context of SB user project and not in the one of `@storybook/core` causing Yarn 2 to throw.

To avoid this, we are now resolving theses deps directly when webpack config is built (so in `@storybook/core` context) and then using the resolved values in the virtual module.

I didn't find a better way than adding a check on PnP usage to avoid these errors when [building React SB example in our monorepo](https://circleci.com/gh/storybookjs/storybook/205989):

```sh
ERROR in ./.storybook/preview.js-generated-config-entry.js
Module not found: Error: You attempted to import /tmp/storybook/lib/client-api/dist/index.js which falls outside of the project src/ directory. Relative imports outside of src/ are not supported.
You can either move it inside src/, or add a symlink to it from project's node_modules/.
 @ ./.storybook/preview.js-generated-config-entry.js 5:15-69
 @ multi /tmp/storybook/lib/core/dist/server/common/polyfills.js /tmp/storybook/lib/core/dist/server/preview/globals.js ./.storybook/storybook-init-framework-entry.js /tmp/storybook/addons/docs/dist/frameworks/common/config.js-generated-other-entry.js /tmp/storybook/addons/docs/dist/frameworks/react/config.js-generated-other-entry.js /tmp/storybook/addons/actions/dist/preset/addDecorator.js-generated-other-entry.js /tmp/storybook/addons/actions/dist/preset/addArgs.js-generated-other-entry.js /tmp/storybook/addons/links/dist/preset/addDecorator.js-generated-other-entry.js /tmp/storybook/addons/knobs/dist/preset/addDecorator.js-generated-other-entry.js /tmp/storybook/addons/a11y/dist/preset/addDecorator.js-generated-other-entry.js ./.storybook/preview.js-generated-config-entry.js ./.storybook/generated-stories-entry.js (webpack)-hot-middleware/client.js?reload=true&quiet=false
```

## How to test

All tests should still pass and sadly, for now, there is no Yarn 2 automated test.
