### PR TITLE
docs: add correct links in Addon Controls readme

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -28,15 +28,11 @@ The usage is documented in the [documentation](https://storybook.js.org/docs/rea
 
 ## FAQs
 
-- [Storybook Controls Addon](#storybook-controls-addon)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [FAQs](#faqs)
-    - [How will this replace addon-knobs?](#how-will-this-replace-addon-knobs)
-    - [How do I migrate from addon-knobs?](#how-do-i-migrate-from-addon-knobs)
-    - [My controls aren't being auto-generated. What should I do?](#my-controls-arent-being-auto-generated-what-should-i-do)
-    - [How can I disable controls for certain fields on a particular story?](#how-can-i-disable-controls-for-certain-fields-on-a-particular-story)
-    - [How do controls work with MDX?](#how-do-controls-work-with-mdx)
+- [How will this replace addon-knobs?](#how-will-this-replace-addon-knobs)
+- [How do I migrate from addon-knobs?](#how-do-i-migrate-from-addon-knobs)
+- [My controls aren't being auto-generated. What should I do?](#my-controls-arent-being-auto-generated-what-should-i-do)
+- [How can I disable controls for certain fields on a particular story?](#how-can-i-disable-controls-for-certain-fields-on-a-particular-story)
+- [How do controls work with MDX?](#how-do-controls-work-with-mdx)
 
 ### How will this replace addon-knobs?
 

--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -28,10 +28,15 @@ The usage is documented in the [documentation](https://storybook.js.org/docs/rea
 
 ## FAQs
 
-- [How will this replace addon-knobs?](#how-will-this-replace-addon-knobs)
-- [How do I migrate from addon-knobs?](#how-do-i-migrate-from-addon-knobs)
-- [My controls aren't being auto-generated. What should I do?](#my-controls-arent-being-auto-generated-what-should-i-do)
-- [How can I disable controls for certain fields on a particular story?](#how-can-i-disable-controls-for-certain-fields-on-a-particular-story)
+- [Storybook Controls Addon](#storybook-controls-addon)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [FAQs](#faqs)
+    - [How will this replace addon-knobs?](#how-will-this-replace-addon-knobs)
+    - [How do I migrate from addon-knobs?](#how-do-i-migrate-from-addon-knobs)
+    - [My controls aren't being auto-generated. What should I do?](#my-controls-arent-being-auto-generated-what-should-i-do)
+    - [How can I disable controls for certain fields on a particular story?](#how-can-i-disable-controls-for-certain-fields-on-a-particular-story)
+    - [How do controls work with MDX?](#how-do-controls-work-with-mdx)
 
 ### How will this replace addon-knobs?
 
@@ -88,7 +93,7 @@ export const Reflow = () => {
 };
 ```
 
-And again, as above, this can be rewritten using [fully custom args](#fully-custom-args):
+And again, as above, this can be rewritten using [fully custom args](https://storybook.js.org/docs/react/essentials/controls#fully-custom-args):
 
 ```jsx
 export const Reflow = ({ count, label, ...args }) => (
@@ -104,7 +109,7 @@ Reflow.argTypes = {
 
 There are a few known cases where controls can't be auto-generated:
 
-- You're using a framework for which automatic generation [isn't supported](#framework-support)
+- You're using a framework for which automatic generation [isn't supported](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 - You're trying to generate controls for a component defined in an external library
 
 With a little manual work you can still use controls in such cases. Consider the following example:
@@ -127,7 +132,7 @@ Basic.args = {
 };
 ```
 
-The `argTypes` annotation (which can also be applied to individual stories if needed), gives Storybook the hints it needs to generate controls in these unsupported cases. See [control annotations](#control-annotations) for a full list of control types.
+The `argTypes` annotation (which can also be applied to individual stories if needed), gives Storybook the hints it needs to generate controls in these unsupported cases. See [control annotations](https://storybook.js.org/docs/react/essentials/controls#annotation) for a full list of control types.
 
 It's also possible that your Storybook is misconfigured. If you think this might be the case, please search through Storybook's [Github issues](https://github.com/storybookjs/storybook/issues), and file a new issue if you don't find one that matches your use case.
 


### PR DESCRIPTION
Issue:

It's does not have an issue.

## What I did

Updated some links in Addon Controls README, like `Fully custom args`, to point to the correct page information.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
