### PR TITLE
feat(html): add JSX support for html stories

### DIFF
--- a/app/html/package.json
+++ b/app/html/package.json
@@ -34,12 +34,15 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
+    "@babel/plugin-transform-react-jsx": "^7.3.0",
     "@storybook/addons": "6.0.0-beta.22",
     "@storybook/core": "6.0.0-beta.22",
     "@types/webpack-env": "^1.15.2",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "html-loader": "^1.0.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1"
   },

--- a/app/html/src/client/preview/render.ts
+++ b/app/html/src/client/preview/render.ts
@@ -1,5 +1,7 @@
 import { document, Node } from 'global';
 import dedent from 'ts-dedent';
+import ReactDOMServer from 'react-dom/server';
+import { isValidElement } from 'react';
 import { RenderContext } from './types';
 
 const rootElement = document.getElementById('root');
@@ -25,9 +27,12 @@ export default function renderMain({
 
     rootElement.innerHTML = '';
     rootElement.appendChild(element);
+  } else if (isValidElement(element)) {
+    rootElement.innerHTML = '';
+    rootElement.innerHTML = ReactDOMServer.renderToStaticMarkup(element);
   } else {
     showError({
-      title: `Expecting an HTML snippet or DOM node from the story: "${name}" of "${kind}".`,
+      title: `Expecting an HTML snippet, DOM node or JSX element from the story: "${name}" of "${kind}".`,
       description: dedent`
         Did you forget to return the HTML snippet from the story?
         Use "() => <your snippet or node>" or when defining the story.

--- a/app/html/src/server/framework-preset-html.ts
+++ b/app/html/src/server/framework-preset-html.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
+import { TransformOptions } from '@babel/core';
 
 export function webpack(config: Configuration) {
   return {
@@ -18,5 +19,24 @@ export function webpack(config: Configuration) {
         },
       ],
     },
+  };
+}
+
+export function babelDefault(config: TransformOptions) {
+  return {
+    ...config,
+    plugins: [
+      ...config.plugins,
+      [
+        require.resolve('@babel/plugin-transform-react-jsx'),
+        {},
+        // it seems this plugin is already included,
+        // but is not applied for some reason
+        // if removed it will fail with `Module parse failed: Unexpected token`
+        // if added babel will complain about duplicate plugin found
+        // and it recommends to use it under another name
+        'jsx-transpiler',
+      ],
+    ],
   };
 }

--- a/examples/html-kitchen-sink/stories/source-loader.stories.js
+++ b/examples/html-kitchen-sink/stories/source-loader.stories.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import button from './button.html';
 
 const packageName = './button.html';
@@ -24,3 +25,14 @@ export const SimpleStory = () =>
       </strong>
     </p>`;
 SimpleStory.storyName = 'Very simple story';
+
+function JSXComponent() {
+  return (
+    <p>
+      <strong>This is a rendered using JSX</strong>
+    </p>
+  );
+}
+
+export const JSXElement = () => <JSXComponent />;
+JSXElement.storyName = 'Story using JSX';


### PR DESCRIPTION
This is just an experiment feel free to close if this is not needed. I just created this PR if someone wants to learn something from this.

Today I studied how storybook internals work, and wanted to experiment with `JSX` in `HTML` stories. This is the final result.

Note:
Right now `import React from 'react'` is required in files where `JSX` is used. with [`@babel/plugin-transform-react-jsx@^7.9`][1] you can put it in automatic mode, and React import is not needed anymore.

[1]: https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#react-automatic-runtime