### PR TITLE
Addon-docs: Fix custom source manual override

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -41,7 +41,7 @@ export const getSourceProps = (
     source = targetIds
       .map((sourceId) => {
         const data = storyStore.fromId(sourceId);
-        const enhanced = data && enhanceSource(data);
+        const enhanced = data && (enhanceSource(data) || data.parameters);
         return enhanced?.docs?.source?.code || '';
       })
       .join('\n\n');

--- a/examples/html-kitchen-sink/stories/__snapshots__/addon-docs.stories.storyshot
+++ b/examples/html-kitchen-sink/stories/__snapshots__/addon-docs.stories.storyshot
@@ -17,3 +17,9 @@ exports[`Storyshots Addons/Docs heading 1`] = `
   Hello World
 </h1>
 `;
+
+exports[`Storyshots Addons/Docs transformed source 1`] = `
+<h1>
+  Some source
+</h1>
+`;

--- a/examples/html-kitchen-sink/stories/addon-docs.stories.mdx
+++ b/examples/html-kitchen-sink/stories/addon-docs.stories.mdx
@@ -28,8 +28,20 @@ How you like them apples?!
 ## Custom source
 
 <Preview>
-  <Story name="custom source" height="100px" parameters={{ docs: { source: { code: 'hello' }}}}>
+  <Story name="custom source" height="100px" parameters={{ docs: { source: { code: 'hello' } } }}>
     {'<h1>Custom source</h1>'}
+  </Story>
+</Preview>
+
+## Transformed source
+
+<Preview>
+  <Story
+    name="transformed source"
+    height="100px"
+    parameters={{ docs: { transformSource: (src) => `transformed: ${src}` } }}
+  >
+    {'<h1>Some source</h1>'}
   </Story>
 </Preview>
 


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Fixed `docs.source.code` override to work alongside `transformSource` support.
- [x] Added a test case to `html-kitchen-sink`

Self-merging @tmeasday 

## How to test

See attached story docs tab