### PR TITLE
Documentation: Update props-table.md to fix the broken links

### DIFF
--- a/addons/docs/docs/props-tables.md
+++ b/addons/docs/docs/props-tables.md
@@ -25,7 +25,7 @@ Storybook Docs automatically generates props tables for components in supported 
 
 ## Usage
 
-For framework-specific setup instructions, see the framework's README: [React](../../react/README.md), [Vue](../../vue/README.md), [Angular](../../angular/README.md), [Web Components](../../web-components/README.md), [Ember](../../ember/README.md).
+For framework-specific setup instructions, see the framework's README: [React](../react/README.md), [Vue](../vue/README.md), [Angular](../angular/README.md), [Web Components](../web-components/README.md), [Ember](../ember/README.md).
 
 To use the props table in [DocsPage](./docspage.md), simply export a component property on your stories metadata:
 


### PR DESCRIPTION
Issue:

Framework specific docs links in the `usage` section were broken

## What I did
 I have fixed the links by getting the right paths provided in the `more resource` section.

## How to test
NA

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
