### PR TITLE
doc: update readme of addon viewport about configure section more accurately

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -103,16 +103,20 @@ Parameters can be configured for a whole set of stories or a single story via th
 export default {
   title: 'Stories',
   parameters: {
-    viewports: INITIAL_VIEWPORTS,
-    viewport: { defaultViewport: 'iphone6' },
+    viewport: { 
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphone6' 
+     },
   };
 };
 
 export const myStory = () => <div />;
 myStory.story = {
   parameters: {
-    viewports: INITIAL_VIEWPORTS,
-    viewport: { defaultViewport: 'iphonex' },
+    viewport: { 
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphonex' 
+     },
   },
 };
 ```

--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -103,6 +103,7 @@ Parameters can be configured for a whole set of stories or a single story via th
 export default {
   title: 'Stories',
   parameters: {
+    viewports: INITIAL_VIEWPORTS,
     viewport: { defaultViewport: 'iphone6' },
   };
 };
@@ -110,6 +111,7 @@ export default {
 export const myStory = () => <div />;
 myStory.story = {
   parameters: {
+    viewports: INITIAL_VIEWPORTS,
     viewport: { defaultViewport: 'iphonex' },
   },
 };

--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -106,7 +106,7 @@ export default {
     viewport: { 
       viewports: INITIAL_VIEWPORTS,
       defaultViewport: 'iphone6' 
-     },
+    },
   };
 };
 
@@ -114,9 +114,8 @@ export const myStory = () => <div />;
 myStory.story = {
   parameters: {
     viewport: { 
-      viewports: INITIAL_VIEWPORTS,
       defaultViewport: 'iphonex' 
-     },
+    },
   },
 };
 ```


### PR DESCRIPTION
Issue:

Set **defaultViewport** to **iphonex** or **iphone6** works if developers set viewports to [INITIAL_VIEWPORTS](https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts). If follow the readme, the default viewports doesn't work

(because default viewport works when match with key, i had trouble when set viewport with following this readme)


## What I did
So, the example should be change more accurately.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
