### PR TITLE
Addon-controls: Add addon-docs check on startup

### DIFF
--- a/addons/controls/package.json
+++ b/addons/controls/package.json
@@ -34,8 +34,10 @@
     "@storybook/api": "6.0.0-beta.45",
     "@storybook/client-api": "6.0.0-beta.45",
     "@storybook/components": "6.0.0-beta.45",
+    "@storybook/node-logger": "6.0.0-beta.45",
     "@storybook/theming": "6.0.0-beta.45",
-    "core-js": "^3.0.1"
+    "core-js": "^3.0.1",
+    "ts-dedent": "^1.1.1"
   },
   "peerDependencies": {
     "react": "*",

--- a/addons/controls/src/preset/ensureDocsBeforeControls.test.ts
+++ b/addons/controls/src/preset/ensureDocsBeforeControls.test.ts
@@ -1,0 +1,26 @@
+import { verifyDocsBeforeControls } from './ensureDocsBeforeControls';
+
+describe.each([
+  [[]],
+  [['@storybook/addon-controls']],
+  [['@storybook/addon-docs']],
+  [['@storybook/addon-controls', '@storybook/addon-docs']],
+  [['@storybook/addon-essentials', '@storybook/addon-docs']],
+  [['@storybook/addon-controls', '@storybook/addon-essentials']],
+  [['@storybook/addon-essentials', '@storybook/addon-controls', '@storybook/addon-docs']],
+])('verifyDocsBeforeControls', (input) => {
+  it(`invalid ${input}`, () => {
+    expect(verifyDocsBeforeControls(input)).toBeFalsy();
+  });
+});
+
+describe.each([
+  [['@storybook/addon-docs', '@storybook/addon-controls']],
+  [[{ name: '@storybook/addon-docs' }, '@storybook/addon-controls']],
+  [['@storybook/addon-essentials', '@storybook/addon-controls']],
+  [['@storybook/addon-essentials']],
+])('verifyDocsBeforeControls', (input) => {
+  it(`valid ${input}`, () => {
+    expect(verifyDocsBeforeControls(input)).toBeTruthy();
+  });
+});

--- a/addons/controls/src/preset/ensureDocsBeforeControls.ts
+++ b/addons/controls/src/preset/ensureDocsBeforeControls.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import { logger } from '@storybook/node-logger';
+import dedent from 'ts-dedent';
+
+type OptionsEntry = { name: string };
+type Entry = string | OptionsEntry;
+
+const findIndex = (addon: string, addons: Entry[]) =>
+  addons.findIndex((entry) => {
+    const name = (entry as OptionsEntry).name || (entry as string);
+    return name && name.startsWith(addon);
+  });
+
+const indexOfAddonOrEssentials = (addon: string, addons: Entry[]) => {
+  const index = findIndex(addon, addons);
+  return index >= 0 ? index : findIndex('@storybook/addon-essentials', addons);
+};
+
+export const verifyDocsBeforeControls = (addons: Entry[]) => {
+  const docsIndex = indexOfAddonOrEssentials('@storybook/addon-docs', addons);
+  const controlsIndex = indexOfAddonOrEssentials('@storybook/addon-controls', addons);
+  return controlsIndex >= 0 && docsIndex >= 0 && docsIndex <= controlsIndex;
+};
+
+export const ensureDocsBeforeControls = (configDir: string) => {
+  const mainFile = path.join(process.cwd(), configDir, 'main');
+  try {
+    // eslint-disable-next-line global-require,import/no-dynamic-require
+    const main = require(mainFile);
+    if (!main?.addons) {
+      logger.warn(`Unable to find main.js addons: ${mainFile}`);
+      return;
+    }
+    if (!verifyDocsBeforeControls(main.addons)) {
+      logger.warn(dedent`
+        Expected '@storybook/addon-docs' (or essentials) to be listed before '@storybook/addon-controls'. Check your main.js?
+        
+        https://github.com/storybookjs/storybook/issues/11442
+      `);
+    }
+  } catch (err) {
+    logger.warn(`Unable to find main.js: ${mainFile}`);
+  }
+};

--- a/addons/controls/src/preset/index.ts
+++ b/addons/controls/src/preset/index.ts
@@ -1,3 +1,6 @@
-export function managerEntries(entry: any[] = []) {
+import { ensureDocsBeforeControls } from './ensureDocsBeforeControls';
+
+export function managerEntries(entry: any[] = [], options: any) {
+  ensureDocsBeforeControls(options.configDir);
   return [...entry, require.resolve('../register')];
 }

--- a/addons/controls/tsconfig.json
+++ b/addons/controls/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "types": ["webpack-env", "jest"]
+    "types": ["webpack-env", "jest", "node"]
   },
   "include": ["src/**/*"],
   "exclude": ["src/**.test.ts"]


### PR DESCRIPTION
Issue: #11442 

## What I did

Warn if addon-docs preset is not run before addon-controls preset.

## How to test

- See unit tests
- Reorder addon-docs / controls in `official-storybook` and observe warning
