### PR TITLE
documentation: fixed storybook-preview-configure-globaltypes typo

### DIFF
--- a/docs/snippets/common/storybook-preview-configure-globaltypes.js.mdx
+++ b/docs/snippets/common/storybook-preview-configure-globaltypes.js.mdx
@@ -3,7 +3,7 @@
 
 export const globalTypes = {
   theme: {
-    name: 'Theme'
+    name: 'Theme',
     description: 'Global theme for components',
     defaultValue: 'light',
     toolbar: {


### PR DESCRIPTION
Issue:
Missing comma in documentation example resulting in when example code was copied.

## What I did
fixed typo in example code

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
