### PR TITLE
Yarn 2: Fix compatibility with `.storybook/preview.js` file

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -70,8 +70,19 @@ export default async ({
 
       virtualModuleMapping[entryFilename] = entryTemplate
         .replace('{{configFilename}}', configFilename.replace(/\\/g, '/'))
-        .replace('{{clientApi}}', clientApi.replace(/\\/g, '/'))
-        .replace('{{clientLogger}}', clientLogger.replace(/\\/g, '/'));
+        .replace(
+          '{{clientApi}}',
+          clientApi
+            .replace(/\\/g, '/')
+            // As clientApi can contain `$` we need to double every `$` to not have trouble when replacing {{clientApi}}
+            .replace(/\$/g, '$$$')
+        )
+        .replace('{{clientLogger}}', () =>
+          clientLogger
+            .replace(/\\/g, '/')
+            // As clientLogger can contain `$` we need to double every `$` to not have trouble when replacing {{clientLogger}}
+            .replace(/\$/g, '$$$')
+        );
     }
   });
   if (stories) {

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -68,28 +68,16 @@ export default async ({
         ? `${require.resolve('@storybook/client-logger')}`
         : '@storybook/client-logger';
 
-      virtualModuleMapping[entryFilename] = entryTemplate
-        .replace('{{configFilename}}', configFilename.replace(/\\/g, '/'))
-        .replace(
-          '{{clientApi}}',
-          clientApi
-            .replace(/\\/g, '/')
-            // As clientApi can contain `$` we need to double every `$` to not have trouble when replacing {{clientApi}}
-            .replace(/\$/g, '$$$')
-        )
-        .replace('{{clientLogger}}', () =>
-          clientLogger
-            .replace(/\\/g, '/')
-            // As clientLogger can contain `$` we need to double every `$` to not have trouble when replacing {{clientLogger}}
-            .replace(/\$/g, '$$$')
-        );
+      virtualModuleMapping[entryFilename] = interpolate(entryTemplate, {
+        configFilename,
+        clientApi,
+        clientLogger,
+      });
     }
   });
   if (stories) {
-    virtualModuleMapping[
-      path.resolve(path.join(configDir, `generated-stories-entry.js`))
-    ] = storyTemplate
-      .replace('{{framework}}', framework)
+    const storiesFilename = path.resolve(path.join(configDir, `generated-stories-entry.js`));
+    virtualModuleMapping[storiesFilename] = interpolate(storyTemplate, { framework })
       // Make sure we also replace quotes for this one
       .replace("'{{stories}}'", stories.map(toRequireContextString).join(','));
   }
@@ -194,4 +182,19 @@ export default async ({
       hints: isProd ? 'warning' : false,
     },
   };
+};
+
+/**
+ * Return a string corresponding to template filled with bindings using following pattern:
+ * For each (key, value) of `bindings` replace, in template, `{{key}}` by escaped version of `value`
+ *
+ * @param template {String} Template with `{{binding}}`
+ * @param bindings {Object} key-value object use to fill the template, `{{key}}` will be replaced by `escaped(value)`
+ * @returns {String} Filled template
+ */
+const interpolate = (template, bindings) => {
+  return Object.entries(bindings).reduce((acc, [k, v]) => {
+    const escapedString = v.replace(/\\/g, '/').replace(/\$/g, '$$$');
+    return acc.replace(new RegExp(`{{${k}}}`, 'g'), escapedString);
+  }, template);
 };

--- a/lib/core/src/server/preview/virtualModuleEntry.template.js
+++ b/lib/core/src/server/preview/virtualModuleEntry.template.js
@@ -1,6 +1,7 @@
-const { addDecorator, addParameters, addArgTypesEnhancer } = require('{{clientApi}}');
-const { logger } = require('{{clientLogger}}');
-const {
+/* eslint-disable import/no-unresolved */
+import { addDecorator, addParameters, addArgTypesEnhancer } from '{{clientApi}}';
+import { logger } from '{{clientLogger}}';
+import {
   decorators,
   parameters,
   argTypesEnhancers,
@@ -8,7 +9,7 @@ const {
   globalArgTypes,
   args,
   argTypes,
-} = require('{{configFilename}}');
+} from '{{configFilename}}';
 
 if (args || argTypes) {
   logger.warn('Invalid args/argTypes in config, ignoring.', JSON.stringify({ args, argTypes }));


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/10094

## What I did

 Patch `clientApi` and `clientLogger` strings to avoid issues when they contain `$` symbol.

`$` has a special behavior when used in the replacement string of the `replace` function, [see here for more details](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter).

As `clientApi` and `clientLogger` can contain `$` symbol we need to double every `$` to not have trouble when replacing them in the virtual module template 🤷‍♂ .

Also, use ES imports in the virtual module template as it is now transpiled like all other JS files.


## How to test
 
Test locally as we do not have automated tests with yarn 2... for now! I agree it's painful...
