### PR TITLE
Args: Rename ParameterEnhancer to ArgsEnhancer

### DIFF
--- a/addons/actions/src/preset/addArgs.test.ts
+++ b/addons/actions/src/preset/addArgs.test.ts
@@ -33,7 +33,7 @@ describe('actions parameter enhancers', () => {
         actions: { ...baseParameters.actions, disable: true },
       };
       const result = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(parameters.argTypes);
     });
   });
 
@@ -66,7 +66,7 @@ describe('actions parameter enhancers', () => {
     it('should do nothing if actions are disabled', () => {
       const parameters = { ...baseParameters, actions: { disable: true } };
       const result = addActionsFromArgTypes({ parameters } as StoryContext);
-      expect(result).toBeFalsy();
+      expect(result).toEqual(parameters.argTypes);
     });
   });
 });

--- a/addons/actions/src/preset/addArgs.test.ts
+++ b/addons/actions/src/preset/addArgs.test.ts
@@ -1,6 +1,9 @@
 import { StoryContext } from '@storybook/addons';
 import { inferActionsFromArgTypesRegex, addActionsFromArgTypes } from './addArgs';
 
+const withDefaultValue = (argTypes) =>
+  Object.keys(argTypes).filter((key) => !!argTypes[key].defaultValue);
+
 describe('actions parameter enhancers', () => {
   describe('actions.argTypesRegex parameter', () => {
     const baseParameters = {
@@ -10,18 +13,18 @@ describe('actions parameter enhancers', () => {
 
     it('should add actions that match a pattern', () => {
       const parameters = baseParameters;
-      const { args } = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
-      expect(Object.keys(args)).toEqual(['onClick', 'onFocus']);
+      const { argTypes } = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
+      expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onFocus']);
     });
 
-    it('should prioritize pre-existing args', () => {
+    it('should prioritize pre-existing argTypes', () => {
       const parameters = {
         ...baseParameters,
-        args: { onClick: 'pre-existing arg' },
+        argTypes: { onClick: { defaultValue: 'pre-existing value' }, onFocus: {} },
       };
-      const { args } = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
-      expect(Object.keys(args)).toEqual(['onClick', 'onFocus']);
-      expect(args.onClick).toEqual('pre-existing arg');
+      const { argTypes } = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
+      expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onFocus']);
+      expect(argTypes.onClick.defaultValue).toEqual('pre-existing value');
     });
 
     it('should do nothing if actions are disabled', () => {
@@ -41,21 +44,23 @@ describe('actions parameter enhancers', () => {
         onBlur: { action: 'blurred!' },
       },
     };
-
     it('should add actions based on action.args', () => {
       const parameters = baseParameters;
-      const { args } = addActionsFromArgTypes({ parameters } as StoryContext);
-      expect(Object.keys(args)).toEqual(['onClick', 'onBlur']);
+      const { argTypes } = addActionsFromArgTypes({ parameters } as StoryContext);
+      expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onBlur']);
     });
 
     it('should prioritize pre-existing args', () => {
       const parameters = {
         ...baseParameters,
-        args: { onClick: 'pre-existing arg' },
+        argTypes: {
+          onClick: { defaultValue: 'pre-existing value', action: 'onClick' },
+          onBlur: { action: 'onBlur' },
+        },
       };
-      const { args } = addActionsFromArgTypes({ parameters } as StoryContext);
-      expect(Object.keys(args)).toEqual(['onClick', 'onBlur']);
-      expect(args.onClick).toEqual('pre-existing arg');
+      const { argTypes } = addActionsFromArgTypes({ parameters } as StoryContext);
+      expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onBlur']);
+      expect(argTypes.onClick.defaultValue).toEqual('pre-existing value');
     });
 
     it('should do nothing if actions are disabled', () => {

--- a/addons/actions/src/preset/addArgs.test.ts
+++ b/addons/actions/src/preset/addArgs.test.ts
@@ -13,7 +13,7 @@ describe('actions parameter enhancers', () => {
 
     it('should add actions that match a pattern', () => {
       const parameters = baseParameters;
-      const { argTypes } = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
+      const argTypes = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
       expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onFocus']);
     });
 
@@ -22,7 +22,7 @@ describe('actions parameter enhancers', () => {
         ...baseParameters,
         argTypes: { onClick: { defaultValue: 'pre-existing value' }, onFocus: {} },
       };
-      const { argTypes } = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
+      const argTypes = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
       expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onFocus']);
       expect(argTypes.onClick.defaultValue).toEqual('pre-existing value');
     });
@@ -46,7 +46,7 @@ describe('actions parameter enhancers', () => {
     };
     it('should add actions based on action.args', () => {
       const parameters = baseParameters;
-      const { argTypes } = addActionsFromArgTypes({ parameters } as StoryContext);
+      const argTypes = addActionsFromArgTypes({ parameters } as StoryContext);
       expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onBlur']);
     });
 
@@ -58,7 +58,7 @@ describe('actions parameter enhancers', () => {
           onBlur: { action: 'onBlur' },
         },
       };
-      const { argTypes } = addActionsFromArgTypes({ parameters } as StoryContext);
+      const argTypes = addActionsFromArgTypes({ parameters } as StoryContext);
       expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onBlur']);
       expect(argTypes.onClick.defaultValue).toEqual('pre-existing value');
     });

--- a/addons/actions/src/preset/addArgs.ts
+++ b/addons/actions/src/preset/addArgs.ts
@@ -1,5 +1,5 @@
 import { ArgsEnhancer, combineParameters } from '@storybook/client-api';
-import { Args, ArgType } from '@storybook/addons';
+import { ArgTypes, ArgType } from '@storybook/addons';
 
 import { action } from '../index';
 
@@ -13,21 +13,21 @@ import { action } from '../index';
  * matches a regex, such as `^on.*` for react-style `onClick` etc.
  */
 export const inferActionsFromArgTypesRegex: ArgsEnhancer = (context) => {
-  const { args, actions, argTypes } = context.parameters;
+  const { actions, argTypes } = context.parameters;
   if (!actions || actions.disable || !actions.argTypesRegex || !argTypes) {
     return null;
   }
 
   const argTypesRegex = new RegExp(actions.argTypesRegex);
-  const actionArgs = Object.keys(argTypes).reduce((acc, name) => {
+  const actionArgTypes = Object.keys(argTypes).reduce((acc, name) => {
     if (argTypesRegex.test(name)) {
-      acc[name] = action(name);
+      acc[name] = { defaultValue: action(name) };
     }
     return acc;
-  }, {} as Args);
+  }, {} as ArgTypes);
 
   return {
-    args: combineParameters(actionArgs, args),
+    argTypes: combineParameters(actionArgTypes, argTypes),
   };
 };
 
@@ -35,22 +35,22 @@ export const inferActionsFromArgTypesRegex: ArgsEnhancer = (context) => {
  * Add action args for list of strings.
  */
 export const addActionsFromArgTypes: ArgsEnhancer = (context) => {
-  const { args, argTypes, actions } = context.parameters;
+  const { argTypes, actions } = context.parameters;
   if (actions?.disable || !argTypes) {
     return null;
   }
 
-  const actionArgs = Object.keys(argTypes).reduce((acc, argName) => {
+  const actionArgTypes = Object.keys(argTypes).reduce((acc, argName) => {
     const argType: ArgType = argTypes[argName];
     if (argType.action) {
       const message = typeof argType.action === 'string' ? argType.action : argName;
-      acc[argName] = action(message);
+      acc[argName] = { defaultValue: action(message) };
     }
     return acc;
-  }, {} as Args);
+  }, {} as ArgTypes);
 
   return {
-    args: combineParameters(actionArgs, args),
+    argTypes: combineParameters(actionArgTypes, argTypes),
   };
 };
 

--- a/addons/actions/src/preset/addArgs.ts
+++ b/addons/actions/src/preset/addArgs.ts
@@ -1,4 +1,4 @@
-import { ParameterEnhancer, combineParameters } from '@storybook/client-api';
+import { ArgsEnhancer, combineParameters } from '@storybook/client-api';
 import { Args, ArgType } from '@storybook/addons';
 
 import { action } from '../index';
@@ -12,7 +12,7 @@ import { action } from '../index';
  * Automatically add action args for argTypes whose name
  * matches a regex, such as `^on.*` for react-style `onClick` etc.
  */
-export const inferActionsFromArgTypesRegex: ParameterEnhancer = (context) => {
+export const inferActionsFromArgTypesRegex: ArgsEnhancer = (context) => {
   const { args, actions, argTypes } = context.parameters;
   if (!actions || actions.disable || !actions.argTypesRegex || !argTypes) {
     return null;
@@ -34,7 +34,7 @@ export const inferActionsFromArgTypesRegex: ParameterEnhancer = (context) => {
 /**
  * Add action args for list of strings.
  */
-export const addActionsFromArgTypes: ParameterEnhancer = (context) => {
+export const addActionsFromArgTypes: ArgsEnhancer = (context) => {
   const { args, argTypes, actions } = context.parameters;
   if (actions?.disable || !argTypes) {
     return null;
@@ -54,4 +54,4 @@ export const addActionsFromArgTypes: ParameterEnhancer = (context) => {
   };
 };
 
-export const parameterEnhancers = [addActionsFromArgTypes, inferActionsFromArgTypesRegex];
+export const argsEnhancers = [addActionsFromArgTypes, inferActionsFromArgTypesRegex];

--- a/addons/actions/src/preset/addArgs.ts
+++ b/addons/actions/src/preset/addArgs.ts
@@ -15,7 +15,7 @@ import { action } from '../index';
 export const inferActionsFromArgTypesRegex: ArgTypesEnhancer = (context) => {
   const { actions, argTypes } = context.parameters;
   if (!actions || actions.disable || !actions.argTypesRegex || !argTypes) {
-    return null;
+    return argTypes;
   }
 
   const argTypesRegex = new RegExp(actions.argTypesRegex);
@@ -35,7 +35,7 @@ export const inferActionsFromArgTypesRegex: ArgTypesEnhancer = (context) => {
 export const addActionsFromArgTypes: ArgTypesEnhancer = (context) => {
   const { argTypes, actions } = context.parameters;
   if (actions?.disable || !argTypes) {
-    return null;
+    return argTypes;
   }
 
   const actionArgTypes = Object.keys(argTypes).reduce((acc, argName) => {

--- a/addons/actions/src/preset/addArgs.ts
+++ b/addons/actions/src/preset/addArgs.ts
@@ -1,4 +1,4 @@
-import { ArgsEnhancer, combineParameters } from '@storybook/client-api';
+import { ArgTypesEnhancer, combineParameters } from '@storybook/client-api';
 import { ArgTypes, ArgType } from '@storybook/addons';
 
 import { action } from '../index';
@@ -12,7 +12,7 @@ import { action } from '../index';
  * Automatically add action args for argTypes whose name
  * matches a regex, such as `^on.*` for react-style `onClick` etc.
  */
-export const inferActionsFromArgTypesRegex: ArgsEnhancer = (context) => {
+export const inferActionsFromArgTypesRegex: ArgTypesEnhancer = (context) => {
   const { actions, argTypes } = context.parameters;
   if (!actions || actions.disable || !actions.argTypesRegex || !argTypes) {
     return null;
@@ -26,15 +26,13 @@ export const inferActionsFromArgTypesRegex: ArgsEnhancer = (context) => {
     return acc;
   }, {} as ArgTypes);
 
-  return {
-    argTypes: combineParameters(actionArgTypes, argTypes),
-  };
+  return combineParameters(actionArgTypes, argTypes) as ArgTypes;
 };
 
 /**
  * Add action args for list of strings.
  */
-export const addActionsFromArgTypes: ArgsEnhancer = (context) => {
+export const addActionsFromArgTypes: ArgTypesEnhancer = (context) => {
   const { argTypes, actions } = context.parameters;
   if (actions?.disable || !argTypes) {
     return null;
@@ -49,9 +47,7 @@ export const addActionsFromArgTypes: ArgsEnhancer = (context) => {
     return acc;
   }, {} as ArgTypes);
 
-  return {
-    argTypes: combineParameters(actionArgTypes, argTypes),
-  };
+  return combineParameters(actionArgTypes, argTypes) as ArgTypes;
 };
 
-export const argsEnhancers = [addActionsFromArgTypes, inferActionsFromArgTypesRegex];
+export const argTypesEnhancers = [addActionsFromArgTypes, inferActionsFromArgTypesRegex];

--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -1,4 +1,4 @@
-import { ParameterEnhancer, combineParameters } from '@storybook/client-api';
+import { ArgsEnhancer, combineParameters } from '@storybook/client-api';
 
 interface Location {
   line: number;
@@ -36,7 +36,7 @@ const extract = (targetId: string, { source, locationsMap }: StorySource) => {
   ].join('\n');
 };
 
-export const enhanceSource: ParameterEnhancer = (context) => {
+export const enhanceSource: ArgsEnhancer = (context) => {
   const { id, parameters } = context;
   const { storySource, docs = {} } = parameters;
   const { formatSource } = docs;

--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -1,4 +1,5 @@
-import { ArgsEnhancer, combineParameters } from '@storybook/client-api';
+import { combineParameters } from '@storybook/client-api';
+import { StoryContext, Parameters } from '@storybook/addons';
 
 interface Location {
   line: number;
@@ -36,7 +37,7 @@ const extract = (targetId: string, { source, locationsMap }: StorySource) => {
   ].join('\n');
 };
 
-export const enhanceSource: ArgsEnhancer = (context) => {
+export const enhanceSource = (context: StoryContext): Parameters => {
   const { id, parameters } = context;
   const { storySource, docs = {} } = parameters;
   const { formatSource } = docs;

--- a/lib/client-api/README.md
+++ b/lib/client-api/README.md
@@ -34,7 +34,7 @@ Ideally all parameters should be set _at build time_ of the Storybook, either di
 
 However, in some cases it is necessary to set parameters at _load time_ when the Storybook first loads. This should be avoided if at all possible as it is cost that must be paid each time a Storybook loads, rather than just once when the Storybook is built.
 
-To add a parameter enhancer, call `store.addArgsEnhancer(enhancer)` _before_ any stories are loaded (in addon registration or in `preview.js`). As each story is loaded, the enhancer will be called with the full story `context` -- the return value should be an object that will be patched into the Story's parameters.
+To add a parameter enhancer, call `store.addArgTypesEnhancer(enhancer)` _before_ any stories are loaded (in addon registration or in `preview.js`). As each story is loaded, the enhancer will be called with the full story `context` -- the return value should be an object that will be patched into the Story's parameters.
 
 ## Args
 

--- a/lib/client-api/README.md
+++ b/lib/client-api/README.md
@@ -34,7 +34,7 @@ Ideally all parameters should be set _at build time_ of the Storybook, either di
 
 However, in some cases it is necessary to set parameters at _load time_ when the Storybook first loads. This should be avoided if at all possible as it is cost that must be paid each time a Storybook loads, rather than just once when the Storybook is built.
 
-To add a parameter enhancer, call `store.addParameterEnhancer(enhancer)` _before_ any stories are loaded (in addon registration or in `preview.js`). As each story is loaded, the enhancer will be called with the full story `context` -- the return value should be an object that will be patched into the Story's parameters.
+To add a parameter enhancer, call `store.addArgsEnhancer(enhancer)` _before_ any stories are loaded (in addon registration or in `preview.js`). As each story is loaded, the enhancer will be called with the full story `context` -- the return value should be an object that will be patched into the Story's parameters.
 
 ## Args
 

--- a/lib/client-api/README.md
+++ b/lib/client-api/README.md
@@ -34,7 +34,7 @@ Ideally all parameters should be set _at build time_ of the Storybook, either di
 
 However, in some cases it is necessary to set parameters at _load time_ when the Storybook first loads. This should be avoided if at all possible as it is cost that must be paid each time a Storybook loads, rather than just once when the Storybook is built.
 
-To add a parameter enhancer, call `store.addArgTypesEnhancer(enhancer)` _before_ any stories are loaded (in addon registration or in `preview.js`). As each story is loaded, the enhancer will be called with the full story `context` -- the return value should be an object that will be patched into the Story's parameters.
+To add a parameter enhancer, call `store.addArgTypesEnhancer(enhancer)` _before_ any stories are loaded (in addon registration or in `preview.js`). As each story is loaded, the enhancer will be called with the full story `context` -- the return value should be an object that will be patched into the Story's `argTypes`.
 
 ## Args
 

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -8,7 +8,7 @@ import {
   DecoratorFunction,
   ClientApiAddons,
   StoryApi,
-  ArgsEnhancer,
+  ArgTypesEnhancer,
 } from './types';
 import { applyHooks } from './hooks';
 import StoryStore from './story_store';
@@ -31,11 +31,11 @@ export const addParameters = (parameters: Parameters) => {
   singleton.addParameters(parameters);
 };
 
-export const addArgsEnhancer = (enhancer: ArgsEnhancer) => {
+export const addArgTypesEnhancer = (enhancer: ArgTypesEnhancer) => {
   if (!singleton)
-    throw new Error(`Singleton client API not yet initialized, cannot call addArgsEnhancer`);
+    throw new Error(`Singleton client API not yet initialized, cannot call addArgTypesEnhancer`);
 
-  singleton.addArgsEnhancer(enhancer);
+  singleton.addArgTypesEnhancer(enhancer);
 };
 
 export default class ClientApi {
@@ -105,8 +105,8 @@ export default class ClientApi {
     this._storyStore.addGlobalMetadata({ decorators: [], parameters });
   };
 
-  addArgsEnhancer = (enhancer: ArgsEnhancer) => {
-    this._storyStore.addArgsEnhancer(enhancer);
+  addArgTypesEnhancer = (enhancer: ArgTypesEnhancer) => {
+    this._storyStore.addArgTypesEnhancer(enhancer);
   };
 
   clearDecorators = () => {

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -8,7 +8,7 @@ import {
   DecoratorFunction,
   ClientApiAddons,
   StoryApi,
-  ParameterEnhancer,
+  ArgsEnhancer,
 } from './types';
 import { applyHooks } from './hooks';
 import StoryStore from './story_store';
@@ -31,11 +31,11 @@ export const addParameters = (parameters: Parameters) => {
   singleton.addParameters(parameters);
 };
 
-export const addParameterEnhancer = (enhancer: ParameterEnhancer) => {
+export const addArgsEnhancer = (enhancer: ArgsEnhancer) => {
   if (!singleton)
-    throw new Error(`Singleton client API not yet initialized, cannot call addParameterEnhancer`);
+    throw new Error(`Singleton client API not yet initialized, cannot call addArgsEnhancer`);
 
-  singleton.addParameterEnhancer(enhancer);
+  singleton.addArgsEnhancer(enhancer);
 };
 
 export default class ClientApi {
@@ -105,8 +105,8 @@ export default class ClientApi {
     this._storyStore.addGlobalMetadata({ decorators: [], parameters });
   };
 
-  addParameterEnhancer = (enhancer: ParameterEnhancer) => {
-    this._storyStore.addParameterEnhancer(enhancer);
+  addArgsEnhancer = (enhancer: ArgsEnhancer) => {
+    this._storyStore.addArgsEnhancer(enhancer);
   };
 
   clearDecorators = () => {

--- a/lib/client-api/src/index.ts
+++ b/lib/client-api/src/index.ts
@@ -1,4 +1,4 @@
-import ClientApi, { addDecorator, addParameters, addParameterEnhancer } from './client_api';
+import ClientApi, { addDecorator, addParameters, addArgsEnhancer } from './client_api';
 import { defaultDecorateStory } from './decorators';
 import { combineParameters } from './parameters';
 import StoryStore from './story_store';
@@ -15,7 +15,7 @@ export {
   ClientApi,
   addDecorator,
   addParameters,
-  addParameterEnhancer,
+  addArgsEnhancer,
   combineParameters,
   StoryStore,
   ConfigApi,

--- a/lib/client-api/src/index.ts
+++ b/lib/client-api/src/index.ts
@@ -1,4 +1,4 @@
-import ClientApi, { addDecorator, addParameters, addArgsEnhancer } from './client_api';
+import ClientApi, { addDecorator, addParameters, addArgTypesEnhancer } from './client_api';
 import { defaultDecorateStory } from './decorators';
 import { combineParameters } from './parameters';
 import StoryStore from './story_store';
@@ -15,7 +15,7 @@ export {
   ClientApi,
   addDecorator,
   addParameters,
-  addArgsEnhancer,
+  addArgTypesEnhancer,
   combineParameters,
   StoryStore,
   ConfigApi,

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -357,12 +357,12 @@ describe('preview.story_store', () => {
     });
   });
 
-  describe('parameterEnhancer', () => {
+  describe('argsEnhancer', () => {
     it('allows you to alter parameters when stories are added', () => {
       const store = new StoryStore({ channel });
 
       const enhancer = jest.fn().mockReturnValue({ c: 'd' });
-      store.addParameterEnhancer(enhancer);
+      store.addArgsEnhancer(enhancer);
 
       addStoryToStore(store, 'a', '1', () => 0, { a: 'b' });
 
@@ -374,9 +374,9 @@ describe('preview.story_store', () => {
       const store = new StoryStore({ channel });
 
       const firstEnhancer = jest.fn().mockReturnValue({ c: 'd' });
-      store.addParameterEnhancer(firstEnhancer);
+      store.addArgsEnhancer(firstEnhancer);
       const secondEnhancer = jest.fn().mockReturnValue({ e: 'f' });
-      store.addParameterEnhancer(secondEnhancer);
+      store.addArgsEnhancer(secondEnhancer);
 
       addStoryToStore(store, 'a', '1', () => 0, { a: 'b' });
 
@@ -393,9 +393,9 @@ describe('preview.story_store', () => {
       const store = new StoryStore({ channel });
 
       const firstEnhancer = jest.fn().mockReturnValue({ ns: { c: 'd' } });
-      store.addParameterEnhancer(firstEnhancer);
+      store.addArgsEnhancer(firstEnhancer);
       const secondEnhancer = jest.fn().mockReturnValue({ ns: { e: 'f' } });
-      store.addParameterEnhancer(secondEnhancer);
+      store.addArgsEnhancer(secondEnhancer);
 
       addStoryToStore(store, 'a', '1', () => 0, { ns: { a: 'b' } });
 
@@ -413,7 +413,7 @@ describe('preview.story_store', () => {
       addons.setChannel(channel);
 
       const enhancer = jest.fn().mockReturnValue({ c: 'd' });
-      store.addParameterEnhancer(enhancer);
+      store.addArgsEnhancer(enhancer);
 
       addStoryToStore(store, 'a', '1', () => 0, { a: 'b' });
 

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -405,20 +405,6 @@ describe('preview.story_store', () => {
       expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ c: 'd' });
     });
 
-    it('leaves argTypes untouched when enhancer returns a falsey result', () => {
-      const store = new StoryStore({ channel });
-
-      const enhancer = jest.fn().mockReturnValue(null);
-      store.addArgTypesEnhancer(enhancer);
-
-      addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
-
-      expect(enhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { argTypes: { a: 'b' } } })
-      );
-      expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ a: 'b' });
-    });
-
     it('allows you to alter argTypes when stories are re-added', () => {
       const store = new StoryStore({ channel });
       addons.setChannel(channel);

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -405,6 +405,20 @@ describe('preview.story_store', () => {
       expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ c: 'd' });
     });
 
+    it('leaves argTypes untouched when enhancer returns a falsey result', () => {
+      const store = new StoryStore({ channel });
+
+      const enhancer = jest.fn().mockReturnValue(null);
+      store.addArgTypesEnhancer(enhancer);
+
+      addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
+
+      expect(enhancer).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { argTypes: { a: 'b' } } })
+      );
+      expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ a: 'b' });
+    });
+
     it('allows you to alter argTypes when stories are re-added', () => {
       const store = new StoryStore({ channel });
       addons.setChannel(channel);

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -357,72 +357,71 @@ describe('preview.story_store', () => {
     });
   });
 
-  describe('argsEnhancer', () => {
-    it('allows you to alter parameters when stories are added', () => {
+  describe('argTypesEnhancer', () => {
+    it('allows you to alter argTypes when stories are added', () => {
+      const store = new StoryStore({ channel });
+
+      const enhancer = jest.fn((context) => ({ ...context.parameters.argTypes, c: 'd' }));
+      store.addArgTypesEnhancer(enhancer);
+
+      addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
+
+      expect(enhancer).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { argTypes: { a: 'b' } } })
+      );
+      expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ a: 'b', c: 'd' });
+    });
+
+    it('recursively passes argTypes to successive enhancers', () => {
+      const store = new StoryStore({ channel });
+
+      const firstEnhancer = jest.fn((context) => ({ ...context.parameters.argTypes, c: 'd' }));
+      store.addArgTypesEnhancer(firstEnhancer);
+      const secondEnhancer = jest.fn((context) => ({ ...context.parameters.argTypes, e: 'f' }));
+      store.addArgTypesEnhancer(secondEnhancer);
+
+      addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
+
+      expect(firstEnhancer).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { argTypes: { a: 'b' } } })
+      );
+      expect(secondEnhancer).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { argTypes: { a: 'b', c: 'd' } } })
+      );
+      expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ a: 'b', c: 'd', e: 'f' });
+    });
+
+    it('does not merge argType enhancer results', () => {
       const store = new StoryStore({ channel });
 
       const enhancer = jest.fn().mockReturnValue({ c: 'd' });
-      store.addArgsEnhancer(enhancer);
+      store.addArgTypesEnhancer(enhancer);
 
-      addStoryToStore(store, 'a', '1', () => 0, { a: 'b' });
+      addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
 
-      expect(enhancer).toHaveBeenCalledWith(expect.objectContaining({ parameters: { a: 'b' } }));
-      expect(store.getRawStory('a', '1').parameters).toEqual({ a: 'b', c: 'd' });
+      expect(enhancer).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { argTypes: { a: 'b' } } })
+      );
+      expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ c: 'd' });
     });
 
-    it('recursively passes parameters to successive enhancers', () => {
-      const store = new StoryStore({ channel });
-
-      const firstEnhancer = jest.fn().mockReturnValue({ c: 'd' });
-      store.addArgsEnhancer(firstEnhancer);
-      const secondEnhancer = jest.fn().mockReturnValue({ e: 'f' });
-      store.addArgsEnhancer(secondEnhancer);
-
-      addStoryToStore(store, 'a', '1', () => 0, { a: 'b' });
-
-      expect(firstEnhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { a: 'b' } })
-      );
-      expect(secondEnhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { a: 'b', c: 'd' } })
-      );
-      expect(store.getRawStory('a', '1').parameters).toEqual({ a: 'b', c: 'd', e: 'f' });
-    });
-
-    it('does not merge subkeys of parameter enhancer results', () => {
-      const store = new StoryStore({ channel });
-
-      const firstEnhancer = jest.fn().mockReturnValue({ ns: { c: 'd' } });
-      store.addArgsEnhancer(firstEnhancer);
-      const secondEnhancer = jest.fn().mockReturnValue({ ns: { e: 'f' } });
-      store.addArgsEnhancer(secondEnhancer);
-
-      addStoryToStore(store, 'a', '1', () => 0, { ns: { a: 'b' } });
-
-      expect(firstEnhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { ns: { a: 'b' } } })
-      );
-      expect(secondEnhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { ns: { c: 'd' } } })
-      );
-      expect(store.getRawStory('a', '1').parameters).toEqual({ ns: { e: 'f' } });
-    });
-
-    it('allows you to alter parameters when stories are re-added', () => {
+    it('allows you to alter argTypes when stories are re-added', () => {
       const store = new StoryStore({ channel });
       addons.setChannel(channel);
 
-      const enhancer = jest.fn().mockReturnValue({ c: 'd' });
-      store.addArgsEnhancer(enhancer);
+      const enhancer = jest.fn((context) => ({ ...context.parameters.argTypes, c: 'd' }));
+      store.addArgTypesEnhancer(enhancer);
 
-      addStoryToStore(store, 'a', '1', () => 0, { a: 'b' });
+      addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
 
       enhancer.mockClear();
       store.removeStoryKind('a');
 
-      addStoryToStore(store, 'a', '1', () => 0, { e: 'f' });
-      expect(enhancer).toHaveBeenCalledWith(expect.objectContaining({ parameters: { e: 'f' } }));
-      expect(store.getRawStory('a', '1').parameters).toEqual({ e: 'f', c: 'd' });
+      addStoryToStore(store, 'a', '1', () => 0, { argTypes: { e: 'f' } });
+      expect(enhancer).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { argTypes: { e: 'f' } } })
+      );
+      expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ e: 'f', c: 'd' });
     });
   });
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -25,7 +25,7 @@ import {
   PublishedStoreItem,
   ErrorLike,
   GetStorybookKind,
-  ArgsEnhancer,
+  ArgTypesEnhancer,
 } from './types';
 import { HooksContext } from './hooks';
 import storySort from './storySort';
@@ -101,7 +101,7 @@ export default class StoryStore {
   // Keyed on storyId
   _stories: StoreData;
 
-  _argsEnhancers: ArgsEnhancer[];
+  _argTypesEnhancers: ArgTypesEnhancer[];
 
   _revision: number;
 
@@ -115,7 +115,7 @@ export default class StoryStore {
     this._globalMetadata = { parameters: {}, decorators: [] };
     this._kinds = {};
     this._stories = {};
-    this._argsEnhancers = [];
+    this._argTypesEnhancers = [];
     this._revision = 0;
     this._selection = {} as any;
     this._error = undefined;
@@ -219,11 +219,11 @@ export default class StoryStore {
     this._kinds[kind].decorators.push(...decorators);
   }
 
-  addArgsEnhancer(argsEnhancer: ArgsEnhancer) {
+  addArgTypesEnhancer(argTypesEnhancer: ArgTypesEnhancer) {
     if (Object.keys(this._stories).length > 0)
       throw new Error('Cannot add a parameter enhancer to the store after a story has been added.');
 
-    this._argsEnhancers.push(argsEnhancer);
+    this._argTypesEnhancers.push(argTypesEnhancer);
   }
 
   addStory(
@@ -283,15 +283,16 @@ export default class StoryStore {
       storyParameters
     );
 
-    const parameters = this._argsEnhancers.reduce(
+    const parameters = this._argTypesEnhancers.reduce(
       (accumlatedParameters, enhancer) => ({
         ...accumlatedParameters,
-        ...enhancer({
-          ...identification,
-          parameters: accumlatedParameters,
-          args: {},
-          globalArgs: {},
-        }),
+        argTypes:
+          enhancer({
+            ...identification,
+            parameters: accumlatedParameters,
+            args: {},
+            globalArgs: {},
+          }) || accumlatedParameters.argTypes,
       }),
       parametersBeforeEnhancement
     );

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -25,7 +25,7 @@ import {
   PublishedStoreItem,
   ErrorLike,
   GetStorybookKind,
-  ParameterEnhancer,
+  ArgsEnhancer,
 } from './types';
 import { HooksContext } from './hooks';
 import storySort from './storySort';
@@ -101,7 +101,7 @@ export default class StoryStore {
   // Keyed on storyId
   _stories: StoreData;
 
-  _parameterEnhancers: ParameterEnhancer[];
+  _argsEnhancers: ArgsEnhancer[];
 
   _revision: number;
 
@@ -115,7 +115,7 @@ export default class StoryStore {
     this._globalMetadata = { parameters: {}, decorators: [] };
     this._kinds = {};
     this._stories = {};
-    this._parameterEnhancers = [];
+    this._argsEnhancers = [];
     this._revision = 0;
     this._selection = {} as any;
     this._error = undefined;
@@ -219,11 +219,11 @@ export default class StoryStore {
     this._kinds[kind].decorators.push(...decorators);
   }
 
-  addParameterEnhancer(parameterEnhancer: ParameterEnhancer) {
+  addArgsEnhancer(argsEnhancer: ArgsEnhancer) {
     if (Object.keys(this._stories).length > 0)
       throw new Error('Cannot add a parameter enhancer to the store after a story has been added.');
 
-    this._parameterEnhancers.push(parameterEnhancer);
+    this._argsEnhancers.push(argsEnhancer);
   }
 
   addStory(
@@ -283,7 +283,7 @@ export default class StoryStore {
       storyParameters
     );
 
-    const parameters = this._parameterEnhancers.reduce(
+    const parameters = this._argsEnhancers.reduce(
       (accumlatedParameters, enhancer) => ({
         ...accumlatedParameters,
         ...enhancer({

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -286,13 +286,12 @@ export default class StoryStore {
     const parameters = this._argTypesEnhancers.reduce(
       (accumlatedParameters, enhancer) => ({
         ...accumlatedParameters,
-        argTypes:
-          enhancer({
-            ...identification,
-            parameters: accumlatedParameters,
-            args: {},
-            globalArgs: {},
-          }) || accumlatedParameters.argTypes,
+        argTypes: enhancer({
+          ...identification,
+          parameters: accumlatedParameters,
+          args: {},
+          globalArgs: {},
+        }),
       }),
       parametersBeforeEnhancement
     );

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -22,7 +22,7 @@ export interface StoryMetadata {
   parameters: Parameters;
   decorators: DecoratorFunction[];
 }
-export type ParameterEnhancer = (context: StoryContext) => Parameters;
+export type ArgsEnhancer = (context: StoryContext) => Parameters;
 
 export type AddStoryArgs = StoryIdentifier & {
   storyFn: StoryFn<any>;

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -4,6 +4,7 @@ import {
   StoryFn,
   Parameters,
   Args,
+  ArgTypes,
   StoryApi,
   DecoratorFunction,
   DecorateStoryFunction,
@@ -22,7 +23,7 @@ export interface StoryMetadata {
   parameters: Parameters;
   decorators: DecoratorFunction[];
 }
-export type ArgsEnhancer = (context: StoryContext) => Parameters;
+export type ArgTypesEnhancer = (context: StoryContext) => ArgTypes;
 
 export type AddStoryArgs = StoryIdentifier & {
   storyFn: StoryFn<any>;

--- a/lib/core/src/server/preview/virtualModuleEntry.template.js
+++ b/lib/core/src/server/preview/virtualModuleEntry.template.js
@@ -1,9 +1,9 @@
-const { addDecorator, addParameters, addParameterEnhancer } = require('{{clientApi}}');
+const { addDecorator, addParameters, addArgsEnhancer } = require('{{clientApi}}');
 const { logger } = require('{{clientLogger}}');
 const {
   decorators,
   parameters,
-  parameterEnhancers,
+  argsEnhancers,
   globalArgs,
   globalArgTypes,
   args,
@@ -19,6 +19,6 @@ if (decorators) {
 if (parameters || globalArgs || globalArgTypes) {
   addParameters({ ...parameters, globalArgs, globalArgTypes });
 }
-if (parameterEnhancers) {
-  parameterEnhancers.forEach((enhancer) => addParameterEnhancer(enhancer));
+if (argsEnhancers) {
+  argsEnhancers.forEach((enhancer) => addArgsEnhancer(enhancer));
 }

--- a/lib/core/src/server/preview/virtualModuleEntry.template.js
+++ b/lib/core/src/server/preview/virtualModuleEntry.template.js
@@ -1,9 +1,9 @@
-const { addDecorator, addParameters, addArgsEnhancer } = require('{{clientApi}}');
+const { addDecorator, addParameters, addArgTypesEnhancer } = require('{{clientApi}}');
 const { logger } = require('{{clientLogger}}');
 const {
   decorators,
   parameters,
-  argsEnhancers,
+  argTypesEnhancers,
   globalArgs,
   globalArgTypes,
   args,
@@ -19,6 +19,6 @@ if (decorators) {
 if (parameters || globalArgs || globalArgTypes) {
   addParameters({ ...parameters, globalArgs, globalArgTypes });
 }
-if (argsEnhancers) {
-  argsEnhancers.forEach((enhancer) => addArgsEnhancer(enhancer));
+if (argTypesEnhancers) {
+  argTypesEnhancers.forEach((enhancer) => addArgTypesEnhancer(enhancer));
 }


### PR DESCRIPTION
Issue: #10374

## What I did

NOTE: This is a telescoping PR to #10383 which is required for this change

Make parameter enhancement more restrictive. Note that the interface is actually the same, since ArgsEnhancers can enhance either `args` or `argTypes`.

## How to test

`yarn test --core`
