### PR TITLE
Add large resource class to build job on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
             - lib
   build:
     <<: *defaults
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
Add memory capacity to avoid build errors. Attempt job on Large resource class and investigate if more ram is needed or if the class could be lowered to "medium+"

Issue:

4Gb memory limitations in CI builds resulting in 137 killed errors.

## What I did

Raise resource class from "medium" to large". The doubles the amount of RAM and CPU.
https://circleci.com/docs/2.0/configuration-reference/#docker-executor

If successful, this may be tested against "medium+".

**PLAN/PRICING CHANGE:**
https://circleci.com/pricing/

This change will change the credit consumption of the build job from 10 credits per minute to 20 credits per minute.

It is recommended if this is successful to investigate using "medium+", which consumes 15 credits per minute.

## How to test

Run CI jobs and monitor for memory-related errors.


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
