### PR TITLE
fix(withA11y docs): Fix function call code example

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -623,7 +623,7 @@ addParameters({
     options: {},
     manual: true,
   }
-};
+});
 ```
 
 #### Essentials addon disables differently


### PR DESCRIPTION
Fix `addParameters` function call code example by adding missing closing parenthesis.

Issue:

Closing parenthesis was missing in doc code example.

## What I did

Fix code example in docs
