### PR TITLE
ArgsTable: Updated Boolean control

### DIFF
--- a/addons/controls/src/components/ControlsPanel.tsx
+++ b/addons/controls/src/components/ControlsPanel.tsx
@@ -11,7 +11,9 @@ interface ControlsParameters {
 
 const NoControlsWrapper = styled.div(({ theme }) => ({
   background: theme.background.warning,
-  padding: 20,
+  padding: '10px 15px',
+  lineHeight: '20px',
+  boxShadow: `${theme.appBorderColor} 0 -1px 0 0 inset`,
 }));
 
 const NoControlsWarning = () => (

--- a/addons/controls/src/components/ControlsPanel.tsx
+++ b/addons/controls/src/components/ControlsPanel.tsx
@@ -1,33 +1,13 @@
 import React, { FC } from 'react';
-import { styled } from '@storybook/theming';
-import { ArgsTable, Link } from '@storybook/components';
+import { ArgsTable, NoControlsWarning } from '@storybook/components';
 import { useArgs, useArgTypes, useParameter } from '@storybook/api';
+
 import { PARAM_KEY } from '../constants';
 
 interface ControlsParameters {
   expanded?: boolean;
   hideNoControlsWarning?: boolean;
 }
-
-const NoControlsWrapper = styled.div(({ theme }) => ({
-  background: theme.background.warning,
-  padding: '10px 15px',
-  lineHeight: '20px',
-  boxShadow: `${theme.appBorderColor} 0 -1px 0 0 inset`,
-}));
-
-const NoControlsWarning = () => (
-  <NoControlsWrapper>
-    This story is not configured to handle controls.&nbsp;
-    <Link
-      href="https://github.com/storybookjs/storybook/blob/next/addons/controls/README.md#writing-stories"
-      target="_blank"
-      cancel={false}
-    >
-      Learn how to add controls »
-    </Link>
-  </NoControlsWrapper>
-);
 
 export const ControlsPanel: FC = () => {
   const [args, updateArgs] = useArgs();

--- a/addons/controls/src/components/NoControlsWarning.tsx
+++ b/addons/controls/src/components/NoControlsWarning.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { styled } from '@storybook/theming';
+import { Link } from '@storybook/components';
+
+const NoControlsWrapper = styled.div(({ theme }) => ({
+  background: theme.background.warning,
+  padding: '10px 15px',
+  lineHeight: '20px',
+  boxShadow: `${theme.appBorderColor} 0 -1px 0 0 inset`,
+}));
+
+export const NoControlsWarning = () => (
+  <NoControlsWrapper>
+    This story is not configured to handle controls.&nbsp;
+    <Link
+      href="https://github.com/storybookjs/storybook/blob/next/addons/controls/README.md#writing-stories"
+      target="_blank"
+      cancel={false}
+    >
+      Learn how to add controls »
+    </Link>
+  </NoControlsWrapper>
+);

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.stories.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { ArgsTable, ArgsTableError } from './ArgsTable';
+import { NoControlsWarning } from './NoControlsWarning';
 import * as ArgRow from './ArgRow.stories';
 
 export default {
@@ -36,10 +37,21 @@ Compact.args = {
   compact: true,
 };
 
-export const inAddonPanel = Story.bind({});
-inAddonPanel.args = {
+export const InAddonPanel = Story.bind({});
+InAddonPanel.args = {
   ...Normal.args,
   inAddonPanel: true,
+};
+
+export const InAddonPanelWithWarning = (args) => (
+  <>
+    <NoControlsWarning />
+    <ArgsTable {...args} />
+  </>
+);
+InAddonPanelWithWarning.args = {
+  ...InAddonPanel.args,
+  updateArgs: null,
 };
 
 export const Sections = Story.bind({});

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.stories.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import { styled } from '@storybook/theming';
 import { ArgsTable, ArgsTableError } from './ArgsTable';
 import { NoControlsWarning } from './NoControlsWarning';
 import * as ArgRow from './ArgRow.stories';
@@ -37,11 +38,17 @@ Compact.args = {
   compact: true,
 };
 
+const AddonPanelLayout = styled.div(({ theme }) => ({
+  fontSize: theme.typography.size.s2 - 1,
+  background: theme.background.content,
+}));
+
 export const InAddonPanel = Story.bind({});
 InAddonPanel.args = {
   ...Normal.args,
   inAddonPanel: true,
 };
+InAddonPanel.decorators = [(storyFn) => <AddonPanelLayout>{storyFn()}</AddonPanelLayout>];
 
 export const InAddonPanelWithWarning = (args) => (
   <>
@@ -53,6 +60,7 @@ InAddonPanelWithWarning.args = {
   ...InAddonPanel.args,
   updateArgs: null,
 };
+InAddonPanelWithWarning.decorators = InAddonPanel.decorators;
 
 export const Sections = Story.bind({});
 Sections.args = {

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
@@ -189,16 +189,16 @@ const groupRows = (rows: ArgType) => {
     if (category) {
       const section = sections.sections[category] || { ungrouped: [], subsections: {} };
       if (!subcategory) {
-        section.ungrouped.push(row);
+        section.ungrouped.push({ key, ...row });
       } else {
         const subsection = section.subsections[subcategory] || [];
-        subsection.push(row);
+        subsection.push({ key, ...row });
         section.subsections[subcategory] = subsection;
       }
       sections.sections[category] = section;
     } else if (subcategory) {
       const subsection = sections.ungroupedSubsections[subcategory] || [];
-      subsection.push(row);
+      subsection.push({ key, ...row });
       sections.ungroupedSubsections[subcategory] = subsection;
     } else {
       sections.ungrouped.push({ key, ...row });
@@ -227,7 +227,6 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   const { rows, args, updateArgs, compact, inAddonPanel } = props as ArgsTableRowProps;
 
   const groups = groupRows(rows);
-  console.log(groups);
 
   if (
     groups.ungrouped.length === 0 &&

--- a/lib/components/src/blocks/ArgsTable/NoControlsWarning.tsx
+++ b/lib/components/src/blocks/ArgsTable/NoControlsWarning.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { styled } from '@storybook/theming';
+import { Link } from '../../typography/link/link';
+
+const NoControlsWrapper = styled.div(({ theme }) => ({
+  background: theme.background.warning,
+  padding: '10px 15px',
+  lineHeight: '20px',
+  boxShadow: `${theme.appBorderColor} 0 -1px 0 0 inset`,
+}));
+
+export const NoControlsWarning = () => (
+  <NoControlsWrapper>
+    This story is not configured to handle controls.&nbsp;
+    <Link
+      href="https://github.com/storybookjs/storybook/blob/next/addons/controls/README.md#writing-stories"
+      target="_blank"
+      cancel={false}
+    >
+      Learn how to add controls »
+    </Link>
+  </NoControlsWrapper>
+);

--- a/lib/components/src/blocks/ArgsTable/SectionRow.stories.tsx
+++ b/lib/components/src/blocks/ArgsTable/SectionRow.stories.tsx
@@ -31,7 +31,9 @@ Collapsed.args = { ...Section.args, initialExpanded: false };
 export const Nested = () => (
   <SectionRow {...Section.args}>
     <SectionRow {...Subsection.args}>
-      <div>Some content</div>
+      <tr>
+        <td>Some content</td>
+      </tr>
     </SectionRow>
   </SectionRow>
 );

--- a/lib/components/src/blocks/ArgsTable/index.ts
+++ b/lib/components/src/blocks/ArgsTable/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './ArgsTable';
 export * from './TabbedArgsTable';
+export * from './NoControlsWarning';

--- a/lib/components/src/blocks/Description.stories.tsx
+++ b/lib/components/src/blocks/Description.stories.tsx
@@ -10,15 +10,14 @@ export default {
 
 const textCaption = `That was Wintermute, manipulating the lock the way it had manipulated the drone micro and the amplified breathing of the room where Case waited. The semiotics of the bright void beyond the chain link. The tug Marcus Garvey, a steel drum nine meters long and two in diameter, creaked and shuddered as Maelcum punched for a California gambling cartel, then as a paid killer in the dark, curled in his capsule in some coffin hotel, his hands clawed into the nearest door and watched the other passengers as he rode. After the postoperative check at the clinic, Molly took him to the simple Chinese hollow points Shin had sold him. Still it was a handgun and nine rounds of ammunition, and as he made his way down Shiga from the missionaries, the train reached Case’s station. Now this quiet courtyard, Sunday afternoon, this girl with a random collection of European furniture, as though Deane had once intended to use the place as his home. Case felt the edge of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses. They were dropping, losing altitude in a canyon of rainbow foliage, a lurid communal mural that completely covered the hull of the console in faded pinks and yellows.`;
 
-export const Text = (args) => {
-  console.log({ args });
-  return <Description {...args} />;
-};
+const Story = (args) => <Description {...args} />;
+
+export const Text = Story.bind({});
 Text.args = {
   markdown: textCaption,
 };
 
-export const Markdown = (args) => <Description {...args} />;
+export const Markdown = Story.bind({});
 Markdown.args = {
   markdown: markdownCaption,
 };

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -48,7 +48,7 @@ const Label = styled.label(({ theme }) => ({
     borderRadius: '3em',
 
     boxShadow: `${opacify(0.05, theme.appBorderColor)} 0 0 0 1px inset`,
-    color: opacify(0.7, theme.color.defaultText),
+    color: transparentize(0.4, theme.color.defaultText),
     background: 'transparent',
 
     '&:hover': {

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -1,29 +1,86 @@
 import React, { FC } from 'react';
 
 import { styled } from '@storybook/theming';
+import { darken, lighten, rgba, opacify, transparentize } from 'polished';
+
 import { ControlProps, BooleanValue, BooleanConfig } from './types';
 
-const Input = styled.input({
-  display: 'table-cell',
-  boxSizing: 'border-box',
-  verticalAlign: 'top',
-  height: 21,
-  outline: 'none',
-  border: '1px solid #ececec',
-  fontSize: '12px',
-  color: '#555',
-});
+const Label = styled.label(({ theme }) => ({
+  lineHeight: '20px',
+  alignItems: 'center',
+  marginBottom: 8,
+  display: 'inline-block',
+  position: 'relative',
+
+  input: {
+    appearance: 'none',
+    width: '100%',
+    height: '100%',
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    margin: 0,
+    padding: 0,
+    border: 'none',
+    background: 'transparent',
+    cursor: 'pointer',
+  },
+
+  span: {
+    fontSize: theme.typography.size.s1,
+    fontWeight: theme.typography.weight.bold,
+    lineHeight: '1',
+    cursor: 'pointer',
+    display: 'inline-block',
+    padding: '8px 16px',
+    transition: 'all 150ms ease-out',
+    userSelect: 'none',
+    borderRadius: '3em',
+
+    boxShadow: `${opacify(0.05, theme.appBorderColor)} 0 0 0 1px inset`,
+    color: opacify(0.7, theme.color.defaultText),
+    background: 'transparent',
+
+    '&:hover': {
+      boxShadow: `${opacify(0.3, theme.appBorderColor)} 0 0 0 1px inset`,
+    },
+
+    '&:active': {
+      boxShadow: `${opacify(0.05, theme.appBorderColor)} 0 0 0 2px inset`,
+      color: opacify(1, theme.appBorderColor),
+    },
+
+    '&:first-of-type': {
+      borderTopRightRadius: 0,
+      borderBottomRightRadius: 0,
+    },
+    '&:last-of-type': {
+      borderTopLeftRadius: 0,
+      borderBottomLeftRadius: 0,
+    },
+  },
+
+  'input:checked ~ span:first-of-type, input:not(:checked) ~ span:last-of-type': {
+    background: `${opacify(0.05, theme.appBorderColor)}`,
+    boxShadow: `transparent 0 0 0 1px inset`,
+    color: theme.color.darkest,
+  },
+}));
 
 const format = (value: BooleanValue): string | null => (value ? String(value) : null);
 const parse = (value: string | null) => value === 'true';
 
 export type BooleanProps = ControlProps<BooleanValue> & BooleanConfig;
 export const BooleanControl: FC<BooleanProps> = ({ name, value, onChange }) => (
-  <Input
-    id={name}
-    name={name}
-    type="checkbox"
-    onChange={(e) => onChange(name, e.target.checked)}
-    checked={value}
-  />
+  <Label htmlFor={name}>
+    <input
+      id={name}
+      name={name}
+      type="checkbox"
+      onChange={(e) => onChange(name, e.target.checked)}
+      checked={value}
+    />
+    <span>True</span>
+    <span>False</span>
+  </Label>
 );

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -24,6 +24,14 @@ const Label = styled.label(({ theme }) => ({
     border: 'none',
     background: 'transparent',
     cursor: 'pointer',
+
+    '&:focus': {
+      outline: 'none',
+
+      '& ~ span': {
+        boxShadow: `${theme.color.secondary} 0 0 0 1px inset !important`,
+      },
+    },
   },
 
   span: {

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { styled } from '@storybook/theming';
-import { darken, lighten, rgba, opacify, transparentize } from 'polished';
+import { opacify, transparentize } from 'polished';
 
 import { ControlProps, BooleanValue, BooleanConfig } from './types';
 

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -27,6 +27,8 @@ const Label = styled.label(({ theme }) => ({
   },
 
   span: {
+    minWidth: 60,
+    textAlign: 'center',
     fontSize: theme.typography.size.s1,
     fontWeight: theme.typography.weight.bold,
     lineHeight: '1',


### PR DESCRIPTION
Issue: #11211

## What I did
- Updated boolean 
- Updated Control addon panel warning message 

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes. Go to UI Review PR check to see what changed.

@shilman Can you do me a favor and document `ControlsPanel:default` and `ControlsPanel: not configured`? I styled them just now but I'm afraid we're going to have UI regressions if we don't have stories. Especially since the ControlsPanel layout is different from the ArgsTable in SB Docs.

| default  | not configured  |
|---|---|
|![image](https://user-images.githubusercontent.com/263385/85345447-836e8400-b4c0-11ea-9948-5c222a55e769.png)   | ![image](https://user-images.githubusercontent.com/263385/85345382-54581280-b4c0-11ea-82d0-69540aa506b3.png)  |
