### PR TITLE
CLI: replace notes with background in generated examples

### DIFF
--- a/cypress/generated/addon-backgrounds.spec.ts
+++ b/cypress/generated/addon-backgrounds.spec.ts
@@ -1,0 +1,12 @@
+describe('addon-backgrounds', () => {
+  before(() => {
+    cy.visitStorybook();
+  });
+
+  it('should have a dark background', () => {
+    // click on the button
+    cy.navigateToStory('button', 'with custom background');
+
+    cy.getPreviewIframe().should('have.css', 'background-color', 'rgb(51, 51, 51)');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -62,6 +62,13 @@ Cypress.Commands.add('getStoryElement', {}, () => {
     .then((storyRoot) => cy.wrap(storyRoot, { log: false }));
 });
 
+Cypress.Commands.add('getPreviewIframe', {}, () => {
+  cy.log('getPreviewIframe');
+  return cy
+    .get(`#storybook-preview-iframe`, { log: false })
+    .then((iframe) => cy.wrap(iframe, { log: false }));
+});
+
 Cypress.Commands.add('getDocsElement', {}, () => {
   cy.log('getDocsElement');
   return cy

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -10,9 +10,15 @@ declare namespace Cypress {
     visitStorybook(): Chainable<Element>;
 
     /**
+     * Custom command to select the DOM element of the preview iframe in the canvas tab.
+     */
+    getPreviewIframe(): Chainable<Element>;
+
+    /**
      * Custom command to select the DOM element of a story in the canvas tab.
      */
     getStoryElement(): Chainable<Element>;
+
     /**
      * Custom command to select the DOM element of a docs story in the canvas tab.
      */

--- a/lib/cli/src/frameworks/angular/1-Button.stories.ts
+++ b/lib/cli/src/frameworks/angular/1-Button.stories.ts
@@ -24,6 +24,19 @@ Emoji.args = {
   text: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  text: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => ({
   component: Button,
   props: {

--- a/lib/cli/src/frameworks/angular/1-Button.stories.ts
+++ b/lib/cli/src/frameworks/angular/1-Button.stories.ts
@@ -24,8 +24,6 @@ Emoji.args = {
   text: '😀 😎 👍 💯',
 };
 
-Emoji.parameters = { notes: 'My notes on a button with emojis' };
-
 export const TextWithAction = () => ({
   component: Button,
   props: {
@@ -35,7 +33,6 @@ export const TextWithAction = () => ({
 });
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => ({
   component: Button,

--- a/lib/cli/src/frameworks/aurelia/1-Button.stories.ts
+++ b/lib/cli/src/frameworks/aurelia/1-Button.stories.ts
@@ -36,7 +36,6 @@ export const TextWithAction = () => ({
 });
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => ({
   component: Button,

--- a/lib/cli/src/frameworks/aurelia/1-Button.stories.ts
+++ b/lib/cli/src/frameworks/aurelia/1-Button.stories.ts
@@ -27,6 +27,19 @@ Emoji.args = {
   text: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  text: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => ({
   component: Button,
   props: {

--- a/lib/cli/src/frameworks/ember/1-Button.stories.js
+++ b/lib/cli/src/frameworks/ember/1-Button.stories.js
@@ -37,7 +37,6 @@ export const TextWithAction = () => ({
 });
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => ({
   template: hbs`

--- a/lib/cli/src/frameworks/ember/1-Button.stories.js
+++ b/lib/cli/src/frameworks/ember/1-Button.stories.js
@@ -25,6 +25,19 @@ Emoji.args = {
   children: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => ({
   template: hbs`
     <button {{action onClick}}>

--- a/lib/cli/src/frameworks/html/1-Button.stories.js
+++ b/lib/cli/src/frameworks/html/1-Button.stories.js
@@ -27,6 +27,19 @@ Emoji.args = {
   children: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => {
   const btn = document.createElement('button');
   btn.type = 'button';

--- a/lib/cli/src/frameworks/html/1-Button.stories.js
+++ b/lib/cli/src/frameworks/html/1-Button.stories.js
@@ -36,7 +36,6 @@ export const TextWithAction = () => {
 };
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => {
   const btn = document.createElement('button');

--- a/lib/cli/src/frameworks/marko/1-Button.stories.js
+++ b/lib/cli/src/frameworks/marko/1-Button.stories.js
@@ -18,3 +18,16 @@ Text.args = {
   children: 'Button',
   onClick: action('onClick'),
 };
+
+export const WithCustomBackground = ButtonStory.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};

--- a/lib/cli/src/frameworks/mithril/1-Button.stories.js
+++ b/lib/cli/src/frameworks/mithril/1-Button.stories.js
@@ -31,7 +31,6 @@ export const TextWithAction = () => ({
 });
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => ({
   view: () => m(Button, { onclick: linkTo('example-introduction--page') }, 'Go to Welcome Story'),

--- a/lib/cli/src/frameworks/mithril/1-Button.stories.js
+++ b/lib/cli/src/frameworks/mithril/1-Button.stories.js
@@ -26,6 +26,19 @@ Emoji.args = {
   children: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => ({
   view: () => m(Button, { onclick: () => action('This was clicked')() }, 'Trigger Action'),
 });

--- a/lib/cli/src/frameworks/preact/1-Button.stories.js
+++ b/lib/cli/src/frameworks/preact/1-Button.stories.js
@@ -31,7 +31,6 @@ export const TextWithAction = () => (
 );
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => (
   <Button onClick={linkTo('example-introduction--page')}>Go to Welcome Story</Button>

--- a/lib/cli/src/frameworks/preact/1-Button.stories.js
+++ b/lib/cli/src/frameworks/preact/1-Button.stories.js
@@ -26,6 +26,19 @@ Emoji.args = {
   children: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => (
   <Button onClick={() => action('This was clicked')()}>Trigger Action</Button>
 );

--- a/lib/cli/src/frameworks/rax/1-Button.stories.js
+++ b/lib/cli/src/frameworks/rax/1-Button.stories.js
@@ -35,7 +35,6 @@ export const TextWithAction = () => (
 );
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => (
   <button onClick={linkTo('example-introduction--page')} type="button">

--- a/lib/cli/src/frameworks/rax/1-Button.stories.js
+++ b/lib/cli/src/frameworks/rax/1-Button.stories.js
@@ -28,6 +28,19 @@ Emoji.args = {
   children: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => (
   <button onClick={() => action('This was clicked')()} type="button">
     <RaxText>Trigger Action</RaxText>

--- a/lib/cli/src/frameworks/react/js/1-Button.stories.js
+++ b/lib/cli/src/frameworks/react/js/1-Button.stories.js
@@ -27,7 +27,6 @@ Emoji.args = {
     </span>
   ),
 };
-Emoji.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => (
   <Button onClick={linkTo('example-introduction--page')}>Go to Welcome Story</Button>

--- a/lib/cli/src/frameworks/react/js/1-Button.stories.js
+++ b/lib/cli/src/frameworks/react/js/1-Button.stories.js
@@ -28,6 +28,19 @@ Emoji.args = {
   ),
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const ButtonWithLinkToAnotherStory = () => (
   <Button onClick={linkTo('example-introduction--page')}>Go to Welcome Story</Button>
 );

--- a/lib/cli/src/frameworks/react/ts/1-Button.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/1-Button.stories.tsx
@@ -23,6 +23,19 @@ Emoji.args = {
   ),
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const ButtonWithLinkToAnotherStory = () => (
   <Button onClick={linkTo('example-introduction--page')}>Go to Welcome Story</Button>
 );

--- a/lib/cli/src/frameworks/react/ts/1-Button.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/1-Button.stories.tsx
@@ -22,7 +22,6 @@ Emoji.args = {
     </span>
   ),
 };
-Emoji.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => (
   <Button onClick={linkTo('example-introduction--page')}>Go to Welcome Story</Button>

--- a/lib/cli/src/frameworks/riot/1-Button.stories.js
+++ b/lib/cli/src/frameworks/riot/1-Button.stories.js
@@ -26,6 +26,19 @@ Emoji.args = {
   content: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  content: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const WithScenario = () => ({
   tags: [{ content: MyButtonRaw, boundAs: 'MyButton' }],
   template: '<MyButton>With scenario</MyButton>',

--- a/lib/cli/src/frameworks/svelte/1-button.stories.js
+++ b/lib/cli/src/frameworks/svelte/1-button.stories.js
@@ -41,7 +41,6 @@ export const TextWithAction = () => ({
 });
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => ({
   Component: Button,

--- a/lib/cli/src/frameworks/svelte/1-button.stories.js
+++ b/lib/cli/src/frameworks/svelte/1-button.stories.js
@@ -30,6 +30,19 @@ Emoji.args = {
   text: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  text: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => ({
   Component: Button,
   props: {

--- a/lib/cli/src/frameworks/vue/1-Button.stories.js
+++ b/lib/cli/src/frameworks/vue/1-Button.stories.js
@@ -32,7 +32,6 @@ export const TextWithAction = () => ({
 });
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => ({
   components: { MyButton },

--- a/lib/cli/src/frameworks/vue/1-Button.stories.js
+++ b/lib/cli/src/frameworks/vue/1-Button.stories.js
@@ -25,6 +25,19 @@ Emoji.args = {
   children: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => ({
   components: { MyButton },
   template: '<my-button @click="action">Trigger Action</my-button>',

--- a/lib/cli/src/frameworks/web-components/1-Button.stories.js
+++ b/lib/cli/src/frameworks/web-components/1-Button.stories.js
@@ -26,6 +26,19 @@ Emoji.args = {
   children: '😀 😎 👍 💯',
 };
 
+export const WithCustomBackground = Template.bind({});
+WithCustomBackground.args = {
+  children: 'Defined via addon-backgrounds!',
+};
+
+WithCustomBackground.storyName = 'With custom background';
+
+WithCustomBackground.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const TextWithAction = () => html`
   <button @click=${() => action('This was clicked')()}>
     Trigger Action

--- a/lib/cli/src/frameworks/web-components/1-Button.stories.js
+++ b/lib/cli/src/frameworks/web-components/1-Button.stories.js
@@ -33,7 +33,6 @@ export const TextWithAction = () => html`
 `;
 
 TextWithAction.storyName = 'With an action';
-TextWithAction.parameters = { notes: 'My notes on a button with emojis' };
 
 export const ButtonWithLinkToAnotherStory = () => html`<button
   @click=${linkTo('example-introduction--page')}


### PR DESCRIPTION
Issue: #10796 

## What I did

In this PR I introduce two things, done together for convenience:
1 - Removal of notes addon, given that it's deprecated in favor of docs.
2 - Addition of backgrounds usage so we can still have a story using parameters.

## How to test

Modify `scripts/run-e2e.ts` under `initStorybook`:
```
await exec(`node ../../storybook/lib/cli/dist/generate init`, { cwd });
// await exec(`npx -p @storybook/cli sb init --yes ${type}`, { cwd });
```

Then run:
```
yarn test:e2e-framework react   (or other framework of your choice)
```

From there you can access http://localhost:4000/?path=/story/button--with-custom-background and see it. 

- Is this testable with Jest or Chromatic screenshots?
Yes
