### PR TITLE
Addon-docs: Handle JSON.parse exception for Angular union types

### DIFF
--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -101,7 +101,12 @@ const extractEnumValues = (compodocType: any) => {
   if (typeof compodocType !== 'string' || compodocType.indexOf('|') === -1) {
     return null;
   }
-  return compodocType.split('|').map((value) => JSON.parse(value));
+
+  try {
+    return compodocType.split('|').map((value) => JSON.parse(value));
+  } catch (e) {
+    return null;
+  }
 };
 
 export const extractType = (property: Property, defaultValue: any) => {
@@ -127,7 +132,7 @@ const extractDefaultValue = (property: Property) => {
     const value = eval(property.defaultValue);
     return value;
   } catch (err) {
-    logger.info(`Error extracting ${property.name}: $ {property.defaultValue}`);
+    logger.debug(`Error extracting ${property.name}: ${property.defaultValue}`);
     return undefined;
   }
 };


### PR DESCRIPTION
Issue:

I found some problems while parsing our large set of components, specifically, an exception thrown while trying to parse this union type `string | number | Date` or `string | null` as an enum.

## What I did

I tracked the exception down, and changed the default return of `extractEnumValues` as an empty array, so if it's ends up to be empty, it means it's not an enum of literal values.

Also, I fixed the displaying of the `Error extracting` defaultData :)