### PR TITLE
Remove all ts-ignore in vue, tighten typings

### DIFF
--- a/app/angular/src/client/preview/index.ts
+++ b/app/angular/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 import { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
@@ -18,7 +18,7 @@ interface ClientApi extends ClientStoryApi<StoryFnAngularReturnType> {
   load: (...args: any[]) => void;
 }
 
-const api = start(render);
+const api = client.start(render);
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
@@ -27,8 +27,10 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 };
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
-export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
-export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
+export const addDecorator: ClientApi['addDecorator'] = api.clientApi
+  .addDecorator as ClientApi['addDecorator'];
+export const addParameters: ClientApi['addParameters'] = api.clientApi
+  .addParameters as ClientApi['addParameters'];
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;
 export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;

--- a/app/aurelia/src/client/preview/index.ts
+++ b/app/aurelia/src/client/preview/index.ts
@@ -1,6 +1,6 @@
 import { Constructable, CustomElement } from 'aurelia';
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 import { ClientStoryApi, Loadable } from '@storybook/addons';
 import { text, boolean, number, date } from '@storybook/addon-knobs';
 
@@ -21,7 +21,7 @@ interface ClientApi extends ClientStoryApi<Partial<StoryFnAureliaReturnType>> {
   load: (...args: any[]) => void;
 }
 
-const api = start(render);
+const api = client.start(render);
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
@@ -32,8 +32,10 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 export { StoryFnAureliaReturnType, addRegistries, addContainer, Component, addComponents };
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
-export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
-export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
+export const addDecorator: ClientApi['addDecorator'] = api.clientApi
+  .addDecorator as ClientApi['addDecorator'];
+export const addParameters: ClientApi['addParameters'] = api.clientApi
+  .addParameters as ClientApi['addParameters'];
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;
 export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;

--- a/app/aurelia/src/client/preview/render.ts
+++ b/app/aurelia/src/client/preview/render.ts
@@ -8,23 +8,22 @@ import {
   Constructable,
   IViewModel,
 } from 'aurelia';
-import { RenderMainArgs } from './types';
+import { RenderContext } from '@storybook/core';
+import { StoryFnAureliaReturnType } from './types';
 import { generateKnobsFor } from '.';
 
 const host = document.getElementById('root'); // the root iframe provided by storybook
 let previousAurelia: Aurelia;
 export default async function render({
   storyFn,
-  selectedKind,
-  selectedStory,
   showMain,
   showError,
-}: RenderMainArgs) {
+}: RenderContext<Partial<StoryFnAureliaReturnType>>) {
   const element = storyFn();
 
   if (!element) {
     showError({
-      title: `Expecting an Aurelia component from the story: "${selectedStory}" of "${selectedKind}".`,
+      title: `Expecting an Aurelia component from the story.`,
       description: `
         Did you forget to return the Aurelia component from the story?
         Use "() => ({ template: '<custom-component></custom-component>' })" when defining the story.

--- a/app/ember/src/client/preview/index.ts
+++ b/app/ember/src/client/preview/index.ts
@@ -1,9 +1,9 @@
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 
 import './globals';
 import render from './render';
 
-const { configure: coreConfigure, clientApi, forceReRender } = start(render);
+const { configure: coreConfigure, clientApi, forceReRender } = client.start(render);
 
 export const {
   setAddon,
@@ -15,8 +15,9 @@ export const {
 } = clientApi;
 
 const framework = 'ember';
-export const storiesOf = (...args: any) =>
-  clientApi.storiesOf(...args).addParameters({ framework });
-export const configure = (...args: any) => coreConfigure(framework, ...args);
+export const storiesOf = (kind: string, m: NodeModule) =>
+  clientApi.storiesOf(kind, m).addParameters({ framework });
+export const configure = (loadable: any, m: NodeModule, showDeprecationWarning?: boolean) =>
+  coreConfigure(framework, loadable, m, showDeprecationWarning);
 
 export { forceReRender };

--- a/app/ember/src/client/preview/render.ts
+++ b/app/ember/src/client/preview/render.ts
@@ -57,7 +57,13 @@ function render(options: OptionsArgs, el: ElementArgs) {
     });
 }
 
-export default function renderMain({ storyFn, kind, name, showMain, showError }: RenderContext) {
+export default function renderMain({
+  storyFn,
+  kind,
+  name,
+  showMain,
+  showError,
+}: RenderContext<OptionsArgs>) {
   const element = storyFn();
 
   if (!element) {

--- a/app/html/src/client/preview/index.ts
+++ b/app/html/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 import { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
@@ -17,7 +17,7 @@ interface ClientApi extends ClientStoryApi<StoryFnHtmlReturnType> {
   raw: () => any; // todo add type
 }
 
-const api = start(render);
+const api = client.start(render);
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
@@ -26,8 +26,10 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 };
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
-export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
-export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
+export const addDecorator: ClientApi['addDecorator'] = api.clientApi
+  .addDecorator as ClientApi['addDecorator'];
+export const addParameters: ClientApi['addParameters'] = api.clientApi
+  .addParameters as ClientApi['addParameters'];
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;
 export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;

--- a/app/marionette/src/client/preview/index.js
+++ b/app/marionette/src/client/preview/index.js
@@ -1,9 +1,9 @@
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 
 import './globals';
 import render from './render';
 
-const { load: coreLoad, clientApi, configApi, forceReRender } = start(render);
+const { load: coreLoad, clientApi, configApi, forceReRender } = client.start(render);
 
 export const {
   setAddon,

--- a/app/marko/src/client/preview/index.js
+++ b/app/marko/src/client/preview/index.js
@@ -1,9 +1,9 @@
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 
 import './globals';
 import render from './render';
 
-const { configure: coreConfigure, clientApi, forceReRender } = start(render);
+const { configure: coreConfigure, clientApi, forceReRender } = client.start(render);
 
 export const {
   setAddon,

--- a/app/mithril/src/client/preview/index.ts
+++ b/app/mithril/src/client/preview/index.ts
@@ -1,4 +1,4 @@
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 
 import './globals';
 import { ClientStoryApi, Loadable } from '@storybook/addons';
@@ -6,7 +6,7 @@ import render from './render';
 
 import { IStorybookSection, StoryFnMithrilReturnType } from './types';
 
-const { configure: coreConfigure, clientApi, forceReRender } = start(render);
+const { configure: coreConfigure, clientApi, forceReRender } = client.start(render);
 
 const framework = 'mithril';
 

--- a/app/mithril/src/client/preview/render.ts
+++ b/app/mithril/src/client/preview/render.ts
@@ -1,14 +1,20 @@
 import { document } from 'global';
 /** @jsx m */
 
-import m from 'mithril';
+import m, { ComponentTypes } from 'mithril';
 import dedent from 'ts-dedent';
 
 import { RenderContext } from './types';
 
 const rootEl = document.getElementById('root');
 
-export default function renderMain({ storyFn, kind, name, showMain, showError }: RenderContext) {
+export default function renderMain({
+  storyFn,
+  kind,
+  name,
+  showMain,
+  showError,
+}: RenderContext<ComponentTypes>) {
   const element = storyFn();
 
   if (!element) {

--- a/app/preact/src/client/preview/index.ts
+++ b/app/preact/src/client/preview/index.ts
@@ -1,12 +1,12 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 
 import './globals';
 import render from './render';
 import { ClientApi } from './types';
 
 const framework = 'preact';
-const api = start(render);
+const api = client.start(render);
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
@@ -15,8 +15,10 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 };
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
-export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
-export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
+export const addDecorator: ClientApi['addDecorator'] = api.clientApi
+  .addDecorator as ClientApi['addDecorator'];
+export const addParameters: ClientApi['addParameters'] = api.clientApi
+  .addParameters as ClientApi['addParameters'];
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;
 export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;

--- a/app/preact/src/client/preview/render.tsx
+++ b/app/preact/src/client/preview/render.tsx
@@ -18,7 +18,13 @@ function preactRender(element: StoryFnPreactReturnType | null): void {
   }
 }
 
-export default function renderMain({ storyFn, kind, name, showMain, showError }: RenderContext) {
+export default function renderMain({
+  storyFn,
+  kind,
+  name,
+  showMain,
+  showError,
+}: RenderContext<StoryFnPreactReturnType>) {
   const element = storyFn();
 
   if (!element) {

--- a/app/rax/src/client/preview/index.js
+++ b/app/rax/src/client/preview/index.js
@@ -1,9 +1,9 @@
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 
 import './globals';
 import render from './render';
 
-const { configure: coreConfigure, clientApi, forceReRender } = start(render);
+const { configure: coreConfigure, clientApi, forceReRender } = client.start(render);
 
 export const {
   setAddon,

--- a/app/react/src/client/preview/index.ts
+++ b/app/react/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 import { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
@@ -17,7 +17,7 @@ interface ClientApi extends ClientStoryApi<StoryFnReactReturnType> {
   raw: () => any; // todo add type
 }
 
-const api = start(render);
+const api = client.start(render);
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
@@ -26,9 +26,11 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 };
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
-export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
+export const addDecorator: ClientApi['addDecorator'] = api.clientApi
+  .addDecorator as ClientApi['addDecorator'];
 export type DecoratorFn = Parameters<typeof addDecorator>[0];
-export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
+export const addParameters: ClientApi['addParameters'] = api.clientApi
+  .addParameters as ClientApi['addParameters'];
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;
 export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;

--- a/app/riot/src/client/preview/index.js
+++ b/app/riot/src/client/preview/index.js
@@ -1,11 +1,11 @@
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 
 import './globals';
 import riot, { tag2, mount as vendorMount } from 'riot';
 import render from './render';
 import { compileNow as unboundCompileNow, asCompiledCode } from './compileStageFunctions';
 
-const { configure: coreConfigure, clientApi, forceReRender } = start(render);
+const { configure: coreConfigure, clientApi, forceReRender } = client.start(render);
 
 export const {
   setAddon,

--- a/app/server/src/client/index.ts
+++ b/app/server/src/client/index.ts
@@ -5,7 +5,6 @@ export {
   addParameters,
   configure,
   getStorybook,
-  forceReRender,
   raw,
 } from './preview';
 

--- a/app/server/src/client/preview/index.ts
+++ b/app/server/src/client/preview/index.ts
@@ -1,4 +1,4 @@
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 import { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
@@ -16,7 +16,7 @@ interface ClientApi extends ClientStoryApi<StoryFnServerReturnType> {
   raw: () => any; // todo add type
 }
 
-const api = start(render);
+const api = client.start(render);
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
@@ -28,7 +28,7 @@ const setRenderFetchAndConfigure: ClientApi['configure'] = (loader, module, opti
   if (options && options.fetchStoryHtml) {
     setFetchStoryHtml(options.fetchStoryHtml);
   }
-  api.configure(loader, module, framework);
+  api.configure(framework, loader, module);
 };
 
 export const configure: ClientApi['configure'] = setRenderFetchAndConfigure;
@@ -37,7 +37,6 @@ export const {
   addParameters,
   clearDecorators,
   setAddon,
-  forceReRender,
   getStorybook,
   raw,
 } = api.clientApi;

--- a/app/server/src/client/preview/render.ts
+++ b/app/server/src/client/preview/render.ts
@@ -21,7 +21,7 @@ export async function renderMain({
   showError,
   forceRender,
   parameters,
-}: RenderContext) {
+}: RenderContext<Record<string, string>>) {
   const storyParams = storyFn();
 
   const {

--- a/app/svelte/src/client/preview/index.ts
+++ b/app/svelte/src/client/preview/index.ts
@@ -1,9 +1,9 @@
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 
 import './globals';
 import render from './render';
 
-const { configure: coreConfigure, clientApi, forceReRender } = start(render);
+const { configure: coreConfigure, clientApi, forceReRender } = client.start(render);
 
 export const {
   setAddon,
@@ -15,8 +15,9 @@ export const {
 } = clientApi;
 
 const framework = 'svelte';
-export const storiesOf = (...args: any) =>
-  clientApi.storiesOf(...args).addParameters({ framework });
-export const configure = (...args: any) => coreConfigure(framework, ...args);
+export const storiesOf = (kind: string, m: NodeModule) =>
+  clientApi.storiesOf(kind, m).addParameters({ framework });
+export const configure = (loadable: any, m: NodeModule, showDeprecationWarning?: boolean) =>
+  coreConfigure(framework, loadable, m, showDeprecationWarning);
 
 export { forceReRender };

--- a/app/svelte/src/client/preview/render.ts
+++ b/app/svelte/src/client/preview/render.ts
@@ -73,7 +73,13 @@ function mountView({ Component, target, props, on, Wrapper, WrapperData }: Mount
   previousComponent = component;
 }
 
-export default function render({ storyFn, kind, name, showMain, showError }: RenderContext) {
+export default function render({
+  storyFn,
+  kind,
+  name,
+  showMain,
+  showError,
+}: RenderContext<MountViewArgs>) {
   const {
     /** @type {SvelteComponent} */
     Component,

--- a/app/vue/.eslintrc.js
+++ b/app/vue/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 'error',
+      },
+    },
+  ],
+};

--- a/app/vue/src/client/preview/globals.ts
+++ b/app/vue/src/client/preview/globals.ts
@@ -1,4 +1,18 @@
 import { window } from 'global';
 
+declare global {
+  interface Window {
+    /**
+     * Unused in @storybook/vue.
+     */
+    STORYBOOK_REACT_CLASSES: Record<string, any>;
+
+    /**
+     * Current environment storybook is running in.
+     */
+    STORYBOOK_ENV: string;
+  }
+}
+
 window.STORYBOOK_REACT_CLASSES = {};
 window.STORYBOOK_ENV = 'vue';

--- a/app/vue/src/client/preview/render.ts
+++ b/app/vue/src/client/preview/render.ts
@@ -1,18 +1,15 @@
 import dedent from 'ts-dedent';
-import Vue from 'vue';
-import { RenderContext } from './types';
-
-export const COMPONENT = 'STORYBOOK_COMPONENT';
-export const VALUES = 'STORYBOOK_VALUES';
+import Vue, { VNode, VueConstructor, FunctionalComponentOptions } from 'vue';
+import { RenderContext, COMPONENT, VALUES } from './types';
 
 const root = new Vue({
-  data() {
+  data(): Record<string, any> {
     return {
       [COMPONENT]: undefined,
       [VALUES]: {},
     };
   },
-  render(h) {
+  render(h): VNode {
     const children = this[COMPONENT] ? [h(this[COMPONENT])] : undefined;
     return h('div', { attrs: { id: 'root' } }, children);
   },
@@ -27,7 +24,7 @@ export default function render({
   showError,
   showException,
   forceRender,
-}: RenderContext) {
+}: RenderContext<VueConstructor>): void {
   Vue.config.errorHandler = showException;
 
   // FIXME: move this into root[COMPONENT] = element
@@ -53,8 +50,7 @@ export default function render({
     root[COMPONENT] = element;
   }
 
-  // @ts-ignore https://github.com/storybookjs/storrybook/pull/7578#discussion_r307986139
-  root[VALUES] = { ...element.options[VALUES], ...args };
+  root[VALUES] = { ...(element.options as FunctionalComponentOptions)[VALUES], ...args };
 
   if (!root.$el) {
     root.$mount('#root');

--- a/app/vue/src/client/preview/types.ts
+++ b/app/vue/src/client/preview/types.ts
@@ -1,4 +1,4 @@
-import { Component } from 'vue';
+import { VueConstructor } from 'vue';
 
 export { RenderContext } from '@storybook/core';
 
@@ -7,8 +7,10 @@ export interface ShowErrorArgs {
   description: string;
 }
 
-// TODO: some vue expert needs to look at this
-export type StoryFnVueReturnType = string | Component;
+/** Any options that can be passed into Vue.extend */
+export type VueOptions = Exclude<Parameters<VueConstructor['extend']>[0], undefined>;
+
+export type StoryFnVueReturnType = string | VueConstructor | VueOptions;
 
 export interface IStorybookStory {
   name: string;
@@ -19,3 +21,7 @@ export interface IStorybookSection {
   kind: string;
   stories: IStorybookStory[];
 }
+
+export const WRAPS = 'STORYBOOK_WRAPS';
+export const COMPONENT = 'STORYBOOK_COMPONENT';
+export const VALUES = 'STORYBOOK_VALUES';

--- a/app/vue/src/client/preview/util.ts
+++ b/app/vue/src/client/preview/util.ts
@@ -1,23 +1,38 @@
 import { VueConstructor } from 'vue';
+import { PropValidator } from 'vue/types/options';
 
-function getType(fn: Function) {
-  const match = fn && fn.toString().match(/^\s*function (\w+)/);
+function getType(fn?: Function): string {
+  const match = fn?.toString().match(/^\s*function (\w+)/);
   return match ? match[1] : '';
 }
 
-// https://github.com/vuejs/vue/blob/dev/src/core/util/props.js#L92
-function resolveDefault({ type, default: def }: any) {
-  if (typeof def === 'function' && getType(type) !== 'Function') {
-    // known limitation: we don't have the component instance to pass
-    return def.call();
+/**
+ * Extracts the default value of a prop
+ * Also see https://github.com/vuejs/vue/blob/dev/src/core/util/props.js#L92
+ */
+function resolveDefault<T>(validator: PropValidator<T>): T | null | undefined {
+  if (typeof validator === 'function' || Array.isArray(validator)) {
+    return undefined;
   }
 
-  return def;
+  const canTakeFunctionProp = Array.isArray(validator.type)
+    ? validator.type.some((t) => getType(t) === 'Function')
+    : getType(validator.type) === 'Function';
+
+  if (typeof validator.default === 'function' && canTakeFunctionProp) {
+    // known limitation: we don't have the component instance to pass
+    return (validator.default as () => T | null | undefined)();
+  }
+
+  return validator.default as T | null | undefined;
 }
 
-export function extractProps(component: VueConstructor) {
-  // @ts-ignore this options business seems not good according to the types
-  return Object.entries(component.options.props || {})
+/** Extracts the default values for all props in a component */
+export function extractProps(component: VueConstructor): Record<string, unknown> {
+  if (Array.isArray(component.options.props)) {
+    return component.options.props.reduce((wrap, prop) => ({ ...wrap, [prop]: undefined }), {});
+  }
+  return Object.entries(component.options.props ?? {})
     .map(([name, prop]) => ({ [name]: resolveDefault(prop) }))
     .reduce((wrap, prop) => ({ ...wrap, ...prop }), {});
 }

--- a/app/vue/src/global.d.ts
+++ b/app/vue/src/global.d.ts
@@ -1,0 +1,5 @@
+declare module 'global' {
+  export declare const window: Window;
+}
+
+declare module '@storybook/core/server';

--- a/app/vue/src/server/framework-preset-vue.ts
+++ b/app/vue/src/server/framework-preset-vue.ts
@@ -1,14 +1,14 @@
-import VueLoaderPlugin from 'vue-loader/lib/plugin';
+import { VueLoaderPlugin } from 'vue-loader';
 import { Configuration } from 'webpack';
 
-export function webpack(config: Configuration) {
+export function webpack(config: Configuration): Configuration {
   return {
     ...config,
-    plugins: [...config.plugins, new VueLoaderPlugin()],
+    plugins: [...(config.plugins ?? []), new VueLoaderPlugin()],
     module: {
       ...config.module,
       rules: [
-        ...config.module.rules,
+        ...(config.module?.rules ?? []),
         {
           test: /\.vue$/,
           loader: require.resolve('vue-loader'),
@@ -30,9 +30,9 @@ export function webpack(config: Configuration) {
     },
     resolve: {
       ...config.resolve,
-      extensions: [...config.resolve.extensions, '.vue'],
+      extensions: [...(config.resolve?.extensions ?? []), '.vue'],
       alias: {
-        ...config.resolve.alias,
+        ...config.resolve?.alias,
         vue$: require.resolve('vue/dist/vue.esm.js'),
       },
     },

--- a/app/vue/src/typings.d.ts
+++ b/app/vue/src/typings.d.ts
@@ -1,6 +1,0 @@
-declare module '@storybook/core/*';
-declare module 'global';
-// todo check for correct types
-declare module 'webpack/lib/RuleSet';
-
-declare module 'vue-loader/lib/plugin';

--- a/app/vue/src/vue-augments.d.ts
+++ b/app/vue/src/vue-augments.d.ts
@@ -1,0 +1,28 @@
+import Vue, { ComponentOptions, FunctionalComponentOptions } from 'vue';
+import { WRAPS, VALUES, VueOptions } from './client/preview/types';
+
+declare module 'vue' {
+  export default interface Vue {
+    /** @storybook/vue augment, stores the current values passed in to the story. Values are reactive, so will update story components that use them. */
+    [VALUES]: Record<string, any>;
+  }
+
+  export interface VueConstructor<V extends Vue = Vue> {
+    /** Undocumented Vue API - is set on VueConstructor. */
+    _isVue: true;
+
+    /** Undocumented Vue API - gets the options object for the VueConstructor (data, props, etc.) */
+    options: VueOptions;
+  }
+
+  export interface FunctionalComponentOptions<
+    Props = DefaultProps,
+    PropDefs = PropsDefinition<Props>
+  > {
+    /** @storybook/vue augment, stores the component that has been wrapped (the story component) */
+    [WRAPS]?: VueConstructor;
+
+    /** @storybook/vue augment, stores the default values to pass in as props, extracted from the props of the story component. */
+    [VALUES]?: Record<string, any>;
+  }
+}

--- a/app/vue/tsconfig.json
+++ b/app/vue/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "rootDir": "./src",
     "types": ["webpack-env"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": true,
+    "noImplicitReturns": true
   },
   "include": [
     "src/**/*"

--- a/app/web-components/src/client/preview/index.ts
+++ b/app/web-components/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import client from '@storybook/core/client';
 import { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
@@ -17,7 +17,7 @@ interface ClientApi extends ClientStoryApi<StoryFnHtmlReturnType> {
   raw: () => any; // todo add type
 }
 
-const api = start(render);
+const api = client.start(render);
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
   return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
@@ -26,8 +26,10 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 };
 
 export const configure: ClientApi['configure'] = (...args) => api.configure(framework, ...args);
-export const addDecorator: ClientApi['addDecorator'] = api.clientApi.addDecorator;
-export const addParameters: ClientApi['addParameters'] = api.clientApi.addParameters;
+export const addDecorator: ClientApi['addDecorator'] = api.clientApi
+  .addDecorator as ClientApi['addDecorator'];
+export const addParameters: ClientApi['addParameters'] = api.clientApi
+  .addParameters as ClientApi['addParameters'];
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;
 export const setAddon: ClientApi['setAddon'] = api.clientApi.setAddon;
 export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -26,7 +26,10 @@ const addDecoratorDeprecationWarning = deprecate(
 Instead, use \`export const decorators = [];\` in your \`preview.js\`.
 Read more at https://github.com/storybookjs/storybook/MIGRATION.md#deprecated-addparameters-and-adddecorator).`
 );
-export const addDecorator = (decorator: DecoratorFunction, deprecationWarning = true) => {
+export const addDecorator = <StoryFnReturnType extends unknown>(
+  decorator: DecoratorFunction<StoryFnReturnType>,
+  deprecationWarning = true
+) => {
   if (!singleton)
     throw new Error(`Singleton client API not yet initialized, cannot call addDecorator`);
 
@@ -98,7 +101,9 @@ export default class ClientApi {
     `
   );
 
-  addDecorator = (decorator: DecoratorFunction) => {
+  addDecorator = <StoryFnReturnType extends unknown>(
+    decorator: DecoratorFunction<StoryFnReturnType>
+  ) => {
     this._storyStore.addGlobalMetadata({ decorators: [decorator], parameters: {} });
   };
 

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -23,9 +23,9 @@ export interface ErrorLike {
 }
 
 // Metadata about a story that can be set at various levels: global, for a kind, or for a single story.
-export interface StoryMetadata {
+export interface StoryMetadata<StoryFnReturnType = unknown> {
   parameters: Parameters;
-  decorators: DecoratorFunction[];
+  decorators: DecoratorFunction<StoryFnReturnType>[];
 }
 export type ArgTypesEnhancer = (context: StoryContext) => ArgTypes;
 
@@ -41,17 +41,17 @@ export interface StoreSelection {
   viewMode: ViewMode;
 }
 
-export type AddStoryArgs = StoryIdentifier & {
-  storyFn: StoryFn<any>;
+export type AddStoryArgs<StoryFnReturnType = unknown> = StoryIdentifier & {
+  storyFn: StoryFn<StoryFnReturnType>;
   parameters?: Parameters;
-  decorators?: DecoratorFunction[];
+  decorators?: DecoratorFunction<StoryFnReturnType>[];
 };
 
-export type StoreItem = StoryIdentifier & {
+export type StoreItem<StoryFnReturnType = unknown> = StoryIdentifier & {
   parameters: Parameters;
-  getDecorated: () => StoryFn<any>;
-  getOriginal: () => StoryFn<any>;
-  storyFn: StoryFn<any>;
+  getDecorated: () => StoryFn<StoryFnReturnType>;
+  getOriginal: () => StoryFn<StoryFnReturnType>;
+  storyFn: StoryFn<StoryFnReturnType>;
   hooks: HooksContext;
   args: Args;
 };
@@ -60,13 +60,13 @@ export type PublishedStoreItem = StoreItem & {
   globals: Args;
 };
 
-export interface StoreData {
-  [key: string]: StoreItem;
+export interface StoreData<StoryFnReturnType = unknown> {
+  [key: string]: StoreItem<StoryFnReturnType>;
 }
 
-export interface ClientApiParams {
+export interface ClientApiParams<StoryFnReturnType = unknown> {
   storyStore: StoryStore;
-  decorateStory?: DecorateStoryFunction;
+  decorateStory?: DecorateStoryFunction<StoryFnReturnType>;
   noStoryModuleAddMethodHotDispose?: boolean;
 }
 
@@ -82,9 +82,9 @@ export interface ClientApiAddons<StoryFnReturnType> {
   [key: string]: ClientApiAddon<StoryFnReturnType>;
 }
 
-export interface GetStorybookStory {
+export interface GetStorybookStory<StoryFnReturnType = unknown> {
   name: string;
-  render: StoryFn;
+  render: StoryFn<StoryFnReturnType>;
 }
 
 export interface GetStorybookKind {
@@ -95,7 +95,7 @@ export interface GetStorybookKind {
 
 // This really belongs in lib/core, but that depends on lib/ui which (dev) depends on app/react
 // which needs this type. So we put it here to avoid the circular dependency problem.
-export type RenderContext = StoreItem & {
+export type RenderContext<StoryFnReturnType = unknown> = StoreItem<StoryFnReturnType> & {
   forceRender: boolean;
 
   showMain: () => void;

--- a/lib/core/client.d.ts
+++ b/lib/core/client.d.ts
@@ -1,0 +1,2 @@
+import start from './dist/client/index';
+export = start;

--- a/lib/core/src/client/preview/start.ts
+++ b/lib/core/src/client/preview/start.ts
@@ -54,9 +54,9 @@ function focusInInput(event: Event) {
 }
 
 // todo improve typings
-export default function start(
-  render: RenderStoryFunction,
-  { decorateStory }: { decorateStory?: DecorateStoryFunction } = {}
+export default function start<StoryFnReturnType = unknown>(
+  render: RenderStoryFunction<StoryFnReturnType>,
+  { decorateStory }: { decorateStory?: DecorateStoryFunction<StoryFnReturnType> } = {}
 ) {
   const channel = getOrCreateChannel();
   const { clientApi, storyStore } = getClientApi(decorateStory, channel);

--- a/lib/core/src/client/preview/types.ts
+++ b/lib/core/src/client/preview/types.ts
@@ -26,4 +26,6 @@ export type Loadable = RequireContext | RequireContext[] | LoaderFunction;
 export { RenderContext };
 
 // The function used by a framework to render story to the DOM
-export type RenderStoryFunction = (context: RenderContext) => void;
+export type RenderStoryFunction<StoryFnReturnType = unknown> = (
+  context: RenderContext<StoryFnReturnType>
+) => void;

--- a/lib/core/tsconfig.json
+++ b/lib/core/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": "./src"
   },
-  "include": ["src/**/*", "typings.d.ts"],
-  "exclude": ["src/**.test.ts"],
-  "files": ["./typings.d.ts"]
+  "include": ["src/**/*", "*.d.ts"],
+  "exclude": ["src/**.test.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
     "ts-dedent": "^1.1.1",
     "ts-jest": "^26.1.0",
     "ts-node": "^8.9.1",
-    "typescript": "^3.7.0",
+    "typescript": "^3.9.6",
     "wait-on": "^4.0.0",
     "window-size": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
     "ts-dedent": "^1.1.1",
     "ts-jest": "^26.1.0",
     "ts-node": "^8.9.1",
-    "typescript": "^3.4.0",
+    "typescript": "^3.7.0",
     "wait-on": "^4.0.0",
     "window-size": "^1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -31463,7 +31463,7 @@ typescript@^3.0.0, typescript@^3.2.4, typescript@^3.4.0, typescript@^3.5.3, type
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
   integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
-typescript@^3.7.0:
+typescript@^3.9.6:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
   integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -31463,6 +31463,11 @@ typescript@^3.0.0, typescript@^3.2.4, typescript@^3.4.0, typescript@^3.5.3, type
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
   integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
+typescript@^3.7.0:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+
 ua-parser-js@^0.7.18:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"


### PR DESCRIPTION
## What I did

Well while learning how the Vue integration works for fixing unrelated issues I went down the typescript rabbit-hole and ended up improving the typings for Vue, and a little bit for all of the apps.

- All `@ts-ignore` and most `todo` are removed
- Reduced the amount of `any` in the code
- Tightened the typings, for example `StoryFnVueReturnType` is now `string | VueConstructor | VueOptions`, where `VueOptions` is any argument that `Vue.extend()` accepts.
- More edge cases revealed and accounted for, because of the more-correct typings.

Some of the changes (such as to `@storybook/client-api` and `@storybook/core`) leaked out of the changes here and into the other apps. Those changes enhance type-safety across the board, so in my opinion they're good to have. I'll add comments to point them out.

@backbone87 reviewed #7578 and I got a lot of insight from those comments so maybe they would want to look this over.

All tests, builds, & linting passing (on my machine at least).

## How to test

- Is this testable with Jest or Chromatic screenshots?
Existing tests cover the changes
- Does this need a new example in the kitchen sink apps?
Nope
- Does this need an update to the documentation?
Nope

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
