### PR TITLE
docs: update addon-queryparams docs to use CSF

### DIFF
--- a/addons/queryparams/README.md
+++ b/addons/queryparams/README.md
@@ -1,6 +1,6 @@
 # storybook-addon-queryparams
 
-This storybook addon can be helpful if your components need special query parameters to work the way you want them.
+This storybook addon can be helpful if your components need special query parameters to work the way you want them to. It allows you to mock query params per story so that you can easily reproduce different states of your component.
 
 ## Getting started
 
@@ -10,13 +10,41 @@ First, install the addon.
 $ yarn add @storybook/addon-queryparams --dev
 ```
 
-Add this line to your `main.js` file (create this file inside your storybook config directory if needed).
+Register it by adding it in the addons attribute in your `main.js` file (create this file inside your storybook config directory if needed).
 
 ```js
 module.exports = {
   addons: ['@storybook/addon-queryparams'],
 };
 ```
+
+In your story, add the `withQuery` decorator and define the query parameters you want to mock:
+
+```js
+import React from 'react';
+import { Button } from '@storybook/react/demo';
+import { withQuery } from '@storybook/addon-queryparams';
+
+export default {
+  title: 'Button',
+  component: Button,
+  decorators: [withQuery],
+  parameters: {
+    query: {
+      mock: 'Hello world!',
+    },
+  },
+};
+
+export const WithMockedSearch = () => {
+  const urlParams = new URLSearchParams(document.location.search);
+  const mockedParam = urlParams.get('mock');
+  return <div>Mocked value: {mockedParam}</div>;
+};
+```
+
+<details>
+  <summary>Example with storiesOf API</summary>
 
 ```js
 import React from 'react';
@@ -25,12 +53,14 @@ import { storiesOf } from '@storybook/react';
 storiesOf('button', module)
   .addParameters({
     query: {
-      mock: true,
-    }
+      mock: 'Hello World!',
+    },
   })
-  .add('Prints the document.search', () => (
-    <div>
-      This is the current document.search: {document.search}, it includes `mock`!
-    </div>
-  ));
+  .add('Prints the mocked parameter', () => {
+    const urlParams = new URLSearchParams(document.location.search);
+    const mockedParam = urlParams.get('mock');
+    return <div>Mocked value: {mockedParam}</div>;
+  });
 ```
+
+</details>


### PR DESCRIPTION
Issue: #9475 

## What I did
This PR updates the docs to use the newest CSF format. 
Also fixes the example that was getting values from `document.search` rather than `document.location.search`. 
I changed the value of mock in the examples to "Hello World" so that it doesn't seem like `mock: true` is some sort of configuration that you need to pass and thus avoid confusion.

While CSF is the way to go, I thought it would be nice to keep the example of `storiesOf` API for whoever needs that (it is displayed as a collapsible which is collapsed by default):

![image](https://user-images.githubusercontent.com/1671563/79594633-ac982000-80dd-11ea-93df-0cf7fb998d1e.png)

