### PR TITLE
Addons: extract ArgTypes consistently

### DIFF
--- a/addons/controls/src/components/ControlsPanel.tsx
+++ b/addons/controls/src/components/ControlsPanel.tsx
@@ -1,11 +1,12 @@
 import React, { FC } from 'react';
 import { styled } from '@storybook/theming';
 import { ArgsTable, Link } from '@storybook/components';
-import { useArgs, useArgTypes, useParameter } from '@storybook/api';
+import { ArgType, useArgs, useArgTypes, useParameter } from '@storybook/api';
 import { PARAM_KEY } from '../constants';
 
 interface ControlsParameters {
   expanded?: boolean;
+  filterFn?: (argType: ArgType) => boolean;
   hideNoControlsWarning?: boolean;
 }
 
@@ -30,11 +31,17 @@ const NoControlsWarning = () => (
 export const ControlsPanel: FC = () => {
   const [args, updateArgs] = useArgs();
   const rows = useArgTypes();
-  const { expanded, hideNoControlsWarning = false } = useParameter<ControlsParameters>(
-    PARAM_KEY,
-    {}
-  );
+  const {
+    expanded,
+    filterFn = (argType) => !argType?.table?.type?.private,
+    hideNoControlsWarning = false,
+  } = useParameter<ControlsParameters>(PARAM_KEY, {});
   const hasControls = Object.values(rows).filter((argType) => argType?.control?.type).length > 0;
+
+  Object.keys(rows).forEach((key) => {
+    if (!filterFn(rows[key])) delete rows[key];
+  });
+
   return (
     <>
       {hasControls || hideNoControlsWarning ? null : <NoControlsWarning />}

--- a/addons/docs/docs/multiframework.md
+++ b/addons/docs/docs/multiframework.md
@@ -50,7 +50,7 @@ addParameters({
 });
 ```
 
-The `extractProps`function receives a component as an argument, and returns an object of type [`PropsTableProps`](https://github.com/storybookjs/storybook/blob/next/lib/components/src/blocks/PropsTable/PropsTable.tsx#L147), which can either be an array of `PropDef` rows (React), or a mapping of section name to an array of `PropDef` rows (e.g. `Props`/`Events`/`Slots` in Vue).
+The `extractProps` function receives a component as an argument, and returns an object of type [`PropsTableProps`](https://github.com/storybookjs/storybook/blob/next/lib/components/src/blocks/PropsTable/PropsTable.tsx#L148), which can either be an array of `PropDef` rows (React), or a mapping of section name to an array of `PropDef` rows (e.g. `Props`/`Events`/`Slots` in Vue).
 
 ```ts
 export interface PropDef {

--- a/addons/docs/src/frameworks/angular/__testfixtures__/doc-button/argtypes.snapshot
+++ b/addons/docs/src/frameworks/angular/__testfixtures__/doc-button/argtypes.snapshot
@@ -9,6 +9,7 @@ Object {
     "table": Object {
       "category": "properties",
       "type": Object {
+        "private": true,
         "required": true,
         "summary": "string",
       },
@@ -25,6 +26,7 @@ Object {
     "table": Object {
       "category": "properties",
       "type": Object {
+        "private": true,
         "required": true,
         "summary": "string",
       },
@@ -41,6 +43,7 @@ Object {
     "table": Object {
       "category": "inputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "\\"primary\\" | \\"secondary\\"",
       },
@@ -55,11 +58,12 @@ Object {
   },
   "buttonRef": Object {
     "defaultValue": undefined,
-    "description": "",
+    "description": "\`@ViewChild('buttonRef', {static: false})\`",
     "name": "buttonRef",
     "table": Object {
       "category": "view child",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "ElementRef",
       },
@@ -76,6 +80,7 @@ Object {
     "table": Object {
       "category": "methods",
       "type": Object {
+        "private": false,
         "required": false,
         "summary": "(x: number, y: string | number) => number",
       },
@@ -92,6 +97,7 @@ Object {
     "table": Object {
       "category": "inputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "string",
       },
@@ -108,6 +114,7 @@ Object {
     "table": Object {
       "category": "properties",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "string",
       },
@@ -124,6 +131,7 @@ Object {
     "table": Object {
       "category": "inputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": undefined,
       },
@@ -134,11 +142,12 @@ Object {
   },
   "item": Object {
     "defaultValue": undefined,
-    "description": undefined,
+    "description": "",
     "name": "item",
     "table": Object {
       "category": "inputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "[]",
       },
@@ -155,6 +164,7 @@ Object {
     "table": Object {
       "category": "inputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "string",
       },
@@ -172,6 +182,7 @@ Object {
     "table": Object {
       "category": "outputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "EventEmitter",
       },
@@ -188,6 +199,7 @@ Object {
     "table": Object {
       "category": "methods",
       "type": Object {
+        "private": true,
         "required": false,
         "summary": "(password: string) => void",
       },
@@ -203,6 +215,7 @@ Object {
     "table": Object {
       "category": "properties",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "T[]",
       },
@@ -219,6 +232,7 @@ Object {
     "table": Object {
       "category": "methods",
       "type": Object {
+        "private": false,
         "required": false,
         "summary": "(id?: number) => void",
       },
@@ -235,6 +249,7 @@ Object {
     "table": Object {
       "category": "methods",
       "type": Object {
+        "private": false,
         "required": false,
         "summary": "(things: ISomeInterface) => void",
       },
@@ -245,11 +260,12 @@ Object {
   },
   "showKeyAlias": Object {
     "defaultValue": undefined,
-    "description": undefined,
+    "description": "",
     "name": "showKeyAlias",
     "table": Object {
       "category": "inputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "",
       },
@@ -266,6 +282,7 @@ Object {
     "table": Object {
       "category": "inputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": "ButtonSize",
       },
@@ -282,6 +299,7 @@ Object {
     "table": Object {
       "category": "inputs",
       "type": Object {
+        "private": false,
         "required": true,
         "summary": undefined,
       },

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -106,6 +106,10 @@ const displaySignature = (item: Method): string => {
   return `(${args.join(', ')}) => ${item.returnType}`;
 };
 
+const doesHaveModifier = (kind: number, modifierKind?: number[]) => {
+  return (modifierKind || []).includes(kind);
+};
+
 const extractTypeFromValue = (defaultValue: any) => {
   const valueType = typeof defaultValue;
   return defaultValue || valueType === 'boolean' ? valueType : null;
@@ -183,6 +187,7 @@ export const extractArgTypesFromData = (componentData: Class | Directive | Injec
           type: {
             summary: isMethod(item) ? displaySignature(item) : item.type,
             required: isMethod(item) ? false : !item.optional,
+            private: doesHaveModifier(112 /* SyntaxKind.PrivateKeyword */, item.modifierKind),
           },
         },
       };

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -177,11 +177,19 @@ export const extractArgTypesFromData = (componentData: Class | Directive | Injec
         isMethod(item) || section !== 'inputs'
           ? { name: 'void' }
           : extractType(item as Property, defaultValue);
+      const decorators = (item.decorators || [])
+        .map(({ name, stringifiedArguments }) => {
+          return `@${name}${stringifiedArguments ? `(${stringifiedArguments})` : ''}`;
+        })
+        .join(' ');
+      const description = [item.description, decorators ? `\`${decorators}\`` : '']
+        .filter(Boolean)
+        .join('<br />');
       const argType = {
         name: item.name,
-        description: item.description,
-        defaultValue,
+        description,
         type,
+        defaultValue,
         table: {
           category: section,
           type: {

--- a/addons/docs/src/frameworks/angular/types.ts
+++ b/addons/docs/src/frameworks/angular/types.ts
@@ -1,18 +1,32 @@
+export interface Argument {
+  name: string;
+  type: string;
+  optional?: boolean;
+}
+
+export interface Decorator {
+  name: string;
+  stringifiedArguments: string;
+}
+
 export interface Method {
   name: string;
   args: Argument[];
   returnType: string;
+  optional: boolean;
+  modifierKind?: number[];
   decorators?: Decorator[];
   description?: string;
 }
 
 export interface Property {
   name: string;
-  decorators?: Decorator[];
+  defaultValue?: string;
   type: string;
   optional: boolean;
-  defaultValue?: string;
   description?: string;
+  decorators?: Decorator[];
+  modifierKind?: number[];
 }
 
 export interface Class {
@@ -55,16 +69,6 @@ export interface Directive {
 }
 
 export type Component = Directive;
-
-export interface Argument {
-  name: string;
-  type: string;
-  optional?: boolean;
-}
-
-export interface Decorator {
-  name: string;
-}
 
 export interface CompodocJson {
   directives: Directive[];

--- a/addons/docs/src/frameworks/ember/jsondoc.js
+++ b/addons/docs/src/frameworks/ember/jsondoc.js
@@ -19,14 +19,16 @@ export const extractArgTypes = (componentName) => {
     return null;
   }
   const rows = componentDoc.attributes.arguments.map((prop) => {
+    const required = prop.tags.length ? prop.tags.some((tag) => tag.name === 'required') : false;
     return {
       name: prop.name,
-      defaultValue: prop.defaultValue,
       description: prop.description,
+      required,
+      defaultValue: prop.defaultValue,
       table: {
         type: {
           summary: prop.type,
-          required: prop.tags.length ? prop.tags.some((tag) => tag.name === 'required') : false,
+          required,
         },
       },
     };

--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -19,8 +19,9 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
 
         acc[row.name] = {
           ...row,
-          defaultValue,
           type: { required, ...sbType },
+          required,
+          defaultValue,
           table: {
             type,
             jsDocTags,

--- a/addons/docs/src/frameworks/vue/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue/extractArgTypes.ts
@@ -21,12 +21,13 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
         name,
         description,
         type: { required, ...sbType },
+        required,
         defaultValue: defaultValue && trim(defaultValue.detail || defaultValue.summary),
         table: {
+          category: section,
           type,
           jsDocTags,
           defaultValue,
-          category: section,
         },
       };
     });

--- a/addons/docs/src/frameworks/web-components/custom-elements.ts
+++ b/addons/docs/src/frameworks/web-components/custom-elements.ts
@@ -39,9 +39,9 @@ function mapData(data: TagItem[], category: string) {
       const type = category === 'properties' ? { name: item.type } : { name: 'void' };
       acc[item.name] = {
         name: item.name,
-        required: false,
         description: item.description,
         type,
+        required: false,
         table: {
           category,
           type: { summary: item.type },


### PR DESCRIPTION
Issue:

1. I wanted to exclude the private ArgTypes from the ControlPanel
2. I needed to extend Angular's props description to include the decorators.

## What I did

1. I extended Angular's compodoc `extractArgTypes` to add the private flag if `SyntaxKind.PrivateKeyword` is present in the `item.modifierKind` array.

2. Also I extended the description with the code of the property injectors to look like:
![image](https://user-images.githubusercontent.com/260185/83954086-a6840d00-a80b-11ea-8890-f1481a59a6f9.png)

## Findings

I saw duplicated definitions of the `ArgType` interface, and I'm not sure why not just use the `@storybook/api` one. Because of this, I got no clue of where `ArgType.required` nor `ArgType.type` is used, there should be improvements in the typings to track this better.