### PR TITLE
[addon-controls] Delete useless wording "annotation" in README

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -134,7 +134,7 @@ It's also possible that your Storybook is misconfigured. If you think this might
 
 ### How can I disable controls for certain fields on a particular story?
 
-The `argTypes` annotation annotation can be used to hide controls for a particular row, or even hide rows.
+The `argTypes` annotation can be used to hide controls for a particular row, or even hide rows.
 
 Suppose you have a `Button` component with `borderWidth` and `label` properties (auto-generated or otherwise) and you want to hide the `borderWidth` row completely and disable controls for the `label` row on a specific story. Here's how you'd do that:
 


### PR DESCRIPTION
## What I did

I've deleted useless wording "annotation" in README

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
