### PR TITLE
Addon-Docs: Fix Args table generation for story with no component

### DIFF
--- a/addons/docs/src/frameworks/common/enhanceArgTypes.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.ts
@@ -12,33 +12,12 @@ const isSubset = (kind: string, subset: object, superset: object) => {
 };
 
 export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
-  const {
-    component,
-    subcomponents,
-    argTypes: userArgTypes = {},
-    docs = {},
-    args = {},
-  } = context.parameters;
+  const { component, argTypes: userArgTypes = {}, docs = {}, args = {} } = context.parameters;
   const { extractArgTypes } = docs;
 
   const namedArgTypes = mapValues(userArgTypes, (val, key) => ({ name: key, ...val }));
   const inferredArgTypes = inferArgTypes(args);
-  const components = { Primary: component, ...subcomponents };
-  let extractedArgTypes: ArgTypes = {};
-
-  if (extractArgTypes && components) {
-    const componentArgTypes = mapValues(components, (comp) => extractArgTypes(comp));
-    extractedArgTypes = Object.entries(componentArgTypes).reduce((acc, [label, compTypes]) => {
-      if (compTypes) {
-        Object.entries(compTypes).forEach(([key, argType]) => {
-          if (label === 'Primary') {
-            acc[key] = argType;
-          }
-        });
-      }
-      return acc;
-    }, {} as ArgTypes);
-  }
+  let extractedArgTypes: ArgTypes = component ? extractArgTypes(component) : {};
 
   if (
     (Object.keys(userArgTypes).length > 0 &&

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.ts
@@ -17,7 +17,7 @@ export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
 
   const namedArgTypes = mapValues(userArgTypes, (val, key) => ({ name: key, ...val }));
   const inferredArgTypes = inferArgTypes(args);
-  let extractedArgTypes: ArgTypes = component ? extractArgTypes(component) : {};
+  let extractedArgTypes: ArgTypes = extractArgTypes && component ? extractArgTypes(component) : {};
 
   if (
     (Object.keys(userArgTypes).length > 0 &&

--- a/examples/ember-cli/.storybook/preset.js
+++ b/examples/ember-cli/.storybook/preset.js
@@ -1,1 +1,0 @@
-module.exports = ['@storybook/addon-docs/preset'];

--- a/lib/components/src/controls/Date.stories.tsx
+++ b/lib/components/src/controls/Date.stories.tsx
@@ -7,7 +7,7 @@ export default {
 };
 
 export const Basic = () => {
-  const [value, setValue] = useState(new Date());
+  const [value, setValue] = useState(new Date(2020, 4, 20));
   return (
     <>
       <DateControl name="date" value={value} onChange={(name, newVal) => setValue(newVal)} />


### PR DESCRIPTION
Issue: #6639 

## What I did

Removed redundant code that broke `examples/ember-cli`.

## Still TODO

Looks like maybe https://github.com/storybookjs/storybook/pull/10381 is broken for that example?

Repro:

```
cd examples/ember-cli
yarn storybook
```