### PR TITLE
Build: Add artifacts for e2e CI task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,9 @@ jobs:
       - run:
           name: cypress run
           command: yarn test:e2e
+      - store_artifacts:
+          path: /tmp/storybook/cypress
+          destination: cypress
 
   smoke-tests:
     <<: *defaults


### PR DESCRIPTION
Issue: -when the CI e2e task fails, it's hard to work out if it's flake or a real problem-

## What I did
I added CI config to store artifacts to CI storage so the video and screenshots from cypress are retrievable after CI completed