### PR TITLE
Addon-docs: Eval argTypes default value

### DIFF
--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -24,7 +24,7 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
           table: {
             type,
             jsDocTags,
-            defaultValue,
+            defaultValue: defaultSummary,
           },
         };
         return acc;

--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -1,10 +1,7 @@
 import { PropDef, PropsTableRowsProps } from '@storybook/components';
 import { ArgTypes } from '@storybook/api';
 import { ArgTypesExtractor } from '../../lib/docgen';
-import { trimQuotes } from '../../lib/sbtypes/utils';
 import { extractProps } from './extractProps';
-
-const trim = (val: any) => (val && typeof val === 'string' ? trimQuotes(val) : val);
 
 export const extractArgTypes: ArgTypesExtractor = (component) => {
   if (component) {
@@ -13,7 +10,7 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
     if (rows) {
       return rows.reduce((acc: ArgTypes, row: PropDef) => {
         const { type, sbType, defaultValue: defaultSummary, jsDocTags, required } = row;
-        let defaultValue = defaultSummary && trim(defaultSummary.detail || defaultSummary.summary);
+        let defaultValue = defaultSummary && (defaultSummary.detail || defaultSummary.summary);
         try {
           // eslint-disable-next-line no-eval
           defaultValue = eval(defaultValue);

--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -12,10 +12,17 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
     const { rows } = props as PropsTableRowsProps;
     if (rows) {
       return rows.reduce((acc: ArgTypes, row: PropDef) => {
-        const { type, sbType, defaultValue, jsDocTags, required } = row;
+        const { type, sbType, defaultValue: defaultSummary, jsDocTags, required } = row;
+        let defaultValue = defaultSummary && trim(defaultSummary.detail || defaultSummary.summary);
+        try {
+          // eslint-disable-next-line no-eval
+          defaultValue = eval(defaultValue);
+          // eslint-disable-next-line no-empty
+        } catch {}
+
         acc[row.name] = {
           ...row,
-          defaultValue: defaultValue && trim(defaultValue.detail || defaultValue.summary),
+          defaultValue,
           type: { required, ...sbType },
           table: {
             type,

--- a/examples/official-storybook/main.js
+++ b/examples/official-storybook/main.js
@@ -3,7 +3,7 @@ module.exports = {
     // FIXME: Breaks e2e tests './intro.stories.mdx',
     '../../lib/ui/src/**/*.stories.(js|tsx|mdx)',
     '../../lib/components/src/**/*.stories.(js|tsx|mdx)',
-    './stories/**/*.stories.(js|tsx|mdx)',
+    './stories/**/*.stories.(js|ts|tsx|mdx)',
     './../../addons/docs/**/*.stories.tsx',
   ],
   addons: [


### PR DESCRIPTION
Issue: #10497 

## What I did

Docgen produces default value as a string. We need to `eval` the string 🙈 to get the actual default value.

Self-merging @ndelangen @patricklafrance 

## How to test

See the `ArgsStory` `DocsPage` before and after the change
