### PR TITLE
Addon-docs: Fix react forwardRefs with destructured props

### DIFF
--- a/addons/docs/src/frameworks/react/extractProps.ts
+++ b/addons/docs/src/frameworks/react/extractProps.ts
@@ -26,7 +26,7 @@ function getPropDefs(component: Component, section: string): PropDef[] {
   // eslint-disable-next-line react/forbid-foreign-prop-types
   if (!hasDocgen(component) && !component.propTypes) {
     if (isForwardRef(component) || component.render) {
-      processedComponent = component.render().type;
+      processedComponent = component.render({}).type;
     }
     if (isMemo(component)) {
       processedComponent = component.type().type;

--- a/examples/official-storybook/stories/addon-docs/forward-ref.stories.js
+++ b/examples/official-storybook/stories/addon-docs/forward-ref.stories.js
@@ -1,15 +1,23 @@
 import React from 'react';
 import { DocgenButton } from '../../components/DocgenButton';
 
-const ForwardedButton = React.forwardRef((props = { label: '' }, ref) => (
-  <DocgenButton ref={ref} {...props} />
-));
-
 export default {
   title: 'Addons|Docs/ForwardRef',
   component: ForwardedButton,
   parameters: { chromatic: { disable: true } },
 };
 
-export const displaysCorrectly = () => <ForwardedButton label="hello" />;
-displaysCorrectly.story = { name: 'Displays forwarded ref components correctly' };
+const ForwardedButton = React.forwardRef((props = { label: '' }, ref) => (
+  <DocgenButton ref={ref} {...props} />
+));
+export const DisplaysCorrectly = () => <ForwardedButton label="hello" />;
+DisplaysCorrectly.story = { name: 'Displays forwarded ref components correctly (default props)' };
+
+// eslint-disable-next-line react/prop-types
+const ForwardedDestructuredButton = React.forwardRef(({ label = '', ...props }, ref) => (
+  <DocgenButton ref={ref} label={label} {...props} />
+));
+export const AlsoDisplaysCorrectly = () => <ForwardedDestructuredButton label="hello" />;
+AlsoDisplaysCorrectly.story = {
+  name: 'Displays forwarded ref components correctly (destructured props)',
+};


### PR DESCRIPTION
Issue: #10655

## What I did
Add default props when rendering forward ref or component class 

## How to test

Check story `Addons|Docs/ForwardRef`