### PR TITLE
Addon-backgrounds: Allow gradients in story preview

### DIFF
--- a/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -178,7 +178,7 @@ export class BackgroundSelector extends Component<Props> {
                 <Global
                   styles={(theme: Theme) => ({
                     [`#${iframeId}`]: {
-                      backgroundColor:
+                      background:
                         selectedBackgroundColor === 'transparent'
                           ? theme.background.content
                           : selectedBackgroundColor,


### PR DESCRIPTION
Issue: #11231

## What I did
I have changed the `backgroundColor` property in backgrounds addon to the `background`, so we can also use gradients.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
