### PR TITLE
Addon-docs: Fix Props `components` input

### DIFF
--- a/addons/docs/src/blocks/Props.tsx
+++ b/addons/docs/src/blocks/Props.tsx
@@ -230,6 +230,10 @@ export const Props: FC<PropsProps> = (props) => {
     return <ArgsTable {...mainProps} />;
   }
 
+  if (components) {
+    return <ComponentsTable {...(props as ComponentsProps)} components={components} />;
+  }
+
   const mainLabel = getComponentName(main);
   return (
     <ComponentsTable

--- a/examples/vue-kitchen-sink/src/stories/addon-controls.stories.mdx
+++ b/examples/vue-kitchen-sink/src/stories/addon-controls.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Preview, Story, Props } from '@storybook/addon-docs/blocks';
 import MyButton from './Button.vue';
+import InfoButton from './components/InfoButton.vue';
 
 <Meta
   title="Addon/ControlsMDX"
@@ -52,3 +53,7 @@ Controls can also be defined and used in MDX stories.
 </Preview>
 
 <Props story="Square" />
+
+## Multiple components
+
+<Props components={{ MyButton, InfoButton }} />


### PR DESCRIPTION
Issue: #11583 

## What I did

- [x] Fix `components` handling in the Props doc block
- [x] Add example story to `vue-kitchen-sink`

## How to test

See updated example

