### PR TITLE
Addon-docs: Fix object array in Props

### DIFF
--- a/addons/docs/src/frameworks/common/inferArgTypes.ts
+++ b/addons/docs/src/frameworks/common/inferArgTypes.ts
@@ -16,7 +16,7 @@ const inferType = (value?: any): SBType => {
   if (Array.isArray(value)) {
     const childType: SBType =
       value.length > 0 ? inferType(value[0]) : { name: 'other', value: 'unknown' };
-    return { name: 'array', value: [childType] };
+    return { name: 'array', value: childType };
   }
   if (value) {
     const fieldTypes = mapValues(value, (field) => inferType(field));

--- a/addons/docs/src/frameworks/common/inferControls.ts
+++ b/addons/docs/src/frameworks/common/inferControls.ts
@@ -4,13 +4,19 @@ import { Control } from '@storybook/components';
 import { SBEnumType } from '../../lib/sbtypes';
 
 const inferControl = (argType: ArgType): Control => {
-  if (!argType.type) {
+  const { type } = argType;
+  if (!type) {
     // console.log('no sbtype', { argType });
     return null;
   }
-  switch (argType.type.name) {
-    case 'array':
+  switch (type.name) {
+    case 'array': {
+      const { value } = type;
+      if (value?.name && ['object', 'other'].includes(value.name)) {
+        return { type: 'object' };
+      }
       return { type: 'array' };
+    }
     case 'boolean':
       return { type: 'boolean' };
     case 'string':
@@ -18,7 +24,7 @@ const inferControl = (argType: ArgType): Control => {
     case 'number':
       return { type: 'number' };
     case 'enum': {
-      const { value } = argType.type as SBEnumType;
+      const { value } = type as SBEnumType;
       return { type: 'options', controlType: 'select', options: value };
     }
     case 'function':

--- a/addons/docs/src/frameworks/common/inferControls.ts
+++ b/addons/docs/src/frameworks/common/inferControls.ts
@@ -13,7 +13,10 @@ const inferControl = (argType: ArgType): Control => {
     case 'array': {
       const { value } = type;
       if (value?.name && ['object', 'other'].includes(value.name)) {
-        return { type: 'object' };
+        return {
+          type: 'object',
+          validator: (obj: any) => Array.isArray(obj),
+        };
       }
       return { type: 'array' };
     }

--- a/addons/docs/src/lib/sbtypes/types.ts
+++ b/addons/docs/src/lib/sbtypes/types.ts
@@ -9,7 +9,7 @@ export type SBScalarType = SBBaseType & {
 
 export type SBArrayType = SBBaseType & {
   name: 'array';
-  value: SBType[];
+  value: SBType;
 };
 export type SBObjectType = SBBaseType & {
   name: 'object';

--- a/examples/official-storybook/stories/addon-docs/props.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/props.stories.mdx
@@ -6,7 +6,7 @@ import { MemoButton } from '../../components/MemoButton';
 
 <Meta title="Addons/Docs/props" component={ButtonGroup} />
 
-export const FooBar = ({ foo, bar } = {}) => (
+export const FooBar = ({ foo, bar, baz } = {}) => (
   <table>
     <tr>
       <td>Foo</td>
@@ -15,6 +15,10 @@ export const FooBar = ({ foo, bar } = {}) => (
     <tr>
       <td>Bar</td>
       <td>{bar}</td>
+    </tr>
+    <tr>
+      <td>Baz</td>
+      <td>{baz && baz.toString()}</td>
     </tr>
   </table>
 );
@@ -27,10 +31,16 @@ export const FooBar = ({ foo, bar } = {}) => (
     args={{
       foo: false,
       bar: '',
+      baz: ['a', 'b'],
     }}
     argTypes={{
       foo: { name: 'foo', type: { name: 'boolean' }, description: 'foo description' },
       bar: { name: 'bar', type: { name: 'string' }, description: 'bar description' },
+      baz: {
+        name: 'baz',
+        type: { name: 'array', value: { name: 'string' } },
+        description: 'baz description',
+      },
     }}
   >
     {(args) => <FooBar {...args} />}

--- a/lib/components/src/blocks/ArgsTable/ArgControl.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgControl.tsx
@@ -32,7 +32,7 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs }) => {
     return <>-</>;
   }
 
-  const props = { name, value: arg, onChange };
+  const props = { name, argType: row, value: arg, onChange };
   switch (control.type) {
     case 'array':
       return <ArrayControl {...props} {...control} />;

--- a/lib/components/src/controls/Object.stories.tsx
+++ b/lib/components/src/controls/Object.stories.tsx
@@ -32,9 +32,9 @@ export const ValidatedAsArray = () => {
     <>
       <ObjectControl
         name="object"
+        argType={{ type: { name: 'array' } }}
         value={value}
         onChange={(name, newVal) => setValue(newVal)}
-        validator={(obj: any) => Array.isArray(obj)}
       />
       <p>{value && JSON.stringify(value)}</p>
     </>

--- a/lib/components/src/controls/Object.stories.tsx
+++ b/lib/components/src/controls/Object.stories.tsx
@@ -25,3 +25,18 @@ export const Null = () => {
     </>
   );
 };
+
+export const ValidatedAsArray = () => {
+  const [value, setValue] = useState([]);
+  return (
+    <>
+      <ObjectControl
+        name="object"
+        value={value}
+        onChange={(name, newVal) => setValue(newVal)}
+        validator={(obj: any) => Array.isArray(obj)}
+      />
+      <p>{value && JSON.stringify(value)}</p>
+    </>
+  );
+};

--- a/lib/components/src/controls/Object.tsx
+++ b/lib/components/src/controls/Object.tsx
@@ -2,6 +2,7 @@ import React, { FC, ChangeEvent, useState, useCallback } from 'react';
 import deepEqual from 'fast-deep-equal';
 import { Form } from '../form';
 import { ControlProps, ObjectValue, ObjectConfig } from './types';
+import { ArgType } from '../blocks';
 
 const format = (value: any) => (value ? JSON.stringify(value) : '');
 
@@ -10,8 +11,15 @@ const parse = (value: string) => {
   return trimmed ? JSON.parse(trimmed) : {};
 };
 
+const validate = (value: any, argType: ArgType) => {
+  if (argType && argType.type.name === 'array') {
+    return Array.isArray(value);
+  }
+  return true;
+};
+
 export type ObjectProps = ControlProps<ObjectValue> & ObjectConfig;
-export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange, validator }) => {
+export const ObjectControl: FC<ObjectProps> = ({ name, argType, value, onChange }) => {
   const [valid, setValid] = useState(true);
   const [text, setText] = useState(format(value));
 
@@ -19,7 +27,7 @@ export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange, validato
     (e: ChangeEvent<HTMLTextAreaElement>) => {
       try {
         const newVal = parse(e.target.value);
-        const newValid = !validator || validator(newVal);
+        const newValid = validate(newVal, argType);
         if (newValid && !deepEqual(value, newVal)) {
           onChange(name, newVal);
         }

--- a/lib/components/src/controls/Object.tsx
+++ b/lib/components/src/controls/Object.tsx
@@ -11,7 +11,7 @@ const parse = (value: string) => {
 };
 
 export type ObjectProps = ControlProps<ObjectValue> & ObjectConfig;
-export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange }) => {
+export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange, validator }) => {
   const [valid, setValid] = useState(true);
   const [text, setText] = useState(format(value));
 
@@ -19,10 +19,11 @@ export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange }) => {
     (e: ChangeEvent<HTMLTextAreaElement>) => {
       try {
         const newVal = parse(e.target.value);
-        if (!deepEqual(value, newVal)) {
+        const newValid = !validator || validator(newVal);
+        if (newValid && !deepEqual(value, newVal)) {
           onChange(name, newVal);
         }
-        setValid(true);
+        setValid(newValid);
       } catch (err) {
         setValid(false);
       }

--- a/lib/components/src/controls/types.ts
+++ b/lib/components/src/controls/types.ts
@@ -1,8 +1,11 @@
+import { ArgType } from '../blocks';
+
 /* eslint-disable @typescript-eslint/no-empty-interface */
 export interface ControlProps<T> {
   name: string;
   value: T;
   defaultValue?: T;
+  argType?: ArgType;
   onChange: (name: string, value: T) => T | void;
 }
 
@@ -30,9 +33,7 @@ export interface NumberConfig {
 export type RangeConfig = NumberConfig;
 
 export type ObjectValue = any;
-export interface ObjectConfig {
-  validator?: (obj: any) => boolean;
-}
+export interface ObjectConfig {}
 
 export type OptionsSingleSelection = any;
 export type OptionsMultiSelection = any[];

--- a/lib/components/src/controls/types.ts
+++ b/lib/components/src/controls/types.ts
@@ -30,7 +30,9 @@ export interface NumberConfig {
 export type RangeConfig = NumberConfig;
 
 export type ObjectValue = any;
-export interface ObjectConfig {}
+export interface ObjectConfig {
+  validator?: (obj: any) => boolean;
+}
 
 export type OptionsSingleSelection = any;
 export type OptionsMultiSelection = any[];


### PR DESCRIPTION
Issue: #10499 #10498 

## What I did

- [x] Fix the array type. Before the "value" of the array was an array of types. Now it's a single type, which I think is more correct.
- [x] Change the control inference to show a basic JSON object editor when an array element has a complex type (e.g. object / unknown). Array control should only be used for arrays of scalars.

NOTE: The UX on this leaves a lot to be desired. This is a step up from the current state of things, though. cc @domyen 

## How to test

official-storybook:
- I added a story to test the "array of scalars" case
- There is an "array of react element" case already in the same file