### PR TITLE
Composition: Fix missing version property in autoref

### DIFF
--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -59,11 +59,12 @@ async function getManagerWebpackConfig(options, presets) {
   const refs = {};
 
   if (autoRefs && autoRefs.length) {
-    autoRefs.forEach(({ id, url, title }) => {
+    autoRefs.forEach(({ id, url, title, version }) => {
       refs[id.toLowerCase()] = {
         id: id.toLowerCase(),
         url: stripTrailingSlash(url),
         title,
+        version,
       };
     });
   }


### PR DESCRIPTION
Issue: -autorefs have a version that's appended to the ref url-

## What I did

Ensure the version is passed from the package.json into the refs config