### PR TITLE
Explanation for template and addDecorators

### DIFF
--- a/addons/docs/angular/README.md
+++ b/addons/docs/angular/README.md
@@ -145,6 +145,7 @@ import { moduleMetadata } from '@storybook/angular';
 ]} />
 
 # Basic Checkbox
+
 <Story name='basic check' height='400px'>{{
   template: `
     <div class="some-wrapper-with-padding">
@@ -157,6 +158,7 @@ import { moduleMetadata } from '@storybook/angular';
 }}</Story>
 
 # Basic Radiobutton
+
 <Story name='basic radio' height='400px'>{{
   moduleMetadata: {
     declarations: [RadioButtonComponent]

--- a/addons/docs/angular/README.md
+++ b/addons/docs/angular/README.md
@@ -131,6 +131,47 @@ Yes, it's redundant to declare `component` twice. [Coming soon](https://github.c
 
 Also, to use the `Props` doc block, you need to set up Compodoc, [as described above](#docspage).
 
+When you are using `template`, `moduleMetadata` and/or `addDecorators` with `storiesOf` then you can easily translate your story to MDX, too:
+
+```md
+import { Meta, Story, Props } from '@storybook/addon-docs/blocks';
+import { CheckboxComponent, RadioButtonComponent } from './my-components';
+import { moduleMetadata } from '@storybook/angular';
+
+<Meta title='Checkbox' decorators={[
+  moduleMetadata({
+    declarations: [CheckboxComponent]
+  })
+]} />
+
+# Basic Checkbox
+<Story name='basic check' height='400px'>{{
+  template: `
+    <div class="some-wrapper-with-padding">
+      <my-checkbox [checked]="checked">Some Checkbox</my-checkbox>
+    </div>
+  `,
+  props: {
+    checked: true
+  }
+}}</Story>
+
+# Basic Radiobutton
+<Story name='basic radio' height='400px'>{{
+  moduleMetadata: {
+    declarations: [RadioButtonComponent]
+  }
+  template: `
+    <div class="some-wrapper-with-padding">
+      <my-radio-btn [checked]="checked">Some Checkbox</my-radio-btn>
+    </div>
+  `,
+  props: {
+    checked: true
+  }
+}}</Story>
+```
+
 ## IFrame height
 
 Storybook Docs renders all Angular stories inside IFrames, with a default height of `60px`. You can update this default globally, or modify the IFrame height locally per story in `DocsPage` and `MDX`.


### PR DESCRIPTION
Issue:
For Angular devs it would be helpful to see how to use template and addDecorators and moduleMetadata with the MDX format because it is very common with the storiesOf-API.

## What I did
Added an example how to use template, moduleMetadata and addDecorators.

## How to test
Only documentation update.