### PR TITLE
Update Docs docs to replace existing <Props /> references

### DIFF
--- a/addons/docs/docs/docspage.md
+++ b/addons/docs/docs/docspage.md
@@ -126,7 +126,7 @@ import {
   Subtitle,
   Description,
   Primary,
-  Props,
+  ArgsTable,
   Stories,
 } from '@storybook/addon-docs/blocks';
 import { DocgenButton } from '../../components/DocgenButton';

--- a/addons/docs/docs/props-tables.md
+++ b/addons/docs/docs/props-tables.md
@@ -38,11 +38,11 @@ export default {
 
 ### MDX
 
-To use the props table in [MDX](./mdx.md), use the `Props` block:
+To use the props table in [MDX](./mdx.md), use the `ArgsTable` block:
 
 ```js
 // MyComponent.stories.mdx
-import { Props } from '@storybook/addon-docs/blocks';
+import { ArgsTable } from '@storybook/addon-docs/blocks';
 import { MyComponent } from './MyComponent';
 
 # My Component!
@@ -52,7 +52,7 @@ import { MyComponent } from './MyComponent';
 
 ## Controls
 
-Starting in SB 6.0, the `Props` block has built-in `Controls` (formerly known as "knobs") for editing stories dynamically.
+Starting in SB 6.0, the `ArgsTable` block has built-in `Controls` (formerly known as "knobs") for editing stories dynamically.
 
 <center>
   <img src="./media/args-controls.gif" width="80%" />
@@ -73,7 +73,7 @@ export default {
 export const WithControls = (args) => <MyComponent {...args} />;
 ```
 
-**MDX.** In [MDX](./mdx.md), the `Props` controls are more configurable than in DocsPage. In order to show controls, `Props` must be a function of a story, not a component:
+**MDX.** In [MDX](./mdx.md), the `ArgsTable` controls are more configurable than in DocsPage. In order to show controls, `ArgsTable` must be a function of a story, not a component:
 
 ```js
 <Story name="WithControls">


### PR DESCRIPTION
Issue: References to the `<Props>` component still existed in the docs

## What I did

Replaced a few instances of the `<Props>` component I noticed were left in - if I replaced something that shouldn't have been let me know and I can fix it