### PR TITLE
Updates React Guide with Gatsby config link

### DIFF
--- a/docs/src/pages/guides/guide-react/index.md
+++ b/docs/src/pages/guides/guide-react/index.md
@@ -24,6 +24,8 @@ If you're using [Create React App](https://create-react-app.dev/) (or a fork of 
 npx -p @storybook/cli sb init --type react_scripts
 ```
 
+If you're using [Gatsby](https://www.gatsbyjs.org/), some added config is required - see [Gatsby's Storybook guide](https://www.gatsbyjs.org/docs/visual-testing-with-storybook/).
+
 Note: You must have a `package.json` in your project or the above commands will fail.
 
 ## Manual setup


### PR DESCRIPTION
Issue: 
To use Storybook 5.3 or higher with Gatsby, custom configuration is required. 

## What I did

This adds a link to [Gatsby's Storybook guide](https://www.gatsbyjs.org/docs/visual-testing-with-storybook/).

Changes adds to:
## Automatic setup 

The following sentence
If you're using [Gatsby](https://www.gatsbyjs.org/), some added config is required - see [Gatsby's Storybook guide](https://www.gatsbyjs.org/docs/visual-testing-with-storybook/).

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
