### PR TITLE
Controls: Fix enum extraction for react-docgen-typescript

### DIFF
--- a/addons/docs/src/lib/sbtypes/proptypes/convert.ts
+++ b/addons/docs/src/lib/sbtypes/proptypes/convert.ts
@@ -41,9 +41,23 @@ export const convert = (type: PTType): SBType | any => {
     case 'instanceOf':
     case 'element':
     case 'elementType':
-    default:
+    default: {
+      if (name?.indexOf('|') > 0) {
+        // react-docgen-typescript-loader doesn't always produce proper
+        // enum types, possibly due to https://github.com/strothj/react-docgen-typescript-loader/issues/81
+        // this hack tries to parse out values from the string and should be
+        // removed when RDTL gets a little smarter about this
+        try {
+          const literalValues = name.split('|').map((v: string) => JSON.parse(v));
+          return { ...base, name: 'enum', value: literalValues };
+        } catch (err) {
+          // fall through
+        }
+      }
       const otherVal = value ? `${name}(${value})` : name;
       const otherName = SIGNATURE_REGEXP.test(name) ? 'function' : 'other';
+
       return { ...base, name: otherName, value: otherVal };
+    }
   }
 };

--- a/docs/src/pages/configurations/typescript-config/index.md
+++ b/docs/src/pages/configurations/typescript-config/index.md
@@ -33,6 +33,7 @@ module.exports = {
     checkOptions: {},
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
       propFilter: (prop) => (prop.parent ? !/node_modules/.test(prop.parent.fileName) : true),
     },
   },

--- a/lib/core/src/server/config/defaults.js
+++ b/lib/core/src/server/config/defaults.js
@@ -2,6 +2,7 @@ export const typeScriptDefaults = {
   check: false,
   reactDocgen: 'react-docgen-typescript',
   reactDocgenTypescriptOptions: {
+    shouldExtractLiteralValuesFromEnum: true,
     propFilter: (prop) => (prop.parent ? !/node_modules/.test(prop.parent.fileName) : true),
   },
 };


### PR DESCRIPTION
Issue: #11019 

## What I did

Enable the enum extraction setting for `react-docgen-typescript-loader`, plus a little hack to workaround some deficiencies there

## How to test

See `typescript > union` stories in `official-storybook`