### PR TITLE
UI: Add version release notes

### DIFF
--- a/lib/api/src/index.tsx
+++ b/lib/api/src/index.tsx
@@ -29,6 +29,8 @@ import * as provider from './modules/provider';
 import * as addons from './modules/addons';
 import * as channel from './modules/channel';
 import * as notifications from './modules/notifications';
+import * as settings from './modules/settings';
+import * as releaseNotes from './modules/release-notes';
 import * as stories from './modules/stories';
 import * as refs from './modules/refs';
 import * as layout from './modules/layout';
@@ -187,6 +189,8 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
       addons,
       layout,
       notifications,
+      settings,
+      releaseNotes,
       shortcuts,
       stories,
       refs,

--- a/lib/api/src/index.tsx
+++ b/lib/api/src/index.tsx
@@ -224,16 +224,6 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
     return null;
   };
 
-  componentDidMount() {
-    // Now every module has had a chance to set its API, call init on each module which gives it
-    // a chance to do things that call other modules' APIs.
-    this.modules.forEach(({ init }) => {
-      if (init) {
-        init();
-      }
-    });
-  }
-
   shouldComponentUpdate(nextProps: ManagerProviderProps, nextState: State) {
     const prevState = this.state;
     const prevProps = this.props;
@@ -247,6 +237,16 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
     return false;
   }
 
+  initModules = () => {
+    // Now every module has had a chance to set its API, call init on each module which gives it
+    // a chance to do things that call other modules' APIs.
+    this.modules.forEach(({ init }) => {
+      if (init) {
+        init();
+      }
+    });
+  };
+
   render() {
     const { children } = this.props;
     const value = {
@@ -255,12 +255,27 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
     };
 
     return (
-      <ManagerContext.Provider value={value}>
-        <ManagerConsumer>{children}</ManagerConsumer>
-      </ManagerContext.Provider>
+      <EffectOnMount effect={this.initModules}>
+        <ManagerContext.Provider value={value}>
+          <ManagerConsumer>{children}</ManagerConsumer>
+        </ManagerContext.Provider>
+      </EffectOnMount>
     );
   }
 }
+
+// EffectOnMount exists to work around a bug in Reach Router where calling
+// navigate inside of componentDidMount (as could happen when we call init on any
+// of our modules) does not cause Reach Router's LocationProvider to update with
+// the correct path. Calling navigate inside on an effect does not have the
+// same problem. See https://github.com/reach/router/issues/404
+const EffectOnMount: FunctionComponent<{
+  children: ReactElement;
+  effect: () => void;
+}> = ({ children, effect }) => {
+  React.useEffect(effect, []);
+  return children;
+};
 
 interface ManagerConsumerProps<P = unknown> {
   filter?: (combo: Combo) => P;

--- a/lib/api/src/modules/release-notes.ts
+++ b/lib/api/src/modules/release-notes.ts
@@ -1,0 +1,60 @@
+import { RELEASE_NOTES_DATA } from 'global';
+import memoize from 'memoizerific';
+
+import { ModuleFn, State } from '../index';
+
+export interface ReleaseNotes {
+  success?: boolean;
+  currentVersion?: string;
+  showOnFirstLaunch?: boolean;
+}
+
+const getReleaseNotesData = memoize(1)(
+  (): ReleaseNotes => {
+    try {
+      return { ...(JSON.parse(RELEASE_NOTES_DATA) || {}) };
+    } catch (e) {
+      return {};
+    }
+  }
+);
+
+export interface SubAPI {
+  releaseNotesVersion: () => string;
+  showReleaseNotesOnLaunch: () => Promise<boolean>;
+}
+
+export const init: ModuleFn = ({ fullAPI, store }) => {
+  let initStoreState: Promise<State[]>;
+  const releaseNotesData = getReleaseNotesData();
+
+  const api: SubAPI = {
+    releaseNotesVersion: () => releaseNotesData.currentVersion,
+    showReleaseNotesOnLaunch: async () => {
+      // Make sure any consumers of this function's return value have waited for
+      // this module's state to have been setup. Otherwise, it may be called
+      // before the store state is set and therefore have inaccurate data.
+      await initStoreState;
+      const { showReleaseNotesOnLaunch } = store.getState();
+      return showReleaseNotesOnLaunch;
+    },
+  };
+
+  const initModule = () => {
+    const { releaseNotesViewed: persistedReleaseNotesViewed } = store.getState();
+    let releaseNotesViewed = persistedReleaseNotesViewed || [];
+    const didViewReleaseNotes = releaseNotesViewed.includes(releaseNotesData.currentVersion);
+    const showReleaseNotesOnLaunch = releaseNotesData.showOnFirstLaunch && !didViewReleaseNotes;
+
+    if (showReleaseNotesOnLaunch) {
+      releaseNotesViewed = [...releaseNotesViewed, releaseNotesData.currentVersion];
+    }
+
+    initStoreState = Promise.all([
+      store.setState({ showReleaseNotesOnLaunch }),
+      store.setState({ releaseNotesViewed }, { persistence: 'permanent' }),
+    ]);
+  };
+
+  return { init: initModule, api };
+};

--- a/lib/api/src/modules/settings.ts
+++ b/lib/api/src/modules/settings.ts
@@ -1,0 +1,49 @@
+import { ModuleFn } from '../index';
+
+export interface SubAPI {
+  changeSettingsTab: (tab: string) => void;
+  closeSettings: () => void;
+  isSettingsScreenActive: () => boolean;
+  navigateToSettingsPage: (path: string) => Promise<void>;
+}
+
+export const init: ModuleFn = ({ store, navigate, fullAPI }) => {
+  const isSettingsScreenActive = () => {
+    const { path } = fullAPI.getUrlState();
+    return !!(path || '').match(/^\/settings/);
+  };
+  const api: SubAPI = {
+    closeSettings: () => {
+      const {
+        settings: { lastTrackedStoryId },
+      } = store.getState();
+
+      if (lastTrackedStoryId) {
+        fullAPI.selectStory(lastTrackedStoryId);
+      } else {
+        fullAPI.selectFirstStory();
+      }
+    },
+    changeSettingsTab: (tab: string) => {
+      navigate(`/settings/${tab}`);
+    },
+    isSettingsScreenActive,
+    navigateToSettingsPage: async (path) => {
+      if (!isSettingsScreenActive()) {
+        const { settings, storyId } = store.getState();
+
+        await store.setState({
+          settings: { ...settings, lastTrackedStoryId: storyId },
+        });
+      }
+
+      navigate(path);
+    },
+  };
+
+  const initModule = async () => {
+    await store.setState({ settings: { lastTrackedStoryId: null } });
+  };
+
+  return { init: initModule, api };
+};

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -226,17 +226,16 @@ export const init: ModuleFn = ({
     },
     selectFirstStory: () => {
       const { storiesHash } = store.getState();
-      const lookupList = Object.keys(storiesHash).filter(
+      const firstStory = Object.keys(storiesHash).find(
         (k) => !(storiesHash[k].children || Array.isArray(storiesHash[k]))
       );
-      const firstStory = lookupList[0];
 
       if (firstStory) {
         api.selectStory(firstStory);
         return;
       }
 
-      navigate('/story/*');
+      navigate('/');
     },
     selectStory: (kindOrId, story = undefined, options = {}) => {
       const { ref, viewMode: viewModeFromArgs } = options;

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -156,7 +156,7 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
     });
 
     if (fullAPI.showReleaseNotesOnLaunch()) {
-      setTimeout(() => navigate('/settings/release-notes', { replace: true }), 1);
+      navigate('/settings/release-notes');
     }
   };
 

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -150,13 +150,13 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
     },
   };
 
-  const initModule = async () => {
+  const initModule = () => {
     fullAPI.on(NAVIGATE_URL, (url: string, options: { [k: string]: any }) => {
       fullAPI.navigateUrl(url, options);
     });
 
-    if (await fullAPI.showReleaseNotesOnLaunch()) {
-      navigate('/settings/release-notes');
+    if (fullAPI.showReleaseNotesOnLaunch()) {
+      setTimeout(() => navigate('/settings/release-notes', { replace: true }), 1);
     }
   };
 

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -150,10 +150,14 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
     },
   };
 
-  const initModule = () => {
+  const initModule = async () => {
     fullAPI.on(NAVIGATE_URL, (url: string, options: { [k: string]: any }) => {
       fullAPI.navigateUrl(url, options);
     });
+
+    if (await fullAPI.showReleaseNotesOnLaunch()) {
+      navigate('/settings/release-notes');
+    }
   };
 
   return {

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -338,7 +338,12 @@ describe('stories API', () => {
   describe('CURRENT_STORY_WAS_SET event', () => {
     it('navigates to the story', async () => {
       const navigate = jest.fn();
-      const api = new LocalEventEmitter();
+      class EventEmitterWithSettings extends LocalEventEmitter {
+        isSettingsScreenActive() {
+          return false;
+        }
+      }
+      const api = new EventEmitterWithSettings();
       const store = createMockStore({});
       const { init } = initStories({ store, navigate, provider, fullAPI: api });
 
@@ -350,7 +355,12 @@ describe('stories API', () => {
 
     it('DOES not navigate if a settings page was selected', async () => {
       const navigate = jest.fn();
-      const api = new LocalEventEmitter();
+      class EventEmitterWithSettings extends LocalEventEmitter {
+        isSettingsScreenActive() {
+          return true;
+        }
+      }
+      const api = new EventEmitterWithSettings();
       const store = createMockStore({ viewMode: 'settings', storyId: 'about' });
       initStories({ store, navigate, provider, fullAPI: api });
 

--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -124,6 +124,20 @@ const updateCheck = async (version) => {
   return result;
 };
 
+const getReleaseNotesHistory = async (version) => {
+  let result;
+  try {
+    const fromCache = await cache.get('releaseNotesHistory', []);
+    if (!fromCache.includes(version)) {
+      await cache.set('releaseNotesHistory', [...fromCache, version]);
+    }
+    result = { success: true, current: version, history: fromCache };
+  } catch (error) {
+    result = { success: false };
+  }
+  return result;
+};
+
 function listenToServer(server, listenAddr) {
   let serverResolve = () => {};
   let serverReject = () => {};
@@ -253,18 +267,21 @@ function openInBrowser(address) {
 
 export async function buildDevStandalone(options) {
   try {
-    const { host, extendServer, packageJson, versionUpdates } = options;
+    const { host, extendServer, packageJson, versionUpdates, releaseNotes } = options;
     const { version } = packageJson;
 
-    const [port, check] = await Promise.all([
+    const [port, versionCheck, releaseNotesHistory] = await Promise.all([
       getFreePort(options.port),
       versionUpdates
         ? updateCheck(version)
         : Promise.resolve({ success: false, data: {}, time: Date.now() }),
+      releaseNotes ? getReleaseNotesHistory(version) : Promise.resolve({ success: false }),
     ]);
 
-    // eslint-disable-next-line no-param-reassign
-    options.versionCheck = check;
+    /* eslint-disable no-param-reassign */
+    options.versionCheck = versionCheck;
+    options.releaseNotesHistory = releaseNotesHistory;
+    /* eslint-enable no-param-reassign */
 
     if (!options.ci && !options.smokeTest && options.port != null && port !== options.port) {
       const { shouldChangePort } = await inquirer.prompt({
@@ -313,7 +330,7 @@ export async function buildDevStandalone(options) {
 
     const serverListening = listenToServer(server, listenAddr);
 
-    const [updateInfo] = await Promise.all([Promise.resolve(check), serverListening]);
+    const [updateInfo] = await Promise.all([Promise.resolve(versionCheck), serverListening]);
 
     const proto = options.https ? 'https' : 'http';
     const address = `${proto}://${options.host || 'localhost'}:${port}/`;

--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -178,19 +178,7 @@ export const getReleaseNotesData = async (currentVersionToParse, fileSystemCache
         isMajorOrMinorDiff,
       currentVersion: releaseNotesVersion,
     };
-  } catch (error) {
-    console.log(`
-    
-    
-    
-    
-    ERROR
-    
-    
-    
-    
-    `);
-    console.log(error);
+  } catch (e) {
     result = getReleaseNotesFailedState(currentVersionToParse);
   }
   return result;

--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -124,16 +124,74 @@ const updateCheck = async (version) => {
   return result;
 };
 
-const getReleaseNotesHistory = async (version) => {
+// We only expect to have release notes available for major and minor releases.
+// For this reason, we convert the actual version of the build here so that
+// every place that relies on this data can reference the version of the
+// release notes that we expect to use.
+const getReleaseNotesVersion = (version) => {
+  const { major, minor } = semver.parse(version);
+  const { version: releaseNotesVersion } = semver.coerce(`${major}.${minor}`);
+  return releaseNotesVersion;
+};
+
+const getReleaseNotesFailedState = (version) => {
+  return {
+    success: false,
+    currentVersion: getReleaseNotesVersion(version),
+    showOnFirstLaunch: false,
+  };
+};
+
+export const RELEASE_NOTES_CACHE_KEY = 'releaseNotesData';
+
+export const getReleaseNotesData = async (currentVersionToParse, fileSystemCache) => {
   let result;
   try {
-    const fromCache = await cache.get('releaseNotesHistory', []);
-    if (!fromCache.includes(version)) {
-      await cache.set('releaseNotesHistory', [...fromCache, version]);
+    const fromCache = await fileSystemCache.get('releaseNotesData', []);
+    const releaseNotesVersion = getReleaseNotesVersion(currentVersionToParse);
+    const versionHasNotBeenSeen = !fromCache.includes(releaseNotesVersion);
+
+    if (versionHasNotBeenSeen) {
+      await fileSystemCache.set('releaseNotesData', [...fromCache, releaseNotesVersion]);
     }
-    result = { success: true, current: version, history: fromCache };
+
+    const sortedHistory = semver.sort(fromCache);
+    const highestVersionSeenInThePast = sortedHistory.slice(-1)[0];
+
+    let isUpgrading = false;
+    let isMajorOrMinorDiff = false;
+
+    if (highestVersionSeenInThePast) {
+      isUpgrading = semver.gt(releaseNotesVersion, highestVersionSeenInThePast);
+      const versionDiff = semver.diff(releaseNotesVersion, highestVersionSeenInThePast);
+      isMajorOrMinorDiff = versionDiff === 'major' || versionDiff === 'minor';
+    }
+
+    result = {
+      success: true,
+      showOnFirstLaunch:
+        versionHasNotBeenSeen &&
+        // Only show the release notes if this is not the first time Storybook
+        // has been built.
+        !!highestVersionSeenInThePast &&
+        isUpgrading &&
+        isMajorOrMinorDiff,
+      currentVersion: releaseNotesVersion,
+    };
   } catch (error) {
-    result = { success: false };
+    console.log(`
+    
+    
+    
+    
+    ERROR
+    
+    
+    
+    
+    `);
+    console.log(error);
+    result = getReleaseNotesFailedState(currentVersionToParse);
   }
   return result;
 };
@@ -270,17 +328,19 @@ export async function buildDevStandalone(options) {
     const { host, extendServer, packageJson, versionUpdates, releaseNotes } = options;
     const { version } = packageJson;
 
-    const [port, versionCheck, releaseNotesHistory] = await Promise.all([
+    const [port, versionCheck, releaseNotesData] = await Promise.all([
       getFreePort(options.port),
       versionUpdates
         ? updateCheck(version)
         : Promise.resolve({ success: false, data: {}, time: Date.now() }),
-      releaseNotes ? getReleaseNotesHistory(version) : Promise.resolve({ success: false }),
+      releaseNotes
+        ? getReleaseNotesData(version, cache)
+        : Promise.resolve(getReleaseNotesFailedState(version)),
     ]);
 
     /* eslint-disable no-param-reassign */
     options.versionCheck = versionCheck;
-    options.releaseNotesHistory = releaseNotesHistory;
+    options.releaseNotesData = releaseNotesData;
     /* eslint-enable no-param-reassign */
 
     if (!options.ci && !options.smokeTest && options.port != null && port !== options.port) {

--- a/lib/core/src/server/build-dev.test.js
+++ b/lib/core/src/server/build-dev.test.js
@@ -1,0 +1,80 @@
+import { getReleaseNotesData, RELEASE_NOTES_CACHE_KEY } from './build-dev';
+
+describe('getReleaseNotesData', () => {
+  it('handles errors gracefully', async () => {
+    const version = '4.0.0';
+    // The cache is missing necessary functions. This will cause an error.
+    const cache = {};
+
+    expect(await getReleaseNotesData(version, cache)).toEqual({
+      currentVersion: version,
+      showOnFirstLaunch: false,
+      success: false,
+    });
+  });
+
+  it('does not show the release notes on first build', async () => {
+    const version = '4.0.0';
+    const set = jest.fn(() => Promise.resolve());
+    const cache = { get: () => Promise.resolve([]), set };
+
+    expect(await getReleaseNotesData(version, cache)).toEqual({
+      currentVersion: version,
+      showOnFirstLaunch: false,
+      success: true,
+    });
+    expect(set).toHaveBeenCalledWith(RELEASE_NOTES_CACHE_KEY, ['4.0.0']);
+  });
+
+  it('shows the release notes after upgrading a major version', async () => {
+    const version = '4.0.0';
+    const set = jest.fn(() => Promise.resolve());
+    const cache = { get: () => Promise.resolve(['3.0.0']), set };
+
+    expect(await getReleaseNotesData(version, cache)).toEqual({
+      currentVersion: version,
+      showOnFirstLaunch: true,
+      success: true,
+    });
+    expect(set).toHaveBeenCalledWith(RELEASE_NOTES_CACHE_KEY, ['3.0.0', '4.0.0']);
+  });
+
+  it('shows the release notes after upgrading a minor version', async () => {
+    const version = '4.1.0';
+    const set = jest.fn(() => Promise.resolve());
+    const cache = { get: () => Promise.resolve(['4.0.0']), set };
+
+    expect(await getReleaseNotesData(version, cache)).toEqual({
+      currentVersion: version,
+      showOnFirstLaunch: true,
+      success: true,
+    });
+    expect(set).toHaveBeenCalledWith(RELEASE_NOTES_CACHE_KEY, ['4.0.0', '4.1.0']);
+  });
+
+  it('transforms patch versions to the closest major.minor version', async () => {
+    const version = '4.0.1';
+    const set = jest.fn(() => Promise.resolve());
+    const cache = { get: () => Promise.resolve(['4.0.0']), set };
+
+    expect(await getReleaseNotesData(version, cache)).toEqual({
+      currentVersion: '4.0.0',
+      showOnFirstLaunch: false,
+      success: true,
+    });
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('does not show release notes when downgrading', async () => {
+    const version = '3.0.0';
+    const set = jest.fn(() => Promise.resolve());
+    const cache = { get: () => Promise.resolve(['4.0.0']), set };
+
+    expect(await getReleaseNotesData(version, cache)).toEqual({
+      currentVersion: '3.0.0',
+      showOnFirstLaunch: false,
+      success: true,
+    });
+    expect(set).toHaveBeenCalledWith(RELEASE_NOTES_CACHE_KEY, ['4.0.0', '3.0.0']);
+  });
+});

--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -28,7 +28,11 @@ async function getCLI(packageJson) {
     .option('--loglevel [level]', 'Control level of logging during build')
     .option('--quiet', 'Suppress verbose build output')
     .option('--no-version-updates', 'Suppress update check', true)
-    .option('--no-release-notes', 'Suppress release notes', true)
+    .option(
+      '--no-release-notes',
+      'Suppress automatic redirects to the release notes after upgrading',
+      true
+    )
     .option('--no-dll', 'Do not use dll reference')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(

--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -28,6 +28,7 @@ async function getCLI(packageJson) {
     .option('--loglevel [level]', 'Control level of logging during build')
     .option('--quiet', 'Suppress verbose build output')
     .option('--no-version-updates', 'Suppress update check', true)
+    .option('--no-release-notes', 'Suppress release notes', true)
     .option('--no-dll', 'Do not use dll reference')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -36,7 +36,7 @@ export default async ({
   cache,
   previewUrl,
   versionCheck,
-  releaseNotesHistory,
+  releaseNotesData,
   presets,
 }) => {
   const { raw, stringified } = loadEnv();
@@ -87,7 +87,7 @@ export default async ({
           globals: {
             LOGLEVEL: logLevel,
             VERSIONCHECK: JSON.stringify(versionCheck),
-            RELEASE_NOTES_HISTORY: JSON.stringify(releaseNotesHistory),
+            RELEASE_NOTES_DATA: JSON.stringify(releaseNotesData),
             DOCS_MODE: docsMode, // global docs mode
             PREVIEW_URL: previewUrl, // global preview URL
           },

--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -36,6 +36,7 @@ export default async ({
   cache,
   previewUrl,
   versionCheck,
+  releaseNotesHistory,
   presets,
 }) => {
   const { raw, stringified } = loadEnv();
@@ -86,6 +87,7 @@ export default async ({
           globals: {
             LOGLEVEL: logLevel,
             VERSIONCHECK: JSON.stringify(versionCheck),
+            RELEASE_NOTES_HISTORY: JSON.stringify(releaseNotesHistory),
             DOCS_MODE: docsMode, // global docs mode
             PREVIEW_URL: previewUrl, // global preview URL
           },

--- a/lib/theming/src/animation.ts
+++ b/lib/theming/src/animation.ts
@@ -4,7 +4,7 @@ export const easing = {
   rubber: 'cubic-bezier(0.175, 0.885, 0.335, 1.05)',
 };
 
-const rotate360 = keyframes`
+export const rotate360 = keyframes`
 	from {
 		transform: rotate(0deg);
 	}

--- a/lib/theming/src/animation.ts
+++ b/lib/theming/src/animation.ts
@@ -4,7 +4,7 @@ export const easing = {
   rubber: 'cubic-bezier(0.175, 0.885, 0.335, 1.05)',
 };
 
-export const rotate360 = keyframes`
+const rotate360 = keyframes`
 	from {
 		transform: rotate(0deg);
 	}

--- a/lib/theming/src/index.ts
+++ b/lib/theming/src/index.ts
@@ -4,6 +4,7 @@ import { Theme } from './types';
 export const styled = emotionStyled as CreateStyled<Theme>;
 
 export * from './base';
+export * from './animation';
 export * from './types';
 
 export * from '@emotion/core';

--- a/lib/theming/src/index.ts
+++ b/lib/theming/src/index.ts
@@ -4,7 +4,6 @@ import { Theme } from './types';
 export const styled = emotionStyled as CreateStyled<Theme>;
 
 export * from './base';
-export * from './animation';
 export * from './types';
 
 export * from '@emotion/core';

--- a/lib/ui/src/containers/menu.tsx
+++ b/lib/ui/src/containers/menu.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { Badge } from '@storybook/components';
 import { API } from '@storybook/api';
+import { color } from '@storybook/theming';
 
 import { shortcutToHumanString } from '@storybook/api/shortcut';
 import { MenuItemIcon } from '../components/sidebar/Menu';
@@ -23,6 +24,39 @@ export const useMenu = (
   enableShortcuts: boolean
 ) => {
   const shortcutKeys = api.getShortcutKeys();
+
+  const about = useMemo(
+    () => ({
+      id: 'about',
+      title: 'About your Storybook',
+      onClick: () => api.navigateToSettingsPage('/settings/about'),
+      right: api.versionUpdateAvailable() && <Badge status="positive">Update</Badge>,
+      left: <MenuItemIcon />,
+    }),
+    [api, shortcutToHumanStringIfEnabled, enableShortcuts, shortcutKeys]
+  );
+
+  const releaseNotes = useMemo(
+    () => ({
+      id: 'release-notes',
+      title: 'Release notes',
+      onClick: () => api.navigateToSettingsPage('/settings/release-notes'),
+      left: <MenuItemIcon />,
+    }),
+    [api, shortcutToHumanStringIfEnabled, enableShortcuts, shortcutKeys]
+  );
+
+  const shortcuts = useMemo(
+    () => ({
+      id: 'shortcuts',
+      title: 'Keyboard shortcuts',
+      onClick: () => api.navigateToSettingsPage('/settings/shortcuts'),
+      right: shortcutToHumanStringIfEnabled(shortcutKeys.shortcutsPage, enableShortcuts),
+      left: <MenuItemIcon />,
+      style: { borderBottom: `4px solid ${color.mediumlight}` },
+    }),
+    [api, shortcutToHumanStringIfEnabled, enableShortcuts, shortcutKeys]
+  );
 
   const sidebarToggle = useMemo(
     () => ({
@@ -123,28 +157,6 @@ export const useMenu = (
     [api, shortcutToHumanStringIfEnabled, enableShortcuts, shortcutKeys]
   );
 
-  const about = useMemo(
-    () => ({
-      id: 'about',
-      title: 'About your Storybook',
-      onClick: () => api.navigate('/settings/about'),
-      right: api.versionUpdateAvailable() && <Badge status="positive">Update</Badge>,
-      left: <MenuItemIcon />,
-    }),
-    [api, shortcutToHumanStringIfEnabled, enableShortcuts, shortcutKeys]
-  );
-
-  const shortcuts = useMemo(
-    () => ({
-      id: 'shortcuts',
-      title: 'Keyboard shortcuts',
-      onClick: () => api.navigate('/settings/shortcuts'),
-      right: shortcutToHumanStringIfEnabled(shortcutKeys.shortcutsPage, enableShortcuts),
-      left: <MenuItemIcon />,
-    }),
-    [api, shortcutToHumanStringIfEnabled, enableShortcuts, shortcutKeys]
-  );
-
   const collapse = useMemo(
     () => ({
       id: 'collapse',
@@ -158,6 +170,9 @@ export const useMenu = (
 
   return useMemo(
     () => [
+      about,
+      releaseNotes,
+      shortcuts,
       sidebarToggle,
       addonsToggle,
       addonsOrientationToggle,
@@ -167,11 +182,12 @@ export const useMenu = (
       down,
       prev,
       next,
-      about,
-      shortcuts,
       collapse,
     ],
     [
+      about,
+      releaseNotes,
+      shortcuts,
       sidebarToggle,
       addonsToggle,
       addonsOrientationToggle,
@@ -181,8 +197,6 @@ export const useMenu = (
       down,
       prev,
       next,
-      about,
-      shortcuts,
       collapse,
     ]
   );

--- a/lib/ui/src/settings/about.stories.js
+++ b/lib/ui/src/settings/about.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { actions as createActions } from '@storybook/addon-actions';
 
-import AboutScreen from './about';
+import { AboutScreen } from './about';
 
 const info = {
   plain: `- upgrade webpack & babel to latest\n- new addParameters and third argument to .add to pass data to addons\n- added the ability to theme storybook\n- improved ui for mobile devices\n- improved performance of addon-knobs`,

--- a/lib/ui/src/settings/about.tsx
+++ b/lib/ui/src/settings/about.tsx
@@ -123,89 +123,68 @@ const AboutScreen: FunctionComponent<{
 
   return (
     <GlobalHotKeys handlers={{ CLOSE: onClose }} keyMap={keyMap}>
-      <Tabs
-        absolute
-        selected="about"
-        actions={{ onSelect: () => {} }}
-        tools={
+      <Container>
+        <Header>
+          <StorybookIcon />
+          Storybook {current.version}
+        </Header>
+
+        {updateMessage}
+
+        {latest ? (
           <Fragment>
-            <IconButton
-              onClick={(e: SyntheticEvent) => {
-                e.preventDefault();
-                return onClose();
-              }}
-              title="close"
-            >
-              <Icons icon="close" />
-            </IconButton>
+            <Subheader>
+              <Subheading>{latest.version} Changelog</Subheading>
+              <SubheadingLink
+                secondary
+                href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md"
+                withArrow
+                cancel={false}
+                target="_blank"
+              >
+                Read full changelog
+              </SubheadingLink>
+            </Subheader>
+            <DocumentWrapper>
+              <Markdown>{latest.info.plain}</Markdown>
+            </DocumentWrapper>
           </Fragment>
-        }
-      >
-        <div id="about" title="About">
-          <Container>
-            <Header>
-              <StorybookIcon />
-              Storybook {current.version}
-            </Header>
+        ) : (
+          <ErrorMessage>
+            <Link
+              href="https://github.com/storybookjs/storybook/releases"
+              target="_blank"
+              withArrow
+              secondary
+              cancel={false}
+            >
+              Check Storybook's release history
+            </Link>
+          </ErrorMessage>
+        )}
 
-            {updateMessage}
+        {canUpdate && (
+          <Upgrade>
+            <DocumentWrapper>
+              <p>
+                <b>Upgrade all Storybook packages to latest:</b>
+              </p>
+              <SyntaxHighlighter language="bash" copyable padded bordered>
+                npx npm-check-updates '/storybook/' -u && npm install
+              </SyntaxHighlighter>
+              <p>
+                Alternatively, if you're using yarn run the following command, and check all
+                Storybook related packages:
+              </p>
+              <SyntaxHighlighter language="bash" copyable padded bordered>
+                yarn upgrade-interactive --latest
+              </SyntaxHighlighter>
+            </DocumentWrapper>
+          </Upgrade>
+        )}
 
-            {latest ? (
-              <Fragment>
-                <Subheader>
-                  <Subheading>{latest.version} Changelog</Subheading>
-                  <SubheadingLink
-                    secondary
-                    href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md"
-                    withArrow
-                    cancel={false}
-                    target="_blank"
-                  >
-                    Read full changelog
-                  </SubheadingLink>
-                </Subheader>
-                <DocumentWrapper>
-                  <Markdown>{latest.info.plain}</Markdown>
-                </DocumentWrapper>
-              </Fragment>
-            ) : (
-              <ErrorMessage>
-                <Link
-                  href="https://github.com/storybookjs/storybook/releases"
-                  target="_blank"
-                  withArrow
-                  secondary
-                  cancel={false}
-                >
-                  Check Storybook's release history
-                </Link>
-              </ErrorMessage>
-            )}
-
-            {canUpdate && (
-              <Upgrade>
-                <DocumentWrapper>
-                  <p>
-                    <b>Upgrade all Storybook packages to latest:</b>
-                  </p>
-                  <SyntaxHighlighter language="bash" copyable padded bordered>
-                    npx npm-check-updates '/storybook/' -u && npm install
-                  </SyntaxHighlighter>
-                  <p>
-                    Alternatively, if you're using yarn run the following command, and check all
-                    Storybook related packages:
-                  </p>
-                  <SyntaxHighlighter language="bash" copyable padded bordered>
-                    yarn upgrade-interactive --latest
-                  </SyntaxHighlighter>
-                </DocumentWrapper>
-              </Upgrade>
-            )}
-
-            <SettingsFooter />
-          </Container>
-        </div>
-      </Tabs>
+        <SettingsFooter />
+      </Container>
     </GlobalHotKeys>
   );
 };

--- a/lib/ui/src/settings/about.tsx
+++ b/lib/ui/src/settings/about.tsx
@@ -1,19 +1,11 @@
-import React, { Fragment, FunctionComponent, SyntheticEvent } from 'react';
+import React, { Fragment, FunctionComponent } from 'react';
 import semver from '@storybook/semver';
 import { styled } from '@storybook/theming';
 import { State } from '@storybook/api';
 import { GlobalHotKeys } from 'react-hotkeys';
 import Markdown from 'markdown-to-jsx';
 
-import {
-  StorybookIcon,
-  SyntaxHighlighter,
-  IconButton,
-  Icons,
-  Tabs,
-  Link,
-  DocumentWrapper,
-} from '@storybook/components';
+import { StorybookIcon, SyntaxHighlighter, Link, DocumentWrapper } from '@storybook/components';
 
 import SettingsFooter from './SettingsFooter';
 

--- a/lib/ui/src/settings/about.tsx
+++ b/lib/ui/src/settings/about.tsx
@@ -189,4 +189,4 @@ const AboutScreen: FunctionComponent<{
   );
 };
 
-export { AboutScreen as default };
+export { AboutScreen };

--- a/lib/ui/src/settings/about_page.tsx
+++ b/lib/ui/src/settings/about_page.tsx
@@ -1,10 +1,8 @@
-import { history } from 'global';
 import React, { Component, FunctionComponent } from 'react';
 
-import { Route } from '@storybook/router';
 import { Consumer, API, Combo } from '@storybook/api';
 
-import AboutScreen from './about';
+import { AboutScreen } from './about';
 
 // Clear a notification on mount. This could be exported by core/notifications.js perhaps?
 class NotificationClearer extends Component<{ api: API; notificationId: string }> {
@@ -33,4 +31,4 @@ const AboutPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => (
   </Consumer>
 );
 
-export { AboutPage as default };
+export { AboutPage };

--- a/lib/ui/src/settings/about_page.tsx
+++ b/lib/ui/src/settings/about_page.tsx
@@ -20,17 +20,15 @@ class NotificationClearer extends Component<{ api: API; notificationId: string }
 }
 
 export default () => (
-  <Route path="about">
-    <Consumer>
-      {({ api }: Combo) => (
-        <NotificationClearer api={api} notificationId="update">
-          <AboutScreen
-            current={api.getCurrentVersion()}
-            latest={api.getLatestVersion()}
-            onClose={() => history.back()}
-          />
-        </NotificationClearer>
-      )}
-    </Consumer>
-  </Route>
+  <Consumer>
+    {({ api }: Combo) => (
+      <NotificationClearer api={api} notificationId="update">
+        <AboutScreen
+          current={api.getCurrentVersion()}
+          latest={api.getLatestVersion()}
+          onClose={() => history.back()}
+        />
+      </NotificationClearer>
+    )}
+  </Consumer>
 );

--- a/lib/ui/src/settings/about_page.tsx
+++ b/lib/ui/src/settings/about_page.tsx
@@ -1,5 +1,5 @@
 import { history } from 'global';
-import React, { Component } from 'react';
+import React, { Component, FunctionComponent } from 'react';
 
 import { Route } from '@storybook/router';
 import { Consumer, API, Combo } from '@storybook/api';
@@ -19,16 +19,18 @@ class NotificationClearer extends Component<{ api: API; notificationId: string }
   }
 }
 
-export default () => (
+const AboutPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => (
   <Consumer>
     {({ api }: Combo) => (
       <NotificationClearer api={api} notificationId="update">
         <AboutScreen
           current={api.getCurrentVersion()}
           latest={api.getLatestVersion()}
-          onClose={() => history.back()}
+          onClose={onClose}
         />
       </NotificationClearer>
     )}
   </Consumer>
 );
+
+export { AboutPage as default };

--- a/lib/ui/src/settings/index.tsx
+++ b/lib/ui/src/settings/index.tsx
@@ -46,19 +46,19 @@ const PureSettingsPages: FunctionComponent<PureSettingsPagesProps> = ({
     >
       <div id={ABOUT} title="About">
         <Route path={ABOUT}>
-          <AboutPage key={ABOUT} />
+          <AboutPage key={ABOUT} onClose={onClose} />
         </Route>
       </div>
 
       <div id={RELEASE_NOTES} title="Release notes">
         <Route path={RELEASE_NOTES}>
-          <ReleaseNotesPage key={RELEASE_NOTES} />
+          <ReleaseNotesPage key={RELEASE_NOTES} onClose={onClose} />
         </Route>
       </div>
 
       <div id={SHORTCUTS} title="Keyboard shortcuts">
         <Route path={SHORTCUTS}>
-          <ShortcutsPage key={SHORTCUTS} />
+          <ShortcutsPage key={SHORTCUTS} onClose={onClose} />
         </Route>
       </div>
     </Tabs>

--- a/lib/ui/src/settings/index.tsx
+++ b/lib/ui/src/settings/index.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent, SyntheticEvent, useEffect, useState } from 'react';
+import React, { FunctionComponent, SyntheticEvent } from 'react';
 import { Tabs, IconButton, Icons } from '@storybook/components';
 import { useStorybookApi } from '@storybook/api';
 import { Location, Route } from '@storybook/router';
 import { styled } from '@storybook/theming';
-import AboutPage from './about_page';
-import ReleaseNotesPage from './release_notes_page';
-import ShortcutsPage from './shortcuts_page';
+import { AboutPage } from './about_page';
+import { ReleaseNotesPage } from './release_notes_page';
+import { ShortcutsPage } from './shortcuts_page';
 
 const ABOUT = 'about';
 const SHORTCUTS = 'shortcuts';

--- a/lib/ui/src/settings/index.tsx
+++ b/lib/ui/src/settings/index.tsx
@@ -1,12 +1,85 @@
-import React, { FunctionComponent, Fragment } from 'react';
+import React, { FunctionComponent, SyntheticEvent, useEffect, useState } from 'react';
+import { Tabs, IconButton, Icons } from '@storybook/components';
+import { useStorybookApi } from '@storybook/api';
+import { Location, Route } from '@storybook/router';
+import { styled } from '@storybook/theming';
 import AboutPage from './about_page';
+import ReleaseNotesPage from './release_notes_page';
 import ShortcutsPage from './shortcuts_page';
 
-const SettingsPages: FunctionComponent = () => (
-  <Fragment>
-    <AboutPage key="about" />
-    <ShortcutsPage key="shortcuts" />
-  </Fragment>
+const ABOUT = 'about';
+const SHORTCUTS = 'shortcuts';
+const RELEASE_NOTES = 'release-notes';
+
+export const Wrapper = styled.div`
+  div[role='tabpanel'] {
+    height: 100%;
+  }
+`;
+
+interface PureSettingsPagesProps {
+  activeTab: string;
+  changeTab: (tab: string) => {};
+  onClose: () => {};
+}
+
+const PureSettingsPages: FunctionComponent<PureSettingsPagesProps> = ({
+  activeTab,
+  changeTab,
+  onClose,
+}) => (
+  <Wrapper>
+    <Tabs
+      absolute
+      selected={activeTab}
+      actions={{ onSelect: changeTab }}
+      tools={
+        <IconButton
+          onClick={(e: SyntheticEvent) => {
+            e.preventDefault();
+            return onClose();
+          }}
+        >
+          <Icons icon="close" />
+        </IconButton>
+      }
+    >
+      <div id={ABOUT} title="About">
+        <Route path={ABOUT}>
+          <AboutPage key={ABOUT} />
+        </Route>
+      </div>
+
+      <div id={RELEASE_NOTES} title="Release notes">
+        <Route path={RELEASE_NOTES}>
+          <ReleaseNotesPage key={RELEASE_NOTES} />
+        </Route>
+      </div>
+
+      <div id={SHORTCUTS} title="Keyboard shortcuts">
+        <Route path={SHORTCUTS}>
+          <ShortcutsPage key={SHORTCUTS} />
+        </Route>
+      </div>
+    </Tabs>
+  </Wrapper>
 );
+
+const SettingsPages: FunctionComponent = () => {
+  const api = useStorybookApi();
+  const changeTab = (tab: string) => api.changeSettingsTab(tab);
+
+  return (
+    <Location key="location.consumer">
+      {(locationData) => (
+        <PureSettingsPages
+          activeTab={locationData.storyId}
+          changeTab={changeTab}
+          onClose={api.closeSettings}
+        />
+      )}
+    </Location>
+  );
+};
 
 export { SettingsPages as default };

--- a/lib/ui/src/settings/release_notes.stories.tsx
+++ b/lib/ui/src/settings/release_notes.stories.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { actions as makeActions } from '@storybook/addon-actions';
 
-import { DecoratorFn } from '@storybook/react';
-import { PureReleaseNotes } from './release_notes';
+import { PureReleaseNotesScreen } from './release_notes';
 
 export default {
-  component: PureReleaseNotes,
+  component: PureReleaseNotesScreen,
   title: 'UI/Settings/ReleaseNotes',
 };
 
@@ -14,9 +13,14 @@ const actions = makeActions('setLoaded', 'onClose');
 const VERSION = '6.0.0';
 
 export const Loading = () => (
-  <PureReleaseNotes didHitMaxWaitTime={false} isLoaded={false} version={VERSION} {...actions} />
+  <PureReleaseNotesScreen
+    didHitMaxWaitTime={false}
+    isLoaded={false}
+    version={VERSION}
+    {...actions}
+  />
 );
 
 export const DidHitMaxWaitTime = () => (
-  <PureReleaseNotes didHitMaxWaitTime isLoaded={false} version={VERSION} {...actions} />
+  <PureReleaseNotesScreen didHitMaxWaitTime isLoaded={false} version={VERSION} {...actions} />
 );

--- a/lib/ui/src/settings/release_notes.stories.tsx
+++ b/lib/ui/src/settings/release_notes.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { actions as makeActions } from '@storybook/addon-actions';
+
+import { DecoratorFn } from '@storybook/react';
+import { PureReleaseNotes } from './release_notes';
+
+export default {
+  component: PureReleaseNotes,
+  title: 'UI/Settings/ReleaseNotes',
+};
+
+const actions = makeActions('setLoaded');
+
+const VERSION = '6.0.0';
+
+export const Loading = () => (
+  <PureReleaseNotes didHitMaxWaitTime={false} isLoaded={false} version={VERSION} {...actions} />
+);
+
+export const DidHitMaxWaitTime = () => (
+  <PureReleaseNotes didHitMaxWaitTime isLoaded={false} version={VERSION} {...actions} />
+);

--- a/lib/ui/src/settings/release_notes.stories.tsx
+++ b/lib/ui/src/settings/release_notes.stories.tsx
@@ -9,7 +9,7 @@ export default {
   title: 'UI/Settings/ReleaseNotes',
 };
 
-const actions = makeActions('setLoaded');
+const actions = makeActions('setLoaded', 'onClose');
 
 const VERSION = '6.0.0';
 

--- a/lib/ui/src/settings/release_notes.tsx
+++ b/lib/ui/src/settings/release_notes.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { color, styled, typography } from '@storybook/theming';
 import { Icons, Loader } from '@storybook/components';
+import { GlobalHotKeys } from 'react-hotkeys';
 
 export const Centered = styled.div({
   top: '50%',
@@ -50,9 +51,14 @@ const MaxWaitTimeMessaging: FunctionComponent = () => (
   </Centered>
 );
 
+const keyMap = {
+  CLOSE: 'escape',
+};
+
 interface ReleaseNotesProps {
   didHitMaxWaitTime: boolean;
   isLoaded: boolean;
+  onClose: () => void;
   setLoaded: (isLoaded: boolean) => void;
   version: string;
 }
@@ -60,10 +66,11 @@ interface ReleaseNotesProps {
 const PureReleaseNotes: FunctionComponent<ReleaseNotesProps> = ({
   didHitMaxWaitTime,
   isLoaded,
+  onClose,
   setLoaded,
   version,
 }) => (
-  <>
+  <GlobalHotKeys handlers={{ CLOSE: onClose }} keyMap={keyMap}>
     {!isLoaded && !didHitMaxWaitTime && <ReleaseNotesLoader />}
     {didHitMaxWaitTime ? (
       <MaxWaitTimeMessaging />
@@ -75,7 +82,7 @@ const PureReleaseNotes: FunctionComponent<ReleaseNotesProps> = ({
         title={`Release notes for Storybook version ${version}`}
       />
     )}
-  </>
+  </GlobalHotKeys>
 );
 
 const MAX_WAIT_TIME = 10000; // 10 seconds
@@ -90,7 +97,7 @@ const ReleaseNotes: FunctionComponent<Omit<
   useEffect(() => {
     const timer = setTimeout(() => !isLoaded && setDidHitMaxWaitTime(true), MAX_WAIT_TIME);
     return () => clearTimeout(timer);
-  });
+  }, []);
 
   return (
     <PureReleaseNotes

--- a/lib/ui/src/settings/release_notes.tsx
+++ b/lib/ui/src/settings/release_notes.tsx
@@ -97,7 +97,7 @@ const ReleaseNotes: FunctionComponent<Omit<
   useEffect(() => {
     const timer = setTimeout(() => !isLoaded && setDidHitMaxWaitTime(true), MAX_WAIT_TIME);
     return () => clearTimeout(timer);
-  }, []);
+  }, [isLoaded]);
 
   return (
     <PureReleaseNotes

--- a/lib/ui/src/settings/release_notes.tsx
+++ b/lib/ui/src/settings/release_notes.tsx
@@ -63,7 +63,7 @@ interface ReleaseNotesProps {
   version: string;
 }
 
-const PureReleaseNotes: FunctionComponent<ReleaseNotesProps> = ({
+const PureReleaseNotesScreen: FunctionComponent<ReleaseNotesProps> = ({
   didHitMaxWaitTime,
   isLoaded,
   onClose,
@@ -87,7 +87,7 @@ const PureReleaseNotes: FunctionComponent<ReleaseNotesProps> = ({
 
 const MAX_WAIT_TIME = 10000; // 10 seconds
 
-const ReleaseNotes: FunctionComponent<Omit<
+const ReleaseNotesScreen: FunctionComponent<Omit<
   ReleaseNotesProps,
   'isLoaded' | 'setLoaded' | 'didHitMaxWaitTime'
 >> = (props) => {
@@ -100,7 +100,7 @@ const ReleaseNotes: FunctionComponent<Omit<
   }, [isLoaded]);
 
   return (
-    <PureReleaseNotes
+    <PureReleaseNotesScreen
       didHitMaxWaitTime={didHitMaxWaitTime}
       isLoaded={isLoaded}
       setLoaded={setLoaded}
@@ -109,4 +109,4 @@ const ReleaseNotes: FunctionComponent<Omit<
   );
 };
 
-export { ReleaseNotes as default, PureReleaseNotes };
+export { ReleaseNotesScreen, PureReleaseNotesScreen };

--- a/lib/ui/src/settings/release_notes.tsx
+++ b/lib/ui/src/settings/release_notes.tsx
@@ -55,7 +55,7 @@ const keyMap = {
   CLOSE: 'escape',
 };
 
-interface ReleaseNotesProps {
+export interface ReleaseNotesProps {
   didHitMaxWaitTime: boolean;
   isLoaded: boolean;
   onClose: () => void;

--- a/lib/ui/src/settings/release_notes.tsx
+++ b/lib/ui/src/settings/release_notes.tsx
@@ -31,7 +31,10 @@ export const Iframe = styled.iframe({
   height: '100%',
 });
 
-const getIframeUrl = (version: string) => `https://storybook.js.org/release-notes/${version}`;
+const getIframeUrl = (version: string) => {
+  const [major, minor] = version.split('.');
+  return `https://storybook.js.org/releases/iframe/${major}.${minor}`;
+};
 
 const ReleaseNotesLoader: FunctionComponent = () => (
   <Centered>

--- a/lib/ui/src/settings/release_notes.tsx
+++ b/lib/ui/src/settings/release_notes.tsx
@@ -1,0 +1,105 @@
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import { color, styled, typography } from '@storybook/theming';
+import { Icons, Loader } from '@storybook/components';
+
+export const Centered = styled.div({
+  top: '50%',
+  position: 'absolute',
+  transform: 'translateY(-50%)',
+  width: '100%',
+  textAlign: 'center',
+});
+
+export const LoaderWrapper = styled.div({
+  position: 'relative',
+  height: '32px',
+});
+
+export const Message = styled.div({
+  paddingTop: '12px',
+  color: color.mediumdark,
+  maxWidth: '295px',
+  margin: '0 auto',
+  fontSize: `${typography.size.s1}px`,
+  lineHeight: `16px`,
+});
+
+export const Iframe = styled.iframe({
+  border: 0,
+  width: '100%',
+  height: '100%',
+});
+
+const getIframeUrl = (version: string) => `https://storybook.js.org/release-notes/${version}`;
+
+const ReleaseNotesLoader: FunctionComponent = () => (
+  <Centered>
+    <LoaderWrapper>
+      <Loader />
+    </LoaderWrapper>
+    <Message>Loading release notes</Message>
+  </Centered>
+);
+
+const MaxWaitTimeMessaging: FunctionComponent = () => (
+  <Centered>
+    <Icons icon="alert" style={{ color: color.mediumdark, width: '40px', margin: '0 auto' }} />
+    <Message>
+      The release notes couldn't be loaded. Check your internet connection and try again.
+    </Message>
+  </Centered>
+);
+
+interface ReleaseNotesProps {
+  didHitMaxWaitTime: boolean;
+  isLoaded: boolean;
+  setLoaded: (isLoaded: boolean) => void;
+  version: string;
+}
+
+const PureReleaseNotes: FunctionComponent<ReleaseNotesProps> = ({
+  didHitMaxWaitTime,
+  isLoaded,
+  setLoaded,
+  version,
+}) => (
+  <>
+    {!isLoaded && !didHitMaxWaitTime && <ReleaseNotesLoader />}
+    {didHitMaxWaitTime ? (
+      <MaxWaitTimeMessaging />
+    ) : (
+      <Iframe
+        style={{ visibility: isLoaded ? 'visible' : 'hidden' }}
+        onLoad={() => setLoaded(true)}
+        src={getIframeUrl(version)}
+        title={`Release notes for Storybook version ${version}`}
+      />
+    )}
+  </>
+);
+
+const MAX_WAIT_TIME = 10000; // 10 seconds
+
+const ReleaseNotes: FunctionComponent<Omit<
+  ReleaseNotesProps,
+  'isLoaded' | 'setLoaded' | 'didHitMaxWaitTime'
+>> = (props) => {
+  const [isLoaded, setLoaded] = useState(false);
+  const [didHitMaxWaitTime, setDidHitMaxWaitTime] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => !isLoaded && setDidHitMaxWaitTime(true), MAX_WAIT_TIME);
+    return () => clearTimeout(timer);
+  });
+
+  return (
+    <PureReleaseNotes
+      didHitMaxWaitTime={didHitMaxWaitTime}
+      isLoaded={isLoaded}
+      setLoaded={setLoaded}
+      {...props}
+    />
+  );
+};
+
+export { ReleaseNotes as default, PureReleaseNotes };

--- a/lib/ui/src/settings/release_notes_page.tsx
+++ b/lib/ui/src/settings/release_notes_page.tsx
@@ -1,10 +1,15 @@
 import { useStorybookApi } from '@storybook/api';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 
 import ReleaseNotesScreen from './release_notes';
 
 const ReleaseNotesPage: FunctionComponent = () => {
   const api = useStorybookApi();
+
+  useEffect(() => {
+    api.setDidViewReleaseNotes();
+  }, []);
+
   return <ReleaseNotesScreen version={api.releaseNotesVersion()} />;
 };
 

--- a/lib/ui/src/settings/release_notes_page.tsx
+++ b/lib/ui/src/settings/release_notes_page.tsx
@@ -3,14 +3,14 @@ import React, { FunctionComponent, useEffect } from 'react';
 
 import ReleaseNotesScreen from './release_notes';
 
-const ReleaseNotesPage: FunctionComponent = () => {
+const ReleaseNotesPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => {
   const api = useStorybookApi();
 
   useEffect(() => {
     api.setDidViewReleaseNotes();
   }, []);
 
-  return <ReleaseNotesScreen version={api.releaseNotesVersion()} />;
+  return <ReleaseNotesScreen onClose={onClose} version={api.releaseNotesVersion()} />;
 };
 
 export { ReleaseNotesPage as default };

--- a/lib/ui/src/settings/release_notes_page.tsx
+++ b/lib/ui/src/settings/release_notes_page.tsx
@@ -1,0 +1,11 @@
+import { useStorybookApi } from '@storybook/api';
+import React, { FunctionComponent } from 'react';
+
+import ReleaseNotesScreen from './release_notes';
+
+const ReleaseNotesPage: FunctionComponent = () => {
+  const api = useStorybookApi();
+  return <ReleaseNotesScreen version={api.releaseNotesVersion()} />;
+};
+
+export { ReleaseNotesPage as default };

--- a/lib/ui/src/settings/release_notes_page.tsx
+++ b/lib/ui/src/settings/release_notes_page.tsx
@@ -1,7 +1,7 @@
 import { useStorybookApi } from '@storybook/api';
 import React, { FunctionComponent, useEffect } from 'react';
 
-import ReleaseNotesScreen from './release_notes';
+import { ReleaseNotesScreen } from './release_notes';
 
 const ReleaseNotesPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => {
   const api = useStorybookApi();
@@ -13,4 +13,4 @@ const ReleaseNotesPage: FunctionComponent<{ onClose: () => void }> = ({ onClose 
   return <ReleaseNotesScreen onClose={onClose} version={api.releaseNotesVersion()} />;
 };
 
-export { ReleaseNotesPage as default };
+export { ReleaseNotesPage };

--- a/lib/ui/src/settings/shortcuts.stories.tsx
+++ b/lib/ui/src/settings/shortcuts.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { actions as makeActions } from '@storybook/addon-actions';
 
 import { DecoratorFn } from '@storybook/react';
-import ShortcutsScreen from './shortcuts';
+import { ShortcutsScreen } from './shortcuts';
 
 const defaultShortcuts = {
   fullScreen: ['F'],

--- a/lib/ui/src/settings/shortcuts.test.js
+++ b/lib/ui/src/settings/shortcuts.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { render } from '@testing-library/react';
 
 import { ThemeProvider, themes, convert } from '@storybook/theming';
-import ShortcutsScreen from './shortcuts';
+import { ShortcutsScreen } from './shortcuts';
 
 // A limited set of keys we use in this test file
 const shortcutKeys = {

--- a/lib/ui/src/settings/shortcuts.tsx
+++ b/lib/ui/src/settings/shortcuts.tsx
@@ -307,36 +307,16 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
     const layout = this.renderKeyForm();
     return (
       <GlobalHotKeys handlers={{ CLOSE: onClose }} keyMap={keyMap}>
-        <Tabs
-          absolute
-          selected="shortcuts"
-          actions={{ onSelect: () => {} }}
-          tools={
-            <Fragment>
-              <IconButton
-                onClick={(e: SyntheticEvent) => {
-                  e.preventDefault();
-                  return onClose();
-                }}
-              >
-                <Icons icon="close" />
-              </IconButton>
-            </Fragment>
-          }
-        >
-          <div id="shortcuts" title="Keyboard Shortcuts">
-            <Container>
-              <Header>Keyboard shortcuts</Header>
+        <Container>
+          <Header>Keyboard shortcuts</Header>
 
-              {layout}
-              <Button tertiary small id="restoreDefaultsHotkeys" onClick={this.restoreDefaults}>
-                Restore defaults
-              </Button>
+          {layout}
+          <Button tertiary small id="restoreDefaultsHotkeys" onClick={this.restoreDefaults}>
+            Restore defaults
+          </Button>
 
-              <SettingsFooter />
-            </Container>
-          </div>
-        </Tabs>
+          <SettingsFooter />
+        </Container>
       </GlobalHotKeys>
     );
   }

--- a/lib/ui/src/settings/shortcuts.tsx
+++ b/lib/ui/src/settings/shortcuts.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment, SyntheticEvent } from 'react';
+import React, { Component } from 'react';
 import { styled, keyframes } from '@storybook/theming';
 import { GlobalHotKeys } from 'react-hotkeys';
 
@@ -7,7 +7,7 @@ import {
   shortcutToHumanString,
   shortcutMatchesShortcut,
 } from '@storybook/api/shortcut';
-import { Form, IconButton, Icons, Tabs } from '@storybook/components';
+import { Form, Icons } from '@storybook/components';
 import SettingsFooter from './SettingsFooter';
 
 const { Button, Input } = Form;
@@ -322,4 +322,4 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
   }
 }
 
-export default ShortcutsScreen;
+export { ShortcutsScreen };

--- a/lib/ui/src/settings/shortcuts_page.tsx
+++ b/lib/ui/src/settings/shortcuts_page.tsx
@@ -1,11 +1,11 @@
 import { history } from 'global';
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 
 import { Consumer } from '@storybook/api';
 
 import ShortcutsScreen from './shortcuts';
 
-export default () => (
+const ShortcutsPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => (
   <Consumer>
     {({
       api: { getShortcutKeys, setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts },
@@ -13,8 +13,10 @@ export default () => (
       <ShortcutsScreen
         shortcutKeys={getShortcutKeys()}
         {...{ setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts }}
-        onClose={() => history.back()}
+        onClose={onClose}
       />
     )}
   </Consumer>
 );
+
+export { ShortcutsPage as default };

--- a/lib/ui/src/settings/shortcuts_page.tsx
+++ b/lib/ui/src/settings/shortcuts_page.tsx
@@ -1,25 +1,20 @@
 import { history } from 'global';
 import React from 'react';
 
-import { Route } from '@storybook/router';
 import { Consumer } from '@storybook/api';
 
 import ShortcutsScreen from './shortcuts';
 
 export default () => (
-  <Route path="shortcuts">
-    <Consumer>
-      {({
-        api: { getShortcutKeys, setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts },
-      }) => (
-        <Route path="shortcuts">
-          <ShortcutsScreen
-            shortcutKeys={getShortcutKeys()}
-            {...{ setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts }}
-            onClose={() => history.back()}
-          />
-        </Route>
-      )}
-    </Consumer>
-  </Route>
+  <Consumer>
+    {({
+      api: { getShortcutKeys, setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts },
+    }) => (
+      <ShortcutsScreen
+        shortcutKeys={getShortcutKeys()}
+        {...{ setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts }}
+        onClose={() => history.back()}
+      />
+    )}
+  </Consumer>
 );

--- a/lib/ui/src/settings/shortcuts_page.tsx
+++ b/lib/ui/src/settings/shortcuts_page.tsx
@@ -1,4 +1,3 @@
-import { history } from 'global';
 import React, { FunctionComponent } from 'react';
 
 import { Consumer } from '@storybook/api';

--- a/lib/ui/src/settings/shortcuts_page.tsx
+++ b/lib/ui/src/settings/shortcuts_page.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent } from 'react';
 
 import { Consumer } from '@storybook/api';
 
-import ShortcutsScreen from './shortcuts';
+import { ShortcutsScreen } from './shortcuts';
 
 const ShortcutsPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => (
   <Consumer>
@@ -19,4 +19,4 @@ const ShortcutsPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) 
   </Consumer>
 );
 
-export { ShortcutsPage as default };
+export { ShortcutsPage };


### PR DESCRIPTION
# This depends on https://github.com/storybookjs/frontpage/pull/107

Issue: #11232 

## What I did

This PR sets up the release notes logic in the build process & also in the ui.

## How to test

- **Is this testable with Jest or Chromatic screenshots?**

Yeah. I added some stories for the release notes page states, though I left the iframe out as that will likely change quite often.

- **Does this need a new example in the kitchen sink apps?**

Not sure. I added a new CLI flag for disabling the auto-messaging around release notes. Does that warrant a new example?

- **Does this need an update to the documentation?**

There is a new CLI flag, so that should be documented. Does that happen automatically though? I couldn't quite tell. I added it to `lib/core/src/server/cli/dev.js` with a note, which seemed to be documentation, but not sure where that shows up.


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
