### PR TITLE
FIX bad shortcutpage layout

### DIFF
--- a/lib/ui/src/settings/index.tsx
+++ b/lib/ui/src/settings/index.tsx
@@ -4,7 +4,8 @@ import ShortcutsPage from './shortcuts_page';
 
 const SettingsPages: FunctionComponent = () => (
   <Fragment>
-    <AboutPage key="about" />, <ShortcutsPage key="shortcuts" />
+    <AboutPage key="about" />
+    <ShortcutsPage key="shortcuts" />
   </Fragment>
 );
 


### PR DESCRIPTION
Issue: 
<img width="1007" alt="Screenshot 2020-04-16 at 14 02 24" src="https://user-images.githubusercontent.com/3070389/79454186-11268280-7feb-11ea-9465-808bfe74a718.png">

## What I did

REMOVE the `,`