### PR TITLE
Update readme with small ThemeProvider example

### DIFF
--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -297,6 +297,33 @@ import { Meta, DocsContainer } from '@storybook/addon-docs/blocks';
 Rest of your file...
 ```
 
+This is especially useful if you are using `styled-components` and need to wrap your JSX with a `ThemeProvider` to have access to your theme:
+
+```js
+import { Meta, DocsContainer } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components'
+import { theme } from '../path/to/theme'
+
+<Meta
+  title="Addons/Docs/container-override"
+  parameters={{
+    docs: {
+      container: ({ children, context }) => (
+        <DocsContainer context={context}>
+          <ThemeProvider theme={theme}>
+            {children}
+          </ThemeProvider>
+        </DocsContainer>
+      ),
+    },
+  }}
+/>
+
+# Title
+
+Rest of your file...
+```
+
 ## More resources
 
 - References: [README](../README.md) / [DocsPage](docspage.md) / [MDX](mdx.md) / [FAQ](faq.md) / [Recipes](recipes.md) / [Theming](theming.md) / [Props](props-tables.md)


### PR DESCRIPTION
Issue:

## What I did

Added a small example of wrapping JSX with `ThemeProvider` to the docs recipes.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
