### PR TITLE
Fix screenshot path

### DIFF
--- a/addons/viewport/README.md
+++ b/addons/viewport/README.md
@@ -4,7 +4,7 @@ Storybook Viewport Addon allows your stories to be displayed in different sizes 
 
 [Framework Support](https://github.com/storybookjs/storybook/blob/master/ADDONS_SUPPORT.md)
 
-![Screenshot](https://github.com/storybookjs/storybook/blob/master/addons/viewport/docs/viewport.png)
+![Screenshot](https://github.com/storybookjs/storybook/raw/master/addons/viewport/docs/viewport.png)
 
 ## Installation
 


### PR DESCRIPTION
This change fixes the screenshot path when the README.md is rendered not on Github for instance, on npm https://www.npmjs.com/package/@storybook/addon-viewport

Issue:

## What I did
Changed the image path to its `raw` version

## How to test
The screenshot should not be broken if viewed outside of Github
