### PR TITLE
Controls: Fix null entry in options array handling

### DIFF
--- a/lib/components/src/controls/options/Options.tsx
+++ b/lib/components/src/controls/options/Options.tsx
@@ -16,7 +16,7 @@ import { ControlProps, OptionsSelection, OptionsConfig, Options } from '../types
 const normalizeOptions = (options: Options) => {
   if (Array.isArray(options)) {
     return options.reduce((acc, item) => {
-      acc[item.toString()] = item;
+      acc[String(item)] = item;
       return acc;
     }, {});
   }


### PR DESCRIPTION
We have a component with `@Input size: null | 'large'` to generate a selector control for it.
In `beta.21` it throws an exception because `.toString()` is called for each item.

## What I did

Implemented a safer `String(item)` instead `item.toString()` for those cases.

![image](https://user-images.githubusercontent.com/260185/83812551-5bd68980-a681-11ea-8845-ad01019590e5.png)
