### PR TITLE
Fix typo on "Configuration overview" docs page.

### DIFF
--- a/docs/src/pages/configurations/overview/index.md
+++ b/docs/src/pages/configurations/overview/index.md
@@ -11,7 +11,7 @@ For CLI options see: [here](../cli-options).
 
 Storybook has a few files it uses for configuration, and they are grouped together into a directory (default: `.storybook`).
 
-The most import file is the `main.js` file. This is where general config is declared.
+The most important file is the `main.js` file. This is where general config is declared.
 
 Here's an minimal example of that file:
 


### PR DESCRIPTION
Issue: Was reading through https://storybook.js.org/docs/configurations/overview/ page and found a typo.

## What I did
change text: `import` to `important`.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
