### PR TITLE
DocsPage: Fix controls to point to primary story

### DIFF
--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -5,6 +5,7 @@ import { Description } from './Description';
 import { Primary } from './Primary';
 import { Props } from './Props';
 import { Stories } from './Stories';
+import { PRIMARY_STORY } from './types';
 
 export const DocsPage: FC = () => (
   <>
@@ -12,7 +13,7 @@ export const DocsPage: FC = () => (
     <Subtitle />
     <Description />
     <Primary />
-    <Props story="." />
+    <Props story={PRIMARY_STORY} />
     <Stories />
   </>
 );

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -14,8 +14,8 @@ import { StoryStore } from '@storybook/client-api';
 import Events from '@storybook/core-events';
 
 import { DocsContext, DocsContextProps } from './DocsContext';
-import { Component, CURRENT_SELECTION } from './types';
-import { getComponentName } from './utils';
+import { Component, CURRENT_SELECTION, PRIMARY_STORY } from './types';
+import { getComponentName, getDocsStories } from './utils';
 import { ArgTypesExtractor } from '../lib/docgen/types';
 import { lookupStoryId } from './Story';
 
@@ -138,13 +138,23 @@ export const StoryTable: FC<StoryProps & { components: Record<string, Component>
   let storyArgTypes;
   try {
     let storyId;
-    if (story === CURRENT_SELECTION) {
-      storyId = currentId;
-      storyArgTypes = argTypes;
-    } else {
-      storyId = lookupStoryId(story, context);
-      const data = storyStore.fromId(storyId);
-      storyArgTypes = data.parameters.argTypes;
+    switch (story) {
+      case CURRENT_SELECTION: {
+        storyId = currentId;
+        storyArgTypes = argTypes;
+        break;
+      }
+      case PRIMARY_STORY: {
+        const primaryStory = getDocsStories(context)[0];
+        storyId = primaryStory.id;
+        storyArgTypes = primaryStory.parameters.argTypes;
+        break;
+      }
+      default: {
+        storyId = lookupStoryId(story, context);
+        const data = storyStore.fromId(storyId);
+        storyArgTypes = data.parameters.argTypes;
+      }
     }
     storyArgTypes = filterArgTypes(storyArgTypes, include, exclude);
 

--- a/addons/docs/src/blocks/types.ts
+++ b/addons/docs/src/blocks/types.ts
@@ -1,4 +1,5 @@
 export const CURRENT_SELECTION = '.';
+export const PRIMARY_STORY = '^';
 
 export type Component = any;
 

--- a/examples/official-storybook/stories/addon-docs/subcomponents.stories.js
+++ b/examples/official-storybook/stories/addon-docs/subcomponents.stories.js
@@ -14,8 +14,15 @@ export default {
   },
 };
 
-export const Basic = (args) => (
+export const Args = (args) => (
   <ButtonGroup {...args}>
+    <DocgenButton label="foo" />
+    <DocgenButton label="bar" />
+  </ButtonGroup>
+);
+
+export const NoArgs = () => (
+  <ButtonGroup background="#eee">
     <DocgenButton label="foo" />
     <DocgenButton label="bar" />
   </ButtonGroup>


### PR DESCRIPTION
Issue: #10478 

## What I did

Create a new "primary story" constant for the props table, and make it the default for the DocsPage Props controls

## How to test

See updated example in `official-storybook`
