### PR TITLE
Addon-knobs: Fix select types for undefined, null and boolean

### DIFF
--- a/addons/knobs/src/__types__/knob-test-cases.ts
+++ b/addons/knobs/src/__types__/knob-test-cases.ts
@@ -112,6 +112,14 @@ expectKnobOfType<string>(
   select<ButtonVariant>('select with string enum options', ButtonVariant, ButtonVariant.primary)
 );
 
+expectKnobOfType<string | undefined | null | boolean>(
+  select(
+    'select with an undefined in array',
+    ['Apple', 'Banana', 'Grapes', undefined, null, false] as const,
+    undefined
+  )
+);
+
 expectKnobOfType<string | null>(
   select('select with null option', { a: 'Option', b: null }, null, groupId)
 );

--- a/addons/knobs/src/components/types/Select.tsx
+++ b/addons/knobs/src/components/types/Select.tsx
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 import { Form } from '@storybook/components';
 import { KnobControlConfig, KnobControlProps } from './types';
 
-export type SelectTypeKnobValue = string | number | null | undefined | PropertyKey[];
+export type SelectTypeKnobValue = string | number | boolean | null | undefined | PropertyKey[];
 
 export type SelectTypeOptionsProp<T extends SelectTypeKnobValue = SelectTypeKnobValue> =
   | Record<PropertyKey, T>
   | Record<Extract<T, PropertyKey>, T[keyof T]>
-  | Extract<T, PropertyKey>[]
-  | readonly Extract<T, PropertyKey>[];
+  | T[]
+  | readonly T[];
 
 export interface SelectTypeKnob<T extends SelectTypeKnobValue = SelectTypeKnobValue>
   extends KnobControlConfig<T> {


### PR DESCRIPTION
Issue:
Currently select gives TypeScript error while using with `undefined`, `null`, or `boolean` values in an array of options.

## What I did
I added `boolean` to `SelectTypeKnobValue` and replaced `Extract<T, PropertyKey>`with `T`itself to allow all types to be included while using it with an array of options.