### PR TITLE
UI: Increase max-height of menu tooltip so scrollbars don't appear

### DIFF
--- a/docs/src/new-components/basics/tooltip/TooltipLinkList.js
+++ b/docs/src/new-components/basics/tooltip/TooltipLinkList.js
@@ -7,7 +7,7 @@ const List = styled.div`
   min-width: 180px;
   overflow: hidden;
   overflow-y: auto;
-  max-height: ${11.5 * 32 /* 11.5 items */};
+  max-height: ${13.5 * 32 /* 11.5 items */};
 `;
 
 function TooltipLinkList({ links, LinkWrapper }) {

--- a/lib/components/src/tooltip/TooltipLinkList.tsx
+++ b/lib/components/src/tooltip/TooltipLinkList.tsx
@@ -8,7 +8,7 @@ const List = styled.div<{}>(
     minWidth: 180,
     overflow: 'hidden',
     overflowY: 'auto',
-    maxHeight: 11.5 * 32, // 11.5 items
+    maxHeight: 13.5 * 32, // 11.5 items
   },
   ({ theme }) => ({
     borderRadius: theme.appBorderRadius * 2,


### PR DESCRIPTION
Issue: #11470

## What I did
Increased max-height of the menu tooltip contents so the scrollbar doesn't appear.

## How to test

1. Go to the published Storybook for this PR. 
2. Click on the menu button
3. It should look like this (no scrollbar)
![image](https://user-images.githubusercontent.com/263385/86961663-983d4f80-c12f-11ea-82b7-c0a5fbd1e25a.png)


- Is this testable with Jest or Chromatic screenshots? No, it's behind a user interaction. (we haven't set up a test for this yet).


