### PR TITLE
(SB tests) Fix iframe test flake

### DIFF
--- a/lib/ui/src/components/preview/iframe.stories.tsx
+++ b/lib/ui/src/components/preview/iframe.stories.tsx
@@ -25,6 +25,11 @@ export const workingStory = () => (
     scale={1.0}
   />
 );
+workingStory.story = {
+  parameters: {
+    chromatic: { delay: 300 },
+  },
+};
 
 export const missingStory = () => (
   <IFrame


### PR DESCRIPTION
Issue: 
There's a story `Iframe: Working Story` that loads content in an iframe. Iframes take unpredictable times to load so it may not have loaded by the time Chromatic thinks it loaded. Here's the [test flake in action on a PR](https://www.chromatic.com/snapshot?appId=5a375b97f4b14f0020b0cda3&id=5f0614fd81f92800225cfae9). And if you have Storybook open on your local machine, [this is the path](http://localhost:9011/?path=/story/ui-iframe--working-story) to it. 

A video of the behavior that causes the flake: https://www.loom.com/share/0395dc2983d34823930ff03f8b4b0430

## What I did
Tell Chromatic to wait 300ms before taking a snapshot of this story. That should give the story enough time to load.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes and no. Yes it's tested by Chromatic. No, in that the test flake should not be visible if this PR succeeds.


If your answer is yes to any of these, please make sure 