### PR TITLE
UI: Don't emit storyChange event when viewmode not renderable by preview

### DIFF
--- a/lib/ui/src/components/preview/preview.tsx
+++ b/lib/ui/src/components/preview/preview.tsx
@@ -149,7 +149,7 @@ const Preview: FunctionComponent<PreviewProps> = (props) => {
   const tabs = useTabs(previewId, baseUrl, withLoader, getElements, story);
 
   useEffect(() => {
-    if (story) {
+    if (story && viewMode && viewMode.match(/docs|story/)) {
       const { refId, id } = story;
       api.emit(SET_CURRENT_STORY, {
         storyId: id,


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/10551

## What I did
Added a filter, so the event is only emitted if the viewMode matches `/(story|docs)/`.