### PR TITLE
Props: Fix subcomponents 

### DIFF
--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -170,13 +170,14 @@ export const StoryTable: FC<StoryProps & { components: Record<string, Component>
       string,
       ArgsTableProps
     >;
-    if (!storyArgTypes || !Object.values(storyArgTypes).find((v) => !!v?.control)) {
+    const storyHasArgsWithControls = !storyArgTypes || !Object.values(storyArgTypes).find((v) => !!v?.control);
+    if (storyHasArgsWithControls) {
       updateArgs = null;
       tabs = {};
     }
 
     // Use the dynamically generated component tabs if there are no controls
-    if (showComponents || !updateArgs) {
+    if (showComponents || !storyHasArgsWithControls) {
       tabs = addComponentTabs(tabs, components, context, include, exclude);
     }
 

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -160,15 +160,17 @@ export const StoryTable: FC<StoryProps & { components: Record<string, Component>
 
     // eslint-disable-next-line prefer-const
     let [args, updateArgs] = useArgs(storyId, storyStore);
-    if (!storyArgTypes || !Object.values(storyArgTypes).find((v) => !!v?.control)) {
-      updateArgs = null;
-    }
-
     let tabs = { Story: { rows: storyArgTypes, args, updateArgs } } as Record<
       string,
       ArgsTableProps
     >;
-    if (showComponents) {
+    if (!storyArgTypes || !Object.values(storyArgTypes).find((v) => !!v?.control)) {
+      updateArgs = null;
+      tabs = {};
+    }
+
+    // Use the dynamically generated component tabs if there are no controls
+    if (showComponents || !updateArgs) {
       tabs = addComponentTabs(tabs, components, context, include, exclude);
     }
 

--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -158,6 +158,12 @@ export const StoryTable: FC<StoryProps & { components: Record<string, Component>
     }
     storyArgTypes = filterArgTypes(storyArgTypes, include, exclude);
 
+    // This code handles three cases:
+    //  1. the story has args, in which case we want to show controls for the story
+    //  2. the story has args, and the user specifies showComponents, in which case
+    //     we want to show controls for the primary component AND show props for each component
+    //  3. the story has NO args, in which case we want to show props for each component
+
     // eslint-disable-next-line prefer-const
     let [args, updateArgs] = useArgs(storyId, storyStore);
     let tabs = { Story: { rows: storyArgTypes, args, updateArgs } } as Record<

--- a/examples/official-storybook/stories/addon-docs/subcomponents.stories.js
+++ b/examples/official-storybook/stories/addon-docs/subcomponents.stories.js
@@ -7,21 +7,9 @@ export default {
   component: ButtonGroup,
   parameters: { viewMode: 'docs' },
   subcomponents: { DocgenButton },
-  argTypes: {
-    background: {
-      control: { type: 'color' },
-    },
-  },
 };
 
-export const Args = (args) => (
-  <ButtonGroup {...args}>
-    <DocgenButton label="foo" />
-    <DocgenButton label="bar" />
-  </ButtonGroup>
-);
-
-export const NoArgs = () => (
+export const Basic = () => (
   <ButtonGroup background="#eee">
     <DocgenButton label="foo" />
     <DocgenButton label="bar" />


### PR DESCRIPTION
Issue: #10596

## What I did

The Args-based props controls PR caused subcomponents handling to regress.

- [x] Fix DocsPage `subcomponents` handling
- [x] Update tests

NOTE: the logic is convoluted. suggestions welcome on how to clean this up!

## How to test

In official-storybook:
- See attached story for the subcomponents behavior
- Also see the `Addons/Docs/props` stories for testing the old behavior

