### PR TITLE
UI: Center toolbar icon buttons 

### DIFF
--- a/lib/components/src/bar/button.tsx
+++ b/lib/components/src/bar/button.tsx
@@ -77,6 +77,8 @@ export interface IconButtonProps {
 export const IconButton = styled(ButtonOrLink, { shouldForwardProp: isPropValid })<IconButtonProps>(
   ({ theme }) => ({
     display: 'inline-flex',
+    justifyContent: 'center',
+    alignItems: 'center',
     height: 40,
     background: 'none',
     color: 'inherit',


### PR DESCRIPTION
Issue: #10870 Toolbar styles not centered

## What I did

Added flex center aligmnent styles to IconButton

![image](https://user-images.githubusercontent.com/260185/82734370-45731a00-9ce0-11ea-9cb8-9f777ce52cd1.png)
