### PR TITLE
Addon-docs: Add opt-in Markdown transclusion in MDX

### DIFF
--- a/examples/official-storybook/main.ts
+++ b/examples/official-storybook/main.ts
@@ -9,7 +9,10 @@ module.exports = {
     './../../addons/docs/**/*.stories.tsx',
   ],
   addons: [
-    '@storybook/addon-docs',
+    {
+      name: '@storybook/addon-docs',
+      options: { transcludeMarkdown: true },
+    },
     '@storybook/addon-storysource',
     '@storybook/addon-design-assets',
     '@storybook/addon-actions',

--- a/examples/official-storybook/stories/addon-docs/addon-docs.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/addon-docs.stories.mdx
@@ -13,12 +13,17 @@ import { action } from '@storybook/addon-actions';
 import { Button } from '@storybook/react/demo';
 import FlowTypeButton from '../../components/FlowTypeButton';
 import { DocgenButton } from '../../components/DocgenButton';
+import MdNotes from '../notes/notes.md';
+import MdxNotes from '../notes/notes.mdx';
 
 <Meta
   title="Addons/Docs/mdx"
   component={Button}
   id="addons-docs-mdx-id"
-  decorators={[storyFn => <div style={{ backgroundColor: 'yellow' }}>{storyFn()}</div>, withKnobs]}
+  decorators={[
+    (storyFn) => <div style={{ backgroundColor: 'yellow' }}>{storyFn()}</div>,
+    withKnobs,
+  ]}
   parameters={{ notes: 'component notes' }}
 />
 
@@ -33,6 +38,16 @@ import { DocgenButton } from '../../components/DocgenButton';
 <Preview>
   <Story id="nonexistent-story" />
 </Preview>
+
+## Transclusion
+
+### Markdown
+
+<MdNotes />
+
+### MDX
+
+<MdxNotes />
 
 ## A random color ColorPalette
 
@@ -88,7 +103,10 @@ export const nonStory2 = () => <Button>Not a story</Button>; // another one
   <>This is an iframe!</>
 </Story>
 
-<Story name="decorator story" decorators={[storyFn => <div style={{ backgroundColor: 'pink' }}>{storyFn()}</div>]}>
+<Story
+  name="decorator story"
+  decorators={[(storyFn) => <div style={{ backgroundColor: 'pink' }}>{storyFn()}</div>]}
+>
   <>Story decorators</>
 </Story>
 
@@ -150,11 +168,11 @@ Flow types are not officially supported
   <Button>This souldn't show up in docs page</Button>
 </Story>
 
-
 ## Story with multiple children
+
 <Preview>
   <Story name="story multiple children">
     <p>Hello Child #1</p>
     <p>Hello Child #2</p>
   </Story>
-</Preview>  
+</Preview>

--- a/lib/components/src/blocks/Description.stories.tsx
+++ b/lib/components/src/blocks/Description.stories.tsx
@@ -1,14 +1,22 @@
 import React from 'react';
 import { Description } from './Description';
 
-import markdownCaption from './DocsPageExampleCaption.md';
-
 export default {
   title: 'Docs/Description',
   component: Description,
 };
 
 const textCaption = `That was Wintermute, manipulating the lock the way it had manipulated the drone micro and the amplified breathing of the room where Case waited. The semiotics of the bright void beyond the chain link. The tug Marcus Garvey, a steel drum nine meters long and two in diameter, creaked and shuddered as Maelcum punched for a California gambling cartel, then as a paid killer in the dark, curled in his capsule in some coffin hotel, his hands clawed into the nearest door and watched the other passengers as he rode. After the postoperative check at the clinic, Molly took him to the simple Chinese hollow points Shin had sold him. Still it was a handgun and nine rounds of ammunition, and as he made his way down Shiga from the missionaries, the train reached Case’s station. Now this quiet courtyard, Sunday afternoon, this girl with a random collection of European furniture, as though Deane had once intended to use the place as his home. Case felt the edge of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses. They were dropping, losing altitude in a canyon of rainbow foliage, a lurid communal mural that completely covered the hull of the console in faded pinks and yellows.`;
+
+const markdownCaption = `
+# My Example Markdown
+
+The group looked like tall, exotic grazing animals, swaying gracefully and unconsciously with the movement of the train, their high heels like polished hooves against the gray metal of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses.
+
+![An image](http://placehold.it/350x150)
+
+He stared at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a skyscraper canyon. 
+`;
 
 const Story = (args) => <Description {...args} />;
 

--- a/lib/components/src/typography/DocumentWrapper.stories.tsx
+++ b/lib/components/src/typography/DocumentWrapper.stories.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import Markdown from 'markdown-to-jsx';
 import { DocumentWrapper } from './DocumentWrapper';
-import markdownSample from './DocumentFormattingSample.md';
+import MarkdownSample from './DocumentFormattingSample.md';
 
 export default {
   component: DocumentWrapper,
@@ -12,7 +11,7 @@ export default {
 
 export const withMarkdown = () => (
   <DocumentWrapper>
-    <Markdown>{markdownSample}</Markdown>
+    <MarkdownSample />
   </DocumentWrapper>
 );
 


### PR DESCRIPTION
Issue: #7644

## What I did

Telescoping PR off #11333

- [x] Add `transcludeMarkdown` option which overrides default `.md` webpack settings

## How to test

See `official-storybook` updates
