### PR TITLE
ArgsTable: Fix styles to allow long text to wrap

### DIFF
--- a/lib/components/src/blocks/ArgsTable/ArgValue.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgValue.tsx
@@ -30,10 +30,11 @@ const Summary = styled.div<{ isExpanded?: boolean }>(({ isExpanded }) => ({
   flexWrap: 'wrap',
   alignItems: 'flex-start',
   marginBottom: '-4px',
+  minWidth: 100,
 }));
 
 const Text = styled.span<{}>(codeCommon, ({ theme }) => ({
-  flex: 0,
+  flex: '0 0 auto',
   fontFamily: theme.typography.fonts.mono,
   fontSize: theme.typography.size.s1,
   wordBreak: 'break-word',
@@ -43,6 +44,8 @@ const Text = styled.span<{}>(codeCommon, ({ theme }) => ({
   paddingTop: '2px',
   paddingBottom: '2px',
   lineHeight: '13px',
+  whiteSpace: 'normal',
+  maxWidth: '100%',
 }));
 
 const ExpandButton = styled.button<{}>(({ theme }) => ({


### PR DESCRIPTION
Issue: #11362 

## What I did
[This PR](https://github.com/storybookjs/storybook/pull/11805), while doing some awesome things, doesn't resolve the word wrapping issue.

Specifically, the new `word-break: break-all` property conflicts with the existing `word-wrap: nowrap` property that is inherited from `styles.span`. I also added a min-width to keep it from breaking on short words.

Current behavior: 
![image](https://user-images.githubusercontent.com/5115526/89467961-88bc2100-d744-11ea-9126-3ced527d6764.png)

New behavior:
![image](https://user-images.githubusercontent.com/5115526/89468073-b739fc00-d744-11ea-8cdf-bdc47da74b21.png)


## How to test

- Is this testable with Jest or Chromatic screenshots? Chromatic (but apparently I can't do that from a fork)
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
