### PR TITLE
Core: Deprecate configure and clearDecorators

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -39,6 +39,7 @@
     - [Deprecated polymer](#deprecated-polymer)
     - [Deprecated immutable options parameters](#deprecated-immutable-options-parameters)
     - [Deprecated addParameters and addDecorator](#deprecated-addparameters-and-adddecorator)
+    - [Deprecated configure](#deprecated-configure)
 - [From version 5.2.x to 5.3.x](#from-version-52x-to-53x)
   - [To main.js configuration](#to-mainjs-configuration)
     - [Using main.js](#using-mainjs)
@@ -649,6 +650,32 @@ addons.setConfig({
 The `addParameters` and `addDecorator` APIs to add global decorators and parameters, exported by the various frameworks (e.g. `@storybook/react`) and `@storybook/client` are now deprecated.
 
 Instead, use `export const parameters = {};` and `export const decorators = [];` in your `.storybook/preview.js`. Addon authors similarly should use such an export in a `previewEntry` file.
+
+#### Deprecated configure
+
+The `configure` API to load stories from `preview.js`, exported by the various frameworks (e.g. `@storybook/react`) is now deprecated.
+
+To load stories, use the `stories` field in `main.js`. You can pass a glob or array of globs to load stories like so:
+
+```js
+// in .storybook/main.js
+module.exports = {
+  stories: ['../src/**/*.stories.js'],
+};
+```
+
+You can also pass an array of single file names if you want to be careful about loading files:
+
+```js
+// in .storybook/main.js
+module.exports = {
+  stories: [
+    '../src/components/Button.stories.js',
+    '../src/components/Table.stories.js',
+    '../src/components/Page.stories.js',
+  ],
+};
+```
 
 ## From version 5.2.x to 5.3.x
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -39,6 +39,7 @@
     - [Deprecated polymer](#deprecated-polymer)
     - [Deprecated immutable options parameters](#deprecated-immutable-options-parameters)
     - [Deprecated addParameters and addDecorator](#deprecated-addparameters-and-adddecorator)
+    - [Deprecated clearDecorators](#deprecated-cleardecorators)
     - [Deprecated configure](#deprecated-configure)
 - [From version 5.2.x to 5.3.x](#from-version-52x-to-53x)
   - [To main.js configuration](#to-mainjs-configuration)
@@ -650,6 +651,10 @@ addons.setConfig({
 The `addParameters` and `addDecorator` APIs to add global decorators and parameters, exported by the various frameworks (e.g. `@storybook/react`) and `@storybook/client` are now deprecated.
 
 Instead, use `export const parameters = {};` and `export const decorators = [];` in your `.storybook/preview.js`. Addon authors similarly should use such an export in a `previewEntry` file.
+
+#### Deprecated clearDecorators
+
+Similarly, `clearDecorators`, exported by the various frameworks (e.g. `@storybook/react`) is deprecated.
 
 #### Deprecated configure
 

--- a/app/angular/src/client/preview/index.ts
+++ b/app/angular/src/client/preview/index.ts
@@ -26,7 +26,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   });
 };
 
-export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
+export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;

--- a/app/aurelia/src/client/preview/index.ts
+++ b/app/aurelia/src/client/preview/index.ts
@@ -31,7 +31,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 
 export { StoryFnAureliaReturnType, addRegistries, addContainer, Component, addComponents };
 
-export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
+export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;

--- a/app/ember/src/client/preview/index.ts
+++ b/app/ember/src/client/preview/index.ts
@@ -17,6 +17,6 @@ export const {
 const framework = 'ember';
 export const storiesOf = (...args: any) =>
   clientApi.storiesOf(...args).addParameters({ framework });
-export const configure = (...args: any) => coreConfigure(...args, framework);
+export const configure = (...args: any) => coreConfigure(framework, ...args);
 
 export { forceReRender };

--- a/app/html/src/client/preview/index.ts
+++ b/app/html/src/client/preview/index.ts
@@ -25,7 +25,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   });
 };
 
-export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
+export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;

--- a/app/marko/src/client/preview/index.js
+++ b/app/marko/src/client/preview/index.js
@@ -16,6 +16,6 @@ export const {
 
 const framework = 'marko';
 export const storiesOf = (...args) => clientApi.storiesOf(...args).addParameters({ framework });
-export const configure = (...args) => coreConfigure(...args, framework);
+export const configure = (...args) => coreConfigure(framework, ...args);
 
 export { forceReRender };

--- a/app/mithril/src/client/preview/index.ts
+++ b/app/mithril/src/client/preview/index.ts
@@ -22,7 +22,7 @@ interface ClientApi extends ClientStoryApi<StoryFnMithrilReturnType> {
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) =>
   (clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({ framework });
 
-export const configure: ClientApi['configure'] = (...args) => coreConfigure(...args, framework);
+export const configure: ClientApi['configure'] = (...args) => coreConfigure(framework, ...args);
 
 export const { setAddon } = clientApi;
 export const { addDecorator } = clientApi;

--- a/app/preact/src/client/preview/index.ts
+++ b/app/preact/src/client/preview/index.ts
@@ -14,7 +14,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   });
 };
 
-export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
+export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;

--- a/app/rax/src/client/preview/index.js
+++ b/app/rax/src/client/preview/index.js
@@ -16,6 +16,6 @@ export const {
 
 const framework = 'rax';
 export const storiesOf = (...args) => clientApi.storiesOf(...args).addParameters({ framework });
-export const configure = (...args) => coreConfigure(...args, framework);
+export const configure = (...args) => coreConfigure(framework, ...args);
 
 export { forceReRender };

--- a/app/react/src/client/preview/index.ts
+++ b/app/react/src/client/preview/index.ts
@@ -25,7 +25,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   });
 };
 
-export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
+export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
 export type DecoratorFn = Parameters<typeof addDecorator>[0];
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;

--- a/app/riot/src/client/preview/index.js
+++ b/app/riot/src/client/preview/index.js
@@ -18,7 +18,7 @@ export const {
 
 const framework = 'riot';
 export const storiesOf = (...args) => clientApi.storiesOf(...args).addParameters({ framework });
-export const configure = (...args) => coreConfigure(...args, framework);
+export const configure = (...args) => coreConfigure(framework, ...args);
 
 const mount = vendorMount.bind(riot, '#root');
 const compileNow = unboundCompileNow.bind(null, tag2);

--- a/app/svelte/src/client/preview/index.ts
+++ b/app/svelte/src/client/preview/index.ts
@@ -17,6 +17,6 @@ export const {
 const framework = 'svelte';
 export const storiesOf = (...args: any) =>
   clientApi.storiesOf(...args).addParameters({ framework });
-export const configure = (...args: any) => coreConfigure(...args, framework);
+export const configure = (...args: any) => coreConfigure(framework, ...args);
 
 export { forceReRender };

--- a/app/vue/src/client/preview/index.ts
+++ b/app/vue/src/client/preview/index.ts
@@ -121,7 +121,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   });
 };
 
-export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
+export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;

--- a/app/web-components/src/client/preview/index.ts
+++ b/app/web-components/src/client/preview/index.ts
@@ -25,7 +25,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   });
 };
 
-export const configure: ClientApi['configure'] = (...args) => api.configure(...args, framework);
+export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
 export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -110,10 +110,6 @@ export default class ClientApi {
     this._storyStore.addArgTypesEnhancer(enhancer);
   };
 
-  clearDecorators = () => {
-    this._storyStore.clearGlobalDecorators();
-  };
-
   // what are the occasions that "m" is a boolean vs an obj
   storiesOf = <StoryFnReturnType = unknown>(
     kind: string,

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -92,7 +92,7 @@ export default class ClientApi {
       };
     },
     dedent`
-      setAddon is deprecated and will be removed in Storybook 7.0
+      \`setAddon\` is deprecated and will be removed in Storybook 7.0.
 
       https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-setaddon
     `
@@ -101,6 +101,17 @@ export default class ClientApi {
   addDecorator = (decorator: DecoratorFunction) => {
     this._storyStore.addGlobalMetadata({ decorators: [decorator], parameters: {} });
   };
+
+  clearDecorators = deprecate(
+    () => {
+      this._storyStore.clearGlobalDecorators();
+    },
+    dedent`
+      \`clearDecorators\` is deprecated and will be removed in Storybook 7.0.
+
+      https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-cleardecorators
+    `
+  );
 
   addParameters = (parameters: Parameters) => {
     this._storyStore.addGlobalMetadata({ decorators: [], parameters });

--- a/lib/client-api/src/config_api.ts
+++ b/lib/client-api/src/config_api.ts
@@ -28,17 +28,5 @@ export default class ConfigApi {
       this._storyStore.setError(err);
     }
     this._storyStore.finishConfiguring();
-
-    if (module.hot) {
-      module.hot.accept();
-      // The generated entry point for main.js:stories adds this flag as it cannot
-      // set decorators but calls configure, and aims not to clear decorators added by other files.
-      // HOWEVER: this will still clear global decorators added by addons when reloading preview.js
-      //   which is a bug!
-      // @ts-ignore
-      if (!module._StorybookPreserveDecorators) {
-        module.hot.dispose(() => this._storyStore.clearGlobalDecorators());
-      }
-    }
   };
 }

--- a/lib/client-api/src/config_api.ts
+++ b/lib/client-api/src/config_api.ts
@@ -1,23 +1,14 @@
 /* eslint no-underscore-dangle: 0 */
-
-import Channel from '@storybook/channels';
 import StoryStore from './story_store';
-import ClientApi from './client_api';
 
 export default class ConfigApi {
-  _channel: Channel;
-
   _storyStore: StoryStore;
-
-  _clearDecorators: () => void;
-
-  clientApi: ClientApi;
 
   constructor({ storyStore }: { storyStore: StoryStore }) {
     this._storyStore = storyStore;
   }
 
-  configure = (loaders: () => void, module: NodeModule) => {
+  configure = (loaders: () => void, module: NodeModule, showDeprecationWarning = true) => {
     this._storyStore.startConfiguring();
 
     try {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -246,10 +246,6 @@ export default class StoryStore {
     this._globalMetadata.decorators.push(...decorators);
   }
 
-  clearGlobalDecorators() {
-    this._globalMetadata.decorators = [];
-  }
-
   ensureKind(kind: string) {
     if (!this._kinds[kind]) {
       this._kinds[kind] = {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -246,6 +246,10 @@ export default class StoryStore {
     this._globalMetadata.decorators.push(...decorators);
   }
 
+  clearGlobalDecorators() {
+    this._globalMetadata.decorators = [];
+  }
+
   ensureKind(kind: string) {
     if (!this._kinds[kind]) {
       this._kinds[kind] = {

--- a/lib/core/src/client/preview/loadCsf.test.ts
+++ b/lib/core/src/client/preview/loadCsf.test.ts
@@ -76,7 +76,7 @@ describe('core.preview.loadCsf', () => {
         2: Object.assign(() => 0, { storyName: 'two' }),
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     expect(mockedStoriesOf).toHaveBeenCalledWith('a', true);
@@ -106,7 +106,7 @@ describe('core.preview.loadCsf', () => {
         __namedExportsOrder: ['w', 'x', 'z', 'y'],
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
@@ -129,7 +129,7 @@ describe('core.preview.loadCsf', () => {
         w: () => 0,
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
@@ -151,7 +151,7 @@ describe('core.preview.loadCsf', () => {
         w: () => 0,
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
@@ -170,7 +170,7 @@ describe('core.preview.loadCsf', () => {
         x: () => 0,
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
@@ -189,7 +189,7 @@ describe('core.preview.loadCsf', () => {
         },
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
@@ -217,7 +217,7 @@ describe('core.preview.loadCsf', () => {
         x: () => 0,
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
@@ -247,7 +247,7 @@ describe('core.preview.loadCsf', () => {
         }),
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
@@ -278,7 +278,7 @@ describe('core.preview.loadCsf', () => {
         }),
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
@@ -303,7 +303,7 @@ describe('core.preview.loadCsf', () => {
         x: () => 0,
       },
     };
-    configure(makeRequireContext(firstInput), mod, 'react');
+    configure('react', makeRequireContext(firstInput), mod);
 
     // HMR dispose callbacks
     doHMRDispose();
@@ -319,7 +319,7 @@ describe('core.preview.loadCsf', () => {
         x: () => 0,
       },
     };
-    configure(makeRequireContext(secondInput), mod, 'react');
+    configure('react', makeRequireContext(secondInput), mod);
 
     expect(storyStore.removeStoryKind).not.toHaveBeenCalled();
     expect(mockedStoriesOf).toHaveBeenCalledWith('b', true);
@@ -342,7 +342,7 @@ describe('core.preview.loadCsf', () => {
         x: () => 0,
       },
     };
-    configure(makeRequireContext(firstInput), mod, 'react');
+    configure('react', makeRequireContext(firstInput), mod);
 
     // HMR dispose callbacks
     doHMRDispose();
@@ -352,7 +352,7 @@ describe('core.preview.loadCsf', () => {
     const secondInput = {
       a: firstInput.a,
     };
-    configure(makeRequireContext(secondInput), mod, 'react');
+    configure('react', makeRequireContext(secondInput), mod);
 
     expect(storyStore.removeStoryKind).toHaveBeenCalledWith('b');
     expect(mockedStoriesOf).not.toHaveBeenCalled();
@@ -376,7 +376,7 @@ describe('core.preview.loadCsf', () => {
         x: () => 0,
       },
     };
-    configure(makeRequireContext(firstInput), mod, 'react');
+    configure('react', makeRequireContext(firstInput), mod);
 
     // HMR dispose callbacks
     doHMRDispose();
@@ -393,7 +393,7 @@ describe('core.preview.loadCsf', () => {
         y: () => 0,
       },
     };
-    configure(makeRequireContext(secondInput), mod, 'react');
+    configure('react', makeRequireContext(secondInput), mod);
 
     expect(storyStore.removeStoryKind).toHaveBeenCalledTimes(1);
     expect(storyStore.removeStoryKind).toHaveBeenCalledWith('a');
@@ -411,7 +411,7 @@ describe('core.preview.loadCsf', () => {
         // no named exports, will not present a story
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
     expect(logger.warn).toHaveBeenCalled();
   });
 
@@ -426,7 +426,7 @@ describe('core.preview.loadCsf', () => {
         x: () => 0,
       },
     };
-    configure(makeRequireContext(input), mod, 'react');
+    configure('react', makeRequireContext(input), mod);
     expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -189,6 +189,12 @@ const loadStories = (
   previousExports = currentExports;
 };
 
+const configureDeprecationWarning = deprecate(
+  () => {},
+  `\`configure()\` is deprecated and will be removed in Storybook 7.0. 
+Please use the \`stories\` field of \`main.js\` to load stories.
+Read more at https://github.com/storybookjs/storybook/MIGRATE.md#deprecated-configure`
+);
 let loaded = false;
 export const loadCsf = ({
   clientApi,
@@ -209,7 +215,11 @@ export const loadCsf = ({
    * @param {*} m - ES module object for hot-module-reloading (HMR)
    * @param {boolean} showDeprecationWarning - show the deprecation warning (default true)
    */
-  (loadable: Loadable, m: NodeModule, framework: string) => {
+  (framework: string, loadable: Loadable, m: NodeModule, showDeprecationWarning = true) => {
+    if (showDeprecationWarning) {
+      configureDeprecationWarning();
+    }
+
     if (typeof m === 'string') {
       throw new Error(
         `Invalid module '${m}'. Did you forget to pass \`module\` as the second argument to \`configure\`"?`

--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -204,9 +204,10 @@ export const loadCsf = ({
    * file and process its named exports as stories. If not, assume it's an old-style
    * storiesof file and require it.
    *
+   * @param {*} framework - name of framework in use, e.g. "react"
    * @param {*} loadable a require.context `req`, an array of `req`s, or a loader function that returns void or an array of exports
    * @param {*} m - ES module object for hot-module-reloading (HMR)
-   * @param {*} framework - name of framework in use, e.g. "react"
+   * @param {boolean} showDeprecationWarning - show the deprecation warning (default true)
    */
   (loadable: Loadable, m: NodeModule, framework: string) => {
     if (typeof m === 'string') {

--- a/lib/core/src/server/preview/virtualModuleStory.template.js
+++ b/lib/core/src/server/preview/virtualModuleStory.template.js
@@ -1,3 +1,3 @@
 import { configure } from '@storybook/{{framework}}';
 
-configure(['{{stories}}'], module);
+configure(['{{stories}}'], module, false);

--- a/lib/core/src/server/preview/virtualModuleStory.template.js
+++ b/lib/core/src/server/preview/virtualModuleStory.template.js
@@ -1,6 +1,3 @@
 import { configure } from '@storybook/{{framework}}';
 
-// eslint-disable-next-line no-underscore-dangle
-module._StorybookPreserveDecorators = true;
-
 configure(['{{stories}}'], module);


### PR DESCRIPTION
Issue: for #10005

## What I did

 - Deprecated configure
 - Stopped HMR for configure to be consistent with `main.js:stories`

## How to test

Try adding a `configure()` call to `preview.js` in official SB