### PR TITLE
Core: Avoid re-render on HMR of other stories

### DIFF
--- a/examples/official-storybook/stories/core/rendering.stories.js
+++ b/examples/official-storybook/stories/core/rendering.stories.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 
 export default {
   title: 'Core/Rendering',

--- a/examples/official-storybook/stories/core/rendering.stories.js
+++ b/examples/official-storybook/stories/core/rendering.stories.js
@@ -4,6 +4,7 @@ export default {
   title: 'Core/Rendering',
 };
 
+// NOTE: in our example apps each component is mounted twice as we render in strict mode
 let timesMounted = 0;
 export const Counter = () => {
   const countRef = useRef();

--- a/examples/official-storybook/stories/core/rendering.stories.js
+++ b/examples/official-storybook/stories/core/rendering.stories.js
@@ -1,0 +1,19 @@
+import React, { useEffect, useRef } from 'react';
+
+export default {
+  title: 'Core/Rendering',
+};
+
+let timesMounted = 0;
+export const Counter = () => {
+  const countRef = useRef();
+
+  if (!countRef.current) timesMounted += 1;
+  countRef.current = (countRef.current || 0) + 1;
+
+  return (
+    <div>
+      Mounted: {timesMounted}, rendered (this mount): {countRef.current}
+    </div>
+  );
+};

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -442,22 +442,6 @@ describe('preview.client_api', () => {
       };
     }
 
-    it('should increment store revision when the module reloads', () => {
-      const {
-        storyStore,
-        clientApi: { storiesOf },
-      } = getContext();
-      const mod = new MockModule();
-
-      expect(storyStore.getRevision()).toEqual(0);
-
-      storiesOf('kind', (mod as unknown) as NodeModule);
-
-      mod.hot.reload();
-
-      expect(storyStore.getRevision()).toEqual(1);
-    });
-
     it('should replace a kind when the module reloads', () => {
       const {
         clientApi: { storiesOf, getStorybook },

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -145,7 +145,6 @@ export default class ClientApi {
         // and be handled by the HMR.allow in config_api, leading to a re-run of configuration.
         // So configuration is about to happen--we can skip the safety check.
         _storyStore.removeStoryKind(kind, { allowUnsafe: true });
-        _storyStore.incrementRevision();
       });
     }
 
@@ -184,7 +183,6 @@ export default class ClientApi {
           const { _storyStore } = this;
           // See note about allowUnsafe above
           _storyStore.remove(id, { allowUnsafe: true });
-          _storyStore.incrementRevision();
         });
       }
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -110,8 +110,6 @@ export default class StoryStore {
 
   _argTypesEnhancers: ArgTypesEnhancer[];
 
-  _revision: number;
-
   _selection: Selection;
 
   constructor(params: { channel: Channel }) {
@@ -123,7 +121,6 @@ export default class StoryStore {
     this._kinds = {};
     this._stories = {};
     this._argTypesEnhancers = [];
-    this._revision = 0;
     this._selection = {} as any;
     this._error = undefined;
     this._channel = params.channel;
@@ -521,14 +518,6 @@ export default class StoryStore {
 
   getRawStory(kind: string, name: string) {
     return this.getStoriesForKind(kind).find((s) => s.name === name);
-  }
-
-  getRevision() {
-    return this._revision;
-  }
-
-  incrementRevision() {
-    this._revision += 1;
   }
 
   cleanHooks(id: string) {

--- a/lib/core/src/client/preview/StoryRenderer.test.ts
+++ b/lib/core/src/client/preview/StoryRenderer.test.ts
@@ -1,3 +1,4 @@
+// a
 import { StoryStore, defaultDecorateStory } from '@storybook/client-api';
 import createChannel from '@storybook/channel-postmessage';
 import {
@@ -249,6 +250,7 @@ describe('core.preview.StoryRenderer', () => {
         kind: 'a',
         name: '1',
         viewMode: 'story',
+        getDecorated: expect.any(Function),
       });
     });
     it('does re-render the current story if it has not changed if forceRender is true', () => {

--- a/lib/core/src/client/preview/StoryRenderer.test.ts
+++ b/lib/core/src/client/preview/StoryRenderer.test.ts
@@ -248,7 +248,6 @@ describe('core.preview.StoryRenderer', () => {
         id: 'a--1',
         kind: 'a',
         name: '1',
-        revision: 0,
         viewMode: 'story',
       });
     });
@@ -282,7 +281,7 @@ describe('core.preview.StoryRenderer', () => {
 
       expect(onStoryChanged).toHaveBeenCalledWith('a--1');
     });
-    it('does re-render if the store revision changes', () => {
+    it('does re-render if the story implementation changes', () => {
       const { render, channel, storyStore, renderer } = prepareRenderer();
       addAndSelectStory(storyStore, 'a', '1');
       renderer.renderCurrentStory(false);
@@ -291,7 +290,8 @@ describe('core.preview.StoryRenderer', () => {
       channel.on(STORY_CHANGED, onStoryChanged);
 
       render.mockClear();
-      storyStore.incrementRevision();
+      storyStore.removeStoryKind('a');
+      addAndSelectStory(storyStore, 'a', '1');
       renderer.renderCurrentStory(false);
       expect(render).toHaveBeenCalled();
 

--- a/lib/core/src/client/preview/StoryRenderer.tsx
+++ b/lib/core/src/client/preview/StoryRenderer.tsx
@@ -99,7 +99,7 @@ export class StoryRenderer {
     if (this.channel) {
       this.channel.on(Events.RENDER_CURRENT_STORY, () => this.renderCurrentStory(false));
       this.channel.on(Events.STORY_ARGS_UPDATED, () => this.forceReRender());
-      // this.channel.on(Events.GLOBAL_ARGS_UPDATED, () => this.forceReRender());
+      this.channel.on(Events.GLOBAL_ARGS_UPDATED, () => this.forceReRender());
       this.channel.on(Events.FORCE_RE_RENDER, () => this.forceReRender());
     }
   }
@@ -155,7 +155,6 @@ export class StoryRenderer {
     const { forceRender, name } = context;
 
     const { previousMetadata, storyStore } = this;
-    console.log('renderStoryIfChanged', { previousMetadata, metadata, context });
 
     const storyChanged = !previousMetadata || previousMetadata.id !== metadata.id;
     // getDecorated is a function that returns a decorated story function. It'll change whenever the story
@@ -164,8 +163,6 @@ export class StoryRenderer {
       !previousMetadata || previousMetadata.getDecorated !== metadata.getDecorated;
     const viewModeChanged = !previousMetadata || previousMetadata.viewMode !== metadata.viewMode;
     const kindChanged = !previousMetadata || previousMetadata.kind !== metadata.kind;
-
-    console.log({ forceRender, storyChanged, implementationChanged, viewModeChanged, kindChanged });
 
     // Don't re-render the story if nothing has changed to justify it
     if (!forceRender && !storyChanged && !implementationChanged && !viewModeChanged) {
@@ -279,11 +276,9 @@ export class StoryRenderer {
   }
 
   renderStory({ context, context: { id, getDecorated } }: { context: RenderContext }) {
-    console.log('renderStory', context);
     if (getDecorated) {
       (async () => {
         try {
-          console.log('calling render');
           await this.render(context);
           this.channel.emit(Events.STORY_RENDERED, id);
         } catch (err) {

--- a/lib/core/src/client/preview/StoryRenderer.tsx
+++ b/lib/core/src/client/preview/StoryRenderer.tsx
@@ -120,14 +120,14 @@ export class StoryRenderer {
     const { storyId, viewMode: urlViewMode } = storyStore.getSelection();
 
     const data = storyStore.fromId(storyId);
-    const { kind, id, parameters = {} } = data || {};
+    const { kind, id, parameters = {}, getDecorated } = data || {};
     const { docsOnly, layout } = parameters;
 
     const metadata: RenderMetadata = {
       id,
       kind,
       viewMode: docsOnly ? 'docs' : urlViewMode,
-      getDecorated: data.getDecorated,
+      getDecorated,
     };
 
     this.applyLayout(layout);
@@ -174,7 +174,7 @@ export class StoryRenderer {
     }
 
     // If we are rendering something new (as opposed to re-rendering the same or first story), emit
-    if (!forceRender && previousMetadata && !implementationChanged) {
+    if (previousMetadata && (storyChanged || kindChanged || viewModeChanged)) {
       this.channel.emit(Events.STORY_CHANGED, metadata.id);
     }
 

--- a/lib/core/src/client/preview/loadCsf.test.ts
+++ b/lib/core/src/client/preview/loadCsf.test.ts
@@ -33,7 +33,6 @@ function makeMocks() {
   const configApi = ({ configure: (x: Function) => x() } as unknown) as ConfigApi;
   const storyStore = ({
     removeStoryKind: jest.fn(),
-    incrementRevision: jest.fn(),
   } as unknown) as StoryStore;
   const clientApi = ({
     storiesOf: jest.fn().mockImplementation(() => ({
@@ -290,7 +289,6 @@ describe('core.preview.loadCsf', () => {
     configure(makeRequireContext(secondInput), mod, 'react');
 
     expect(storyStore.removeStoryKind).not.toHaveBeenCalled();
-    expect(storyStore.incrementRevision).not.toHaveBeenCalled();
     expect(mockedStoriesOf).toHaveBeenCalledWith('b', true);
   });
 
@@ -324,7 +322,6 @@ describe('core.preview.loadCsf', () => {
     configure(makeRequireContext(secondInput), mod, 'react');
 
     expect(storyStore.removeStoryKind).toHaveBeenCalledWith('b');
-    expect(storyStore.incrementRevision).toHaveBeenCalled();
     expect(mockedStoriesOf).not.toHaveBeenCalled();
   });
 
@@ -367,7 +364,6 @@ describe('core.preview.loadCsf', () => {
 
     expect(storyStore.removeStoryKind).toHaveBeenCalledTimes(1);
     expect(storyStore.removeStoryKind).toHaveBeenCalledWith('a');
-    expect(storyStore.incrementRevision).toHaveBeenCalled();
     expect(mockedStoriesOf).toHaveBeenCalledWith('a', true);
   });
 

--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -51,9 +51,6 @@ const loadStories = (
       storyStore.removeStoryKind(exp.default.title);
     }
   });
-  if (removed.length > 0) {
-    storyStore.incrementRevision();
-  }
 
   const added = Array.from(currentExports.keys()).filter((exp) => !previousExports.has(exp));
 


### PR DESCRIPTION
Issue: #10616 

## What I did

Refactored our story change detection to use reference equality check rather than a global revision

## How to test

Use the "core/rendering" story

1. Check it *does not* re-render if you change a different story
2. Check it does re-render if you change the current story.
3. Check it does re-render if you switch stories (and then back)

Note that (1) doesn't currently work due to https://github.com/storybookjs/storybook/issues/10893 (global args). Fixing that in a separate PR, but you can check if you comment out the global args event listener.