### PR TITLE
Set viewMode to story when calling selectStory from non story pages

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -212,10 +212,18 @@ export const init: ModuleFn = ({
         const s = hash[kindOrId] || hash[sanitize(kindOrId)];
         // eslint-disable-next-line no-nested-ternary
         const id = s ? (s.children ? s.children[0] : s.id) : kindOrId;
-        const viewMode =
+        let viewMode =
           viewModeFromArgs || (s && s.parameters.viewMode)
             ? s.parameters.viewMode
             : viewModeFromState;
+
+        // In some cases, the viewMode could be something other than docs/story
+        // ('settings', for example) and therefore we should make sure we go back
+        // to the 'story' viewMode when navigating away from those pages.
+        if (!viewMode.match(/docs|story/)) {
+          viewMode = 'story';
+        }
+
         const p = s && s.refId ? `/${viewMode}/${s.refId}_${id}` : `/${viewMode}/${id}`;
 
         navigate(p);

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -679,6 +679,20 @@ describe('stories API', () => {
       expect(navigate).toHaveBeenCalledWith('/story/a--2');
     });
 
+    it('allows navigating away from the settings pages', () => {
+      const navigate = jest.fn();
+      const store = {
+        getState: () => ({ viewMode: 'settings', storyId: 'about', storiesHash }),
+      };
+
+      const {
+        api: { selectStory },
+      } = initStories({ store, navigate, provider });
+
+      selectStory('a--2');
+      expect(navigate).toHaveBeenCalledWith('/story/a--2');
+    });
+
     it('allows navigating to first story in kind on call by kind', () => {
       const navigate = jest.fn();
       const store = createMockStore();


### PR DESCRIPTION
Issue: When on either of the settings pages (About/Keyboard shortcuts) & navigating back to a story from the sidebar, the viewMode remained as "settings", leaving you with this:

![Screen Shot 2020-06-25 at 11 54 10 AM](https://user-images.githubusercontent.com/3035355/85772977-9d83ae80-b6da-11ea-91c6-67b55a5e17bf.png)


## What I did

Updated the logic to set the `viewMode` to "story" when calling `api.selectStory` and the `viewMode` is not already "docs" or 
"story".

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

There is an automated test in this PR for the behavior.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
