### PR TITLE
Server: Fix serialization of knobs params back to server

### DIFF
--- a/app/server/src/lib/compiler/__testfixtures__/knobs.json
+++ b/app/server/src/lib/compiler/__testfixtures__/knobs.json
@@ -14,7 +14,7 @@
         { "type": "text", "name": "Name", "value": "John Doe", "param": "name"},
         { "type": "date", "name": "Birthday", "value": "1960-12-25T00:42:03.600Z", "param": "birthday"},
         { "type": "color", "name": "Favorite Color", "value": "red", "param": "favorite_color"},
-        { "type": "boolean", "name": "Acive", "value": true, "param": "active"},
+        { "type": "boolean", "name": "Active", "value": true, "param": "active"},
         { "type": "number", "name": "Pets", "value": 2, "param": "pets"},
         { "type": "array", "name": "Sports", "value": ["football", "baseball"], "param": "sports"},
           { 

--- a/app/server/src/lib/compiler/__testfixtures__/knobs.json
+++ b/app/server/src/lib/compiler/__testfixtures__/knobs.json
@@ -12,7 +12,24 @@
       },
       "knobs": [
         { "type": "text", "name": "Name", "value": "John Doe", "param": "name"},
-        { "type": "number", "name": "Age", "value": 44, "param": "age"}
+        { "type": "date", "name": "Birthday", "value": "1960-12-25T00:42:03.600Z", "param": "birthday"},
+        { "type": "color", "name": "Favorite Color", "value": "red", "param": "favorite_color"},
+        { "type": "boolean", "name": "Acive", "value": true, "param": "active"},
+        { "type": "number", "name": "Pets", "value": 2, "param": "pets"},
+        { "type": "array", "name": "Sports", "value": ["football", "baseball"], "param": "sports"},
+          { 
+            "type": "select",
+            "name": "Favorite Food",
+            "value": "Ice Cream",
+            "options": {
+              "hot_dog": "Hot Dog",
+              "pizza": "Pizza",
+              "burgers": "Burgers",
+              "ice_cream": "Ice Cream"
+            },
+            "param": "favorite_food"
+          },
+        { "type": "object", "name": "Other Things", "value": {"hair": "Brown", "eyes": "Blue"}, "param": "other_thinkgs"}
       ]
     }
   ]

--- a/app/server/src/lib/compiler/__testfixtures__/knobs.snapshot
+++ b/app/server/src/lib/compiler/__testfixtures__/knobs.snapshot
@@ -18,7 +18,24 @@ export default {
 export const Simple = () => {
   return {
     name: text('Name', 'John Doe'),
-    age: number('Age', 44, {}),
+    birthday: new Date(date('Birthday', new Date('1960-12-25T00:42:03.600Z'))).toISOString(),
+    favorite_color: color('Favorite Color', 'red'),
+    active: boolean('Acive', true),
+    pets: number('Pets', 2, {}),
+    sports: array('Sports', [
+      'football',
+      'baseball'
+    ], ',').join(','),
+    favorite_food: select('Favorite Food', {
+      hot_dog: 'Hot Dog',
+      pizza: 'Pizza',
+      burgers: 'Burgers',
+      ice_cream: 'Ice Cream'
+    }, 'Ice Cream'),
+    other_thinkgs: JSON.stringify(object('Other Things', {
+      hair: 'Brown',
+      eyes: 'Blue'
+    })),
   };
 };
 Simple.story = {

--- a/app/server/src/lib/compiler/__testfixtures__/knobs.snapshot
+++ b/app/server/src/lib/compiler/__testfixtures__/knobs.snapshot
@@ -20,7 +20,7 @@ export const Simple = () => {
     name: text('Name', 'John Doe'),
     birthday: new Date(date('Birthday', new Date('1960-12-25T00:42:03.600Z'))).toISOString(),
     favorite_color: color('Favorite Color', 'red'),
-    active: boolean('Acive', true),
+    active: boolean('Active', true),
     pets: number('Pets', 2, {}),
     sports: array('Sports', [
       'football',

--- a/app/server/src/lib/compiler/decorators/knobs.ts
+++ b/app/server/src/lib/compiler/decorators/knobs.ts
@@ -27,14 +27,16 @@ function stringifyKnob(knob: StoryKnob) {
         return `number('${name}', ${stringifiedValue}, ${stringifyObject(opts, level)})`;
       case 'color':
         return `color('${name}', ${stringifiedValue})`;
-      case 'array':
-        return `array('${name}', ${stringifiedValue}).join(',')`;
+      case 'array': {
+        const separator = opts.separator || ',';
+        return `array('${name}', ${stringifiedValue}, '${separator}').join('${separator}')`;
+      }
       case 'boolean':
         return `boolean('${name}', ${stringifiedValue})`;
       case 'object':
-        return `object('${name}', ${stringifiedValue})`;
+        return `JSON.stringify(object('${name}', ${stringifiedValue}))`;
       case 'date':
-        return `date('${name}', new Date(${stringifiedValue}))`;
+        return `new Date(date('${name}', new Date(${stringifiedValue}))).toISOString()`;
       case 'select':
         return `select('${name}', ${stringifyObject(opts.options, level)}, ${stringifiedValue})`;
       default:


### PR DESCRIPTION

## What I did

Changed how @storybook/server serializes knobs parameters back to the server. In particular:
 * Array knobs get joined using their supplied separator option
 * Object knobs get JSON stringified
 * Dates get converted to ISO format rather than unix timestamps (which is a mess to parse if you don't know it the integer includes time or is just a date0 

## How to test

II expanded the snapshots to cover the changes.
