### PR TITLE
Addon-docs: Add `docs.forceExtractedArgTypes` parameter

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -242,7 +242,14 @@ This generates the following UI with a custom range slider:
   <img src="https://raw.githubusercontent.com/storybookjs/storybook/next/addons/controls/docs/media/addon-controls-args-reflow-slider.png" width="80%" />
 </center>
 
-<h4>Angular</h4>
+**Note:** If you add an `ArgType` that is not part of the component, Storybook will *only* use your argTypes definitions.  
+If you want to merge new controls with the existing component properties, you must enable this parameter:
+
+```jsx
+  docs: { forceExtractedArgTypes: true },
+```
+
+#### Angular
 
 To achieve this within an angular-cli build.
 

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.ts
@@ -13,17 +13,18 @@ const isSubset = (kind: string, subset: object, superset: object) => {
 
 export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
   const { component, argTypes: userArgTypes = {}, docs = {}, args = {} } = context.parameters;
-  const { extractArgTypes } = docs;
+  const { extractArgTypes, forceExtractedArgTypes = false } = docs;
 
   const namedArgTypes = mapValues(userArgTypes, (val, key) => ({ name: key, ...val }));
   const inferredArgTypes = inferArgTypes(args);
   let extractedArgTypes: ArgTypes = extractArgTypes && component ? extractArgTypes(component) : {};
 
   if (
-    (Object.keys(userArgTypes).length > 0 &&
+    !forceExtractedArgTypes &&
+    ((Object.keys(userArgTypes).length > 0 &&
       !isSubset(context.kind, userArgTypes, extractedArgTypes)) ||
-    (Object.keys(inferredArgTypes).length > 0 &&
-      !isSubset(context.kind, inferredArgTypes, extractedArgTypes))
+      (Object.keys(inferredArgTypes).length > 0 &&
+        !isSubset(context.kind, inferredArgTypes, extractedArgTypes)))
   ) {
     extractedArgTypes = {};
   }


### PR DESCRIPTION
Issue:

I wanted to extend the Inputs of my Story with a couple custom controls, but ATM adding a non-Subset of args/argTypes results on a resetted `extractedArgTypes = {}`. I wanted to preserve the extracted Args while adding/overriding some controls.

## What I did

I added the `docs.forceExtractedArgTypes: boolean` parameter to skip the validation and be able to combine all the existing parameters: extractedArgTypes, userArgTypes and inferredArgTypes.

@shilman I'm not sure where to document this because it's mostly related to `argTypes` customization (addon-controls), but the parameters seems logically connected to the extraction located in the addon-docs.

PS/ as always, if you realize a better name, it's fine.