### PR TITLE
CLI: Clarify error when `sb init` fails on angular

### DIFF
--- a/lib/cli/src/generators/ANGULAR/index.js
+++ b/lib/cli/src/generators/ANGULAR/index.js
@@ -65,7 +65,7 @@ function editAngularAppTsConfig() {
 export default async (npmOptions, { storyFormat }) => {
   if (!isDefaultProjectSet()) {
     throw new Error(
-      'Could not find a default project in your Angular workspace. Add a project and re-run the installation.'
+      'Could not find a default project in your Angular workspace.\nSet a defaultProject in your angular.json and re-run the installation.'
     );
   }
 


### PR DESCRIPTION
Issue: #10549 

## What I did
Changed the error message to make the fix step more clear to understand.