### PR TITLE
Addon-controls: Expose `presetColors` for the color control

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -326,7 +326,7 @@ Here is the full list of available controls:
 |             | select       | select dropdown input                                          | options        |
 |             | multi-select | multi-select dropdown input                                    | options        |
 | **string**  | text         | simple text input                                              | -              |
-|             | color        | color picker input that assumes strings are color values       | -              |
+|             | color        | color picker input that assumes strings are color values       | presetColors   |
 |             | date         | date picker input                                              | -              |
 
 Example customizing a control for an `enum` data type (defaults to `select` control type):
@@ -352,6 +352,20 @@ export default {
   argTypes: {
     width: {
       control: { type: 'range', min: 400, max: 1200, step: 50 },
+    },
+  },
+};
+```
+
+Example customizing a `color` data type:
+
+```js
+export default {
+  title: 'Button',
+  component: Button,
+  argTypes: {
+    backgroundColor: {
+      control: { type: 'color', presetColors: ['#FFF', '#000', '#AAA'] },
     },
   },
 };

--- a/lib/components/src/controls/Color.stories.tsx
+++ b/lib/components/src/controls/Color.stories.tsx
@@ -13,7 +13,7 @@ export const Basic = () => {
   return <ColorControl name="Color" value={value} onChange={(name, newVal) => setValue(newVal)} />;
 };
 
-export const withPresetColors = () => {
+export const WithPresetColors = () => {
   const [value, setValue] = useState('#ff0');
   return (
     <ColorControl

--- a/lib/components/src/controls/Color.stories.tsx
+++ b/lib/components/src/controls/Color.stories.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { ColorControl } from './Color';
 
+const presetColors = ['#FE4A49', '#FED766', '#009FB7', '#E6E6EA', '#F4F4F8'];
+
 export default {
   title: 'Controls/Color',
   component: ColorControl,
@@ -9,4 +11,16 @@ export default {
 export const Basic = () => {
   const [value, setValue] = useState('#ff0');
   return <ColorControl name="Color" value={value} onChange={(name, newVal) => setValue(newVal)} />;
+};
+
+export const withPresetColors = () => {
+  const [value, setValue] = useState('#ff0');
+  return (
+    <ColorControl
+      name="Color"
+      value={value}
+      onChange={(name, newVal) => setValue(newVal)}
+      presetColors={presetColors}
+    />
+  );
 };

--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -56,7 +56,14 @@ export const ColorControl: FC<ColorProps> = ({
       {value ? value.toUpperCase() : 'Choose color'}
       <Swatch style={{ background: value }} />
       {showPicker ? (
-        <Popover onClick={(e: MouseEvent) => e.stopPropagation()}>
+        <Popover
+          onClick={(e: MouseEvent) => {
+            // @ts-ignore
+            if (e.target.tagName === 'INPUT') {
+              e.stopPropagation();
+            }
+          }}
+        >
           <SketchPicker
             color={value}
             onChange={(color: ColorResult) => onChange(name, format(color))}

--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -30,7 +30,14 @@ const format = (color: ColorResult) =>
   `rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`;
 
 export type ColorProps = ControlProps<ColorValue> & ColorConfig;
-export const ColorControl: FC<ColorProps> = ({ name, value, onChange, onFocus, onBlur }) => {
+export const ColorControl: FC<ColorProps> = ({
+  name,
+  value,
+  onChange,
+  onFocus,
+  onBlur,
+  presetColors,
+}) => {
   const [showPicker, setShowPicker] = useState(false);
 
   return (
@@ -48,7 +55,7 @@ export const ColorControl: FC<ColorProps> = ({ name, value, onChange, onFocus, o
           <SketchPicker
             color={value}
             onChange={(color: ColorResult) => onChange(name, format(color))}
-            {...{ onFocus, onBlur }}
+            {...{ onFocus, onBlur, presetColors }}
           />
         </Popover>
       ) : null}

--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -51,7 +51,6 @@ export const ColorControl: FC<ColorProps> = ({
           setShowPicker(!showPicker);
         }
       }}
-      onBlur={() => setShowPicker(!showPicker)}
       size="flex"
     >
       {value ? value.toUpperCase() : 'Choose color'}

--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, MouseEvent, KeyboardEvent } from 'react';
 import { SketchPicker, ColorResult } from 'react-color';
 
 import { styled } from '@storybook/theming';
@@ -46,12 +46,18 @@ export const ColorControl: FC<ColorProps> = ({
       type="button"
       name={name}
       onClick={() => setShowPicker(!showPicker)}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          setShowPicker(!showPicker);
+        }
+      }}
+      onBlur={() => setShowPicker(!showPicker)}
       size="flex"
     >
       {value ? value.toUpperCase() : 'Choose color'}
       <Swatch style={{ background: value }} />
       {showPicker ? (
-        <Popover>
+        <Popover onClick={(e: MouseEvent) => e.stopPropagation()}>
           <SketchPicker
             color={value}
             onChange={(color: ColorResult) => onChange(name, format(color))}

--- a/lib/components/src/controls/types.ts
+++ b/lib/components/src/controls/types.ts
@@ -20,7 +20,9 @@ export type BooleanValue = boolean;
 export interface BooleanConfig {}
 
 export type ColorValue = string;
-export interface ColorConfig {}
+export interface ColorConfig {
+  presetColors?: string[];
+}
 
 export type DateValue = Date | number;
 export interface DateConfig {}


### PR DESCRIPTION
Issue: #10167 

## What I did
- Exposed `SketchPickerProps.presetColors` for the color control component.
- Stop click event propagation at the popup level, to give user the chance to click on the Hex input box and edit the color value this way. One side-effect of this change is that now the user will have to click on the color control button to close the color picker, instead of closing it automatically per mouse click.

## How to test

- Is this testable with Jest or Chromatic screenshots? **No.**
- Does this need a new example in the kitchen sink apps? **No.**
- Does this need an update to the documentation? **Yes, included in this PR.**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
