### PR TITLE
Addon-toolbars: Show tool icons for all viewModes

### DIFF
--- a/addons/toolbars/src/register.tsx
+++ b/addons/toolbars/src/register.tsx
@@ -7,7 +7,7 @@ addons.register(ID, (api) =>
   addons.add(ID, {
     title: ID,
     type: types.TOOL,
-    match: ({ viewMode }) => viewMode === 'story',
+    match: () => true,
     render: () => <ToolbarManager />,
   })
 );


### PR DESCRIPTION
Issue: N/A

Related to #6700 

## What I did

![global-args-toolbars](https://user-images.githubusercontent.com/488689/82135626-5979d000-9837-11ea-808f-6eeb8329ce5d.gif)

`addon-toolbars` uses `globalArgs`, which is compatible with all viewModes, so we can show it no matter what viewMode we're in.

We can probably do something similar for `addon-backgrounds` once it gets `docs` compatibility.  @yannbf

Not sure what other addons this applies to, but it's a step forward!

Self-merging cc @lifeiscontent @ndelangen @patricklafrance 

## How to test

See `official-storybook` and attached gif
