### PR TITLE
Source-loader: Handle bind expression stories

### DIFF
--- a/__mocks__/inject-parameters.ts.csf.txt
+++ b/__mocks__/inject-parameters.ts.csf.txt
@@ -20,3 +20,11 @@ WithDocsParams.parameters = { docs: { iframeHeight: 200 } };
 
 export const WithStorySourceParams = () => <Button>WithStorySourceParams</Button>;
 WithStorySourceParams.parameters = { storySource: { source: 'foo' } };
+
+const Template = (args: Args) => <Button {...args} />;
+
+export const WithTemplate = Template.bind({});
+WithTemplate.args = { foo: 'bar' }
+
+export const WithEmptyTemplate = Template.bind();
+WithEmptyTemplate.args = { foo: 'baz' };

--- a/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
+++ b/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
@@ -7,7 +7,9 @@ exports[`inject-decorator injectStoryParameters - ts - csf includes storySource 
 Basic.parameters = { storySource: { source: \\"() => (\\\\n  <Button onClick={action(\\\\\\"clicked\\\\\\")}>Hello Button</Button>\\\\n)\\" }, ...Basic.parameters };
 WithParams.parameters = { storySource: { source: \\"() => <Button>WithParams</Button>\\" }, ...WithParams.parameters };
 WithDocsParams.parameters = { storySource: { source: \\"() => <Button>WithDocsParams</Button>\\" }, ...WithDocsParams.parameters };
-WithStorySourceParams.parameters = { storySource: { source: \\"() => <Button>WithStorySourceParams</Button>\\" }, ...WithStorySourceParams.parameters };"
+WithStorySourceParams.parameters = { storySource: { source: \\"() => <Button>WithStorySourceParams</Button>\\" }, ...WithStorySourceParams.parameters };
+WithTemplate.parameters = { storySource: { source: \\"(args: Args) => <Button {...args} />\\" }, ...WithTemplate.parameters };
+WithEmptyTemplate.parameters = { storySource: { source: \\"(args: Args) => <Button {...args} />\\" }, ...WithEmptyTemplate.parameters };"
 `;
 
 exports[`inject-decorator positive - ts - csf includes storySource parameter in the default exported object 1`] = `

--- a/lib/source-loader/src/abstract-syntax-tree/parse-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/parse-helpers.js
@@ -28,7 +28,62 @@ export function patchNode(node) {
   return node;
 }
 
-export function handleExportedName(storyName, node) {
+function findTemplate(templateName, program) {
+  let template = null;
+  program.body.find((node) => {
+    let declarations = null;
+    if (node.type === 'VariableDeclaration') {
+      declarations = node.declarations;
+    } else if (
+      node.type === 'ExportNamedDeclaration' &&
+      node.declaration.type === 'VariableDeclaration'
+    ) {
+      declarations = node.declaration.declarations;
+    }
+    return (
+      declarations &&
+      declarations.find((decl) => {
+        if (
+          decl.type === 'VariableDeclarator' &&
+          decl.id.type === 'Identifier' &&
+          decl.id.name === templateName
+        ) {
+          template = decl.init;
+          return true; // stop looking
+        }
+        return false;
+      })
+    );
+  });
+  return template;
+}
+
+function expandBindExpression(node, parent) {
+  if (node.type === 'CallExpression') {
+    const { callee, arguments: bindArguments } = node;
+    if (
+      parent.type === 'Program' &&
+      callee.type === 'MemberExpression' &&
+      callee.object.type === 'Identifier' &&
+      callee.property.type === 'Identifier' &&
+      callee.property.name === 'bind' &&
+      (bindArguments.length === 0 ||
+        (bindArguments.length === 1 &&
+          bindArguments[0].type === 'ObjectExpression' &&
+          bindArguments[0].properties.length === 0))
+    ) {
+      const boundIdentifier = callee.object.name;
+      const template = findTemplate(boundIdentifier, parent);
+      if (template) {
+        return template;
+      }
+    }
+  }
+  return node;
+}
+
+export function handleExportedName(storyName, originalNode, parent) {
+  const node = expandBindExpression(originalNode, parent);
   const startLoc = {
     col: node.loc.start.column,
     line: node.loc.start.line,

--- a/lib/source-loader/src/abstract-syntax-tree/traverse-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/traverse-helpers.js
@@ -159,7 +159,7 @@ export function findExportsMap(ast) {
   const addsMap = {};
   estraverse.traverse(ast, {
     fallback: 'iteration',
-    enter: (node) => {
+    enter: (node, parent) => {
       patchNode(node);
 
       const isNamedExport = node.type === 'ExportNamedDeclaration' && node.declaration;
@@ -188,7 +188,8 @@ export function findExportsMap(ast) {
           : node.declaration;
         const toAdd = handleExportedName(
           exportDeclaration.id.name,
-          exportDeclaration.init || exportDeclaration
+          exportDeclaration.init || exportDeclaration,
+          parent
         );
         Object.assign(addsMap, toAdd);
       }


### PR DESCRIPTION
Issue: #11678

## What I did

Telescoping PR from #11707

When source-loader sees:

```
export const Foo = Bar.bind({});
```

It tries to track down `Bar` definition and use that as the source instead if it finds a matching declaration.

## How to test

See the updated snapshots & the `ForceCodeSource` story in `official-storybook` for e2e
