### PR TITLE
Addon-docs: Fix Ember args

### DIFF
--- a/addons/docs/src/frameworks/ember/jsondoc.js
+++ b/addons/docs/src/frameworks/ember/jsondoc.js
@@ -18,20 +18,21 @@ export const extractArgTypes = (componentName) => {
   if (!componentDoc) {
     return null;
   }
-  
-  return componentDoc.attributes.arguments.map((prop) => {
-    return {
+  return componentDoc.attributes.arguments.reduce((acc, prop) => {
+    acc[prop.name] = {
       name: prop.name,
-      defaultValue: { summary: prop.defaultValue },
+      defaultValue: prop.defaultValue,
       description: prop.description,
       table: {
+        defaultValue: { summary: prop.defaultValue },
         type: {
           summary: prop.type,
           required: prop.tags.length ? prop.tags.some((tag) => tag.name === 'required') : false,
         },
       },
     };
-  });
+    return acc;
+  }, {});
 };
 
 export const extractComponentDescription = (componentName) => {

--- a/examples/ember-cli/stories/welcome-banner.stories.js
+++ b/examples/ember-cli/stories/welcome-banner.stories.js
@@ -4,9 +4,18 @@ import { action } from '@storybook/addon-actions';
 export default {
   title: 'welcome-banner',
   component: 'WelcomeBanner',
+  parameters: {
+    docs: {
+      iframeHeight: 200,
+    },
+  },
+  argTypes: {
+    backgroundColor: { control: 'color' },
+    subTitleColor: { control: 'color' },
+  },
 };
 
-export const Basic = () => ({
+export const Basic = (args) => ({
   template: hbs`
       {{welcome-banner
         backgroundColor=backgroundColor
@@ -17,12 +26,13 @@ export const Basic = () => ({
         click=(action onClick)
       }}
     `,
-  context: {
-    backgroundColor: '#FDF4E7',
-    titleColor: '#DF4D37',
-    subTitleColor: '#B8854F',
-    title: 'Welcome to storybook',
-    subtitle: 'This environment is completely editable',
-    onClick: action('clicked'),
-  },
+  context: args,
 });
+Basic.args = {
+  backgroundColor: '#FDF4E7',
+  titleColor: '#DF4D37',
+  subTitleColor: '#B8854F',
+  title: 'Welcome to storybook',
+  subtitle: 'This environment is completely editable',
+  onClick: action('clicked'),
+};


### PR DESCRIPTION
Issue: #10511 #10524

## What I did

Follow-up to fix ember Args with @gossi 

- [x] extractArgTypes should return an object
- [x] Fix bug in default value extraction
- [x] Update `welcome-banner` to be an args story

## How to test

See updated story. Note:
- works in controls tab
- doesn't work in docs tab (possibly unrelated to ember?--have seen this problem in Angular also, which also doesn't use inline stories)