### PR TITLE
WIP: feat(addon-docs): Angular inline rendering support

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -78,10 +78,16 @@
     "ts-dedent": "^1.1.1",
     "util-deprecate": "^1.0.2",
     "vue-docgen-api": "^4.7.0",
-    "vue-docgen-loader": "^1.4.0"
+    "vue-docgen-loader": "^1.4.0",
+    "@angular/common": "8.2.14",
+    "@angular/compiler": "8.2.14",
+    "@angular/platform-browser": "8.2.14",
+    "@angular/platform-browser-dynamic": "8.2.14",
+    "reflect-metadata": "0.1.13",
+    "zone.js": "^0.10.2",
+    "@angular/core": "^9.1.0"
   },
   "devDependencies": {
-    "@angular/core": "^9.1.0",
     "@babel/core": "^7.9.6",
     "@emotion/core": "^10.0.20",
     "@emotion/styled": "^10.0.17",
@@ -115,8 +121,7 @@
     "tmp": "^0.2.1",
     "tslib": "^2.0.0",
     "web-component-analyzer": "^1.0.3",
-    "webpack": "^4.33.0",
-    "zone.js": "^0.10.2"
+    "webpack": "^4.33.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/addons/docs/src/frameworks/angular/angular-to-react.tsx
+++ b/addons/docs/src/frameworks/angular/angular-to-react.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable no-console */
+import 'reflect-metadata';
+import 'zone.js/dist/zone';
+import 'zone.js/dist/zone-error';
+import { document } from 'global';
+import { NgModule, NgModuleRef, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import React from 'react';
+
+const defaultPassProps = (props: any) => props;
+
+export const SELECTOR = 'app-root';
+
+const bootstrapAngularApp = (
+  node: HTMLElement,
+  AppComponentInstance: any
+): Promise<NgModuleRef<any>> => {
+  node.appendChild(document.createElement(SELECTOR));
+  const AppModule = NgModule({
+    declarations: [AppComponentInstance],
+    imports: [BrowserModule],
+    bootstrap: [AppComponentInstance],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  })(class {});
+  return platformBrowserDynamic().bootstrapModule(AppModule);
+};
+
+export default (Component: any, { passProps = defaultPassProps } = {}) => {
+  console.log('debugging... trying to display: ', Component);
+  return (props: any) => {
+    console.log('debugging... Executing function with props', props);
+    const el = React.useRef(null);
+
+    React.useEffect(() => {
+      console.log('debugging... Executing useEffect with el', el);
+      let module: any;
+      // eslint-disable-next-line no-return-assign
+      bootstrapAngularApp(el.current, Component).then((m) => (module = m));
+      // eslint-disable-next-line consistent-return
+      return () => {
+        while (!module) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        console.log('debugging... Destroy.', el);
+        module.destroy();
+      };
+    });
+    console.log('debugging... createElement', el);
+    return React.createElement('div', null, React.createElement('div', { ref: el }));
+  };
+};

--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -1,9 +1,0 @@
-import { addParameters } from '@storybook/client-api';
-import { extractArgTypes, extractComponentDescription } from './compodoc';
-
-addParameters({
-  docs: {
-    extractArgTypes,
-    extractComponentDescription,
-  },
-});

--- a/addons/docs/src/frameworks/angular/config.tsx
+++ b/addons/docs/src/frameworks/angular/config.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { addParameters } from '@storybook/client-api';
+import { StoryFn, StoryContext } from '@storybook/addons';
+import { extractArgTypes, extractComponentDescription } from './compodoc';
+import toReact from './angular-to-react';
+
+addParameters({
+  docs: {
+    inlineStories: true,
+    prepareForInline: (storyFn: StoryFn, { args }: StoryContext) => {
+      const Story = toReact(storyFn());
+      return <Story {...args} />;
+    },
+    extractArgTypes,
+    extractComponentDescription,
+  },
+});


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/8153

🚀 This is a first attempt to allow inlining Angular stories in addon-docs.
⚠️  While this is not working yet, it might give birth to discussions permitting to reach that goal.

## What I did

- Add angular-to-react logic offered by @petermikitsh in https://github.com/storybookjs/storybook/issues/3889#issuecomment-616907568
- Modify that logic to get somewhere close to what is currently done for the Vue part (https://github.com/egoist/vue-to-react/blob/master/src/index.js)
- Include that logic in Angular config.tsx, while getting as close as the Vue configuration as possible.
- 🗑️ Adding a lot of dependencies in the addon to try to make it work

## What I miss

- Currently this isn't working. 
    - I'm suspecting this is because Angular doesn't allow to bootstrap multiple applications in the same page.
    - There might be a way to make it work properly, but it implies to change the story rendering workflow...
         - https://stackoverflow.com/questions/40783186/bootstrap-the-same-angular2-module-multiple-times-in-a-page
- Shall we put the angular-to-react logic inside addon-docs? Or should we put it in an external project like for vue-to-react?
    - This question also relates to dependency management in addon-docs


## How to test

Go into the angular-cli storybook, then take any story and display the DocPage.
⚠️ Currently, this results in the following error : 
`Error: A platform with a different configuration has been created. Please destroy it first. zone-error.js:97`

- Is this testable with Jest or Chromatic screenshots?
    - Yes, if we can apply Chromatic screenshots to addon-docs (is it??)
- Does this need a new example in the kitchen sink apps?
    - Yes, to showcase both possible cases : inline vs iframe.
- Does this need an update to the documentation?
    - Yes, Angular inlineStories will probably be disabled by default so it'll be up to the user to toggle this flag.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
