### PR TITLE
Add/composition auto disable

### DIFF
--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -70,7 +70,7 @@ async function getManagerWebpackConfig(options, presets) {
 
   if (definedRefs) {
     Object.entries(definedRefs).forEach(([key, value]) => {
-      if (value === null) {
+      if (value?.disabled) {
         delete refs[key];
         return;
       }

--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -70,6 +70,10 @@ async function getManagerWebpackConfig(options, presets) {
 
   if (definedRefs) {
     Object.entries(definedRefs).forEach(([key, value]) => {
+      if (value === null) {
+        delete refs[key];
+      }
+
       const url = typeof value === 'string' ? value : value.url;
       const rest =
         typeof value === 'string'

--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -72,6 +72,7 @@ async function getManagerWebpackConfig(options, presets) {
     Object.entries(definedRefs).forEach(([key, value]) => {
       if (value === null) {
         delete refs[key];
+        return;
       }
 
       const url = typeof value === 'string' ? value : value.url;


### PR DESCRIPTION
Issue: -auto refs are **always added** users might not want that-

## What I did

I added some code that would deal with:
```js
module.exports = {
  refs: {
    'my-auto-loaded-ref-id': null,
  },
};
```

This would remove the ref that was auto-injected