### PR TITLE
Vue: update boilerplate link on readme

### DIFF
--- a/app/vue/README.md
+++ b/app/vue/README.md
@@ -19,7 +19,7 @@ For more information visit: [storybook.js.org](https://storybook.js.org)
 
 ## Starter Storybook-for-Vue Boilerplate project with [Vuetify](https://github.com/vuetifyjs/vuetify) Material Component Framework
 
-<https://github.com/white-rabbit-japan/vuetify-storyboard-boilerplate>
+<https://github.com/white-rabbit-japan/vue-vuetify-storybook>
 
 ---
 


### PR DESCRIPTION
Issue: #10355 

## What I did
The vue boilerplate repository has been renamed. Link is updated.

closes #10355 