### PR TITLE
Addon-docs: Prettier, collapsible values in ArgsTable

### DIFF
--- a/lib/components/src/blocks/ArgsTable/ArgRow.stories.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgRow.stories.tsx
@@ -262,6 +262,42 @@ Func.args = {
   },
 };
 
+const enumeration =
+  '"search" | "arrow-to-bottom" | "arrow-to-right" | "bell" | "check" | "check-circle"';
+
+export const Enum = Template.bind({});
+Enum.args = {
+  ...baseArgs,
+  row: {
+    key: 'enum',
+    name: 'Some enum',
+    type: { required: true },
+    table: {
+      type: {
+        summary: enumeration,
+      },
+    },
+  },
+};
+
+const long_enumeration =
+  '"search" | "arrow-to-bottom" | "arrow-to-right" | "bell" | "check" | "check-circle" | "chevron-up" | "chevron-down" | "chevron-left" | "chevron-right" | "envelope" | "exchange" | "file" | "file-check" | "file-import" | "file-pdf" | "file-times" | "pencil" | "question" | "question-circle" | "sitemap" | "user" | "times" | "plus" | "exclamation-triangle" | "trash-alt" | "long-arrow-up" | "long-arrow-down" | "long-arrow-left" | "long-arrow-right" | "external-link-alt" | "sticky-note" | "chart-line" | "spinner-third"';
+
+export const LongEnum = Template.bind({});
+LongEnum.args = {
+  ...baseArgs,
+  row: {
+    key: 'longEnum',
+    name: 'Long enum',
+    type: { required: true },
+    table: {
+      type: {
+        summary: long_enumeration,
+      },
+    },
+  },
+};
+
 export const Markdown = Template.bind({});
 Markdown.args = {
   ...baseArgs,

--- a/lib/components/src/blocks/ArgsTable/ArgRow.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgRow.tsx
@@ -14,6 +14,7 @@ export interface ArgRowProps {
   updateArgs?: (args: Args) => void;
   compact?: boolean;
   expandable?: boolean;
+  initialExpandedArgs?: boolean;
 }
 
 const Name = styled.span({ fontWeight: 'bold' });
@@ -64,7 +65,7 @@ const StyledTd = styled.td<{ expandable: boolean }>(({ theme, expandable }) => (
 }));
 
 export const ArgRow: FC<ArgRowProps> = (props) => {
-  const { row, updateArgs, compact, expandable } = props;
+  const { row, updateArgs, compact, expandable, initialExpandedArgs } = props;
   const { name, description } = row;
   const table = (row.table || {}) as TableAnnotation;
   const type = table.type || row.type;
@@ -88,20 +89,20 @@ export const ArgRow: FC<ArgRowProps> = (props) => {
           {table.jsDocTags != null ? (
             <>
               <TypeWithJsDoc hasDescription={hasDescription}>
-                <ArgValue value={type} />
+                <ArgValue value={type} initialExpandedArgs={initialExpandedArgs} />
               </TypeWithJsDoc>
               <ArgJsDoc tags={table.jsDocTags} />
             </>
           ) : (
             <Type hasDescription={hasDescription}>
-              <ArgValue value={type} />
+              <ArgValue value={type} initialExpandedArgs={initialExpandedArgs} />
             </Type>
           )}
         </td>
       )}
       {compact ? null : (
         <td>
-          <ArgValue value={defaultValue} />
+          <ArgValue value={defaultValue} initialExpandedArgs={initialExpandedArgs} />
         </td>
       )}
       {updateArgs ? (

--- a/lib/components/src/blocks/ArgsTable/ArgValue.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgValue.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 import { styled } from '@storybook/theming';
 import memoize from 'memoizerific';
+import uniq from 'lodash/uniq';
 import { PropSummaryValue } from './types';
 import { WithTooltipPure } from '../../tooltip/WithTooltip';
 import { Icons } from '../../icon/icon';
@@ -98,9 +99,6 @@ const calculateDetailWidth = memoize(1000)((detail: string): string => {
 
   return `${Math.max(...lines.map((x) => x.length))}ch`;
 });
-
-const uniq = (arr: string[]): string[] =>
-  arr.filter((value, index, self) => self.indexOf(value) === index);
 
 const getSummaryItems = (summary: string) => {
   if (!summary) return [summary];

--- a/lib/components/src/blocks/ArgsTable/ArgValue.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgValue.tsx
@@ -9,6 +9,7 @@ import { codeCommon } from '../../typography/shared';
 
 interface ArgValueProps {
   value?: PropSummaryValue;
+  initialExpandedArgs?: boolean;
 }
 
 interface ArgTextProps {
@@ -17,6 +18,7 @@ interface ArgTextProps {
 
 interface ArgSummaryProps {
   value: PropSummaryValue;
+  initialExpandedArgs?: boolean;
 }
 
 const ITEMS_BEFORE_EXPANSION = 8;
@@ -117,11 +119,11 @@ const renderSummaryItems = (summaryItems: string[], isExpanded = true) => {
   return items.map((item) => <ArgText key={item} text={item === '' ? '""' : item} />);
 };
 
-const ArgSummary: FC<ArgSummaryProps> = ({ value }) => {
+const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
   const { summary, detail } = value;
 
   const [isOpen, setIsOpen] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(initialExpandedArgs || false);
 
   if (summary === undefined || summary === null) return null;
   // summary is used for the default value
@@ -170,6 +172,10 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value }) => {
   );
 };
 
-export const ArgValue: FC<ArgValueProps> = ({ value }) => {
-  return value == null ? <EmptyArg /> : <ArgSummary value={value} />;
+export const ArgValue: FC<ArgValueProps> = ({ value, initialExpandedArgs }) => {
+  return value == null ? (
+    <EmptyArg />
+  ) : (
+    <ArgSummary value={value} initialExpandedArgs={initialExpandedArgs} />
+  );
 };

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.stories.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.stories.tsx
@@ -23,6 +23,8 @@ const htmlElementSubsection = { subcategory: 'HTMLElement' };
 const stringType = ArgRow.String.args.row;
 const numberType = ArgRow.Number.args.row;
 
+const longEnumType = ArgRow.LongEnum.args.row;
+
 const Template = (args) => <ArgsTable {...args} />;
 
 export const Normal = Template.bind({});
@@ -129,3 +131,11 @@ Error.args = {
 
 export const Empty = Template.bind({});
 Empty.args = { rows: {} };
+
+export const WithDefaultExpandedArgs = Template.bind({});
+WithDefaultExpandedArgs.args = {
+  rows: {
+    longEnumType,
+  },
+  initialExpandedArgs: true,
+};

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
@@ -233,6 +233,7 @@ export interface ArgsTableRowProps {
   resetArgs?: (argNames?: string[]) => void;
   compact?: boolean;
   inAddonPanel?: boolean;
+  initialExpandedArgs?: boolean;
 }
 
 export interface ArgsTableErrorProps {
@@ -297,7 +298,15 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     );
   }
 
-  const { rows, args, updateArgs, resetArgs, compact, inAddonPanel } = props as ArgsTableRowProps;
+  const {
+    rows,
+    args,
+    updateArgs,
+    resetArgs,
+    compact,
+    inAddonPanel,
+    initialExpandedArgs,
+  } = props as ArgsTableRowProps;
 
   const groups = groupRows(pickBy(rows, (row) => !row?.table?.disable));
 
@@ -321,7 +330,7 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   if (!compact) colSpan += 2;
   const expandable = Object.keys(groups.sections).length > 0;
 
-  const common = { updateArgs, compact, inAddonPanel };
+  const common = { updateArgs, compact, inAddonPanel, initialExpandedArgs };
   return (
     <ResetWrapper>
       <TableWrapper {...{ compact, inAddonPanel }} className="docblock-argstable">


### PR DESCRIPTION
Issue: #11681

## What I did
To make values in prop table more obvious and clean, I wrapped all values in a code-like wrapper. For long enums with more than 8 values, I introduced expanding wrapper, where the first 8 values are inlined with a "Show *n* more..." button. When the button is clicked all values are expanded and each value is on its own row.

<img width="860" alt="Screenshot 2020-08-03 at 10 09 38" src="https://user-images.githubusercontent.com/18654425/89164058-daaf4c00-d576-11ea-85ef-eb10e9d5e0bb.png">
<img width="860" alt="Screenshot 2020-08-03 at 10 10 00" src="https://user-images.githubusercontent.com/18654425/89164054-d97e1f00-d576-11ea-9e20-458a079f1637.png">


## How to test

- Is this testable with Jest or Chromatic screenshots? yes, Chromatic
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no
