### PR TITLE
Addon-docs: Fix function argType inference in react-docgen-typescript

### DIFF
--- a/addons/docs/src/lib/sbtypes/proptypes/convert.ts
+++ b/addons/docs/src/lib/sbtypes/proptypes/convert.ts
@@ -4,10 +4,13 @@ import { PTType } from './types';
 import { SBType } from '../types';
 import { trimQuotes } from '../utils';
 
+const SIGNATURE_REGEXP = /^\(.*\) => /;
+
 export const convert = (type: PTType): SBType | any => {
   const { name, raw, computed, value } = type;
   const base: any = {};
   if (typeof raw !== 'undefined') base.raw = raw;
+
   switch (name) {
     case 'enum': {
       const values = computed ? value : value.map((v: PTType) => trimQuotes(v.value));
@@ -40,6 +43,7 @@ export const convert = (type: PTType): SBType | any => {
     case 'elementType':
     default:
       const otherVal = value ? `${name}(${value})` : name;
-      return { ...base, name: 'other', value: otherVal };
+      const otherName = SIGNATURE_REGEXP.test(name) ? 'function' : 'other';
+      return { ...base, name: otherName, value: otherVal };
   }
 };


### PR DESCRIPTION
Issue: #10996 

## What I did

Hacked around function type inference in `react-docgen-typescript`

This needs proper unit testing, but our stories test this

## How to test

See https://gist.github.com/shilman/69c1dd41a466bae137cc88bd2c6ef487 and Chromatic tests below