### PR TITLE
fix issue https://github.com/storybookjs/react-native/issues/24

### DIFF
--- a/lib/core/src/server/manager/manager-preset.js
+++ b/lib/core/src/server/manager/manager-preset.js
@@ -13,13 +13,12 @@ export async function managerEntries(installedAddons, options) {
     entries.push(...installedAddons);
   }
 
-  entries.push(require.resolve(managerEntry));
-
   const managerConfig = loadManagerOrAddonsFile(options);
   if (managerConfig) {
     entries.push(managerConfig);
   }
 
+  entries.push(require.resolve(managerEntry));
   return entries;
 }
 


### PR DESCRIPTION
Issue: this commit https://github.com/storybookjs/storybook/commit/693f17e6b81057c7cb9ec92adcf11bad4cfd93e8#diff-053b4430c28e7628f95731ed99a7723e from @core introduced a bug in react-native-server since v5.3.0-rc.6. 
We can't see addon tabs anymore on the webpage as stated in this issue https://github.com/storybookjs/react-native/issues/24

## What I did
As @Gongreg stated, addon.js file is loaded only after provider.handleAPI(). It seems that is because entries order has been changed. This PR seems to put entries back in right order and makes addon tab reapear.

## How to test

- Is this testable with Jest or Chromatic screenshots?
I don't know
- Does this need a new example in the kitchen sink apps?
No
- Does this need an update to the documentation?
No

