### PR TITLE
Addon-docs: Rename `formatSource` to `transformSource`

### DIFF
--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -251,13 +251,13 @@ Example.story = {
 };
 ```
 
-Alternatively, you can provide a function in the `docs.formatSource` parameter. For example, the following snippet in `.storybook/preview.js` globally removes the arrow at the beginning of a function that returns a string:
+Alternatively, you can provide a function in the `docs.transformSource` parameter. For example, the following snippet in `.storybook/preview.js` globally removes the arrow at the beginning of a function that returns a string:
 
 ```js
 const SOURCE_REGEX = /^\(\) => `(.*)`$/;
 export const parameters = {
   docs: {
-    formatSource: (src, storyId) => {
+    transformSource: (src, storyId) => {
       const match = SOURCE_REGEX.exec(src);
       return match ? match[1] : src;
     },

--- a/addons/docs/src/blocks/enhanceSource.test.ts
+++ b/addons/docs/src/blocks/enhanceSource.test.ts
@@ -10,16 +10,16 @@ const emptyContext: StoryContext = {
   parameters: {},
 };
 
-const formatSource = (src?: string) => (src ? `formatted: ${src}` : 'no src');
+const transformSource = (src?: string) => (src ? `formatted: ${src}` : 'no src');
 
 describe('addon-docs enhanceSource', () => {
   describe('no source loaded', () => {
     const baseContext = emptyContext;
-    it('no formatSource', () => {
+    it('no transformSource', () => {
       expect(enhanceSource(baseContext)).toBeNull();
     });
-    it('formatSource', () => {
-      const parameters = { ...baseContext.parameters, docs: { formatSource } };
+    it('transformSource', () => {
+      const parameters = { ...baseContext.parameters, docs: { transformSource } };
       expect(enhanceSource({ ...baseContext, parameters })).toBeNull();
     });
   });
@@ -28,13 +28,13 @@ describe('addon-docs enhanceSource', () => {
       ...emptyContext,
       parameters: { storySource: { source: 'storySource.source' } },
     };
-    it('no formatSource', () => {
+    it('no transformSource', () => {
       expect(enhanceSource(baseContext)).toEqual({
         docs: { source: { code: 'storySource.source' } },
       });
     });
-    it('formatSource', () => {
-      const parameters = { ...baseContext.parameters, docs: { formatSource } };
+    it('transformSource', () => {
+      const parameters = { ...baseContext.parameters, docs: { transformSource } };
       expect(enhanceSource({ ...baseContext, parameters }).docs.source).toEqual({
         code: 'formatted: storySource.source',
       });
@@ -52,11 +52,11 @@ describe('addon-docs enhanceSource', () => {
         },
       },
     };
-    it('no formatSource', () => {
+    it('no transformSource', () => {
       expect(enhanceSource(baseContext)).toEqual({ docs: { source: { code: 'Source' } } });
     });
-    it('formatSource', () => {
-      const parameters = { ...baseContext.parameters, docs: { formatSource } };
+    it('transformSource', () => {
+      const parameters = { ...baseContext.parameters, docs: { transformSource } };
       expect(enhanceSource({ ...baseContext, parameters }).docs.source).toEqual({
         code: 'formatted: Source',
       });
@@ -70,12 +70,12 @@ describe('addon-docs enhanceSource', () => {
         docs: { source: { code: 'docs.source.code' } },
       },
     };
-    it('no formatSource', () => {
+    it('no transformSource', () => {
       expect(enhanceSource(baseContext)).toBeNull();
     });
-    it('formatSource', () => {
+    it('transformSource', () => {
       const { source } = baseContext.parameters.docs;
-      const parameters = { ...baseContext.parameters, docs: { source, formatSource } };
+      const parameters = { ...baseContext.parameters, docs: { source, transformSource } };
       expect(enhanceSource({ ...baseContext, parameters })).toBeNull();
     });
   });

--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -40,7 +40,7 @@ const extract = (targetId: string, { source, locationsMap }: StorySource) => {
 export const enhanceSource = (context: StoryContext): Parameters => {
   const { id, parameters } = context;
   const { storySource, docs = {} } = parameters;
-  const { formatSource } = docs;
+  const { transformSource } = docs;
 
   // no input or user has manually overridden the output
   if (!storySource?.source || docs.source?.code) {
@@ -48,7 +48,7 @@ export const enhanceSource = (context: StoryContext): Parameters => {
   }
 
   const input = extract(id, storySource);
-  const code = formatSource ? formatSource(input, id) : input;
+  const code = transformSource ? transformSource(input, id) : input;
 
   return { docs: combineParameters(docs, { source: { code } }) };
 };

--- a/examples/html-kitchen-sink/.storybook/preview.js
+++ b/examples/html-kitchen-sink/.storybook/preview.js
@@ -15,7 +15,7 @@ addParameters({
   },
   docs: {
     iframeHeight: '200px',
-    formatSource: (src) => {
+    transformSource: (src) => {
       const match = SOURCE_REGEX.exec(src);
       return match ? match[1] : src;
     },


### PR DESCRIPTION
Issue: #10491 

## What I did

Global rename to reduce confusion (see issue for details)

## How to test

N/A