### PR TITLE
Update TOC format, setup with currently ready pages

### DIFF
--- a/docs/toc.js
+++ b/docs/toc.js
@@ -2,66 +2,79 @@ module.exports = {
   toc: [
     {
       title: 'Get Started',
+      pathSegment: 'get-started',
       type: 'menu',
       children: [
         {
-          path: '/docs/get-started/introduction/',
+          pathSegment: 'introduction',
           title: 'Introduction',
           type: 'bullet-link',
         },
         {
-          path: '/docs/get-started/install/',
+          pathSegment: 'install',
           title: 'Install',
           type: 'bullet-link',
+          // DOCSTODO: Update the description
+          description: 'Install the Storybook package in your project',
         },
         {
-          path: '/docs/get-started/whats-a-story/',
+          pathSegment: 'whats-a-story',
           title: "What's a story?",
           type: 'bullet-link',
+          // DOCSTODO: Update the description
+          description: 'Learn the base construct of stories within Storybook',
         },
         {
-          path: '/docs/get-started/browse-stories/',
+          pathSegment: 'browse-stories',
           title: 'Browse stories',
           type: 'bullet-link',
+          // DOCSTODO: Update the description
+          description: 'Learn how to explore your stories within Storybook',
         },
         {
-          path: '/docs/get-started/setup/',
+          pathSegment: 'setup',
           title: 'Setup',
           type: 'bullet-link',
+          // DOCSTODO: Update the description
+          description:
+            'Write your first story & adjust Storybook configuration for your environment',
         },
         {
-          path: '/docs/get-started/conclusion/',
+          pathSegment: 'conclusion',
           title: 'Conclusion',
           type: 'bullet-link',
+          // DOCSTODO: Update the description
+          description: 'Take your Storybook skills to the next level',
         },
       ],
     },
     {
       title: 'Writing Stories',
+      pathSegment: 'writing-stories',
       type: 'menu',
       children: [
         {
-          path: '/docs/writing-stories/introduction/',
+          pathSegment: 'introduction',
           title: 'Introduction',
           type: 'link',
         },
         {
-          path: '/docs/writing-stories/args/',
+          pathSegment: 'args',
           title: 'Args',
           type: 'link',
         },
         {
-          path: '/docs/writing-stories/parameters/',
+          pathSegment: 'parameters',
           title: 'Parameters',
           type: 'link',
         },
         {
-          path: '/docs/writing-stories/decorators/',
+          pathSegment: 'decorators',
           title: 'Decorators',
           type: 'link',
         },
         {
-          path: '/docs/writing-stories/naming-components-and-hierarchy/',
+          pathSegment: 'naming-components-and-hierarchy',
           title: 'Naming components and hierarchy',
           type: 'link',
         },
@@ -69,25 +82,26 @@ module.exports = {
     },
     {
       title: 'Writing Docs',
+      pathSegment: 'writing-docs',
       type: 'menu',
       children: [
         {
-          path: '/docs/writing-docs/introduction/',
+          pathSegment: 'introduction',
           title: 'Introduction',
           type: 'link',
         },
         {
-          path: '/docs/writing-docs/docs-page/',
+          pathSegment: 'docs-page',
           title: 'Docs Page',
           type: 'link',
         },
         {
-          path: '/docs/writing-docs/mdx/',
+          pathSegment: 'mdx',
           title: 'MDX',
           type: 'link',
         },
         {
-          path: '/docs/writing-docs/doc-blocks/',
+          pathSegment: 'doc-blocks',
           title: 'Docs Blocks',
           type: 'link',
         },
@@ -95,35 +109,36 @@ module.exports = {
     },
     {
       title: 'Essentials',
+      pathSegment: 'essentials',
       type: 'menu',
       children: [
         {
-          path: '/docs/essentials/introduction/',
+          pathSegment: 'introduction',
           title: 'Introduction',
           type: 'link',
         },
         {
-          path: '/docs/essentials/controls/',
+          pathSegment: 'controls',
           title: 'Controls',
           type: 'link',
         },
         {
-          path: '/docs/essentials/actions/',
+          pathSegment: 'actions',
           title: 'Actions',
           type: 'link',
         },
         {
-          path: '/docs/essentials/viewports/',
+          pathSegment: 'viewports',
           title: 'Viewports',
           type: 'link',
         },
         {
-          path: '/docs/essentials/backgrounds/',
+          pathSegment: 'backgrounds',
           title: 'Backgrounds',
           type: 'link',
         },
         {
-          path: '/docs/essentials/toolbars-and-globals/',
+          pathSegment: 'toolbars-and-globals',
           title: 'Toolbars & globals',
           type: 'link',
         },
@@ -131,25 +146,26 @@ module.exports = {
     },
     {
       title: 'Configure',
+      pathSegment: 'configure',
       type: 'menu',
       children: [
         {
-          path: '/docs/configure/overview/',
+          pathSegment: 'overview',
           title: 'Overview',
           type: 'link',
         },
         {
-          path: '/docs/configure/integration/',
+          pathSegment: 'integration',
           title: 'Integration',
           type: 'link',
         },
         {
-          path: '/docs/configure/story-rendering/',
+          pathSegment: 'story-rendering',
           title: 'Story rendering',
           type: 'link',
         },
         {
-          path: '/docs/configure/user-interface/',
+          pathSegment: 'user-interface',
           title: 'User interface',
           type: 'link',
         },
@@ -157,61 +173,64 @@ module.exports = {
     },
     {
       title: 'Workflows',
+      pathSegment: 'workflows',
       type: 'menu',
       children: [
         {
-          path: '/docs/workflows/publish-storybook/',
+          pathSegment: 'publish-storybook',
           title: 'Publish Storybook',
           type: 'link',
         },
         {
-          path: '/docs/workflows/build-pages-with-storybook/',
+          pathSegment: 'build-pages-with-storybook',
           title: 'Building pages with Storybook',
           type: 'link',
         },
         {
-          path: '/docs/workflows/stories-for-multiple-components/',
+          pathSegment: 'stories-for-multiple-components',
           title: 'Stories for multiple components',
           type: 'link',
         },
         {
           title: 'Testing with Storybook',
+          // Despite having a child menu, this does not currently affect the path
+          pathSegment: '',
           type: 'menu',
           children: [
             {
-              path: '/docs/workflows/testing-with-storybook/',
+              pathSegment: 'testing-with-storybook',
               title: 'Introduction',
               type: 'link',
             },
             {
-              path: '/docs/workflows/unit-testing/',
+              pathSegment: 'unit-testing',
               title: 'Unit testing',
               type: 'link',
             },
             {
-              path: '/docs/workflows/visual-testing/',
+              pathSegment: 'visual-testing',
               title: 'Visual testing',
               type: 'link',
             },
             {
-              path: '/docs/workflows/interaction-testing/',
+              pathSegment: 'interaction-testing',
               title: 'Interaction testing',
               type: 'link',
             },
             {
-              path: '/docs/workflows/snapshot-testing/',
+              pathSegment: 'snapshot-testing',
               title: 'Snapshot testing',
               type: 'link',
             },
           ],
         },
         {
-          path: '/docs/workflows/storybook-composition/',
+          pathSegment: 'storybook-composition',
           title: 'Storybook Composition',
           type: 'link',
         },
         {
-          path: '/docs/workflows/package-composition/',
+          pathSegment: 'package-composition',
           title: 'Package Composition',
           type: 'link',
         },
@@ -219,30 +238,31 @@ module.exports = {
     },
     {
       title: 'API',
+      pathSegment: 'api',
       type: 'menu',
       children: [
         {
-          path: '/docs/api/stories/',
+          pathSegment: 'stories',
           title: 'Stories',
           type: 'link',
         },
         {
-          path: '/docs/api/addons/',
+          pathSegment: 'addons',
           title: 'Addons',
           type: 'link',
         },
         {
-          path: '/docs/api/new-frameworks/',
+          pathSegment: 'new-frameworks',
           title: 'Frameworks',
           type: 'link',
         },
         {
-          path: '/docs/api/cli-options/',
+          pathSegment: 'cli-options',
           title: 'CLI Options',
           type: 'link',
         },
         {
-          path: '/docs/api/frameworks-feature-support/',
+          pathSegment: 'frameworks-feature-support',
           title: 'Feature support for frameworks',
           type: 'link',
         },

--- a/docs/toc.js
+++ b/docs/toc.js
@@ -2,56 +2,251 @@ module.exports = {
   toc: [
     {
       title: 'Get Started',
-      prefix: 'get-started',
-      pages: ['introduction', 'install', 'whats-a-story', 'browse-stories', 'setup', 'conclusion'],
+      type: 'menu',
+      children: [
+        {
+          path: '/docs/get-started/introduction/',
+          title: 'Introduction',
+          type: 'bullet-link',
+        },
+        {
+          path: '/docs/get-started/install/',
+          title: 'Install',
+          type: 'bullet-link',
+        },
+        {
+          path: '/docs/get-started/whats-a-story/',
+          title: "What's a story?",
+          type: 'bullet-link',
+        },
+        {
+          path: '/docs/get-started/browse-stories/',
+          title: 'Browse stories',
+          type: 'bullet-link',
+        },
+        {
+          path: '/docs/get-started/setup/',
+          title: 'Setup',
+          type: 'bullet-link',
+        },
+        {
+          path: '/docs/get-started/conclusion/',
+          title: 'Conclusion',
+          type: 'bullet-link',
+        },
+      ],
     },
     {
       title: 'Writing Stories',
-      prefix: 'writing-stories',
-      pages: [
-        'introduction',
-        'args',
-        'parameters',
-        'decorators',
-        'naming-components-and-hierarchy',
+      type: 'menu',
+      children: [
+        {
+          path: '/docs/writing-stories/introduction/',
+          title: 'Introduction',
+          type: 'link',
+        },
+        {
+          path: '/docs/writing-stories/args/',
+          title: 'Args',
+          type: 'link',
+        },
+        {
+          path: '/docs/writing-stories/parameters/',
+          title: 'Parameters',
+          type: 'link',
+        },
+        {
+          path: '/docs/writing-stories/decorators/',
+          title: 'Decorators',
+          type: 'link',
+        },
+        {
+          path: '/docs/writing-stories/naming-components-and-hierarchy/',
+          title: 'Naming components and hierarchy',
+          type: 'link',
+        },
       ],
     },
     {
       title: 'Writing Docs',
-      prefix: 'writing-docs',
-      pages: ['introduction', 'docs-page', 'mdx', 'doc-blocks'],
+      type: 'menu',
+      children: [
+        {
+          path: '/docs/writing-docs/introduction/',
+          title: 'Introduction',
+          type: 'link',
+        },
+        {
+          path: '/docs/writing-docs/docs-page/',
+          title: 'Docs Page',
+          type: 'link',
+        },
+        {
+          path: '/docs/writing-docs/mdx/',
+          title: 'MDX',
+          type: 'link',
+        },
+        {
+          path: '/docs/writing-docs/doc-blocks/',
+          title: 'Docs Blocks',
+          type: 'link',
+        },
+      ],
     },
     {
       title: 'Essentials',
-      prefix:'essentials',
-      pages:['introduction','controls','actions','viewports','backgrounds','toolbars-and-globals']
+      type: 'menu',
+      children: [
+        {
+          path: '/docs/essentials/introduction/',
+          title: 'Introduction',
+          type: 'link',
+        },
+        {
+          path: '/docs/essentials/controls/',
+          title: 'Controls',
+          type: 'link',
+        },
+        {
+          path: '/docs/essentials/actions/',
+          title: 'Actions',
+          type: 'link',
+        },
+        {
+          path: '/docs/essentials/viewports/',
+          title: 'Viewports',
+          type: 'link',
+        },
+        {
+          path: '/docs/essentials/backgrounds/',
+          title: 'Backgrounds',
+          type: 'link',
+        },
+        {
+          path: '/docs/essentials/toolbars-and-globals/',
+          title: 'Toolbars & globals',
+          type: 'link',
+        },
+      ],
     },
     {
       title: 'Configure',
-      prefix: 'configure',
-      pages: ['overview', 'integration', 'story-rendering', 'user-interface'],
+      type: 'menu',
+      children: [
+        {
+          path: '/docs/configure/overview/',
+          title: 'Overview',
+          type: 'link',
+        },
+        {
+          path: '/docs/configure/integration/',
+          title: 'Integration',
+          type: 'link',
+        },
+        {
+          path: '/docs/configure/story-rendering/',
+          title: 'Story rendering',
+          type: 'link',
+        },
+        {
+          path: '/docs/configure/user-interface/',
+          title: 'User interface',
+          type: 'link',
+        },
+      ],
     },
     {
-      title:'Workflows',
-      prefix:'workflows',
-      pages:[
-        'publish-storybook',
-        'build-pages-with-storybook',
-        'stories-for-multiple-components',
-        'testing-with-storybook',
-        'unit-testing',
-        'visual-testing',
-        'interaction-testing',
-        'snapshot-testing',
-        'storybook-composition',
-        'package-composition'
-      ]
+      title: 'Workflows',
+      type: 'menu',
+      children: [
+        {
+          path: '/docs/workflows/publish-storybook/',
+          title: 'Publish Storybook',
+          type: 'link',
+        },
+        {
+          path: '/docs/workflows/build-pages-with-storybook/',
+          title: 'Building pages with Storybook',
+          type: 'link',
+        },
+        {
+          path: '/docs/workflows/stories-for-multiple-components/',
+          title: 'Stories for multiple components',
+          type: 'link',
+        },
+        {
+          title: 'Testing with Storybook',
+          type: 'menu',
+          children: [
+            {
+              path: '/docs/workflows/testing-with-storybook/',
+              title: 'Introduction',
+              type: 'link',
+            },
+            {
+              path: '/docs/workflows/unit-testing/',
+              title: 'Unit testing',
+              type: 'link',
+            },
+            {
+              path: '/docs/workflows/visual-testing/',
+              title: 'Visual testing',
+              type: 'link',
+            },
+            {
+              path: '/docs/workflows/interaction-testing/',
+              title: 'Interaction testing',
+              type: 'link',
+            },
+            {
+              path: '/docs/workflows/snapshot-testing/',
+              title: 'Snapshot testing',
+              type: 'link',
+            },
+          ],
+        },
+        {
+          path: '/docs/workflows/storybook-composition/',
+          title: 'Storybook Composition',
+          type: 'link',
+        },
+        {
+          path: '/docs/workflows/package-composition/',
+          title: 'Package Composition',
+          type: 'link',
+        },
+      ],
     },
     {
-
       title: 'API',
-      prefix:'api',
-      pages:['stories','addons','new-frameworks','cli-options','frameworks-feature-support']
+      type: 'menu',
+      children: [
+        {
+          path: '/docs/api/stories/',
+          title: 'Stories',
+          type: 'link',
+        },
+        {
+          path: '/docs/api/addons/',
+          title: 'Addons',
+          type: 'link',
+        },
+        {
+          path: '/docs/api/new-frameworks/',
+          title: 'Frameworks',
+          type: 'link',
+        },
+        {
+          path: '/docs/api/cli-options/',
+          title: 'CLI Options',
+          type: 'link',
+        },
+        {
+          path: '/docs/api/frameworks-feature-support/',
+          title: 'Feature support for frameworks',
+          type: 'link',
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
Issue: n/a

## What I did

Updated the toc.js file for the 6.0 docs so that it reflects the current state of the MD files we have for the docs as well as the expected format of the frontpage for consumption.

