### PR TITLE
fix: cannot get iframe.html contnet correctly

### DIFF
--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -154,7 +154,6 @@ export const init: ModuleFn = ({ store, provider, fullAPI }, { runCheck = true }
           credentials: 'omit',
         }),
         fetch(`${url}/iframe.html${query}`, {
-          mode: 'no-cors',
           credentials: 'omit',
         }),
       ]);


### PR DESCRIPTION
Issue: Currently Composition only works when `stories.json` exists.

I've tracked down the history, it failed since `v6.0.0-rc.2`.

## What I did

> if stories.json 404's storybook should fallback to loading the iframe.html

It did fallback! However, somehow using `fetch` with `mode: 'no-cors'`,  it doesn't get the content correctly. 

## How to test

Leverage the composition feature without generating `stories.json`.

- Is this testable with Jest or Chromatic screenshots? N
- Does this need a new example in the kitchen sink apps? N
- Does this need an update to the documentation? N

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
