### PR TITLE
Source-loader: Fix `.add` detection

### DIFF
--- a/__mocks__/inject-parameters.ts.csf.txt
+++ b/__mocks__/inject-parameters.ts.csf.txt
@@ -28,3 +28,10 @@ WithTemplate.args = { foo: 'bar' }
 
 export const WithEmptyTemplate = Template.bind();
 WithEmptyTemplate.args = { foo: 'baz' };
+
+export const WithAddFunctionParameters = () => null
+WithAddFunctionParameters.parameters = {
+  foobar: () => {
+    document.addEventListener('foo', () => console.log('bar'))
+  },
+}

--- a/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
+++ b/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf.test.js.snap
@@ -9,7 +9,8 @@ WithParams.parameters = { storySource: { source: \\"() => <Button>WithParams</Bu
 WithDocsParams.parameters = { storySource: { source: \\"() => <Button>WithDocsParams</Button>\\" }, ...WithDocsParams.parameters };
 WithStorySourceParams.parameters = { storySource: { source: \\"() => <Button>WithStorySourceParams</Button>\\" }, ...WithStorySourceParams.parameters };
 WithTemplate.parameters = { storySource: { source: \\"(args: Args) => <Button {...args} />\\" }, ...WithTemplate.parameters };
-WithEmptyTemplate.parameters = { storySource: { source: \\"(args: Args) => <Button {...args} />\\" }, ...WithEmptyTemplate.parameters };"
+WithEmptyTemplate.parameters = { storySource: { source: \\"(args: Args) => <Button {...args} />\\" }, ...WithEmptyTemplate.parameters };
+WithAddFunctionParameters.parameters = { storySource: { source: \\"() => null\\" }, ...WithAddFunctionParameters.parameters };"
 `;
 
 exports[`inject-decorator positive - ts - csf includes storySource parameter in the default exported object 1`] = `

--- a/lib/source-loader/src/abstract-syntax-tree/parse-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/parse-helpers.js
@@ -103,7 +103,7 @@ export function handleExportedName(storyName, originalNode, parent) {
 }
 
 export function handleADD(node, parent, storiesOfIdentifiers) {
-  if (!node.property || !node.property.name || node.property.name.indexOf('add') !== 0) {
+  if (!node.property || !node.property.name || node.property.name !== 'add') {
     return {};
   }
 


### PR DESCRIPTION
Issue: #11914 

## What I did

Fix `.add` detection. This is still brittle / lame, but much better than before. Better solution would be to drop `storiesOf` support in the future.

## How to test

See attached snapshot tests