### PR TITLE
CSF: Warn when there are no exported stories

### DIFF
--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -1,6 +1,7 @@
 import { ConfigApi, ClientApi, StoryStore } from '@storybook/client-api';
 import { isExportStory, storyNameFromExport, toId } from '@storybook/csf';
 import { logger } from '@storybook/client-logger';
+import dedent from 'ts-dedent';
 
 import { Loadable, LoaderFunction, RequireContext } from './types';
 
@@ -115,27 +116,31 @@ const loadStories = (
 
     const storyExports = Object.keys(exports);
     if (storyExports.length === 0) {
-      logger.warn(`Found a storyfile for "${kindName}" but no exported stories.`);
-    } else {
-      storyExports.forEach((key) => {
-        if (isExportStory(key, meta)) {
-          const storyFn = exports[key];
-          const { name, parameters, decorators, args, argTypes } = storyFn.story || {};
-          const decoratorParams = decorators ? { decorators } : null;
-          const exportName = storyNameFromExport(key);
-          const idParams = { __id: toId(componentId || kindName, exportName) };
-
-          const storyParams = {
-            ...parameters,
-            ...decoratorParams,
-            ...idParams,
-            args,
-            argTypes,
-          };
-          kind.add(name || exportName, storyFn, storyParams);
-        }
-      });
+      logger.warn(
+        dedent`Found a story file for "${kindName}" but no exported stories.
+        Check the docs for reference: https://storybook.js.org/docs/formats/component-story-format/`
+      );
+      return;
     }
+
+    storyExports.forEach((key) => {
+      if (isExportStory(key, meta)) {
+        const storyFn = exports[key];
+        const { name, parameters, decorators, args, argTypes } = storyFn.story || {};
+        const decoratorParams = decorators ? { decorators } : null;
+        const exportName = storyNameFromExport(key);
+        const idParams = { __id: toId(componentId || kindName, exportName) };
+
+        const storyParams = {
+          ...parameters,
+          ...decoratorParams,
+          ...idParams,
+          args,
+          argTypes,
+        };
+        kind.add(name || exportName, storyFn, storyParams);
+      }
+    });
   });
   previousExports = currentExports;
 };

--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -113,24 +113,29 @@ const loadStories = (
       kind.addDecorator(decorator);
     });
 
-    Object.keys(exports).forEach((key) => {
-      if (isExportStory(key, meta)) {
-        const storyFn = exports[key];
-        const { name, parameters, decorators, args, argTypes } = storyFn.story || {};
-        const decoratorParams = decorators ? { decorators } : null;
-        const exportName = storyNameFromExport(key);
-        const idParams = { __id: toId(componentId || kindName, exportName) };
+    const storyExports = Object.keys(exports);
+    if (storyExports.length === 0) {
+      logger.warn(`Found a storyfile for "${kindName}" but no exported stories.`);
+    } else {
+      storyExports.forEach((key) => {
+        if (isExportStory(key, meta)) {
+          const storyFn = exports[key];
+          const { name, parameters, decorators, args, argTypes } = storyFn.story || {};
+          const decoratorParams = decorators ? { decorators } : null;
+          const exportName = storyNameFromExport(key);
+          const idParams = { __id: toId(componentId || kindName, exportName) };
 
-        const storyParams = {
-          ...parameters,
-          ...decoratorParams,
-          ...idParams,
-          args,
-          argTypes,
-        };
-        kind.add(name || exportName, storyFn, storyParams);
-      }
-    });
+          const storyParams = {
+            ...parameters,
+            ...decoratorParams,
+            ...idParams,
+            args,
+            argTypes,
+          };
+          kind.add(name || exportName, storyFn, storyParams);
+        }
+      });
+    }
   });
   previousExports = currentExports;
 };


### PR DESCRIPTION
Issue: #10326 is an example that could benefit from this.

## What I did
Warning message when there are story files but no exported stories:
![image](https://user-images.githubusercontent.com/1671563/78866123-1a3daf80-7a3f-11ea-9889-4c3a39c9103b.png)

## How to test
Have a story file which does not contain a named export and run storybook:
```js
// button.stories.js
import Button from "./button";

export default { 
    title: 'Button',
    component: Button
};
```