### PR TITLE
Addon-docs: Fix ArgsTable regression

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -249,9 +249,7 @@ In SB 5.2, each framework had its own preset, e.g. `@storybook/addon-docs/react/
 
 #### Preview/Props renamed
 
-In 6.0 we renamed `Preview` to `Canvas`, `Props` to `ArgsTable`.
-
-In addition to the rename, `<Props />` shows the current component, whereas `<ArgsTable />` shows the primary story for the current component. If you want the old behavior, pass `<ArgsTable of='.' />`.
+In 6.0 we renamed `Preview` to `Canvas`, `Props` to `ArgsTable`. The change should be otherwise backwards-compatible.
 
 #### Docs theme separated
 

--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -211,9 +211,7 @@ export const ComponentsTable: FC<ComponentsProps> = (props) => {
 
 export const ArgsTable: FC<ArgsTableProps> = (props) => {
   const context = useContext(DocsContext);
-  const {
-    parameters: { subcomponents },
-  } = context;
+  const { parameters: { subcomponents } = {} } = context;
 
   const { include, exclude, components } = props as ComponentsProps;
   const { story } = props as StoryProps;

--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -247,5 +247,5 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
 };
 
 ArgsTable.defaultProps = {
-  story: PRIMARY_STORY,
+  of: CURRENT_SELECTION,
 };

--- a/addons/docs/src/blocks/DocsPage.tsx
+++ b/addons/docs/src/blocks/DocsPage.tsx
@@ -3,6 +3,7 @@ import { Title } from './Title';
 import { Subtitle } from './Subtitle';
 import { Description } from './Description';
 import { Primary } from './Primary';
+import { PRIMARY_STORY } from './types';
 import { ArgsTable } from './ArgsTable';
 import { Stories } from './Stories';
 
@@ -12,7 +13,7 @@ export const DocsPage: FC = () => (
     <Subtitle />
     <Description />
     <Primary />
-    <ArgsTable />
+    <ArgsTable story={PRIMARY_STORY} />
     <Stories />
   </>
 );

--- a/examples/official-storybook/stories/addon-docs/addon-docs.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/addon-docs.stories.mdx
@@ -11,6 +11,7 @@ import {
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { Button } from '@storybook/react/demo';
+import TsButton from '../../components/TsButton';
 import FlowTypeButton from '../../components/FlowTypeButton';
 import { DocgenButton } from '../../components/DocgenButton';
 import MdNotes from '../notes/notes.md';
@@ -18,7 +19,7 @@ import MdxNotes from '../notes/notes.mdx';
 
 <Meta
   title="Addons/Docs/mdx"
-  component={Button}
+  component={TsButton}
   id="addons-docs-mdx-id"
   decorators={[
     (storyFn) => <div style={{ backgroundColor: 'yellow' }}>{storyFn()}</div>,

--- a/examples/official-storybook/stories/notes/notes.mdx
+++ b/examples/official-storybook/stories/notes/notes.mdx
@@ -1,5 +1,5 @@
 import { ArgsTable, Story } from '@storybook/addon-docs/blocks';
-import { Button } from '@storybook/react/demo';
+import Button from '../../components/TsButton';
 
 # Welcome!
 


### PR DESCRIPTION
Issue: #11870 

## What I did

PR #11744 introduced a regression to `Props`/`ArgsTable`. I changed the `defaultProps` but did not update the rendering logic accordingly. Because we don't have good test coverage for the `Docs` tab, the bug got through.

This change:
- [x] Reverts the `defaultProps` change
- [x] Updates the documentation

## How to test

See the `Docs/mdx` stories in `official-storybook` on the `Docs` tab.