### PR TITLE
Docs: Percy Storybook

### DIFF
--- a/docs/src/pages/testing/automated-visual-testing/index.md
+++ b/docs/src/pages/testing/automated-visual-testing/index.md
@@ -43,7 +43,7 @@ Here are some in alphabetical order:
 - [Creevey](https://github.com/wKich/creevey)
 - [Happo](https://happo.io)
 - [Loki](https://loki.js.org/)
-- [Percy](https://docs.percy.io/docs/storybook-for-react)
+- [Percy](https://docs.percy.io/docs/storybook)
 - [Screener](https://screener.io/v2/docs)
 - [StoryShots](https://github.com/storybookjs/storybook/tree/master/addons/storyshots) with its [seamless integration](https://github.com/storybookjs/storybook/tree/master/addons/storyshots#configure-storyshots-for-image-snapshots) with [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot)
 


### PR DESCRIPTION
## What I did

Update link to Percy Storybook SDK. The previous link was pointing to the old SDK used by Storybook V4.

## How to test

Visit https://docs.percy.io/docs/storybook for more information