### PR TITLE
fix(addon-docs): markdown tables right align support

### DIFF
--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -176,13 +176,11 @@ export const Table = styled.table<{}>(withReset, withMargin, ({ theme }) => ({
   '& tr th': {
     fontWeight: 'bold',
     border: `1px solid ${theme.appBorderColor}`,
-    textAlign: 'left',
     margin: 0,
     padding: '6px 13px',
   },
   '& tr td': {
     border: `1px solid ${theme.appBorderColor}`,
-    textAlign: 'left',
     margin: 0,
     padding: '6px 13px',
   },


### PR DESCRIPTION
Closes #10666 

## What I did

I removed hardcoded text alignment on tables.
So if they are defined to be right-aligned, let's the tables be left-aligned when we use Markdown. 🤷‍♂️ 

## How to test

- Is this testable with Jest or Chromatic screenshots? Of course 🙏 
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No