### PR TITLE
Docs typo: replace `:` with `.`

### DIFF
--- a/docs/api/new-frameworks.md
+++ b/docs/api/new-frameworks.md
@@ -12,7 +12,7 @@ We recommend adopting the same project structure as the Storybook monorepo. That
 
 This may seem like a little more hierarchy than what’s necessary. But because the structure mirrors the way Storybook’s own monorepo is structured, you can reuse Storybook’s tooling and it also makes it easier to move the framework into the Storybook into the monorepo at a later point if that is desirable.
 
-We recommend using `@storybook/html` as a starter framework since it’s the simplest one and doesn’t contain any framework-specific oddities. There is a boilerplate to get you started [here](https://github.com/CodeByAlex/storybook-framework-boilerplate):
+We recommend using `@storybook/html` as a starter framework since it’s the simplest one and doesn’t contain any framework-specific oddities. There is a boilerplate to get you started [here](https://github.com/CodeByAlex/storybook-framework-boilerplate).
 
 ## Framework architecture
 


### PR DESCRIPTION
Issue: na

## What I did
Docs typo on [this page](https://storybook.js.org/docs/react/api/new-frameworks). Has a `:` when it should be a `.`.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

