### PR TITLE
Addon-docs: Fix broken props logic for no-args stories

### DIFF
--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -170,14 +170,16 @@ export const StoryTable: FC<StoryProps & { components: Record<string, Component>
       string,
       ArgsTableProps
     >;
+
+    // Use the dynamically generated component tabs if there are no controls
     const storyHasArgsWithControls =
-      !storyArgTypes || !Object.values(storyArgTypes).find((v) => !!v?.control);
-    if (storyHasArgsWithControls) {
+      storyArgTypes && Object.values(storyArgTypes).find((v) => !!v?.control);
+
+    if (!storyHasArgsWithControls) {
       updateArgs = null;
       tabs = {};
     }
 
-    // Use the dynamically generated component tabs if there are no controls
     if (showComponents || !storyHasArgsWithControls) {
       tabs = addComponentTabs(tabs, components, context, include, exclude);
     }


### PR DESCRIPTION
Issue: N/A

## What I did

Fix typo introduced in code review for #10608 

Self-merging @tmeasday. We probably need a better way to test the docs tab 🤕 

## How to test

See props stories in `official-storybook`
