### PR TITLE
React: Fix react-docgen for JS files

### DIFF
--- a/app/react/src/server/framework-preset-react-docgen.ts
+++ b/app/react/src/server/framework-preset-react-docgen.ts
@@ -6,10 +6,6 @@ import ReactDocgenTypescriptPlugin from 'react-docgen-typescript-plugin';
 export function babel(config: TransformOptions, { typescriptOptions }: StorybookOptions) {
   const { reactDocgen } = typescriptOptions;
 
-  if (!reactDocgen || reactDocgen === 'react-docgen-typescript') {
-    return config;
-  }
-
   return {
     ...config,
     overrides: [


### PR DESCRIPTION
Issue: N/A


## What I did

#11106 typescript upgrade inadvertently removed react-docgen processing for JS files. This fixes it per [this thread](https://github.com/storybookjs/storybook/pull/11105#issuecomment-645080618).

## How to test

There's a repro in `examples/react-ts` `EmojiButton` stories