### PR TITLE
feat(docs): add useName parameter to the Title docblock

### DIFF
--- a/addons/docs/src/blocks/Title.tsx
+++ b/addons/docs/src/blocks/Title.tsx
@@ -5,8 +5,13 @@ import { DocsContext, DocsContextProps } from './DocsContext';
 
 interface TitleProps {
   children?: JSX.Element | string;
+  useName?: boolean;
 }
-export const extractTitle = ({ kind, parameters }: DocsContextProps) => {
+export const extractTitle = ({ name, kind, parameters }: DocsContextProps, useName?: boolean) => {
+  if (useName && name) {
+    return name;
+  }
+
   const {
     showRoots,
     hierarchyRootSeparator: rootSeparator = '|',
@@ -27,11 +32,11 @@ export const extractTitle = ({ kind, parameters }: DocsContextProps) => {
   return (groups && groups[groups.length - 1]) || kind;
 };
 
-export const Title: FunctionComponent<TitleProps> = ({ children }) => {
+export const Title: FunctionComponent<TitleProps> = ({ children, useName = false }) => {
   const context = useContext(DocsContext);
   let text: JSX.Element | string = children;
   if (!text) {
-    text = extractTitle(context);
+    text = extractTitle(context, useName);
   }
   return text ? <PureTitle className="sbdocs-title">{text}</PureTitle> : null;
 };


### PR DESCRIPTION
Issue:

Our company has a lot of stories inside some hierarchy categories, and the default template gets too big showing all of them inside the `<Stories />` block. So I changed the default doc template to be granular and show only the current story with its props.

I configured a default granular MDX template like this:
```
import { Description, Props, Story, Subtitle, Title } from '@storybook/addon-docs/blocks';

<Title />
<Subtitle />
<Description />

<Story id="." />

<Props of="." />
```
with this code within `preview.js`:
```
import page from './docs/default.mdx';

addParameters({
  docs: { page },
  ...
```

And I realized that the title was always the Category name instead the Story name.

## What I did

I went deep into the existing component and added an optional `useName` parameter to be able to fetch the Story name instead the Kind.

I wonder if there's another way to do it with MDX, like:
```
<Title text={context.name} />
```
but this PR aims to be able to display the Story name via
```
<Title useName={true} />
```

## How to test

- Is this testable with Jest or Chromatic screenshots?
Yes, but I'm not familiar with the testing mechanism
- Does this need a new example in the kitchen sink apps?
Maybe
- Does this need an update to the documentation?
DocBlocks docs are not available yet