### PR TITLE
Remove @next to ensure same version is installed

### DIFF
--- a/addons/docs/vue/README.md
+++ b/addons/docs/vue/README.md
@@ -19,7 +19,7 @@ To learn more about Storybook Docs, read the [general documentation](../README.m
 First add the package. Make sure that the versions for your `@storybook/*` packages match:
 
 ```sh
-yarn add -D @storybook/addon-docs@next
+yarn add -D @storybook/addon-docs
 ```
 
 Then add the following to your `.storybook/main.js` addons:


### PR DESCRIPTION
Remove`@next` to ensure same version is installed

Issue:

## What I did

Changed the documentation to remove `@next` when downloading the package from `npm`

## How to test

- This is a documentation change.
