### PR TITLE
Core: Optimize `storiesHash` by removing unused parameters

### DIFF
--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -19,11 +19,6 @@ export interface Root {
   isComponent: false;
   isRoot: true;
   isLeaf: false;
-  // MDX stories are "Group" type
-  parameters?: {
-    docsOnly?: boolean;
-    [k: string]: any;
-  };
 }
 
 export interface Group {
@@ -36,11 +31,10 @@ export interface Group {
   isComponent: boolean;
   isRoot: false;
   isLeaf: false;
-  // MDX stories are "Group" type
+  // MDX docs-only stories are "Group" type
   parameters?: {
     docsOnly?: boolean;
     viewMode?: ViewMode;
-    [parameterName: string]: any;
   };
 }
 
@@ -203,7 +197,6 @@ export const transformStoriesRawToStoriesHash = (
               isComponent: false,
               isLeaf: false,
               isRoot: true,
-              parameters,
             };
             return soFar.concat([result]);
           }
@@ -216,7 +209,10 @@ export const transformStoriesRawToStoriesHash = (
             isComponent: false,
             isLeaf: false,
             isRoot: false,
-            parameters,
+            parameters: {
+              docsOnly: parameters?.docsOnly,
+              viewMode: parameters?.viewMode,
+            },
           };
           return soFar.concat([result]);
         }, [] as GroupsList);

--- a/lib/api/src/modules/addons.ts
+++ b/lib/api/src/modules/addons.ts
@@ -3,6 +3,7 @@ import { ReactElement } from 'react';
 import { WindowLocation } from '@reach/router';
 import { ModuleFn } from '../index';
 import { Options } from '../store';
+import { isStory } from '../lib/stories';
 
 export type ViewMode = 'story' | 'info' | 'settings' | 'page' | undefined | string;
 
@@ -94,7 +95,7 @@ export const init: ModuleFn = ({ provider, store, fullAPI }) => {
       const { storyId } = store.getState();
       const story = fullAPI.getData(storyId);
 
-      if (!allPanels || !story) {
+      if (!allPanels || !story || !isStory(story)) {
         return allPanels;
       }
 

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -260,7 +260,7 @@ export const init: ModuleFn = ({
         // eslint-disable-next-line no-nested-ternary
         const id = s ? (s.children ? s.children[0] : s.id) : kindOrId;
         let viewMode =
-          viewModeFromArgs || (s && s.parameters.viewMode)
+          s && !isRoot(s) && (viewModeFromArgs || s.parameters.viewMode)
             ? s.parameters.viewMode
             : viewModeFromState;
 

--- a/lib/api/src/tests/addons.test.js
+++ b/lib/api/src/tests/addons.test.js
@@ -75,6 +75,7 @@ describe('Addons API', () => {
       const storyId = 'story 1';
       const storiesHash = {
         [storyId]: {
+          isLeaf: true,
           parameters: {
             a11y: { disabled: true },
           },

--- a/lib/ui/src/components/preview/preview.tsx
+++ b/lib/ui/src/components/preview/preview.tsx
@@ -124,7 +124,7 @@ const useTabs = (
   }, [getElements]);
 
   return useMemo(() => {
-    if (story && story.parameters) {
+    if (story?.parameters) {
       return filterTabs([canvas, ...tabsFromConfig], story.parameters);
     }
 

--- a/lib/ui/src/components/sidebar/Tree/ListItem.stories.tsx
+++ b/lib/ui/src/components/sidebar/Tree/ListItem.stories.tsx
@@ -17,7 +17,6 @@ const baseProps: ComponentProps<typeof ListItem> = {
   isSelected: false,
   kind: 'foo',
   name: 'bar',
-  parameters: {},
   refId: '',
 };
 

--- a/lib/ui/src/components/sidebar/Tree/ListItem.tsx
+++ b/lib/ui/src/components/sidebar/Tree/ListItem.tsx
@@ -118,7 +118,6 @@ export type ListItemProps = ComponentProps<typeof Item> & {
   kind: string;
   refId?: string;
   depth: number;
-  parameters: Record<string, any>;
 };
 
 export const ListItem: FunctionComponent<ListItemProps> = ({


### PR DESCRIPTION
Issue: #11618 #11229

## What I did

`storiesHash` is the manager-side version of the story store. Currently it's doing a bunch of unnecessary work merging story parameters up the hierarchy of stories/groups/roots, which can be slow for storybooks with large sets of parameters.

With @ndelangen:
- [x] Removed parameters for the root node (which we believe is safe)
- [x] Only propagate `viewMode` and `docsOnly` parameters up the tree, as they are used in group nodes

## Performance implications

We saw a minor perf improvement on `official-storybook`. We assume this would be more pronounced for a more parameter-heavy/deeply nested storybook:

- Before: `setStories` = 885ms
- After: `setStories` = 640ms

## How to test

- [ ] CI / updated snapshots
- [ ] Run `official-storybook` and verify
  - [ ] Search
  - [ ] Docs-only stories
  - [ ] View-mode stories