### PR TITLE
Addon-controls: Add hideNoControlsWarning parameter

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -333,6 +333,7 @@ export default {
 Controls supports the following configuration parameters, either [globally or on a per-story basis](https://storybook.js.org/docs/basics/writing-stories/#parameters):
 
 - [Expanded: show property documentation](#expanded-show-property-documentation)
+- [Hide NoControls warning](#hide-nocontrols-warning)
 
 #### Expanded: show property documentation
 
@@ -351,6 +352,16 @@ And here's what the resulting UI looks like:
 <center>
   <img src="https://raw.githubusercontent.com/storybookjs/storybook/next/addons/controls/docs/media/addon-controls-expanded.png" width="80%" />
 </center>
+
+#### Hide NoControls warning
+
+If you don't plan to handle the control args inside your Story, you can remove the warning with:
+
+```jsx
+Basic.parameters = {
+  controls: { hideNoControlsWarning: true },
+};
+```
 
 ## Framework support
 

--- a/addons/controls/src/components/ControlsPanel.tsx
+++ b/addons/controls/src/components/ControlsPanel.tsx
@@ -6,6 +6,7 @@ import { PARAM_KEY } from '../constants';
 
 interface ControlsParameters {
   expanded?: boolean;
+  hideNoControlsWarning?: boolean;
 }
 
 const NoControlsWrapper = styled.div(({ theme }) => ({
@@ -15,7 +16,7 @@ const NoControlsWrapper = styled.div(({ theme }) => ({
 
 const NoControlsWarning = () => (
   <NoControlsWrapper>
-    No controls found for this component.&nbsp;
+    This story is not configured to handle controls.&nbsp;
     <Link
       href="https://github.com/storybookjs/storybook/blob/next/addons/controls/README.md#writing-stories"
       target="_blank"
@@ -29,11 +30,14 @@ const NoControlsWarning = () => (
 export const ControlsPanel: FC = () => {
   const [args, updateArgs] = useArgs();
   const rows = useArgTypes();
-  const { expanded } = useParameter<ControlsParameters>(PARAM_KEY, {});
+  const { expanded, hideNoControlsWarning = false } = useParameter<ControlsParameters>(
+    PARAM_KEY,
+    {}
+  );
   const hasControls = Object.values(rows).filter((argType) => argType?.control?.type).length > 0;
   return (
     <>
-      {hasControls ? null : <NoControlsWarning />}
+      {hasControls || hideNoControlsWarning ? null : <NoControlsWarning />}
       <ArgsTable {...{ compact: !expanded && hasControls, rows, args, updateArgs }} />
     </>
   );

--- a/examples/angular-cli/src/stories/doc-injectable/doc-injectable.stories.ts
+++ b/examples/angular-cli/src/stories/doc-injectable/doc-injectable.stories.ts
@@ -3,7 +3,10 @@ import { DocInjectableService } from './doc-injectable.service';
 export default {
   title: 'DocInjectable',
   component: DocInjectableService,
-  parameters: { docs: { iframeHeight: 120 } },
+  parameters: {
+    docs: { iframeHeight: 120 },
+    controls: { hideNoControlsWarning: true },
+  },
 };
 
 const modules = {

--- a/examples/angular-cli/src/stories/doc-pipe/doc-pipe.stories.ts
+++ b/examples/angular-cli/src/stories/doc-pipe/doc-pipe.stories.ts
@@ -3,7 +3,10 @@ import { DocPipe } from './doc-pipe.pipe';
 export default {
   title: 'DocPipe',
   component: DocPipe,
-  parameters: { docs: { iframeHeight: 120 } },
+  parameters: {
+    docs: { iframeHeight: 120 },
+    controls: { hideNoControlsWarning: true },
+  },
 };
 
 const modules = {


### PR DESCRIPTION
Issue:

Right now the warning will be always visible even if we don't want to have interactive controls for a specific Story, and just have the expanded controls.

## What I did

I added a new parameter to be able to hide it in general or for a specific story with:
```
{ controls: { hideNoControlsWarning: true } }
```
