### PR TITLE
Addon-docs: Skip dynamic source rendering when not needed

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -10,31 +10,9 @@ import { logger } from '@storybook/client-logger';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { SourceContext, SourceContextProps } from './SourceContainer';
 import { CURRENT_SELECTION } from './types';
+import { SourceType } from '../shared';
 
 import { enhanceSource } from './enhanceSource';
-
-enum SourceType {
-  /**
-   * AUTO is the default
-   *
-   * Use the CODE logic if:
-   * - the user has set a custom source snippet in `docs.source.code` story parameter
-   * - the story is not an args-based story
-   *
-   * Use the DYNAMIC rendered snippet if the story is an args story
-   */
-  AUTO = 'auto',
-
-  /**
-   * Render the code extracted by source-loader
-   */
-  CODE = 'code',
-
-  /**
-   * Render dynamically-rendered source snippet from the story's virtual DOM (currently React only)
-   */
-  DYNAMIC = 'dynamic',
-}
 
 interface CommonProps {
   language?: string;

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -4,12 +4,7 @@ import reactElementToJSXString, { Options } from 'react-element-to-jsx-string';
 import { addons, StoryContext } from '@storybook/addons';
 import { logger } from '@storybook/client-logger';
 
-import { SNIPPET_RENDERED } from '../../shared';
-
-type VueComponent = {
-  /** The template for the Vue component */
-  template?: string;
-};
+import { SourceType, SNIPPET_RENDERED } from '../../shared';
 
 interface JSXOptions {
   /** How many wrappers to skip when rendering the jsx */
@@ -100,8 +95,22 @@ const defaultOpts = {
   enableBeautify: true,
 };
 
+export const skipJsxRender = (context: StoryContext) => {
+  const { parameters } = context;
+  const sourceParams = parameters?.docs?.source;
+  if (sourceParams?.type === SourceType.DYNAMIC) {
+    return false;
+  }
+  // eslint-disable-next-line no-underscore-dangle
+  return !parameters.__isArgsStory || sourceParams?.code || sourceParams?.type === SourceType.CODE;
+};
+
 export const jsxDecorator = (storyFn: any, context: StoryContext) => {
-  const story: ReturnType<typeof storyFn> & VueComponent = storyFn();
+  const story = storyFn();
+
+  if (skipJsxRender(context)) {
+    return story;
+  }
 
   const channel = addons.getChannel();
 

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -97,10 +97,16 @@ const defaultOpts = {
 
 export const skipJsxRender = (context: StoryContext) => {
   const { parameters } = context;
-  const sourceParams = parameters?.docs?.source;
+  const sourceParams = parameters.docs?.source;
+
+  // always render if the user forces it
   if (sourceParams?.type === SourceType.DYNAMIC) {
     return false;
   }
+
+  // never render if the user is forcing the block to render code, or
+  // if the user provides code, or if it's not an args story.
+
   // eslint-disable-next-line no-underscore-dangle
   return !parameters.__isArgsStory || sourceParams?.code || sourceParams?.type === SourceType.CODE;
 };
@@ -108,6 +114,8 @@ export const skipJsxRender = (context: StoryContext) => {
 export const jsxDecorator = (storyFn: any, context: StoryContext) => {
   const story = storyFn();
 
+  // We only need to render JSX if the source block is actually going to
+  // consume it. Otherwise it's just slowing us down.
   if (skipJsxRender(context)) {
     return story;
   }

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -96,8 +96,8 @@ const defaultOpts = {
 };
 
 export const skipJsxRender = (context: StoryContext) => {
-  const { parameters } = context;
-  const sourceParams = parameters.docs?.source;
+  const sourceParams = context?.parameters.docs?.source;
+  const isArgsStory = context?.parameters.__isArgsStory;
 
   // always render if the user forces it
   if (sourceParams?.type === SourceType.DYNAMIC) {
@@ -106,9 +106,7 @@ export const skipJsxRender = (context: StoryContext) => {
 
   // never render if the user is forcing the block to render code, or
   // if the user provides code, or if it's not an args story.
-
-  // eslint-disable-next-line no-underscore-dangle
-  return !parameters.__isArgsStory || sourceParams?.code || sourceParams?.type === SourceType.CODE;
+  return !isArgsStory || sourceParams?.code || sourceParams?.type === SourceType.CODE;
 };
 
 export const jsxDecorator = (storyFn: any, context: StoryContext) => {
@@ -124,7 +122,7 @@ export const jsxDecorator = (storyFn: any, context: StoryContext) => {
 
   const options = {
     ...defaultOpts,
-    ...((context && context.parameters.jsx) || {}),
+    ...(context?.parameters.jsx || {}),
   } as Required<JSXOptions>;
 
   let jsx = '';

--- a/addons/docs/src/shared.ts
+++ b/addons/docs/src/shared.ts
@@ -3,3 +3,26 @@ export const PANEL_ID = `${ADDON_ID}/panel`;
 export const PARAM_KEY = `docs`;
 
 export const SNIPPET_RENDERED = `${ADDON_ID}/snippet-rendered`;
+
+export enum SourceType {
+  /**
+   * AUTO is the default
+   *
+   * Use the CODE logic if:
+   * - the user has set a custom source snippet in `docs.source.code` story parameter
+   * - the story is not an args-based story
+   *
+   * Use the DYNAMIC rendered snippet if the story is an args story
+   */
+  AUTO = 'auto',
+
+  /**
+   * Render the code extracted by source-loader
+   */
+  CODE = 'code',
+
+  /**
+   * Render dynamically-rendered source snippet from the story's virtual DOM (currently React only)
+   */
+  DYNAMIC = 'dynamic',
+}


### PR DESCRIPTION
Issue: N/A

## What I did

Follow-up to https://github.com/storybookjs/storybook/pull/11601

If we're not going to use the dynamically rendered source snippet, don't even bother rendering it.

## How to test

See `official-storybook`
