### PR TITLE
React: Load root tsconfig.json into docgen-typescript if none provided

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react-dev-utils": "^10.0.0",
-    "react-docgen-typescript-plugin": "^0.4.0",
+    "react-docgen-typescript-plugin": "^0.5.0",
     "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1",
     "webpack": "^4.43.0"

--- a/app/react/src/server/framework-preset-react-docgen.ts
+++ b/app/react/src/server/framework-preset-react-docgen.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import type { TransformOptions } from '@babel/core';
 import type { Configuration } from 'webpack';
 import type { StorybookOptions } from '@storybook/core/types';
@@ -28,11 +29,21 @@ export function babel(config: TransformOptions, { typescriptOptions }: Storybook
   };
 }
 
+const tsconfigPath = './tsconfig.json';
+
 export function webpackFinal(config: Configuration, { typescriptOptions }: StorybookOptions) {
-  const { reactDocgen, reactDocgenTypescriptOptions } = typescriptOptions;
+  const { reactDocgen, reactDocgenTypescriptOptions = {} } = typescriptOptions;
 
   if (reactDocgen !== 'react-docgen-typescript') {
     return config;
+  }
+
+  if (
+    !reactDocgenTypescriptOptions.tsconfigPath &&
+    !reactDocgenTypescriptOptions.compilerOptions &&
+    fs.existsSync(tsconfigPath)
+  ) {
+    reactDocgenTypescriptOptions.tsconfigPath = tsconfigPath;
   }
 
   return {

--- a/app/react/src/server/framework-preset-react-docgen.ts
+++ b/app/react/src/server/framework-preset-react-docgen.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import type { TransformOptions } from '@babel/core';
 import type { Configuration } from 'webpack';
 import type { StorybookOptions } from '@storybook/core/types';
@@ -29,21 +28,11 @@ export function babel(config: TransformOptions, { typescriptOptions }: Storybook
   };
 }
 
-const tsconfigPath = './tsconfig.json';
-
 export function webpackFinal(config: Configuration, { typescriptOptions }: StorybookOptions) {
-  const { reactDocgen, reactDocgenTypescriptOptions = {} } = typescriptOptions;
+  const { reactDocgen, reactDocgenTypescriptOptions } = typescriptOptions;
 
   if (reactDocgen !== 'react-docgen-typescript') {
     return config;
-  }
-
-  if (
-    !reactDocgenTypescriptOptions.tsconfigPath &&
-    !reactDocgenTypescriptOptions.compilerOptions &&
-    fs.existsSync(tsconfigPath)
-  ) {
-    reactDocgenTypescriptOptions.tsconfigPath = tsconfigPath;
   }
 
   return {

--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -47,7 +47,7 @@
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.4.1",
     "fork-ts-checker-webpack-plugin": "^4.0.3",
-    "react-docgen-typescript-plugin": "^0.4.0",
+    "react-docgen-typescript-plugin": "^0.5.0",
     "react-moment-proptypes": "^1.7.0",
     "ts-node": "~8.9.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26565,10 +26565,10 @@ react-docgen-typescript-loader@^3.7.2:
     loader-utils "^1.2.3"
     react-docgen-typescript "^1.15.0"
 
-react-docgen-typescript-plugin@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.4.0.tgz#79416e040a7e2c8ece49ded538b6e6661462d46a"
-  integrity sha512-04zRzxpx5BOC0i8QKBH8lNDMuSxZQHH7OVvXwfShaVNd482MnNlf2+MjN6I3vYUhd0X85i3r2KFRFeMS7fOpCA==
+react-docgen-typescript-plugin@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.5.0.tgz#704733d99be7d41c64ee651240212d7fd6f8edc5"
+  integrity sha512-7bTj/or5u4UZls7x07MwEFj6Ak9icHwMLSs2mUL5QZON51gDdGCTbbmSR0nKsPISYP+iNqtbsRnlsbvjcM06nw==
   dependencies:
     debug "^4.1.1"
     endent "^2.0.1"


### PR DESCRIPTION
Issue: #11146

## What I did

Use root `tsconfig.json` for react-docgen-typescript if no tsconfig options are provided

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

Tested in bug reproduction repo

![Screen Shot 2020-06-15 at 6 28 19 PM](https://user-images.githubusercontent.com/1192452/84721647-febabd80-af35-11ea-9d99-24922c6ad40a.png)
