### PR TITLE
Revert "Core: Fix source-map strategy for production"

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -113,7 +113,7 @@ export default async ({
   return {
     mode: isProd ? 'production' : 'development',
     bail: isProd,
-    devtool: isProd ? 'inline-source-map' : '#cheap-module-source-map',
+    devtool: '#cheap-module-source-map',
     entry: entries,
     output: {
       path: path.resolve(process.cwd(), outputDir),


### PR DESCRIPTION
Reverts storybookjs/storybook#10290

Turns out this more than doubles the bundle size and is a non-starter for performance reasons. We'll need to fix the issue some other way.

Self-merging @ndelangen @tmeasday 