### PR TITLE
Source-loader: Fix storiesOf missing `__STORY__` variable

### DIFF
--- a/lib/source-loader/src/build.js
+++ b/lib/source-loader/src/build.js
@@ -2,7 +2,6 @@ import { getOptions } from 'loader-utils';
 import { readStory } from './dependencies-lookup/readAsObject';
 
 export function transform(inputSource) {
-  const options = getOptions(this) || {};
   return readStory(this, inputSource).then((sourceObject) => {
     // if source-loader had trouble parsing the story exports, return the original story
     // example is

--- a/lib/source-loader/src/build.js
+++ b/lib/source-loader/src/build.js
@@ -11,10 +11,8 @@ export function transform(inputSource) {
     if (!sourceObject.source || sourceObject.source.length === 0) {
       return inputSource;
     }
+
     const { source, sourceJson, addsMap } = sourceObject;
-    if (options.injectStoryParameters) {
-      return source;
-    }
     const preamble = `
       /* eslint-disable */
       // @ts-nocheck


### PR DESCRIPTION
Issue: N/A

## What I did

Fix storiesOf source bug introduced in https://github.com/storybookjs/storybook/pull/11707

Always generate preamble global vars to avoid warning. Real fix is to remove need for those vars, possibly in conjunction with removing `storiesOf` support.

## How to test

See `angular-cli`