### PR TITLE
Fix install command for addon-controls

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -11,7 +11,7 @@
 Controls is part of [essentials](https://storybook.js.org/docs/react/essentials/introduction) and so is installed in all new Storybooks by default. If you need to add it to your Storybook, you can run:
 
 ```sh
-npm i -D @storybook/addon-toolbars
+npm i -D @storybook/addon-controls
 ```
 
 Then, add following content to [`.storybook/main.js`](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project):


### PR DESCRIPTION
Issue:

## What I did
- Noticed the suggested install command for the controls addon was wrong, so in this PR I have updated the documentation to now be correct

## How to test
- `npm i -D @storybook/addon-controls`
- `yarn add --dev @storybook/addon-controls`