### PR TITLE
Chore: updates to the writing docs section

### DIFF
--- a/docs/api/argtypes.md
+++ b/docs/api/argtypes.md
@@ -59,7 +59,7 @@ In this ArgTypes data structure, name, type, defaultValue, and description are s
 
 #### Manual specification
 
-If you want more control over the props table or any other aspect of using argTypes, you can overwrite the generated argTypes for you component on a per-arg basis. For instance, with the above inferred argTypes and the following default export:
+If you want more control over the args table or any other aspect of using argTypes, you can overwrite the generated argTypes for you component on a per-arg basis. For instance, with the above inferred argTypes and the following default export:
 
 <!-- prettier-ignore-start -->
 

--- a/docs/snippets/common/component-story-mdx-argstable-block.mdx.mdx
+++ b/docs/snippets/common/component-story-mdx-argstable-block.mdx.mdx
@@ -1,10 +1,10 @@
 ```md
 <!--- MyComponent.stories.mdx -->
 
-import { Props } from '@storybook/addon-docs/blocks';
+import { ArgsTable } from '@storybook/addon-docs/blocks';
 import { MyComponent } from './MyComponent';
 
 # My Component!
 
-<Props of={MyComponent} />
+<ArgsTable of={MyComponent} />
 ```

--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -49,13 +49,13 @@ To use the `ArgsTable` in [DocsPage](./docs-page.md#component-parameter), export
 
 ### MDX
 
-To use the `ArgsTable` in MDX, use the Props block:
+To use the `ArgsTable` block in MDX, add the following:
 
 <!-- prettier-ignore-start -->
 
 <CodeSnippets
   paths={[
-    'common/component-story-mdx-argstable-propsblock.mdx.mdx',
+    'common/component-story-mdx-argstable-block.mdx.mdx',
   ]}
 />
 

--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -2,7 +2,7 @@
 title: 'DocsPage'
 ---
 
-When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/next/addons/docs/README.md), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, props tables, and code examples into a single page for each component.
+When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/next/addons/docs/README.md), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
 
 The best practice for docs is for each component to have its own set of documentation and stories.
 


### PR DESCRIPTION
With this pull request, some mentions to props tables are now removed.

What was done:
- Updated the docs files to mention the nomenclature used.
- Adjusted the snippet accordingly.

@shilman can you vet if that's the use case for the snippet? If that's want we want to document?

Feel free to provide feedback