### PR TITLE
Scripts: parallel execution on build package scripts

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -143,7 +143,7 @@ function run() {
 
         if (watchMode) {
           const runWatchMode = () => {
-            const baseWatchCommand = `lerna exec --scope "${glob}" -- cross-env-shell node ${resolve(
+            const baseWatchCommand = `lerna exec --scope "${glob}" --parallel -- cross-env-shell node ${resolve(
               __dirname
             )}`;
             const watchTsc = `${baseWatchCommand}/watch-tsc.js`;


### PR DESCRIPTION
## What I did

This PR adds:
- Parallel execution when using `yarn build` on watch mode internally in the storybook repo
- Warning log when running `--all` together with `--watch`

## How to test

1 - Checkout the branch
2 - Run `yarn build --all`
3 - Run `yarn build --all --watch`