### PR TITLE
Marko: Always destroy old component when switching stories

### DIFF
--- a/app/marko/src/client/preview/render.js
+++ b/app/marko/src/client/preview/render.js
@@ -6,6 +6,7 @@ import { logger } from '@storybook/client-logger';
 const rootEl = document.getElementById('root');
 let activeComponent = null; // currently loaded marko component.
 let activeTemplate = null; // template for the currently loaded component.
+let activeStoryFn = null; // used to determine if we've switched stories.
 
 export default function renderMain({
   storyFn,
@@ -16,7 +17,9 @@ export default function renderMain({
   parameters,
   // forceRender,
 }) {
+  const isSameStory = activeStoryFn === storyFn;
   const config = storyFn();
+  activeStoryFn = storyFn;
 
   if (!config || !(config.appendTo || config.component || parameters.component)) {
     showError({
@@ -43,7 +46,7 @@ export default function renderMain({
   } else {
     const template = config.component || parameters.component;
 
-    if (activeTemplate === template) {
+    if (isSameStory && activeTemplate === template) {
       // When rendering the same template with new input, we reuse the same instance.
       activeComponent.input = config.input;
       activeComponent.update();


### PR DESCRIPTION
Issue:
In storybook@5 the Marko plugin was updated to prefer reusing component instances (passing in new input) if the last rendered component was the same. This change improved support for knobs and other plugins which rerender a story to preserve the Marko components state.

This issue is that this can be a bit confusing when switching between stories since you likely expect things to be in a fresh state when doing so.

## What I did

I updated the Marko plugin to keep track of the last rendered story and it now only does a rerender if the same component was previously rendered _and_ the story function has not changed.
