### PR TITLE
Addon-docs: Add argTypes type/control shorthand

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -28,11 +28,13 @@ Controls replaces [Storybook Knobs](https://github.com/storybookjs/storybook/tre
   - [Auto-generated args](#auto-generated-args)
   - [Custom controls args](#custom-controls-args)
   - [Fully custom args](#fully-custom-args)
+    - [Angular](#angular)
   - [Template stories](#template-stories)
 - [Configuration](#configuration)
   - [Control annotations](#control-annotations)
   - [Parameters](#parameters)
     - [Expanded: show property documentation](#expanded-show-property-documentation)
+    - [Hide NoControls warning](#hide-nocontrols-warning)
 - [Framework support](#framework-support)
 - [FAQs](#faqs)
   - [How will this replace addon-knobs?](#how-will-this-replace-addon-knobs)
@@ -186,7 +188,7 @@ export default {
   title: 'Button',
   component: Button,
   argTypes: {
-    background: { control: { type: 'color' } },
+    background: { control: 'color' },
   },
 };
 
@@ -199,6 +201,8 @@ This generates the following UI, which is what we wanted in the first place:
 <center>
   <img src="https://raw.githubusercontent.com/storybookjs/storybook/next/addons/controls/docs/media/addon-controls-args-background-color.png" width="80%" />
 </center>
+
+> **NOTE:** `@storybook/addon-docs` provide shorthand for `type` and `control` fields, so in the previous example, `control: 'color'` is shorthand `control: { type: 'color' }`. Similarly, `type: 'number'` can be written as shorthand for `type: { name: 'number' }`.
 
 ### Fully custom args
 
@@ -242,7 +246,7 @@ This generates the following UI with a custom range slider:
   <img src="https://raw.githubusercontent.com/storybookjs/storybook/next/addons/controls/docs/media/addon-controls-args-reflow-slider.png" width="80%" />
 </center>
 
-**Note:** If you add an `ArgType` that is not part of the component, Storybook will *only* use your argTypes definitions.  
+**Note:** If you add an `ArgType` that is not part of the component, Storybook will _only_ use your argTypes definitions.  
 If you want to merge new controls with the existing component properties, you must enable this parameter:
 
 ```jsx
@@ -257,11 +261,10 @@ To achieve this within an angular-cli build.
 export const Reflow = ({ count, label, ...args }) => ({
   props: {
     label: label,
-    count: [...Array(count).keys()]
+    count: [...Array(count).keys()],
   },
-  template: `<Button *ngFor="let i of count">{{label}} {{i}}</Button>`
- }
-);
+  template: `<Button *ngFor="let i of count">{{label}} {{i}}</Button>`,
+});
 Reflow.args = { count: 3, label: 'reflow' };
 ```
 
@@ -279,7 +282,7 @@ VeryLongLabel.args = { label: 'this is a very long string', background: '#ff0' }
 This works, but it repeats code. What we want is to reuse the `Basic` story, but with a different initial state. In Storybook we do this idiomatically for Args stories:
 
 ```jsx
-export const VeryLongLabel = Basic.bind();
+export const VeryLongLabel = Basic.bind({});
 VeryLongLabel.args = { label: 'this is a very long string', background: '#ff0' };
 ```
 

--- a/addons/controls/src/components/ControlsPanel.tsx
+++ b/addons/controls/src/components/ControlsPanel.tsx
@@ -34,7 +34,7 @@ export const ControlsPanel: FC = () => {
     PARAM_KEY,
     {}
   );
-  const hasControls = Object.values(rows).filter((argType) => argType?.control?.type).length > 0;
+  const hasControls = Object.values(rows).filter((argType) => !!argType?.control).length > 0;
   return (
     <>
       {hasControls || hideNoControlsWarning ? null : <NoControlsWarning />}

--- a/addons/controls/src/title.ts
+++ b/addons/controls/src/title.ts
@@ -2,12 +2,7 @@ import { useArgTypes } from '@storybook/api';
 
 export function getTitle(): string {
   const rows = useArgTypes();
-
-  const controlsCount = Object.values(rows).filter((argType) => argType?.control?.type).length;
-
-  if (controlsCount === 0) {
-    return 'Controls';
-  }
-
-  return `Controls (${controlsCount})`;
+  const controlsCount = Object.values(rows).filter((argType) => argType?.control).length;
+  const suffix = controlsCount === 0 ? '' : ` (${controlsCount})`;
+  return `Controls${suffix}`;
 }

--- a/addons/docs/docs/props-tables.md
+++ b/addons/docs/docs/props-tables.md
@@ -182,6 +182,11 @@ const argTypes = {
 
 This would render a row with a modified description, a type display with a dropdown that shows the detail, and no control.
 
+> **NOTE:** `@storybook/addon-docs` provide shorthand for common tasks:
+>
+> - `type: 'number'` is shorthand for `type: { name: 'number' }`
+> - `control: 'radio'` is shorthand for `control: { type: 'radio' }`
+
 Controls customization has an entire section in the [`addon-controls` README](https://github.com/storybookjs/storybook/blob/next/addons/controls/README.md#configuration).
 
 Here are the possible customizations for the rest of the prop table:

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.ts
@@ -3,6 +3,7 @@ import { ArgTypesEnhancer, combineParameters } from '@storybook/client-api';
 import { ArgTypes } from '@storybook/api';
 import { inferArgTypes } from './inferArgTypes';
 import { inferControls } from './inferControls';
+import { normalizeArgTypes } from './normalizeArgTypes';
 
 const isSubset = (kind: string, subset: object, superset: object) => {
   const keys = Object.keys(subset);
@@ -15,14 +16,15 @@ export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
   const { component, argTypes: userArgTypes = {}, docs = {}, args = {} } = context.parameters;
   const { extractArgTypes, forceExtractedArgTypes = false } = docs;
 
-  const namedArgTypes = mapValues(userArgTypes, (val, key) => ({ name: key, ...val }));
+  const normalizedArgTypes = normalizeArgTypes(userArgTypes);
+  const namedArgTypes = mapValues(normalizedArgTypes, (val, key) => ({ name: key, ...val }));
   const inferredArgTypes = inferArgTypes(args);
   let extractedArgTypes: ArgTypes = extractArgTypes && component ? extractArgTypes(component) : {};
 
   if (
     !forceExtractedArgTypes &&
-    ((Object.keys(userArgTypes).length > 0 &&
-      !isSubset(context.kind, userArgTypes, extractedArgTypes)) ||
+    ((Object.keys(normalizedArgTypes).length > 0 &&
+      !isSubset(context.kind, normalizedArgTypes, extractedArgTypes)) ||
       (Object.keys(inferredArgTypes).length > 0 &&
         !isSubset(context.kind, inferredArgTypes, extractedArgTypes)))
   ) {

--- a/addons/docs/src/frameworks/common/normalizeArgTypes.ts
+++ b/addons/docs/src/frameworks/common/normalizeArgTypes.ts
@@ -14,6 +14,5 @@ export const normalizeArgTypes = (argTypes: ArgTypes) =>
     const { type, control } = argType;
     if (type) normalized.type = normalizeType(type);
     if (control) normalized.control = normalizeControl(control);
-    console.log({ argType, normalized });
     return normalized;
   });

--- a/addons/docs/src/frameworks/common/normalizeArgTypes.ts
+++ b/addons/docs/src/frameworks/common/normalizeArgTypes.ts
@@ -1,0 +1,19 @@
+import mapValues from 'lodash/mapValues';
+import { ArgTypes } from '@storybook/api';
+import { SBType } from '../../lib/sbtypes';
+
+const normalizeType = (type: SBType | string) => (typeof type === 'string' ? { name: type } : type);
+
+const normalizeControl = (control?: any) =>
+  typeof control === 'string' ? { type: control } : control;
+
+export const normalizeArgTypes = (argTypes: ArgTypes) =>
+  mapValues(argTypes, (argType) => {
+    if (!argType) return argType;
+    const normalized = { ...argType };
+    const { type, control } = argType;
+    if (type) normalized.type = normalizeType(type);
+    if (control) normalized.control = normalizeControl(control);
+    console.log({ argType, normalized });
+    return normalized;
+  });

--- a/examples/vue-kitchen-sink/src/stories/components/button.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/components/button.stories.js
@@ -4,7 +4,7 @@ export default {
   title: 'Button',
   component: MyButton,
   argTypes: {
-    color: { control: { type: 'color' } },
+    color: { control: 'color' },
   },
 };
 

--- a/lib/components/src/controls/Object.stories.tsx
+++ b/lib/components/src/controls/Object.stories.tsx
@@ -32,7 +32,7 @@ export const ValidatedAsArray = () => {
     <>
       <ObjectControl
         name="object"
-        argType={{ type: 'array' }}
+        argType={{ type: { name: 'array' } }}
         value={value}
         onChange={(name, newVal) => setValue(newVal)}
       />

--- a/lib/components/src/controls/Object.stories.tsx
+++ b/lib/components/src/controls/Object.stories.tsx
@@ -32,7 +32,7 @@ export const ValidatedAsArray = () => {
     <>
       <ObjectControl
         name="object"
-        argType={{ type: { name: 'array' } }}
+        argType={{ type: 'array' }}
         value={value}
         onChange={(name, newVal) => setValue(newVal)}
       />


### PR DESCRIPTION
Issue: #11170 

## What I did

Allow shorthand for `type`/`control` in `argTypes`:

- [x] `type: 'string'` => `type: { name: 'string' }`
- [x] `control: 'range` => `control: { type: 'range' }`
- [x] Update examples and docs

## How to test

See updated stories
