### PR TITLE
Core: Fix default Babel config for CRA

### DIFF
--- a/lib/core/src/server/common/common-preset.js
+++ b/lib/core/src/server/common/common-preset.js
@@ -4,9 +4,14 @@ import babelConfig from './babel';
 
 export const babel = async (_, options) => {
   const { configDir, presets } = options;
+  const hasCRAPreset = options.presetsList.some(
+    (preset) => (preset.name || preset) === '@storybook/preset-create-react-app'
+  );
+
+  const babelDefault = hasCRAPreset ? { presets: [], plugins: [] } : babelConfig();
 
   return loadCustomBabelConfig(configDir, () =>
-    presets.apply('babelDefault', babelConfig(), options)
+    presets.apply('babelDefault', babelDefault, options)
   );
 };
 


### PR DESCRIPTION
Issue: #11045

## What I did
Our default Babel config is no longer returned for CRA, but user-provided config is still respected. We need a more scalable option for this in future.

## How to test

There should be no difference in behaviour for users, but the edge case reported in #11045 should be resolved - which was caused by duplicate presets/plugins.
