### PR TITLE
Fix link to testing-with-storybook

### DIFF
--- a/docs/get-started/whats-a-story.md
+++ b/docs/get-started/whats-a-story.md
@@ -77,6 +77,6 @@ Stories are also useful for checking that UI continues to look correct as you ma
   />
 </video>
 
-Checking a component’s stories as you develop helps prevent accidental regressions. Tools that integrate with Storybook can also [automate](..workflows/testing-with-storybook.md) this for you.
+Checking a component’s stories as you develop helps prevent accidental regressions. Tools that integrate with Storybook can also [automate](../workflows/testing-with-storybook.md) this for you.
 
 Now we’ve seen the basic anatomy of a story, let’s see how we use Storybook’s UI to develop stories.


### PR DESCRIPTION


Issue: The link with text `automate` at the end is not working properly.

## What I did
It read `..workflows/testing-with-storybook.md` and is updated to read `../workflows/testing-with-storybook.md`

## How to test
Click the link in getting started > what's a story, scroll to the bottom and press the link text 'automate'
 
- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
