### PR TITLE
Addon-docs: Add inline rendering support for HTML

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -14,6 +14,7 @@
     - [React prop tables with Typescript](#react-prop-tables-with-typescript)
     - [ConfigureJSX true by default in React](#configurejsx-true-by-default-in-react)
     - [Docs description parameter](#docs-description-parameter)
+    - [6.0 Inline stories](#60-inline-stories)
   - [New addon presets](#new-addon-presets)
   - [Removed babel-preset-vue from Vue preset](#removed-babel-preset-vue-from-vue-preset)
   - [Removed Deprecated APIs](#removed-deprecated-apis)
@@ -304,6 +305,12 @@ Basic.parameters = { docs: { description: { story: 'some story **markdown**' }}}
 ```
 
 In 5.3 you customized a story description with the `docs.storyDescription` parameter. This has been deprecated, and support will be removed in 7.0.
+
+#### 6.0 Inline stories
+
+The following frameworks now render stories inline on the Docs tab by default, rather than in an iframe: `react`, `vue`, `web-components`, `html`.
+
+To disable inline rendering, set the `docs.inlineStories` parameter to `false`.
 
 ### New addon presets
 

--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -89,7 +89,7 @@ Storybook Docs supports all view layers that Storybook supports except for React
 | Props table       |   +   |  +  |    +    |   +   |       +        |      |        |        |      |         |       |
 | Props controls    |   +   |  +  |         |       |                |      |        |        |      |         |       |
 | Description       |   +   |  +  |    +    |   +   |       +        |      |        |        |      |         |       |
-| Inline stories    |   +   |  +  |         |       |       +        |      |        |        |      |         |       |
+| Inline stories    |   +   |  +  |         |       |       +        |  +   |        |        |      |         |       |
 
 **Note:** `#` = WIP support
 

--- a/addons/docs/src/frameworks/html/config.tsx
+++ b/addons/docs/src/frameworks/html/config.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { StoryFn } from '@storybook/addons';
+
+export const parameters = {
+  docs: {
+    inlineStories: true,
+    prepareForInline: (storyFn: StoryFn<string>) => (
+      // eslint-disable-next-line react/no-danger
+      <div dangerouslySetInnerHTML={{ __html: storyFn() }} />
+    ),
+  },
+};


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Added `prepareForInline`
- [x] Made it the default
- [x] Updated docs

## How to test

See `html-kitchen-sink`, esp the controls stories which is broken in iframe mode
