### PR TITLE
docs(controls): Fix example story of Controls + MDX section

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -575,13 +575,13 @@ Here's the MDX equivalent:
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 import { Button } from './Button';
 
-<Meta title="Button" component={Button} argTypes={{ background: { control: 'color' } }} />;
+<Meta title="Button" component={Button} argTypes={{ background: { control: 'color' } }} />
 
 export const Template = (args) => <Button {...args} />;
 
 <Story name="Basic" args={{ label: 'hello', background: '#ff0' }}>
   {Template.bind({})}
-</Story>;
+</Story>
 ```
 
 For more info, see a full [Controls example in MDX for Vue](https://raw.githubusercontent.com/storybookjs/storybook/next/examples/vue-kitchen-sink/src/stories/addon-controls.stories.mdx).


### PR DESCRIPTION
Issue: The sample code provided in `addons/controls/README.md > How do controls work with MDX?` is not working out of the box so I fixed it.

## What I did

It looks like the extra `;` after a `Story` tag makes `@mdx-js/loader` unhappy, it throws `SyntaxError: Unexpected token (3:8)`. 
Removing that `;` fixes the issue. I also removed the one after `Meta` as it is not needed.

## How to test

- Copy/paste the updated code and... it should just work 
