### PR TITLE
Add missing colon in object in Svelte example

### DIFF
--- a/docs/src/pages/guides/guide-svelte/index.md
+++ b/docs/src/pages/guides/guide-svelte/index.md
@@ -117,7 +117,7 @@ You would then write a story for this "view" the exact same way you did with a c
 ```js
 import MyButtonView from '../views/MyButtonView.svelte';
 
-export default { title 'Button' }
+export default { title: 'Button' }
 
 export const wrappedComponentExample = () => ({
   Components: MyButtonView,


### PR DESCRIPTION
Issue: Example in Svelte set up was missing a colon

## What I did

Added a colon

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
