### PR TITLE
Core: Fix support for main.ts/preview.ts files

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -50,6 +50,7 @@
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.9.0",
+    "@babel/register": "^7.10.5",
     "@storybook/addons": "6.0.0-rc.30",
     "@storybook/api": "6.0.0-rc.30",
     "@storybook/channel-postmessage": "6.0.0-rc.30",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1684,6 +1684,17 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/register@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.10.5.tgz#354f3574895f1307f79efe37a51525e52fd38d89"
+  integrity sha512-eYHdLv43nyvmPn9bfNfrcC4+iYNwdQ8Pxk1MFJuU/U5LpSYl/PH4dFMazCYZDFVi8ueG3shvO+AQfLrxpYulQw==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.19"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
+
 "@babel/runtime-corejs3@^7.7.4", "@babel/runtime-corejs3@^7.8.3":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.9.6.tgz#67aded13fffbbc2cb93247388cf84d77a4be9a71"


### PR DESCRIPTION
Issue: #11763

This is basically the same as #10099, for in depth information please check the description of that PR.

## What I did

TLDR: @babel/register is a dependency of a few libs in the monorepo, and that's why the examples using `main.ts` work. As soon as a user installs storybook in their projects, they don't have that dependency, which is required for server to be able to resolve ts files. 

## How to test

1 - start a new storybook project with storybook 6 or just use `sb upgrade` in an existing project
2 - run `yarn storybook` and see it working fine.
2 - rename main.js to main.ts
3 - run `yarn storybook` and see it failing.
4 - install `yarn add @babel/register -D`
5 - run `yarn storybook` and see it working fine again.