### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ Storybook comes with a lot of [addons](https://storybook.js.org/addons/introduct
 
 ## Table of contents
 
-- 🚀[Getting Started](#getting-started)
-- 📒[Projects](#projects)
-  - 🛠[Supported Frameworks & Examples](#supported-frameworks)
-  - 🚇[Sub Projects](#sub-projects)
+- 🚀 [Getting Started](#getting-started)
+- 📒 [Projects](#projects)
+  - 🛠 [Supported Frameworks & Examples](#supported-frameworks)
+  - 🚇[ Sub Projects](#sub-projects)
   - 🔗[Addons](#addons)
-- 🏅[Badges & Presentation materials](#badges--presentation-materials)
-- 👥[Community](#community)
-- 👏[Contributing](#contributing)
-  - 👨‍💻[Development scripts](#development-scripts)
-  - 💵[Backers](#backers)
-  - 💸[Sponsors](#sponsors)
-- :memo:[License](#license)
+- 🏅 [Badges & Presentation materials](#badges--presentation-materials)
+- 👥 [Community](#community)
+- 👏 [Contributing](#contributing)
+  - 👨‍💻 [Development scripts](#development-scripts)
+  - 💵 [Backers](#backers)
+  - 💸 [Sponsors](#sponsors)
+- :memo: [License](#license)
 
 ## Getting Started
 


### PR DESCRIPTION
space between icon and text

Issue: icons overlapping text in readme
![Screen Shot 2020-07-07 at 5 30 06 PM](https://user-images.githubusercontent.com/21677355/86850828-8bf5bb80-c077-11ea-9d04-bbb34c63a425.png)

## What I did
put space between icon and text

## How to test
visually!

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
