### PR TITLE
Add missing types for react-native

### DIFF
--- a/app/react-native/src/index.ts
+++ b/app/react-native/src/index.ts
@@ -1,17 +1,20 @@
 /* eslint-disable prefer-destructuring */
+import { ClientApi } from '@storybook/client-api';
 import Preview from './preview';
 
 const preview = new Preview();
 
-const rawStoriesOf = preview.api().storiesOf.bind(preview);
-export const setAddon = preview.api().setAddon.bind(preview);
-export const addDecorator = preview.api().addDecorator.bind(preview);
-export const addParameters = preview.api().addParameters.bind(preview);
-export const clearDecorators = preview.api().clearDecorators.bind(preview);
+const rawStoriesOf: ClientApi['storiesOf'] = preview.api().storiesOf.bind(preview);
+export const setAddon: ClientApi['setAddon'] = preview.api().setAddon.bind(preview);
+export const addDecorator: ClientApi['addDecorator'] = preview.api().addDecorator.bind(preview);
+export const addParameters: ClientApi['addParameters'] = preview.api().addParameters.bind(preview);
+export const clearDecorators: ClientApi['clearDecorators'] = preview
+  .api()
+  .clearDecorators.bind(preview);
 export const configure = preview.configure;
-export const getStorybook = preview.api().getStorybook.bind(preview);
+export const getStorybook: ClientApi['getStorybook'] = preview.api().getStorybook.bind(preview);
 export const getStorybookUI = preview.getStorybookUI;
-export const raw = preview.api().raw.bind(preview);
+export const raw: ClientApi['raw'] = preview.api().raw.bind(preview);
 
-export const storiesOf = (...args: any[]) =>
-  rawStoriesOf(...args).addParameters({ framework: 'react-native' });
+export const storiesOf = (kind: string, module: NodeModule) =>
+  rawStoriesOf(kind, module).addParameters({ framework: 'react-native' });


### PR DESCRIPTION
Issue: I started using Storybook for react-native with TypeScript and noticed that `storiesOf` type was `any` also everything else was too from `@storybook/react-native` package was `any`.

## What I did

The problem was that when using `bind` with TypeScript it returns `any` which is considered very bad. The solution was to type the exported variables.

## How to test

Just make a TypeScript file which imports for example `storiesOf` and see that TypeScript compiler sees the correct typing.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
