### PR TITLE
Fix url linking to argTypes documentation

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -17,7 +17,7 @@ Controls does not require any modification to your components. Stories for contr
 - Portable. Reuse your interactive stories in documentation, tests, and even in designs.
 - Rich. Customize the controls and interactive data to suit your exact needs.
 
-To use the Controls addon, you need to write your stories using [args](../writing-stories/args.md). Storybook will automatically generate UI controls based on your args and what it can infer about your component; but you can configure the controls further using [argTypes](../api/mdx.md#argtypes), see below.
+To use the Controls addon, you need to write your stories using [args](../writing-stories/args.md). Storybook will automatically generate UI controls based on your args and what it can infer about your component; but you can configure the controls further using [argTypes](../api/argtypes.md), see below.
 
 <div class="aside">
 
@@ -62,7 +62,7 @@ By default, Storybook will render a free text input for the `backgroundColor` ar
 
 This works as long as you type a valid string into the auto-generated text control, but it's not the best UI for picking a color. Let’s replace it with Storybook’s color picker component.
 
-We can specify which controls get used by declaring a custom [argType](../api/mdx.md#argtypes) for the `backgroundColor` property. ArgTypes encode basic metadata for args, such as name, description, defaultValue for an arg. These get automatically filled in by Storybook Docs.
+We can specify which controls get used by declaring a custom [argType](../api/argtypes.md) for the `backgroundColor` property. ArgTypes encode basic metadata for args, such as name, description, defaultValue for an arg. These get automatically filled in by Storybook Docs.
 
 ArgTypes can also contain arbitrary annotations which can be overridden by the user. Since `backgroundColor` is a property of the component, let's put that annotation on the default export.
 


### PR DESCRIPTION
Issue: Link to argTypes does not direct to proper documentation.

## What I did

Updating linking to argTypes documentation.