### PR TITLE
Hoist CSF `.story` annotations

### DIFF
--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -12,7 +12,7 @@ const deprecatedStoryAnnotationWarning = deprecate(
     CSF .story annotations deprecated; annotate story functions directly:
     - StoryFn.story.name => StoryFn.storyName
     - StoryFn.story.(parameters|decorators) => StoryFn.(parameters|decorators)
-    See https://github.com/storybookjs/storybook/issues/10906 for details and codemod.
+    See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#hoisted-csf-annotations for details and codemod.
 `
 );
 

--- a/lib/ui/src/components/preview/iframe.stories.tsx
+++ b/lib/ui/src/components/preview/iframe.stories.tsx
@@ -25,10 +25,8 @@ export const workingStory = () => (
     scale={1.0}
   />
 );
-workingStory.story = {
-  parameters: {
-    chromatic: { delay: 300 },
-  },
+workingStory.parameters = {
+  chromatic: { delay: 300 },
 };
 
 export const missingStory = () => (


### PR DESCRIPTION
Issue: Warnings about `.story =`

## What I did

Got rid of it

