### PR TITLE
Cherry pick #11576, fix bug for non-dev builds of SB for release notes

### DIFF
--- a/lib/api/src/index.tsx
+++ b/lib/api/src/index.tsx
@@ -60,6 +60,8 @@ export type State = layout.SubState &
   version.SubState &
   url.SubState &
   shortcuts.SubState &
+  releaseNotes.SubState &
+  settings.SubState &
   globals.SubState &
   RouterData &
   Other;
@@ -73,6 +75,8 @@ export type API = addons.SubAPI &
   layout.SubAPI &
   notifications.SubAPI &
   shortcuts.SubAPI &
+  releaseNotes.SubAPI &
+  settings.SubAPI &
   version.SubAPI &
   url.SubAPI &
   Other;

--- a/lib/api/src/modules/release-notes.ts
+++ b/lib/api/src/modules/release-notes.ts
@@ -25,6 +25,10 @@ export interface SubAPI {
   showReleaseNotesOnLaunch: () => boolean;
 }
 
+export interface SubState {
+  releaseNotesViewed: string[];
+}
+
 export const init: ModuleFn = ({ store }) => {
   const releaseNotesData = getReleaseNotesData();
   const getReleaseNotesViewed = () => {
@@ -45,6 +49,8 @@ export const init: ModuleFn = ({ store }) => {
       }
     },
     showReleaseNotesOnLaunch: () => {
+      // The currentVersion will only exist for dev builds
+      if (!releaseNotesData.currentVersion) return false;
       const releaseNotesViewed = getReleaseNotesViewed();
       const didViewReleaseNotes = releaseNotesViewed.includes(releaseNotesData.currentVersion);
       const showReleaseNotesOnLaunch = releaseNotesData.showOnFirstLaunch && !didViewReleaseNotes;

--- a/lib/api/src/modules/settings.ts
+++ b/lib/api/src/modules/settings.ts
@@ -7,6 +7,14 @@ export interface SubAPI {
   navigateToSettingsPage: (path: string) => Promise<void>;
 }
 
+export interface Settings {
+  lastTrackedStoryId: string;
+}
+
+export interface SubState {
+  settings: Settings;
+}
+
 export const init: ModuleFn = ({ store, navigate, fullAPI }) => {
   const isSettingsScreenActive = () => {
     const { path } = fullAPI.getUrlState();

--- a/lib/ui/src/components/sidebar/Menu.stories.tsx
+++ b/lib/ui/src/components/sidebar/Menu.stories.tsx
@@ -37,28 +37,50 @@ const DoubleThemeRenderingHack = styled.div({
   },
 });
 
+const ExpandedMenu: FunctionComponent<{ menu: any }> = ({ menu }) => (
+  <DoubleThemeRenderingHack>
+    <WithTooltip
+      placement="top"
+      trigger="click"
+      closeOnClick
+      startOpen
+      tooltip={({ onHide }) => <SidebarMenuList onHide={onHide} menu={menu} />}
+    >
+      <MenuButton outline small containsIcon highlighted={false} title="Shortcuts">
+        <Icons icon="ellipsis" />
+      </MenuButton>
+    </WithTooltip>
+  </DoubleThemeRenderingHack>
+);
+
 export const Expanded = () => {
   const menu = useMenu(
-    // @ts-ignore
-    { getShortcutKeys: () => ({}), versionUpdateAvailable: () => false },
+    {
+      // @ts-ignore
+      getShortcutKeys: () => ({}),
+      versionUpdateAvailable: () => false,
+      releaseNotesVersion: () => '6.0.0',
+    },
     false,
     false,
     false,
     false
   );
-  return (
-    <DoubleThemeRenderingHack>
-      <WithTooltip
-        placement="top"
-        trigger="click"
-        closeOnClick
-        startOpen
-        tooltip={({ onHide }) => <SidebarMenuList onHide={onHide} menu={menu} />}
-      >
-        <MenuButton outline small containsIcon highlighted={false} title="Shortcuts">
-          <Icons icon="ellipsis" />
-        </MenuButton>
-      </WithTooltip>
-    </DoubleThemeRenderingHack>
+  return <ExpandedMenu menu={menu} />;
+};
+
+export const ExpandedWithoutReleaseNotes = () => {
+  const menu = useMenu(
+    {
+      // @ts-ignore
+      getShortcutKeys: () => ({}),
+      versionUpdateAvailable: () => false,
+      releaseNotesVersion: () => undefined,
+    },
+    false,
+    false,
+    false,
+    false
   );
+  return <ExpandedMenu menu={menu} />;
 };

--- a/lib/ui/src/containers/menu.tsx
+++ b/lib/ui/src/containers/menu.tsx
@@ -174,7 +174,7 @@ export const useMenu = (
   return useMemo(
     () => [
       about,
-      releaseNotes,
+      ...(api.releaseNotesVersion() ? [releaseNotes] : []),
       shortcuts,
       sidebarToggle,
       addonsToggle,
@@ -189,7 +189,7 @@ export const useMenu = (
     ],
     [
       about,
-      releaseNotes,
+      ...(api.releaseNotesVersion() ? [releaseNotes] : []),
       shortcuts,
       sidebarToggle,
       addonsToggle,

--- a/lib/ui/src/settings/about.stories.js
+++ b/lib/ui/src/settings/about.stories.js
@@ -13,15 +13,15 @@ storiesOf('UI/Settings/AboutScreen', module)
   .addParameters({
     component: AboutScreen,
   })
-  .addDecorator((s) => (
+  .addDecorator((storyFn) => (
     <div
       style={{
         position: 'relative',
-        height: 'calc(100vh)',
-        width: 'calc(100vw)',
+        height: '100vh',
+        width: '100vw',
       }}
     >
-      {s()}
+      {storyFn()}
     </div>
   ))
   .add('up to date', () => (

--- a/lib/ui/src/settings/about.tsx
+++ b/lib/ui/src/settings/about.tsx
@@ -2,16 +2,11 @@ import React, { Fragment, FunctionComponent } from 'react';
 import semver from '@storybook/semver';
 import { styled } from '@storybook/theming';
 import { State } from '@storybook/api';
-import { GlobalHotKeys } from 'react-hotkeys';
 import Markdown from 'markdown-to-jsx';
 
 import { StorybookIcon, SyntaxHighlighter, Link, DocumentWrapper } from '@storybook/components';
 
 import SettingsFooter from './SettingsFooter';
-
-const keyMap = {
-  CLOSE: 'escape',
-};
 
 const Header = styled.header(({ theme }) => ({
   marginBottom: 20,
@@ -88,8 +83,7 @@ const Container = styled.div({
 const AboutScreen: FunctionComponent<{
   latest: State['versions']['latest'];
   current: State['versions']['current'];
-  onClose: (e?: KeyboardEvent) => void;
-}> = ({ latest = null, current, onClose }) => {
+}> = ({ latest = null, current }) => {
   const canUpdate = latest && semver.gt(latest.version, current.version);
 
   let updateMessage;
@@ -114,70 +108,68 @@ const AboutScreen: FunctionComponent<{
   }
 
   return (
-    <GlobalHotKeys handlers={{ CLOSE: onClose }} keyMap={keyMap}>
-      <Container>
-        <Header>
-          <StorybookIcon />
-          Storybook {current.version}
-        </Header>
+    <Container>
+      <Header>
+        <StorybookIcon />
+        Storybook {current.version}
+      </Header>
 
-        {updateMessage}
+      {updateMessage}
 
-        {latest ? (
-          <Fragment>
-            <Subheader>
-              <Subheading>{latest.version} Changelog</Subheading>
-              <SubheadingLink
-                secondary
-                href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md"
-                withArrow
-                cancel={false}
-                target="_blank"
-              >
-                Read full changelog
-              </SubheadingLink>
-            </Subheader>
-            <DocumentWrapper>
-              <Markdown>{latest.info.plain}</Markdown>
-            </DocumentWrapper>
-          </Fragment>
-        ) : (
-          <ErrorMessage>
-            <Link
-              href="https://github.com/storybookjs/storybook/releases"
-              target="_blank"
-              withArrow
+      {latest ? (
+        <Fragment>
+          <Subheader>
+            <Subheading>{latest.version} Changelog</Subheading>
+            <SubheadingLink
               secondary
+              href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md"
+              withArrow
               cancel={false}
+              target="_blank"
             >
-              Check Storybook's release history
-            </Link>
-          </ErrorMessage>
-        )}
+              Read full changelog
+            </SubheadingLink>
+          </Subheader>
+          <DocumentWrapper>
+            <Markdown>{latest.info.plain}</Markdown>
+          </DocumentWrapper>
+        </Fragment>
+      ) : (
+        <ErrorMessage>
+          <Link
+            href="https://github.com/storybookjs/storybook/releases"
+            target="_blank"
+            withArrow
+            secondary
+            cancel={false}
+          >
+            Check Storybook's release history
+          </Link>
+        </ErrorMessage>
+      )}
 
-        {canUpdate && (
-          <Upgrade>
-            <DocumentWrapper>
-              <p>
-                <b>Upgrade all Storybook packages to latest:</b>
-              </p>
-              <SyntaxHighlighter language="bash" copyable padded bordered>
-                npx npm-check-updates '/storybook/' -u && npm install
-              </SyntaxHighlighter>
-              <p>
-                Alternatively, if you're using yarn run the following command, and check all
-                Storybook related packages:
-              </p>
-              <SyntaxHighlighter language="bash" copyable padded bordered>
-                yarn upgrade-interactive --latest
-              </SyntaxHighlighter>
-            </DocumentWrapper>
-          </Upgrade>
-        )}
+      {canUpdate && (
+        <Upgrade>
+          <DocumentWrapper>
+            <p>
+              <b>Upgrade all Storybook packages to latest:</b>
+            </p>
+            <SyntaxHighlighter language="bash" copyable padded bordered>
+              npx npm-check-updates '/storybook/' -u && npm install
+            </SyntaxHighlighter>
+            <p>
+              Alternatively, if you're using yarn run the following command, and check all Storybook
+              related packages:
+            </p>
+            <SyntaxHighlighter language="bash" copyable padded bordered>
+              yarn upgrade-interactive --latest
+            </SyntaxHighlighter>
+          </DocumentWrapper>
+        </Upgrade>
+      )}
 
-        <SettingsFooter />
-      </Container>
-    </GlobalHotKeys>
+      <SettingsFooter />
+    </Container>
   );
 };
 

--- a/lib/ui/src/settings/about_page.tsx
+++ b/lib/ui/src/settings/about_page.tsx
@@ -1,6 +1,6 @@
 import React, { Component, FunctionComponent } from 'react';
 
-import { Consumer, API, Combo } from '@storybook/api';
+import { API, useStorybookApi } from '@storybook/api';
 
 import { AboutScreen } from './about';
 
@@ -17,18 +17,14 @@ class NotificationClearer extends Component<{ api: API; notificationId: string }
   }
 }
 
-const AboutPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => (
-  <Consumer>
-    {({ api }: Combo) => (
-      <NotificationClearer api={api} notificationId="update">
-        <AboutScreen
-          current={api.getCurrentVersion()}
-          latest={api.getLatestVersion()}
-          onClose={onClose}
-        />
-      </NotificationClearer>
-    )}
-  </Consumer>
-);
+const AboutPage: FunctionComponent<{}> = () => {
+  const api = useStorybookApi();
+
+  return (
+    <NotificationClearer api={api} notificationId="update">
+      <AboutScreen current={api.getCurrentVersion()} latest={api.getLatestVersion()} />
+    </NotificationClearer>
+  );
+};
 
 export { AboutPage };

--- a/lib/ui/src/settings/index.tsx
+++ b/lib/ui/src/settings/index.tsx
@@ -1,68 +1,92 @@
-import React, { FunctionComponent, SyntheticEvent } from 'react';
-import { Tabs, IconButton, Icons } from '@storybook/components';
-import { useStorybookApi } from '@storybook/api';
+import React, { FunctionComponent, SyntheticEvent, Fragment } from 'react';
+import { IconButton, Icons, FlexBar, TabBar, TabButton, ScrollArea } from '@storybook/components';
+import { useStorybookApi, API, useStorybookState } from '@storybook/api';
 import { Location, Route } from '@storybook/router';
 import { styled } from '@storybook/theming';
+import { GlobalHotKeys } from 'react-hotkeys';
 import { AboutPage } from './about_page';
 import { ReleaseNotesPage } from './release_notes_page';
 import { ShortcutsPage } from './shortcuts_page';
 
-const ABOUT = 'about';
-const SHORTCUTS = 'shortcuts';
-const RELEASE_NOTES = 'release-notes';
-
-export const Wrapper = styled.div`
-  div[role='tabpanel'] {
-    height: 100%;
-  }
-`;
-
-interface PureSettingsPagesProps {
-  activeTab: string;
-  changeTab: (tab: string) => {};
-  onClose: () => {};
-}
-
-const PureSettingsPages: FunctionComponent<PureSettingsPagesProps> = ({
-  activeTab,
-  changeTab,
-  onClose,
-}) => (
-  <Wrapper>
-    <Tabs
-      absolute
-      selected={activeTab}
-      actions={{ onSelect: changeTab }}
-      tools={
-        <IconButton
-          onClick={(e: SyntheticEvent) => {
-            e.preventDefault();
-            return onClose();
-          }}
+const TabBarButton: FunctionComponent<{
+  changeTab: (tab: string) => void;
+  id: string;
+  title: string;
+}> = ({ changeTab, id, title }) => (
+  <Location>
+    {({ navigate, path }) => {
+      const active = path.includes(`settings/${id}`);
+      return (
+        <TabButton
+          id={`tabbutton-${id}`}
+          className={['tabbutton'].concat(active ? ['tabbutton-active'] : []).join(' ')}
+          type="button"
+          key="id"
+          active={active}
+          onClick={() => changeTab(id)}
+          role="tab"
         >
-          <Icons icon="close" />
-        </IconButton>
-      }
-    >
-      <div id={ABOUT} title="About">
-        <Route path={ABOUT}>
-          <AboutPage key={ABOUT} onClose={onClose} />
-        </Route>
-      </div>
+          {title}
+        </TabButton>
+      );
+    }}
+  </Location>
+);
 
-      <div id={RELEASE_NOTES} title="Release notes">
-        <Route path={RELEASE_NOTES}>
-          <ReleaseNotesPage key={RELEASE_NOTES} onClose={onClose} />
-        </Route>
-      </div>
+const Content = styled(ScrollArea)(
+  {
+    position: 'absolute',
+    top: 40,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    overflow: 'auto',
+  },
+  ({ theme }) => ({
+    background: theme.background.content,
+  })
+);
 
-      <div id={SHORTCUTS} title="Keyboard shortcuts">
-        <Route path={SHORTCUTS}>
-          <ShortcutsPage key={SHORTCUTS} onClose={onClose} />
-        </Route>
-      </div>
-    </Tabs>
-  </Wrapper>
+const keyMap = {
+  CLOSE: 'escape',
+};
+
+const Pages: FunctionComponent<{
+  onClose: () => void;
+  hasReleaseNotes?: boolean;
+  changeTab: (tab: string) => void;
+}> = ({ changeTab, onClose, hasReleaseNotes = false }) => (
+  <Fragment>
+    <FlexBar border>
+      <TabBar role="tablist">
+        <TabBarButton id="about" title="About" changeTab={changeTab} />
+        {hasReleaseNotes && (
+          <TabBarButton id="release-notes" title="Release notes" changeTab={changeTab} />
+        )}
+        <TabBarButton id="shortcuts" title="Keyboard shortcuts" changeTab={changeTab} />
+      </TabBar>
+      <IconButton
+        onClick={(e: SyntheticEvent) => {
+          e.preventDefault();
+          return onClose();
+        }}
+      >
+        <Icons icon="close" />
+      </IconButton>
+    </FlexBar>
+    <Content vertical horizontal={false}>
+      <Route path="about">
+        <AboutPage key="about" />
+      </Route>
+      <Route path="release-notes">
+        <ReleaseNotesPage key="release-notes" />
+      </Route>
+      <Route path="shortcuts">
+        <ShortcutsPage key="shortcuts" />
+      </Route>
+    </Content>
+    <GlobalHotKeys handlers={{ CLOSE: onClose }} keyMap={keyMap} />
+  </Fragment>
 );
 
 const SettingsPages: FunctionComponent = () => {
@@ -70,15 +94,11 @@ const SettingsPages: FunctionComponent = () => {
   const changeTab = (tab: string) => api.changeSettingsTab(tab);
 
   return (
-    <Location key="location.consumer">
-      {(locationData) => (
-        <PureSettingsPages
-          activeTab={locationData.storyId}
-          changeTab={changeTab}
-          onClose={api.closeSettings}
-        />
-      )}
-    </Location>
+    <Pages
+      hasReleaseNotes={!!api.releaseNotesVersion()}
+      changeTab={changeTab}
+      onClose={api.closeSettings}
+    />
   );
 };
 

--- a/lib/ui/src/settings/index.tsx
+++ b/lib/ui/src/settings/index.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, SyntheticEvent, Fragment } from 'react';
 import { IconButton, Icons, FlexBar, TabBar, TabButton, ScrollArea } from '@storybook/components';
-import { useStorybookApi, API, useStorybookState } from '@storybook/api';
+import { useStorybookApi } from '@storybook/api';
 import { Location, Route } from '@storybook/router';
 import { styled } from '@storybook/theming';
 import { GlobalHotKeys } from 'react-hotkeys';

--- a/lib/ui/src/settings/release_notes_page.tsx
+++ b/lib/ui/src/settings/release_notes_page.tsx
@@ -3,14 +3,16 @@ import React, { FunctionComponent, useEffect } from 'react';
 
 import { ReleaseNotesScreen } from './release_notes';
 
-const ReleaseNotesPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => {
+const ReleaseNotesPage: FunctionComponent<{}> = () => {
   const api = useStorybookApi();
 
   useEffect(() => {
     api.setDidViewReleaseNotes();
   }, []);
 
-  return <ReleaseNotesScreen onClose={onClose} version={api.releaseNotesVersion()} />;
+  const version = api.releaseNotesVersion();
+
+  return <ReleaseNotesScreen version={version} />;
 };
 
 export { ReleaseNotesPage };

--- a/lib/ui/src/settings/shortcuts.tsx
+++ b/lib/ui/src/settings/shortcuts.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { styled, keyframes } from '@storybook/theming';
-import { GlobalHotKeys } from 'react-hotkeys';
 
 import {
   eventToShortcut,
@@ -140,10 +139,6 @@ function toShortcutState(shortcutKeys: ShortcutsScreenProps['shortcutKeys']) {
   );
 }
 
-const keyMap = {
-  CLOSE: 'escape',
-};
-
 export interface ShortcutsScreenState {
   activeFeature: Feature;
   successField: Feature;
@@ -155,7 +150,6 @@ export interface ShortcutsScreenProps {
   setShortcut: Function;
   restoreDefaultShortcut: Function;
   restoreAllDefaultShortcuts: Function;
-  onClose: (e?: KeyboardEvent) => void;
 }
 
 class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenState> {
@@ -303,21 +297,18 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
   );
 
   render() {
-    const { onClose } = this.props;
     const layout = this.renderKeyForm();
     return (
-      <GlobalHotKeys handlers={{ CLOSE: onClose }} keyMap={keyMap}>
-        <Container>
-          <Header>Keyboard shortcuts</Header>
+      <Container>
+        <Header>Keyboard shortcuts</Header>
 
-          {layout}
-          <Button tertiary small id="restoreDefaultsHotkeys" onClick={this.restoreDefaults}>
-            Restore defaults
-          </Button>
+        {layout}
+        <Button tertiary small id="restoreDefaultsHotkeys" onClick={this.restoreDefaults}>
+          Restore defaults
+        </Button>
 
-          <SettingsFooter />
-        </Container>
-      </GlobalHotKeys>
+        <SettingsFooter />
+      </Container>
     );
   }
 }

--- a/lib/ui/src/settings/shortcuts_page.tsx
+++ b/lib/ui/src/settings/shortcuts_page.tsx
@@ -4,7 +4,7 @@ import { Consumer } from '@storybook/api';
 
 import { ShortcutsScreen } from './shortcuts';
 
-const ShortcutsPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) => (
+const ShortcutsPage: FunctionComponent<{}> = () => (
   <Consumer>
     {({
       api: { getShortcutKeys, setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts },
@@ -12,7 +12,6 @@ const ShortcutsPage: FunctionComponent<{ onClose: () => void }> = ({ onClose }) 
       <ShortcutsScreen
         shortcutKeys={getShortcutKeys()}
         {...{ setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts }}
-        onClose={onClose}
       />
     )}
   </Consumer>


### PR DESCRIPTION
Issue: #11483 

## What I did

This PR cherry picks a few things from PR #11576 that are low risk for the 6.0 release (aka not changing the mechanism for how we determine if the settings page is active). There are some bugs in #11576 in how that mechanism was changed & so it is going to be handled in the 6.1 release instead.

## How to test

The main bug that #11576 set out to address is #11483 . The way to test that this bug is fixed is to run a non-dev build of SB & make sure you can load up a settings page w/out error.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
