### PR TITLE
Core: Add `argTypes` to `StoryContext`

### DIFF
--- a/addons/docs/src/blocks/enhanceSource.test.ts
+++ b/addons/docs/src/blocks/enhanceSource.test.ts
@@ -6,6 +6,7 @@ const emptyContext: StoryContext = {
   kind: 'foo',
   name: 'bar',
   args: {},
+  argTypes: {},
   globals: {},
   parameters: {},
 };

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
@@ -35,6 +35,7 @@ const enhance = ({
       },
     },
     args: {},
+    argTypes: {},
     globals: {},
   };
   return enhanceArgTypes(context);

--- a/app/vue/src/client/preview/index.ts
+++ b/app/vue/src/client/preview/index.ts
@@ -69,6 +69,7 @@ const defaultContext: StoryContext = {
   kind: 'unspecified',
   parameters: {},
   args: {},
+  argTypes: {},
   globals: {},
 };
 

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -56,6 +56,7 @@ export type StoryContext = StoryIdentifier & {
   [key: string]: any;
   parameters: Parameters;
   args: Args;
+  argTypes: ArgTypes;
   globals: Args;
   hooks?: HooksContext;
 };

--- a/lib/client-api/src/decorators.ts
+++ b/lib/client-api/src/decorators.ts
@@ -11,6 +11,7 @@ const defaultContext: StoryContext = {
   kind: 'unspecified',
   parameters: {},
   args: {},
+  argTypes: {},
   globals: {},
 };
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -375,6 +375,7 @@ export default class StoryStore {
           storyFn: original,
           parameters: accumlatedParameters,
           args: {},
+          argTypes: {},
           globals: {},
         }),
       }),
@@ -391,6 +392,7 @@ export default class StoryStore {
         parameters: this.combineStoryParameters(storyParametersWithArgTypes, kind),
         hooks,
         args: _stories[id].args,
+        argTypes,
         globals: this._globals,
       });
 
@@ -414,6 +416,7 @@ export default class StoryStore {
 
       parameters: { ...storyParameters, argTypes },
       args: initialArgs,
+      argTypes,
       initialArgs,
     };
   }

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -55,6 +55,7 @@ export type StoreItem = StoryIdentifier & {
   hooks: HooksContext;
   args: Args;
   initialArgs: Args;
+  argTypes: ArgTypes;
 };
 
 export type PublishedStoreItem = StoreItem & {


### PR DESCRIPTION
Issue: #11555

We store `argTypes` on `parameters` but that's just a convenience.

## What I did

Added `argTypes` to `StoryContext`
