### PR TITLE
Storyshots: Fix metadata (parameters/decorators) handling

### DIFF
--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -33,6 +33,20 @@ Now run your Jest test command. (Usually, `npm test`.) Then you can see all of y
 
 ![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/HEAD/addons/storyshots/storyshots-core/docs/storyshots.png)
 
+### Testing stories that rely on addon-added decorators
+
+If you have stories in your Storybook that can only render inside a decorator (for instance the [`apollo-storybook-decorator`](https://github.com/abhiaiyer91/apollo-storybook-decorator)), you'll need to ensure those decorators are applied in Storyshots.
+
+If you export those decorators from your `.storybook/preview.js` then Storyshots will apply those decorators for you in the same way that Storybook does. However if the addon _automatically_ adds the decorator for you (which is a new feature in Storybook 6.0), you will find the decorator does not get added in Storyshots. This is a limitation in Storyshots currently.
+
+To ensure such decorators get added, simply ensure you export them from `.storybook/preview.js`:
+
+```js
+import addonDecorator from 'some-addon';
+
+export const decorators = [addonDecorator];
+```
+
 ## Configure your app for Jest
 
 In many cases, for example Create React App, it's already configured for Jest. You need to create a filename with the extension `.test.js`.

--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -39,7 +39,7 @@ If you have stories in your Storybook that can only render inside a decorator (f
 
 If you export those decorators from your `.storybook/preview.js` then Storyshots will apply those decorators for you in the same way that Storybook does. However if the addon _automatically_ adds the decorator for you (which is a new feature in Storybook 6.0), you will find the decorator does not get added in Storyshots. This is a limitation in Storyshots currently.
 
-To ensure such decorators get added, simply ensure you export them from `.storybook/preview.js`:
+To ensure such decorators get added, export them from `.storybook/preview.js`:
 
 ```js
 import addonDecorator from 'some-addon';

--- a/addons/storyshots/storyshots-core/src/frameworks/Loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/Loader.ts
@@ -12,6 +12,7 @@ export interface ClientApi extends ClientStoryApi<unknown> {
   getStorybook: ClientApiThing['getStorybook'];
   setAddon: ClientApiThing['setAddon'];
   raw: ClientApiThing['raw'];
+  addArgTypesEnhancer: ClientApiThing['addArgTypesEnhancer'];
 }
 
 export interface Loader {

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { toRequireContext } from '@storybook/core/server';
 import registerRequireContextHook from 'babel-plugin-require-context-hook/register';
 import global from 'global';
+import { ArgTypesEnhancer, DecoratorFunction } from '@storybook/client-api';
+
 import { ClientApi } from './Loader';
 import { StoryshotsOptions } from '../api/StoryshotsOptions';
 
@@ -17,8 +19,8 @@ const isFile = (file: string): boolean => {
 };
 
 interface Output {
-  stories: string[];
-  files: string[];
+  preview?: string;
+  stories?: string[];
 }
 
 const supportedExtensions = ['ts', 'tsx', 'js', 'jsx'];
@@ -39,13 +41,13 @@ function getConfigPathParts(input: string): Output {
   const configDir = path.resolve(input);
 
   if (fs.lstatSync(configDir).isDirectory()) {
-    const output: Output = { files: [], stories: [] };
+    const output: Output = {};
 
     const preview = getPreviewFile(configDir);
     const main = getMainFile(configDir);
 
     if (preview) {
-      output.files.push(preview);
+      output.preview = preview;
     }
     if (main) {
       const { stories = [] } = jest.requireActual(main);
@@ -64,7 +66,7 @@ function getConfigPathParts(input: string): Output {
     return output;
   }
 
-  return { files: [configDir], stories: [] };
+  return { preview: configDir };
 }
 
 function configure(
@@ -79,11 +81,26 @@ function configure(
     return;
   }
 
-  const { files, stories } = getConfigPathParts(configPath);
+  const { preview, stories } = getConfigPathParts(configPath);
 
-  files.forEach((f) => {
-    jest.requireActual(f);
-  });
+  if (preview) {
+    // This is essentially the same code as lib/core/src/server/preview/virtualModuleEntry.template
+    const { parameters, decorators, globals, globalTypes, argTypesEnhancers } = jest.requireActual(
+      preview
+    );
+
+    if (decorators) {
+      decorators.forEach((decorator: DecoratorFunction) => storybook.addDecorator(decorator));
+    }
+    if (parameters || globals || globalTypes) {
+      storybook.addParameters({ ...parameters, globals, globalTypes });
+    }
+    if (argTypesEnhancers) {
+      argTypesEnhancers.forEach((enhancer: ArgTypesEnhancer) =>
+        storybook.addArgTypesEnhancer(enhancer)
+      );
+    }
+  }
 
   if (stories && stories.length) {
     storybook.configure(stories, false);

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.metadata.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.metadata.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Text Simple 1`] = `"contents"`;

--- a/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.metadata.test.js.snap
+++ b/addons/storyshots/storyshots-core/stories/__snapshots__/storyshot.metadata.test.js.snap
@@ -1,3 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Text Simple 1`] = `"contents"`;
+exports[`Storyshots Text Simple 1`] = `
+<div>
+  prefix
+   
+  contents
+   
+  suffix
+</div>
+`;

--- a/addons/storyshots/storyshots-core/stories/exported_metadata/Text.stories.js
+++ b/addons/storyshots/storyshots-core/stories/exported_metadata/Text.stories.js
@@ -1,0 +1,5 @@
+export default {
+  title: 'Text',
+};
+
+export const Simple = () => 'contents';

--- a/addons/storyshots/storyshots-core/stories/exported_metadata/main.js
+++ b/addons/storyshots/storyshots-core/stories/exported_metadata/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+  stories: ['./Text.stories.js'],
+};

--- a/addons/storyshots/storyshots-core/stories/exported_metadata/preview.js
+++ b/addons/storyshots/storyshots-core/stories/exported_metadata/preview.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const decorators = [
+  (StoryFn, { parameters, globals }) => (
+    <div>
+      {parameters.prefix} <StoryFn /> {globals.suffix}
+    </div>
+  ),
+];
+
+export const parameters = { prefix: 'prefix' };
+export const globals = { suffix: 'suffix' };

--- a/addons/storyshots/storyshots-core/stories/storyshot.metadata.test.js
+++ b/addons/storyshots/storyshots-core/stories/storyshot.metadata.test.js
@@ -1,0 +1,9 @@
+import path from 'path';
+import initStoryshots from '../dist';
+
+// jest.mock('@storybook/node-logger');
+
+initStoryshots({
+  framework: 'react',
+  configPath: path.join(__dirname, 'exported_metadata'),
+});

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
@@ -5,6 +5,9 @@ exports[`Storyshots Core/Parameters passed to story 1`] = `
   Parameters are 
   <pre>
     {
+  "docs": {
+    "iframeHeight": "60px"
+  },
   "globalParameter": "globalParameter",
   "framework": "vue",
   "chapterParameter": "chapterParameter",

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/custom-decorators.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/custom-decorators.stories.storyshot
@@ -48,6 +48,9 @@ exports[`Storyshots Custom/Decorator for Vue With Data 1`] = `
   "name": "With Data",
   "story": "With Data",
   "parameters": {
+    "docs": {
+      "iframeHeight": "60px"
+    },
     "globalParameter": "globalParameter",
     "framework": "vue",
     "argTypes": {},


### PR DESCRIPTION
Issue: #11488 

Now you can export parameters + decorators in `preview.js` we need to ensure we handle it in Storyshots

## What I did

Basically duplicated the template in storyshots + added a test

## How to test

- Is this testable with Jest or Chromatic screenshots?

Yes, see new test

## IMPORTANT NOTE:

This is related to https://github.com/storybookjs/storybook/pull/11478 -- as in that case, if a story relies on a decorator added automatically by an addon this will *NOT* apply in storyshots.

Probably the solution is to re-import/export the decorator in `preview.js`, something like:

```js
import { addFooDecorator } from 'some-addon';

const decorators;
if ( /* is storyshots */) {
  decorators.push(addFooDecorator);
}

export decorators;
```

