### PR TITLE
CLI: Generate `docs:json` command dynamically for Angular project

### DIFF
--- a/cypress/generated/addon-viewport.spec.ts
+++ b/cypress/generated/addon-viewport.spec.ts
@@ -4,7 +4,7 @@ describe('addon-viewport', () => {
   });
 
   it('should have viewport button in the toolbar', () => {
-    cy.navigateToStory('button', 'Text');
+    cy.navigateToStory('example-button', 'Primary');
 
     // Click on viewport button and select small mobile
     cy.get('[title="Change the size of the preview"]').click();

--- a/lib/cli/src/generators/ANGULAR/angular-helpers.ts
+++ b/lib/cli/src/generators/ANGULAR/angular-helpers.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import { pathExists } from 'fs-extra';
+
 import { readFileAsJson, writeFileAsJson } from '../../helpers';
 
 type TsConfig = {
@@ -51,4 +53,8 @@ export function editStorybookTsConfig(tsconfigPath: string) {
 export function isDefaultProjectSet() {
   const angularJson = readFileAsJson('angular.json', true);
   return angularJson && !!angularJson.defaultProject;
+}
+
+export async function getBaseTsConfigName() {
+  return (await pathExists('./tsconfig.base.json')) ? 'tsconfig.base.json' : 'tsconfig.json';
 }

--- a/lib/cli/src/generators/ANGULAR/index.ts
+++ b/lib/cli/src/generators/ANGULAR/index.ts
@@ -4,6 +4,7 @@ import {
   editStorybookTsConfig,
   getAngularAppTsConfigJson,
   getAngularAppTsConfigPath,
+  getBaseTsConfigName,
 } from './angular-helpers';
 import { writeFileAsJson, copyTemplate } from '../../helpers';
 import { baseGenerator, Generator } from '../baseGenerator';
@@ -40,8 +41,9 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   editStorybookTsConfig(path.resolve('./.storybook/tsconfig.json'));
 
   // edit scripts to generate docs
+  const tsConfigFile = await getBaseTsConfigName();
   packageManager.addScripts({
-    'docs:json': 'compodoc -p ./tsconfig.base.json -e json -d .',
+    'docs:json': `compodoc -p ./${tsConfigFile} -e json -d .`,
   });
   packageManager.addStorybookCommandInScripts({
     port: 6006,


### PR DESCRIPTION
Issue: #11609 

## What I did

 - Angular CLI 10 introduced a `tsconfig.base.json` file that we have to use to generate doc with compodoc. So if `tsconfig.base.json` exists then use it, otherwise assume there is a `tsconfig.json` file.
 - Update E2E test of `addon-viewport` to match the latest example stories

## How to test

- I checked locally that generated `docs:json` commands are OK.
- CI should be 🟢
- In the CI logs we should have valid logs displaying compodoc output:
```
[19:53:11] found          : ButtonComponent
[19:53:11] parsing        : /tmp/storybook-e2e-testing/angular-vv8-lts/src/stories/header.component.ts
[19:53:11] found          : HeaderComponent
[19:53:11] parsing        : /tmp/storybook-e2e-testing/angular-vv8-lts/src/stories/page.component.ts
[19:53:11] found          : PageComponent
```