### PR TITLE
Update widget-story-controls-enum.js.mdx

### DIFF
--- a/docs/snippets/common/widget-story-controls-enum.js.mdx
+++ b/docs/snippets/common/widget-story-controls-enum.js.mdx
@@ -6,8 +6,10 @@ export default {
   component: Widget,
   argTypes: {
     loadingState: {
-      control: 'inline-radio',
-      options: ['loading', 'error', 'ready'],
+      control: {
+        type: 'inline-radio',
+        options: ['loading', 'error', 'ready'],
+      },
     },
   },
 };

--- a/docs/snippets/common/widget-story-controls-enum.js.mdx
+++ b/docs/snippets/common/widget-story-controls-enum.js.mdx
@@ -6,7 +6,7 @@ export default {
   component: Widget,
   argTypes: {
     loadingState: {
-      type: 'inline-radio',
+      control: 'inline-radio',
       options: ['loading', 'error', 'ready'],
     },
   },


### PR DESCRIPTION
This is the only way I got the custom control types working. Following the argTypes-Docs from https://storybook.js.org/docs/react/api/argtypes the `type` field is for setting the property-type, not the control type.

Issue: Custom Controls not working as expected. Or to be more specific, the control type doesn't change.

## What I did

Updated the example code-snippet to match the argTypes api-docs by using `control` property instead of `type` property which is used for the actual property type.

## How to test

Try to run a story with custom-controls set via `argTypes` in the default export.

- Is this testable with Jest or Chromatic screenshots? 
  I'm not sure.
- Does this need a new example in the kitchen sink apps? 
  Probably not.
- Does this need an update to the documentation? 
  This actually is an update to the documentation :)

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
