### PR TITLE
CLI: Pass --quiet to disable HMR logging in browser console

### DIFF
--- a/lib/core/src/server/preview/preview-preset.js
+++ b/lib/core/src/server/preview/preview-preset.js
@@ -9,8 +9,12 @@ export const entries = async (_, options) => {
   result = result.concat(await createPreviewEntry(options));
 
   if (options.configType === 'DEVELOPMENT') {
+    // Suppress informational messages when --quiet is specified. webpack-hot-middleware's quiet
+    // parameter would also suppress warnings.
     result = result.concat(
-      `${require.resolve('webpack-hot-middleware/client')}?reload=true&quiet=${options.quiet}`
+      `${require.resolve('webpack-hot-middleware/client')}?reload=true&quiet=false&noInfo=${
+        options.quiet
+      }`
     );
   }
 

--- a/lib/core/src/server/preview/preview-preset.js
+++ b/lib/core/src/server/preview/preview-preset.js
@@ -10,7 +10,7 @@ export const entries = async (_, options) => {
 
   if (options.configType === 'DEVELOPMENT') {
     result = result.concat(
-      `${require.resolve('webpack-hot-middleware/client')}?reload=true&quiet=false`
+      `${require.resolve('webpack-hot-middleware/client')}?reload=true&quiet=${options.quiet}`
     );
   }
 


### PR DESCRIPTION
Issue: #8461

Pass the CLI `--quiet` option to the hot module replacement client
instead of hardcoding it in development builds. A minor improvement to
60961d380ed4b132c690e3fef0f7c0ce19d3f6c3 (#9535).

https://github.com/storybookjs/storybook/issues/8461#issuecomment-640515472

## What I did

Pass `--quiet` to webpack-hot-middleware/client. Default to true.

## How to test

Pass `--quiet` to `start-storybook` and HMR messages should disappear.

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
