### PR TITLE
Replace document.execCommand with navigator.clipboard

### DIFF
--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentProps, FunctionComponent, MouseEvent, useState } from 'react';
+import { logger } from '@storybook/client-logger';
 import { styled } from '@storybook/theming';
-import { document, window } from 'global';
+import { navigator, window } from 'global';
 import memoize from 'memoizerific';
 
 import jsx from 'react-syntax-highlighter/dist/cjs/languages/prism/jsx';
@@ -127,20 +128,14 @@ export const SyntaxHighlighter: FunctionComponent<Props> = ({
 
   const onClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    const tmp = document.createElement('TEXTAREA');
-    const focus = document.activeElement;
 
-    tmp.value = children;
-
-    document.body.appendChild(tmp);
-    tmp.select();
-    document.execCommand('copy');
-    document.body.removeChild(tmp);
-    focus.focus();
-
-    setCopied(true);
-
-    window.setTimeout(() => setCopied(false), 1500);
+    navigator.clipboard
+      .writeText(children)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(logger.error);
   };
 
   return children ? (


### PR DESCRIPTION
Issue: #10526

## What I did

Replace document.execCommand with navigator.clipboard

[Navigator API: clipboard support table](https://caniuse.com/#feat=mdn-api_navigator_clipboard)

## How to test

1. Open `?path=/story/basics-syntaxhighlighter--bordered-copy-able` in `examples/official-storybook`
2. Click 'Copy' button
3. Check that your clipboard equals to
```
import { Good, Things } from 'life';

        const result = () => <Good><Things /></Good>;

        export { result as default };
      
```

(clipboard output is not formatted on `next` branch too. I think it better to fix in another pr)

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
