### PR TITLE
Remove dead-link TOC header

### DIFF
--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -13,7 +13,6 @@
 - [Disabling docs stories](#disabling-docs-stories)
   - [DocsPage](#docspage)
   - [MDX Stories](#mdx-stories)
-- [Controlling a story's view mode](#controlling-a-storys-view-mode)
 - [More resources](#more-resources)
 
 ## Component Story Format (CSF) with DocsPage


### PR DESCRIPTION
Looks like this section was removed, but the header/link still exists.

Either this header should be removed, or the section should be created.

