### PR TITLE
Composition: Fix remote stories by passing refs to virtual module safely

### DIFF
--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -55,8 +55,8 @@ export default ({
       refs
         ? new VirtualModulePlugin({
             [path.resolve(path.join(configDir, `generated-refs.js`))]: refsTemplate.replace(
-              '{{refs}}',
-              refs
+              /'{{refs}}'/g,
+              JSON.stringify(refs)
             ),
           })
         : null,

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -55,7 +55,7 @@ export default ({
       refs
         ? new VirtualModulePlugin({
             [path.resolve(path.join(configDir, `generated-refs.js`))]: refsTemplate.replace(
-              /'{{refs}}'/g,
+              /'{{refs}}'/,
               JSON.stringify(refs)
             ),
           })


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/10509

## What I did
In `manager-webpack.config.js` I changed ln. 58 to make sure that the single quote characters (`'`) are replaced in the template file and on ln. 59 I added a call to `JSON.stringify` so that the `refs` object is safely converted to a string before `String.prototype.replace` is called since calling it with an object returns the string `"[object Object]"`.

## How to test

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.

To test follow the steps in https://github.com/storybookjs/storybook/issues/10509 on the `next` branch and with the code in this pull request. You will notice that the `undefined` value is no longer in the URLs of remote storybooks.