### PR TITLE
Addon-docs: Fix MDX handling to ignore babel.config.js

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -31,6 +31,7 @@ function createBabelOptions({ babelOptions, mdxBabelOptions, configureJSX }: Bab
   return {
     // don't use the root babelrc by default (users can override this in mdxBabelOptions)
     babelrc: false,
+    configFile: false,
     ...babelOptions,
     ...mdxBabelOptions,
     plugins,


### PR DESCRIPTION
Issue: #8096 

## What I did

Follow-up to #11185 

Turns out babel has both `babelrc: false` AND a separate `configFile: false`

H/T @ghengeveld for the great intuition on this 🔥  self-merging

## How to test

Run in a Vue project with a `babel.config.js`, such as the one in #11422 