### PR TITLE
Build: Exclude stories from collecting coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -70,6 +70,7 @@ module.exports = {
     '/dll/',
     '/__mocks__ /',
     '/__testfixtures__/',
+    '^.*\\.stories\\.[jt]sx?$',
   ],
   globals: {
     DOCS_MODE: false,


### PR DESCRIPTION
## What I did
I've excluded story files from collecting coverage.

## How to test

This pr's [`ci/circleci: coverage`](https://codecov.io/gh/storybookjs/storybook/tree/b55d7c386bacb466cf5c6c3c83708b083e910e8f) greater than  storybookjs:next's [`ci/circleci: coverage`](https://codecov.io/gh/storybookjs/storybook/tree/d28d8b598dfbfa4ff2e361e75937d89f83566dd1)

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
