### PR TITLE
Revert #11502: Remove z-index on ActionBar

### DIFF
--- a/lib/components/src/ActionBar/ActionBar.tsx
+++ b/lib/components/src/ActionBar/ActionBar.tsx
@@ -9,6 +9,7 @@ const Container = styled.div<{}>(({ theme }) => ({
   maxWidth: '100%',
   display: 'flex',
   background: theme.background.content,
+  zIndex: 1,
 }));
 
 export const ActionButton = styled.button<{ disabled: boolean }>(


### PR DESCRIPTION
Issue: #11502

## What I did

ADD the zIndex back for https://github.com/storybookjs/storybook/pull/11502#issuecomment-663774680
