### PR TITLE
Remove deprecated addParameters from docs snippet

### DIFF
--- a/addons/docs/react/README.md
+++ b/addons/docs/react/README.md
@@ -107,13 +107,11 @@ Some **markdown** description, or whatever you want.
 Storybook Docs renders all React stories inline on the page by default. If you want to render stories in an `iframe` so that they are better isolated. To do this, update `.storybook/preview.js`:
 
 ```js
-import { addParameters } from '@storybook/react';
-
-addParameters({
+export const parameters = {
   docs: {
     inlineStories: false,
   },
-});
+};
 ```
 
 ## TypeScript props with `react-docgen`


### PR DESCRIPTION
## What I did

Replaced the deprecated `addParameters` with the named export

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
