### PR TITLE
Core: Add babel plugin for typescript decorators

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/plugin-proposal-export-default-from": "^7.8.3",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.6",

--- a/lib/core/src/server/common/babel.js
+++ b/lib/core/src/server/common/babel.js
@@ -1,6 +1,7 @@
 export const plugins = [
   require.resolve('@babel/plugin-transform-shorthand-properties'),
   require.resolve('@babel/plugin-transform-block-scoping'),
+  [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
   [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
   [require.resolve('@babel/plugin-proposal-private-methods'), { loose: true }],
   require.resolve('@babel/plugin-proposal-export-default-from'),

--- a/lib/core/src/server/common/babel.js
+++ b/lib/core/src/server/common/babel.js
@@ -1,6 +1,10 @@
 export const plugins = [
   require.resolve('@babel/plugin-transform-shorthand-properties'),
   require.resolve('@babel/plugin-transform-block-scoping'),
+  /*
+   * Added for TypeScript experimental decorator support
+   * https://babeljs.io/docs/en/babel-plugin-transform-typescript#typescript-compiler-options
+   */
   [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
   [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
   [require.resolve('@babel/plugin-proposal-private-methods'), { loose: true }],


### PR DESCRIPTION
Issue: #11061 

## What I did
- Added the `@babel/plugin-proposal-decorators` to the babel config

## How to test

- I've tested it locally but I'd like to add a new example in the kitchen sink apps.
