### PR TITLE
CLI: Fix cli when working with Yarn 2 and Node 10

### DIFF
--- a/lib/cli/src/latest_version.js
+++ b/lib/cli/src/latest_version.js
@@ -122,29 +122,25 @@ function spawnVersionsWithYarn(packageName, constraint) {
  * @param {Object} constraint Version range to use to constraint the returned version
  * @returns {Promise<string|Array<string>>} versions  Promise resolved with a version or an array of versions
  */
-function spawnVersionsWithYarn2(packageName, constraint) {
+async function spawnVersionsWithYarn2(packageName, constraint) {
   const field = constraint ? 'versions' : 'version';
-  return new Promise((resolve, reject) => {
-    const command = spawn('yarn', ['npm', 'info', packageName, '--fields', field, '--json'], {
-      cwd: process.cwd(),
-      env: process.env,
-      stdio: 'pipe',
-      encoding: 'utf-8',
-      silent: true,
-    });
 
-    command.stdout.on('data', (data) => {
-      try {
-        const info = JSON.parse(data);
-        resolve(info[field]);
-      } catch (e) {
-        reject(new Error(`Unable to find versions of ${packageName} using yarn 2`));
-      }
-    });
-
-    command.stderr.on('data', (data) => {
-      const info = JSON.parse(data);
-      reject(new Error(info));
-    });
+  const commandResult = sync('yarn', ['npm', 'info', packageName, '--fields', field, '--json'], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'pipe',
+    encoding: 'utf-8',
+    silent: true,
   });
+
+  if (commandResult.status !== 0) {
+    throw new Error(commandResult.stderr.toString());
+  }
+
+  try {
+    const parsedOutput = JSON.parse(commandResult.stdout.toString());
+    return parsedOutput[field];
+  } catch (e) {
+    throw new Error(`Unable to find versions of ${packageName} using yarn 2`);
+  }
 }

--- a/lib/cli/src/latest_version.js
+++ b/lib/cli/src/latest_version.js
@@ -2,7 +2,7 @@ import { spawn, sync } from 'cross-spawn';
 import { satisfies } from 'semver';
 
 /**
- * Get latest version of the package available on npmjs.com.
+ * Get the latest version of the package available on npmjs.com.
  * If constraint is set then it returns a version satisfying it, otherwise the latest version available is returned.
  *
  * @param {Object} npmOptions Object containing a `useYarn: boolean` attribute
@@ -10,8 +10,8 @@ import { satisfies } from 'semver';
  * @param {Object} constraint Version range to use to constraint the returned version
  * @return {Promise<string>} Promise resolved with a version
  */
-export function latestVersion(npmOptions, packageName, constraint) {
-  let getPackageVersions;
+export async function latestVersion(npmOptions, packageName, constraint) {
+  let versions;
 
   // TODO: Refactor things to hide the package manager details:
   // Create a `PackageManager` interface that expose some functions like `version`, `add` etc
@@ -23,19 +23,19 @@ export function latestVersion(npmOptions, packageName, constraint) {
       .replace(/"/g, '');
 
     if (/^1\.+/.test(yarnVersion)) {
-      getPackageVersions = spawnVersionsWithYarn(packageName, constraint);
+      versions = await spawnVersionsWithYarn(packageName, constraint);
     } else {
-      getPackageVersions = spawnVersionsWithYarn2(packageName, constraint);
+      versions = await spawnVersionsWithYarn2(packageName, constraint);
     }
   } else {
-    getPackageVersions = spawnVersionsWithNpm(packageName, constraint);
+    versions = await spawnVersionsWithNpm(packageName, constraint);
   }
 
-  return getPackageVersions.then((versions) => {
-    if (!constraint) return versions;
+  if (!constraint) {
+    return versions;
+  }
 
-    return versions.reverse().find((version) => satisfies(version, constraint));
-  });
+  return versions.reverse().find((version) => satisfies(version, constraint));
 }
 
 /**


### PR DESCRIPTION
## What I did

Update the command used to get a package's version using CLI with Yarn 2.

Using CLI with Yarn 2 and Node 10 results in an output polluted with:
```sh
(node:87281) ExperimentalWarning: The XXX.promises API is experimental
```

These messages are warnings but are sent to `stderr` which is causing CLI to throw an error too.
With `sync` function we can check the `status` to know if command ends in error or not and process accordingly.

## How to test

Checkout the branch locally, run: 
 - `nvm use 10`
 - `yarn bootstrap`
 - `cd lib/cli && yarn test-yarn-2`
