### PR TITLE
fix(html-examples): use correct parameters syntax

### DIFF
--- a/examples/html-kitchen-sink/stories/addon-jest.stories.js
+++ b/examples/html-kitchen-sink/stories/addon-jest.stories.js
@@ -7,4 +7,6 @@ export default {
 };
 
 export const WithTests = () => 'This story shows test results';
-WithTests.parameters = { jest: 'addon-jest' };
+WithTests.story = {
+  parameters: { jest: 'addon-jest' },
+};


### PR DESCRIPTION
Issue: #11581

## What I did
In 5.3 we use the story syntax rather than `.parameters` as a static property, thus I fixed its usage in the html-kitchensink.