### PR TITLE
Addon-Docs: Fix ArgsTable controls on Docs tab

### DIFF
--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -52,9 +52,9 @@ const useArgs = (storyId: string, storyStore: StoryStore): [Args, (args: Args) =
   const { args: initialArgs } = story;
   const [args, setArgs] = useState(initialArgs);
   useEffect(() => {
-    const cb = (changedId: string, newArgs: Args) => {
-      if (changedId === storyId) {
-        setArgs(newArgs);
+    const cb = (changed: { storyId: string; args: Args }) => {
+      if (changed.storyId === storyId) {
+        setArgs(changed.args);
       }
     };
     storyStore._channel.on(Events.STORY_ARGS_UPDATED, cb);

--- a/examples/official-storybook/stories/core/args.stories.js
+++ b/examples/official-storybook/stories/core/args.stories.js
@@ -53,7 +53,7 @@ export const PassedToStory = (inputArgs) => {
   );
 };
 
-PassedToStory.argTypes = { name: { defaultValue: 'initial' } };
+PassedToStory.argTypes = { name: { defaultValue: 'initial', control: 'text' } };
 
 PassedToStory.propTypes = {
   args: PropTypes.shape({}).isRequired,


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Fix a critical bug where args were not being properly updated on the `Docs` tab (split out from #11550)

## How to test

```
cd examples/official-storybook
yarn storybook
open http://localhost:9011/?path=/docs/addons-docs-props--controls
```

Edit args in both addon panel and `Docs` tab & story itself and verify that everything stays in sync

