### PR TITLE
Addon-docs: Automatic source selection based on story type

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -90,7 +90,7 @@ const getSnippet = (
     }
 
     // otherwise, use the source code logic
-    const enhanced = data && (enhanceSource(data) || data.parameters);
+    const enhanced = enhanceSource(data) || data.parameters;
     return enhanced?.docs?.source?.code || '';
   }
   // Fallback if we can't get the story data for this story

--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -70,32 +70,33 @@ const getSnippet = (
   const data = storyStore?.fromId(storyId);
 
   if (data) {
-    const { parameters } = data;
-    // eslint-disable-next-line no-underscore-dangle
-    const isArgsStory = parameters.__isArgsStory;
-    const type = parameters.docs?.source?.type || SourceType.AUTO;
-
-    // if user has hard-coded the snippet, that takes precedence
-    const userCode = parameters.docs?.source?.code;
-    if (userCode) return userCode;
-
-    // if user has explicitly set this as dynamic, use snippet
-    if (type === SourceType.DYNAMIC) {
-      return snippet || '';
-    }
-
-    // if this is an args story and there's a snippet
-    if (type === SourceType.AUTO && snippet && isArgsStory) {
-      return snippet;
-    }
-
-    // otherwise, use the source code logic
-    const enhanced = enhanceSource(data) || data.parameters;
-    return enhanced?.docs?.source?.code || '';
+    // Fallback if we can't get the story data for this story
+    logger.warn(`Unable to find source for story ID '${storyId}'`);
+    return snippet || '';
   }
-  // Fallback if we can't get the story data for this story
-  logger.warn(`Unable to find source for story ID '${storyId}'`);
-  return snippet || '';
+
+  const { parameters } = data;
+  // eslint-disable-next-line no-underscore-dangle
+  const isArgsStory = parameters.__isArgsStory;
+  const type = parameters.docs?.source?.type || SourceType.AUTO;
+
+  // if user has hard-coded the snippet, that takes precedence
+  const userCode = parameters.docs?.source?.code;
+  if (userCode) return userCode;
+
+  // if user has explicitly set this as dynamic, use snippet
+  if (type === SourceType.DYNAMIC) {
+    return snippet || '';
+  }
+
+  // if this is an args story and there's a snippet
+  if (type === SourceType.AUTO && snippet && isArgsStory) {
+    return snippet;
+  }
+
+  // otherwise, use the source code logic
+  const enhanced = enhanceSource(data) || data.parameters;
+  return enhanced?.docs?.source?.code || '';
 };
 
 export const getSourceProps = (

--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -69,7 +69,7 @@ const getSnippet = (
   const snippet = sources && sources[storyId];
   const data = storyStore?.fromId(storyId);
 
-  if (data) {
+  if (!data) {
     // Fallback if we can't get the story data for this story
     logger.warn(`Unable to find source for story ID '${storyId}'`);
     return snippet || '';

--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -75,14 +75,21 @@ const getSnippet = (
     const isArgsStory = parameters.__isArgsStory;
     const type = parameters.docs?.source?.type || SourceType.AUTO;
 
-    // if user has explicitly set this as a dynamic story, or this is an args story and there's a snippet
-    if (
-      type === SourceType.DYNAMIC ||
-      (type === SourceType.AUTO && snippet && isArgsStory && !parameters.docs?.source?.code)
-    ) {
+    // if user has hard-coded the snippet, that takes precedence
+    const userCode = parameters.docs?.source?.code;
+    if (userCode) return userCode;
+
+    // if user has explicitly set this as dynamic, use snippet
+    if (type === SourceType.DYNAMIC) {
       return snippet || '';
     }
 
+    // if this is an args story and there's a snippet
+    if (type === SourceType.AUTO && snippet && isArgsStory) {
+      return snippet;
+    }
+
+    // otherwise, use the source code logic
     const enhanced = data && (enhanceSource(data) || data.parameters);
     return enhanced?.docs?.source?.code || '';
   }

--- a/examples/official-storybook/stories/addon-docs/source.stories.tsx
+++ b/examples/official-storybook/stories/addon-docs/source.stories.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Button from '../../components/TsButton';
+
+export default {
+  title: 'Addons/Docs/Source',
+  component: Button,
+  argTypes: {
+    children: { control: 'text' },
+    type: { control: 'text' },
+  },
+  parameters: {
+    chromatic: { enabled: false },
+  },
+};
+
+const Template = (args) => <Button {...args} />;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  children: 'basic',
+  somethingElse: { a: 2 },
+};
+
+export const NoArgs = () => <Button>no args</Button>;
+
+export const ForceCodeSource = Template.bind({});
+ForceCodeSource.args = { ...Basic.args };
+ForceCodeSource.parameters = { docs: { source: { type: 'code' } } };
+
+export const CustomSource = Template.bind({});
+CustomSource.args = { ...Basic.args };
+CustomSource.parameters = { docs: { source: { code: 'custom source' } } };

--- a/examples/official-storybook/stories/addon-docs/source.stories.tsx
+++ b/examples/official-storybook/stories/addon-docs/source.stories.tsx
@@ -9,7 +9,7 @@ export default {
     type: { control: 'text' },
   },
   parameters: {
-    chromatic: { enabled: false },
+    chromatic: { disable: true },
   },
 };
 


### PR DESCRIPTION
Issue: #11526 

## What I did

- [x] Add a new story parameter `docs.source.type`
- [x] Use the `type` to determine which snippet to render 

What this change means for users:
- No-args stories will go back to using the raw source code unless otherwise specified
- Args stories will use the dynamically-rendered source unless otherwise specified

## How to test

See updated stories in `official-storybook`
