### PR TITLE
Docs: fix examples in README of storyshots-puppeteer

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -93,12 +93,14 @@ You might use `getGotoOptions` to specify options when the storybook is navigati
 
 ```js
 import initStoryshots from '@storybook/addon-storyshots';
-import { imageSnapshot } from '@storybook/addon-storyshots-puppeteer';
+import { puppeteerTest } from '@storybook/addon-storyshots-puppeteer';
+
 const getGotoOptions = ({ context, url }) => {
   return {
     waitUntil: 'networkidle0',
   };
 };
+
 initStoryshots({
   suite: 'Puppeteer storyshots',
   test: puppeteerTest({ storybookUrl: 'http://localhost:6006', getGotoOptions }),
@@ -220,7 +222,7 @@ Runs [Axe](https://www.deque.com/axe/) accessibility checks and verifies that th
 import initStoryshots from '@storybook/addon-storyshots';
 import { axeTest } from '@storybook/addon-storyshots-puppeteer';
 
-axeTest({ suite: 'A11y checks', test: axeTest() });
+initStoryshots({ suite: 'A11y checks', test: axeTest() });
 ```
 
 For configuration, it uses the same `story.parameters.a11y` parameter as [`@storybook/addon-a11y`](https://github.com/storybookjs/storybook/tree/next/addons/a11y#parameters)


### PR DESCRIPTION
Issue: examples in the README for storyshots-puppeteer contain a few small typos

## What I did

Update the README.md of storyshots-puppeteer to fix typos

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
