### PR TITLE
Addon-docs: Fix Vue args rendering in Docs mode

### DIFF
--- a/addons/docs/docs/docspage.md
+++ b/addons/docs/docs/docspage.md
@@ -173,9 +173,9 @@ import { addParameters } from '@storybook/vue';
 
 addParameters({
   docs: {
-    prepareForInline: (storyFn) => {
+    prepareForInline: (storyFn, { args }) => {
       const Story = toReact(storyFn());
-      return <Story />;
+      return <Story {...args} />;
     },
   },
 });

--- a/addons/docs/docs/multiframework.md
+++ b/addons/docs/docs/multiframework.md
@@ -88,15 +88,15 @@ import toReact from '@egoist/vue-to-react';
 addParameters({
   docs: {
     // `container`, `page`, etc. here
-    prepareForInline: (storyFn) => {
+    prepareForInline: (storyFn, { args }) => {
       const Story = toReact(storyFn());
-      return <Story />;
+      return <Story {...args} />;
     },
   },
 });
 ```
 
-The input is the story function, and the output is a React element, because we render docs pages in react. In the case of Vue, all of the work is done by the `@egoist/vue-to-react` library. If there's no analogous library for your framework, you may need to figure it out yourself!
+The input is the story function and the story context (id, parameters, args, etc.), and the output is a React element, because we render docs pages in react. In the case of Vue, all of the work is done by the `@egoist/vue-to-react` library. If there's no analogous library for your framework, you may need to figure it out yourself!
 
 ## More resources
 

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -64,7 +64,7 @@ export const getStoryProps = (props: StoryProps, context: DocsContextProps): Pur
     parameters,
     inline: storyIsInline,
     id: previewId,
-    storyFn: prepareForInline && storyFn ? () => prepareForInline(storyFn) : storyFn,
+    storyFn: prepareForInline && storyFn ? () => prepareForInline(storyFn, data) : storyFn,
     height: height || (storyIsInline ? undefined : iframeHeight),
     title: storyName,
   };

--- a/addons/docs/src/frameworks/vue/config.tsx
+++ b/addons/docs/src/frameworks/vue/config.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import toReact from '@egoist/vue-to-react';
-import { StoryFn } from '@storybook/addons';
+import { StoryFn, StoryContext } from '@storybook/addons';
 import { addParameters } from '@storybook/client-api';
 import { extractArgTypes } from './extractArgTypes';
 import { extractComponentDescription } from '../../lib/docgen';
@@ -8,9 +8,9 @@ import { extractComponentDescription } from '../../lib/docgen';
 addParameters({
   docs: {
     inlineStories: true,
-    prepareForInline: (storyFn: StoryFn) => {
+    prepareForInline: (storyFn: StoryFn, { args }: StoryContext) => {
       const Story = toReact(storyFn());
-      return <Story />;
+      return <Story {...args} />;
     },
     extractArgTypes,
     extractComponentDescription,

--- a/examples/vue-kitchen-sink/src/stories/components/__snapshots__/button.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/components/__snapshots__/button.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots Button Rounded 1`] = `
 exports[`Storyshots Button Square 1`] = `
 <button
   class="button"
-  style="color: rgb(66, 185, 131); border-color: #42b983;"
+  style="color: rgb(0, 0, 255); border-color: #00f;"
 >
   A Button with square edges!
 </button>

--- a/examples/vue-kitchen-sink/src/stories/components/button.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/components/button.stories.js
@@ -3,19 +3,25 @@ import MyButton from '../Button.vue';
 export default {
   title: 'Button',
   component: MyButton,
+  argTypes: {
+    color: { control: { type: 'color' } },
+  },
 };
 
 export const Rounded = (args) => ({
   props: Object.keys(args),
   components: { MyButton },
-  template: '<my-button :color="color" :rounded="rounded">A Button with rounded edges</my-button>',
+  template: '<my-button :color="color" :rounded="rounded">{{label}}</my-button>',
 });
-Rounded.argTypes = {
-  rounded: { defaultValue: true },
-  color: { control: { type: 'color' }, defaultValue: '#f00' },
+Rounded.args = {
+  rounded: true,
+  color: '#f00',
+  label: 'A Button with rounded edges',
 };
 
-export const Square = () => ({
-  components: { MyButton },
-  template: '<my-button :rounded="false">A Button with square edges</my-button>',
-});
+export const Square = Rounded.bind();
+Square.args = {
+  rounded: false,
+  color: '#00f',
+  label: 'A Button with square edges',
+};


### PR DESCRIPTION
Issue: #11051 

## What I did

Worked with @backbone87 to:

- [x] Extend docs prepareForInline to also take the story context
- [x] Fix args rendering in `Docs` tab by injecting the args as props in Docs mode (to match what we already did in Canvas mode)
- [x] Update Vue args example to current best practices

**NOTE:** this probably needs more work to handle decorators, but let's get this project unstuck first.

## How to test

See updated example in `vue-kitchen-sink`

