### PR TITLE
Addon-docs: Simplify argType inference

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -247,12 +247,7 @@ This generates the following UI with a custom range slider:
   <img src="https://raw.githubusercontent.com/storybookjs/storybook/next/addons/controls/docs/media/addon-controls-args-reflow-slider.png" width="80%" />
 </center>
 
-**Note:** If you add an `ArgType` that is not part of the component, Storybook will _only_ use your argTypes definitions.  
-If you want to merge new controls with the existing component properties, you must enable this parameter:
-
-```jsx
-  docs: { forceExtractedArgTypes: true },
-```
+**Note:** If you set a `component` for your stories, these `argTypes` will always be added automatically. If you ONLY want to use custom `argTypes`, don't set a `component`. You can still show metadata about your component by adding it to `subcomponents`.
 
 #### Angular
 

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
@@ -308,6 +308,14 @@ describe('enhanceArgTypes', () => {
               "type": {
                 "name": "number"
               }
+            },
+            "foo": {
+              "control": {
+                "type": "number"
+              },
+              "type": {
+                "name": "number"
+              }
             }
           }
         `);

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.ts
@@ -4,13 +4,6 @@ import { inferArgTypes } from './inferArgTypes';
 import { inferControls } from './inferControls';
 import { normalizeArgTypes } from './normalizeArgTypes';
 
-const isSubset = (kind: string, subset: object, superset: object) => {
-  const keys = Object.keys(subset);
-  // eslint-disable-next-line no-prototype-builtins
-  const overlap = keys.filter((key) => superset.hasOwnProperty(key));
-  return overlap.length === keys.length;
-};
-
 export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
   const { component, argTypes: userArgTypes = {}, docs = {}, args = {} } = context.parameters;
   const { extractArgTypes } = docs;

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.ts
@@ -1,6 +1,5 @@
 import mapValues from 'lodash/mapValues';
 import { ArgTypesEnhancer, combineParameters } from '@storybook/client-api';
-import { ArgTypes } from '@storybook/api';
 import { inferArgTypes } from './inferArgTypes';
 import { inferControls } from './inferControls';
 import { normalizeArgTypes } from './normalizeArgTypes';
@@ -14,23 +13,12 @@ const isSubset = (kind: string, subset: object, superset: object) => {
 
 export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
   const { component, argTypes: userArgTypes = {}, docs = {}, args = {} } = context.parameters;
-  const { extractArgTypes, forceExtractedArgTypes = false } = docs;
+  const { extractArgTypes } = docs;
 
   const normalizedArgTypes = normalizeArgTypes(userArgTypes);
   const namedArgTypes = mapValues(normalizedArgTypes, (val, key) => ({ name: key, ...val }));
   const inferredArgTypes = inferArgTypes(args);
-  let extractedArgTypes: ArgTypes = extractArgTypes && component ? extractArgTypes(component) : {};
-
-  if (
-    !forceExtractedArgTypes &&
-    ((Object.keys(normalizedArgTypes).length > 0 &&
-      !isSubset(context.kind, normalizedArgTypes, extractedArgTypes)) ||
-      (Object.keys(inferredArgTypes).length > 0 &&
-        !isSubset(context.kind, inferredArgTypes, extractedArgTypes)))
-  ) {
-    extractedArgTypes = {};
-  }
-
+  const extractedArgTypes = extractArgTypes && component ? extractArgTypes(component) : {};
   const withArgTypes = combineParameters(inferredArgTypes, extractedArgTypes, namedArgTypes);
 
   if (context.storyFn.length === 0) {


### PR DESCRIPTION
Issue: N/A

## What I did

Previously, there was complex logic for whether or not to use user-specified `argTypes` or `component`-inferred `argTypes`. This led to difficult-to-debug cases where `argTypes` would be missing.

This change simplifies inference:
- If you specify a `component` for your stories, its `argTypes` will get added
- If you don't want them, but still want a props tab for your component, add it to `subcomponents`
- No need for the `forceExtractedArgTypes` flag

## How to test

See updated snapshots