### PR TITLE
Deploy the `next` branch of frontpage too

### DIFF
--- a/scripts/build-frontpage.js
+++ b/scripts/build-frontpage.js
@@ -4,19 +4,21 @@
 const fetch = require('node-fetch');
 const { execSync } = require('child_process');
 
-const { FRONTPAGE_WEBHOOK } = process.env;
+const { FRONTPAGE_WEBHOOK, FRONTPAGE_WEBHOOK_NEXT } = process.env;
 
 const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
 
+const branchToHook = {
+  master: FRONTPAGE_WEBHOOK,
+  '6.0-docs': FRONTPAGE_WEBHOOK_NEXT, // <- NOTE: change this to `next` when we merge the new docs
+};
+
 console.log('build-frontpage');
-if (branch === 'master') {
-  if (FRONTPAGE_WEBHOOK) {
-    console.log('triggering frontpage build');
-    const url = `https://api.netlify.com/build_hooks/${FRONTPAGE_WEBHOOK}`;
-    fetch(url, { method: 'post' }).then((res) => console.log('result', res.status));
-  } else {
-    console.log('no webhook defined');
-  }
+const hook = branchToHook[branch];
+if (hook) {
+  console.log('triggering frontpage build');
+  const url = `https://api.netlify.com/build_hooks/${hook}`;
+  fetch(url, { method: 'post' }).then((res) => console.log('result', res.status));
 } else {
   console.log('skipping branch', branch);
 }


### PR DESCRIPTION
I want the `next` branch of frontpage to auto-deploy also, based on `next` SB (currently we are using `6.0-docs` while we refactor it).

I added a new build hook on netlify and a new env var to the circle ci config.