### PR TITLE
Capitalize "Design Assets" panel tab title

### DIFF
--- a/addons/design-assets/src/register.tsx
+++ b/addons/design-assets/src/register.tsx
@@ -7,7 +7,7 @@ import { Panel } from './panel';
 
 addons.register(ADDON_ID, () => {
   addons.add(PANEL_ID, {
-    title: 'design assets',
+    title: 'Design Assets',
     type: types.PANEL,
     render: ({ active, key }) => (
       <AddonPanel active={active} key={key}>


### PR DESCRIPTION
Leaving them lower case looks a tiny weenie bit unprofessional, imho.
