### PR TITLE
Configuration: Remove hierarchy separators

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,6 +17,7 @@
   - [Removed Deprecated APIs](#removed-deprecated-apis)
   - [New setStories event](#new-setstories-event)
   - [Removed renderCurrentStory event](#removed-rendercurrentstory-event)
+  - [Removed hierarchy separators](#removed-hierarchy-separators)
   - [Client API changes](#client-api-changes)
     - [Removed Legacy Story APIs](#removed-legacy-story-apis)
     - [Can no longer add decorators/parameters after stories](#can-no-longer-add-decoratorsparameters-after-stories)
@@ -390,6 +391,26 @@ const parameters = combineParameters(
 ### Removed renderCurrentStory event
 
 The story store no longer emits `renderCurrentStory`/`RENDER_CURRENT_STORY` to tell the renderer to render the story. Instead it emits a new declarative `CURRENT_STORY_WAS_SET` (in response to the existing `SET_CURRENT_STORY`) which is used to decide to render.
+
+### Removed hierarchy separators
+
+We've removed the ability to specify the hierarchy separators (how you control the grouping of story kinds in the sidebar). From Storybook 6.0 we have a single separator `/`, which cannot be configured.
+
+If you are currently using using custom separators, we encourage you to migrate to using `/` as the sole separator. If you are using `|` or `.` as a separator currently, we provide a codemod, [`upgrade-hierarchy-separators`](https://github.com/storybookjs/storybook/blob/next/lib/codemod/README.md#upgrade-hierarchy-separators), that can be used to rename all your components.
+
+```
+yarn sb migrate upgrade-hierarchy-separators --glob="*.stories.js"
+```
+
+We also now default to showing "roots", which are non-expandable groupings in the sidebar for the top-level groups. If you'd like to disable this, set the `showRoots` option in `.storybook/manager.js`:
+
+```js
+import addons from '@storybook/addons';
+
+addons.setConfig({
+  showRoots: false,
+});
+```
 
 ### Client API changes
 

--- a/addons/docs/src/blocks/DocsPage.test.ts
+++ b/addons/docs/src/blocks/DocsPage.test.ts
@@ -1,24 +1,10 @@
 import { extractTitle } from './Title';
 
 describe('defaultTitleSlot', () => {
-  it('showRoots', () => {
-    const parameters = {
-      options: { showRoots: true },
-    };
+  it('splits on last /', () => {
+    const parameters = {};
     expect(extractTitle({ kind: 'a/b/c', parameters })).toBe('c');
     expect(extractTitle({ kind: 'a|b', parameters })).toBe('a|b');
     expect(extractTitle({ kind: 'a/b/c.d', parameters })).toBe('c.d');
-  });
-  it('no showRoots', () => {
-    const parameters = {};
-    expect(extractTitle({ kind: 'a/b/c', parameters })).toBe('c');
-    expect(extractTitle({ kind: 'a|b', parameters })).toBe('b');
-    expect(extractTitle({ kind: 'a/b/c.d', parameters })).toBe('d');
-  });
-  it('empty options', () => {
-    const parameters = { options: {} };
-    expect(extractTitle({ kind: 'a/b/c', parameters })).toBe('c');
-    expect(extractTitle({ kind: 'a|b', parameters })).toBe('b');
-    expect(extractTitle({ kind: 'a/b/c.d', parameters })).toBe('d');
   });
 });

--- a/addons/docs/src/blocks/Title.tsx
+++ b/addons/docs/src/blocks/Title.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, FunctionComponent } from 'react';
-import { parseKind } from '@storybook/csf';
 import { Title as PureTitle } from '@storybook/components';
 import { DocsContext, DocsContextProps } from './DocsContext';
 

--- a/addons/docs/src/blocks/Title.tsx
+++ b/addons/docs/src/blocks/Title.tsx
@@ -7,22 +7,7 @@ interface TitleProps {
   children?: JSX.Element | string;
 }
 export const extractTitle = ({ kind, parameters }: DocsContextProps) => {
-  const {
-    showRoots,
-    hierarchyRootSeparator: rootSeparator = '|',
-    hierarchySeparator: groupSeparator = /\/|\./,
-  } = (parameters && parameters.options) || {};
-
-  let groups;
-  if (typeof showRoots !== 'undefined') {
-    groups = kind.split('/');
-  } else {
-    // This covers off all the remaining cases:
-    //   - If the separators were set above, we should use them
-    //   - If they weren't set, we should only should use the old defaults if the kind contains '.' or '|',
-    //     which for this particular splitting is the only case in which it actually matters.
-    ({ groups } = parseKind(kind, { rootSeparator, groupSeparator }));
-  }
+  const groups = kind.split('/');
 
   return (groups && groups[groups.length - 1]) || kind;
 };

--- a/docs/src/pages/configurations/options-parameter/index.md
+++ b/docs/src/pages/configurations/options-parameter/index.md
@@ -86,7 +86,7 @@ export const parameters = {
      * display the top-level grouping as a "root" in the sidebar
      * @type {Boolean}
      */
-    showRoots: false,
+    showRoots: true,
   },
 });
 ```

--- a/examples/angular-cli/.storybook/manager.js
+++ b/examples/angular-cli/.storybook/manager.js
@@ -1,5 +1,0 @@
-import { addons } from '@storybook/addons';
-
-addons.setConfig({
-  showRoots: true,
-});

--- a/examples/aurelia-kitchen-sink/.storybook/manager.js
+++ b/examples/aurelia-kitchen-sink/.storybook/manager.js
@@ -1,7 +1,6 @@
 import { addons } from '@storybook/addons';
 
 addons.setConfig({
-  showRoots: true,
   brandTitle: 'Aurelia Kitchen Sink',
   brandUrl: 'https://github.com/storybookjs/storybook/tree/master/examples/aurelia-kitchen-sink',
 });

--- a/examples/aurelia-kitchen-sink/.storybook/preview.ts
+++ b/examples/aurelia-kitchen-sink/.storybook/preview.ts
@@ -1,7 +1,0 @@
-import { addParameters } from '@storybook/aurelia';
-
-addParameters({
-  options: {
-    showRoots: true,
-  },
-});

--- a/examples/cra-ts-kitchen-sink/.storybook/preview.ts
+++ b/examples/cra-ts-kitchen-sink/.storybook/preview.ts
@@ -6,6 +6,5 @@ addParameters({
   options: {
     brandTitle: 'CRA TypeScript Kitchen Sink',
     brandUrl: 'https://github.com/storybookjs/storybook/tree/master/examples/cra-ts-kitchen-sink',
-    showRoots: true,
   },
 });

--- a/examples/ember-cli/.storybook/preview.js
+++ b/examples/ember-cli/.storybook/preview.js
@@ -1,11 +1,5 @@
-import { addParameters } from '@storybook/ember';
 import { setJSONDoc } from '@storybook/addon-docs/ember';
 // eslint-disable-next-line import/no-unresolved
 import docJson from '../ember-output/storybook-docgen/index.json';
 
 setJSONDoc(docJson);
-addParameters({
-  options: {
-    showRoots: true,
-  },
-});

--- a/examples/html-kitchen-sink/.storybook/preview.js
+++ b/examples/html-kitchen-sink/.storybook/preview.js
@@ -10,9 +10,6 @@ addParameters({
       restoreScroll: true,
     },
   },
-  options: {
-    showRoots: true,
-  },
   docs: {
     iframeHeight: '200px',
     transformSource: (src) => {

--- a/examples/marko-cli/.storybook/manager.js
+++ b/examples/marko-cli/.storybook/manager.js
@@ -1,5 +1,0 @@
-import { addons } from '@storybook/addons';
-
-addons.setConfig({
-  showRoots: true,
-});

--- a/examples/mithril-kitchen-sink/.storybook/manager.js
+++ b/examples/mithril-kitchen-sink/.storybook/manager.js
@@ -1,5 +1,0 @@
-import { addons } from '@storybook/addons';
-
-addons.setConfig({
-  showRoots: true,
-});

--- a/examples/official-storybook/manager.js
+++ b/examples/official-storybook/manager.js
@@ -6,7 +6,6 @@ import addHeadWarning from './head-warning';
 addHeadWarning('manager-head-not-loaded', 'Manager head not loaded');
 
 addons.setConfig({
-  showRoots: true,
   theme: themes.light, // { base: 'dark', brandTitle: 'Storybook!' },
   previewTabs: {
     canvas: null,

--- a/examples/preact-kitchen-sink/.storybook/manager.js
+++ b/examples/preact-kitchen-sink/.storybook/manager.js
@@ -1,5 +1,0 @@
-import { addons } from '@storybook/addons';
-
-addons.setConfig({
-  showRoots: true,
-});

--- a/examples/rax-kitchen-sink/.storybook/manager.js
+++ b/examples/rax-kitchen-sink/.storybook/manager.js
@@ -9,7 +9,6 @@ const theme = create({
 });
 
 addons.setConfig({
-  showRoots: true,
   panelPosition: 'bottom',
   theme,
 });

--- a/examples/riot-kitchen-sink/.storybook/manager.js
+++ b/examples/riot-kitchen-sink/.storybook/manager.js
@@ -1,5 +1,0 @@
-import { addons } from '@storybook/addons';
-
-addons.setConfig({
-  showRoots: true,
-});

--- a/examples/server-kitchen-sink/.storybook/preview.js
+++ b/examples/server-kitchen-sink/.storybook/preview.js
@@ -13,9 +13,6 @@ addParameters({
       restoreScroll: true,
     },
   },
-  options: {
-    showRoots: true,
-  },
   docs: {
     iframeHeight: '200px',
   },

--- a/examples/svelte-kitchen-sink/.storybook/manager.js
+++ b/examples/svelte-kitchen-sink/.storybook/manager.js
@@ -1,5 +1,0 @@
-import { addons } from '@storybook/addons';
-
-addons.setConfig({
-  showRoots: true,
-});

--- a/examples/vue-kitchen-sink/.storybook/manager.js
+++ b/examples/vue-kitchen-sink/.storybook/manager.js
@@ -1,5 +1,0 @@
-import { addons } from '@storybook/addons';
-
-addons.setConfig({
-  showRoots: true,
-});

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -78,8 +78,6 @@ export type StorySortParameter = Comparator<any> | StorySortObjectParameter;
 
 export interface OptionsParameter extends Object {
   storySort?: StorySortParameter;
-  hierarchyRootSeparator?: string;
-  hierarchySeparator?: RegExp;
   showRoots?: boolean;
   theme?: {
     base: string;

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -78,7 +78,6 @@ export type StorySortParameter = Comparator<any> | StorySortObjectParameter;
 
 export interface OptionsParameter extends Object {
   storySort?: StorySortParameter;
-  showRoots?: boolean;
   theme?: {
     base: string;
     brandTitle?: string;

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -1,6 +1,6 @@
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
-import { sanitize, parseKind } from '@storybook/csf';
+import { sanitize } from '@storybook/csf';
 import mapValues from 'lodash/mapValues';
 
 import { StoryId, StoryKind, Args, Parameters, combineParameters } from '../index';
@@ -58,8 +58,6 @@ export interface Story {
   parameters?: {
     fileName: string;
     options: {
-      hierarchyRootSeparator?: RegExp;
-      hierarchySeparator?: RegExp;
       showRoots?: boolean;
       [optionName: string]: any;
     };
@@ -79,8 +77,6 @@ export interface StoryInput {
   parameters: {
     fileName: string;
     options: {
-      hierarchyRootSeparator: RegExp;
-      hierarchySeparator: RegExp;
       showRoots?: boolean;
       [optionName: string]: any;
     };
@@ -119,25 +115,10 @@ export interface SetStoriesPayloadV2 extends SetStoriesPayload {
   };
 }
 
-const warnUsingHierarchySeparatorsAndShowRoots = deprecate(
+const warnChangedDefaultHierarchySeparators = deprecate(
   () => {},
   dedent`
-    You cannot use both the hierarchySeparator/hierarchyRootSeparator and showRoots options.
-  `
-);
-
-const warnRemovingHierarchySeparators = deprecate(
-  () => {},
-  dedent`
-    hierarchySeparator and hierarchyRootSeparator are deprecated and will be removed in Storybook 6.0.
-    Read more about it in the migration guide: https://github.com/storybookjs/storybook/blob/master/MIGRATION.md
-  `
-);
-
-const warnChangingDefaultHierarchySeparators = deprecate(
-  () => {},
-  dedent`
-    The default hierarchy separators are changing in Storybook 6.0.
+    The default hierarchy separators changed in Storybook 6.0.
     '|' and '.' will no longer create a hierarchy, but codemods are available.
     Read more about it in the migration guide: https://github.com/storybookjs/storybook/blob/master/MIGRATION.md
   `
@@ -179,39 +160,21 @@ export const transformStoriesRawToStoriesHash = (
     .filter(Boolean)
     .reduce((acc, item) => {
       const { kind, parameters } = item;
-      const {
-        hierarchyRootSeparator: rootSeparator = undefined,
-        hierarchySeparator: groupSeparator = undefined,
-        showRoots = undefined,
-      } = { ...provider.getConfig(), ...((parameters && parameters.options) || {}) };
+      const { showRoots } = provider.getConfig();
 
-      const usingShowRoots = typeof showRoots !== 'undefined';
+      const setShowRoots = typeof showRoots !== 'undefined';
+      if (anyKindMatchesOldHierarchySeparators && !setShowRoots) {
+        warnChangedDefaultHierarchySeparators();
+      }
 
-      // Kind splitting behavior as per https://github.com/storybookjs/storybook/issues/8793
       let root = '';
       let groups: string[];
-      // 1. If the user has passed separators, use the old behavior but warn them
-      if (typeof rootSeparator !== 'undefined' || typeof groupSeparator !== 'undefined') {
-        warnRemovingHierarchySeparators();
-        if (usingShowRoots) warnUsingHierarchySeparatorsAndShowRoots();
-        ({ root, groups } = parseKind(kind, {
-          rootSeparator: rootSeparator || '|',
-          groupSeparator: groupSeparator || /\/|\./,
-        }));
-
-        // 2. If the user hasn't passed separators, but is using | or . in kinds, use the old behaviour but warn
-      } else if (anyKindMatchesOldHierarchySeparators && !usingShowRoots) {
-        warnChangingDefaultHierarchySeparators();
-        ({ root, groups } = parseKind(kind, { rootSeparator: '|', groupSeparator: /\/|\./ }));
-
-        // 3. If the user passes showRoots, or doesn't match above, do a simpler splitting.
+      const parts: string[] = kind.split('/');
+      // Default showRoots to true if they didn't set it.
+      if ((!setShowRoots || showRoots) && parts.length > 1) {
+        [root, ...groups] = parts;
       } else {
-        const parts: string[] = kind.split('/');
-        if (showRoots && parts.length > 1) {
-          [root, ...groups] = parts;
-        } else {
-          groups = parts;
-        }
+        groups = parts;
       }
 
       const rootAndGroups = []

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -58,7 +58,6 @@ export interface Story {
   parameters?: {
     fileName: string;
     options: {
-      showRoots?: boolean;
       [optionName: string]: any;
     };
     docsOnly?: boolean;
@@ -77,7 +76,6 @@ export interface StoryInput {
   parameters: {
     fileName: string;
     options: {
-      showRoots?: boolean;
       [optionName: string]: any;
     };
     docsOnly?: boolean;

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -20,11 +20,11 @@ function createMockStore(initialState) {
   };
 }
 
-const provider = {
-  getConfig() {
-    return {};
-  },
-};
+const provider = { getConfig: jest.fn() };
+
+beforeEach(() => {
+  provider.getConfig.mockReturnValue({});
+});
 
 class LocalEventEmitter extends EventEmitter {
   on(event, callback) {
@@ -92,6 +92,7 @@ describe('stories API', () => {
         api: { setStories },
       } = initStories({ store, navigate, provider });
 
+      provider.getConfig.mockReturnValue({ showRoots: false });
       setStories(storiesHash);
 
       const { storiesHash: storedStoriesHash } = store.getState();
@@ -211,12 +212,12 @@ describe('stories API', () => {
         api: { setStories },
       } = initStories({ store, navigate, provider });
 
-      const showRootsParameters = { options: { showRoots: true } };
+      provider.getConfig.mockReturnValue({ showRoots: true });
       setStories({
         'a-b--1': {
           kind: 'a/b',
           name: '1',
-          parameters: showRootsParameters,
+          parameters,
           path: 'a-b--1',
           id: 'a-b--1',
           args: {},
@@ -245,7 +246,7 @@ describe('stories API', () => {
         parent: 'a-b',
         kind: 'a/b',
         name: '1',
-        parameters: showRootsParameters,
+        parameters,
         args: {},
       });
     });
@@ -258,12 +259,12 @@ describe('stories API', () => {
         api: { setStories },
       } = initStories({ store, navigate, provider });
 
-      const showRootsParameters = { options: { showRoots: true } };
+      provider.getConfig.mockReturnValue({ showRoots: true });
       setStories({
         'a--1': {
           kind: 'a',
           name: '1',
-          parameters: showRootsParameters,
+          parameters,
           path: 'a--1',
           id: 'a--1',
           args: {},
@@ -285,99 +286,6 @@ describe('stories API', () => {
         parent: 'a',
         kind: 'a',
         name: '1',
-        parameters: showRootsParameters,
-        args: {},
-      });
-    });
-
-    it('handles roots also', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-
-      const {
-        api: { setStories },
-      } = initStories({ store, navigate, provider });
-
-      await setStories({
-        'a--1': { kind: 'a', name: '1', parameters, path: 'a--1', id: 'a--1', args: {} },
-        'a--2': { kind: 'a', name: '2', parameters, path: 'a--2', id: 'a--2', args: {} },
-        'b-c--1': {
-          kind: 'b|c',
-          name: '1',
-          parameters,
-          path: 'b-c--1',
-          id: 'b-c--1',
-          args: {},
-        },
-        'b-d--1': {
-          kind: 'b|d',
-          name: '1',
-          parameters,
-          path: 'b-d--1',
-          id: 'b-d--1',
-          args: {},
-        },
-        'b-d--2': {
-          kind: 'b|d',
-          name: '2',
-          parameters,
-          path: 'b-d--2',
-          id: 'b-d--2',
-          args: {},
-        },
-      });
-      const { storiesHash: storedStoriesHash } = store.getState();
-
-      // We need exact key ordering, even if in theory JS doens't guarantee it
-      expect(Object.keys(storedStoriesHash)).toEqual([
-        'a',
-        'a--1',
-        'a--2',
-        'b',
-        'b-c',
-        'b-c--1',
-        'b-d',
-        'b-d--1',
-        'b-d--2',
-      ]);
-      expect(storedStoriesHash.b).toMatchObject({
-        id: 'b',
-        children: ['b-c', 'b-d'],
-        isRoot: true,
-        isComponent: false,
-      });
-
-      expect(storedStoriesHash['b-c']).toMatchObject({
-        id: 'b-c',
-        parent: 'b',
-        children: ['b-c--1'],
-        isRoot: false,
-        isComponent: true,
-      });
-
-      expect(storedStoriesHash['b-c--1']).toMatchObject({
-        id: 'b-c--1',
-        parent: 'b-c',
-        kind: 'b|c',
-        name: '1',
-        parameters,
-        args: {},
-      });
-
-      expect(storedStoriesHash['b-d--1']).toMatchObject({
-        id: 'b-d--1',
-        parent: 'b-d',
-        kind: 'b|d',
-        name: '1',
-        parameters,
-        args: {},
-      });
-
-      expect(storedStoriesHash['b-d--2']).toMatchObject({
-        id: 'b-d--2',
-        parent: 'b-d',
-        kind: 'b|d',
-        name: '2',
         parameters,
         args: {},
       });

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -334,50 +334,6 @@ describe('preview.client_api', () => {
       ]);
     });
 
-    describe('getSeparators', () => {
-      it('returns values set via parameters', () => {
-        const {
-          clientApi: { getSeparators, storiesOf, addParameters },
-        } = getContext();
-
-        const options = { hierarchySeparator: /a/, hierarchyRootSeparator: 'b' };
-        addParameters({ options });
-        storiesOf('kind 1', module).add('name 1', () => '1');
-        expect(getSeparators()).toEqual(options);
-      });
-
-      it('returns old defaults if kind uses old separators', () => {
-        const {
-          clientApi: { getSeparators, storiesOf },
-        } = getContext();
-
-        storiesOf('kind|1', module).add('name 1', () => '1');
-        expect(getSeparators()).toEqual({
-          hierarchySeparator: /\/|\./,
-          hierarchyRootSeparator: '|',
-        });
-      });
-
-      it('returns new values if showRoots is set', () => {
-        const {
-          clientApi: { getSeparators, storiesOf, addParameters },
-        } = getContext();
-        addParameters({ options: { showRoots: false } });
-
-        storiesOf('kind|1', module).add('name 1', () => '1');
-        expect(getSeparators()).toEqual({ hierarchySeparator: '/' });
-      });
-
-      it('returns new values if kind does not use old separators', () => {
-        const {
-          clientApi: { getSeparators, storiesOf },
-        } = getContext();
-
-        storiesOf('kind/1', module).add('name 1', () => '1');
-        expect(getSeparators()).toEqual({ hierarchySeparator: '/' });
-      });
-    });
-
     it('reads filename from module', () => {
       const {
         clientApi: { getStorybook, storiesOf },

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -81,31 +81,6 @@ export default class ClientApi {
     `
   );
 
-  getSeparators = () => {
-    const { hierarchySeparator, hierarchyRootSeparator, showRoots } =
-      this._storyStore._globalMetadata.parameters.options || {};
-
-    // Note these checks will be removed in 6.0, leaving this much simpler
-    if (
-      typeof hierarchySeparator !== 'undefined' ||
-      typeof hierarchyRootSeparator !== 'undefined'
-    ) {
-      return { hierarchySeparator, hierarchyRootSeparator };
-    }
-    if (
-      typeof showRoots === 'undefined' &&
-      this.store()
-        .getStoryKinds()
-        .some((kind) => kind.match(/\.|\|/))
-    ) {
-      return {
-        hierarchyRootSeparator: '|',
-        hierarchySeparator: /\/|\./,
-      };
-    }
-    return { hierarchySeparator: '/' };
-  };
-
   addDecorator = (decorator: DecoratorFunction) => {
     this._storyStore.addGlobalMetadata({ decorators: [decorator], parameters: {} });
   };


### PR DESCRIPTION
Issue: #10346 

## What I did

 - Removed `parameters.options.hierarchySeparator` and `parameters.options.hierarchyRootSeparator`
 - Removed `ClientApi.getSeparators`
 - Removed old special handling for deprecated usage
 - Removed `parameters.options.showRoots`, use `addons.config.showRoots` instead [1]
 - Keep deprecation warnings for old default separators
 - Added migration notes

[1] Should we instead deprecate this @shilman?

## How to test

- Is this testable with Jest or Chromatic screenshots?

Yes we have tests for all of this apart from the deprecation warnings
