### PR TITLE
[docs] Add common Vue.js devtools workarounds

### DIFF
--- a/docs/src/pages/guides/guide-vue/index.md
+++ b/docs/src/pages/guides/guide-vue/index.md
@@ -3,6 +3,31 @@ id: 'guide-vue'
 title: 'Storybook for Vue'
 ---
 
+---
+**NOTE**
+
+[Vue.js devtools] [browser extension support is in the works] but not yet available!
+<details markdown>
+<summary>See workarounds…</summary>
+
+- In Firefox:
+  1. Open the story you wish to inspect.
+  2. Right-click anywhere in the story and select This Frame → Open Frame in New Tab. devtools should now work correctly in the new tab.
+
+- In Chromium / Chrome:
+  1. Open the story you wish to inspect.
+  2. Right-click anywhere in the story and select View frame source which will open in a new tab. E.g., `view-source:http://localhost:6006/iframe.html?id=components-fancybutton--button&viewMode=story`.
+  3. Remove the `view-source:` scheme from the URL in the address bar to load just the frame. devtools should now work correctly.
+
+- Launch the standalone Vue.js devtools app via `npx -p @vue/devtools vue-devtools` and add (or create) `<script src="//localhost:8098"></script>` to `.storybook/preview-head.html`. Now run Storybook and devtools should connect.
+
+</details>
+
+[Vue.js devtools]: https://github.com/vuejs/vue-devtools
+[browser extension support is in the works]: https://github.com/storybookjs/storybook/issues/1708
+
+---
+
 ## Automatic setup
 
 You may have tried to use our quick start guide to setup your project for Storybook.


### PR DESCRIPTION
Issue: #1708

## What I did

As a Vuebie, I knew that Vue.js devtools worked correctly with the Vue
CLI. I mistakenly assumed the CLI used Storybook under the hood.
Because of these incorrect assumptions, I spent a couple hours trying
to figure out why devtools wasn't working in my project which uses
Webpack and Storybook directly. I thought it was something broken in my
setup when actually it was a known issue.

I hope this documentation will help alert others that this is a known
issue, it's in progress, and practical workarounds exist.

:+1: Thank you for writing amazing software.

## How to test

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps?  No.
- Does this need an update to the documentation? Yes.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following: documentation

-->
