### PR TITLE
do not use zoom on docs content

### DIFF
--- a/lib/ui/src/components/preview/preview.tsx
+++ b/lib/ui/src/components/preview/preview.tsx
@@ -147,6 +147,7 @@ const Preview: FunctionComponent<PreviewProps> = (props) => {
 
   const tabs = useTabs(previewId, baseUrl, withLoader, getElements, story);
 
+  const shouldScale = viewMode === 'story';
   const isToolshown =
     !(viewMode === 'docs' && tabs.filter((t) => !t.hidden).length < 2) && options.isToolshown;
 
@@ -179,7 +180,7 @@ const Preview: FunctionComponent<PreviewProps> = (props) => {
           <title>{description}</title>
         </Helmet>
       )}
-      <ZoomProvider>
+      <ZoomProvider shouldScale={shouldScale}>
         <ToolbarComp key="tools" story={story} api={api} isShown={isToolshown} tabs={tabs} />
         <S.FrameWrap key="frame" offset={isToolshown ? 40 : 0}>
           {tabs.map(({ render: Render, match, ...t }, i) => {

--- a/lib/ui/src/components/preview/tools/zoom.tsx
+++ b/lib/ui/src/components/preview/tools/zoom.tsx
@@ -3,21 +3,26 @@ import React, { Fragment, Component, FunctionComponent, SyntheticEvent } from 'r
 import { Icons, IconButton, Separator } from '@storybook/components';
 import { Addon } from '@storybook/addons';
 
-const Context = React.createContext({ value: 1, set: (v: number) => {} });
+const initialZoom = 1 as const;
 
-class ZoomProvider extends Component<{}, { value: number }> {
+const Context = React.createContext({ value: initialZoom, set: (v: number) => {} });
+
+class ZoomProvider extends Component<{ shouldScale: boolean }, { value: number }> {
   state = {
-    value: 1,
+    value: initialZoom,
   };
 
   set = (value: number) => this.setState({ value });
 
   render() {
-    const { children } = this.props;
+    const { children, shouldScale } = this.props;
     const { set } = this;
     const { value } = this.state;
-
-    return <Context.Provider value={{ value, set }}>{children}</Context.Provider>;
+    return (
+      <Context.Provider value={{ value: shouldScale ? value : initialZoom, set }}>
+        {children}
+      </Context.Provider>
+    );
   }
 }
 
@@ -59,7 +64,7 @@ export const zoomTool: Addon = {
     <Fragment>
       <ZoomConsumer>
         {({ set, value }) => (
-          <Zoom key="zoom" set={(v: number) => set(value * v)} reset={() => set(1)} />
+          <Zoom key="zoom" set={(v: number) => set(value * v)} reset={() => set(initialZoom)} />
         )}
       </ZoomConsumer>
       <Separator />


### PR DESCRIPTION
Issue: #11662 

## What I did

* Added new prop `shouldScale` for `ZoomProvider`
* Added `initialZoom` to `ZoomProvider`
* Do not scale if prop `shouldScale` is set to `false

## How to test

![Kapture 2020-08-04 at 23 18 27](https://user-images.githubusercontent.com/1872246/89298591-dbe09600-d6a8-11ea-842d-0b82aebfd19d.gif)

* Go to a component
* increase the zoom
* Click on `Docs`
* The scale should now be back to the initial value
* Click on the `Canvas`
* The scale should now be increased to the previous value 

