### PR TITLE
docs: mention env vars on custom head/body pages

### DIFF
--- a/docs/src/pages/configurations/add-custom-body/index.md
+++ b/docs/src/pages/configurations/add-custom-body/index.md
@@ -21,7 +21,7 @@ If using relative sizing in your project (like `rem` or `em`), you may update th
 </style>
 ```
 
-That's it. Storybook will inject these tags to html body.
+That’s it. Storybook will inject these tags to the html body. It is also possible to use [environment variables](https://storybook.js.org/docs/configurations/env-vars/#usage-in-custom-headbody).
 
 > **Important**
 >

--- a/docs/src/pages/configurations/add-custom-head-tags/index.md
+++ b/docs/src/pages/configurations/add-custom-head-tags/index.md
@@ -12,7 +12,7 @@ You can accomplish this by creating a file called `preview-head.html` inside the
 <script>try{ Typekit.load(); } catch(e){ }</script>
 ```
 
-That's it. Storybook will inject these tags.
+That's it. Storybook will inject these tags. It is also possible to use [environment variables](https://storybook.js.org/docs/configurations/env-vars/#usage-in-custom-headbody).
 
 > **Important**
 >


### PR DESCRIPTION
Issue: [custom body](https://storybook.js.org/docs/configurations/add-custom-body/) and [custom head](https://storybook.js.org/docs/configurations/add-custom-head-tags) doc pages did not mention the possibility to use env vars.

## What I did
Updated the docs 😃 
