### PR TITLE
docs(storybook-server): update examples url

### DIFF
--- a/app/server/README.md
+++ b/app/server/README.md
@@ -33,7 +33,7 @@ For more information visit: [storybook.js.org](https://storybook.js.org)
 
 ## Writing Stories
 
-To write a story, use whatever API is natural for your server-side rendering framework to generate set of JSON files of stories analogous to CSF files (see the [`server-kitchen-sink`](../../server-kitchen-sink/stories) example for ideas):
+To write a story, use whatever API is natural for your server-side rendering framework to generate set of JSON files of stories analogous to CSF files (see the [`server-kitchen-sink`](../../examples/server-kitchen-sink/stories) example for ideas):
 
 ```json
 {


### PR DESCRIPTION
## What I did

Fixed a broken link in the docs for server

## How to test

Click on the link, you should not go to a 404 page anymore