### PR TITLE
Addon-toolbars: Show name if there is no icon

### DIFF
--- a/addons/toolbars/src/components/MenuToolbar.tsx
+++ b/addons/toolbars/src/components/MenuToolbar.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { useGlobals } from '@storybook/api';
-import { Icons, IconButton, WithTooltip, TooltipLinkList } from '@storybook/components';
+import { Icons, IconButton, WithTooltip, TooltipLinkList, TabButton } from '@storybook/components';
 import { NormalizedToolbarArgType } from '../types';
 
 export type MenuToolbarProps = NormalizedToolbarArgType & { id: string };
@@ -15,6 +15,7 @@ export const MenuToolbar: FC<MenuToolbarProps> = ({
   const selectedValue = globals[id];
   const active = selectedValue != null;
   const selectedItem = active && items.find((item) => item.value === selectedValue);
+  const selectedIcon = (selectedItem && selectedItem.icon) || icon;
 
   return (
     <WithTooltip
@@ -39,9 +40,13 @@ export const MenuToolbar: FC<MenuToolbarProps> = ({
       }}
       closeOnClick
     >
-      <IconButton key={name} active={active} title={description}>
-        <Icons icon={(selectedItem && selectedItem.icon) || icon} />
-      </IconButton>
+      {selectedIcon ? (
+        <IconButton key={name} active={active} title={description}>
+          <Icons icon={selectedIcon} />
+        </IconButton>
+      ) : (
+        <TabButton active={active}>{name}</TabButton>
+      )}
     </WithTooltip>
   );
 };


### PR DESCRIPTION
Issue: #11474 

## What I did

- [x] Show `TabButton` per `addon-contexts` behavior

## How to test

- Remove the `icon` setting one of the toolbars in `official-storybook`

