### PR TITLE
Typescript: Update react-docgen-typescript-plugin

### DIFF
--- a/addons/docs/src/lib/sbtypes/proptypes/convert.ts
+++ b/addons/docs/src/lib/sbtypes/proptypes/convert.ts
@@ -43,9 +43,9 @@ export const convert = (type: PTType): SBType | any => {
     case 'elementType':
     default: {
       if (name?.indexOf('|') > 0) {
-        // react-docgen-typescript-plugin doesn't always produce proper
-        // this hack tries to parse out values from the string and should be
-        // removed when RDTL gets a little smarter about this
+        // react-docgen-typescript-plugin doesn't always produce enum-like unions
+        // (like if a user has turned off shouldExtractValuesFromUnion) so here we
+        // try to recover and construct one.
         try {
           const literalValues = name.split('|').map((v: string) => JSON.parse(v));
           return { ...base, name: 'enum', value: literalValues };

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react-dev-utils": "^10.0.0",
-    "react-docgen-typescript-plugin": "^0.0.2",
+    "react-docgen-typescript-plugin": "^0.4.0",
     "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1",
     "webpack": "^4.43.0"

--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -47,7 +47,7 @@
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.4.1",
     "fork-ts-checker-webpack-plugin": "^4.0.3",
-    "react-docgen-typescript-plugin": "^0.0.2",
+    "react-docgen-typescript-plugin": "^0.4.0",
     "react-moment-proptypes": "^1.7.0",
     "ts-node": "~8.9.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -27117,12 +27117,14 @@ react-docgen-typescript-loader@^3.7.2:
     loader-utils "^1.2.3"
     react-docgen-typescript "^1.15.0"
 
-react-docgen-typescript-plugin@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.0.2.tgz#80aa25b5195cc2be1b21b734becaf71cccfb5208"
-  integrity sha512-8M6bECmvc9T5uW8lBt79+EZC9IYx7fSApWxtWPq7awqPwCecxd2xIay1m/9kBk+DfpShgxU+5fpdviPVBWxtdQ==
+react-docgen-typescript-plugin@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.4.0.tgz#79416e040a7e2c8ece49ded538b6e6661462d46a"
+  integrity sha512-04zRzxpx5BOC0i8QKBH8lNDMuSxZQHH7OVvXwfShaVNd482MnNlf2+MjN6I3vYUhd0X85i3r2KFRFeMS7fOpCA==
   dependencies:
+    debug "^4.1.1"
     endent "^2.0.1"
+    micromatch "^4.0.2"
     react-docgen-typescript "^1.16.6"
     react-docgen-typescript-loader "^3.7.2"
     tslib "^2.0.0"


### PR DESCRIPTION
## What I did

`react-docgen-typescript-plugin` loads an dummy plugin when typescript is not installed

## How to test

- Is this testable with Jest or Chromatic screenshots? yes
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
