### PR TITLE
Core: Fix global args initial state for addon-toolbars

### DIFF
--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -184,6 +184,9 @@ export default class StoryStore {
       },
       { ...defaultGlobalArgs, ...initialGlobalArgs }
     );
+    if (this._channel) {
+      this._channel.emit(Events.GLOBAL_ARGS_UPDATED, this._globalArgs);
+    }
   }
 
   addGlobalMetadata({ parameters, decorators }: StoryMetadata) {


### PR DESCRIPTION
Issue: #10239 

## What I did

Fixed a global args bug where the values were not getting propagated correctly on initial render.

## How to test

See `official-storybook`. The initial render for the theme toolbar is NOT set, but the toolbar for locale is:

<img width="476" alt="Addons___Docs___props_-_ArgTypes_⋅_Storybook" src="https://user-images.githubusercontent.com/488689/82315562-0a31cc00-99fe-11ea-9794-488f427925af.png">
