### PR TITLE
CLI: Automatically detect typescript in `sb init`

### DIFF
--- a/lib/cli/src/detect.js
+++ b/lib/cli/src/detect.js
@@ -1,7 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 
-import types, {
+import {
+  PROJECT_TYPES,
   supportedTemplates,
   SUPPORTED_FRAMEWORKS,
   SUPPORTED_LANGUAGES,
@@ -23,10 +24,10 @@ const hasPeerDependency = (packageJson, name) => {
  * and/or `peerDependencies` which we use to get installed packages.
  * @param {Object} framework contains a configuration of a framework preset.
  * Refer to supportedTemplates in project_types.js for more info.
- * @returns a preset name like projectTypes.REACT, or null if not found.
+ * @returns a preset name like PROJECT_TYPES.REACT, or null if not found.
  * @example
  * getFrameworkPreset(packageJson,  * {
- *   preset: projectTypes.REACT,
+ *   preset: PROJECT_TYPES.REACT,
  *   dependencies: ['react'],
  *   matcherFunction: ({ dependencies }) => {
  *     return dependencies.every(Boolean);
@@ -62,7 +63,7 @@ export function detectFrameworkPreset(packageJson = {}) {
     return getFrameworkPreset(packageJson, framework) !== null;
   });
 
-  return result ? result.preset : types.UNDETECTED;
+  return result ? result.preset : PROJECT_TYPES.UNDETECTED;
 }
 
 export function isStorybookInstalled(dependencies, force) {
@@ -78,14 +79,14 @@ export function isStorybookInstalled(dependencies, force) {
         false
       )
     ) {
-      return types.ALREADY_HAS_STORYBOOK;
+      return PROJECT_TYPES.ALREADY_HAS_STORYBOOK;
     }
 
     if (
       dependencies.devDependencies['@kadira/storybook'] ||
       dependencies.devDependencies['@kadira/react-native-storybook']
     ) {
-      return types.UPDATE_PACKAGE_ORGANIZATIONS;
+      return PROJECT_TYPES.UPDATE_PACKAGE_ORGANIZATIONS;
     }
   }
   return false;
@@ -111,7 +112,7 @@ export function detect(options = {}) {
   const bowerJson = getBowerJson();
 
   if (!packageJson && !bowerJson) {
-    return types.UNDETECTED;
+    return PROJECT_TYPES.UNDETECTED;
   }
 
   const storyBookInstalled = isStorybookInstalled(packageJson, options.force);
@@ -120,7 +121,7 @@ export function detect(options = {}) {
   }
 
   if (options.html) {
-    return types.HTML;
+    return PROJECT_TYPES.HTML;
   }
 
   return detectFrameworkPreset(packageJson || bowerJson);

--- a/lib/cli/src/detect.js
+++ b/lib/cli/src/detect.js
@@ -1,128 +1,47 @@
 import path from 'path';
 import fs from 'fs';
-import types, { supportedFrameworks } from './project_types';
+
+import types, { supportedTemplates, supportedFrameworks } from './project_types';
 import { getBowerJson, getPackageJson } from './helpers';
 
-function detectFramework(dependencies) {
-  if (!dependencies) {
-    return false;
-  }
-  if (
-    dependencies.devDependencies &&
-    (dependencies.devDependencies['vue-loader'] || dependencies.devDependencies.vueify)
-  ) {
-    return types.SFC_VUE;
+const hasDependency = (packageJson, name) => {
+  return !!packageJson.dependencies?.[name] || !!packageJson.devDependencies?.[name];
+};
+
+const hasPeerDependency = (packageJson, name) => {
+  return !!packageJson.peerDependencies?.[name];
+};
+
+const isFramework = (packageJson, framework) => {
+  const matches = {
+    dependencies: [false],
+    peerDependencies: [false],
+    files: [false],
+  };
+
+  const { preset, files, dependencies, peerDependencies, matcherFunction } = framework;
+
+  if (Array.isArray(dependencies) && dependencies.length > 0) {
+    matches.dependencies = dependencies.map((name) => hasDependency(packageJson, name));
   }
 
-  if (
-    (dependencies.dependencies && dependencies.dependencies.vue) ||
-    (dependencies.devDependencies && dependencies.devDependencies.vue) ||
-    (dependencies.dependencies && dependencies.dependencies.nuxt) ||
-    (dependencies.devDependencies && dependencies.devDependencies.nuxt)
-  ) {
-    return types.VUE;
+  if (Array.isArray(peerDependencies) && peerDependencies.length > 0) {
+    matches.peerDependencies = peerDependencies.map((name) => hasPeerDependency(packageJson, name));
   }
 
-  if (
-    (dependencies.dependencies && dependencies.dependencies['ember-cli']) ||
-    (dependencies.devDependencies && dependencies.devDependencies['ember-cli'])
-  ) {
-    return types.EMBER;
+  if (Array.isArray(files) && files.length > 0) {
+    matches.files = files.map((name) => fs.existsSync(path.join(process.cwd(), name)));
   }
 
-  if (
-    (dependencies.dependencies && dependencies.dependencies['react-scripts']) ||
-    (dependencies.devDependencies && dependencies.devDependencies['react-scripts']) ||
-    // For projects using a custom/forked `react-scripts` package.
-    fs.existsSync(path.join(process.cwd(), '/node_modules/.bin/react-scripts'))
-  ) {
-    return types.REACT_SCRIPTS;
-  }
+  return matcherFunction(matches) ? preset : null;
+};
 
-  if (
-    ((dependencies.devDependencies && dependencies.devDependencies.webpack) ||
-      (dependencies.dependencies && dependencies.dependencies.webpack)) &&
-    ((dependencies.devDependencies && dependencies.devDependencies.react) ||
-      (dependencies.dependencies && dependencies.dependencies.react))
-  ) {
-    return types.WEBPACK_REACT;
-  }
+export function detectFramework(packageJson = {}) {
+  const result = supportedTemplates.find((framework) => {
+    return isFramework(packageJson, framework) !== null;
+  });
 
-  if (dependencies.peerDependencies && dependencies.peerDependencies.react) {
-    return types.REACT_PROJECT;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies['react-native']) ||
-    (dependencies.dependencies && dependencies.dependencies['react-native-scripts']) ||
-    (dependencies.devDependencies && dependencies.devDependencies['react-native-scripts'])
-  ) {
-    return types.REACT_NATIVE;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies.react) ||
-    (dependencies.devDependencies && dependencies.devDependencies.react)
-  ) {
-    return types.REACT;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies['@angular/core']) ||
-    (dependencies.devDependencies && dependencies.devDependencies['@angular/core'])
-  ) {
-    return types.ANGULAR;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies['lit-element']) ||
-    (dependencies.devDependencies && dependencies.devDependencies['lit-element'])
-  ) {
-    return types.WEB_COMPONENTS;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies.mithril) ||
-    (dependencies.devDependencies && dependencies.devDependencies.mithril)
-  ) {
-    return types.MITHRIL;
-  }
-  if (
-    (dependencies.dependencies && dependencies.dependencies['backbone.marionette']) ||
-    (dependencies.devDependencies && dependencies.devDependencies['backbone.marionette'])
-  ) {
-    return types.MARIONETTE;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies.marko) ||
-    (dependencies.devDependencies && dependencies.devDependencies.marko)
-  ) {
-    return types.MARKO;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies.riot) ||
-    (dependencies.devDependencies && dependencies.devDependencies.riot)
-  ) {
-    return types.RIOT;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies.preact) ||
-    (dependencies.devDependencies && dependencies.devDependencies.preact)
-  ) {
-    return types.PREACT;
-  }
-
-  if (
-    (dependencies.dependencies && dependencies.dependencies.rax) ||
-    (dependencies.devDependencies && dependencies.devDependencies.rax)
-  ) {
-    return types.RAX;
-  }
-
-  return false;
+  return result ? result.preset : types.UNDETECTED;
 }
 
 export function isStorybookInstalled(dependencies, force) {
@@ -151,7 +70,7 @@ export function isStorybookInstalled(dependencies, force) {
   return false;
 }
 
-export function detect(options) {
+export function detect(options = {}) {
   if (options.html) {
     return types.HTML;
   }
@@ -163,14 +82,10 @@ export function detect(options) {
     return types.UNDETECTED;
   }
 
-  if (fs.existsSync(path.resolve('.meteor'))) {
-    return types.METEOR;
-  }
-
   const storyBookInstalled = isStorybookInstalled(packageJson, options.force);
   if (storyBookInstalled) {
     return storyBookInstalled;
   }
 
-  return detectFramework(packageJson) || detectFramework(bowerJson) || types.UNDETECTED;
+  return detectFramework(packageJson || bowerJson);
 }

--- a/lib/cli/src/detect.js
+++ b/lib/cli/src/detect.js
@@ -1,7 +1,11 @@
 import path from 'path';
 import fs from 'fs';
 
-import types, { supportedTemplates, supportedFrameworks } from './project_types';
+import types, {
+  supportedTemplates,
+  supportedFrameworks,
+  supportedLanguages,
+} from './project_types';
 import { getBowerJson, getPackageJson } from './helpers';
 
 const hasDependency = (packageJson, name) => {
@@ -12,7 +16,24 @@ const hasPeerDependency = (packageJson, name) => {
   return !!packageJson.peerDependencies?.[name];
 };
 
-const isFramework = (packageJson, framework) => {
+/**
+ * Returns a framework preset based on a given configuration.
+ *
+ * @param {Object} packageJson contains `dependencies`, `devDependencies`
+ * and/or `peerDependencies` which we use to get installed packages.
+ * @param {Object} framework contains a configuration of a framework preset.
+ * Refer to supportedTemplates in project_types.js for more info.
+ * @returns a preset name like projectTypes.REACT, or null if not found.
+ * @example
+ * getFrameworkPreset(packageJson,  * {
+ *   preset: projectTypes.REACT,
+ *   dependencies: ['react'],
+ *   matcherFunction: ({ dependencies }) => {
+ *     return dependencies.every(Boolean);
+ *   },
+ * });
+ */
+const getFrameworkPreset = (packageJson, framework) => {
   const matches = {
     dependencies: [false],
     peerDependencies: [false],
@@ -36,9 +57,9 @@ const isFramework = (packageJson, framework) => {
   return matcherFunction(matches) ? preset : null;
 };
 
-export function detectFramework(packageJson = {}) {
+export function detectFrameworkPreset(packageJson = {}) {
   const result = supportedTemplates.find((framework) => {
-    return isFramework(packageJson, framework) !== null;
+    return getFrameworkPreset(packageJson, framework) !== null;
   });
 
   return result ? result.preset : types.UNDETECTED;
@@ -70,6 +91,21 @@ export function isStorybookInstalled(dependencies, force) {
   return false;
 }
 
+export function detectLanguage() {
+  let language = supportedLanguages.JAVASCRIPT;
+  const packageJson = getPackageJson();
+  const bowerJson = getBowerJson();
+  if (!packageJson && !bowerJson) {
+    return language;
+  }
+
+  if (hasDependency(packageJson || bowerJson, 'typescript')) {
+    language = supportedLanguages.TYPESCRIPT;
+  }
+
+  return language;
+}
+
 export function detect(options = {}) {
   const packageJson = getPackageJson();
   const bowerJson = getBowerJson();
@@ -87,5 +123,5 @@ export function detect(options = {}) {
     return types.HTML;
   }
 
-  return detectFramework(packageJson || bowerJson);
+  return detectFrameworkPreset(packageJson || bowerJson);
 }

--- a/lib/cli/src/detect.js
+++ b/lib/cli/src/detect.js
@@ -71,10 +71,6 @@ export function isStorybookInstalled(dependencies, force) {
 }
 
 export function detect(options = {}) {
-  if (options.html) {
-    return types.HTML;
-  }
-
   const packageJson = getPackageJson();
   const bowerJson = getBowerJson();
 
@@ -85,6 +81,10 @@ export function detect(options = {}) {
   const storyBookInstalled = isStorybookInstalled(packageJson, options.force);
   if (storyBookInstalled) {
     return storyBookInstalled;
+  }
+
+  if (options.html) {
+    return types.HTML;
   }
 
   return detectFramework(packageJson || bowerJson);

--- a/lib/cli/src/detect.js
+++ b/lib/cli/src/detect.js
@@ -4,7 +4,7 @@ import fs from 'fs';
 import types, {
   supportedTemplates,
   supportedFrameworks,
-  supportedLanguages,
+  SUPPORTED_LANGUAGES,
 } from './project_types';
 import { getBowerJson, getPackageJson } from './helpers';
 
@@ -92,7 +92,7 @@ export function isStorybookInstalled(dependencies, force) {
 }
 
 export function detectLanguage() {
-  let language = supportedLanguages.JAVASCRIPT;
+  let language = SUPPORTED_LANGUAGES.JAVASCRIPT;
   const packageJson = getPackageJson();
   const bowerJson = getBowerJson();
   if (!packageJson && !bowerJson) {
@@ -100,7 +100,7 @@ export function detectLanguage() {
   }
 
   if (hasDependency(packageJson || bowerJson, 'typescript')) {
-    language = supportedLanguages.TYPESCRIPT;
+    language = SUPPORTED_LANGUAGES.TYPESCRIPT;
   }
 
   return language;

--- a/lib/cli/src/detect.js
+++ b/lib/cli/src/detect.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 import types, {
   supportedTemplates,
-  supportedFrameworks,
+  SUPPORTED_FRAMEWORKS,
   SUPPORTED_LANGUAGES,
 } from './project_types';
 import { getBowerJson, getPackageJson } from './helpers';
@@ -72,7 +72,7 @@ export function isStorybookInstalled(dependencies, force) {
 
   if (!force && dependencies.devDependencies) {
     if (
-      supportedFrameworks.reduce(
+      SUPPORTED_FRAMEWORKS.reduce(
         (storybookPresent, framework) =>
           storybookPresent || dependencies.devDependencies[`@storybook/${framework}`],
         false

--- a/lib/cli/src/detect.test.js
+++ b/lib/cli/src/detect.test.js
@@ -2,8 +2,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { getBowerJson, getPackageJson } from './helpers';
-import { isStorybookInstalled, detectFramework, detect } from './detect';
-import projectTypes, { supportedFrameworks } from './project_types';
+import { isStorybookInstalled, detectFrameworkPreset, detect, detectLanguage } from './detect';
+import projectTypes, { supportedFrameworks, supportedLanguages } from './project_types';
 
 jest.mock('./helpers', () => ({
   getBowerJson: jest.fn(),
@@ -194,14 +194,29 @@ const MOCK_FRAMEWORK_FILES = [
 ];
 
 describe('Detect', () => {
-  it(`should return ${projectTypes.HTML} if html option is passed`, () => {
+  it(`should return type ${projectTypes.HTML} if html option is passed`, () => {
+    getPackageJson.mockImplementation(() => true);
     expect(detect({ html: true })).toBe(projectTypes.HTML);
   });
 
-  it(`should return ${projectTypes.UNDETECTED} if neither packageJson or bowerJson exist`, () => {
+  it(`should return type ${projectTypes.UNDETECTED} if neither packageJson or bowerJson exist`, () => {
     getPackageJson.mockImplementation(() => false);
     getBowerJson.mockImplementation(() => false);
     expect(detect()).toBe(projectTypes.UNDETECTED);
+  });
+
+  it(`should return language ${supportedLanguages.TYPESCRIPT} if the dependency is present`, () => {
+    getPackageJson.mockImplementation(() => ({
+      dependencies: {
+        typescript: '1.0.0',
+      },
+    }));
+    expect(detectLanguage()).toBe(supportedLanguages.TYPESCRIPT);
+  });
+
+  it(`should return language ${supportedLanguages.JAVASCRIPT} by default`, () => {
+    getPackageJson.mockImplementation(() => true);
+    expect(detectLanguage()).toBe(supportedLanguages.JAVASCRIPT);
   });
 
   describe('isStorybookInstalled should return', () => {
@@ -231,7 +246,7 @@ describe('Detect', () => {
     });
   });
 
-  describe('detectFramework', () => {
+  describe('detectFrameworkPreset', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -242,14 +257,14 @@ describe('Detect', () => {
           return Object.keys(structure.files).includes(filePath);
         });
 
-        const result = detectFramework(structure.files['package.json']);
+        const result = detectFrameworkPreset(structure.files['package.json']);
 
         expect(result).toBe(structure.name);
       });
     });
 
     it(`should return ${projectTypes.UNDETECTED} for unknown frameworks`, () => {
-      const result = detectFramework();
+      const result = detectFrameworkPreset();
       expect(result).toBe(projectTypes.UNDETECTED);
     });
 
@@ -262,7 +277,7 @@ describe('Detect', () => {
         return Object.keys(forkedReactScriptsConfig).includes(filePath);
       });
 
-      const result = detectFramework();
+      const result = detectFrameworkPreset();
       expect(result).toBe(projectTypes.REACT_SCRIPTS);
     });
   });

--- a/lib/cli/src/detect.test.js
+++ b/lib/cli/src/detect.test.js
@@ -198,18 +198,18 @@ const MOCK_FRAMEWORK_FILES = [
 ];
 
 describe('Detect', () => {
-  it(`should return type ${projectTypes.HTML} if html option is passed`, () => {
+  it(`should return type HTML if html option is passed`, () => {
     getPackageJson.mockImplementation(() => true);
     expect(detect({ html: true })).toBe(projectTypes.HTML);
   });
 
-  it(`should return type ${projectTypes.UNDETECTED} if neither packageJson or bowerJson exist`, () => {
+  it(`should return type UNDETECTED if neither packageJson or bowerJson exist`, () => {
     getPackageJson.mockImplementation(() => false);
     getBowerJson.mockImplementation(() => false);
     expect(detect()).toBe(projectTypes.UNDETECTED);
   });
 
-  it(`should return language ${supportedLanguages.TYPESCRIPT} if the dependency is present`, () => {
+  it(`should return language typescript if the dependency is present`, () => {
     getPackageJson.mockImplementation(() => ({
       dependencies: {
         typescript: '1.0.0',
@@ -218,7 +218,7 @@ describe('Detect', () => {
     expect(detectLanguage()).toBe(supportedLanguages.TYPESCRIPT);
   });
 
-  it(`should return language ${supportedLanguages.JAVASCRIPT} by default`, () => {
+  it(`should return language javascript by default`, () => {
     getPackageJson.mockImplementation(() => true);
     expect(detectLanguage()).toBe(supportedLanguages.JAVASCRIPT);
   });
@@ -241,22 +241,41 @@ describe('Detect', () => {
       });
     });
 
-    it('true if forced flag', () => {
+    it('false if forced flag', () => {
+      expect(
+        isStorybookInstalled(
+          {
+            devDependencies: { '@storybook/react': '4.0.0-alpha.21' },
+          },
+          true
+        )
+      ).toBe(false);
+    });
+
+    it('ALREADY_HAS_STORYBOOK if lib is present', () => {
       expect(
         isStorybookInstalled({
-          devDependencies: { 'storybook/react': '4.0.0-alpha.21' },
+          devDependencies: { '@storybook/react': '4.0.0-alpha.21' },
         })
-      ).toBe(false);
+      ).toBe(projectTypes.ALREADY_HAS_STORYBOOK);
+    });
+
+    it('UPDATE_PACKAGE_ORGANIZATIONS if legacy lib is detected', () => {
+      expect(
+        isStorybookInstalled({
+          devDependencies: { '@kadira/storybook': '4.0.0-alpha.21' },
+        })
+      ).toBe(projectTypes.UPDATE_PACKAGE_ORGANIZATIONS);
     });
   });
 
-  describe('detectFrameworkPreset', () => {
+  describe('detectFrameworkPreset should return', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
 
     MOCK_FRAMEWORK_FILES.forEach((structure) => {
-      it(`should detect ${structure.name}`, () => {
+      it(`${structure.name}`, () => {
         fs.existsSync.mockImplementation((filePath) => {
           return Object.keys(structure.files).includes(filePath);
         });
@@ -267,12 +286,12 @@ describe('Detect', () => {
       });
     });
 
-    it(`should return ${projectTypes.UNDETECTED} for unknown frameworks`, () => {
+    it(`UNDETECTED for unknown frameworks`, () => {
       const result = detectFrameworkPreset();
       expect(result).toBe(projectTypes.UNDETECTED);
     });
 
-    it('should detect custom REACT_SCRIPTS', () => {
+    it('REACT_SCRIPTS for custom react scripts config', () => {
       const forkedReactScriptsConfig = {
         '/node_modules/.bin/react-scripts': 'file content',
       };

--- a/lib/cli/src/detect.test.js
+++ b/lib/cli/src/detect.test.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 
 import { getBowerJson, getPackageJson } from './helpers';
 import { isStorybookInstalled, detectFrameworkPreset, detect, detectLanguage } from './detect';
-import projectTypes, { SUPPORTED_FRAMEWORKS, SUPPORTED_LANGUAGES } from './project_types';
+import { PROJECT_TYPES, SUPPORTED_FRAMEWORKS, SUPPORTED_LANGUAGES } from './project_types';
 
 jest.mock('./helpers', () => ({
   getBowerJson: jest.fn(),
@@ -20,13 +20,13 @@ jest.mock('path', () => ({
 
 const MOCK_FRAMEWORK_FILES = [
   {
-    name: projectTypes.METEOR,
+    name: PROJECT_TYPES.METEOR,
     files: {
       '.meteor': 'file content',
     },
   },
   {
-    name: projectTypes.SFC_VUE,
+    name: PROJECT_TYPES.SFC_VUE,
     files: {
       'package.json': {
         dependencies: {
@@ -39,7 +39,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.VUE,
+    name: PROJECT_TYPES.VUE,
     files: {
       'package.json': {
         dependencies: {
@@ -49,7 +49,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.EMBER,
+    name: PROJECT_TYPES.EMBER,
     files: {
       'package.json': {
         devDependencies: {
@@ -59,7 +59,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.REACT_PROJECT,
+    name: PROJECT_TYPES.REACT_PROJECT,
     files: {
       'package.json': {
         peerDependencies: {
@@ -69,7 +69,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.REACT_NATIVE,
+    name: PROJECT_TYPES.REACT_NATIVE,
     files: {
       'package.json': {
         dependencies: {
@@ -82,7 +82,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.REACT_SCRIPTS,
+    name: PROJECT_TYPES.REACT_SCRIPTS,
     files: {
       'package.json': {
         devDependencies: {
@@ -92,7 +92,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.WEBPACK_REACT,
+    name: PROJECT_TYPES.WEBPACK_REACT,
     files: {
       'package.json': {
         dependencies: {
@@ -105,7 +105,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.REACT,
+    name: PROJECT_TYPES.REACT,
     files: {
       'package.json': {
         dependencies: {
@@ -115,7 +115,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.ANGULAR,
+    name: PROJECT_TYPES.ANGULAR,
     files: {
       'package.json': {
         dependencies: {
@@ -125,7 +125,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.WEB_COMPONENTS,
+    name: PROJECT_TYPES.WEB_COMPONENTS,
     files: {
       'package.json': {
         dependencies: {
@@ -135,7 +135,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.MITHRIL,
+    name: PROJECT_TYPES.MITHRIL,
     files: {
       'package.json': {
         dependencies: {
@@ -145,7 +145,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.MARIONETTE,
+    name: PROJECT_TYPES.MARIONETTE,
     files: {
       'package.json': {
         dependencies: {
@@ -155,7 +155,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.MARKO,
+    name: PROJECT_TYPES.MARKO,
     files: {
       'package.json': {
         dependencies: {
@@ -165,7 +165,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.RIOT,
+    name: PROJECT_TYPES.RIOT,
     files: {
       'package.json': {
         dependencies: {
@@ -175,7 +175,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.PREACT,
+    name: PROJECT_TYPES.PREACT,
     files: {
       'package.json': {
         dependencies: {
@@ -185,7 +185,7 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
-    name: projectTypes.RAX,
+    name: PROJECT_TYPES.RAX,
     files: {
       '.rax': 'file content',
       'package.json': {
@@ -200,13 +200,13 @@ const MOCK_FRAMEWORK_FILES = [
 describe('Detect', () => {
   it(`should return type HTML if html option is passed`, () => {
     getPackageJson.mockImplementation(() => true);
-    expect(detect({ html: true })).toBe(projectTypes.HTML);
+    expect(detect({ html: true })).toBe(PROJECT_TYPES.HTML);
   });
 
   it(`should return type UNDETECTED if neither packageJson or bowerJson exist`, () => {
     getPackageJson.mockImplementation(() => false);
     getBowerJson.mockImplementation(() => false);
-    expect(detect()).toBe(projectTypes.UNDETECTED);
+    expect(detect()).toBe(PROJECT_TYPES.UNDETECTED);
   });
 
   it(`should return language typescript if the dependency is present`, () => {
@@ -257,7 +257,7 @@ describe('Detect', () => {
         isStorybookInstalled({
           devDependencies: { '@storybook/react': '4.0.0-alpha.21' },
         })
-      ).toBe(projectTypes.ALREADY_HAS_STORYBOOK);
+      ).toBe(PROJECT_TYPES.ALREADY_HAS_STORYBOOK);
     });
 
     it('UPDATE_PACKAGE_ORGANIZATIONS if legacy lib is detected', () => {
@@ -265,7 +265,7 @@ describe('Detect', () => {
         isStorybookInstalled({
           devDependencies: { '@kadira/storybook': '4.0.0-alpha.21' },
         })
-      ).toBe(projectTypes.UPDATE_PACKAGE_ORGANIZATIONS);
+      ).toBe(PROJECT_TYPES.UPDATE_PACKAGE_ORGANIZATIONS);
     });
   });
 
@@ -288,7 +288,7 @@ describe('Detect', () => {
 
     it(`UNDETECTED for unknown frameworks`, () => {
       const result = detectFrameworkPreset();
-      expect(result).toBe(projectTypes.UNDETECTED);
+      expect(result).toBe(PROJECT_TYPES.UNDETECTED);
     });
 
     it('REACT_SCRIPTS for custom react scripts config', () => {
@@ -301,7 +301,7 @@ describe('Detect', () => {
       });
 
       const result = detectFrameworkPreset();
-      expect(result).toBe(projectTypes.REACT_SCRIPTS);
+      expect(result).toBe(PROJECT_TYPES.REACT_SCRIPTS);
     });
   });
 });

--- a/lib/cli/src/detect.test.js
+++ b/lib/cli/src/detect.test.js
@@ -1,27 +1,269 @@
-import { isStorybookInstalled } from './detect';
-import { supportedFrameworks } from './project_types';
+import fs from 'fs';
+import path from 'path';
 
-describe('isStorybookInstalled should return', () => {
-  it('false if empty devDependency', () => {
-    expect(isStorybookInstalled({ devDependencies: {} }, false)).toBe(false);
-  });
-  it('false if no devDependency', () => {
-    expect(isStorybookInstalled({}, false)).toBe(false);
+import { getBowerJson, getPackageJson } from './helpers';
+import { isStorybookInstalled, detectFramework, detect } from './detect';
+import projectTypes, { supportedFrameworks } from './project_types';
+
+jest.mock('./helpers', () => ({
+  getBowerJson: jest.fn(),
+  getPackageJson: jest.fn(),
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+}));
+
+const MOCK_FRAMEWORK_FILES = [
+  {
+    name: projectTypes.METEOR,
+    files: {
+      [path.join(process.cwd(), '.meteor')]: 'file content',
+    },
+  },
+  {
+    name: projectTypes.SFC_VUE,
+    files: {
+      'package.json': {
+        dependencies: {
+          vuetify: '1.0.0',
+        },
+        devDependencies: {
+          'vue-loader': '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.VUE,
+    files: {
+      'package.json': {
+        dependencies: {
+          vue: '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.EMBER,
+    files: {
+      'package.json': {
+        devDependencies: {
+          'ember-cli': '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.REACT_PROJECT,
+    files: {
+      'package.json': {
+        peerDependencies: {
+          react: '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.REACT_NATIVE,
+    files: {
+      'package.json': {
+        dependencies: {
+          'react-native': '1.0.0',
+        },
+        devDependencies: {
+          'react-native-scripts': '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.REACT_SCRIPTS,
+    files: {
+      'package.json': {
+        devDependencies: {
+          'react-scripts': '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.WEBPACK_REACT,
+    files: {
+      'package.json': {
+        dependencies: {
+          react: '1.0.0',
+        },
+        devDependencies: {
+          webpack: '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.REACT,
+    files: {
+      'package.json': {
+        dependencies: {
+          react: '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.ANGULAR,
+    files: {
+      'package.json': {
+        dependencies: {
+          '@angular/core': '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.WEB_COMPONENTS,
+    files: {
+      'package.json': {
+        dependencies: {
+          'lit-element': '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.MITHRIL,
+    files: {
+      'package.json': {
+        dependencies: {
+          mithril: '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.MARIONETTE,
+    files: {
+      'package.json': {
+        dependencies: {
+          'backbone.marionette': '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.MARKO,
+    files: {
+      'package.json': {
+        dependencies: {
+          marko: '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.RIOT,
+    files: {
+      'package.json': {
+        dependencies: {
+          riot: '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.PREACT,
+    files: {
+      'package.json': {
+        dependencies: {
+          preact: '1.0.0',
+        },
+      },
+    },
+  },
+  {
+    name: projectTypes.RAX,
+    files: {
+      '.rax': 'file content',
+      'package.json': {
+        dependencies: {
+          rax: '1.0.0',
+        },
+      },
+    },
+  },
+];
+
+describe('Detect', () => {
+  it(`should return ${projectTypes.HTML} if html option is passed`, () => {
+    expect(detect({ html: true })).toBe(projectTypes.HTML);
   });
 
-  supportedFrameworks.forEach((framework) => {
-    it(`true if devDependencies has ${framework} Storybook version`, () => {
-      const devDependencies = {};
-      devDependencies[`@storybook/${framework}`] = '4.0.0-alpha.21';
-      expect(isStorybookInstalled({ devDependencies }, false)).toBeTruthy();
+  it(`should return ${projectTypes.UNDETECTED} if neither packageJson or bowerJson exist`, () => {
+    getPackageJson.mockImplementation(() => false);
+    getBowerJson.mockImplementation(() => false);
+    expect(detect()).toBe(projectTypes.UNDETECTED);
+  });
+
+  describe('isStorybookInstalled should return', () => {
+    it('false if empty devDependency', () => {
+      expect(isStorybookInstalled({ devDependencies: {} }, false)).toBe(false);
+    });
+
+    it('false if no devDependency', () => {
+      expect(isStorybookInstalled({}, false)).toBe(false);
+    });
+
+    supportedFrameworks.forEach((framework) => {
+      it(`true if devDependencies has ${framework} Storybook version`, () => {
+        const devDependencies = {
+          [`@storybook/${framework}`]: '4.0.0-alpha.21',
+        };
+        expect(isStorybookInstalled({ devDependencies }, false)).toBeTruthy();
+      });
+    });
+
+    it('true if forced flag', () => {
+      expect(
+        isStorybookInstalled({
+          devDependencies: { 'storybook/react': '4.0.0-alpha.21' },
+        })
+      ).toBe(false);
     });
   });
 
-  it('true if forced flag', () => {
-    expect(
-      isStorybookInstalled({
-        devDependencies: { 'storybook/react': '4.0.0-alpha.21' },
-      })
-    ).toBe(false);
+  describe('detectFramework', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    MOCK_FRAMEWORK_FILES.forEach((structure) => {
+      it(`should detect ${structure.name}`, () => {
+        fs.existsSync.mockImplementation((filePath) => {
+          return Object.keys(structure.files).includes(filePath);
+        });
+
+        const result = detectFramework(structure.files['package.json']);
+
+        expect(result).toBe(structure.name);
+      });
+    });
+
+    it(`should return ${projectTypes.UNDETECTED} for unknown frameworks`, () => {
+      const result = detectFramework();
+      expect(result).toBe(projectTypes.UNDETECTED);
+    });
+
+    it('should detect custom REACT_SCRIPTS', () => {
+      const forkedReactScriptsConfig = {
+        [path.join(process.cwd(), '/node_modules/.bin/react-scripts')]: 'file content',
+      };
+
+      fs.existsSync.mockImplementation((filePath) => {
+        return Object.keys(forkedReactScriptsConfig).includes(filePath);
+      });
+
+      const result = detectFramework();
+      expect(result).toBe(projectTypes.REACT_SCRIPTS);
+    });
   });
 });

--- a/lib/cli/src/detect.test.js
+++ b/lib/cli/src/detect.test.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 
 import { getBowerJson, getPackageJson } from './helpers';
 import { isStorybookInstalled, detectFrameworkPreset, detect, detectLanguage } from './detect';
@@ -14,11 +13,16 @@ jest.mock('fs', () => ({
   existsSync: jest.fn(),
 }));
 
+jest.mock('path', () => ({
+  // make it return just the second path, for easier testing
+  join: jest.fn((_, p) => p),
+}));
+
 const MOCK_FRAMEWORK_FILES = [
   {
     name: projectTypes.METEOR,
     files: {
-      [path.join(process.cwd(), '.meteor')]: 'file content',
+      '.meteor': 'file content',
     },
   },
   {
@@ -270,7 +274,7 @@ describe('Detect', () => {
 
     it('should detect custom REACT_SCRIPTS', () => {
       const forkedReactScriptsConfig = {
-        [path.join(process.cwd(), '/node_modules/.bin/react-scripts')]: 'file content',
+        '/node_modules/.bin/react-scripts': 'file content',
       };
 
       fs.existsSync.mockImplementation((filePath) => {

--- a/lib/cli/src/detect.test.js
+++ b/lib/cli/src/detect.test.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 
 import { getBowerJson, getPackageJson } from './helpers';
 import { isStorybookInstalled, detectFrameworkPreset, detect, detectLanguage } from './detect';
-import projectTypes, { supportedFrameworks, SUPPORTED_LANGUAGES } from './project_types';
+import projectTypes, { SUPPORTED_FRAMEWORKS, SUPPORTED_LANGUAGES } from './project_types';
 
 jest.mock('./helpers', () => ({
   getBowerJson: jest.fn(),
@@ -232,7 +232,7 @@ describe('Detect', () => {
       expect(isStorybookInstalled({}, false)).toBe(false);
     });
 
-    supportedFrameworks.forEach((framework) => {
+    SUPPORTED_FRAMEWORKS.forEach((framework) => {
       it(`true if devDependencies has ${framework} Storybook version`, () => {
         const devDependencies = {
           [`@storybook/${framework}`]: '4.0.0-alpha.21',

--- a/lib/cli/src/detect.test.js
+++ b/lib/cli/src/detect.test.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 
 import { getBowerJson, getPackageJson } from './helpers';
 import { isStorybookInstalled, detectFrameworkPreset, detect, detectLanguage } from './detect';
-import projectTypes, { supportedFrameworks, supportedLanguages } from './project_types';
+import projectTypes, { supportedFrameworks, SUPPORTED_LANGUAGES } from './project_types';
 
 jest.mock('./helpers', () => ({
   getBowerJson: jest.fn(),
@@ -215,12 +215,12 @@ describe('Detect', () => {
         typescript: '1.0.0',
       },
     }));
-    expect(detectLanguage()).toBe(supportedLanguages.TYPESCRIPT);
+    expect(detectLanguage()).toBe(SUPPORTED_LANGUAGES.TYPESCRIPT);
   });
 
   it(`should return language javascript by default`, () => {
     getPackageJson.mockImplementation(() => true);
-    expect(detectLanguage()).toBe(supportedLanguages.JAVASCRIPT);
+    expect(detectLanguage()).toBe(SUPPORTED_LANGUAGES.JAVASCRIPT);
   });
 
   describe('isStorybookInstalled should return', () => {

--- a/lib/cli/src/generators/ANGULAR/index.js
+++ b/lib/cli/src/generators/ANGULAR/index.js
@@ -14,7 +14,7 @@ import {
   writeFileAsJson,
   copyTemplate,
 } from '../../helpers';
-import { supportedStoryFormats } from '../../project_types';
+import { STORY_FORMAT } from '../../project_types';
 
 async function addDependencies(npmOptions, { storyFormat }) {
   const packages = [
@@ -24,7 +24,7 @@ async function addDependencies(npmOptions, { storyFormat }) {
     '@storybook/addons',
   ];
 
-  if (storyFormat === supportedStoryFormats.MDX) {
+  if (storyFormat === STORY_FORMAT.MDX) {
     packages.push('@storybook/addon-docs');
   }
 

--- a/lib/cli/src/generators/ANGULAR/index.js
+++ b/lib/cli/src/generators/ANGULAR/index.js
@@ -14,6 +14,7 @@ import {
   writeFileAsJson,
   copyTemplate,
 } from '../../helpers';
+import { supportedStoryFormats } from '../../project_types';
 
 async function addDependencies(npmOptions, { storyFormat }) {
   const packages = [
@@ -23,7 +24,7 @@ async function addDependencies(npmOptions, { storyFormat }) {
     '@storybook/addons',
   ];
 
-  if (storyFormat === 'mdx') {
+  if (storyFormat === supportedStoryFormats.MDX) {
     packages.push('@storybook/addon-docs');
   }
 
@@ -61,7 +62,7 @@ function editAngularAppTsConfig() {
   writeFileAsJson(getAngularAppTsConfigPath(), tsConfigJson);
 }
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   if (!isDefaultProjectSet()) {
     throw new Error(
       'Could not find a default project in your Angular workspace. Add a project and re-run the installation.'

--- a/lib/cli/src/generators/EMBER/index.js
+++ b/lib/cli/src/generators/EMBER/index.js
@@ -7,7 +7,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const [
     storybookVersion,
     babelPluginEmberModulePolyfillVersion,

--- a/lib/cli/src/generators/HTML/index.js
+++ b/lib/cli/src/generators/HTML/index.js
@@ -6,12 +6,12 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
-import { supportedStoryFormats } from '../../project_types';
+import { STORY_FORMAT } from '../../project_types';
 
 export default async (npmOptions, { storyFormat }) => {
   const packages = ['@storybook/html'];
   const versionedPackages = await getVersionedPackages(npmOptions, ...packages);
-  if (storyFormat === supportedStoryFormats.MDX) {
+  if (storyFormat === STORY_FORMAT.MDX) {
     packages.push('@storybook/addon-docs');
   }
 

--- a/lib/cli/src/generators/HTML/index.js
+++ b/lib/cli/src/generators/HTML/index.js
@@ -6,11 +6,12 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
+import { supportedStoryFormats } from '../../project_types';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const packages = ['@storybook/html'];
   const versionedPackages = await getVersionedPackages(npmOptions, ...packages);
-  if (storyFormat === 'mdx') {
+  if (storyFormat === supportedStoryFormats.MDX) {
     packages.push('@storybook/addon-docs');
   }
 

--- a/lib/cli/src/generators/MARKO/index.js
+++ b/lib/cli/src/generators/MARKO/index.js
@@ -7,7 +7,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const [storybookVersion, addonActionVersion, addonKnobsVersion] = await getVersions(
     npmOptions,
     '@storybook/marko',

--- a/lib/cli/src/generators/METEOR/index.js
+++ b/lib/cli/src/generators/METEOR/index.js
@@ -9,7 +9,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const [
     storybookVersion,
     actionsVersion,

--- a/lib/cli/src/generators/MITHRIL/index.js
+++ b/lib/cli/src/generators/MITHRIL/index.js
@@ -7,7 +7,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const [
     storybookVersion,
     actionsVersion,

--- a/lib/cli/src/generators/PREACT/index.js
+++ b/lib/cli/src/generators/PREACT/index.js
@@ -7,7 +7,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const [storybookVersion, actionsVersion, linksVersion, addonsVersion] = await getVersions(
     npmOptions,
     '@storybook/preact',

--- a/lib/cli/src/generators/RAX/index.js
+++ b/lib/cli/src/generators/RAX/index.js
@@ -7,7 +7,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const [
     storybookVersion,
     actionsVersion,

--- a/lib/cli/src/generators/REACT/index.js
+++ b/lib/cli/src/generators/REACT/index.js
@@ -6,15 +6,16 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
+import { supportedStoryFormats } from '../../project_types';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const packages = [
     '@storybook/react',
     '@storybook/addon-actions',
     '@storybook/addon-links',
     '@storybook/addons',
   ];
-  if (storyFormat === 'mdx') {
+  if (storyFormat === supportedStoryFormats.MDX) {
     packages.push('@storybook/addon-docs');
   }
 

--- a/lib/cli/src/generators/REACT/index.js
+++ b/lib/cli/src/generators/REACT/index.js
@@ -6,7 +6,7 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
-import { supportedStoryFormats } from '../../project_types';
+import { STORY_FORMAT } from '../../project_types';
 
 export default async (npmOptions, { storyFormat }) => {
   const packages = [
@@ -15,7 +15,7 @@ export default async (npmOptions, { storyFormat }) => {
     '@storybook/addon-links',
     '@storybook/addons',
   ];
-  if (storyFormat === supportedStoryFormats.MDX) {
+  if (storyFormat === STORY_FORMAT.MDX) {
     packages.push('@storybook/addon-docs');
   }
 

--- a/lib/cli/src/generators/REACT_NATIVE/index.js
+++ b/lib/cli/src/generators/REACT_NATIVE/index.js
@@ -10,7 +10,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, installServer, { storyFormat = 'csf' }) => {
+export default async (npmOptions, installServer, { storyFormat }) => {
   const [storybookVersion, addonsVersion, actionsVersion, linksVersion] = await getVersions(
     npmOptions,
     '@storybook/react-native',

--- a/lib/cli/src/generators/REACT_SCRIPTS/index.js
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.js
@@ -8,7 +8,7 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
-import { supportedStoryFormats } from '../../project_types';
+import { STORY_FORMAT } from '../../project_types';
 
 export default async (npmOptions, { storyFormat }) => {
   const packages = [
@@ -19,7 +19,7 @@ export default async (npmOptions, { storyFormat }) => {
     '@storybook/addons',
   ];
 
-  if (storyFormat === supportedStoryFormats.MDX) {
+  if (storyFormat === STORY_FORMAT.MDX) {
     packages.push('@storybook/addon-docs');
   }
 

--- a/lib/cli/src/generators/REACT_SCRIPTS/index.js
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.js
@@ -8,8 +8,9 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
+import { supportedStoryFormats } from '../../project_types';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const packages = [
     '@storybook/react',
     '@storybook/preset-create-react-app',
@@ -18,7 +19,7 @@ export default async (npmOptions, { storyFormat = 'csf' }) => {
     '@storybook/addons',
   ];
 
-  if (storyFormat === 'mdx') {
+  if (storyFormat === supportedStoryFormats.MDX) {
     packages.push('@storybook/addon-docs');
   }
 

--- a/lib/cli/src/generators/RIOT/index.js
+++ b/lib/cli/src/generators/RIOT/index.js
@@ -7,7 +7,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const [
     storybookVersion,
     actionsVersion,

--- a/lib/cli/src/generators/SFC_VUE/index.js
+++ b/lib/cli/src/generators/SFC_VUE/index.js
@@ -6,15 +6,16 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
+import { supportedStoryFormats } from '../../project_types';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const packages = [
     '@storybook/vue',
     '@storybook/addon-actions',
     '@storybook/addon-links',
     '@storybook/addons',
   ];
-  if (storyFormat === 'mdx') {
+  if (storyFormat === supportedStoryFormats.MDX) {
     packages.push('@storybook/addon-docs');
   }
   const versionedPackages = await getVersionedPackages(npmOptions, ...packages);

--- a/lib/cli/src/generators/SFC_VUE/index.js
+++ b/lib/cli/src/generators/SFC_VUE/index.js
@@ -6,7 +6,7 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
-import { supportedStoryFormats } from '../../project_types';
+import { STORY_FORMAT } from '../../project_types';
 
 export default async (npmOptions, { storyFormat }) => {
   const packages = [
@@ -15,7 +15,7 @@ export default async (npmOptions, { storyFormat }) => {
     '@storybook/addon-links',
     '@storybook/addons',
   ];
-  if (storyFormat === supportedStoryFormats.MDX) {
+  if (storyFormat === STORY_FORMAT.MDX) {
     packages.push('@storybook/addon-docs');
   }
   const versionedPackages = await getVersionedPackages(npmOptions, ...packages);

--- a/lib/cli/src/generators/SVELTE/index.js
+++ b/lib/cli/src/generators/SVELTE/index.js
@@ -7,7 +7,7 @@ import {
   copyTemplate,
 } from '../../helpers';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const [
     storybookVersion,
     actionsVersion,

--- a/lib/cli/src/generators/VUE/index.js
+++ b/lib/cli/src/generators/VUE/index.js
@@ -8,8 +8,9 @@ import {
   addToDevDependenciesIfNotPresent,
   copyTemplate,
 } from '../../helpers';
+import { supportedStoryFormats } from '../../project_types';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const packages = [
     '@storybook/vue',
     '@storybook/addon-actions',
@@ -18,7 +19,7 @@ export default async (npmOptions, { storyFormat = 'csf' }) => {
     'babel-preset-vue',
     '@babel/core',
   ];
-  if (storyFormat === 'mdx') {
+  if (storyFormat === supportedStoryFormats.MDX) {
     packages.push('@storybook/addon-docs');
   }
   const versionedPackages = await getVersionedPackages(npmOptions, ...packages);

--- a/lib/cli/src/generators/VUE/index.js
+++ b/lib/cli/src/generators/VUE/index.js
@@ -8,7 +8,7 @@ import {
   addToDevDependenciesIfNotPresent,
   copyTemplate,
 } from '../../helpers';
-import { supportedStoryFormats } from '../../project_types';
+import { STORY_FORMAT } from '../../project_types';
 
 export default async (npmOptions, { storyFormat }) => {
   const packages = [
@@ -19,7 +19,7 @@ export default async (npmOptions, { storyFormat }) => {
     'babel-preset-vue',
     '@babel/core',
   ];
-  if (storyFormat === supportedStoryFormats.MDX) {
+  if (storyFormat === STORY_FORMAT.MDX) {
     packages.push('@storybook/addon-docs');
   }
   const versionedPackages = await getVersionedPackages(npmOptions, ...packages);

--- a/lib/cli/src/generators/WEB-COMPONENTS/index.js
+++ b/lib/cli/src/generators/WEB-COMPONENTS/index.js
@@ -7,12 +7,13 @@ import {
   getBabelDependencies,
   installDependencies,
 } from '../../helpers';
+import { supportedStoryFormats } from '../../project_types';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const storybookVersion = await getVersion(npmOptions, '@storybook/web-components');
   fse.copySync(path.resolve(__dirname, 'template/'), '.', { overwrite: true });
 
-  if (storyFormat === 'mdx') {
+  if (storyFormat === supportedStoryFormats.MDX) {
     // TODO: handle adding of docs mode
   }
 

--- a/lib/cli/src/generators/WEB-COMPONENTS/index.js
+++ b/lib/cli/src/generators/WEB-COMPONENTS/index.js
@@ -7,13 +7,13 @@ import {
   getBabelDependencies,
   installDependencies,
 } from '../../helpers';
-import { supportedStoryFormats } from '../../project_types';
+import { STORY_FORMAT } from '../../project_types';
 
 export default async (npmOptions, { storyFormat }) => {
   const storybookVersion = await getVersion(npmOptions, '@storybook/web-components');
   fse.copySync(path.resolve(__dirname, 'template/'), '.', { overwrite: true });
 
-  if (storyFormat === supportedStoryFormats.MDX) {
+  if (storyFormat === STORY_FORMAT.MDX) {
     // TODO: handle adding of docs mode
   }
 

--- a/lib/cli/src/generators/WEBPACK_REACT/index.js
+++ b/lib/cli/src/generators/WEBPACK_REACT/index.js
@@ -6,15 +6,16 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
+import { supportedStoryFormats } from '../../project_types';
 
-export default async (npmOptions, { storyFormat = 'csf' }) => {
+export default async (npmOptions, { storyFormat }) => {
   const packages = [
     '@storybook/react',
     '@storybook/addon-actions',
     '@storybook/addon-links',
     '@storybook/addons',
   ];
-  if (storyFormat === 'mdx') {
+  if (storyFormat === supportedStoryFormats.MDX) {
     packages.push('@storybook/addon-docs');
   }
   const versionedPackages = await getVersionedPackages(npmOptions, ...packages);

--- a/lib/cli/src/generators/WEBPACK_REACT/index.js
+++ b/lib/cli/src/generators/WEBPACK_REACT/index.js
@@ -6,7 +6,7 @@ import {
   installDependencies,
   copyTemplate,
 } from '../../helpers';
-import { supportedStoryFormats } from '../../project_types';
+import { STORY_FORMAT } from '../../project_types';
 
 export default async (npmOptions, { storyFormat }) => {
   const packages = [
@@ -15,7 +15,7 @@ export default async (npmOptions, { storyFormat }) => {
     '@storybook/addon-links',
     '@storybook/addons',
   ];
-  if (storyFormat === supportedStoryFormats.MDX) {
+  if (storyFormat === STORY_FORMAT.MDX) {
     packages.push('@storybook/addon-docs');
   }
   const versionedPackages = await getVersionedPackages(npmOptions, ...packages);

--- a/lib/cli/src/helpers.js
+++ b/lib/cli/src/helpers.js
@@ -10,7 +10,7 @@ import stripJsonComments from 'strip-json-comments';
 import { latestVersion } from './latest_version';
 import { version, devDependencies } from '../package.json';
 import { npmInit } from './npm_init';
-import { supportedStoryFormats } from './project_types';
+import { STORY_FORMAT } from './project_types';
 
 const logger = console;
 
@@ -318,8 +318,8 @@ export function copyTemplate(templateRoot, storyFormat) {
   const templateDir = path.resolve(templateRoot, `template-${storyFormat}/`);
   if (!fs.existsSync(templateDir)) {
     // Fallback to CSF plain first, in case format is typescript but template is not available.
-    if (storyFormat === supportedStoryFormats.CSF_TYPESCRIPT) {
-      copyTemplate(templateRoot, supportedStoryFormats.CSF);
+    if (storyFormat === STORY_FORMAT.CSF_TYPESCRIPT) {
+      copyTemplate(templateRoot, STORY_FORMAT.CSF);
       return;
     }
 

--- a/lib/cli/src/helpers.js
+++ b/lib/cli/src/helpers.js
@@ -6,10 +6,11 @@ import chalk from 'chalk';
 import { sync as spawnSync } from 'cross-spawn';
 import { gt, satisfies } from 'semver';
 import stripJsonComments from 'strip-json-comments';
-import { latestVersion } from './latest_version';
 
+import { latestVersion } from './latest_version';
 import { version, devDependencies } from '../package.json';
 import { npmInit } from './npm_init';
+import { supportedStoryFormats } from './project_types';
 
 const logger = console;
 
@@ -316,6 +317,12 @@ export function addToDevDependenciesIfNotPresent(packageJson, name, packageVersi
 export function copyTemplate(templateRoot, storyFormat) {
   const templateDir = path.resolve(templateRoot, `template-${storyFormat}/`);
   if (!fs.existsSync(templateDir)) {
+    // Fallback to CSF plain first, in case format is typescript but template is not available.
+    if (storyFormat === supportedStoryFormats.CSF_TYPESCRIPT) {
+      copyTemplate(templateRoot, supportedStoryFormats.CSF);
+      return;
+    }
+
     throw new Error(`Unsupported story format: ${storyFormat}`);
   }
   fse.copySync(templateDir, '.', { overwrite: true });

--- a/lib/cli/src/helpers.test.js
+++ b/lib/cli/src/helpers.test.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import fse from 'fs-extra';
 
 import * as helpers from './helpers';
-import { supportedStoryFormats } from './project_types';
+import { STORY_FORMAT } from './project_types';
 
 jest.mock('fs', () => ({
   existsSync: jest.fn(),
@@ -23,24 +23,24 @@ jest.mock('./npm_init', () => ({
 
 describe('Helpers', () => {
   describe('copyTemplate', () => {
-    it(`should fall back to ${supportedStoryFormats.CSF} 
-        in case ${supportedStoryFormats.CSF_TYPESCRIPT} is not available`, () => {
-      const csfDirectory = `template-${supportedStoryFormats.CSF}/`;
+    it(`should fall back to ${STORY_FORMAT.CSF} 
+        in case ${STORY_FORMAT.CSF_TYPESCRIPT} is not available`, () => {
+      const csfDirectory = `template-${STORY_FORMAT.CSF}/`;
       fs.existsSync.mockImplementation((filePath) => {
         return filePath === csfDirectory;
       });
-      helpers.copyTemplate('', supportedStoryFormats.CSF_TYPESCRIPT);
+      helpers.copyTemplate('', STORY_FORMAT.CSF_TYPESCRIPT);
 
       const copySyncSpy = jest.spyOn(fse, 'copySync');
       expect(copySyncSpy).toHaveBeenCalledWith(csfDirectory, expect.anything(), expect.anything());
     });
 
-    it(`should use ${supportedStoryFormats.CSF_TYPESCRIPT} if it is available`, () => {
-      const csfDirectory = `template-${supportedStoryFormats.CSF_TYPESCRIPT}/`;
+    it(`should use ${STORY_FORMAT.CSF_TYPESCRIPT} if it is available`, () => {
+      const csfDirectory = `template-${STORY_FORMAT.CSF_TYPESCRIPT}/`;
       fs.existsSync.mockImplementation((filePath) => {
         return filePath === csfDirectory;
       });
-      helpers.copyTemplate('', supportedStoryFormats.CSF_TYPESCRIPT);
+      helpers.copyTemplate('', STORY_FORMAT.CSF_TYPESCRIPT);
 
       const copySyncSpy = jest.spyOn(fse, 'copySync');
       expect(copySyncSpy).toHaveBeenCalledWith(csfDirectory, expect.anything(), expect.anything());

--- a/lib/cli/src/helpers.test.js
+++ b/lib/cli/src/helpers.test.js
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import fse from 'fs-extra';
+
+import * as helpers from './helpers';
+import { supportedStoryFormats } from './project_types';
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+}));
+
+jest.mock('fs-extra', () => ({
+  copySync: jest.fn(() => ({})),
+}));
+
+jest.mock('path', () => ({
+  // make it return just the second path, for easier testing
+  resolve: jest.fn((_, p) => p),
+}));
+
+jest.mock('./npm_init', () => ({
+  npmInit: jest.fn(),
+}));
+
+describe('Helpers', () => {
+  describe('copyTemplate', () => {
+    it(`should fall back to ${supportedStoryFormats.CSF} 
+        in case ${supportedStoryFormats.CSF_TYPESCRIPT} is not available`, () => {
+      const csfDirectory = `template-${supportedStoryFormats.CSF}/`;
+      fs.existsSync.mockImplementation((filePath) => {
+        return filePath === csfDirectory;
+      });
+      helpers.copyTemplate('', supportedStoryFormats.CSF_TYPESCRIPT);
+
+      const copySyncSpy = jest.spyOn(fse, 'copySync');
+      expect(copySyncSpy).toHaveBeenCalledWith(csfDirectory, expect.anything(), expect.anything());
+    });
+
+    it(`should use ${supportedStoryFormats.CSF_TYPESCRIPT} if it is available`, () => {
+      const csfDirectory = `template-${supportedStoryFormats.CSF_TYPESCRIPT}/`;
+      fs.existsSync.mockImplementation((filePath) => {
+        return filePath === csfDirectory;
+      });
+      helpers.copyTemplate('', supportedStoryFormats.CSF_TYPESCRIPT);
+
+      const copySyncSpy = jest.spyOn(fse, 'copySync');
+      expect(copySyncSpy).toHaveBeenCalledWith(csfDirectory, expect.anything(), expect.anything());
+    });
+
+    it(`should throw an error for unsupported story format`, () => {
+      const storyFormat = 'non-existent-format';
+      const expectedMessage = `Unsupported story format: ${storyFormat}`;
+      expect(() => {
+        helpers.copyTemplate('', storyFormat);
+      }).toThrowError(expectedMessage);
+    });
+  });
+});

--- a/lib/cli/src/initiate.js
+++ b/lib/cli/src/initiate.js
@@ -5,7 +5,7 @@ import { detect, isStorybookInstalled, detectLanguage } from './detect';
 import { hasYarn } from './has_yarn';
 import types, {
   installableProjectTypes,
-  supportedStoryFormats,
+  STORY_FORMAT,
   supportedLanguages,
 } from './project_types';
 import {
@@ -48,8 +48,8 @@ const installStorybook = (projectType, options) => {
 
   const defaultStoryFormat =
     detectLanguage() === supportedLanguages.TYPESCRIPT
-      ? supportedStoryFormats.CSF_TYPESCRIPT
-      : supportedStoryFormats.CSF;
+      ? STORY_FORMAT.CSF_TYPESCRIPT
+      : STORY_FORMAT.CSF;
 
   const generatorOptions = {
     storyFormat: options.storyFormat || defaultStoryFormat,

--- a/lib/cli/src/initiate.js
+++ b/lib/cli/src/initiate.js
@@ -1,9 +1,13 @@
 import updateNotifier from 'update-notifier';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import { detect, isStorybookInstalled } from './detect';
+import { detect, isStorybookInstalled, detectLanguage } from './detect';
 import { hasYarn } from './has_yarn';
-import types, { installableProjectTypes, supportedStoryFormats } from './project_types';
+import types, {
+  installableProjectTypes,
+  supportedStoryFormats,
+  supportedLanguages,
+} from './project_types';
 import {
   commandLog,
   codeLog,
@@ -42,8 +46,13 @@ const installStorybook = (projectType, options) => {
     skipInstall: options.skipInstall,
   };
 
+  const defaultStoryFormat =
+    detectLanguage() === supportedLanguages.TYPESCRIPT
+      ? supportedStoryFormats.CSF_TYPESCRIPT
+      : supportedStoryFormats.CSF;
+
   const generatorOptions = {
-    storyFormat: options.storyFormat || supportedStoryFormats.CSF,
+    storyFormat: options.storyFormat || defaultStoryFormat,
   };
 
   const runStorybookCommand = useYarn ? 'yarn storybook' : 'npm run storybook';

--- a/lib/cli/src/initiate.js
+++ b/lib/cli/src/initiate.js
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { detect, isStorybookInstalled } from './detect';
 import { hasYarn } from './has_yarn';
-import types, { installableProjectTypes } from './project_types';
+import types, { installableProjectTypes, supportedStoryFormats } from './project_types';
 import {
   commandLog,
   codeLog,
@@ -43,7 +43,7 @@ const installStorybook = (projectType, options) => {
   };
 
   const generatorOptions = {
-    storyFormat: options.storyFormat,
+    storyFormat: options.storyFormat || supportedStoryFormats.CSF,
   };
 
   const runStorybookCommand = useYarn ? 'yarn storybook' : 'npm run storybook';

--- a/lib/cli/src/initiate.js
+++ b/lib/cli/src/initiate.js
@@ -3,8 +3,9 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { detect, isStorybookInstalled, detectLanguage } from './detect';
 import { hasYarn } from './has_yarn';
-import types, {
+import {
   installableProjectTypes,
+  PROJECT_TYPES,
   STORY_FORMAT,
   SUPPORTED_LANGUAGES,
 } from './project_types';
@@ -75,7 +76,7 @@ const installStorybook = (projectType, options) => {
 
   const runGenerator = () => {
     switch (projectType) {
-      case types.ALREADY_HAS_STORYBOOK:
+      case PROJECT_TYPES.ALREADY_HAS_STORYBOOK:
         logger.log();
         paddedLog('There seems to be a storybook already available in this project.');
         paddedLog('Apply following command to force:\n');
@@ -85,23 +86,23 @@ const installStorybook = (projectType, options) => {
         logger.log();
         return Promise.resolve();
 
-      case types.UPDATE_PACKAGE_ORGANIZATIONS:
+      case PROJECT_TYPES.UPDATE_PACKAGE_ORGANIZATIONS:
         return updateOrganisationsGenerator(options.parser, npmOptions)
           .then(() => null) // commmandLog doesn't like to see output
           .then(commandLog('Upgrading your project to the new storybook packages.'))
           .then(end);
 
-      case types.REACT_SCRIPTS:
+      case PROJECT_TYPES.REACT_SCRIPTS:
         return reactScriptsGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Create React App" based project'))
           .then(end);
 
-      case types.REACT:
+      case PROJECT_TYPES.REACT:
         return reactGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "React" app'))
           .then(end);
 
-      case types.REACT_NATIVE: {
+      case PROJECT_TYPES.REACT_NATIVE: {
         return (options.yes
           ? Promise.resolve({ server: true })
           : inquirer.prompt([
@@ -127,82 +128,82 @@ const installStorybook = (projectType, options) => {
           });
       }
 
-      case types.METEOR:
+      case PROJECT_TYPES.METEOR:
         return meteorGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Meteor" app'))
           .then(end);
 
-      case types.WEBPACK_REACT:
+      case PROJECT_TYPES.WEBPACK_REACT:
         return webpackReactGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Webpack React" app'))
           .then(end);
 
-      case types.REACT_PROJECT:
+      case PROJECT_TYPES.REACT_PROJECT:
         return reactGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "React" library'))
           .then(end);
 
-      case types.SFC_VUE:
+      case PROJECT_TYPES.SFC_VUE:
         return sfcVueGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Single File Components Vue" app'))
           .then(end);
 
-      case types.VUE:
+      case PROJECT_TYPES.VUE:
         return vueGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Vue" app'))
           .then(end);
 
-      case types.ANGULAR:
+      case PROJECT_TYPES.ANGULAR:
         return angularGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Angular" app'))
           .then(end);
 
-      case types.EMBER:
+      case PROJECT_TYPES.EMBER:
         return emberGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Ember" app'))
           .then(end);
 
-      case types.MITHRIL:
+      case PROJECT_TYPES.MITHRIL:
         return mithrilGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Mithril" app'))
           .then(end);
 
-      case types.MARIONETTE:
+      case PROJECT_TYPES.MARIONETTE:
         return marionetteGenerator(npmOptions)
           .then(commandLog('Adding storybook support to your "Marionette.js" app'))
           .then(end);
 
-      case types.MARKO:
+      case PROJECT_TYPES.MARKO:
         return markoGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Marko" app'))
           .then(end);
 
-      case types.HTML:
+      case PROJECT_TYPES.HTML:
         return htmlGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "HTML" app'))
           .then(end);
 
-      case types.WEB_COMPONENTS:
+      case PROJECT_TYPES.WEB_COMPONENTS:
         return webComponentsGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "web components" app'))
           .then(end);
 
-      case types.RIOT:
+      case PROJECT_TYPES.RIOT:
         return riotGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "riot.js" app'))
           .then(end);
 
-      case types.PREACT:
+      case PROJECT_TYPES.PREACT:
         return preactGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Preact" app'))
           .then(end);
 
-      case types.SVELTE:
+      case PROJECT_TYPES.SVELTE:
         return svelteGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Svelte" app'))
           .then(end);
 
-      case types.RAX:
+      case PROJECT_TYPES.RAX:
         return raxGenerator(npmOptions, generatorOptions)
           .then(commandLog('Adding storybook support to your "Rax" app'))
           .then(end);
@@ -273,7 +274,9 @@ export default function (options, pkg) {
     if (projectTypeProvided) {
       if (installableProjectTypes.includes(options.type)) {
         const storybookInstalled = isStorybookInstalled(getPackageJson(), options.force);
-        projectType = storybookInstalled ? types.ALREADY_HAS_STORYBOOK : options.type.toUpperCase();
+        projectType = storybookInstalled
+          ? PROJECT_TYPES.ALREADY_HAS_STORYBOOK
+          : options.type.toUpperCase();
       } else {
         done(`The provided project type was not recognized by Storybook.`);
         logger.log(`\nThe project types currently supported by Storybook are:\n`);

--- a/lib/cli/src/initiate.js
+++ b/lib/cli/src/initiate.js
@@ -6,7 +6,7 @@ import { hasYarn } from './has_yarn';
 import types, {
   installableProjectTypes,
   STORY_FORMAT,
-  supportedLanguages,
+  SUPPORTED_LANGUAGES,
 } from './project_types';
 import {
   commandLog,
@@ -47,7 +47,7 @@ const installStorybook = (projectType, options) => {
   };
 
   const defaultStoryFormat =
-    detectLanguage() === supportedLanguages.TYPESCRIPT
+    detectLanguage() === SUPPORTED_LANGUAGES.TYPESCRIPT
       ? STORY_FORMAT.CSF_TYPESCRIPT
       : STORY_FORMAT.CSF;
 

--- a/lib/cli/src/project_types.js
+++ b/lib/cli/src/project_types.js
@@ -34,7 +34,7 @@ export const SUPPORTED_LANGUAGES = {
   TYPESCRIPT: 'typescript',
 };
 
-export const supportedFrameworks = [
+export const SUPPORTED_FRAMEWORKS = [
   'react',
   'react-native',
   'vue',

--- a/lib/cli/src/project_types.js
+++ b/lib/cli/src/project_types.js
@@ -1,4 +1,4 @@
-const projectTypes = {
+export const PROJECT_TYPES = {
   UNDETECTED: 'UNDETECTED',
   REACT_SCRIPTS: 'REACT_SCRIPTS',
   METEOR: 'METEOR',
@@ -59,7 +59,7 @@ export const SUPPORTED_FRAMEWORKS = [
  *
  * @example
  * {
- *   preset: projectTypes.NEW_SUPPORTED_TEMPLATE,
+ *   preset: PROJECT_TYPES.NEW_SUPPORTED_TEMPLATE,
  *   dependencies: [string], // optional, tests for these both as dependencies and devDependencies
  *   peerDependencies: [string], // optional
  *   files: [string], // optional
@@ -71,49 +71,49 @@ export const SUPPORTED_FRAMEWORKS = [
  */
 export const supportedTemplates = [
   {
-    preset: projectTypes.METEOR,
+    preset: PROJECT_TYPES.METEOR,
     files: ['.meteor'],
     matcherFunction: ({ files }) => {
       return files.every(Boolean);
     },
   },
   {
-    preset: projectTypes.SFC_VUE,
+    preset: PROJECT_TYPES.SFC_VUE,
     dependencies: ['vue-loader', 'vuetify'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.some(Boolean);
     },
   },
   {
-    preset: projectTypes.VUE,
+    preset: PROJECT_TYPES.VUE,
     dependencies: ['vue', 'nuxt'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.some(Boolean);
     },
   },
   {
-    preset: projectTypes.EMBER,
+    preset: PROJECT_TYPES.EMBER,
     dependencies: ['ember-cli'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.REACT_PROJECT,
+    preset: PROJECT_TYPES.REACT_PROJECT,
     peerDependencies: ['react'],
     matcherFunction: ({ peerDependencies }) => {
       return peerDependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.REACT_NATIVE,
+    preset: PROJECT_TYPES.REACT_NATIVE,
     dependencies: ['react-native', 'react-native-scripts'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.some(Boolean);
     },
   },
   {
-    preset: projectTypes.REACT_SCRIPTS,
+    preset: PROJECT_TYPES.REACT_SCRIPTS,
     // For projects using a custom/forked `react-scripts` package.
     files: ['/node_modules/.bin/react-scripts'],
     // For standard CRA projects
@@ -123,70 +123,70 @@ export const supportedTemplates = [
     },
   },
   {
-    preset: projectTypes.WEBPACK_REACT,
+    preset: PROJECT_TYPES.WEBPACK_REACT,
     dependencies: ['react', 'webpack'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.REACT,
+    preset: PROJECT_TYPES.REACT,
     dependencies: ['react'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.ANGULAR,
+    preset: PROJECT_TYPES.ANGULAR,
     dependencies: ['@angular/core'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.WEB_COMPONENTS,
+    preset: PROJECT_TYPES.WEB_COMPONENTS,
     dependencies: ['lit-element'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.MITHRIL,
+    preset: PROJECT_TYPES.MITHRIL,
     dependencies: ['mithril'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.MARIONETTE,
+    preset: PROJECT_TYPES.MARIONETTE,
     dependencies: ['backbone.marionette'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.MARKO,
+    preset: PROJECT_TYPES.MARKO,
     dependencies: ['marko'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.RIOT,
+    preset: PROJECT_TYPES.RIOT,
     dependencies: ['riot'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.PREACT,
+    preset: PROJECT_TYPES.PREACT,
     dependencies: ['preact'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
     },
   },
   {
-    preset: projectTypes.RAX,
+    preset: PROJECT_TYPES.RAX,
     dependencies: ['rax'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.every(Boolean);
@@ -195,13 +195,11 @@ export const supportedTemplates = [
 ];
 
 const notInstallableProjectTypes = [
-  projectTypes.UNDETECTED,
-  projectTypes.ALREADY_HAS_STORYBOOK,
-  projectTypes.UPDATE_PACKAGE_ORGANIZATIONS,
+  PROJECT_TYPES.UNDETECTED,
+  PROJECT_TYPES.ALREADY_HAS_STORYBOOK,
+  PROJECT_TYPES.UPDATE_PACKAGE_ORGANIZATIONS,
 ];
 
-export const installableProjectTypes = Object.values(projectTypes)
+export const installableProjectTypes = Object.values(PROJECT_TYPES)
   .filter((type) => !notInstallableProjectTypes.includes(type))
   .map((type) => type.toLowerCase());
-
-export default projectTypes;

--- a/lib/cli/src/project_types.js
+++ b/lib/cli/src/project_types.js
@@ -23,7 +23,7 @@ const projectTypes = {
   RAX: 'RAX',
 };
 
-export const supportedStoryFormats = {
+export const STORY_FORMAT = {
   CSF: 'csf',
   CSF_TYPESCRIPT: 'csf-ts',
   MDX: 'mdx',

--- a/lib/cli/src/project_types.js
+++ b/lib/cli/src/project_types.js
@@ -23,8 +23,6 @@ const projectTypes = {
   RAX: 'RAX',
 };
 
-export default projectTypes;
-
 export const supportedFrameworks = [
   'react',
   'react-native',
@@ -41,6 +39,134 @@ export const supportedFrameworks = [
   'rax',
 ];
 
+// This has to be an array sorted in order of specificity/priority.
+// Example: both REACT and WEBPACK_REACT have react as dependency,
+// therefore WEBPACK_REACT has to come first, as it's more specific.
+export const supportedTemplates = [
+  {
+    preset: projectTypes.METEOR,
+    files: ['.meteor'],
+    matcherFunction: ({ files }) => {
+      return files.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.SFC_VUE,
+    dependencies: ['vue-loader', 'vuetify'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.some(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.VUE,
+    dependencies: ['vue', 'nuxt'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.some(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.EMBER,
+    dependencies: ['ember-cli'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.REACT_PROJECT,
+    peerDependencies: ['react'],
+    matcherFunction: ({ peerDependencies }) => {
+      return peerDependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.REACT_NATIVE,
+    dependencies: ['react-native', 'react-native-scripts'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.some(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.REACT_SCRIPTS,
+    // For projects using a custom/forked `react-scripts` package.
+    files: ['/node_modules/.bin/react-scripts'],
+    // For standard CRA projects
+    dependencies: ['react-scripts'],
+    matcherFunction: ({ dependencies, files }) => {
+      return dependencies.every(Boolean) || files.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.WEBPACK_REACT,
+    dependencies: ['react', 'webpack'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.REACT,
+    dependencies: ['react'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.ANGULAR,
+    dependencies: ['@angular/core'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.WEB_COMPONENTS,
+    dependencies: ['lit-element'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.MITHRIL,
+    dependencies: ['mithril'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.MARIONETTE,
+    dependencies: ['backbone.marionette'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.MARKO,
+    dependencies: ['marko'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.RIOT,
+    dependencies: ['riot'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.PREACT,
+    dependencies: ['preact'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+  {
+    preset: projectTypes.RAX,
+    dependencies: ['rax'],
+    matcherFunction: ({ dependencies }) => {
+      return dependencies.every(Boolean);
+    },
+  },
+];
+
 const notInstallableProjectTypes = [
   projectTypes.UNDETECTED,
   projectTypes.ALREADY_HAS_STORYBOOK,
@@ -50,3 +176,5 @@ const notInstallableProjectTypes = [
 export const installableProjectTypes = Object.values(projectTypes)
   .filter((type) => !notInstallableProjectTypes.includes(type))
   .map((type) => type.toLowerCase());
+
+export default projectTypes;

--- a/lib/cli/src/project_types.js
+++ b/lib/cli/src/project_types.js
@@ -23,6 +23,12 @@ const projectTypes = {
   RAX: 'RAX',
 };
 
+export const supportedStoryFormats = {
+  CSF: 'csf',
+  CSF_TYPESCRIPT: 'csf-ts',
+  MDX: 'mdx',
+};
+
 export const supportedLanguages = {
   JAVASCRIPT: 'javascript',
   TYPESCRIPT: 'typescript',

--- a/lib/cli/src/project_types.js
+++ b/lib/cli/src/project_types.js
@@ -29,7 +29,7 @@ export const STORY_FORMAT = {
   MDX: 'mdx',
 };
 
-export const supportedLanguages = {
+export const SUPPORTED_LANGUAGES = {
   JAVASCRIPT: 'javascript',
   TYPESCRIPT: 'typescript',
 };

--- a/lib/cli/src/project_types.js
+++ b/lib/cli/src/project_types.js
@@ -23,6 +23,11 @@ const projectTypes = {
   RAX: 'RAX',
 };
 
+export const supportedLanguages = {
+  JAVASCRIPT: 'javascript',
+  TYPESCRIPT: 'typescript',
+};
+
 export const supportedFrameworks = [
   'react',
   'react-native',
@@ -39,9 +44,25 @@ export const supportedFrameworks = [
   'rax',
 ];
 
-// This has to be an array sorted in order of specificity/priority.
-// Example: both REACT and WEBPACK_REACT have react as dependency,
-// therefore WEBPACK_REACT has to come first, as it's more specific.
+/**
+ * Configuration objects to match a storybook preset template.
+ *
+ * This has to be an array sorted in order of specificity/priority.
+ * Reason: both REACT and WEBPACK_REACT have react as dependency,
+ * therefore WEBPACK_REACT has to come first, as it's more specific.
+ *
+ * @example
+ * {
+ *   preset: projectTypes.NEW_SUPPORTED_TEMPLATE,
+ *   dependencies: [string], // optional, tests for these both as dependencies and devDependencies
+ *   peerDependencies: [string], // optional
+ *   files: [string], // optional
+ *   matcherFunction: ({ dependencies, files, peerDependencies }) => {
+ *     // every argument is returned as an array of booleans
+ *     return // whatever assertion you want, as long as it returns boolean.
+ *   },
+ * }
+ */
 export const supportedTemplates = [
   {
     preset: projectTypes.METEOR,

--- a/lib/cli/src/project_types.test.js
+++ b/lib/cli/src/project_types.test.js
@@ -1,7 +1,7 @@
-import { installableProjectTypes, supportedFrameworks } from './project_types';
+import { installableProjectTypes, SUPPORTED_FRAMEWORKS } from './project_types';
 
 describe('installableProjectTypes should have an entry for the supported framework', () => {
-  supportedFrameworks.forEach((framework) => {
+  SUPPORTED_FRAMEWORKS.forEach((framework) => {
     it(`${framework}`, () => {
       expect(installableProjectTypes.includes(framework.replace(/-/g, '_'))).toBe(true);
     });

--- a/lib/cli/test/run_tests.sh
+++ b/lib/cli/test/run_tests.sh
@@ -50,14 +50,6 @@ do
       yarn sb init --skip-install --yes --story-format mdx
     fi
     ;;
-  csf-ts)
-    if [[ $dir =~ (react_scripts_ts) ]]
-    then
-      yarn sb init --skip-install --yes --story-format csf-ts
-    else
-      yarn sb init --skip-install --yes
-    fi
-    ;;
   esac
   cd ..
 done


### PR DESCRIPTION
Issue: #5050 

## What I did
This PR adds automatic detection for typescript projects when installing storybook by running `npx @storybook/cli sb init`.
With that, it's not necessary to pass `--story-format` anymore (unless it is desired)!

While I was at it, I revamped the framework detection code to be more scalable. If you need to add a new template, all you have to do is create a new entry at `supportedTemplates` in `project_types.js` like the following:
```js
{
    preset: projectTypes.NEW_SUPPORTED_TEMPLATE,
    dependencies: [], // <-- optional, tests for these both as dependencies and devDependencies
    peerDependencies: [], // <-- optional
    files: [], // <-- optional
    matcherFunction: ({ dependencies, files, peerDependencies }) => {
      // every argument is returned as an array of booleans.
      return // whatever assertion you want, as long as it returns boolean.
    },
}
```
As for the typescript detection heuristics, I believe the common point in typescript projects is `typescript` as dependency. We can definitely change it to use more assertions, such as checking if files like `tsconfig.json` or `tslint.json` exist, or if the project contains at least one `*.ts|*.tsx` file.

I tried really hard to test and assert that the implementation works well, and comparing with the current implementation (in next), this is the only difference in the output (before/after):
<img src="https://user-images.githubusercontent.com/1671563/80286269-a97ae080-872a-11ea-8890-07a1d92c0a58.png" width="600">

But of course there could be edge cases or something I missed, so please help me out make sure this is good. Also please be thorough in the review, spare no comments! even with the simplest thing. 👍 In case you want to discuss, we can have a call if that makes it easier!

## How to test
Checkout this branch, run `yarn build cli`, go to `libs/cli` and run `yarn test`. Tweak with the test script if you want/ You can also check and run the unit tests `helpers.test.js` and `detect.test.js`.

## Does this need an update to the documentation?
I guess [this page](https://storybook.js.org/docs/configurations/typescript-config/) could be updated so the init command is mentioned there, however the page is about general typescript configuration, and currently storybook doesn't have templates for every framework + ts.

## Next steps
* Turn the files to typescript, so there's no way to make silly mistakes/typo and so that the code is easier to understand and use. I added comments but types would have been much better. I didn't convert to TS in this PR because it means turning a lot of other files to typescript as well, and this PR would be even bigger. I'm willing to do that though in a separate PR!
* Add more typescript templates. Currently there is only for react (not counting for angular, which is ts by default). I'm also willing to add templates for the remaining ones.
* Add support for monorepos? Maybe for Lerna based monorepos, as NX for instance has a different way of setting up storybook, using `@nrwl/storybook`.