### PR TITLE
Composition: Don't show versions dropdown if there are no versions

### DIFF
--- a/lib/ui/src/components/sidebar/RefIndicator.tsx
+++ b/lib/ui/src/components/sidebar/RefIndicator.tsx
@@ -192,7 +192,7 @@ export const RefIndicator = forwardRef<
         </IndicatorClickTarget>
       </WithTooltip>
 
-      {ref.versions ? (
+      {ref.versions && Object.keys(ref.versions).length ? (
         <WithTooltip
           placement="bottom-start"
           trigger="click"


### PR DESCRIPTION
Issue: When metadata.json returns version, but it's an empty object, this causes a dropdown to render with 0 items

## What I did
<img width="250" alt="Screenshot 2020-07-10 at 16 45 23" src="https://user-images.githubusercontent.com/3070389/87167248-f9e6f080-c2cc-11ea-83b4-7a328b624354.png">
<img width="161" alt="Screenshot 2020-07-10 at 16 45 33" src="https://user-images.githubusercontent.com/3070389/87167250-fb181d80-c2cc-11ea-9928-37d7e0062979.png">

This adds a check so see if there is more then 0 items in the list of versions