### PR TITLE
[fix] - Detect local addons for windows machines

### DIFF
--- a/lib/core/src/server/presets.js
+++ b/lib/core/src/server/presets.js
@@ -1,6 +1,7 @@
 import dedent from 'ts-dedent';
 import { join } from 'path';
 import { logger } from '@storybook/node-logger';
+import fs from 'fs'
 import { resolveFile } from './utils/resolve-file';
 
 const isObject = (val) => val != null && typeof val === 'object' && Array.isArray(val) === false;
@@ -39,7 +40,7 @@ const resolvePresetFunction = (input, presetOptions, storybookOptions) => {
   return [];
 };
 
-const isLocalFileImport = (packageName) => /^[./]/.test(packageName);
+const isLocalFileImport = (packageName) => fs.existsSync(packageName);
 
 /**
  * Parse an addon into either a managerEntry or a preset. Throw on invalid input.


### PR DESCRIPTION
Issue: Local addons do not work on windows see [issue](https://github.com/storybookjs/storybook/issues/10007)

## What I did
I updated the local compare function to use the fs package to check if the file exists. Seemed to be the most simple solution. Wrong local paths to files that do not exists will now be interpreted as not being local files.

## How to test
- Use a local addon on a windows machine

## Note
Would like to get this change into a 5.x if possible. Can do another PR on that.