### PR TITLE
Addon-docs: Fix docs render layout to always be 'fullscreen'

### DIFF
--- a/lib/core/src/client/preview/StoryRenderer.tsx
+++ b/lib/core/src/client/preview/StoryRenderer.tsx
@@ -128,7 +128,7 @@ export class StoryRenderer {
       getDecorated,
     };
 
-    this.applyLayout(layout);
+    this.applyLayout(metadata.viewMode === 'docs' ? 'fullscreen' : layout);
 
     const context: RenderContext = {
       id: storyId, // <- in case data is null, at least we'll know what we tried to render


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/11398

## What I did
when the viewMode is docs (caused by docsOnly for example) ensure we render in 'fullscreen' layout