### PR TITLE
Essentials: Update auto disable heuristics based on main.js

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,9 +23,10 @@
   - [Story Store immutable outside of configuration](#story-store-immutable-outside-of-configuration)
   - [Improved story source handling](#improved-story-source-handling)
   - [6.0 Addon API changes](#60-addon-api-changes)
-    - [Actions Addon uses parameters](#actions-addon-uses-parameters)
+    - [Actions addon uses parameters](#actions-addon-uses-parameters)
     - [Removed action decorator APIs](#removed-action-decorator-apis)
     - [Removed withA11y decorator](#removed-witha11y-decorator)
+    - [Essentials addon disables differently](#essentials-addon-disables-differently)
   - [6.0 Deprecations](#60-deprecations)
     - [Deprecated addon-info, addon-notes](#deprecated-addon-info-addon-notes)
     - [Deprecated addon-contexts](#deprecated-addon-contexts)
@@ -470,7 +471,7 @@ The MDX analog:
 
 ### 6.0 Addon API changes
 
-#### Actions Addon uses parameters
+#### Actions addon uses parameters
 
 Leveraging the new preset `@storybook/addon-actions` uses parameters to pass action options. If you previously had:
 
@@ -514,6 +515,10 @@ addParameters({
   }
 };
 ```
+
+#### Essentials addon disables differently
+
+In 6.0, `addon-essentials` doesn't configure addons if the user has already configured them in `main.js`. In 5.3 it previously checked to see whether the package had been installed in `package.json` to disable configuration. The new setup is preferably because now users' can install essential packages and import from them without disabling their configuration.
 
 ### 6.0 Deprecations
 

--- a/addons/essentials/README.md
+++ b/addons/essentials/README.md
@@ -32,7 +32,7 @@ module.exports = {
 
 Essentials is "zero config." That means that comes with a recommended configuration out of the box.
 
-If you want to reconfigure an addon, simply install that addon per that addon's installation instructions and configure it as normal. Essentials scans your project's `package.json` on startup and if detects one of its addons is already installed, it will skip that addon's configuration entirely.
+If you want to reconfigure an addon, simply install that addon per that addon's installation instructions and configure it as normal. Essentials scans your project's `main.js` on startup and if detects one of its addons is already configured in the `addons` field, it will skip that addon's configuration entirely.
 
 ## Disabling addons
 
@@ -49,4 +49,4 @@ module.exports = {
 };
 ```
 
-Valid addon keys include: `backgrounds`, `viewport`, `docs`
+Valid addon keys include: `backgrounds`, `viewport`, `docs`.

--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -1,36 +1,40 @@
-import fs from 'fs';
+import path from 'path';
 import { logger } from '@storybook/node-logger';
 
 interface PresetOptions {
+  configDir?: string;
   backgrounds?: any;
   viewport?: any;
+  docs?: any;
 }
 
-let packageJson: any = {};
-if (fs.existsSync('./package.json')) {
+const requireMain = (configDir: string) => {
+  let main = {};
+  const mainFile = path.join(process.cwd(), configDir, 'main');
   try {
-    packageJson = JSON.parse(fs.readFileSync('./package.json').toString());
+    // eslint-disable-next-line global-require,import/no-dynamic-require
+    main = require(mainFile);
   } catch (err) {
-    logger.error(`Error reading package.json: ${err.message}`);
+    logger.warn(`Unable to find main.js: ${mainFile}`);
   }
-}
-
-const isInstalled = (addon: string) => {
-  const { dependencies, devDependencies } = packageJson;
-  return (dependencies && dependencies[addon]) || (devDependencies && devDependencies[addon]);
+  return main;
 };
 
-const makeAddon = (key: string) => `@storybook/addon-${key}`;
-
-const makeAddons = (keys: string[], suffix: string, options: PresetOptions) =>
-  keys
-    .filter((key) => (options as any)[key] !== false)
-    .map((key) => makeAddon(key))
-    .filter((addon) => !isInstalled(addon))
-    .map((addon) => require.resolve(`${addon}/${suffix}`));
-
 export function addons(options: PresetOptions = {}) {
-  const presetAddons = makeAddons(['docs'], 'preset', options);
-  const registerAddons = makeAddons(['backgrounds', 'viewport'], 'register', options);
-  return [...presetAddons, ...registerAddons];
+  const checkInstalled = (addon: string, main: any) => {
+    const existingAddon = main.addons?.find((entry: string | { name: string }) => {
+      const name = typeof entry === 'string' ? entry : entry.name;
+      return name?.startsWith(addon);
+    });
+    if (existingAddon) {
+      logger.warn(`Found existing addon ${JSON.stringify(existingAddon)}, skipping.`);
+    }
+    return !!existingAddon;
+  };
+
+  const main = requireMain(options.configDir);
+  return ['docs', 'backgrounds', 'viewport']
+    .filter((key) => (options as any)[key] !== false)
+    .map((key) => `@storybook/addon-${key}`)
+    .filter((addon) => !checkInstalled(addon, main));
 }

--- a/addons/essentials/tsconfig.json
+++ b/addons/essentials/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "types": ["webpack-env", "jest"]
+    "types": ["webpack-env", "jest", "node"]
   },
   "include": ["src/**/*"],
   "exclude": ["src/**.test.ts"]


### PR DESCRIPTION
Issue: N/A

## What I did

Update the auto-disable heuristics for `addon-essentials`. Disable configuration of an essential addon if it's configured in main.js.

- [x] Improve heuristic, with warnings
- [x] Update docs
- [x] Add migration docs

Self-merging @ndelangen @tmeasday 

## How to test

Add `addon-docs` to `cra-ts-essentials` and observe console warning.
