### PR TITLE
Client-logger: Replace magic numbers with constants

### DIFF
--- a/lib/client-logger/src/index.ts
+++ b/lib/client-logger/src/index.ts
@@ -12,21 +12,21 @@ const levels: Record<LogLevel, number> = {
 };
 
 const currentLogLevelString: LogLevel = LOGLEVEL as LogLevel;
-const currentLogLevelNumber: number = levels[currentLogLevelString] || 3;
+const currentLogLevelNumber: number = levels[currentLogLevelString] || levels.info;
 
 export const logger = {
   trace: (message: any, ...rest: any[]): void =>
-    currentLogLevelNumber <= 1 && console.trace(message, ...rest),
+    currentLogLevelNumber <= levels.trace && console.trace(message, ...rest),
   debug: (message: any, ...rest: any[]): void =>
-    currentLogLevelNumber <= 2 && console.debug(message, ...rest),
+    currentLogLevelNumber <= levels.debug && console.debug(message, ...rest),
   info: (message: any, ...rest: any[]): void =>
-    currentLogLevelNumber <= 3 && console.info(message, ...rest),
+    currentLogLevelNumber <= levels.info && console.info(message, ...rest),
   warn: (message: any, ...rest: any[]): void =>
-    currentLogLevelNumber <= 4 && console.warn(message, ...rest),
+    currentLogLevelNumber <= levels.warn && console.warn(message, ...rest),
   error: (message: any, ...rest: any[]): void =>
-    currentLogLevelNumber <= 5 && console.error(message, ...rest),
+    currentLogLevelNumber <= levels.error && console.error(message, ...rest),
   log: (message: any, ...rest: any[]): void =>
-    currentLogLevelNumber <= 9 && console.log(message, ...rest),
+    currentLogLevelNumber < levels.silent && console.log(message, ...rest),
 } as const;
 
 export const pretty = (type: keyof typeof logger) => (...args: string[]) => {


### PR DESCRIPTION
## What I did
I've just found some magic numbers and replace them with constants defined above.

## How to test

- Is this testable with Jest or Chromatic screenshots? **yes**
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

Tests `lib/client-logger/src/index.test.ts` pass

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
