### PR TITLE
CLI: Remove CRA fixtures from Yarn 2 tests run

### DIFF
--- a/lib/cli/test/fixtures/react_scripts_ts/package.json
+++ b/lib/cli/test/fixtures/react_scripts_ts/package.json
@@ -24,13 +24,13 @@
     "extends": "react-app"
   },
   "dependencies": {
-    "@types/jest": "24.0.19",
-    "@types/node": "12.11.1",
-    "@types/react": "16.9.9",
-    "@types/react-dom": "16.9.2",
-    "react": "^16.10.2",
-    "react-dom": "^16.10.2",
-    "react-scripts": "3.2.0",
-    "typescript": "3.6.4"
+    "@types/jest": "^24.9.1",
+    "@types/node": "^12.11.1",
+    "@types/react": "^16.9.34",
+    "@types/react-dom": "^16.9.7",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-scripts": "^3.4.1",
+    "typescript": "^3.8.3"
   }
 }

--- a/lib/cli/test/run_tests_yarn_2.sh
+++ b/lib/cli/test/run_tests_yarn_2.sh
@@ -30,8 +30,6 @@ mkdir $test_folder
 # copy some files from fixtures directory, the goal is to test that CLI is running well with Yarn 2 not to have all framework covered (especially because some are not compatible with Yarn 2 yet)
 cp -r $fixtures_dir/react $test_folder/react
 cp -r $fixtures_dir/react_babelrc_js $test_folder/react_babelrc_js
-cp -r $fixtures_dir/react_scripts_ts $test_folder/react_scripts_ts
-cp -r $fixtures_dir/react_scripts_v2 $test_folder/react_scripts_v2
 cp -r $fixtures_dir/webpack_react $test_folder/webpack_react
 cd $test_folder
 
@@ -45,9 +43,6 @@ do
   # Do some magic to make Yarn 2 work inside a Yarn 1 monorepo
   unset YARN_WRAP_OUTPUT
   touch yarn.lock
-
-  # Use a global cache to avoid fetching the same dep multiple times across all fixtures
-  echo "enableGlobalCache: true" >> .yarnrc.yml
 
   # Transform `package.json`:
   #   - add `@storybook/cli` dep to be able to do `yarn sb init` with Yarn 2


### PR DESCRIPTION
## What I did

When testing Yarn 2 compatibility of Storybook CLI, we are using Yarn 2 in fixture directories inside a Yarn 1 workspace. To access local versions of `@storybook` packages we use Yarn 2 `portal` [protocol](https://yarnpkg.com/features/protocols#table). 

However, it looks like CRA is not playing well with `portal` protocol and is throwing this kind of error: `Relative imports outside of src/ are not supported.`.

As new E2E tests will be soon available - see https://github.com/storybookjs/storybook/pull/10702, I just removed the CRA tests (that are always 🔴) instead of trying to hack them a bit more.

