### PR TITLE
Don't show deprecation warning in storyshots

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/Loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/Loader.ts
@@ -6,7 +6,7 @@ import { SupportedFramework } from './SupportedFramework';
 export type RenderTree = (story: any, context?: any, options?: any) => any;
 
 export interface ClientApi extends ClientStoryApi<unknown> {
-  configure(loader: Loadable, module: NodeModule | false): void;
+  configure(loader: Loadable, module: NodeModule | false, showDeprecationWarning?: boolean): void;
   forceReRender(): void;
   clearDecorators: ClientApiThing['clearDecorators'];
   getStorybook: ClientApiThing['getStorybook'];

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -86,7 +86,7 @@ function configure(
   });
 
   if (stories && stories.length) {
-    storybook.configure(stories, false);
+    storybook.configure(stories, false, false);
   }
 }
 


### PR DESCRIPTION
Issue: #11585 

## What I did

Pass no deprecation flag from SS

## How to test

I couldn't actually get the deprecation warning to show in our tests (it should have happened in `vueshots` for instance). I'm never sure with Jest + logging TBH. In any case I checked the code path was getting run and that this fixed it but adding custom logging.