### PR TITLE
fix(to-require-context): fixed regex to glob conversion

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -54,12 +54,7 @@ function getConfigPathParts(input: string): Output {
         (pattern: string | { path: string; recursive: boolean; match: string }) => {
           const { path: basePath, recursive, match } = toRequireContext(pattern);
           // eslint-disable-next-line no-underscore-dangle
-          return global.__requireContext(
-            configDir,
-            basePath,
-            recursive,
-            new RegExp(match.slice(1, -1))
-          );
+          return global.__requireContext(configDir, basePath, recursive, match);
         }
       );
     }

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -85,7 +85,7 @@
     "ip": "^1.1.5",
     "json5": "^2.1.1",
     "lazy-universal-dotenv": "^3.0.1",
-    "micromatch": "^4.0.2",
+    "nanomatch": "^1.2.13",
     "node-fetch": "^2.6.0",
     "pkg-dir": "^4.2.0",
     "pnp-webpack-plugin": "1.6.4",

--- a/lib/core/src/server/preview/to-require-context.js
+++ b/lib/core/src/server/preview/to-require-context.js
@@ -1,16 +1,12 @@
 import globBase from 'glob-base';
-import { makeRe } from 'micromatch';
+import { makeRe } from 'nanomatch';
 
 const isObject = (val) => val != null && typeof val === 'object' && Array.isArray(val) === false;
 export const toRequireContext = (input) => {
   switch (true) {
     case typeof input === 'string': {
       const { base, glob } = globBase(input);
-      const regex = makeRe(glob)
-        .toString()
-        // webpack prepends the relative path with './'
-        .replace(/^\/\^/, '/^\\.\\/')
-        .replace(/\?:\^/g, '?:');
+      const regex = makeRe(glob);
 
       return { path: base, recursive: glob.startsWith('**'), match: regex };
     }

--- a/lib/core/src/server/preview/to-require-context.test.js
+++ b/lib/core/src/server/preview/to-require-context.test.js
@@ -1,0 +1,68 @@
+import path from 'path';
+import { toRequireContext } from './to-require-context';
+
+const testCases = [
+  {
+    glob: '**/*.stories.tsx',
+    validPaths: [
+      './Icon.stories.tsx',
+      './src/Icon.stories.tsx',
+      './src/components/Icon.stories.tsx',
+      './src/components/Icon.stories/Icon.stories.tsx',
+    ],
+    invalidPaths: [
+      './stories.tsx',
+      './Icon.stories.ts',
+      './Icon.stories.js',
+      './src/components/stories.tsx',
+      './src/components/Icon.stories/stories.tsx',
+      './src/components/Icon.stories.ts',
+      './src/components/Icon.stories.js',
+    ],
+  },
+  {
+    glob: '../src/stories/**/*.stories.(js|mdx)',
+    validPaths: [
+      '../src/stories/components/Icon.stories.js',
+      '../src/stories/Icon.stories.js',
+      '../src/stories/Icon.stories.mdx',
+      '../src/stories/components/Icon/Icon.stories.js',
+      '../src/stories/components/Icon.stories/Icon.stories.mdx',
+    ],
+    invalidPaths: [
+      './stories.js',
+      './src/stories/Icon.stories.js',
+      './Icon.stories.js',
+      '../src/Icon.stories.mdx',
+      '../src/stories/components/Icon/Icon.stories.ts',
+      '../src/stories/components/Icon/Icon.mdx',
+    ],
+  },
+  {
+    glob: 'dirname/../stories/*.stories.*',
+    validPaths: [
+      './dirname/../stories/App.stories.js',
+      './dirname/../stories/addon-centered.stories.js',
+    ],
+    invalidPaths: ['./dirname/../stories.js', './dirname/../App.stories.js'],
+  },
+];
+
+describe('toRequireContext', () => {
+  it('matches only suitable paths', () => {
+    testCases.forEach(({ glob, validPaths, invalidPaths }) => {
+      const { path: base, match: regex } = toRequireContext(glob);
+
+      function isMatched(filePath) {
+        const relativePath = `./${path.relative(base, filePath)}`;
+        return filePath.includes(base) && regex.test(relativePath);
+      }
+
+      const isMatchedForValidPaths = validPaths.every(isMatched);
+      const isMatchedForInvalidPaths = invalidPaths.every(filePath => !isMatched(filePath));
+
+      expect(isMatchedForValidPaths).toBe(true);
+      expect(isMatchedForInvalidPaths).toBe(true);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -20880,7 +20880,7 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nanomatch@^1.2.9:
+nanomatch@^1.2.13, nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
   integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==


### PR DESCRIPTION
Issue: described here: https://github.com/storybookjs/storybook/issues/10322

## What I did

Fixed conversion from glob to regex. Added tests for `to-require-context` module.

## How to test

```sh
npx jest lib/core/src/server/preview/to-require-context.test.js
```
