### PR TITLE
CLI: Fix `sb init` in Yarn workspace environment

### DIFF
--- a/lib/cli/src/helpers.ts
+++ b/lib/cli/src/helpers.ts
@@ -255,6 +255,10 @@ export function installDependencies(
       installArgs.push('-D');
     }
 
+    if (options.useYarn) {
+      installArgs.push('--ignore-workspace-root-check');
+    }
+
     const dependencyResult = spawnSync(spawnCommand, installArgs, {
       stdio: 'inherit',
     });

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -152,3 +152,13 @@ export const yarn2Cra: Parameters = {
     `yarn dlx create-react-app@{{version}} {{name}}-v{{version}}`,
   ].join(' && '),
 };
+
+export const reactInYarnWorkspace: Parameters = {
+  name: 'reactInYarnWorkspace',
+  version: 'latest',
+  generator: [
+    'cd {{name}}-v{{version}}',
+    'echo "{ \\"name\\": \\"workspace-root\\", \\"private\\": true, \\"workspaces\\": [] }" > package.json',
+    `yarn add react react-dom --silent -W`,
+  ].join(' && '),
+};

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -85,7 +85,7 @@ const initStorybook = async ({ cwd, autoDetect = true, name }: Options) => {
   logger.info(`🎨 Initializing Storybook with @storybook/cli`);
   try {
     const type = autoDetect ? '' : `--type ${name}`;
-    await exec(`npx -p @storybook/cli sb init --skip-install --yes ${type}`, { cwd });
+    await exec(`npx -p @storybook/cli sb init --yes ${type}`, { cwd });
   } catch (e) {
     logger.error(`🚨 Storybook initialization failed`);
     throw e;
@@ -187,10 +187,10 @@ const runTests = async ({ name, version, ...rest }: Parameters) => {
     await generate({ ...options, cwd: siblingDir });
     logger.log();
 
-    await initStorybook(options);
+    await setResolutions(options);
     logger.log();
 
-    await setResolutions(options);
+    await initStorybook(options);
     logger.log();
 
     await addRequiredDeps(options);

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -274,13 +274,18 @@ if (frameworkArgs.length > 0) {
 const perform = () => {
   const limit = pLimit(1);
   const narrowedConfigs = Object.values(e2eConfigs);
-  const [a, b] = [+process.env.CIRCLE_NODE_INDEX || 0, +process.env.CIRCLE_NODE_TOTAL || 1];
-  const step = Math.ceil(narrowedConfigs.length / b);
-  const offset = step * a;
+  const nodeIndex = +process.env.CIRCLE_NODE_INDEX || 0;
+  const numberOfNodes = +process.env.CIRCLE_NODE_TOTAL || 1;
 
-  const list = narrowedConfigs.slice().splice(offset, step);
+  const list = narrowedConfigs.filter((_, index) => {
+    return index % numberOfNodes === nodeIndex;
+  });
 
-  logger.info(`📑 Assigning jobs ${list.map((c) => c.name).join(', ')} to node ${a} (on ${b})`);
+  logger.info(
+    `📑 Assigning jobs ${list
+      .map((c) => c.name)
+      .join(', ')} to node ${nodeIndex} (on ${numberOfNodes})`
+  );
 
   return Promise.all(list.map((config) => limit(() => runE2E(config))));
 };


### PR DESCRIPTION
Issue: #10915 

## What I did

 - Add `--ignore-workspace-root-check` flag when CLI is running `yarn add` command.
 - Add E2E test for Yarn workspace. It's based on a simple React setup.
 - Remove `skip-install` option from `sb init` command used in E2E because it can hide some issues with the dependency installation process of @storybook/cli. For instance, missing Yarn flags needed to have the CLI working in Yarn workspaces.

--

Also, improve jobs assignment on CI nodes: 

With the current algorithm, some nodes have no jobs assigned to them due to rounding consideration. For instance, with 10 nodes and 13 jobs to assign:
 - 13 jobs / 10 nodes -> 1.3 jobs per node -> rounded to 2 -> only the 1st 6 nodes run 2 jobs, the 7th 1 job and the other 0 job.

Using a modulo ensures that each node will at least run 1 job and thus reduce the E2E run duration (in theory 🤞).

## How to test

- E2E tests should be 🟢 on CI, especially new E2E test run in `example-v2` job
