### PR TITLE
Addon-knobs: Move `@types/react-color` to devDeps

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -36,7 +36,6 @@
     "@storybook/components": "6.0.0-rc.14",
     "@storybook/core-events": "6.0.0-rc.14",
     "@storybook/theming": "6.0.0-rc.14",
-    "@types/react-color": "^3.0.1",
     "copy-to-clipboard": "^3.0.8",
     "core-js": "^3.0.1",
     "escape-html": "^1.0.3",
@@ -53,6 +52,7 @@
   "devDependencies": {
     "@types/enzyme": "^3.10.5",
     "@types/escape-html": "0.0.20",
+    "@types/react-color": "^3.0.1",
     "@types/react-lifecycles-compat": "^3.0.1",
     "@types/react-select": "^3.0.12",
     "@types/webpack-env": "^1.15.2",

--- a/addons/knobs/src/components/types/Checkboxes.tsx
+++ b/addons/knobs/src/components/types/Checkboxes.tsx
@@ -78,7 +78,7 @@ export default class CheckboxesType extends Component<CheckboxesTypeProps, Check
     };
   }
 
-  handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  private handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { onChange } = this.props;
     const currentValue = (e.target as HTMLInputElement).value;
     const { values } = this.state;
@@ -94,10 +94,10 @@ export default class CheckboxesType extends Component<CheckboxesTypeProps, Check
     onChange(values);
   };
 
-  renderCheckboxList = ({ options }: CheckboxesTypeKnob) =>
+  private renderCheckboxList = ({ options }: CheckboxesTypeKnob) =>
     Object.keys(options).map((key) => this.renderCheckbox(key, options[key]));
 
-  renderCheckbox = (label: string, value: string) => {
+  private renderCheckbox = (label: string, value: string) => {
     const { knob } = this.props;
     const { name } = knob;
     const id = `${name}-${value}`;

--- a/addons/knobs/src/components/types/Color.tsx
+++ b/addons/knobs/src/components/types/Color.tsx
@@ -95,7 +95,7 @@ export default class ColorType extends Component<ColorTypeProps, ColorTypeState>
     });
   };
 
-  handleClick = () => {
+  private handleClick = () => {
     const { displayColorPicker } = this.state;
 
     this.setState({
@@ -103,7 +103,7 @@ export default class ColorType extends Component<ColorTypeProps, ColorTypeState>
     });
   };
 
-  handleChange = (color: ColorResult) => {
+  private handleChange = (color: ColorResult) => {
     const { onChange } = this.props;
 
     onChange(`rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`);

--- a/addons/knobs/src/components/types/Date.tsx
+++ b/addons/knobs/src/components/types/Date.tsx
@@ -78,7 +78,7 @@ export default class DateType extends Component<DateTypeProps, DateTypeState> {
     }
   }
 
-  onDateChange = (e: ChangeEvent<HTMLInputElement>) => {
+  private onDateChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { knob, onChange } = this.props;
     const { state } = this;
 
@@ -99,7 +99,7 @@ export default class DateType extends Component<DateTypeProps, DateTypeState> {
     }
   };
 
-  onTimeChange = (e: ChangeEvent<HTMLInputElement>) => {
+  private onTimeChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { knob, onChange } = this.props;
     const { state } = this;
 

--- a/addons/knobs/src/components/types/Number.tsx
+++ b/addons/knobs/src/components/types/Number.tsx
@@ -80,7 +80,7 @@ export default class NumberType extends Component<NumberTypeProps> {
     return nextProps.knob.value !== knob.value;
   }
 
-  handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+  private handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onChange } = this.props;
     const { value } = event.target;
 

--- a/addons/knobs/src/components/types/Radio.tsx
+++ b/addons/knobs/src/components/types/Radio.tsx
@@ -59,14 +59,14 @@ class RadiosType extends Component<RadiosTypeProps> {
 
   static deserialize = (value: RadiosTypeKnobValue) => value;
 
-  renderRadioButtonList({ options }: RadiosTypeKnob) {
+  private renderRadioButtonList({ options }: RadiosTypeKnob) {
     if (Array.isArray(options)) {
       return options.map((val) => this.renderRadioButton(val, val));
     }
     return Object.keys(options).map((key) => this.renderRadioButton(key, options[key]));
   }
 
-  renderRadioButton(label: string, value: RadiosTypeKnobValue) {
+  private renderRadioButton(label: string, value: RadiosTypeKnobValue) {
     const opts = { label, value };
     const { onChange, knob } = this.props;
     const { name } = knob;

--- a/addons/knobs/src/components/types/Text.tsx
+++ b/addons/knobs/src/components/types/Text.tsx
@@ -32,7 +32,7 @@ export default class TextType extends Component<TextTypeProps> {
     return nextProps.knob.value !== knob.value;
   }
 
-  handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+  private handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const { onChange } = this.props;
     const { value } = event.target;
 


### PR DESCRIPTION
Issue: #11315

## What I did

See https://github.com/storybookjs/storybook/issues/11315#issuecomment-650012060

**TLDR;**

It looks like some function of components from `addon-knob` (`handleChange` and `handleClick`) should be private functions as they are used to handle internal stuff. Making then private leads to a generated `Color.d.ts` that doesn't import things from `@types/react-color` anymore so we can move this dependency from regular dep to devDep 🎉 .

## How to test

- `addon-knobs` should compile
- CI should be 🟢 (except `example-v2`, but for other reasons: https://github.com/storybookjs/storybook/pull/11354 fixes that)
