### PR TITLE
Storyshots: Don't ship typescript files in dist

### DIFF
--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -32,7 +32,7 @@ function cleanup() {
   // --copy-files option doesn't work with --ignore
   // https://github.com/babel/babel/issues/6226
   if (fs.existsSync(path.join(process.cwd(), 'dist'))) {
-    const inStoryShoots = process.cwd().includes('storyshots'); // This is a helper the exclude storyshots folder from the regex
+    const inStoryshots = process.cwd().includes('storyshots'); // This is a helper the exclude storyshots folder from the regex
     const files = shell.find('dist').filter((filePath) => {
       // Do not remove folder
       // And do not clean anything for:
@@ -44,7 +44,7 @@ function cleanup() {
       if (
         fs.lstatSync(filePath).isDirectory() ||
         /generators\/.+\/template.*/.test(filePath) ||
-        (/dist\/frameworks\/.*/.test(filePath) && !inStoryShoots)
+        (/dist\/frameworks\/.*/.test(filePath) && !inStoryshots)
       ) {
         return false;
       }

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -32,6 +32,7 @@ function cleanup() {
   // --copy-files option doesn't work with --ignore
   // https://github.com/babel/babel/issues/6226
   if (fs.existsSync(path.join(process.cwd(), 'dist'))) {
+    const inStoryShoots = process.cwd().includes('storyshots'); // This is a helper the exclude storyshots folder from the regex
     const files = shell.find('dist').filter((filePath) => {
       // Do not remove folder
       // And do not clean anything for:
@@ -39,10 +40,11 @@ function cleanup() {
       // - @storybook/cli/dist/frameworks/*
       // because these are the template files
       // that will be copied to init SB on users' projects
+
       if (
         fs.lstatSync(filePath).isDirectory() ||
         /generators\/.+\/template.*/.test(filePath) ||
-        /dist\/frameworks\/.*/.test(filePath)
+        (/dist\/frameworks\/.*/.test(filePath) && !inStoryShoots)
       ) {
         return false;
       }


### PR DESCRIPTION
Issue: #11377 

## What I did
Added a check if we are currently cleaning up the storyshot directory, ignoring the pattern to not clean up files in 'framework' in this case.

## How to test

1.  yarn bootstrap -> build with any previous commit. => _addons/storyshots/storyshot-cli/dist/frameworks_ contains .ts files (unwanted) & _lib\cli\dist\frameworks\angular_ also contains .ts files (wanted)
2. switch to this branch
3. yarn bootstrap -> build => _addons/storyshots/storyshot-cli/dist/frameworks_ **no longer** contains .ts files (wanted) & _lib\cli\dist\frameworks\angula_r still contains .ts files (wanted)

