### PR TITLE
Addon-controls: Fix no-args warning if argTypes are used

### DIFF
--- a/addons/controls/src/components/ControlsPanel.tsx
+++ b/addons/controls/src/components/ControlsPanel.tsx
@@ -12,6 +12,7 @@ interface ControlsParameters {
 export const ControlsPanel: FC = () => {
   const [args, updateArgs, resetArgs] = useArgs();
   const rows = useArgTypes();
+  const isArgsStory = useParameter<boolean>('__isArgsStory', false);
   const { expanded, hideNoControlsWarning = false } = useParameter<ControlsParameters>(
     PARAM_KEY,
     {}
@@ -19,7 +20,7 @@ export const ControlsPanel: FC = () => {
   const hasControls = Object.values(rows).filter((argType) => !!argType?.control).length > 0;
   return (
     <>
-      {hasControls || hideNoControlsWarning ? null : <NoControlsWarning />}
+      {(hasControls && isArgsStory) || hideNoControlsWarning ? null : <NoControlsWarning />}
       <ArgsTable
         {...{
           compact: !expanded && hasControls,

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
@@ -1,4 +1,4 @@
-import { ArgType, ArgTypes, Args } from '@storybook/api';
+import { ArgType, ArgTypes } from '@storybook/api';
 import { enhanceArgTypes } from './enhanceArgTypes';
 
 expect.addSnapshotSerializer({

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
@@ -10,20 +10,20 @@ const enhance = ({
   argType,
   arg,
   extractedArgTypes,
-  storyFn = (args: Args) => 0,
+  isArgsStory = true,
 }: {
   argType?: ArgType;
   arg?: any;
   extractedArgTypes?: ArgTypes;
-  storyFn?: any;
+  isArgsStory?: boolean;
 }) => {
   const context = {
     id: 'foo--bar',
     kind: 'foo',
     name: 'bar',
-    storyFn,
     parameters: {
       component: 'dummy',
+      __isArgsStory: isArgsStory,
       docs: {
         extractArgTypes: extractedArgTypes && (() => extractedArgTypes),
       },
@@ -47,7 +47,7 @@ describe('enhanceArgTypes', () => {
       expect(
         enhance({
           argType: { foo: 'unmodified', type: { name: 'number' } },
-          storyFn: () => 0,
+          isArgsStory: false,
         }).input
       ).toMatchInlineSnapshot(`
         {

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.ts
@@ -4,7 +4,7 @@ import { inferControls } from './inferControls';
 import { normalizeArgTypes } from './normalizeArgTypes';
 
 export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
-  const { component, argTypes: userArgTypes = {}, docs = {} } = context.parameters;
+  const { __isArgsStory, component, argTypes: userArgTypes = {}, docs = {} } = context.parameters;
   const { extractArgTypes } = docs;
 
   const normalizedArgTypes = normalizeArgTypes(userArgTypes);
@@ -12,7 +12,7 @@ export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
   const extractedArgTypes = extractArgTypes && component ? extractArgTypes(component) : {};
   const withArgTypes = combineParameters(extractedArgTypes, namedArgTypes);
 
-  if (context.storyFn.length === 0) {
+  if (!__isArgsStory) {
     return withArgTypes;
   }
 

--- a/examples/angular-cli/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/angular-cli/src/stories/__snapshots__/core.stories.storyshot
@@ -21,7 +21,8 @@ exports[`Storyshots Core/Parameters passed to story 1`] = `
     "chapterParameter": "chapterParameter",
     "argTypes": {},
     "storyParameter": "storyParameter",
-    "__id": "core-parameters--passed-to-story"
+    "__id": "core-parameters--passed-to-story",
+    "__isArgsStory": true
   }
     </button>
   </storybook-button-component>

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -31,3 +31,5 @@ CustomControls.argTypes = {
   children: { table: { disable: true } },
   type: { control: { disable: true } },
 };
+
+export const NoArgs = () => <Button>no args</Button>;

--- a/examples/riot-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/riot-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
@@ -14,6 +14,7 @@ exports[`Storyshots Core/Parameters passed to story 1`] = `
   "chapterParameter": "chapterParameter",
   "argTypes": {},
   "__id": "core-parameters--passed-to-story",
+  "__isArgsStory": true,
   "storyParameter": "storyParameter",
   "id": "root",
   "dataIs": "parameters"

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
@@ -10,7 +10,8 @@ exports[`Storyshots Core/Parameters passed to story 1`] = `
   "chapterParameter": "chapterParameter",
   "argTypes": {},
   "storyParameter": "storyParameter",
-  "__id": "core-parameters--passed-to-story"
+  "__id": "core-parameters--passed-to-story",
+  "__isArgsStory": true
 }
   </pre>
 </div>

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/custom-decorators.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/custom-decorators.stories.storyshot
@@ -53,7 +53,8 @@ exports[`Storyshots Custom/Decorator for Vue With Data 1`] = `
     "globalParameter": "globalParameter",
     "framework": "vue",
     "argTypes": {},
-    "__id": "custom-decorator-for-vue--with-data"
+    "__id": "custom-decorator-for-vue--with-data",
+    "__isArgsStory": true
   },
   "args": {},
   "argTypes": {},

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -145,7 +145,8 @@ export const init: ModuleFn = ({
     getCurrentParameter: (parameterName) => {
       const { storyId, refId } = store.getState();
       const parameters = api.getParameters({ storyId, refId }, parameterName);
-      // FIXME I don't know why this is needed
+      // FIXME Returning falsey parameters breaks a bunch of toolbars code,
+      // so this strange logic needs to be here until various client code is updated.
       return parameters || undefined;
     },
     jumpToComponent: (direction) => {

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -144,7 +144,9 @@ export const init: ModuleFn = ({
     },
     getCurrentParameter: (parameterName) => {
       const { storyId, refId } = store.getState();
-      return api.getParameters({ storyId, refId }, parameterName);
+      const parameters = api.getParameters({ storyId, refId }, parameterName);
+      // FIXME I don't know why this is needed
+      return parameters || undefined;
     },
     jumpToComponent: (direction) => {
       const { storiesHash, storyId, refs, refId } = store.getState();

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -144,12 +144,7 @@ export const init: ModuleFn = ({
     },
     getCurrentParameter: (parameterName) => {
       const { storyId, refId } = store.getState();
-      const parameters = api.getParameters({ storyId, refId }, parameterName);
-
-      if (parameters) {
-        return parameters;
-      }
-      return undefined;
+      return api.getParameters({ storyId, refId }, parameterName);
     },
     jumpToComponent: (direction) => {
       const { storiesHash, storyId, refs, refId } = store.getState();

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -120,7 +120,7 @@ describe('preview.client_api', () => {
 
       const result = storyStore.fromId('kind--name').storyFn();
       // @ts-ignore
-      const { docs, fileName, options, argTypes, ...rest } = result;
+      const { docs, fileName, options, argTypes, __isArgsStory, ...rest } = result;
 
       expect(rest).toEqual({ a: 1 });
     });
@@ -540,6 +540,7 @@ describe('preview.client_api', () => {
         a: 'global',
         b: 'kind',
         c: 'story',
+        __isArgsStory: false,
         fileName: expect.any(String),
         argTypes: {},
       });
@@ -593,6 +594,7 @@ describe('preview.client_api', () => {
             local: true,
           },
         },
+        __isArgsStory: false,
         fileName: expect.any(String),
         argTypes: {},
       });

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -577,6 +577,20 @@ describe('preview.story_store', () => {
   });
 
   describe('argTypesEnhancer', () => {
+    it('records whether the given story processes args', () => {
+      const store = new StoryStore({ channel });
+
+      const enhancer = jest.fn((context) => ({ ...context.parameters.argTypes, c: 'd' }));
+      store.addArgTypesEnhancer(enhancer);
+
+      addStoryToStore(store, 'a', '1', (args: any) => 0, { argTypes: { a: 'b' } });
+
+      expect(enhancer).toHaveBeenCalledWith(
+        expect.objectContaining({ parameters: { __isArgsStory: true, argTypes: { a: 'b' } } })
+      );
+      expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ a: 'b', c: 'd' });
+    });
+
     it('allows you to alter argTypes when stories are added', () => {
       const store = new StoryStore({ channel });
 
@@ -586,7 +600,7 @@ describe('preview.story_store', () => {
       addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
 
       expect(enhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { argTypes: { a: 'b' } } })
+        expect.objectContaining({ parameters: { __isArgsStory: false, argTypes: { a: 'b' } } })
       );
       expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ a: 'b', c: 'd' });
     });
@@ -602,10 +616,12 @@ describe('preview.story_store', () => {
       addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
 
       expect(firstEnhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { argTypes: { a: 'b' } } })
+        expect.objectContaining({ parameters: { __isArgsStory: false, argTypes: { a: 'b' } } })
       );
       expect(secondEnhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { argTypes: { a: 'b', c: 'd' } } })
+        expect.objectContaining({
+          parameters: { __isArgsStory: false, argTypes: { a: 'b', c: 'd' } },
+        })
       );
       expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ a: 'b', c: 'd', e: 'f' });
     });
@@ -619,7 +635,7 @@ describe('preview.story_store', () => {
       addStoryToStore(store, 'a', '1', () => 0, { argTypes: { a: 'b' } });
 
       expect(enhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { argTypes: { a: 'b' } } })
+        expect.objectContaining({ parameters: { __isArgsStory: false, argTypes: { a: 'b' } } })
       );
       expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ c: 'd' });
     });
@@ -638,7 +654,7 @@ describe('preview.story_store', () => {
 
       addStoryToStore(store, 'a', '1', () => 0, { argTypes: { e: 'f' } });
       expect(enhancer).toHaveBeenCalledWith(
-        expect.objectContaining({ parameters: { argTypes: { e: 'f' } } })
+        expect.objectContaining({ parameters: { __isArgsStory: false, argTypes: { e: 'f' } } })
       );
       expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ e: 'f', c: 'd' });
     });

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -577,7 +577,7 @@ describe('preview.story_store', () => {
   });
 
   describe('argTypesEnhancer', () => {
-    it('records whether the given story processes args', () => {
+    it('records when the given story processes args', () => {
       const store = new StoryStore({ channel });
 
       const enhancer = jest.fn((context) => ({ ...context.parameters.argTypes, c: 'd' }));

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -366,7 +366,11 @@ export default class StoryStore {
     // We need the combined parameters now in order to calculate argTypes, but we won't keep them
     const combinedParameters = this.combineStoryParameters(storyParameters, kind);
 
-    // storyFn is not available in manager, so we record whether the storyFn accepts args
+    // We are going to make various UI changes in both the manager and the preview
+    // based on whether it's an "args story", i.e. whether the story accepts a first
+    // argument which is an `Args` object. Here we store it as a parameter on every story
+    // for convenience, but we preface it with `__` to denote that it's an internal API
+    // and that users probably shouldn't look at it.
     const { passArgsFirst = true } = combinedParameters;
     const __isArgsStory = passArgsFirst && original.length > 0;
 

--- a/lib/core/src/client/preview/StoryRenderer.test.ts
+++ b/lib/core/src/client/preview/StoryRenderer.test.ts
@@ -85,7 +85,7 @@ describe('core.preview.StoryRenderer', () => {
         id: 'a--1',
         kind: 'a',
         name: '1',
-        parameters: { argTypes: {}, p: 'q' },
+        parameters: { __isArgsStory: false, argTypes: {}, p: 'q' },
         forceRender: false,
 
         showMain: expect.any(Function),


### PR DESCRIPTION
Issue: #11083 

## What I did

- [x] Store whether story accepts args as an "internal" parameter in story store
- [x] ~~Fix related bug (?) in API where false parameters are returned as `undefined`~~ => reverted
- [x] Update controls addon to use this parameter
- [x] Add test case to `official-storybook`
- [x] Update unit tests/snapshots

## How to test

See test case in `official-storybook`

