### PR TITLE
fix: remove corejs-upgrade-webpack-plugin dependency

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -821,6 +821,8 @@ After a few iterations, this approach seems to be working. However, there are a 
 
 We'll update this section as we find more problem cases. If you have a `core-js` problem, please file an issue (preferably with a repro), and we'll do our best to get you sorted.
 
+__Update__: [corejs-upgrade-webpack-plugin](https://github.com/ndelangen/corejs-upgrade-webpack-plugin) has been removed again after running into further issues as described in [https://github.com/storybookjs/storybook/issues/7445](https://github.com/storybookjs/storybook/issues/7445).
+
 ## From version 5.0.1 to 5.0.2
 
 ### Deprecate webpack extend mode

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -97,7 +97,6 @@
     "@types/util-deprecate": "^1.0.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-react-docgen": "^4.1.0",
-    "corejs-upgrade-webpack-plugin": "^4.0.1",
     "cross-spawn": "^7.0.1",
     "fs-extra": "^9.0.0",
     "jest": "^25.5.2",

--- a/addons/docs/scripts/webpackDllsConfig.js
+++ b/addons/docs/scripts/webpackDllsConfig.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import { ProgressPlugin, DllPlugin } from 'webpack';
 import TerserPlugin from 'terser-webpack-plugin';
-import CoreJSUpgradeWebpackPlugin from 'corejs-upgrade-webpack-plugin';
 
 const resolveLocal = (dir) => path.join(__dirname, dir);
 
@@ -60,7 +59,6 @@ export default ({ entry, provided = [] }) => ({
       path: `${out}/storybook_docs-manifest.json`,
       name: 'storybook_docs_dll',
     }),
-    new CoreJSUpgradeWebpackPlugin(),
   ],
   optimization: {
     concatenateModules: true,

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -65,7 +65,6 @@
     "cli-table3": "0.6.0",
     "commander": "^5.0.0",
     "core-js": "^3.0.1",
-    "corejs-upgrade-webpack-plugin": "^4.0.1",
     "css-loader": "^3.5.3",
     "detect-port": "^1.3.0",
     "dotenv-webpack": "^1.7.0",

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -4,7 +4,6 @@ import { DefinePlugin, DllReferencePlugin } from 'webpack';
 import Dotenv from 'dotenv-webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
-import CoreJSUpgradeWebpackPlugin from 'corejs-upgrade-webpack-plugin';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';
 
@@ -96,7 +95,6 @@ export default ({
         'process.env': stringified,
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       }),
-      new CoreJSUpgradeWebpackPlugin({ resolveFrom: __dirname }),
     ].filter(Boolean),
     module: {
       rules: [

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -6,7 +6,6 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import WatchMissingNodeModulesPlugin from 'react-dev-utils/WatchMissingNodeModulesPlugin';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
-import CoreJSUpgradeWebpackPlugin from 'corejs-upgrade-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
 
@@ -130,7 +129,6 @@ export default async ({
       new CaseSensitivePathsPlugin(),
       quiet ? null : new ProgressPlugin(),
       new Dotenv({ silent: true }),
-      new CoreJSUpgradeWebpackPlugin({ resolveFrom: __dirname }),
     ].filter(Boolean),
     module: {
       rules: [

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -72,7 +72,6 @@
     "@testing-library/react": "^10.0.3",
     "babel-loader": "^8.0.6",
     "chromatic": "^4.0.2",
-    "corejs-upgrade-webpack-plugin": "^4.0.1",
     "enzyme": "^3.11.0",
     "flush-promises": "^1.0.2",
     "terser-webpack-plugin": "^3.0.0",

--- a/lib/ui/scripts/webpackDllsConfig.js
+++ b/lib/ui/scripts/webpackDllsConfig.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import { ProgressPlugin, DllPlugin } from 'webpack';
 import TerserPlugin from 'terser-webpack-plugin';
-import CoreJSUpgradeWebpackPlugin from 'corejs-upgrade-webpack-plugin';
 
 const resolveLocal = (dir) => path.join(__dirname, dir);
 
@@ -60,7 +59,6 @@ export default ({ entry, provided = [] }) => ({
       path: `${out}/storybook_ui-manifest.json`,
       name: 'storybook_ui_dll',
     }),
-    new CoreJSUpgradeWebpackPlugin(),
   ],
   optimization: {
     concatenateModules: true,

--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "commander": "^5.1.0",
     "concurrently": "^5.2.0",
     "core-js": "^3.0.1",
-    "corejs-upgrade-webpack-plugin": "^4.0.1",
     "cross-env": "^7.0.0",
     "danger": "^10.1.1",
     "del": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10595,7 +10595,7 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.0.1, core-js@^3.0.4, core-js@^3.5.0, core-js@^3.6.4:
+core-js@^3.0.1, core-js@^3.0.4, core-js@^3.5.0:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
@@ -10611,16 +10611,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-
-corejs-upgrade-webpack-plugin@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/corejs-upgrade-webpack-plugin/-/corejs-upgrade-webpack-plugin-4.0.1.tgz#c29d61099418b77f17a8b57066d8f71abcbb64c1"
-  integrity sha512-hQl/FyyCuo9pQloW2zNaRpb2GZBb4JaULICUArLDR3O4bPqDZHAXbVov1O+UEfKPb9lqXrRL1miDIXZVO3AN9Q==
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^3.6.4"
-    resolve-from "^5.0.0"
-    webpack "^4.42.1"
 
 cors@^2.8.5, cors@latest:
   version "2.8.5"
@@ -32211,7 +32201,7 @@ webpack@4.42.0:
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
 
-webpack@^4.27.1, webpack@^4.33.0, webpack@^4.38.0, webpack@^4.41.2, webpack@^4.41.4, webpack@^4.42.1, webpack@^4.43.0:
+webpack@^4.27.1, webpack@^4.33.0, webpack@^4.38.0, webpack@^4.41.2, webpack@^4.41.4, webpack@^4.43.0:
   version "4.43.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"
   integrity sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==


### PR DESCRIPTION
The dependency caused multiple issues, since it's not possible to
just replace one dependency version with another if a specific
version is required.
Remove the dependency from storybook to fix the issue.

Fixes: https://github.com/storybookjs/storybook/issues/7445

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
