### PR TITLE
Composition: Fix composition of older storybooks

### DIFF
--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -45,7 +45,7 @@
     "react": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "store2": "^2.7.1",
-    "telejson": "^4.0.0",
+    "telejson": "^4.0.1",
     "ts-dedent": "^1.1.1",
     "util-deprecate": "^1.0.2"
   },

--- a/lib/channel-postmessage/package.json
+++ b/lib/channel-postmessage/package.json
@@ -34,7 +34,7 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "qs": "^6.6.0",
-    "telejson": "^4.0.0"
+    "telejson": "^4.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/channel-websocket/package.json
+++ b/lib/channel-websocket/package.json
@@ -31,7 +31,7 @@
     "@storybook/channels": "6.0.0-rc.14",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "telejson": "^4.0.0"
+    "telejson": "^4.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17709,6 +17709,13 @@ is-regex@^1.0.3, is-regex@^1.0.4, is-regex@^1.0.5:
   dependencies:
     has "^1.0.3"
 
+is-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
+  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
+  dependencies:
+    has-symbols "^1.0.1"
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -21138,6 +21145,11 @@ lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0,
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@3.0.0, log-symbols@^3.0.0:
   version "3.0.0"
@@ -30238,6 +30250,20 @@ telejson@^4.0.0:
     is-symbol "^1.0.3"
     isobject "^4.0.0"
     lodash "^4.17.15"
+    memoizerific "^1.11.3"
+
+telejson@^4.0.1-0:
+  version "4.0.1-0"
+  resolved "https://registry.yarnpkg.com/telejson/-/telejson-4.0.1-0.tgz#a8b7bbf5434e6ce6eb35865c9773c43500de3b47"
+  integrity sha512-M2tr8iWQnd/xVobS2tFxcY3oT+aBbI0/Z1c+fuO7jiQr3qI3x/YMLD0qODPSUxOcidXA0EdELRRta47nvJLbbA==
+  dependencies:
+    "@types/is-function" "^1.0.0"
+    global "^4.4.0"
+    is-function "^1.0.2"
+    is-regex "^1.1.0"
+    is-symbol "^1.0.3"
+    isobject "^4.0.0"
+    lodash "^4.17.19"
     memoizerific "^1.11.3"
 
 temp-dir@^1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -30238,24 +30238,10 @@ teeny-request@6.0.1:
     stream-events "^1.0.5"
     uuid "^3.3.2"
 
-telejson@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/telejson/-/telejson-4.0.0.tgz#91ac1747f1efbc88a58e4344fbd8fe438695f77e"
-  integrity sha512-xTDEZd7bVIsbnOzTBTlUed+uKPThxMQPYtjN9OhvtsJQLJ7zEEX8bl8G72SlzfvQlTpxv1RTDq7Qfk1hMOw2zA==
-  dependencies:
-    "@types/is-function" "^1.0.0"
-    global "^4.4.0"
-    is-function "^1.0.2"
-    is-regex "^1.0.5"
-    is-symbol "^1.0.3"
-    isobject "^4.0.0"
-    lodash "^4.17.15"
-    memoizerific "^1.11.3"
-
-telejson@^4.0.1-0:
-  version "4.0.1-0"
-  resolved "https://registry.yarnpkg.com/telejson/-/telejson-4.0.1-0.tgz#a8b7bbf5434e6ce6eb35865c9773c43500de3b47"
-  integrity sha512-M2tr8iWQnd/xVobS2tFxcY3oT+aBbI0/Z1c+fuO7jiQr3qI3x/YMLD0qODPSUxOcidXA0EdELRRta47nvJLbbA==
+telejson@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/telejson/-/telejson-4.0.1.tgz#74030dd4456bb99f9e6a5add9a40f71794aba158"
+  integrity sha512-NsZukWlbwMYf56bMxnno1K7lMtv2eRO882YU5JlmzXaH5KpkC5tZTh5oMoKhkORHMNSafO+v4W5wayoQnX8Geg==
   dependencies:
     "@types/is-function" "^1.0.0"
     global "^4.4.0"


### PR DESCRIPTION
Issue: -telejson v4.0.1 is now compatible with v3.x-

In some cases of composition, if the composed storybook uses telejson v3, the composed storybook would fail to load.

## What I did
This upgrade to the latest version of telejson that has backwards compatibility to deal with the v3 data.