### PR TITLE
Change reference for jest-preset-angular/build/setupJest as per migration guide

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/angular/loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/angular/loader.ts
@@ -13,11 +13,11 @@ function setupAngularJestPreset() {
   // jest.requireActual('core-js/es7/reflect');
 
   // Angular + Jest + Storyshots = Crazy Shit:
-  // We need to require 'jest-preset-angular/setupJest' before any storybook code
-  // is running inside jest -  one of the things that `jest-preset-angular/setupJest` does is
+  // We need to require 'jest-preset-angular/build/setupJest' before any storybook code
+  // is running inside jest -  one of the things that `jest-preset-angular/build/setupJest` does is
   // extending the `window.Reflect` with all the needed metadata functions, that are required
   // for emission of the TS decorations like 'design:paramtypes'
-  jest.requireActual('jest-preset-angular/setupJest');
+  jest.requireActual('jest-preset-angular/build/setupJest');
 }
 
 function test(options: StoryshotsOptions): boolean {


### PR DESCRIPTION
Issue: #9072 - Affects addon-storyshots

## What I did
Modified the path to jest-preset-angular/setupJest as per migration documentation https…://github.com/thymikee/jest-preset-angular/blob/5c071692d174d78639f952bf795bc06abd72d28c/CHANGELOG.md#migration-guide

## How to test

This is testable by running within an Angular project which requires addon-storyshots

- Is this testable with Jest or Chromatic screenshots? 
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
