### PR TITLE
Fix invalid glob warning for absolute paths

### DIFF
--- a/lib/core/src/server/preview/entries.js
+++ b/lib/core/src/server/preview/entries.js
@@ -58,7 +58,7 @@ export async function createPreviewEntry(options) {
     entries.push(path.resolve(path.join(configDir, `generated-stories-entry.js`)));
 
     const files = (
-      await Promise.all(stories.map((g) => glob(path.join(configDir, g))))
+      await Promise.all(stories.map((g) => glob(path.isAbsolute(g) ? g : path.join(configDir, g))))
     ).reduce((a, b) => a.concat(b));
 
     if (files.length === 0) {


### PR DESCRIPTION
When passing absolute paths to the `stories` option (in `main.js`),
Storybook will build these stories just fine. However, it displays an
erroneous warning on startup asking you if your glob pattern is invalid.


## What I did

Check if the `stories` path is absolute before joining with the
configuration directory.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->