### PR TITLE
MDX: Don't use root babelrc by default

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -14,17 +14,19 @@ const context = coreDirName.includes('node_modules')
   : path.join(coreDirName, '../../node_modules'); // SB Monorepo
 
 function createBabelOptions(babelOptions?: any, configureJSX?: boolean) {
-  if (!configureJSX) {
-    return babelOptions;
-  }
-
+  // for frameworks that are not working with react, we need to configure
+  // the jsx to transpile mdx, for now there will be a flag for that
+  // for more complex solutions we can find alone that we need to add '@babel/plugin-transform-react-jsx'
   const babelPlugins = (babelOptions && babelOptions.plugins) || [];
+  const plugins = configureJSX
+    ? [...babelPlugins, '@babel/plugin-transform-react-jsx']
+    : babelPlugins;
+
   return {
+    // don't use the root babelrc by default (users can override this in babelOptions)
+    babelrc: false,
     ...babelOptions,
-    // for frameworks that are not working with react, we need to configure
-    // the jsx to transpile mdx, for now there will be a flag for that
-    // for more complex solutions we can find alone that we need to add '@babel/plugin-transform-react-jsx'
-    plugins: [...babelPlugins, '@babel/plugin-transform-react-jsx'],
+    plugins,
   };
 }
 


### PR DESCRIPTION
Issue: #11094 #8096

## What I did

Make the MDX processing opt out of user's babelrc config by default. User can opt-in if needed by overriding it with `babelrc: true`.

This was causing a problem especially in Vue, where the users' babelrc presets were conflicting with the React MDX plugins. This fixes those issues.

## How to test

See the `Addons/Docs` stories in `vue-kitchen-sink` before & after this change.
- Before: docs tab broken with `h is not undefined`
- After: success
