### PR TITLE
core: use dedicated loader for es6 modules

### DIFF
--- a/lib/core/src/server/common/es6Transpiler.js
+++ b/lib/core/src/server/common/es6Transpiler.js
@@ -1,0 +1,29 @@
+import { plugins } from './babel';
+
+const es6Transpiler = () => {
+  // TODO: generate regexp using are-you-es5
+
+  const include = /[\\/]node_modules[\\/](@storybook\/node-logger|are-you-es5|better-opn|boxen|chalk|commander|find-cache-dir|find-up|fs-extra|json5|node-fetch|pkg-dir|resolve-from|semver)/;
+  return {
+    test: /\.js$/,
+    use: [
+      {
+        loader: require.resolve('babel-loader'),
+        options: {
+          sourceType: 'unambiguous',
+          presets: [
+            [
+              require.resolve('@babel/preset-env'),
+              { shippedProposals: true, useBuiltIns: 'usage', corejs: '3' },
+            ],
+            require.resolve('@babel/preset-react'),
+          ],
+          plugins,
+        },
+      },
+    ],
+    include,
+  };
+};
+
+export default es6Transpiler;

--- a/lib/core/src/server/config/utils.js
+++ b/lib/core/src/server/config/utils.js
@@ -26,16 +26,6 @@ const projectRoot = () => {
 export const includePaths = [projectRoot()];
 export const nodeModulesPaths = path.resolve('./node_modules');
 
-// Run `npx are-you-es5 check lib/core -r`
-// to get this regexp
-export const excludePaths = [
-  /[\\/]node_modules[\\/](?!(@storybook\/node-logger|are-you-es5|better-opn|boxen|chalk|commander|find-cache-dir|find-up|fs-extra|json5|node-fetch|pkg-dir|resolve-from|semver)[\\/])/,
-  // Never transpile again the following:
-  /[\\/]node_modules[\\/]webpack/,
-  /[\\/]node_modules[\\/]core-js/,
-  /[\\/]node_modules[\\/]regenerator-runtime/,
-];
-
 const nodePathsToArray = (nodePath) =>
   nodePath
     .split(process.platform === 'win32' ? ';' : ':')

--- a/lib/core/src/server/manager/babel-loader-manager.js
+++ b/lib/core/src/server/manager/babel-loader-manager.js
@@ -1,4 +1,4 @@
-import { includePaths, excludePaths } from '../config/utils';
+import { includePaths } from '../config/utils';
 import { plugins, presets } from '../common/babel';
 
 export default () => ({
@@ -18,6 +18,6 @@ export default () => ({
       },
     },
   ],
-  include: [...includePaths, /node_modules/],
-  exclude: [...excludePaths, /dist/],
+  include: includePaths,
+  exclude: [/node_modules/, /dist/],
 });

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -16,6 +16,7 @@ import { loadEnv } from '../config/utils';
 
 import babelLoader from './babel-loader-manager';
 import { resolvePathInStorybookCache } from '../utils/resolve-path-in-sb-cache';
+import es6Transpiler from '../common/es6Transpiler';
 
 const coreDirName = path.dirname(require.resolve('@storybook/core/package.json'));
 // TODO: improve node_modules detection
@@ -99,6 +100,7 @@ export default ({
     module: {
       rules: [
         babelLoader(),
+        es6Transpiler(),
         {
           test: /\.css$/,
           use: [

--- a/lib/core/src/server/preview/babel-loader-preview.js
+++ b/lib/core/src/server/preview/babel-loader-preview.js
@@ -1,5 +1,4 @@
-import { includePaths, excludePaths } from '../config/utils';
-import { plugins } from '../common/babel';
+import { includePaths } from '../config/utils';
 import { useBaseTsSupport } from '../config/useBaseTsSupport';
 
 export const createBabelLoader = (options, framework) => ({
@@ -11,26 +10,5 @@ export const createBabelLoader = (options, framework) => ({
     },
   ],
   include: includePaths,
-  exclude: excludePaths,
+  exclude: /node_modules/,
 });
-
-export const es6ModulesRule = {
-  test: /\.js$/,
-  use: [
-    {
-      loader: require.resolve('babel-loader'),
-      options: {
-        sourceType: 'unambiguous',
-        presets: [
-          [
-            require.resolve('@babel/preset-env'),
-            { shippedProposals: true, useBuiltIns: 'usage', corejs: '3' },
-          ],
-        ],
-        plugins,
-      },
-    },
-  ],
-  include: [/node_modules/],
-  exclude: excludePaths,
-};

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -12,7 +12,8 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 import resolveFrom from 'resolve-from';
 
-import { createBabelLoader, es6ModulesRule } from './babel-loader-preview';
+import { createBabelLoader } from './babel-loader-preview';
+import es6Transpiler from '../common/es6Transpiler';
 
 import { nodeModulesPaths, loadEnv } from '../config/utils';
 import { getPreviewHeadHtml, getPreviewBodyHtml } from '../utils/template';
@@ -140,7 +141,7 @@ export default async ({
     module: {
       rules: [
         babelLoader,
-        es6ModulesRule,
+        es6Transpiler(),
         {
           test: /\.md$/,
           use: [


### PR DESCRIPTION
Issue: 
All previous attempts didn't worked.
When we're outside the monorepo, the way modules are resolved cause modules not being transpiled.

## What I did
Decicated babel loader

## How to test
IE 11 OUTSIDE the monorepo
