### PR TITLE
Vue: Fix force rendering

### DIFF
--- a/app/vue/src/client/preview/render.ts
+++ b/app/vue/src/client/preview/render.ts
@@ -44,10 +44,8 @@ export default function render({
 
   showMain();
 
-  // at component creation || refresh by HMR
-  if (!root[COMPONENT] || forceRender) {
-    root[COMPONENT] = element;
-  }
+  // always refresh the component
+  root[COMPONENT] = element;
 
   // @ts-ignore https://github.com/storybookjs/storybook/pull/7578#discussion_r307986139
   root[VALUES] = element.options[VALUES];

--- a/app/vue/src/client/preview/render.ts
+++ b/app/vue/src/client/preview/render.ts
@@ -45,7 +45,7 @@ export default function render({
   showMain();
 
   // at component creation || refresh by HMR
-  if (!root[COMPONENT] || !forceRender) {
+  if (!root[COMPONENT] || forceRender) {
     root[COMPONENT] = element;
   }
 

--- a/examples/vue-kitchen-sink/.storybook/main.js
+++ b/examples/vue-kitchen-sink/.storybook/main.js
@@ -2,6 +2,7 @@ module.exports = {
   stories: ['../src/stories/**/*.stories.@(js|mdx)'],
   addons: [
     '@storybook/addon-docs',
+    '@storybook/addon-controls',
     '@storybook/addon-storysource',
     '@storybook/addon-actions',
     '@storybook/addon-links',

--- a/examples/vue-kitchen-sink/package.json
+++ b/examples/vue-kitchen-sink/package.json
@@ -17,6 +17,7 @@
     "@storybook/addon-a11y": "6.0.0-beta.22",
     "@storybook/addon-actions": "6.0.0-beta.22",
     "@storybook/addon-backgrounds": "6.0.0-beta.22",
+    "@storybook/addon-controls": "6.0.0-beta.22",
     "@storybook/addon-docs": "6.0.0-beta.22",
     "@storybook/addon-knobs": "6.0.0-beta.22",
     "@storybook/addon-links": "6.0.0-beta.22",


### PR DESCRIPTION
Issue: #11051 

## What I did

- [x] Added controls to `vue-kitchen-sink` to repro.
- [x] Diagnose and fix

## Notes

This is a "major" change to Vue. AFAICT the core rendering logic was backwards for the past two years 🤦 . Let's see what Chromatic says. cc @tmeasday @ndelangen 

I'd also like feedback from @Aaron-Pool @pksunkara @graup on this. Since it was getting fully re-rendered on every HMR and re-used on every force render, we could potentially just remove that optimization entirely. WDYT?

## How to test

Open `vue-kitchen-sink` and try editing the `Button > rounded` story in the `Controls` addon (before & after change)