### PR TITLE
Addon-docs: Re-enable source-loader by default

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -50,7 +50,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
     babelOptions,
     mdxBabelOptions,
     configureJSX = true,
-    sourceLoaderOptions = options.framework === 'react' ? null : {},
+    sourceLoaderOptions = {},
     transcludeMarkdown = false,
   } = options;
 


### PR DESCRIPTION
Issue: #11526 

## What I did

We are automatically rendering source code as snippets (as opposed to dynamic snippets) for all non-args stories, but `source-loader` is not enabled by default in React. Enable it by default.

Self-merging @tmeasday 

## How to test

See examples e.g. https://github.com/TomWija/storybook-source-test