### PR TITLE
Docs: Fix broken link on configure > overview page

### DIFF
--- a/docs/configure/overview.md
+++ b/docs/configure/overview.md
@@ -72,4 +72,4 @@ If you’re looking to change how your stories are ordered, read about [sorting 
 
 To control the behaviour of Storybook’s UI (the **“manager”**), you can create a `.storybook/manager.js` file.
 
-This file does not have a specific API but is the place to set [UI options](./user-interface.md) and to configure Storybook’s [theme](./theming.md).
+This file does not have a specific API but is the place to set [UI options](./features-and-behavior.md) and to configure Storybook’s [theme](./theming.md).


### PR DESCRIPTION
Reported here https://github.com/storybookjs/frontpage/issues/151#issuecomment-673495491

## What I did
- Fix broken link on configure > overview page

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

