### PR TITLE
Core: Fix `register.tsx` as manager code in preset heuristic

### DIFF
--- a/lib/core/src/server/presets.js
+++ b/lib/core/src/server/presets.js
@@ -71,7 +71,7 @@ export const resolveAddonName = (name) => {
     return {
       name,
       // Accept `register`, `register.js`, `require.resolve('foo/register'), `register-panel`
-      type: path.match(/register(-panel)?(.js)?$/) ? 'managerEntries' : 'presets',
+      type: path.match(/register(-panel)?(.(js|ts|tsx|jsx))?$/) ? 'managerEntries' : 'presets',
     };
   }
 

--- a/lib/core/src/server/presets.test.js
+++ b/lib/core/src/server/presets.test.js
@@ -389,6 +389,8 @@ describe('splitAddons', () => {
       '@storybook/addon-actions/register',
       'storybook-addon-readme/register',
       'addon-foo/register.js',
+      'addon-bar/register.ts',
+      'addon-baz/register.tsx',
       '@storybook/addon-notes/register-panel',
     ];
     expect(splitAddons(addons)).toEqual({


### PR DESCRIPTION
Issue: #10938 

## What I did

`register.tsx` addon entries were incorrectly getting treated as presets files (which are processed by node, and don't currently support ts in all cases. fixed the regex so that they are run in the manager, which gets processed with webpack/babel

## How to test

Tested by hand in https://github.com/TheKnarf/storybookjs-issue-10938
Updated unit tests