### PR TITLE
Core: Don't force re-render on global args update 

### DIFF
--- a/lib/core/src/client/preview/StoryRenderer.tsx
+++ b/lib/core/src/client/preview/StoryRenderer.tsx
@@ -99,7 +99,7 @@ export class StoryRenderer {
     if (this.channel) {
       this.channel.on(Events.RENDER_CURRENT_STORY, () => this.renderCurrentStory(false));
       this.channel.on(Events.STORY_ARGS_UPDATED, () => this.forceReRender());
-      this.channel.on(Events.GLOBAL_ARGS_UPDATED, () => this.forceReRender());
+      this.channel.on(Events.GLOBAL_ARGS_UPDATED, () => this.renderCurrentStory(false));
       this.channel.on(Events.FORCE_RE_RENDER, () => this.forceReRender());
     }
   }


### PR DESCRIPTION
Issue: #10891

Angular preview is screwed by the forced render on `GLOBAL_ARGS_UPDATED`
Maybe in the refactor of #10893 we could have a new `SET_GLOBAL_ARGS` event to be processed depending on the context.

## What I did

Changed the forced rendering because of `GLOBAL_ARGS_UPDATED` to a normal render, and this prevents the exception shown on #10891.

Edit: locally the e2e test is successful, the whole process:
`yarn build-storybooks` `yarn serve-storybooks` and `yarn test:e2e` :-?