### PR TITLE
Fix malformed markdown in 6.0 documentation that was causing bugs

### DIFF
--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -29,7 +29,7 @@ Your project may have additional requirements before components can be rendered 
 
 <details>
 <summary>Build configuration like webpack and Babel</summary>
-  
+
 If you see errors on the CLI when you run the `yarn storybook` command. It’s likely you need to make changes to Storybook’s build configuration. Here are some things to try:
 
 - [Presets](../api/presets.md) bundle common configurations for various technologies into Storybook. In particular presets exist for Create React App, SCSS and Ant Design.
@@ -40,7 +40,7 @@ If you see errors on the CLI when you run the `yarn storybook` command. It’s l
 
 <details>
 <summary>Runtime configuration</summary>
-  
+
 If Storybook builds but you see an error immediately when connecting to it in the browser, then chances are one of your input files is not compiling/transpiling correctly to be interpreted by the browser. Storybook supports modern browsers and IE11, but you may need to check the Babel and webpack settings (see above) to ensure your component code works correctly.
 
 </details>

--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -227,7 +227,7 @@ You can also reuse stories from the child `ListItem` in your `List` component. T
 <!-- prettier-ignore-end -->
 
 <div class="aside">
- 
- Note that there are disadvantages in writing stories like this as you cannot take full advantage of the args mechanism and composing args as you build more complex composite components. For more discussion, set the [multi component stories](../workflows/stories-for-multiple-components.md) workflow article.
- 
- </div>
+
+Note that there are disadvantages in writing stories like this as you cannot take full advantage of the args mechanism and composing args as you build more complex composite components. For more discussion, set the [multi component stories](../workflows/stories-for-multiple-components.md) workflow article.
+
+</div>


### PR DESCRIPTION
Issue:na

## What I did
Removed erroneous spaces which caused bugs.

![image](https://user-images.githubusercontent.com/263385/89849472-931c5780-db56-11ea-8b74-31bd07bd1b7e.png)


## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no
