### PR TITLE
Addon-backgrounds: simplified parameters API 

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,7 @@
 <h1>Migration</h1>
 
 - [From version 5.3.x to 6.0.x](#from-version-53x-to-60x)
+  - [Backgrounds addon has a new API](#backgrounds-addon-has-a-new-api)
   - [CRA preset removed](#cra-preset-removed)
   - [Args passed as first argument to story](#args-passed-as-first-argument-to-story)
   - [Docs theme separated](#docs-theme-separated)
@@ -107,6 +108,68 @@
   - [Deprecated embedded addons](#deprecated-embedded-addons)
 
 ## From version 5.3.x to 6.0.x
+
+### Backgrounds addon has a new api
+
+Starting in 6.0, the backgrounds addon now receives an object instead of an array as parameter, with a property to define the default background.
+
+Consider the following example of its usage in both `preview.js` and `Button.stories.js`:
+```jsx
+// preview.js
+import { addParameters } from '@storybook/react'; // <- or your storybook framework
+
+addParameters({
+  backgrounds: [
+    { name: 'twitter', value: '#00aced', default: true },
+    { name: 'facebook', value: '#3b5998' },
+  ],
+});
+
+// Button.stories.js
+import React from 'react';
+
+export default {
+  title: 'Button',
+  parameters: {
+    backgrounds: [
+      { name: 'twitter', value: '#00aced', default: true },
+      { name: 'facebook', value: '#3b5998' },
+    ],
+  },
+};
+```
+
+Here's an updated version of the example, using the new api:
+```jsx
+// preview.js
+import { addParameters } from '@storybook/react'; // <- or your storybook framework
+
+addParameters({
+  backgrounds: {
+    default: 'twitter',
+    values: [
+      { name: 'twitter', value: '#00aced' },
+      { name: 'facebook', value: '#3b5998' },
+    ],
+  },
+});
+
+// Button.stories.js
+import React from 'react';
+
+export default {
+  title: 'Button',
+  parameters: {
+    backgrounds: {
+      default: 'twitter',
+      values: [
+        { name: 'twitter', value: '#00aced' },
+        { name: 'facebook', value: '#3b5998' },
+      ],
+    },
+  },
+};
+```
 
 ### CRA preset removed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -113,21 +113,9 @@
 
 Starting in 6.0, the backgrounds addon now receives an object instead of an array as parameter, with a property to define the default background.
 
-Consider the following example of its usage in both `preview.js` and `Button.stories.js`:
+Consider the following example of its usage in `Button.stories.js`:
 ```jsx
-// preview.js
-import { addParameters } from '@storybook/react'; // <- or your storybook framework
-
-addParameters({
-  backgrounds: [
-    { name: 'twitter', value: '#00aced', default: true },
-    { name: 'facebook', value: '#3b5998' },
-  ],
-});
-
 // Button.stories.js
-import React from 'react';
-
 export default {
   title: 'Button',
   parameters: {
@@ -141,22 +129,7 @@ export default {
 
 Here's an updated version of the example, using the new api:
 ```jsx
-// preview.js
-import { addParameters } from '@storybook/react'; // <- or your storybook framework
-
-addParameters({
-  backgrounds: {
-    default: 'twitter',
-    values: [
-      { name: 'twitter', value: '#00aced' },
-      { name: 'facebook', value: '#3b5998' },
-    ],
-  },
-});
-
 // Button.stories.js
-import React from 'react';
-
 export default {
   title: 'Button',
   parameters: {

--- a/addons/backgrounds/README.md
+++ b/addons/backgrounds/README.md
@@ -14,9 +14,9 @@ npm i -D @storybook/addon-backgrounds
 
 ## Configuration
 
-Then create a file called `main.js` in your storybook config.
+If it doesn't exist yet, create a file called `main.js` in your storybook config.
 
-Add following content to it:
+Add the following content to it:
 
 ```js
 module.exports = {
@@ -26,18 +26,29 @@ module.exports = {
 
 ## Usage
 
-Then write your stories like this:
+Backgrounds requires two parameters: 
+* `default` - matches the **name** of the value which will be selected by default.
+* `values`  - an array of elements containing name and value (with a valid css color e.g. HEX, RGBA, etc.)
 
-```js
+Write your stories like this:
+
+```jsx
 import React from 'react';
 
+/*
+ * Button.stories.js
+ * Applies backgrounds to the Stories 
+ */
 export default {
   title: 'Button',
   parameters: {
-    backgrounds: [
-      { name: 'twitter', value: '#00aced', default: true },
-      { name: 'facebook', value: '#3b5998' },
-    ]
+    backgrounds: {
+      default: 'twitter',
+      values: [
+        { name: 'twitter', value: '#00aced' },
+        { name: 'facebook', value: '#3b5998' },
+      ],
+    },
   },
 };
 
@@ -52,16 +63,19 @@ You can add the backgrounds to all stories with `addParameters` in `.storybook/p
 import { addParameters } from '@storybook/react'; // <- or your storybook framework
 
 addParameters({
-  backgrounds: [
-    { name: 'twitter', value: '#00aced', default: true },
-    { name: 'facebook', value: '#3b5998' },
-  ],
+  backgrounds: {
+    default: 'twitter',
+    values: [
+      { name: 'twitter', value: '#00aced' },
+      { name: 'facebook', value: '#3b5998' },
+    ],
+  },
 });
 ```
 
 If you want to override backgrounds for a single story or group of stories, pass the `backgrounds` parameter:
 
-```js
+```jsx
 import React from 'react';
 
 export default {
@@ -71,39 +85,39 @@ export default {
 export const defaultView = () => (
   <button>Click me</button>
 );
+
 defaultView.story = {
   parameters: {
-    backgrounds: [
-      { name: 'red', value: 'rgba(255, 0, 0)' },
-    ],
-  },
+    backgrounds: {
+      default: 'red',
+      values: [
+        { name: 'red', value: 'rgba(255, 0, 0)' },
+      ],
+    },
+  }
 };
 ```
 
-If you don't want to use backgrounds for a story, you can set the `backgrounds` parameter to `[]`, or use `{ disable: true }` to skip the addon:
+If you don't want to use backgrounds for a story, you can set the `backgrounds` parameter to `{ disable: true }` to skip the addon:
 
-```js
+```jsx
 import React from 'react';
 
+/*
+ * Button.stories.js
+ * Disables backgrounds for one Story 
+ */
 export default {
   title: 'Button',
 }
 
-export const noBackgrounds = () => (
-  <button>Click me</button>
-);
-noBackgrounds.story = {
-  parameters: {
-    backgrounds: [],
-  },
-};
-
 export const disabledBackgrounds = () => (
   <button>Click me</button>
 );
+
 disabledBackgrounds.story = {
   parameters: {
-    backgrounds: { disabled: true },
+    backgrounds: { disable: true },
   },
 };
 ```

--- a/addons/backgrounds/README.md
+++ b/addons/backgrounds/README.md
@@ -57,12 +57,10 @@ export const defaultView = () => (
 );
 ```
 
-You can add the backgrounds to all stories with `addParameters` in `.storybook/preview.js`:
+You can add the backgrounds to all stories by using `parameters` in `.storybook/preview.js`:
 
 ```js
-import { addParameters } from '@storybook/react'; // <- or your storybook framework
-
-addParameters({
+export const parameters = {
   backgrounds: {
     default: 'twitter',
     values: [
@@ -70,7 +68,7 @@ addParameters({
       { name: 'facebook', value: '#3b5998' },
     ],
   },
-});
+};
 ```
 
 If you want to override backgrounds for a single story or group of stories, pass the `backgrounds` parameter:
@@ -96,6 +94,26 @@ defaultView.story = {
     },
   }
 };
+```
+
+Once you have defined backgrounds for your stories (as can be seen in the examples above), you can set a default background per story by passing the `default` property using a name from the available backgrounds:
+```jsx
+import React from 'react';
+
+/*
+ * Button.stories.js
+ * Applies default background to the Stories 
+ */
+export default {
+  title: 'Button',
+  parameters: {
+    backgrounds: { default: 'twitter' },
+  },
+}
+
+export const twitterColorSelected = () => (
+  <button>Click me</button>
+);
 ```
 
 If you don't want to use backgrounds for a story, you can set the `backgrounds` parameter to `{ disable: true }` to skip the addon:

--- a/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -138,7 +138,7 @@ const getBackgroundsConfig = ({ api, state }: Combo): BackgroundsConfig => {
 
   return {
     disable: false,
-    backgrounds: backgroundsParameter.values,
+    backgrounds: backgroundsParameter?.values,
     selectedBackground: selectedBackgroundValue,
     defaultBackgroundName: backgroundsParameter?.default,
   };

--- a/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -121,7 +121,7 @@ const getBackgroundsConfig = ({ api, state }: Combo): BackgroundsConfig => {
 
   if (Array.isArray(backgroundsParameter)) {
     logger.warn(
-      'Addon Backgrounds api has changed in Storybook 6.0. Please refer to the migration guide.'
+      'Addon Backgrounds api has changed in Storybook 6.0. Please refer to the migration guide: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md'
     );
   }
 

--- a/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -3,13 +3,23 @@ import memoize from 'memoizerific';
 
 import { Combo, Consumer, API } from '@storybook/api';
 import { Global, Theme } from '@storybook/theming';
+import { logger } from '@storybook/client-logger';
 
 import { Icons, IconButton, WithTooltip, TooltipLinkList } from '@storybook/components';
 
-import { PARAM_KEY, EVENTS } from '../constants';
+import { PARAM_KEY as BACKGROUNDS_PARAM_KEY, EVENTS } from '../constants';
 import { ColorIcon } from '../components/ColorIcon';
 
-interface Item {
+interface GlobalState {
+  name: string | undefined;
+  selected: string | undefined;
+}
+
+interface Props {
+  api: API;
+}
+
+interface BackgroundSelectorItem {
   id: string;
   title: string;
   onClick: () => void;
@@ -17,10 +27,22 @@ interface Item {
   right?: ReactElement;
 }
 
-interface Input {
+interface Background {
   name: string;
   value: string;
-  default?: boolean;
+}
+
+interface BackgroundsParameter {
+  default?: string;
+  disable?: boolean;
+  values: Background[];
+}
+
+interface BackgroundsConfig {
+  backgrounds: Background[] | null;
+  selectedBackground: string | null;
+  defaultBackgroundName: string | null;
+  disable: boolean;
 }
 
 const iframeId = 'storybook-preview-iframe';
@@ -32,7 +54,7 @@ const createBackgroundSelectorItem = memoize(1000)(
     value: string,
     hasSwatch: boolean,
     change: (arg: { selected: string; name: string }) => void
-  ): Item => ({
+  ): BackgroundSelectorItem => ({
     id: id || name,
     title: name,
     onClick: () => {
@@ -43,85 +65,114 @@ const createBackgroundSelectorItem = memoize(1000)(
   })
 );
 
-const getSelectedBackgroundColor = (list: Input[], currentSelectedValue: string): string => {
-  if (!list.length) {
+const getDisplayedItems = memoize(10)(
+  (
+    backgrounds: Background[],
+    selectedBackgroundColor: string | null,
+    change: (arg: { selected: string; name: string }) => void
+  ) => {
+    const backgroundSelectorItems = backgrounds.map(({ name, value }) =>
+      createBackgroundSelectorItem(null, name, value, true, change)
+    );
+
+    if (selectedBackgroundColor !== 'transparent') {
+      return [
+        createBackgroundSelectorItem('reset', 'Clear background', 'transparent', null, change),
+        ...backgroundSelectorItems,
+      ];
+    }
+
+    return backgroundSelectorItems;
+  }
+);
+
+const getSelectedBackgroundColor = (
+  backgrounds: Background[] = [],
+  currentSelectedValue: string,
+  defaultName: string
+): string => {
+  if (currentSelectedValue === 'transparent') {
     return 'transparent';
   }
 
-  if (currentSelectedValue === 'transparent') {
+  if (backgrounds.find((background) => background.value === currentSelectedValue)) {
     return currentSelectedValue;
   }
 
-  if (list.find((i) => i.value === currentSelectedValue)) {
-    return currentSelectedValue;
+  const defaultBackground = backgrounds.find((background) => background.name === defaultName);
+  if (defaultBackground) {
+    return defaultBackground.value;
   }
 
-  if (list.find((i) => i.default)) {
-    return list.find((i) => i.default).value;
+  if (defaultName) {
+    const availableColors = backgrounds.map((background) => background.name).join(', ');
+    logger.warn(
+      `Backgrounds Addon: could not find the default color "${defaultName}".
+      These are the available colors for your story based on your configuration: ${availableColors}`
+    );
   }
 
   return 'transparent';
 };
 
-const mapper = ({ api, state }: Combo): { items: Input[]; selected: string | null } => {
-  const list = api.getCurrentParameter<Input[]>(PARAM_KEY);
-  const selected = state.addons[PARAM_KEY] || null;
+const getBackgroundsConfig = ({ api, state }: Combo): BackgroundsConfig => {
+  const backgroundsParameter = api.getCurrentParameter<BackgroundsParameter>(BACKGROUNDS_PARAM_KEY);
+  const selectedBackgroundValue = state.addons[BACKGROUNDS_PARAM_KEY] || null;
 
-  return { items: list || [], selected };
-};
-
-const getDisplayedItems = memoize(10)(
-  (
-    list: Input[],
-    selected: string | null,
-    change: (arg: { selected: string; name: string }) => void
-  ) => {
-    let availableBackgroundSelectorItems: Item[] = [];
-
-    if (selected !== 'transparent') {
-      availableBackgroundSelectorItems.push(
-        createBackgroundSelectorItem('reset', 'Clear background', 'transparent', null, change)
-      );
-    }
-
-    if (list.length) {
-      availableBackgroundSelectorItems = [
-        ...availableBackgroundSelectorItems,
-        ...list.map(({ name, value }) =>
-          createBackgroundSelectorItem(null, name, value, true, change)
-        ),
-      ];
-    }
-
-    return availableBackgroundSelectorItems;
+  if (Array.isArray(backgroundsParameter)) {
+    logger.warn(
+      'Addon Backgrounds api has changed in Storybook 6.0. Please refer to the migration guide.'
+    );
   }
-);
 
-interface GlobalState {
-  name: string | undefined;
-  selected: string | undefined;
-}
+  const isBackgroundsEmpty = !backgroundsParameter?.values?.length;
+  if (backgroundsParameter?.disable || isBackgroundsEmpty) {
+    // other null properties are necessary to keep the same return shape for Consumer memoization
+    return {
+      disable: true,
+      backgrounds: null,
+      selectedBackground: null,
+      defaultBackgroundName: null,
+    };
+  }
 
-interface Props {
-  api: API;
-}
+  return {
+    disable: false,
+    backgrounds: backgroundsParameter.values,
+    selectedBackground: selectedBackgroundValue,
+    defaultBackgroundName: backgroundsParameter?.default,
+  };
+};
 
 export class BackgroundSelector extends Component<Props> {
   change = ({ selected, name }: GlobalState) => {
     const { api } = this.props;
     if (typeof selected === 'string') {
-      api.setAddonState<string>(PARAM_KEY, selected);
+      api.setAddonState<string>(BACKGROUNDS_PARAM_KEY, selected);
     }
     api.emit(EVENTS.UPDATE, { selected, name });
   };
 
   render() {
     return (
-      <Consumer filter={mapper}>
-        {({ items, selected }: ReturnType<typeof mapper>) => {
-          const selectedBackgroundColor = getSelectedBackgroundColor(items, selected);
+      <Consumer filter={getBackgroundsConfig}>
+        {({
+          disable,
+          backgrounds,
+          selectedBackground,
+          defaultBackgroundName,
+        }: BackgroundsConfig) => {
+          if (disable) {
+            return null;
+          }
 
-          return items.length ? (
+          const selectedBackgroundColor = getSelectedBackgroundColor(
+            backgrounds,
+            selectedBackground,
+            defaultBackgroundName
+          );
+
+          return (
             <Fragment>
               {selectedBackgroundColor ? (
                 <Global
@@ -138,26 +189,26 @@ export class BackgroundSelector extends Component<Props> {
               <WithTooltip
                 placement="top"
                 trigger="click"
+                closeOnClick
                 tooltip={({ onHide }) => (
                   <TooltipLinkList
-                    links={getDisplayedItems(items, selectedBackgroundColor, (i) => {
+                    links={getDisplayedItems(backgrounds, selectedBackgroundColor, (i) => {
                       this.change(i);
                       onHide();
                     })}
                   />
                 )}
-                closeOnClick
               >
                 <IconButton
                   key="background"
-                  active={selectedBackgroundColor !== 'transparent'}
                   title="Change the background of the preview"
+                  active={selectedBackgroundColor !== 'transparent'}
                 >
                   <Icons icon="photo" />
                 </IconButton>
               </WithTooltip>
             </Fragment>
-          ) : null;
+          );
         }}
       </Consumer>
     );

--- a/examples/angular-cli/src/stories/addon-background.stories.ts
+++ b/examples/angular-cli/src/stories/addon-background.stories.ts
@@ -9,10 +9,13 @@ storiesOf('Addon/Background', module)
     })
   )
   .addParameters({
-    backgrounds: [
-      { name: 'twitter', value: '#00aced', default: true },
-      { name: 'facebook', value: '#3b5998' },
-    ],
+    backgrounds: {
+      default: 'twitter',
+      values: [
+        { name: 'twitter', value: '#00aced' },
+        { name: 'facebook', value: '#3b5998' },
+      ],
+    },
   })
   .add('background component', () => ({
     component: AppComponent,

--- a/examples/ember-cli/stories/addon-backgrounds.stories.js
+++ b/examples/ember-cli/stories/addon-backgrounds.stories.js
@@ -4,10 +4,13 @@ export default {
   title: 'Addon/Backgrounds',
 
   parameters: {
-    backgrounds: [
-      { name: 'light', value: '#eeeeee' },
-      { name: 'dark', value: '#222222', default: true },
-    ],
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'light', value: '#eeeeee' },
+        { name: 'dark', value: '#222222' },
+      ],
+    },
   },
 };
 

--- a/examples/html-kitchen-sink/stories/addon-backgrounds.stories.js
+++ b/examples/html-kitchen-sink/stories/addon-backgrounds.stories.js
@@ -1,10 +1,13 @@
 export default {
   title: 'Addons/Backgrounds',
   parameters: {
-    backgrounds: [
-      { name: 'light', value: '#eeeeee' },
-      { name: 'dark', value: '#222222', default: true },
-    ],
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'light', value: '#eeeeee' },
+        { name: 'dark', value: '#222222' },
+      ],
+    },
   },
 };
 

--- a/examples/mithril-kitchen-sink/src/stories/addon-backgrounds.stories.js
+++ b/examples/mithril-kitchen-sink/src/stories/addon-backgrounds.stories.js
@@ -6,10 +6,13 @@ import BaseButton from '../BaseButton';
 export default {
   title: 'Addons/Backgrounds',
   parameters: {
-    backgrounds: [
-      { name: 'light', value: '#eeeeee' },
-      { name: 'dark', value: '#222222', default: true },
-    ],
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'light', value: '#eeeeee' },
+        { name: 'dark', value: '#222222' },
+      ],
+    },
   },
 };
 

--- a/examples/official-storybook/preview.js
+++ b/examples/official-storybook/preview.js
@@ -56,11 +56,14 @@ addParameters({
     storySort: (a, b) =>
       a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
   },
-  backgrounds: [
-    { name: 'storybook app', value: themes.light.appBg, default: true },
-    { name: 'light', value: '#eeeeee' },
-    { name: 'dark', value: '#222222' },
-  ],
+  backgrounds: {
+    default: 'storybook app',
+    values: [
+      { name: 'storybook app', value: themes.light.appBg },
+      { name: 'light', value: '#eeeeee' },
+      { name: 'dark', value: '#222222' },
+    ],
+  },
   docs: {
     theme: themes.light,
     page: () => <DocsPage subtitleSlot={({ kind }) => `Subtitle: ${kind}`} />,

--- a/examples/official-storybook/stories/addon-backgrounds.stories.js
+++ b/examples/official-storybook/stories/addon-backgrounds.stories.js
@@ -6,13 +6,16 @@ export default {
   title: 'Addons/Backgrounds',
 
   parameters: {
-    backgrounds: [
-      { name: 'white', value: '#ffffff' },
-      { name: 'light', value: '#eeeeee' },
-      { name: 'gray', value: '#cccccc' },
-      { name: 'dark', value: '#222222', default: true },
-      { name: 'black', value: '#000000' },
-    ],
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'white', value: '#ffffff' },
+        { name: 'light', value: '#eeeeee' },
+        { name: 'gray', value: '#cccccc' },
+        { name: 'dark', value: '#222222' },
+        { name: 'black', value: '#000000' },
+      ],
+    },
   },
 };
 
@@ -34,29 +37,22 @@ export const Overridden = () => <BaseButton label="This one should have differen
 
 Overridden.story = {
   parameters: {
-    backgrounds: [
-      { name: 'pink', value: 'hotpink' },
-      { name: 'blue', value: 'deepskyblue', default: true },
-    ],
-  },
-};
-
-export const DisabledVia = () => <BaseButton label="This one should not use backgrounds" />;
-
-DisabledVia.story = {
-  name: 'disabled via []',
-
-  parameters: {
-    backgrounds: [],
+    backgrounds: {
+      default: 'blue',
+      values: [
+        { name: 'pink', value: 'hotpink' },
+        { name: 'blue', value: 'deepskyblue' },
+      ],
+    },
   },
 };
 
 export const SkippedViaDisableTrue = () => (
-  <BaseButton label="This one should not use backgrounds either" />
+  <BaseButton label="This one should not use backgrounds" />
 );
 
 SkippedViaDisableTrue.story = {
-  name: 'skipped via disable:true',
+  name: 'skipped via disable: true',
 
   parameters: {
     backgrounds: { disable: true },

--- a/examples/preact-kitchen-sink/src/stories/addon-backgrounds.stories.js
+++ b/examples/preact-kitchen-sink/src/stories/addon-backgrounds.stories.js
@@ -8,10 +8,13 @@ export default {
   title: 'Addons/Backgrounds',
 
   parameters: {
-    backgrounds: [
-      { name: 'twitter', value: '#00aced' },
-      { name: 'facebook', value: '#3b5998', default: true },
-    ],
+    backgrounds: {
+      default: 'facebook',
+      values: [
+        { name: 'twitter', value: '#00aced' },
+        { name: 'facebook', value: '#3b5998' },
+      ],
+    },
   },
 };
 

--- a/examples/riot-kitchen-sink/src/stories/addon-backgrounds.stories.js
+++ b/examples/riot-kitchen-sink/src/stories/addon-backgrounds.stories.js
@@ -3,10 +3,13 @@ import ButtonRaw from './Button.txt';
 export default {
   title: 'Addon/Backgrounds',
   parameters: {
-    backgrounds: [
-      { name: 'light', value: '#eeeeee' },
-      { name: 'dark', value: '#222222', default: true },
-    ],
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'light', value: '#eeeeee' },
+        { name: 'dark', value: '#222222' },
+      ],
+    },
   },
 };
 

--- a/examples/svelte-kitchen-sink/src/stories/addon-backgrounds.stories.js
+++ b/examples/svelte-kitchen-sink/src/stories/addon-backgrounds.stories.js
@@ -3,10 +3,13 @@ import ButtonView from './views/ButtonView.svelte';
 export default {
   title: 'Addon/Backgrounds',
   parameters: {
-    backgrounds: [
-      { name: 'light', value: '#eeeeee' },
-      { name: 'dark', value: '#222222', default: true },
-    ],
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'light', value: '#eeeeee' },
+        { name: 'dark', value: '#222222' },
+      ],
+    },
   },
 };
 

--- a/examples/vue-kitchen-sink/src/stories/addon-backgrounds.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/addon-backgrounds.stories.js
@@ -1,10 +1,13 @@
 export default {
   title: 'Addon/Backgrounds',
   parameters: {
-    backgrounds: [
-      { name: 'light', value: '#eeeeee' },
-      { name: 'dark', value: '#222222', default: true },
-    ],
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'light', value: '#eeeeee' },
+        { name: 'dark', value: '#222222' },
+      ],
+    },
   },
 };
 

--- a/examples/web-components-kitchen-sink/stories/addon-backgrounds.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-backgrounds.stories.js
@@ -5,10 +5,13 @@ import '../demo-wc-card.js';
 export default {
   title: 'Addons/Backgrounds',
   parameters: {
-    backgrounds: [
-      { name: 'light', value: '#eeeeee' },
-      { name: 'dark', value: '#222222', default: true },
-    ],
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'light', value: '#eeeeee' },
+        { name: 'dark', value: '#222222' },
+      ],
+    },
   },
 };
 

--- a/lib/ui/src/components/sidebar/Sidebar.stories.tsx
+++ b/lib/ui/src/components/sidebar/Sidebar.stories.tsx
@@ -89,6 +89,9 @@ export const darkWithRefs = () => (
 
 darkWithRefs.story = {
   parameters: {
-    backgrounds: [{ name: 'dark', value: '#222222', default: true }],
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#222222', default: true }],
+    },
   },
 };


### PR DESCRIPTION
Issue: #10572

## What I did
Simplified the backgrounds addon api, using an object instead of an array so that it allows proper merge in storybook parameters.
While I was at it, I refactored the code to make sure it's more clear so that anyone checking this code without much context would be able to understand it. **I shifted code around, so the diff here might be a bit misleading.**

## How to test

In the monorepo, build the examples and run `yarn start`. From there, select addon backgrounds stories and test them.

- Is this testable with Jest or Chromatic screenshots?
I was writing unit tests but it felt wrong, as I was making private methods public just for the sake of testing them. So Ideally this should be tested with E2E, and will likely be done in #10447 

- Does this need a new example in the kitchen sink apps?
The examples in the monorepo have been updated

- Does this need an update to the documentation?
Both backgrounds README and MIGRATION have been updated

## Next steps

Hopefully write a codemod to help people migrate but also to have a simpler codemod example in the monorepo, so it can be used as reference in the future
