### PR TITLE
Check window parent isn't window (i.e not really a parent)

### DIFF
--- a/lib/channel-postmessage/src/index.ts
+++ b/lib/channel-postmessage/src/index.ts
@@ -122,7 +122,7 @@ export class PostmsgTransport {
 
       return list.length ? list : this.getCurrentFrames();
     }
-    if (window && window.parent) {
+    if (window && window.parent !== window) {
       return [window.parent];
     }
 


### PR DESCRIPTION
Issue: We were setting the "parent" window to be the current window if the iframe was "disconnected", leading to events getting "emitted" twice.

### NOTE THIS TELESCOPES ON https://github.com/storybookjs/storybook/pull/11080

## What I did

Check `window.parent !== window`.

## How to test

Hopefully we didn't accidentally rely on this anywhere