### PR TITLE
Core: Log swallowed errors when requiring stories

### DIFF
--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -24,13 +24,17 @@ const loadStories = (
   if (reqs) {
     reqs.forEach((req) => {
       req.keys().forEach((filename: string) => {
-        const fileExports = req(filename);
-        currentExports.set(
-          fileExports,
-          // todo discuss: types infer that this is RequireContext; no checks needed?
-          // NOTE: turns out `babel-plugin-require-context-hook` doesn't implement this (yet)
-          typeof req.resolve === 'function' ? req.resolve(filename) : null
-        );
+        try {
+          const fileExports = req(filename);
+          currentExports.set(
+            fileExports,
+            // todo discuss: types infer that this is RequireContext; no checks needed?
+            // NOTE: turns out `babel-plugin-require-context-hook` doesn't implement this (yet)
+            typeof req.resolve === 'function' ? req.resolve(filename) : null
+          );
+        } catch (error) {
+          logger.warn(`Unexpected error: ${error}`);
+        }
       });
     });
   } else {


### PR DESCRIPTION
Issue: When stories are written in typescript and they contain type errors, requiring files can swallow the type errors emitted by packages like `fork-ts-checker-webpack-plugin`. Normally this wouldn't be an issue however, when running in certain test environments - like storyshots - this can cause the tests to not be found.

## What I did

This simply wraps the dynamic require in a try-catch block and logs the error. Re-throwing the error is not an option as that is also swallowed.

## How to test

Run storyshots (for example) with a story that has a type error in it in a package with webpack  type checking. The error should be emitted to the console.

- Is this testable with Jest or Chromatic screenshots? - No
- Does this need a new example in the kitchen sink apps? - No
- Does this need an update to the documentation? - No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->