### PR TITLE
Angular: Support `workspace.json` in nx workspace

### DIFF
--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -47,14 +47,19 @@ function getTsConfigOptions(tsConfigPath: Path) {
 }
 
 export function getAngularCliConfig(dirToSearch: string) {
-  const fname = path.join(dirToSearch, 'angular.json');
+  const possibleConfigNames = ['angular.json', 'workspace.json'];
+  const possibleConfigPaths = possibleConfigNames
+    .map(name => path.join(dirToSearch, name))
 
-  if (!fs.existsSync(fname)) {
-    logger.error(`Could not find angular.json using ${fname}`);
+  const validIndex = possibleConfigPaths
+    .findIndex(configPath => fs.existsSync(configPath));
+
+  if (validIndex === -1) {
+    logger.error(`Could not find angular.json using ${possibleConfigPaths[0]}`);
     return undefined;
   }
 
-  return JSON.parse(stripJsonComments(fs.readFileSync(fname, 'utf8')));
+  return JSON.parse(stripJsonComments(fs.readFileSync(possibleConfigPaths[validIndex], 'utf8')));
 }
 
 export function getLeadingAngularCliProject(ngCliConfig: any) {

--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -49,10 +49,10 @@ function getTsConfigOptions(tsConfigPath: Path) {
 export function getAngularCliConfig(dirToSearch: string) {
   const possibleConfigNames = ['angular.json', 'workspace.json'];
   const possibleConfigPaths = possibleConfigNames
-    .map(name => path.join(dirToSearch, name))
+    .map((name) => path.join(dirToSearch, name))
 
   const validIndex = possibleConfigPaths
-    .findIndex(configPath => fs.existsSync(configPath));
+    .findIndex((configPath) => fs.existsSync(configPath));
 
   if (validIndex === -1) {
     logger.error(`Could not find angular.json using ${possibleConfigPaths[0]}`);


### PR DESCRIPTION
Issue:

## What I did
Nx is a tool for managing a monorepo that can contain any kind of javascript framework.  Nx has its own CLI based on the angular CLI, but we also allow the root `angular.json` file to be named `workspace.json` for non-angular devs to be more comfortable.  However, the `@storybook/angular` package will only look for the `angular.json` file.  This PR checks for `angular.json` and falls back to `workspace.json`.  If neither file is present, the same error appears.

## How to test

```bash
npx create-nx-workspace storybook-with-workspace-json --preset=empty --cli=nx
cd storybook-with-workspace-json
yarn add @nrwl/angular @nrwl/storybook
npx nx g @nrwl/angular:ng-add
npx nx g @nrwl/angular:lib ui --no-interactive
npx nx g @schematics/angular:component --name=button --project=ui --no-interactive
npx nx g @nrwl/angular:storybook-configuration --name=ui --generateStories --no-interactive
npx nx run ui:storybook
```

You'll see an error that `angular.json` was not found.  After this PR, the error doesn't show up.
