### PR TITLE
Use `@storybook/client-api`

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -35,7 +35,7 @@ You should now be able to see the viewport addon icon in the the toolbar at the 
 The viewport addon is configured by story parameters with the `viewport` key. To configure globally, import `addParameters` from your app layer in your `preview.js` file.
 
 ```js
-import { addParameters } from '@storybook/react';
+import { addParameters } from '@storybook/client-api';
 
 addParameters({
   viewport: {
@@ -127,7 +127,7 @@ myStory.story = {
 The default viewports being used is [`MINIMAL_VIEWPORTS`](src/defaults.ts). If you'd like to use a more granular list of devices, you can use [`INITIAL_VIEWPORTS`](src/defaults.ts) like so in your `.storybook/preview.js` file.
 
 ```js
-import { addParameters } from '@storybook/react';
+import { addParameters } from '@storybook/client-api';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 addParameters({
@@ -142,7 +142,7 @@ addParameters({
 This will replace all previous devices with `Kindle Fire 2` and `Kindle Fire HD` by calling `addParameters` with the two devices as `viewports` in `.storybook/preview.js` file.
 
 ```js
-import { addParameters } from '@storybook/react';
+import { addParameters } from '@storybook/client-api';
 
 const customViewports = {
   kindleFire2: {


### PR DESCRIPTION
Replace references of `@storybook/react` with `@storybook/client-api`

Issue:
I think the doc of viewport addon is outdated when it explains how to use `addParameter` in `preview.js` file.

## What I did
Update the doc
## How to test
Only doc-related, no test required.

- Is this testable with Jest or Chromatic screenshots?
no
- Does this need a new example in the kitchen sink apps?
no
- Does this need an update to the documentation?
Yes, actually it is a doc update

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
