### PR TITLE
Typo: add missing comma in addons example

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -757,7 +757,7 @@ If you had a `presets.js` file before you can add the array of presets to the ma
 module.exports = {
   stories: ['../**/*.stories.js'],
   addons: [
-    '@storybook/preset-create-react-app'
+    '@storybook/preset-create-react-app',
     {
       name: '@storybook/addon-docs',
       options: { configureJSX: true }


### PR DESCRIPTION
Issue:

## What I did

Added a comma to the example config

