### PR TITLE
Preserve watch output when running dev mode

### DIFF
--- a/examples/cra-ts-kitchen-sink/.storybook/main.ts
+++ b/examples/cra-ts-kitchen-sink/.storybook/main.ts
@@ -14,7 +14,6 @@ module.exports = {
           tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
           shouldExtractLiteralValuesFromEnum: true,
           propFilter: (prop: any) => {
-            // Currently not working, prop.parent is always null.
             if (prop.parent) {
               return !prop.parent.fileName.includes('node_modules/@types/react/');
             }

--- a/scripts/utils/compile-tsc.js
+++ b/scripts/utils/compile-tsc.js
@@ -25,7 +25,7 @@ function getCommand(watch) {
   }
 
   if (watch) {
-    args.push('-w');
+    args.push('-w', '--preserveWatchOutput');
   }
 
   return `${tsc} ${args.join(' ')} && ${downlevelDts} dist ts3.5/dist`;


### PR DESCRIPTION
I noticed that the console would clear everytime a new package would build. This PR adds the `tsc` flag `--preserveWatchOutput`. I also removed a comment that is no longer true.

@shilman 