### PR TITLE
Update webpack config example to include module sass files

### DIFF
--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -186,10 +186,20 @@ module.exports = {
 
     // Make whatever fine-grained changes you need
     config.module.rules.push({
-      test: /\.scss$/,
-      use: ['style-loader', 'css-loader', 'sass-loader'],
-      include: path.resolve(__dirname, '../'),
-    });
+      test: /.scss$/,
+      loader: [
+        'style-loader',
+        {
+          loader: 'css-loader',
+          options: {
+            modules: true, // to support files with '.module.scss' extenstions.
+          },
+        },
+        {
+          loader: 'sass-loader',
+        },
+      ],
+    })
 
     // Return the altered config
     return config;

--- a/docs/src/pages/configurations/custom-webpack-config/index.md
+++ b/docs/src/pages/configurations/custom-webpack-config/index.md
@@ -195,9 +195,7 @@ module.exports = {
             modules: true, // to support files with '.module.scss' extenstions.
           },
         },
-        {
-          loader: 'sass-loader',
-        },
+        'sass-loader',
       ],
     })
 


### PR DESCRIPTION
This change will let users know how to change storybook config to allow using both `.scss` and `.module.scss` files.

Issue:
Nowhere in the docs it explains how to configure webpack in main.js to allow users style their components with modular SASS (or modular CSS).

## What I did
Updated example in the docs.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
