### PR TITLE
Fixed `webpackFinal` being called twice

### DIFF
--- a/lib/core/src/server/preview/custom-webpack-preset.js
+++ b/lib/core/src/server/preview/custom-webpack-preset.js
@@ -20,15 +20,11 @@ export async function webpack(config, options) {
   // return the (extended) base configuration if it's not available.
   const customConfig = loadCustomWebpackConfig(configDir);
 
-  if (customConfig === null) {
-    logger.info('=> Using default Webpack setup.');
-    return finalDefaultConfig;
-  }
-
   if (typeof customConfig === 'function') {
     logger.info('=> Loading custom Webpack config (full-control mode).');
     return customConfig({ config: finalDefaultConfig, mode: configType });
   }
 
+  logger.info('=> Using default Webpack setup.');
   return finalDefaultConfig;
 }

--- a/lib/core/src/server/preview/custom-webpack-preset.js
+++ b/lib/core/src/server/preview/custom-webpack-preset.js
@@ -22,7 +22,7 @@ export async function webpack(config, options) {
 
   if (customConfig === null) {
     logger.info('=> Using default Webpack setup.');
-    return createFinalDefaultConfig(presets, config, options);
+    return finalDefaultConfig;
   }
 
   if (typeof customConfig === 'function') {


### PR DESCRIPTION
Issue:

relate: https://github.com/storybookjs/storybook/pull/10216

Breaking the build because `webpackFinal` will be called twice if write  not idempotent custom webpack configuration.

## What I did

Fix createFinalDefaultConfig call to one time only.
