### PR TITLE
Fix links to "Viewport" and "Toolbars & globals" pages

### DIFF
--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -7,9 +7,9 @@ A major strength of Storybook are [addons](/addons/) that extend Storybook’s U
 - [Docs](../writing-docs/introduction.md)
 - [Controls](./controls.md)
 - [Actions](./actions.md)
-- [Viewport](./viewports.md)
+- [Viewport](./viewport.md)
 - [Backgrounds](./backgrounds.md)
-- [Toolbars](./toolbars.md)
+- [Toolbars & globals](./toolbars-and-globals.md)
 
 ### Configuration
 


### PR DESCRIPTION
On the "Essentials" page of the documentation, the "Viewport" and "Toolbars & globals" links are broken.

## What I did
* Changed the link URLs to match the markdown file names.
* Changed the link text to match the link text for the same pages shown in the sidebar.