### PR TITLE
Workflows documentation update for Storybook start/build with --docs flag

### DIFF
--- a/docs/workflows/publish-storybook.md
+++ b/docs/workflows/publish-storybook.md
@@ -28,7 +28,6 @@ You can learn more about these flag options [here](../api/cli-options.md).
 </div>
 
 
-If you need to build 
 ### Publish Storybook online
 
 Once your Storybook is built as a static web app it can be deployed to any static site hosting services. The Storybook team uses [Chromatic](https://www.chromatic.com/), a free publishing service made by Storybook maintainers that documents, versions, and indexes your UI components securely in the cloud. 

--- a/docs/workflows/publish-storybook.md
+++ b/docs/workflows/publish-storybook.md
@@ -18,6 +18,17 @@ Storybook will create a static web application at the path you specify. This can
 npx http-server ./path/to/build
 ```
 
+<div class="aside">
+
+Asides from the `-o` flag, you can also include other flags to build Storybook, for instance if you're using [Docs](../writing-docs/introduction.md), you can append the `--docs` flag and Storybook will build your [MDX](../writing-docs/mdx.md) and [CSF](../writing-stories/introduction.md#component-story-format) stories into a rich and interactive documentation.
+
+You can learn more about these flag options [here](../api/cli-options.md).
+
+
+</div>
+
+
+If you need to build 
 ### Publish Storybook online
 
 Once your Storybook is built as a static web app it can be deployed to any static site hosting services. The Storybook team uses [Chromatic](https://www.chromatic.com/), a free publishing service made by Storybook maintainers that documents, versions, and indexes your UI components securely in the cloud. 


### PR DESCRIPTION
This pull request adds a bit more context to the workflows section, more specifically to the "Publish Storybook" page. 

The appropriate flag is already added in the pull request that covering the updates for that section, in here #11751

Feel free to provide feedback