### PR TITLE
Core: Close server when e2e test failed

### DIFF
--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -212,10 +212,12 @@ const runTests = async ({ name, version, ...rest }: Parameters) => {
     }));
   }
 
-  await runCypress(options, 'http://localhost:4000', open);
-  logger.log();
-
-  server.close();
+  try {
+    await runCypress(options, 'http://localhost:4000', open);
+    logger.log();
+  } finally {
+    server.close();
+  }
 };
 
 // Run tests!


### PR DESCRIPTION
Issue:
When multiple configs are run on the same node, if the first one fail, the second will show "ADDR already in use"

## What I did
Close server on catch
