### PR TITLE
Addon-docs: Make Meta block subcomponents optional

### DIFF
--- a/addons/docs/src/blocks/Meta.tsx
+++ b/addons/docs/src/blocks/Meta.tsx
@@ -10,7 +10,7 @@ type Decorator = (...args: any) => any;
 interface MetaProps {
   title: string;
   component?: Component;
-  subcomponents: Record<string, Component>;
+  subcomponents?: Record<string, Component>;
   decorators?: [Decorator];
   parameters?: any;
 }


### PR DESCRIPTION
Issue: Meta block accidentally required subcomponents to be declared. Made it optional. Self-merging.