### PR TITLE
Use the denormed params on the first story for initial options

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -375,7 +375,7 @@ export const init: ModuleFn = ({
         }
 
         fullAPI.setStories(stories, error);
-        const { options } = data.globalParameters;
+        const options = fullAPI.getCurrentParameter('options');
         checkDeprecatedOptionParameters(options);
         fullAPI.setOptions(options);
       } else {

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -806,6 +806,7 @@ describe('stories API', () => {
         setStories: jest.fn(),
         setOptions: jest.fn(),
         findRef: jest.fn(),
+        getCurrentParameter: jest.fn(),
       });
       const navigate = jest.fn();
       const store = createMockStore();
@@ -866,23 +867,25 @@ describe('stories API', () => {
       );
     });
 
-    it('calls setOptions with global options parameters', () => {
+    it('calls setOptions w/ first story parameter', () => {
       const fullAPI = Object.assign(new EventEmitter(), {
         setStories: jest.fn(),
         setOptions: jest.fn(),
         findRef: jest.fn(),
+        getCurrentParameter: jest.fn().mockReturnValue('options'),
       });
       const navigate = jest.fn();
       const store = createMockStore();
 
-      const { init } = initStories({ store, navigate, provider, fullAPI });
+      const { init, api } = initStories({ store, navigate, provider, fullAPI });
       init();
 
+      store.setState({});
       const setStoriesPayload = {
         v: 2,
-        globalParameters: { options: 'options' },
-        kindParameters: { a: { options: 'should-be-ignored' } },
-        stories: { 'a--1': { kind: 'a', parameters: { options: 'should-be-ignored-also' } } },
+        globalParameters: {},
+        kindParameters: { a: {} },
+        stories: { 'a--1': { kind: 'a' } },
       };
       fullAPI.emit(SET_STORIES, setStoriesPayload);
 


### PR DESCRIPTION
Issue: #11924 

## What I did

Use the full parameters of the first story (which is what we did on story change anyway), on init.

## How to test

- Is this testable with Jest or Chromatic screenshots?
Yes, we have tests
