### PR TITLE
cli: add legacy flag that transpiles some node_modules

### DIFF
--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -28,7 +28,7 @@ async function getCLI(packageJson) {
     .option('--quiet', 'Suppress verbose build output')
     .option('--no-version-updates', 'Suppress update check', true)
     .option('--no-dll', 'Do not use dll reference')
-    .option('--legacy', 'Transpile node_modules for IE 11')
+    .option('--compatibility < legacy | modern >', 'Transpile node_modules for older browsers')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(
       '--preview-url [string]',

--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -28,6 +28,7 @@ async function getCLI(packageJson) {
     .option('--quiet', 'Suppress verbose build output')
     .option('--no-version-updates', 'Suppress update check', true)
     .option('--no-dll', 'Do not use dll reference')
+    .option('--legacy', 'Transpile node_modules for IE 11')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(
       '--preview-url [string]',

--- a/lib/core/src/server/cli/prod.js
+++ b/lib/core/src/server/cli/prod.js
@@ -15,6 +15,7 @@ function getCLI(packageJson) {
     .option('--quiet', 'Suppress verbose build output')
     .option('--loglevel [level]', 'Control level of logging during build')
     .option('--no-dll', 'Do not use dll reference')
+    .option('--legacy', 'Transpile node_modules for IE 11')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(
       '--preview-url [string]',

--- a/lib/core/src/server/cli/prod.js
+++ b/lib/core/src/server/cli/prod.js
@@ -15,7 +15,7 @@ function getCLI(packageJson) {
     .option('--quiet', 'Suppress verbose build output')
     .option('--loglevel [level]', 'Control level of logging during build')
     .option('--no-dll', 'Do not use dll reference')
-    .option('--legacy', 'Transpile node_modules for IE 11')
+    .option('--compatibility < legacy | modern >', 'Transpile node_modules for older browsers')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(
       '--preview-url [string]',

--- a/lib/core/src/server/common/legacy-loader.js
+++ b/lib/core/src/server/common/legacy-loader.js
@@ -1,0 +1,40 @@
+// Run npx are-you-es5 check lib/core -r
+// to get this regexp
+
+const regexp = /[\\/]node_modules[\\/](?!(@storybook\/node-logger|are-you-es5|better-opn|boxen|chalk|commander|find-cache-dir|find-up|fs-extra|json5|node-fetch|pkg-dir|resolve-from|semver)[\\/])/;
+
+export default {
+  test: /\.(mjs|tsx?|jsx?)$/,
+  use: [
+    {
+      loader: require.resolve('babel-loader'),
+      options: {
+        sourceType: 'unambiguous',
+        presets: [
+          [
+            require.resolve('@babel/preset-env'),
+            {
+              shippedProposals: true,
+              useBuiltIns: 'usage',
+              corejs: '3',
+            },
+          ],
+          require.resolve('@babel/preset-typescript'),
+          require.resolve('@babel/preset-react'),
+        ],
+        plugins: [
+          [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
+          require.resolve('@babel/plugin-proposal-export-default-from'),
+          require.resolve('@babel/plugin-syntax-dynamic-import'),
+          [
+            require.resolve('@babel/plugin-proposal-object-rest-spread'),
+            { loose: true, useBuiltIns: true },
+          ],
+          require.resolve('babel-plugin-macros'),
+        ],
+      },
+    },
+  ],
+  include: [/node_modules/],
+  exclude: [regexp],
+};

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -10,6 +10,7 @@ import VirtualModulePlugin from 'webpack-virtual-modules';
 
 import themingPaths from '@storybook/theming/paths';
 import uiPaths from '@storybook/ui/paths';
+import { logger } from '@storybook/node-logger';
 
 import { version } from '../../../package.json';
 import { getManagerHeadHtml } from '../utils/template';
@@ -17,6 +18,7 @@ import { loadEnv } from '../config/utils';
 
 import babelLoader from './babel-loader-manager';
 import { resolvePathInStorybookCache } from '../utils/resolve-path-in-sb-cache';
+import legacyLoader from '../common/legacy-loader';
 
 const coreDirName = path.dirname(require.resolve('@storybook/core/package.json'));
 // TODO: improve node_modules detection
@@ -31,6 +33,7 @@ export default ({
   entries,
   refs,
   dll,
+  legacy,
   outputDir,
   cache,
   previewUrl,
@@ -41,6 +44,17 @@ export default ({
   const refsTemplate = fse.readFileSync(path.join(__dirname, 'virtualModuleRef.template.js'), {
     encoding: 'utf8',
   });
+
+  if (legacy) {
+    logger.info("=> Transpiling some node_modules, you're brave..");
+  }
+
+  // Don't know why webpack resolves esm modules...
+  const resolveExtension = legacy
+    ? {
+        mainFields: ['main'],
+      }
+    : {};
 
   return {
     name: 'manager',
@@ -63,7 +77,7 @@ export default ({
             ),
           })
         : null,
-      dll
+      !legacy && dll
         ? new DllReferencePlugin({
             context,
             manifest: path.join(coreDirName, 'dll', 'storybook_ui-manifest.json'),
@@ -79,7 +93,7 @@ export default ({
           files,
           options,
           version,
-          dlls: dll ? ['./sb_dll/storybook_ui_dll.js'] : [],
+          dlls: !legacy && dll ? ['./sb_dll/storybook_ui_dll.js'] : [],
           globals: {
             VERSIONCHECK: JSON.stringify(versionCheck),
             DOCS_MODE: docsMode, // global docs mode
@@ -128,7 +142,8 @@ export default ({
             name: 'static/media/[name].[hash:8].[ext]',
           },
         },
-      ],
+        legacy && legacyLoader,
+      ].filter(Boolean),
     },
     resolve: {
       extensions: ['.mjs', '.js', '.jsx', '.json', '.cjs'],
@@ -141,6 +156,7 @@ export default ({
         // Transparently resolve packages via PnP when needed; noop otherwise
         PnpWebpackPlugin,
       ],
+      ...resolveExtension,
     },
     resolveLoader: {
       plugins: [PnpWebpackPlugin.moduleLoader(module)],

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -10,7 +10,6 @@ import VirtualModulePlugin from 'webpack-virtual-modules';
 
 import themingPaths from '@storybook/theming/paths';
 import uiPaths from '@storybook/ui/paths';
-import { logger } from '@storybook/node-logger';
 
 import { version } from '../../../package.json';
 import { getManagerHeadHtml } from '../utils/template';
@@ -33,7 +32,7 @@ export default ({
   entries,
   refs,
   dll,
-  legacy,
+  compatibility = 'modern',
   outputDir,
   cache,
   previewUrl,
@@ -44,10 +43,7 @@ export default ({
   const refsTemplate = fse.readFileSync(path.join(__dirname, 'virtualModuleRef.template.js'), {
     encoding: 'utf8',
   });
-
-  if (legacy) {
-    logger.info("=> Transpiling some node_modules, you're brave..");
-  }
+  const legacy = compatibility === 'legacy';
 
   // Don't know why webpack resolves esm modules...
   const resolveExtension = legacy

--- a/lib/core/src/server/preview/babel-loader-preview.js
+++ b/lib/core/src/server/preview/babel-loader-preview.js
@@ -1,13 +1,17 @@
 import { includePaths, excludePaths } from '../config/utils';
+import legacyLoader from '../common/legacy-loader';
 
-export default (options) => ({
-  test: /\.(mjs|jsx?)$/,
-  use: [
-    {
-      loader: 'babel-loader',
-      options,
-    },
-  ],
-  include: includePaths,
-  exclude: excludePaths,
-});
+export default (options) => [
+  {
+    test: /\.(mjs|jsx?)$/,
+    use: [
+      {
+        loader: 'babel-loader',
+        options,
+      },
+    ],
+    include: includePaths,
+    exclude: excludePaths,
+  },
+  legacyLoader,
+];

--- a/lib/core/src/server/preview/babel-loader-preview.js
+++ b/lib/core/src/server/preview/babel-loader-preview.js
@@ -1,5 +1,4 @@
 import { includePaths, excludePaths } from '../config/utils';
-import legacyLoader from '../common/legacy-loader';
 
 export default (options) => [
   {
@@ -13,5 +12,4 @@ export default (options) => [
     include: includePaths,
     exclude: excludePaths,
   },
-  legacyLoader,
 ];

--- a/lib/core/src/server/preview/babel-loader-preview.js
+++ b/lib/core/src/server/preview/babel-loader-preview.js
@@ -1,15 +1,13 @@
 import { includePaths, excludePaths } from '../config/utils';
 
-export default (options) => [
-  {
-    test: /\.(mjs|jsx?)$/,
-    use: [
-      {
-        loader: 'babel-loader',
-        options,
-      },
-    ],
-    include: includePaths,
-    exclude: excludePaths,
-  },
-];
+export default (options) => ({
+  test: /\.(mjs|jsx?)$/,
+  use: [
+    {
+      loader: 'babel-loader',
+      options,
+    },
+  ],
+  include: includePaths,
+  exclude: excludePaths,
+});

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -38,7 +38,7 @@ export default async ({
   configType,
   framework,
   presets,
-  legacy,
+  compatibility = 'modern',
 }) => {
   const dlls = await presets.apply('webpackDlls', []);
   const { raw, stringified } = loadEnv({ production: true });
@@ -145,7 +145,7 @@ export default async ({
             },
           ],
         },
-        legacy && legacyLoader,
+        compatibility === 'legacy' && legacyLoader,
       ].filter(Boolean),
     },
     resolve: {

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -17,6 +17,7 @@ import createBabelLoader from './babel-loader-preview';
 import { nodeModulesPaths, loadEnv } from '../config/utils';
 import { getPreviewHeadHtml, getPreviewBodyHtml } from '../utils/template';
 import { toRequireContextString } from './to-require-context';
+import legacyLoader from '../common/legacy-loader';
 
 const reactPaths = {};
 try {
@@ -37,6 +38,7 @@ export default async ({
   configType,
   framework,
   presets,
+  legacy,
 }) => {
   const dlls = await presets.apply('webpackDlls', []);
   const { raw, stringified } = loadEnv({ production: true });
@@ -143,7 +145,8 @@ export default async ({
             },
           ],
         },
-      ],
+        legacy && legacyLoader,
+      ].filter(Boolean),
     },
     resolve: {
       extensions: ['.mjs', '.js', '.jsx', '.json', '.cjs'],
@@ -158,6 +161,7 @@ export default async ({
         // Transparently resolve packages via PnP when needed; noop otherwise
         PnpWebpackPlugin,
       ],
+      mainFields: ['main'],
     },
     resolveLoader: {
       plugins: [PnpWebpackPlugin.moduleLoader(module)],

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -44,6 +44,7 @@ export default async ({
   const { raw, stringified } = loadEnv({ production: true });
   const babelLoader = createBabelLoader(babelOptions);
   const isProd = configType === 'PRODUCTION';
+  const legacy = compatibility === 'legacy';
   const entryTemplate = await fse.readFile(path.join(__dirname, 'virtualModuleEntry.template.js'), {
     encoding: 'utf8',
   });
@@ -83,6 +84,12 @@ export default async ({
       // Make sure we also replace quotes for this one
       .replace("'{{stories}}'", stories.map(toRequireContextString).join(','));
   }
+
+  const resolveExtension = legacy
+    ? {
+        mainFields: ['main'],
+      }
+    : {};
 
   return {
     mode: isProd ? 'production' : 'development',
@@ -161,7 +168,7 @@ export default async ({
         // Transparently resolve packages via PnP when needed; noop otherwise
         PnpWebpackPlugin,
       ],
-      mainFields: ['main'],
+      ...resolveExtension,
     },
     resolveLoader: {
       plugins: [PnpWebpackPlugin.moduleLoader(module)],


### PR DESCRIPTION
Issue: #10674 #10670 #10486 

## What I did

Add a legacy flag that take precedence over the dll and transpiles some node_modules detected to not be es5.

This is a suggestion, any idea is welcome !

## How to test

- Launch IE 11 with --compatibility=legacy flag
