### PR TITLE
Addon-docs: Fix Source rendering corner case

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -51,9 +51,8 @@ export const getSourceProps = (
     const targetIds = multiProps.ids || [targetId];
     source = targetIds
       .map((sourceId) => {
-        if (sources) {
-          return sources[sourceId];
-        }
+        const snippet = sources && sources[sourceId];
+        if (snippet) return snippet;
         if (storyStore) {
           const data = storyStore.fromId(sourceId);
           const enhanced = data && (enhanceSource(data) || data.parameters);

--- a/addons/docs/src/blocks/SourceContainer.tsx
+++ b/addons/docs/src/blocks/SourceContainer.tsx
@@ -8,11 +8,11 @@ export type SourceItem = string;
 export type StorySources = Record<StoryId, SourceItem>;
 
 export interface SourceContextProps {
-  sources?: StorySources;
+  sources: StorySources;
   setSource?: (id: StoryId, item: SourceItem) => void;
 }
 
-export const SourceContext: Context<SourceContextProps> = createContext({});
+export const SourceContext: Context<SourceContextProps> = createContext({ sources: {} });
 
 export const SourceContainer: FC<{}> = ({ children }) => {
   const [sources, setSources] = useState<StorySources>({});
@@ -33,7 +33,7 @@ export const SourceContainer: FC<{}> = ({ children }) => {
 
   useEffect(() => {
     if (!deepEqual(sources, sourcesRef.current)) {
-      setSources(sourcesRef.current);
+      setSources(sourcesRef.current || {});
     }
 
     return () => channel.off(SNIPPET_RENDERED, handleSnippetRendered);

--- a/addons/docs/src/blocks/SourceContainer.tsx
+++ b/addons/docs/src/blocks/SourceContainer.tsx
@@ -32,8 +32,9 @@ export const SourceContainer: FC<{}> = ({ children }) => {
   channel.on(SNIPPET_RENDERED, handleSnippetRendered);
 
   useEffect(() => {
-    if (!deepEqual(sources, sourcesRef.current)) {
-      setSources(sourcesRef.current || {});
+    const current = sourcesRef.current || {};
+    if (!deepEqual(sources, current)) {
+      setSources(current);
     }
 
     return () => channel.off(SNIPPET_RENDERED, handleSnippetRendered);


### PR DESCRIPTION
Issue: #11413 

## What I did

Could not repro #11413 but eyeballing the code I can see how allowing a falsey `sources` map could cause the bug. Updated the type and make sure it's never falsey.

## How to test

Unclear
