### PR TITLE
UI: Fix menu alignment regression

### DIFF
--- a/lib/ui/src/components/sidebar/Menu.tsx
+++ b/lib/ui/src/components/sidebar/Menu.tsx
@@ -42,9 +42,7 @@ export const MenuItemIcon = ({ icon, imgSrc }: ListItemIconProps) => {
 };
 
 const MenuButton = styled(Button)<MenuButtonProps>(({ highlighted, theme }) => ({
-  position: 'absolute',
-  right: 0,
-  top: 0,
+  position: 'relative',
   overflow: 'visible',
   padding: 7,
 


### PR DESCRIPTION
Issue: #11468

## What I did
Fix regression by reverting style change in the earlier Composition PR.

## How to test
Click on the menu button. 

✅ It should look like this: 
![image](https://user-images.githubusercontent.com/263385/86956872-d171c180-c127-11ea-993b-a9d45756362c.png)

❌ Not this:
![image](https://user-images.githubusercontent.com/263385/86955735-0ed54f80-c126-11ea-8e93-0dfacfca8ecf.png)

- Is this testable with Jest or Chromatic screenshots? No, it requires user interaction to see.


