### PR TITLE
Core: Fix handling of initial hashes

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -342,7 +342,12 @@ export const init: ModuleFn = ({
       if (fullAPI.isSettingsScreenActive()) return;
 
       if (sourceType === 'local') {
-        navigate(`/${viewMode}/${storyId}`);
+        // Special case -- if we are already at the story being specified (i.e. the user started at a given story),
+        // we don't need to change URL. See https://github.com/storybookjs/storybook/issues/11677
+        const state = store.getState();
+        if (state.storyId !== storyId || state.viewMode !== viewMode) {
+          navigate(`/${viewMode}/${storyId}`);
+        }
       }
     });
 

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -346,6 +346,21 @@ describe('stories API', () => {
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
 
+    it('DOES not navigate if the story was already selected', async () => {
+      const navigate = jest.fn();
+      const api = Object.assign(new EventEmitter(), {
+        isSettingsScreenActive() {
+          return true;
+        },
+      });
+      const store = createMockStore({ viewMode: 'story', storyId: 'a--1' });
+      initStories({ store, navigate, provider, fullAPI: api });
+
+      api.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
+
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
     it('DOES not navigate if a settings page was selected', async () => {
       const navigate = jest.fn();
       const api = Object.assign(new EventEmitter(), {


### PR DESCRIPTION
Issue: #11677

Telescoping on https://github.com/storybookjs/storybook/pull/11766

## What I did

Ensure we don't renavigate if the specified story is already selected

## How to test

- Is this testable with Jest or Chromatic screenshots? yes

- Does this need a new example in the kitchen sink apps?

 - http://localhost:9011/?path=/story/addons-docs-markdown-docs--page#emphasis
