### PR TITLE
Addon-Docs: Fix Ember extractArgTypes default value

### DIFF
--- a/addons/docs/src/frameworks/ember/jsondoc.js
+++ b/addons/docs/src/frameworks/ember/jsondoc.js
@@ -14,7 +14,7 @@ export const extractArgTypes = (componentName) => {
   const rows = componentDoc.attributes.arguments.map((prop) => {
     return {
       name: prop.name,
-      defaultValue: prop.defaultValue,
+      defaultValue: { summary: prop.defaultValue },
       description: prop.description,
       table: {
         type: {

--- a/examples/ember-cli/app/components/welcome-banner.js
+++ b/examples/ember-cli/app/components/welcome-banner.js
@@ -23,6 +23,7 @@ export default Component.extend({
    * The hex-formatted color code for the background.
    * @argument backgroundColor
    * @type {string}
+   * @default null
    */
   backgroundColor: null,
 


### PR DESCRIPTION
Issue: #10511 

## What I did
Fixed it so the default value is being exposed as the expected object type, in the summary field.
Also added an `@defaultValue` snippet in the jsdoc for the welcome-banner.js component, just to see the value appear in the props table.

