### PR TITLE
Fix Yarn 2 compatibility in CLI and Essentials

### DIFF
--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path, { join } from 'path';
 import { logger } from '@storybook/node-logger';
 
 interface PresetOptions {
@@ -33,8 +33,30 @@ export function addons(options: PresetOptions = {}) {
   };
 
   const main = requireMain(options.configDir);
-  return ['actions', 'docs', 'controls', 'backgrounds', 'viewport']
-    .filter((key) => (options as any)[key] !== false)
-    .map((key) => `@storybook/addon-${key}`)
-    .filter((addon) => !checkInstalled(addon, main));
+  return (
+    ['actions', 'docs', 'controls', 'backgrounds', 'viewport']
+      .filter((key) => (options as any)[key] !== false)
+      .map((key) => `@storybook/addon-${key}`)
+      .filter((addon) => !checkInstalled(addon, main))
+      // Use `require.resolve` to ensure Yarn PnP compatibility
+      // Files of various addons should be resolved in the context of `addon-essentials` as they are listed as deps here
+      // and not in `@storybook/core` nor in SB user projects. If `@storybook/core` make the require itself Yarn 2 will
+      // throw an error saying that the package to require must be added as a dependency. Doing `require.resolve` will
+      // allow `@storybook/core` to work with absolute path directly, no more require of dep no more issue.
+      // File to load can be `preset.js`, `register.js`, or the package entry point, so we need to check all these cases
+      // as it's done in `lib/core/src/server/presets.js`.
+      .map((addon) => {
+        try {
+          return require.resolve(join(addon, 'preset'));
+          // eslint-disable-next-line no-empty
+        } catch (err) {}
+
+        try {
+          return require.resolve(join(addon, 'register'));
+          // eslint-disable-next-line no-empty
+        } catch (err) {}
+
+        return require.resolve(addon);
+      })
+  );
 }

--- a/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -8,6 +8,8 @@ import { StoryFormat } from '../../project_types';
 const generator: Generator = async (packageManager, npmOptions, options) => {
   await baseGenerator(packageManager, npmOptions, options, 'react', {
     extraAddons: ['@storybook/preset-create-react-app'],
+    // `@storybook/preset-create-react-app` has `@storybook/node-logger` as peerDep
+    extraPackages: ['@storybook/node-logger'],
     staticDir: fs.existsSync(path.resolve('./public')) ? 'public' : undefined,
   });
   if (options.storyFormat === StoryFormat.MDX) {


### PR DESCRIPTION
Issue: Yarn 2 E2E tests are broken on next for a few days, let's fix them. And then I will think a bit about how to make them faster or add a Yarn 2 fail-fast test.

## What I did
 - CLI: add `@storybook/node-logger` as peerDep in Storybook for CRA generator, as of `@storybook/preset-create-react-app@3.1.3` this dep must be added to the base project directly.
 - Essentials: use `require.resolve` to ensure Yarn PnP compatibility. Files of various addons should be resolved in the context of `addon-essentials` and not in the one of SB user projects. File to load can be `preset.js`, `register.js`, or the package entry point, so we need to check all these cases as it's done in `lib/core/src/server/presets.js`.

--

Outdated, see https://github.com/storybookjs/storybook/pull/11444#issuecomment-654823786, will be done in another PR:
 - E2E: CLI now generates project with `addon-essential` so it enables `addon-viewport` by default. I added a simple test to check that viewport is properly loaded:
   - Go to Welcome Story
   - Click on Viewport button in the toolbar
   - Select "Small Mobile"
   - Check that Welcome Story is still displayed

Note: commit is here https://github.com/storybookjs/storybook/commit/3643404b9e07bbdee9d13d23f43006232e3584bc

## How to test

- CI should be 🟢 
