### PR TITLE
Fix invalid syntax in documentation for addons-info

### DIFF
--- a/addons/info/README.md
+++ b/addons/info/README.md
@@ -64,7 +64,7 @@ export default {
 };
 
 export const defaultView = () => <Component />;
-defaultView = {
+defaultView.story = {
   parameters: {
     info: { inline: true },
   },


### PR DESCRIPTION
Issue: The example showing how to update an individual story was using invalid syntax. 

## What I did

Corrected it to use valid syntax when writing CSF stories.

## How to test

This is just a change to documentation.
