### PR TITLE
Actions: Fix import of `uuid`

### DIFF
--- a/addons/actions/src/preview/action.ts
+++ b/addons/actions/src/preview/action.ts
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 import { addons } from '@storybook/addons';
 import { EVENT_ID } from '../constants';
 import { ActionDisplay, ActionOptions, HandlerFunction } from '../models';
@@ -12,7 +12,7 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
 
   const handler = function actionHandler(...args: any[]) {
     const channel = addons.getChannel();
-    const id = uuid();
+    const id = uuidv4();
     const minDepth = 5; // anything less is really just storybook internals
 
     const actionDisplayToEmit: ActionDisplay = {


### PR DESCRIPTION
## What I did

As of 8d35431027a0e849f8fcfe4f449db82f30136b77 `@storybook/addon-actions` is using version 8.0.0 of `uuid`
However, a breaking change has been missed during the upgrade:
https://github.com/uuidjs/uuid/blob/master/CHANGELOG.md#800-2020-04-29

TLDR;
> Deep requiring specific algorithms of this library like require('uuid/v4'), which has been deprecated in uuid@7, is no longer supported.
   
So I used `import { v4 as uuidv4 } from 'uuid'` instead of `import uuid from 'uuid/v4'`

## How to test

This was not causing any issue with the current test suite but breaks SB build with Yarn 2, so this kind of errors will be caught with the new E2E tests 💪 