### PR TITLE
Addon-controls: Remove residual options-type controls

### DIFF
--- a/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
@@ -136,18 +136,17 @@ describe('enhanceArgTypes', () => {
         it('options', () => {
           expect(
             enhance({
-              argType: { control: { type: 'options', options: [1, 2], controlType: 'radio' } },
+              argType: { control: { type: 'radio', options: [1, 2] } },
             }).input
           ).toMatchInlineSnapshot(`
             {
               "name": "input",
               "control": {
-                "type": "options",
+                "type": "radio",
                 "options": [
                   1,
                   2
-                ],
-                "controlType": "radio"
+                ]
               }
             }
           `);

--- a/examples/official-storybook/stories/addon-docs/props.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/props.stories.mdx
@@ -105,7 +105,7 @@ export const FooBar = ({ foo, bar, baz } = {}) => (
     argTypes={{
       count: { control: { type: 'range', min: 0, max: 10 } },
       label: {
-        control: { type: 'options', options: ['apple', 'banana', 'cherry'] },
+        control: { type: 'select', options: ['apple', 'banana', 'cherry'] },
       },
       background: { control: { type: 'color' } },
     }}

--- a/examples/vue-cli/src/button/Button.stories.ts
+++ b/examples/vue-cli/src/button/Button.stories.ts
@@ -14,5 +14,5 @@ export const ButtonWithProps = (args: any) => ({
   },
 });
 ButtonWithProps.argTypes = {
-  size: { control: { type: 'options', options: ButtonSizes } },
+  size: { control: { type: 'select', options: ButtonSizes } },
 };


### PR DESCRIPTION
Issue: #11003

Updating the flattened `options` control in `beta.20` I found some related code in the source code.