### PR TITLE
Addon-docs: Add subcomponents prop to Meta block

### DIFF
--- a/addons/docs/src/blocks/Meta.tsx
+++ b/addons/docs/src/blocks/Meta.tsx
@@ -3,12 +3,14 @@ import { document } from 'global';
 import { Anchor } from './Anchor';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { getDocsStories } from './utils';
+import { Component } from './types';
 
 type Decorator = (...args: any) => any;
 
 interface MetaProps {
   title: string;
-  component?: any;
+  component?: Component;
+  subcomponents: Record<string, Component>;
   decorators?: [Decorator];
   parameters?: any;
 }


### PR DESCRIPTION
Issue: N/A

## What I did

Add missing subcomponents prop per https://github.com/storybookjs/storybook/issues/9444#issuecomment-620472759

## How to test

N/A