### PR TITLE
docs(a11y): add information on enabling this addon globally for all stories

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -22,6 +22,15 @@ module.exports = {
 };
 ```
 
+To enable `a11y` globally for all stories, add this to your `preview.js` file.
+
+```js
+import { addDecorator } from '@storybook/react';
+import { withA11y } from '@storybook/addon-a11y';
+
+addDecorator(withA11y);
+```
+
 ```js
 import React from 'react';
 


### PR DESCRIPTION
Issue:
README was lacking information on how to enable this addon. This adds documentation related to https://github.com/storybookjs/storybook/issues/9471

## What I did
Added information to README.md for a11y addon, to include information on how to enable this addon globally.

## How to test
Preview the md file

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? This is an update to the documentation

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
