### PR TITLE
Core: Pass normalized parameters to the story sort function

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,6 +18,7 @@
   - [New setStories event](#new-setstories-event)
   - [Removed renderCurrentStory event](#removed-rendercurrentstory-event)
   - [Removed hierarchy separators](#removed-hierarchy-separators)
+  - [No longer pass denormalized parameters to storySort](#no-longer-pass-denormalized-parameters-to-storysort)
   - [Client API changes](#client-api-changes)
     - [Removed Legacy Story APIs](#removed-legacy-story-apis)
     - [Can no longer add decorators/parameters after stories](#can-no-longer-add-decoratorsparameters-after-stories)
@@ -399,6 +400,12 @@ addons.setConfig({
 });
 ```
 
+### No longer pass denormalized parameters to storySort
+
+The `storySort` function (set via the `parameters.options.storySort` parameter) previously compared two entries `[storyId, storeItem]`, where `storeItem` included the full "denormalized" set of parameters of the story (i.e. the global, kind and story parameters that applied to that story).
+
+For performance reasons, we now store the parameters uncombined, and so pass the format: `[storyId, storeItem, kindParameters, globalParameters]`.
+
 ### Client API changes
 
 #### Removed Legacy Story APIs
@@ -760,8 +767,8 @@ module.exports = {
     '@storybook/preset-create-react-app',
     {
       name: '@storybook/addon-docs',
-      options: { configureJSX: true }
-    }
+      options: { configureJSX: true },
+    },
   ],
 };
 ```

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -75,7 +75,10 @@ export interface StorySortObjectParameter {
   order?: any[];
   locales?: string;
 }
-export type StorySortParameter = Comparator<any> | StorySortObjectParameter;
+// The `any` here is the story store's `StoreItem` record. Ideally we should probably only
+// pass a defined subset of that full data, but we pass it all so far :shrug:
+export type StorySortComparator = Comparator<[StoryId, any, Parameters, Parameters]>;
+export type StorySortParameter = StorySortComparator | StorySortObjectParameter;
 
 export interface OptionsParameter extends Object {
   storySort?: StorySortParameter;

--- a/lib/client-api/src/storySort.ts
+++ b/lib/client-api/src/storySort.ts
@@ -1,6 +1,6 @@
-import { StorySortObjectParameter, Comparator } from '@storybook/addons';
+import { StorySortObjectParameter, StorySortComparator } from '@storybook/addons';
 
-export const storySort = (options: StorySortObjectParameter = {}): Comparator<any> => (
+export const storySort = (options: StorySortObjectParameter = {}): StorySortComparator => (
   a: any,
   b: any
 ): number => {

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -1004,7 +1004,7 @@ describe('preview.story_store', () => {
       ]);
     });
 
-    it('denormalizes parameters before passing to sort', () => {
+    it('passes kind and global parameters to sort', () => {
       const store = new StoryStore({ channel });
       const storySort = jest.fn();
       store.addGlobalMetadata({
@@ -1025,14 +1025,18 @@ describe('preview.story_store', () => {
         [
           'a--1',
           expect.objectContaining({
-            parameters: expect.objectContaining({ global: 'global', kind: 'kind', story: '1' }),
+            parameters: expect.objectContaining({ story: '1' }),
           }),
+          { kind: 'kind' },
+          expect.objectContaining({ global: 'global' }),
         ],
         [
           'a--2',
           expect.objectContaining({
-            parameters: expect.objectContaining({ global: 'global', kind: 'kind', story: '2' }),
+            parameters: expect.objectContaining({ story: '2' }),
           }),
+          { kind: 'kind' },
+          expect.objectContaining({ global: 'global' }),
         ]
       );
     });


### PR DESCRIPTION
Issue: #11721

Don't denormalize params before sorting, as this has a perf cost that we don't want to pay. This is a breaking change but hopefully not a huge deal.

Notes:

 - I didn't update the docs because that is happening in the `6.0-docs` branch. We should probably just merge that to `next` now?
 - Do you think we should type / restrict the second entry in the array, as hinted at by the comment?