### PR TITLE
Addon-docs: Add Story.story for CSF stories with MDX docs

### DIFF
--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -70,7 +70,7 @@ import { SomeComponent } from 'path/to/SomeComponent';
 
 I can define a story with the function imported from CSF:
 
-<Story name="basic">{stories.basic()}</Story>
+<Story story={stories.basic} />
 
 And I can also embed arbitrary markdown & JSX in this file.
 
@@ -80,7 +80,8 @@ And I can also embed arbitrary markdown & JSX in this file.
 What's happening here:
 
 - Your stories are defined in CSF, but because of `includeStories: []`, they are not actually added to Storybook.
-- The MDX file is simply importing stories as functions in the MDX, and other aspects of the CSF file, such as decorators, parameters, and any other metadata should be applied as needed in the MDX from the import.
+- The named story exports are annotated with story-level decorators, parameters, args, and the `<Story story={}>` construct respects this.
+- All component-level decorators, parameters, etc. from `Button.stories` default export must be manually copied over into `<Meta>` if desired.
 
 ## CSF Stories with arbitrary MDX
 

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode, ComponentProps } from 'react';
+import React, { FunctionComponent, ReactNode, ElementType, ComponentProps } from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { resetComponents } from '@storybook/components/html';
 import { Story as PureStory } from '@storybook/components';
@@ -23,6 +23,11 @@ type StoryDefProps = {
 
 type StoryRefProps = {
   id?: string;
+} & CommonProps;
+
+type StoryImportProps = {
+  name: string;
+  story: ElementType;
 } & CommonProps;
 
 export type StoryProps = StoryDefProps | StoryRefProps;

--- a/addons/docs/src/mdx/__testfixtures__/csf-imports.mdx
+++ b/addons/docs/src/mdx/__testfixtures__/csf-imports.mdx
@@ -1,0 +1,14 @@
+import { Story, Meta } from '@storybook/addon-docs/blocks';
+import { Welcome, Button } from '@storybook/angular/demo';
+import * as MyStories from './My.stories';
+import { Other } from './Other.stories';
+
+<Meta title="MDX/CSF imports" />
+
+# Stories from CSF imports
+
+<Story story={MyStories.Basic} />
+
+<Story story={Other} />
+
+<Story name="renamed" story={MyStories.Foo} />

--- a/addons/docs/src/mdx/__testfixtures__/csf-imports.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/csf-imports.output.snapshot
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`docs-mdx-compiler-plugin csf-imports.mdx 1`] = `
+"/* @jsx mdx */
+import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+
+import { Story, Meta } from '@storybook/addon-docs/blocks';
+import { Welcome, Button } from '@storybook/angular/demo';
+import * as MyStories from './My.stories';
+import { Other } from './Other.stories';
+
+const makeShortcode = (name) =>
+  function MDXDefaultShortcode(props) {
+    console.warn(
+      'Component ' +
+        name +
+        ' was not imported, exported, or provided by MDXProvider as global scope'
+    );
+    return <div {...props} />;
+  };
+
+const layoutProps = {};
+const MDXLayout = 'wrapper';
+function MDXContent({ components, ...props }) {
+  return (
+    <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
+      <Meta title=\\"MDX/CSF imports\\" mdxType=\\"Meta\\" />
+      <h1>{\`Stories from CSF imports\`}</h1>
+      <Story story={MyStories.Basic} name=\\"BasicStory\\" mdxType=\\"Story\\" />
+      <Story story={Other} name=\\"OtherStory\\" mdxType=\\"Story\\" />
+      <Story name=\\"renamed\\" story={MyStories.Foo} mdxType=\\"Story\\" />
+    </MDXLayout>
+  );
+}
+
+MDXContent.isMDXComponent = true;
+
+export const BasicStory = MyStories.Basic;
+
+export const OtherStory = Other;
+
+export const FooStory = MyStories.Foo;
+FooStory.storyName = 'renamed';
+
+const componentMeta = {
+  title: 'MDX/CSF imports',
+  includeStories: ['BasicStory', 'OtherStory', 'FooStory'],
+};
+
+const mdxStoryNameToKey = {
+  BasicStory: 'BasicStory',
+  OtherStory: 'OtherStory',
+  renamed: 'FooStory',
+};
+
+componentMeta.parameters = componentMeta.parameters || {};
+componentMeta.parameters.docs = {
+  ...(componentMeta.parameters.docs || {}),
+  page: () => (
+    <AddContext mdxStoryNameToKey={mdxStoryNameToKey} mdxComponentMeta={componentMeta}>
+      <MDXContent />
+    </AddContext>
+  ),
+};
+
+export default componentMeta;
+"
+`;

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -79,8 +79,7 @@ function genStoryExport(ast, context) {
   storyId = storyId && storyId.value;
 
   if (!storyId && !storyName && !storyAttr) {
-    const { code: jsx } = generate(ast, {});
-    throw new Error('Expected a Story name, id, or story attribute', jsx);
+    throw new Error('Expected a Story name, id, or story attribute');
   }
 
   // We don't generate exports for story references or the smart "current story"

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -41,22 +41,56 @@ function genAttribute(key, element) {
   return undefined;
 }
 
+function genImportStory(ast, storyDef, storyName, context) {
+  const { code: story } = generate(storyDef.expression, {});
+
+  const storyKey = `${story.split('.').pop()}Story`;
+
+  const statements = [`export const ${storyKey} = ${story};`];
+  if (storyName) {
+    // eslint-disable-next-line no-param-reassign
+    context.storyNameToKey[storyName] = storyKey;
+    statements.push(`${storyKey}.storyName = '${storyName}';`);
+  } else {
+    // eslint-disable-next-line no-param-reassign
+    context.storyNameToKey[storyKey] = storyKey;
+    ast.openingElement.attributes.push({
+      type: 'JSXAttribute',
+      name: {
+        type: 'JSXIdentifier',
+        name: 'name',
+      },
+      value: {
+        type: 'StringLiteral',
+        value: storyKey,
+      },
+    });
+  }
+  return {
+    [storyKey]: statements.join('\n'),
+  };
+}
+
 function genStoryExport(ast, context) {
   let storyName = getAttr(ast.openingElement, 'name');
   let storyId = getAttr(ast.openingElement, 'id');
+  const storyAttr = getAttr(ast.openingElement, 'story');
   storyName = storyName && storyName.value;
   storyId = storyId && storyId.value;
 
-  if (!storyId && !storyName) {
-    throw new Error('Expected a story name or ID attribute');
+  if (!storyId && !storyName && !storyAttr) {
+    const { code: jsx } = generate(ast, {});
+    throw new Error('Expected a Story name, id, or story attribute', jsx);
   }
 
   // We don't generate exports for story references or the smart "current story"
-  if (storyId || !storyName) {
+  if (storyId) {
     return null;
   }
 
-  // console.log('genStoryExport', JSON.stringify(ast, null, 2));
+  if (storyAttr) {
+    return genImportStory(ast, storyAttr, storyName, context);
+  }
 
   const statements = [];
   const storyKey = getStoryKey(storyName, context.counter);
@@ -149,6 +183,8 @@ function genCanvasExports(ast, context) {
     const child = ast.children[i];
     if (child.type === 'JSXElement' && child.openingElement.name.name === 'Story') {
       const storyExport = genStoryExport(child, context);
+      const { code } = generate(child, {});
+      child.value = code;
       if (storyExport) {
         Object.assign(canvasExports, storyExport);
         // eslint-disable-next-line no-param-reassign
@@ -206,6 +242,9 @@ function getExports(node, counter, options) {
       // Single story
       const ast = parser.parseExpression(value, { plugins: ['jsx'] });
       const storyExport = genStoryExport(ast, counter);
+      const { code } = generate(ast, {});
+      // eslint-disable-next-line no-param-reassign
+      node.value = code;
       return storyExport && { stories: storyExport };
     }
     if (CANVAS_REGEX.exec(value)) {
@@ -308,7 +347,6 @@ function extractExports(node, options) {
     }
   });
   // we're overriding default export
-  const defaultJsx = mdxToJsx.toJSX(node, {}, { ...options, skipExport: true });
   const storyExports = [];
   const includeStories = [];
   let metaExport = null;
@@ -345,6 +383,7 @@ function extractExports(node, options) {
   }
   metaExport.includeStories = JSON.stringify(includeStories);
 
+  const defaultJsx = mdxToJsx.toJSX(node, {}, { ...options, skipExport: true });
   const fullJsx = [
     'import { assertIsFn, AddContext } from "@storybook/addon-docs/blocks";',
     defaultJsx,

--- a/addons/docs/src/mdx/mdx-compiler-plugin.test.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.test.js
@@ -40,6 +40,6 @@ describe('docs-mdx-compiler-plugin', () => {
   it('errors on missing story props', async () => {
     await expect(
       generate(path.resolve(__dirname, './__testfixtures__/story-missing-props.mdx'))
-    ).rejects.toThrow('Expected a story name or ID attribute');
+    ).rejects.toThrow('Expected a Story name, id, or story attribute');
   });
 });

--- a/examples/official-storybook/stories/addon-docs/csf-with-mdx-docs.stories.js
+++ b/examples/official-storybook/stories/addon-docs/csf-with-mdx-docs.stories.js
@@ -10,3 +10,9 @@ import { Button } from '@storybook/react/demo';
 // };
 
 export const Basic = () => <Button>Basic</Button>;
+
+export const WithArgs = (args) => <Button {...args} />;
+WithArgs.args = { children: 'with args' };
+
+export const WithTemplate = WithArgs.bind({});
+WithTemplate.args = { children: 'with template' };

--- a/examples/official-storybook/stories/addon-docs/csf-with-mdx-docs.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/csf-with-mdx-docs.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import * as Csf from './csf-with-mdx-docs.stories';
 
 <Meta title="Addons/Docs/csf-with-mdx-docs" />
@@ -8,11 +8,13 @@ import * as Csf from './csf-with-mdx-docs.stories';
 I can define a story with the function imported from CSF:
 
 <Canvas>
-  <Story name="basic" story={Csf.Basic} />
+  <Story name="with args" story={Csf.WithArgs} />
 </Canvas>
 
+<ArgsTable />
+
 <Canvas>
-  <Story name="with args" story={Csf.WithArgs} />
+  <Story name="basic" story={Csf.Basic} />
 </Canvas>
 
 <Canvas>

--- a/examples/official-storybook/stories/addon-docs/csf-with-mdx-docs.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/csf-with-mdx-docs.stories.mdx
@@ -1,5 +1,5 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Basic } from './csf-with-mdx-docs.stories';
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import * as Csf from './csf-with-mdx-docs.stories';
 
 <Meta title="Addons/Docs/csf-with-mdx-docs" />
 
@@ -7,6 +7,14 @@ import { Basic } from './csf-with-mdx-docs.stories';
 
 I can define a story with the function imported from CSF:
 
-<Story name="Basic button">
-  <Basic />
-</Story>
+<Canvas>
+  <Story name="basic" story={Csf.Basic} />
+</Canvas>
+
+<Canvas>
+  <Story name="with args" story={Csf.WithArgs} />
+</Canvas>
+
+<Canvas>
+  <Story name="with template" story={Csf.WithTemplate} />
+</Canvas>


### PR DESCRIPTION
Issue: #11412 

New way to handle with CSF stories in MDX docs.

```js
import * as ButtonStories from 'Button.stories';

<Story story={ButtonStories.Basic} />
```

New construct:
- Preserves args/parameters/decorators/etc. annotations
- Preserves source code

## What I did

- [x] Updated `Story` block with new `story` prop
- [x] Updated MDX compiler & tests
- [x] Updated `official-storybook` example
- [x] Updated recipes docs

## How to test

See updated tests & example
