### PR TITLE
Changed react-native-modal-selector dependency version

### DIFF
--- a/addons/ondevice-knobs/package.json
+++ b/addons/ondevice-knobs/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15.7.2",
     "react-native-color-picker": "^0.4.0",
     "react-native-modal-datetime-picker": "^7.4.2",
-    "react-native-modal-selector": "^1.0.2",
+    "react-native-modal-selector": "^2.0.1",
     "react-native-switch": "^1.5.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Issue:

Error when using addons-ondevice-knobs select on Android platform. 
Issue is related to previous [react-native-modal-selector](https://github.com/peacechen/react-native-modal-selector) version ([fixed in 2.0.1](https://github.com/peacechen/react-native-modal-selector/commit/088a1651887792c3b1ea8b0a2bdf50adfe16ff5e)).


[Video of an issue](https://drive.google.com/file/d/1AerHw-tM4LrWFpCUr0eJlyZSfXbdxw_v/view?usp=sharing)

## What I did

Updated [@storybook/addons-ondevice-knobs](https://github.com/storybookjs/storybook/tree/master/addons/ondevice-knobs) react-native-modal-selector dependency version from ^1.0.2 to ^2.0.1


