### PR TITLE
fix: remove old TypeScript default config

### DIFF
--- a/lib/core/src/server/config/defaults.js
+++ b/lib/core/src/server/config/defaults.js
@@ -1,8 +1,5 @@
 export const typeScriptDefaults = {
   check: false,
   reactDocgen: 'react-docgen-typescript',
-  reactDocgenTypescriptOptions: {
-    shouldExtractLiteralValuesFromEnum: true,
-    propFilter: (prop) => (prop.parent ? !/node_modules/.test(prop.parent.fileName) : true),
-  },
+  reactDocgenTypescriptOptions: {},
 };


### PR DESCRIPTION
These defaults are no longer used as of #11106.