### PR TITLE
remove z-index on ActionBar

### DIFF
--- a/lib/components/src/ActionBar/ActionBar.tsx
+++ b/lib/components/src/ActionBar/ActionBar.tsx
@@ -9,7 +9,6 @@ const Container = styled.div<{}>(({ theme }) => ({
   maxWidth: '100%',
   display: 'flex',
   background: theme.background.content,
-  zIndex: 1,
 }));
 
 export const ActionButton = styled.button<{ disabled: boolean }>(


### PR DESCRIPTION
A z-index was added to the action bar component in the following pr (#[6759](https://github.com/storybookjs/storybook/commit/5cdf31bc1260a32965ad36debb9ad584b0f204d6))

It looks like they added the z-index to make it work for the panel component but after removing the z-index and testing on storybook it looks like the z-index is not needed.
<img width="584" alt="Screen Shot 2020-07-10 at 12 02 30 PM" src="https://user-images.githubusercontent.com/15275462/87184700-b2993980-c2a5-11ea-9497-e75392ab129e.png">


In my own code base I am using the doc's  preview component to add my story examples in my documentation.  When I am using the preview component to render a modal the actions bar appears above my modal. (due to the z-index)

<img width="231" alt="Screen Shot 2020-07-10 at 11 15 43 AM" src="https://user-images.githubusercontent.com/15275462/87184917-16236700-c2a6-11ea-9add-edaac7b01000.png">

^ you can see it appears above my background as well as on my modal. 



Because the z-index is not necessary and will be a problem when working with popups I am proposing to remove it.


 