### PR TITLE
Core: Improve translation of globs for main.js stories

### DIFF
--- a/lib/core/src/server/preview/to-require-context.test.js
+++ b/lib/core/src/server/preview/to-require-context.test.js
@@ -120,6 +120,32 @@ const testCases = [
       '../src/stories/components/Icon/Icon.tsx',
     ],
   },
+  {
+    glob: '../components/*/*.stories.js',
+    validPaths: ['../components/icon/Icon.stories.js'],
+    invalidPaths: [
+      '../components/icon/node_modules/icon/Icon.stories.js',
+      './stories.js',
+      './src/stories/Icon.stories.js',
+      './Icon.stories.js',
+      '../src/Icon.stories.mdx',
+      '../src/stories/components/Icon/Icon.stories.ts',
+      '../src/stories/components/Icon/Icon.mdx',
+    ],
+  },
+  {
+    glob: '../components/*/stories/*.js',
+    validPaths: ['../components/icon/stories/Icon.js'],
+    invalidPaths: [
+      '../components/icon/node_modules/icon/stories/Icon.js',
+      './stories.js',
+      './src/stories/Icon.stories.js',
+      './Icon.stories.js',
+      '../src/Icon.stories.mdx',
+      '../src/stories/components/Icon/Icon.stories.ts',
+      '../src/stories/components/Icon/Icon.mdx',
+    ],
+  },
 ];
 
 describe('toRequireContext', () => {

--- a/lib/core/src/server/preview/to-require-context.test.js
+++ b/lib/core/src/server/preview/to-require-context.test.js
@@ -164,10 +164,10 @@ describe('toRequireContext', () => {
         return baseIncluded && matched;
       }
 
-      const isMatchedForValidPaths = validPaths.filter((filePath) => !isMatched(filePath));
+      const isNotMatchedForValidPaths = validPaths.filter((filePath) => !isMatched(filePath));
       const isMatchedForInvalidPaths = invalidPaths.filter((filePath) => !!isMatched(filePath));
 
-      expect(isMatchedForValidPaths).toEqual([]);
+      expect(isNotMatchedForValidPaths).toEqual([]);
       expect(isMatchedForInvalidPaths).toEqual([]);
     });
   });

--- a/lib/core/src/server/preview/to-require-context.ts
+++ b/lib/core/src/server/preview/to-require-context.ts
@@ -32,13 +32,14 @@ export const toRequireContext = (input: any) => {
       const { base, glob } = globBase(fixedInput);
 
       const recursive = glob.includes('**') || glob.split('/').length > 2;
-      const indicator = glob.replace(/^(\*\*\/)*/, '');
-      const regex = makeRe(indicator, { fastpaths: false, noglobstar: false, bash: true });
+      const regex = makeRe(glob, { fastpaths: false, noglobstar: false, bash: false });
       const { source } = regex;
 
       if (source.startsWith('^')) {
-        // prepended '^' char causes webpack require.context to fail
-        const match = source.substring(1);
+        // webpack's require.context matches against paths starting `./`
+        // Globs starting `**` require special treatment due to the regex they
+        // produce, specifically a negative look-ahead
+        const match = ['^\\.', glob.startsWith('**') ? '' : '/', source.substring(1)].join('');
 
         return { path: base, recursive, match };
       }

--- a/lib/core/src/server/preview/to-require-context.ts
+++ b/lib/core/src/server/preview/to-require-context.ts
@@ -31,7 +31,7 @@ export const toRequireContext = (input: any) => {
     case typeof input === 'string': {
       const { base, glob } = globBase(fixedInput);
 
-      const recursive = glob.startsWith('**');
+      const recursive = glob.includes('**') || glob.split('/').length > 2;
       const indicator = glob.replace(/^(\*\*\/)*/, '');
       const regex = makeRe(indicator, { fastpaths: false, noglobstar: false, bash: true });
       const { source } = regex;

--- a/lib/core/src/server/preview/to-require-context.ts
+++ b/lib/core/src/server/preview/to-require-context.ts
@@ -39,7 +39,7 @@ export const toRequireContext = (input: any) => {
         // webpack's require.context matches against paths starting `./`
         // Globs starting `**` require special treatment due to the regex they
         // produce, specifically a negative look-ahead
-        const match = ['^\\.', glob.startsWith('**') ? '' : '/', source.substring(1)].join('');
+        const match = ['^\\.', glob.startsWith('**') ? '' : '\\/', source.substring(1)].join('');
 
         return { path: base, recursive, match };
       }


### PR DESCRIPTION
~~This PR should probably not be merged.~~ I've raised it to point out a failure in the globbing used by Storybook. However, it would seem that this is due to a bug in the underlying 'micromatch' library.

**Update:** A work-around has been added to fix the tests.

It adds a test case (that fails) for conservative globbing that matches
with wildcards, `*` rather than globstars, `**`.

An item is erroneously matched due what appears to be a bug in the
underlying micromatch package.

For convenience, here are the test failures:
```
Summary of all failing tests
 FAIL  lib/core/src/server/preview/to-require-context.test.js
  ● toRequireContext › matches only suitable paths - ../components/*/*.stories.js

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 3

    - Array []
    + Array [
    +   "../components/icon/node_modules/icon/Icon.stories.js",
    + ]

      169 | 
      170 |       expect(isNotMatchedForValidPaths).toEqual([]);
    > 171 |       expect(isMatchedForInvalidPaths).toEqual([]);
          |                                        ^
      172 |     });
      173 |   });
      174 | });

      at Object.<anonymous> (lib/core/src/server/preview/to-require-context.test.js:171:40)

  ● toRequireContext › matches only suitable paths - ../components/*/stories/*.js

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 3

    - Array []
    + Array [
    +   "../components/icon/node_modules/icon/stories/Icon.js",
    + ]

      169 | 
      170 |       expect(isNotMatchedForValidPaths).toEqual([]);
    > 171 |       expect(isMatchedForInvalidPaths).toEqual([]);
          |                                        ^
      172 |     });
      173 |   });
      174 | });

      at Object.<anonymous> (lib/core/src/server/preview/to-require-context.test.js:171:40)
```