### PR TITLE
Addon-docs: Add syntax highlighting to Code and Description blocks

### DIFF
--- a/examples/official-storybook/components/DocgenButton.js
+++ b/examples/official-storybook/components/DocgenButton.js
@@ -17,6 +17,14 @@ import PropTypes from 'prop-types';
  *  * `"email"` An email address.
  *  * `"tel"` A phone or fax number. Shows the phone number keypad on
  *      mobile keyboards.
+ *
+ * Here is a test for code blocks
+ *
+ * ```jsx
+ * const Foo = () => (
+ *  <div>foo</div>
+ * );
+ * ```
  */
 export const DocgenButton = ({ disabled, label, onClick }) => (
   <button type="button" disabled={disabled} onClick={onClick}>

--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { styled, CSSObject } from '@storybook/theming';
 import { withReset, withMargin, headerCommon, codeCommon } from './shared';
+import { SyntaxHighlighter } from '../syntaxhighlighter/syntaxhighlighter';
 
 export const H1 = styled.h1<{}>(withReset, headerCommon, ({ theme }) => ({
   fontSize: `${theme.typography.size.l1}px`,
@@ -315,7 +316,7 @@ export const P = styled.p<{}>(withReset, withMargin, ({ theme }) => ({
   '& code': codeCommon({ theme }),
 }));
 
-export const Code = styled.code<{}>(
+const DefaultCodeBlock = styled.code<{}>(
   ({ theme }) => ({
     // from reset
     fontFamily: theme.typography.fonts.mono,
@@ -329,6 +330,16 @@ export const Code = styled.code<{}>(
   }),
   codeCommon
 );
+
+export const Code = ({ className, ...props }: React.ComponentProps<typeof DefaultCodeBlock>) => {
+  const language = (className || '').match(/lang-(\S+)/);
+
+  if (!language) {
+    return <DefaultCodeBlock {...props} className={className} />;
+  }
+
+  return <SyntaxHighlighter bordered copyable language={language[1]} format={false} {...props} />;
+};
 
 export const TT = styled.title<{}>(codeCommon);
 


### PR DESCRIPTION
Issue: #9825

## What I did

Change the behavior of the underlying `DocumentFormatting` `Code` to render using the `SyntaxHighlighter` if a `lang-` is detected in the `className`.

## How to test

- Is this testable with Jest or Chromatic screenshots? yes
- Does this need a new example in the kitchen sink apps? yes (I added it)
- Does this need an update to the documentation? no

**Input:**

![Screen Shot 2020-06-15 at 5 42 19 PM](https://user-images.githubusercontent.com/1192452/84719231-a1237280-af2f-11ea-9b3e-2692bfc4449b.png)

**Output:**

![Screen Shot 2020-06-15 at 5 43 07 PM](https://user-images.githubusercontent.com/1192452/84719247-ad0f3480-af2f-11ea-8dad-3b16eac7e0f3.png)

