### PR TITLE
Composition: Fix syntax on `no-cors`

### DIFF
--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -154,7 +154,7 @@ export const init: ModuleFn = ({ store, provider, fullAPI }, { runCheck = true }
           credentials: 'omit',
         }),
         fetch(`${url}/iframe.html${query}`, {
-          cors: 'no-cors',
+          mode: 'no-cors',
           credentials: 'omit',
         }),
       ]);

--- a/lib/api/src/tests/refs.test.js
+++ b/lib/api/src/tests/refs.test.js
@@ -158,8 +158,8 @@ describe('Refs API', () => {
           Array [
             "https://example.com/iframe.html",
             Object {
-              "cors": "no-cors",
               "credentials": "omit",
+              "mode": "no-cors",
             },
           ],
         ]
@@ -203,8 +203,8 @@ describe('Refs API', () => {
           Array [
             "https://example.com/iframe.html?version=2.1.3-rc.2",
             Object {
-              "cors": "no-cors",
               "credentials": "omit",
+              "mode": "no-cors",
             },
           ],
         ]
@@ -265,8 +265,8 @@ describe('Refs API', () => {
           Array [
             "https://example.com/iframe.html",
             Object {
-              "cors": "no-cors",
               "credentials": "omit",
+              "mode": "no-cors",
             },
           ],
         ]
@@ -355,8 +355,8 @@ describe('Refs API', () => {
           Array [
             "https://example.com/iframe.html",
             Object {
-              "cors": "no-cors",
               "credentials": "omit",
+              "mode": "no-cors",
             },
           ],
           Array [
@@ -448,8 +448,8 @@ describe('Refs API', () => {
           Array [
             "https://example.com/iframe.html",
             Object {
-              "cors": "no-cors",
               "credentials": "omit",
+              "mode": "no-cors",
             },
           ],
           Array [
@@ -542,8 +542,8 @@ describe('Refs API', () => {
           Array [
             "https://example.com/iframe.html",
             Object {
-              "cors": "no-cors",
               "credentials": "omit",
+              "mode": "no-cors",
             },
           ],
           Array [
@@ -640,8 +640,8 @@ describe('Refs API', () => {
           Array [
             "https://example.com/iframe.html",
             Object {
-              "cors": "no-cors",
               "credentials": "omit",
+              "mode": "no-cors",
             },
           ],
         ]


### PR DESCRIPTION
Issue: it's `mode: 'no-cors'` not `cors: 'no-cors'` - https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
