### PR TITLE
MDX: Support function.bind({}) syntax

### DIFF
--- a/addons/docs/src/mdx/__testfixtures__/story-args.mdx
+++ b/addons/docs/src/mdx/__testfixtures__/story-args.mdx
@@ -5,6 +5,12 @@ import { Story, Meta } from '@storybook/addon-docs/blocks';
 
 # Args
 
-<Story name="component notes" args={{ a: 1, b: 2 }} argTypes={{ a: { name: 'A' }, b: { name: 'B' } }}>
-  <Button>Component notes</Button>
+export const ButtonStory = (args) => <Button>Component notes</Button>;
+
+<Story
+  name="component notes"
+  args={{ a: 1, b: 2 }}
+  argTypes={{ a: { name: 'A' }, b: { name: 'B' } }}
+>
+  {ButtonStory.bind({})}
 </Story>

--- a/addons/docs/src/mdx/__testfixtures__/story-args.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-args.output.snapshot
@@ -6,7 +6,7 @@ import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';
-
+export const ButtonStory = (args) => <Button mdxType=\\"Button\\">Component notes</Button>;
 const makeShortcode = (name) =>
   function MDXDefaultShortcode(props) {
     console.warn(
@@ -17,13 +17,16 @@ const makeShortcode = (name) =>
     return <div {...props} />;
   };
 
-const layoutProps = {};
+const layoutProps = {
+  ButtonStory,
+};
 const MDXLayout = 'wrapper';
 function MDXContent({ components, ...props }) {
   return (
     <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
       <Meta title=\\"Button\\" mdxType=\\"Meta\\" />
       <h1>{\`Args\`}</h1>
+
       <Story
         name=\\"component notes\\"
         args={{
@@ -40,7 +43,7 @@ function MDXContent({ components, ...props }) {
         }}
         mdxType=\\"Story\\"
       >
-        <Button mdxType=\\"Button\\">Component notes</Button>
+        {ButtonStory.bind({})}
       </Story>
     </MDXLayout>
   );
@@ -48,7 +51,7 @@ function MDXContent({ components, ...props }) {
 
 MDXContent.isMDXComponent = true;
 
-export const componentNotes = () => <Button>Component notes</Button>;
+export const componentNotes = ButtonStory.bind({});
 componentNotes.storyName = 'component notes';
 componentNotes.argTypes = {
   a: {
@@ -62,7 +65,7 @@ componentNotes.args = {
   a: 1,
   b: 2,
 };
-componentNotes.parameters = { storySource: { source: '<Button>Component notes</Button>' } };
+componentNotes.parameters = { storySource: { source: 'ButtonStory.bind({})' } };
 
 const componentMeta = { title: 'Button', includeStories: ['componentNotes'] };
 

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -84,20 +84,25 @@ function genStoryExport(ast, context) {
     const storyReactCode = bodyParts.length > 1 ? `<>\n${storyCode}\n</>` : storyCode;
     // keep track if an indentifier or function call
     // avoid breaking change for 5.3
-    switch (bodyParts.length === 1 && bodyParts[0].body.type) {
-      // We don't know what type the identifier is, but this code
-      // assumes it's a function from CSF. Let's see who complains!
-      case 'Identifier':
-        storyVal = `assertIsFn(${storyCode})`;
-        break;
-      case 'ArrowFunctionExpression':
-        storyVal = `(${storyCode})`;
-        break;
-      default:
-        storyVal = `() => (
+    const BIND_REGEX = /\.bind\(.*\)/;
+    if (bodyParts.length === 1 && BIND_REGEX.test(bodyParts[0].code)) {
+      storyVal = bodyParts[0].code;
+    } else {
+      switch (bodyParts.length === 1 && bodyParts[0].body.type) {
+        // We don't know what type the identifier is, but this code
+        // assumes it's a function from CSF. Let's see who complains!
+        case 'Identifier':
+          storyVal = `assertIsFn(${storyCode})`;
+          break;
+        case 'ArrowFunctionExpression':
+          storyVal = `(${storyCode})`;
+          break;
+        default:
+          storyVal = `() => (
           ${storyReactCode}
         )`;
-        break;
+          break;
+      }
     }
   }
 


### PR DESCRIPTION
Issue: N/A

## What I did

In MDX `<Story name="foo">{contents}</Story>` typically generates a story `foo = () => contents`. In this PR, when `contents` is `Something.bind({})`, an Args idiom, it simply generates `foo = Something.bind({})`.

## How to test

See updated tests, plus examples in #11197