### PR TITLE
Source-loader: Inject source snippets as story parameters

### DIFF
--- a/__mocks__/inject-parameters.ts.csf.txt
+++ b/__mocks__/inject-parameters.ts.csf.txt
@@ -1,0 +1,22 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import { Button } from "@storybook/react/demo";
+
+export default {
+  title: "Button",
+  excludeStories: ["text"],
+  includeStories: /emoji.*/
+};
+
+export const Basic = () => (
+  <Button onClick={action("clicked")}>Hello Button</Button>
+);
+
+export const WithParams = () => <Button>WithParams</Button>;
+WithParams.parameters = { foo: 'bar' }
+
+export const WithDocsParams = () => <Button>WithDocsParams</Button>;
+WithDocsParams.parameters = { docs: { iframeHeight: 200 } };
+
+export const WithStorySourceParams = () => <Button>WithStorySourceParams</Button>;
+WithStorySourceParams.parameters = { storySource: { source: 'foo' } };

--- a/__mocks__/inject-parameters.ts.csf.txt
+++ b/__mocks__/inject-parameters.ts.csf.txt
@@ -20,3 +20,11 @@ WithDocsParams.parameters = { docs: { iframeHeight: 200 } };
 
 export const WithStorySourceParams = () => <Button>WithStorySourceParams</Button>;
 WithStorySourceParams.parameters = { storySource: { source: 'foo' } };
+
+const Template = (args: Args) => <Button {...args} />;
+
+export const WithTemplate = Template.bind({});
+WithTemplate.args = { foo: 'bar' }
+
+export const WithEmptyTemplate = Template.bind();
+WithEmptyTemplate.args = { foo: 'baz' };

--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -50,7 +50,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
     babelOptions,
     mdxBabelOptions,
     configureJSX = true,
-    sourceLoaderOptions = {},
+    sourceLoaderOptions = { injectParameters: true },
     transcludeMarkdown = false,
   } = options;
 

--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -50,7 +50,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
     babelOptions,
     mdxBabelOptions,
     configureJSX = true,
-    sourceLoaderOptions = { injectParameters: true },
+    sourceLoaderOptions = { injectStoryParameters: true },
     transcludeMarkdown = false,
   } = options;
 

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -36,6 +36,7 @@
     "estraverse": "^4.2.0",
     "global": "^4.3.2",
     "loader-utils": "^2.0.0",
+    "lodash": "^4.17.15",
     "prettier": "^2.0.5",
     "regenerator-runtime": "^0.13.3"
   },

--- a/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
+++ b/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
@@ -7,7 +7,9 @@ exports[`inject-decorator injectStoryParameters - ts - csf includes storySource 
 Basic.parameters = { storySource: { source: \\"() => (\\\\n  <Button onClick={action(\\\\\\"clicked\\\\\\")}>Hello Button</Button>\\\\n)\\" }, ...Basic.parameters };
 WithParams.parameters = { storySource: { source: \\"() => <Button>WithParams</Button>\\" }, ...WithParams.parameters };
 WithDocsParams.parameters = { storySource: { source: \\"() => <Button>WithDocsParams</Button>\\" }, ...WithDocsParams.parameters };
-WithStorySourceParams.parameters = { storySource: { source: \\"() => <Button>WithStorySourceParams</Button>\\" }, ...WithStorySourceParams.parameters };"
+WithStorySourceParams.parameters = { storySource: { source: \\"() => <Button>WithStorySourceParams</Button>\\" }, ...WithStorySourceParams.parameters };
+WithTemplate.parameters = { storySource: { source: \\"(args: Args) => <Button {...args} />\\" }, ...WithTemplate.parameters };
+WithEmptyTemplate.parameters = { storySource: { source: \\"(args: Args) => <Button {...args} />\\" }, ...WithEmptyTemplate.parameters };"
 `;
 
 exports[`inject-decorator positive - ts - csf includes storySource parameter in the default exported object 1`] = `

--- a/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
+++ b/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`inject-decorator injectParameters - ts - csf includes storySource parameter in the default exported object 1`] = `
+"
+
+
+Basic.parameters = { storySource: { source: \\"() => (\\\\n  <Button onClick={action(\\\\\\"clicked\\\\\\")}>Hello Button</Button>\\\\n)\\" }, ...Basic.parameters };
+WithParams.parameters = { storySource: { source: \\"() => <Button>WithParams</Button>\\" }, ...WithParams.parameters };
+WithDocsParams.parameters = { storySource: { source: \\"() => <Button>WithDocsParams</Button>\\" }, ...WithDocsParams.parameters };
+WithStorySourceParams.parameters = { storySource: { source: \\"() => <Button>WithStorySourceParams</Button>\\" }, ...WithStorySourceParams.parameters };"
+`;
+
 exports[`inject-decorator positive - ts - csf includes storySource parameter in the default exported object 1`] = `
 "import React from \\"react\\";
 import { action } from \\"@storybook/addon-actions\\";

--- a/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
+++ b/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`inject-decorator injectParameters - ts - csf includes storySource parameter in the default exported object 1`] = `
+exports[`inject-decorator injectStoryParameters - ts - csf includes storySource parameter in the default exported object 1`] = `
 "
 
 

--- a/lib/source-loader/src/abstract-syntax-tree/generate-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/generate-helpers.js
@@ -1,3 +1,5 @@
+import { storyNameFromExport, sanitize } from '@storybook/csf';
+import mapKeys from 'lodash/mapKeys';
 import { patchNode } from './parse-helpers';
 import getParser from './parsers';
 import {
@@ -7,6 +9,12 @@ import {
   popParametersObjectFromDefaultExport,
   findExportsMap as generateExportsMap,
 } from './traverse-helpers';
+
+export function sanitizeSource(source) {
+  return JSON.stringify(source)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
 
 function isUglyComment(comment, uglyCommentsRegex) {
   return uglyCommentsRegex.some((regex) => regex.test(comment));
@@ -134,6 +142,14 @@ export function generateStorySource({ source, ...options }) {
   return storySource;
 }
 
+function transformLocationMapToIds(parameters) {
+  if (!parameters?.locationsMap) return parameters;
+  const locationsMap = mapKeys(parameters.locationsMap, (_value, key) => {
+    return sanitize(storyNameFromExport(key));
+  });
+  return { ...parameters, locationsMap };
+}
+
 export function generateSourcesInExportedParameters(source, ast, additionalParameters) {
   const {
     splicedSource,
@@ -142,10 +158,9 @@ export function generateSourcesInExportedParameters(source, ast, additionalParam
     foundParametersProperty,
   } = popParametersObjectFromDefaultExport(source, ast);
   if (indexWhereToAppend !== -1) {
-    const additionalParametersAsJson = JSON.stringify({ storySource: additionalParameters }).slice(
-      0,
-      -1
-    );
+    const additionalParametersAsJson = JSON.stringify({
+      storySource: transformLocationMapToIds(additionalParameters),
+    }).slice(0, -1);
     const propertyDeclaration = foundParametersProperty ? '' : 'parameters: ';
     const comma = foundParametersProperty ? '' : ',';
     const newParameters = `${propertyDeclaration}${additionalParametersAsJson},${parametersSliceOfCode.substring(
@@ -159,4 +174,48 @@ export function generateSourcesInExportedParameters(source, ast, additionalParam
     return result;
   }
   return source;
+}
+
+/**
+ * given a location, extract the text from the full source
+ */
+function extractSource(location, lines) {
+  const { startBody: start, endBody: end } = location;
+  if (start.line === end.line && lines[start.line - 1] !== undefined) {
+    return lines[start.line - 1].substring(start.col, end.col);
+  }
+  // NOTE: storysource locations are 1-based not 0-based!
+  const startLine = lines[start.line - 1];
+  const endLine = lines[end.line - 1];
+  if (startLine === undefined || endLine === undefined) {
+    return null;
+  }
+  return [
+    startLine.substring(start.col),
+    ...lines.slice(start.line, end.line - 1),
+    endLine.substring(0, end.col),
+  ].join('\n');
+}
+
+function addStorySourceParameter(key, snippet) {
+  const source = sanitizeSource(snippet);
+  return `${key}.parameters = { storySource: { source: ${source} }, ...${key}.parameters };`;
+}
+
+export function generateSourcesInStoryParameters(source, ast, additionalParameters) {
+  if (!additionalParameters || !additionalParameters.source || !additionalParameters.locationsMap) {
+    return source;
+  }
+  const { source: sanitizedSource, locationsMap } = additionalParameters;
+  const lines = sanitizedSource.split('\n');
+  const suffix = Object.entries(locationsMap).reduce((acc, [exportName, location]) => {
+    const exportSource = extractSource(location, lines);
+    if (exportSource) {
+      const generated = addStorySourceParameter(exportName, exportSource);
+      return `${acc}\n${generated}`;
+    }
+    return acc;
+  }, '');
+
+  return suffix ? `${source}\n\n${suffix}` : source;
 }

--- a/lib/source-loader/src/abstract-syntax-tree/inject-decorator.csf.test.js
+++ b/lib/source-loader/src/abstract-syntax-tree/inject-decorator.csf.test.js
@@ -20,12 +20,12 @@ describe('inject-decorator', () => {
     });
   });
 
-  describe('injectParameters - ts - csf', () => {
+  describe('injectStoryParameters - ts - csf', () => {
     it('includes storySource parameter in the default exported object', () => {
       const mockFilePath = './__mocks__/inject-parameters.ts.csf.txt';
       const source = fs.readFileSync(mockFilePath, 'utf-8');
       const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
-        injectParameters: true,
+        injectStoryParameters: true,
         parser: 'typescript',
       });
 

--- a/lib/source-loader/src/abstract-syntax-tree/inject-decorator.csf.test.js
+++ b/lib/source-loader/src/abstract-syntax-tree/inject-decorator.csf.test.js
@@ -4,19 +4,32 @@ import injectDecorator from './inject-decorator';
 
 describe('inject-decorator', () => {
   describe('positive - ts - csf', () => {
-    const mockFilePath = './__mocks__/inject-decorator.ts.csf.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
-      parser: 'typescript',
-    });
-
     it('includes storySource parameter in the default exported object', () => {
+      const mockFilePath = './__mocks__/inject-decorator.ts.csf.txt';
+      const source = fs.readFileSync(mockFilePath, 'utf-8');
+      const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+        parser: 'typescript',
+      });
+
       expect(result.source).toMatchSnapshot();
       expect(result.source).toEqual(
         expect.stringContaining(
           'export default {parameters: {"storySource":{"source":"import React from'
         )
       );
+    });
+  });
+
+  describe('injectParameters - ts - csf', () => {
+    it('includes storySource parameter in the default exported object', () => {
+      const mockFilePath = './__mocks__/inject-parameters.ts.csf.txt';
+      const source = fs.readFileSync(mockFilePath, 'utf-8');
+      const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+        injectParameters: true,
+        parser: 'typescript',
+      });
+
+      expect(result.source).toMatchSnapshot();
     });
   });
 });

--- a/lib/source-loader/src/abstract-syntax-tree/inject-decorator.js
+++ b/lib/source-loader/src/abstract-syntax-tree/inject-decorator.js
@@ -7,6 +7,7 @@ import {
   generateStorySource,
   generateStoriesLocationsMap,
   generateSourcesInExportedParameters,
+  generateSourcesInStoryParameters,
 } from './generate-helpers';
 
 function extendOptions(source, comments, filepath, options) {
@@ -51,10 +52,17 @@ function inject(source, filepath, options = {}, log = (message) => {}) {
   let newSource = cleanedSource;
   if (exportTokenFound) {
     const cleanedSourceAst = parser.parse(cleanedSource);
-    newSource = generateSourcesInExportedParameters(cleanedSource, cleanedSourceAst, {
-      source: storySource,
-      locationsMap: addsMap,
-    });
+    if (injectParameters) {
+      newSource = generateSourcesInStoryParameters(cleanedSource, cleanedSourceAst, {
+        source: storySource,
+        locationsMap: addsMap,
+      });
+    } else {
+      newSource = generateSourcesInExportedParameters(cleanedSource, cleanedSourceAst, {
+        source: storySource,
+        locationsMap: addsMap,
+      });
+    }
   }
 
   if (!changed && Object.keys(addsMap || {}).length === 0) {

--- a/lib/source-loader/src/abstract-syntax-tree/inject-decorator.js
+++ b/lib/source-loader/src/abstract-syntax-tree/inject-decorator.js
@@ -21,7 +21,7 @@ function extendOptions(source, comments, filepath, options) {
 }
 
 function inject(source, filepath, options = {}, log = (message) => {}) {
-  const { injectDecorator = true, injectParameters = false } = options;
+  const { injectDecorator = true, injectStoryParameters = false } = options;
   const obviouslyNotCode = ['md', 'txt', 'json'].includes(options.parser);
   let parser = null;
   try {
@@ -52,7 +52,7 @@ function inject(source, filepath, options = {}, log = (message) => {}) {
   let newSource = cleanedSource;
   if (exportTokenFound) {
     const cleanedSourceAst = parser.parse(cleanedSource);
-    if (injectParameters) {
+    if (injectStoryParameters) {
       newSource = generateSourcesInStoryParameters(cleanedSource, cleanedSourceAst, {
         source: storySource,
         locationsMap: addsMap,

--- a/lib/source-loader/src/abstract-syntax-tree/parse-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/parse-helpers.js
@@ -28,7 +28,62 @@ export function patchNode(node) {
   return node;
 }
 
-export function handleExportedName(storyName, node) {
+function findTemplate(templateName, program) {
+  let template = null;
+  program.body.find((node) => {
+    let declarations = null;
+    if (node.type === 'VariableDeclaration') {
+      declarations = node.declarations;
+    } else if (
+      node.type === 'ExportNamedDeclaration' &&
+      node.declaration.type === 'VariableDeclaration'
+    ) {
+      declarations = node.declaration.declarations;
+    }
+    return (
+      declarations &&
+      declarations.find((decl) => {
+        if (
+          decl.type === 'VariableDeclarator' &&
+          decl.id.type === 'Identifier' &&
+          decl.id.name === templateName
+        ) {
+          template = decl.init;
+          return true; // stop looking
+        }
+        return false;
+      })
+    );
+  });
+  return template;
+}
+
+function expandBindExpression(node, parent) {
+  if (node.type === 'CallExpression') {
+    const { callee, arguments: bindArguments } = node;
+    if (
+      parent.type === 'Program' &&
+      callee.type === 'MemberExpression' &&
+      callee.object.type === 'Identifier' &&
+      callee.property.type === 'Identifier' &&
+      callee.property.name === 'bind' &&
+      (bindArguments.length === 0 ||
+        (bindArguments.length === 1 &&
+          bindArguments[0].type === 'ObjectExpression' &&
+          bindArguments[0].properties.length === 0))
+    ) {
+      const boundIdentifier = callee.object.name;
+      const template = findTemplate(boundIdentifier, parent);
+      if (template) {
+        return template;
+      }
+    }
+  }
+  return node;
+}
+
+export function handleExportedName(storyName, originalNode, parent) {
+  const node = expandBindExpression(originalNode, parent);
   const startLoc = {
     col: node.loc.start.column,
     line: node.loc.start.line,

--- a/lib/source-loader/src/abstract-syntax-tree/parse-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/parse-helpers.js
@@ -38,7 +38,7 @@ export function handleExportedName(storyName, node) {
     line: node.loc.end.line,
   };
   return {
-    [sanitize(storyName)]: {
+    [storyName]: {
       startLoc,
       endLoc,
       startBody: startLoc,

--- a/lib/source-loader/src/abstract-syntax-tree/traverse-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/traverse-helpers.js
@@ -159,7 +159,7 @@ export function findExportsMap(ast) {
   const addsMap = {};
   estraverse.traverse(ast, {
     fallback: 'iteration',
-    enter: (node) => {
+    enter: (node, parent) => {
       patchNode(node);
 
       const isNamedExport = node.type === 'ExportNamedDeclaration' && node.declaration;
@@ -188,7 +188,8 @@ export function findExportsMap(ast) {
           : node.declaration;
         const toAdd = handleExportedName(
           exportDeclaration.id.name,
-          exportDeclaration.init || exportDeclaration
+          exportDeclaration.init || exportDeclaration,
+          parent
         );
         Object.assign(addsMap, toAdd);
       }

--- a/lib/source-loader/src/abstract-syntax-tree/traverse-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/traverse-helpers.js
@@ -1,4 +1,4 @@
-import { storyNameFromExport, isExportStory } from '@storybook/csf';
+import { isExportStory } from '@storybook/csf';
 import { handleADD, handleSTORYOF, patchNode, handleExportedName } from './parse-helpers';
 
 const estraverse = require('estraverse');
@@ -186,8 +186,10 @@ export function findExportsMap(ast) {
         const exportDeclaration = isFunctionVariableExport
           ? node.declaration.declarations[0]
           : node.declaration;
-        const storyName = storyNameFromExport(exportDeclaration.id.name);
-        const toAdd = handleExportedName(storyName, exportDeclaration.init || exportDeclaration);
+        const toAdd = handleExportedName(
+          exportDeclaration.id.name,
+          exportDeclaration.init || exportDeclaration
+        );
         Object.assign(addsMap, toAdd);
       }
     },

--- a/lib/source-loader/src/build.js
+++ b/lib/source-loader/src/build.js
@@ -12,7 +12,7 @@ export function transform(inputSource) {
       return inputSource;
     }
     const { source, sourceJson, addsMap } = sourceObject;
-    if (options.injectParameters) {
+    if (options.injectStoryParameters) {
       return source;
     }
     const preamble = `

--- a/lib/source-loader/src/build.js
+++ b/lib/source-loader/src/build.js
@@ -1,6 +1,8 @@
+import { getOptions } from 'loader-utils';
 import { readStory } from './dependencies-lookup/readAsObject';
 
 export function transform(inputSource) {
+  const options = getOptions(this) || {};
   return readStory(this, inputSource).then((sourceObject) => {
     // if source-loader had trouble parsing the story exports, return the original story
     // example is
@@ -10,6 +12,9 @@ export function transform(inputSource) {
       return inputSource;
     }
     const { source, sourceJson, addsMap } = sourceObject;
+    if (options.injectParameters) {
+      return source;
+    }
     const preamble = `
       /* eslint-disable */
       // @ts-nocheck

--- a/lib/source-loader/src/dependencies-lookup/readAsObject.js
+++ b/lib/source-loader/src/dependencies-lookup/readAsObject.js
@@ -1,5 +1,6 @@
 import { getOptions } from 'loader-utils';
 import injectDecorator from '../abstract-syntax-tree/inject-decorator';
+import { sanitizeSource } from '../abstract-syntax-tree/generate-helpers';
 
 function readAsObject(classLoader, inputSource, mainFile) {
   const options = getOptions(classLoader) || {};
@@ -13,10 +14,7 @@ function readAsObject(classLoader, inputSource, mainFile) {
     classLoader.emitWarning.bind(classLoader)
   );
 
-  const sourceJson = JSON.stringify(result.storySource || inputSource)
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029');
-
+  const sourceJson = sanitizeSource(result.storySource || inputSource);
   const addsMap = result.addsMap || {};
   const source = mainFile ? result.source : inputSource;
 


### PR DESCRIPTION
Issue: #11591 

## What I did

Investigated degraded loading performance for a large production Storybook with 1500 stories and found that `addon-docs` appeared to be the culprit, and specifically `source-loader`.

`source-loader` injects the entire source as a component-level parameter as well as a collection of `location` offsets, one for each story. Something about this arrangement is extremely resource intensive on load.

This setup is necessary for `addon-storysource`, but not for `addon-docs`. As an optimization, I added a parameter `injectStoryParameters` which front-loads the extraction of source snippets. 

- [x] Add a new `source-loader` option, `injectStoryParameters` that inserts source snippets for each story
- [x] Make `injectParameters: true` the default for docs
- [x] Add a snapshot test

## Benchmarks

```
Full RC.14:
- Configure: 4660
- handleEvent: 3530

Injected source (this PR):
- Configure: 1950
- handleEvent: 2650

Removing source entirely:
- Configure: 1770
- handleEvent: 2550

Removing docs entirely:
- Configure: 1500
- handleEvent: 2100
```

## How to test

See updated tests, `official-storybook`
