### PR TITLE
CSF: Support mixed `.x` and deprecated `.story.x` parameters

### DIFF
--- a/examples/angular-cli/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/angular-cli/src/stories/__snapshots__/core.stories.storyshot
@@ -19,6 +19,7 @@ exports[`Storyshots Core/Parameters passed to story 1`] = `
     "globalParameter": "globalParameter",
     "framework": "angular",
     "chapterParameter": "chapterParameter",
+    "args": {},
     "argTypes": {},
     "storyParameter": "storyParameter",
     "__id": "core-parameters--passed-to-story",

--- a/examples/riot-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/riot-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
@@ -12,6 +12,7 @@ exports[`Storyshots Core/Parameters passed to story 1`] = `
   "globalParameter": "globalParameter",
   "framework": "riot",
   "chapterParameter": "chapterParameter",
+  "args": {},
   "argTypes": {},
   "__id": "core-parameters--passed-to-story",
   "__isArgsStory": true,

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
@@ -11,6 +11,7 @@ exports[`Storyshots Core/Parameters passed to story 1`] = `
   "globalParameter": "globalParameter",
   "framework": "vue",
   "chapterParameter": "chapterParameter",
+  "args": {},
   "argTypes": {},
   "storyParameter": "storyParameter",
   "__id": "core-parameters--passed-to-story",

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/custom-decorators.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/custom-decorators.stories.storyshot
@@ -55,6 +55,7 @@ exports[`Storyshots Custom/Decorator for Vue With Data 1`] = `
     },
     "globalParameter": "globalParameter",
     "framework": "vue",
+    "args": {},
     "argTypes": {},
     "__id": "custom-decorator-for-vue--with-data",
     "__isArgsStory": true

--- a/lib/core/src/client/preview/loadCsf.test.ts
+++ b/lib/core/src/client/preview/loadCsf.test.ts
@@ -82,13 +82,14 @@ describe('core.preview.loadCsf', () => {
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     expect(mockedStoriesOf).toHaveBeenCalledWith('a', true);
     const aApi = mockedStoriesOf.mock.results[0].value;
-    expect(aApi.add).toHaveBeenCalledWith('1', input.a[1], { __id: 'a--1' });
-    expect(aApi.add).toHaveBeenCalledWith('2', input.a[2], { __id: 'a--2' });
+    const extras: any = { decorators: [], args: {}, argTypes: {} };
+    expect(aApi.add).toHaveBeenCalledWith('1', input.a[1], { __id: 'a--1', ...extras });
+    expect(aApi.add).toHaveBeenCalledWith('2', input.a[2], { __id: 'a--2', ...extras });
 
     expect(mockedStoriesOf).toHaveBeenCalledWith('b', true);
     const bApi = mockedStoriesOf.mock.results[1].value;
-    expect(bApi.add).toHaveBeenCalledWith('1', input.b[1], { __id: 'b--1' });
-    expect(bApi.add).toHaveBeenCalledWith('two', input.b[2], { __id: 'b--2' });
+    expect(bApi.add).toHaveBeenCalledWith('1', input.b[1], { __id: 'b--1', ...extras });
+    expect(bApi.add).toHaveBeenCalledWith('two', input.b[2], { __id: 'b--2', ...extras });
   });
 
   it('adds stories in the right order if __namedExportsOrder is supplied', () => {
@@ -175,7 +176,12 @@ describe('core.preview.loadCsf', () => {
 
     const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
     const aApi = mockedStoriesOf.mock.results[0].value;
-    expect(aApi.add).toHaveBeenCalledWith('X', input.a.x, { __id: 'random--x' });
+    expect(aApi.add).toHaveBeenCalledWith('X', input.a.x, {
+      __id: 'random--x',
+      decorators: [],
+      args: {},
+      argTypes: {},
+    });
   });
 
   it('sets various parameters on components', () => {

--- a/lib/core/src/client/preview/loadCsf.test.ts
+++ b/lib/core/src/client/preview/loadCsf.test.ts
@@ -293,6 +293,45 @@ describe('core.preview.loadCsf', () => {
     expect(logger.debug).not.toHaveBeenCalled();
   });
 
+  it('allows mixing story parameters and decorators, and args/argTypes and deprecated story params', () => {
+    const { configure, clientApi } = makeMocks();
+
+    const decoratorOld = jest.fn();
+    const decoratorNew = jest.fn();
+    const input = {
+      a: {
+        default: {
+          title: 'a',
+        },
+        x: Object.assign(() => 0, {
+          parameters: { x: 'y' },
+          decorators: [decoratorNew],
+          args: { b: 1 },
+          argTypes: { b: 'string' },
+          story: {
+            parameters: { x: 'z', y: 'z' },
+            decorators: [decoratorOld],
+            args: { b: 2, c: 2 },
+            argTypes: { b: 'number', c: 'number' },
+          },
+        }),
+      },
+    };
+    configure('react', makeRequireContext(input), mod);
+
+    const mockedStoriesOf = clientApi.storiesOf as jest.Mock;
+    const aApi = mockedStoriesOf.mock.results[0].value;
+    expect(aApi.add).toHaveBeenCalledWith('X', input.a.x, {
+      x: 'y',
+      y: 'z',
+      decorators: [decoratorNew, decoratorOld],
+      __id: 'a--x',
+      args: { b: 1, c: 2 },
+      argTypes: { b: 'string', c: 'number' },
+    });
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
   it('handles HMR correctly when adding stories', () => {
     const { configure, clientApi, storyStore } = makeMocks();
 

--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -161,41 +161,27 @@ const loadStories = (
       if (isExportStory(key, meta)) {
         const storyFn = exports[key];
         const { story } = storyFn;
-        const { storyName = story?.name, parameters, decorators, args, argTypes } = storyFn;
-
-        const decoratorParams = decorators ? { decorators } : {};
-        const argsParams = { args, argTypes };
+        const { storyName = story?.name } = storyFn;
 
         // storyFn.x and storyFn.story.x get merged with
         // storyFn.x taking precedence in the merge
-        let deprecatedStoryParams = null;
+        const parameters = { ...story?.parameters, ...storyFn.parameters };
+        const decorators = [...(storyFn.decorators || []), ...(story?.decorators || [])];
+        const args = { ...story?.args, ...storyFn.args };
+        const argTypes = { ...story?.argTypes, ...storyFn.argTypes };
+
         if (story) {
           logger.debug('deprecated story', story);
           deprecatedStoryAnnotationWarning();
-
-          deprecatedStoryParams = story.parameters;
-          if (story.decorators) {
-            decoratorParams.decorators = decoratorParams.decorators
-              ? [...decoratorParams.decorators, ...story.decorators]
-              : story.decorators;
-          }
-          if (story.args) {
-            argsParams.args = { ...story.args, ...argsParams.args };
-          }
-          if (story.argTypes) {
-            argsParams.argTypes = { ...story.argTypes, ...argsParams.argTypes };
-          }
         }
 
         const exportName = storyNameFromExport(key);
-        const idParams = { __id: toId(componentId || kindName, exportName) };
-
         const storyParams = {
-          ...deprecatedStoryParams,
+          __id: toId(componentId || kindName, exportName),
           ...parameters,
-          ...decoratorParams,
-          ...idParams,
-          ...argsParams,
+          decorators,
+          args,
+          argTypes,
         };
         kind.add(storyName || exportName, storyFn, storyParams);
       }

--- a/lib/core/src/client/preview/loadCsf.ts
+++ b/lib/core/src/client/preview/loadCsf.ts
@@ -177,8 +177,8 @@ const loadStories = (
 
         const exportName = storyNameFromExport(key);
         const storyParams = {
-          __id: toId(componentId || kindName, exportName),
           ...parameters,
+          __id: toId(componentId || kindName, exportName),
           decorators,
           args,
           argTypes,


### PR DESCRIPTION
Issue: #11780 

## What I did

Since `source-loader` only supports new-style `Foo.parameters`, make core support mix of deprecated old-style `Foo.story.parameters` and new-style `Foo.parameters` until we remove the old style parameters. Also support `decorators`, `args`, `argTypes`, and `name`.

- [x] Fix CSF loader logic
- [x] Add test case

## How to test

See attached test case