### PR TITLE
UI: update upgrade command in about section

### DIFF
--- a/lib/ui/src/settings/about.tsx
+++ b/lib/ui/src/settings/about.tsx
@@ -155,14 +155,7 @@ const AboutScreen: FunctionComponent<{
               <b>Upgrade all Storybook packages to latest:</b>
             </p>
             <SyntaxHighlighter language="bash" copyable padded bordered>
-              npx npm-check-updates '/storybook/' -u && npm install
-            </SyntaxHighlighter>
-            <p>
-              Alternatively, if you're using yarn run the following command, and check all Storybook
-              related packages:
-            </p>
-            <SyntaxHighlighter language="bash" copyable padded bordered>
-              yarn upgrade-interactive --latest
+              npx sb upgrade
             </SyntaxHighlighter>
           </DocumentWrapper>
         </Upgrade>


### PR DESCRIPTION
## What I did
Now that Storybook is released, users that have older versions will have this button at the bottom:
![image](https://user-images.githubusercontent.com/1671563/90015697-39787200-dca9-11ea-9b17-a2164efcc7d7.png)

That leads to a page showing how to upgrade. The commands in the current page are outdated. I assume we want to promote the usage of the CLI so I have updated the command:
![image](https://user-images.githubusercontent.com/1671563/90015527-046c1f80-dca9-11ea-97c3-b058ff3366c0.png)
