### PR TITLE
Controls: Fix `options` control types

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -290,16 +290,43 @@ Here is the full list of available controls:
 | **boolean** | boolean      | checkbox input                                                 | -              |
 | **number**  | number       | a numberic text box input                                      | min, max, step |
 |             | range        | a range slider input                                           | min, max, step |
-| **object**  | object       | json editor text input                                         |                |
-| **options** | radio        | radio buttons input                                            |                |
-|             | inline-radio | inline radio buttons input                                     |                |
-|             | check        | multi-select checkbox input                                    |                |
-|             | inline-check | multi-select inline checkbox input                             |                |
-|             | select       | select dropdown input                                          |                |
-|             | multi-select | multi-select dropdown input                                    |                |
+| **object**  | object       | json editor text input                                         | -              |
+| **enum**    | radio        | radio buttons input                                            | options        |
+|             | inline-radio | inline radio buttons input                                     | options        |
+|             | check        | multi-select checkbox input                                    | options        |
+|             | inline-check | multi-select inline checkbox input                             | options        |
+|             | select       | select dropdown input                                          | options        |
+|             | multi-select | multi-select dropdown input                                    | options        |
 | **string**  | text         | simple text input                                              | -              |
 |             | color        | color picker input that assumes strings are color values       | -              |
 |             | date         | date picker input                                              | -              |
+
+Example customizing a control for an `enum` data type (defaults to `select` control type):
+
+```js
+export default {
+  title: 'Widget',
+  component: Widget,
+  argTypes: {
+    loadingState: {
+      type: 'inline-radio',
+      options: ['loading', 'error', 'ready'],
+    },
+  },
+};
+```
+
+Example customizing a `number` data type (defaults to `number` control type):
+
+```js
+export default {
+  title: 'Gizmo',
+  component: Gizmo,
+  argTypes: {
+    width: { type: 'range', min: 400, max: 1200, step: 50 };
+  },
+};
+```
 
 ### Parameters
 

--- a/addons/docs/src/frameworks/common/inferControls.ts
+++ b/addons/docs/src/frameworks/common/inferControls.ts
@@ -28,7 +28,7 @@ const inferControl = (argType: ArgType): Control => {
       return { type: 'number' };
     case 'enum': {
       const { value } = type as SBEnumType;
-      return { type: 'options', controlType: 'select', options: value };
+      return { type: 'select', options: value };
     }
     case 'function':
     case 'symbol':

--- a/lib/components/src/blocks/ArgsTable/ArgControl.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgControl.tsx
@@ -44,8 +44,13 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs }) => {
       return <NumberControl {...props} {...control} />;
     case 'object':
       return <ObjectControl {...props} {...control} />;
-    case 'options':
-      return <OptionsControl {...props} {...control} />;
+    case 'check':
+    case 'inline-check':
+    case 'radio':
+    case 'inline-radio':
+    case 'select':
+    case 'multi-select':
+      return <OptionsControl {...props} {...control} controlType={control.type} />;
     case 'range':
       return <RangeControl {...props} {...control} />;
     case 'text':

--- a/lib/components/src/controls/options/Options.tsx
+++ b/lib/components/src/controls/options/Options.tsx
@@ -17,19 +17,19 @@ const normalizeOptions = (options: Options) => {
 
 export type OptionsProps = ControlProps<OptionsSelection> & OptionsConfig;
 export const OptionsControl: FC<OptionsProps> = (props) => {
-  const { controlType, options } = props;
+  const { type = 'select', options } = props;
   const normalized = { ...props, options: normalizeOptions(options) };
-  switch (controlType || 'select') {
+  switch (type) {
     case 'check':
     case 'inline-check':
-      return <CheckboxControl {...normalized} isInline={controlType === 'inline-check'} />;
+      return <CheckboxControl {...normalized} isInline={type === 'inline-check'} />;
     case 'radio':
     case 'inline-radio':
-      return <RadioControl {...normalized} isInline={controlType === 'inline-radio'} />;
+      return <RadioControl {...normalized} isInline={type === 'inline-radio'} />;
     case 'select':
     case 'multi-select':
-      return <SelectControl {...normalized} isMulti={controlType === 'multi-select'} />;
+      return <SelectControl {...normalized} isMulti={type === 'multi-select'} />;
     default:
-      throw new Error(`Unknown options type: ${controlType}`);
+      throw new Error(`Unknown options type: ${type}`);
   }
 };

--- a/lib/components/src/controls/types.ts
+++ b/lib/components/src/controls/types.ts
@@ -51,12 +51,11 @@ export type OptionsControlType =
 
 export interface OptionsConfig {
   options: Options;
-  controlType: OptionsControlType;
+  type: OptionsControlType;
 }
 
 export interface NormalizedOptionsConfig {
   options: OptionsObject;
-  controlType: OptionsControlType;
 }
 
 export type TextValue = string;


### PR DESCRIPTION
Issue: #10947 

## What I did

Add documentation per #10947 request, FLATTEN the `options` control specification.  This was actually a bug--something I'd started earlier but didn't finish.

Before:

```
  argTypes: {
    loadingState: {
      type: 'options',
      controlType: 'inline-radio',
      options: ['loading', 'error', 'ready'],
    },
  },
```

After:

```
  argTypes: {
    loadingState: {
      type: 'inline-radio',
      options: ['loading', 'error', 'ready'],
    },
  },
```

## How to test

See stories: https://github.com/storybookjs/storybook/blob/next/lib/components/src/controls/options/Options.stories.tsx 
