### PR TITLE
CLI: Fix docs & essentials version on `sb@next init`

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -65,6 +65,8 @@
   },
   "devDependencies": {
     "@storybook/addon-actions": "6.0.0-beta.35",
+    "@storybook/addon-docs": "6.0.0-beta.35",
+    "@storybook/addon-essentials": "6.0.0-beta.35",
     "@storybook/addon-graphql": "6.0.0-beta.35",
     "@storybook/addon-knobs": "6.0.0-beta.35",
     "@storybook/addon-links": "6.0.0-beta.35",


### PR DESCRIPTION
Issue: docs or essentials are installed using @latest tag instead of current version

## What I did
Quick fix to resolve right value

@gaetanmaisse I think we shoudn't check the version addons in peer dependency but base them on the framework version.