### PR TITLE
docs(parameters): fix example file name

### DIFF
--- a/docs/writing-stories/parameters.md
+++ b/docs/writing-stories/parameters.md
@@ -56,7 +56,7 @@ export default {
 We can also set the parameters for **all stories** via the `parameters` export of your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering) file (this is the file where you configure all stories):
 
 ```js
-// preview.js
+// .storybook/preview.js
 
 export const parameters = {
   backgrounds: {

--- a/docs/writing-stories/parameters.md
+++ b/docs/writing-stories/parameters.md
@@ -56,7 +56,7 @@ export default {
 We can also set the parameters for **all stories** via the `parameters` export of your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering) file (this is the file where you configure all stories):
 
 ```js
-// Button.story.js
+// preview.js
 
 export const parameters = {
   backgrounds: {


### PR DESCRIPTION
## What I did

There is a simple mistake in the example, the file in the comment should be preview instead of Button.