### PR TITLE
Docs: fix example of story-level decorators with "storiesOf" API

### DIFF
--- a/docs/src/pages/formats/storiesof-api/index.md
+++ b/docs/src/pages/formats/storiesof-api/index.md
@@ -71,7 +71,7 @@ And finally, story-level decorators are provided via parameters:
 storiesOf('Button', module).add(
   'with text',
   () => <Button onClick={action('clicked')}>Hello Button</Button>,
-  { decorators: withKnobs }
+  { decorators: [withKnobs] }
 );
 ```
 


### PR DESCRIPTION
Issue:
There's an invalid example of using story-level decorators with "storiesOf" format in the docs.
We get an exception is we provide a single decorator instead of an array of decorators.

## What I did
Updated docs with the valid example

## How to test

It's just a documentation update so there's no need to test it

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
