### PR TITLE
Addon-controls: Fix ArgsTable bugs and styling

### DIFF
--- a/lib/components/src/blocks/ArgsTable/ArgJsDoc.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgJsDoc.tsx
@@ -57,6 +57,7 @@ export const Table = styled.table(({ theme }) => ({
     '& code': {
       margin: 0,
       display: 'inline-block',
+      fontSize: theme.typography.size.s1,
     },
   },
 }));

--- a/lib/components/src/blocks/ArgsTable/ArgRow.stories.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgRow.stories.tsx
@@ -35,7 +35,7 @@ String.args = {
     control: { type: 'text' },
     table: {
       type: { summary: 'string' },
-      defaultValue: { summary: 'fixme' },
+      defaultValue: { summary: 'reallylongstringnospaces' },
     },
   },
 };

--- a/lib/components/src/blocks/ArgsTable/ArgRow.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgRow.tsx
@@ -29,6 +29,9 @@ const Description = styled.div(({ theme }) => ({
     p: {
       margin: '0 0 10px 0',
     },
+    a: {
+      color: theme.color.secondary,
+    },
   },
 
   code: codeCommon({ theme }),

--- a/lib/components/src/blocks/ArgsTable/ArgValue.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgValue.tsx
@@ -21,12 +21,13 @@ interface ArgSummaryProps {
 
 const Text = styled.span(({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
-  fontSize: theme.typography.size.s2 - 1,
+  fontSize: theme.typography.size.s1,
 }));
 
 const Expandable = styled.div<{}>(codeCommon, ({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
   color: theme.color.secondary,
+  fontSize: theme.typography.size.s1, // overrides codeCommon
   margin: 0,
   whiteSpace: 'nowrap',
   display: 'flex',
@@ -40,7 +41,7 @@ const Detail = styled.div<{ width: string }>(({ theme, width }) => ({
   padding: 15,
   // Dont remove the mono fontFamily here even if it seem useless, this is used by the browser to calculate the length of a "ch" unit.
   fontFamily: theme.typography.fonts.mono,
-  fontSize: theme.typography.size.s2 - 1,
+  fontSize: theme.typography.size.s1,
   // Most custom stylesheet will reset the box-sizing to "border-box" and will break the tooltip.
   boxSizing: 'content-box',
 

--- a/lib/components/src/blocks/ArgsTable/ArgValue.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgValue.tsx
@@ -22,6 +22,7 @@ interface ArgSummaryProps {
 const Text = styled.span(({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
   fontSize: theme.typography.size.s1,
+  wordBreak: 'break-word',
 }));
 
 const Expandable = styled.div<{}>(codeCommon, ({ theme }) => ({

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
@@ -48,16 +48,17 @@ export const TableWrapper = styled.table<{ compact?: boolean; inAddonPanel?: boo
         ...(compact
           ? null
           : {
+              // Description column
               width: '35%',
             }),
       },
 
-      'th:nth-of-type(3), td:nth-of-type(3)': {
+      'td:nth-of-type(3)': {
         ...(compact
           ? null
           : {
+              // Defaults column
               width: '15%',
-              wordBreak: 'break-all',
             }),
       },
 
@@ -66,6 +67,7 @@ export const TableWrapper = styled.table<{ compact?: boolean; inAddonPanel?: boo
         ...(compact
           ? null
           : {
+              // Controls column
               width: '25%',
             }),
       },

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
@@ -134,6 +134,20 @@ export const TableWrapper = styled.table<{ compact?: boolean; inAddonPanel?: boo
           ${opacify(0.05, theme.appBorderColor)} 0 0 0 1px`),
         borderRadius: theme.appBorderRadius,
 
+        // for safari only
+        // CSS hack courtesy of https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari-only-not-chrome
+        '@media not all and (min-resolution:.001dpcm)': {
+          '@supports (-webkit-appearance:none)': {
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor:
+              !inAddonPanel &&
+              (theme.base === 'light'
+                ? transparentize(0.035, theme.appBorderColor)
+                : opacify(0.05, theme.appBorderColor)),
+          },
+        },
+
         tr: {
           background: 'transparent',
           overflow: 'hidden',

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
@@ -36,11 +36,29 @@ export const TableWrapper = styled.table<{ compact?: boolean; inAddonPanel?: boo
       marginBottom: inAddonPanel ? 0 : 40,
 
       'thead th:first-of-type, td:first-of-type': {
-        width: '30%',
+        // intentionally specify thead here
+        width: '25%',
       },
 
       'th:first-of-type, td:first-of-type': {
         paddingLeft: 20,
+      },
+
+      'th:nth-of-type(2), td:nth-of-type(2)': {
+        ...(compact
+          ? null
+          : {
+              width: '35%',
+            }),
+      },
+
+      'th:nth-of-type(3), td:nth-of-type(3)': {
+        ...(compact
+          ? null
+          : {
+              width: '15%',
+              wordBreak: 'break-all',
+            }),
       },
 
       'th:last-of-type, td:last-of-type': {
@@ -48,8 +66,7 @@ export const TableWrapper = styled.table<{ compact?: boolean; inAddonPanel?: boo
         ...(compact
           ? null
           : {
-              minWidth: '15%',
-              maxWidth: '25%',
+              width: '25%',
             }),
       },
 

--- a/lib/components/src/blocks/ArgsTable/NoControlsWarning.tsx
+++ b/lib/components/src/blocks/ArgsTable/NoControlsWarning.tsx
@@ -4,6 +4,7 @@ import { Link } from '../../typography/link/link';
 
 const NoControlsWrapper = styled.div(({ theme }) => ({
   background: theme.background.warning,
+  color: theme.color.darkest,
   padding: '10px 15px',
   lineHeight: '20px',
   boxShadow: `${theme.appBorderColor} 0 -1px 0 0 inset`,

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -11,6 +11,7 @@ const Label = styled.label(({ theme }) => ({
   marginBottom: 8,
   display: 'inline-block',
   position: 'relative',
+  whiteSpace: 'nowrap',
 
   input: {
     appearance: 'none',


### PR DESCRIPTION
Issue: #11362, #11698

## What I did
- Fixed width of ArgsTable columns when not `compact`
- Allow really long code `strings` to flow to the next line
- Prevent Boolean (true|false pill button) control from stacking when it's parent width is constrained
- Some code font-size tweaks 
- Fix missing border style in Safari only #11698

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, look at Chromatic changeset [here](https://www.chromatic.com/pullrequest?appId=5a375b97f4b14f0020b0cda3&number=11805&view=changes)
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

