### PR TITLE
Addon-docs: Fix babel jsx handling for MDX

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,6 +12,7 @@
     - [Docs theme separated](#docs-theme-separated)
     - [DocsPage slots removed](#docspage-slots-removed)
     - [React prop tables with Typescript](#react-prop-tables-with-typescript)
+    - [ConfigureJSX true by default in React](#configurejsx-true-by-default-in-react)
   - [New addon presets](#new-addon-presets)
   - [Removed babel-preset-vue from Vue preset](#removed-babel-preset-vue-from-vue-preset)
   - [Removed Deprecated APIs](#removed-deprecated-apis)
@@ -294,6 +295,23 @@ Props handling in React has changed in 6.0 and should be much less error-prone. 
 Starting in 6.0, we have [zero-config typescript support](#zero-config-typescript). The out-of-box experience should be much better now, since the default configuration is designed to work well with `addon-docs`.
 
 There are also two typescript handling options that can be set in `.storybook/main.js`. `react-docgen-typescript` (default) and `react-docgen`. This is [discussed in detail in the docs](https://github.com/storybookjs/storybook/blob/next/addons/docs/react/README.md#typescript-props-with-react-docgen).
+
+#### ConfigureJSX true by default in React
+
+In SB 6.0, the Storybook Docs preset option `configureJSX` is now set to `true` for all React projects. It was previously `false` by default for React only in 5.x). This `configureJSX` option adds `@babel/plugin-transform-react-jsx`, to process the output of the MDX compiler, which should be a safe change for all projects.
+
+If you need to restore the old JSX handling behavior, you can configure `.storybook/main.js`:
+
+```js
+module.exports = {
+  addons: [
+    {
+      name: '@storybook/addon-docs',
+      options: { configureJSX: false },
+    },
+  ],
+};
+```
 
 ### New addon presets
 

--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -48,7 +48,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
   const {
     babelOptions,
     mdxBabelOptions,
-    configureJSX = options.framework !== 'react', // if not user-specified
+    configureJSX = true,
     sourceLoaderOptions = options.framework === 'react' ? null : {},
     transcludeMarkdown = false,
   } = options;

--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -23,10 +23,11 @@ type BabelParams = {
 };
 function createBabelOptions({ babelOptions, mdxBabelOptions, configureJSX }: BabelParams) {
   const babelPlugins = mdxBabelOptions?.plugins || babelOptions?.plugins || [];
-  const plugins = configureJSX
-    ? [...babelPlugins, '@babel/plugin-transform-react-jsx']
-    : babelPlugins;
-
+  const jsxPlugin = [
+    '@babel/plugin-transform-react-jsx',
+    { pragma: 'React.createElement', pragmaFrag: 'React.Fragment' },
+  ];
+  const plugins = configureJSX ? [...babelPlugins, jsxPlugin] : babelPlugins;
   return {
     // don't use the root babelrc by default (users can override this in mdxBabelOptions)
     babelrc: false,


### PR DESCRIPTION
Issue: #11439

## What I did

- [x] Configure JSX handling in React projects by default
- [x] Support React fragment pragmas by default (to compensate for some breaking change in Babel)

Even tho this is technically a breaking change, we should probably patch it over to 5.3 because (1) it fixes a bug introduced in babel (not our code) that affects 5.3, (2) practically speaking I think it won't break much of anything.

## How to test

See examples `cra-ts-kitchen-sink` before and after
