### PR TITLE
Core: Decrease middleware priority to align with webpack-dev-server

### DIFF
--- a/lib/core/src/server/dev-server.js
+++ b/lib/core/src/server/dev-server.js
@@ -130,6 +130,10 @@ export default function (options) {
         router.use(previewDevMiddlewareInstance);
         router.use(webpackHotMiddleware(previewCompiler));
 
+        // custom middleware
+        const middlewareFn = getMiddleware(configDir);
+        middlewareFn(router);
+
         return new Promise((resolve, reject) => {
           previewReject = reject;
           previewDevMiddlewareInstance.waitUntilValid((stats) => {
@@ -147,10 +151,6 @@ export default function (options) {
           previewProcess = previewDevMiddlewareInstance;
         });
       });
-
-  // custom middleware
-  const middlewareFn = getMiddleware(configDir);
-  middlewareFn(router);
 
   managerPromise.catch((e) => {
     try {


### PR DESCRIPTION
## Issue:

The current middleware router order/priority seems to be wrong.

Express is always picking the first suitable route so in the following example if a user would try to access `/` it would return "First":

```js
router.get('/', (res, req) => req.send('First'));
router.get('/', (res, req) => req.send('Second'));
```

The current implementation looks a little bit like:

```js
router.use(customMiddleWares);
router.use(storybook);
```

So a custom middleware will always overrule storybook routes and potentially break storybook.

Other solutions like the webpack-dev-server proxy feature https://webpack.js.org/configuration/dev-server/#devserverproxy priorities webpack over the custom proxy middleware.

Here is a minimalistic [codesandbox](
https://codesandbox.io/s/storybook-proxy-demo-jfj52?file=/.storybook/middleware.js) to show the why the current implementation could lead to bugs:

middleware.js
```js
module.exports = (router) => {
  router.get("/", (req, res) => res.send("Hello"));
};
```

Now if we access `http://localhost:3000/` we see only "Hello":

![hello](https://user-images.githubusercontent.com/4113649/89985644-b2f96b80-dc7b-11ea-84f4-86e74c406be1.png)

If we access `http://localhost:3000/index.html` we will see storybook:

![middle-ware2](https://user-images.githubusercontent.com/4113649/89985656-b4c32f00-dc7b-11ea-96db-02fe66457973.png)


## What I did

I flipped the order - now storybook routes will always overrule custom middleware routes.  

## Breaking change

middlewares will not be able to overwrite storybook routes anymore 