### PR TITLE
fix(docs): Props > ArgsTable & add props in docs

### DIFF
--- a/docs/snippets/common/button-story-remix-docspage.js.mdx
+++ b/docs/snippets/common/button-story-remix-docspage.js.mdx
@@ -8,6 +8,7 @@ import {
   Primary,
   Props,
   Stories,
+  PRIMARY_STORY,
 } from '@storybook/addon-docs/blocks';
 
 import { Button } from './Button';
@@ -23,7 +24,7 @@ export default {
           <Subtitle />
           <Description />
           <Primary />
-          <Props />
+          <ArgsTable story={PRIMARY_STORY} />
           <Stories />
         </>
       ),

--- a/docs/snippets/common/button-story-remix-docspage.ts.mdx
+++ b/docs/snippets/common/button-story-remix-docspage.ts.mdx
@@ -12,6 +12,7 @@ import {
   Primary,
   Props,
   Stories,
+  PRIMARY_STORY,
 } from '@storybook/addon-docs/blocks';
 import { Button, ButtonProps } from './Button';
 
@@ -26,7 +27,7 @@ export default {
           <Subtitle />
           <Description />
           <Primary />
-          <Props />
+          <ArgsTable story={PRIMARY_STORY} />
           <Stories />
         </>
       ),


### PR DESCRIPTION
## Issue: 
I recently wrote some custom docs that required "remixing" the default `DocsPage`. When using the code examples currently on the [DocsPage](https://storybook.js.org/docs/react/writing-docs/docs-page) ... Docs..page 😄 I noticed I lost the new table that includes `Controls`. I took a look into the code and noticed:

1. `<Props />` was deprecated in favor of `<ArgsTable />`
2. The default `DocsPage` passes a prop to `<ArgsTable />` that is required for controls to work.

([line in the default DocsPage Code](https://github.com/storybookjs/storybook/blob/next/addons/docs/src/blocks/DocsPage.tsx#L16))


## What I did

I updated the documentation to reflect the current state of the default `DocsPage` to hopefully help others when writing their own custom docs.

## How to test

- Is this testable with Jest or Chromatic screenshots? - 🚫 
- Does this need a new example in the kitchen sink apps? - 🚫 
- Does this need an update to the documentation? - ✅ 

If your answer is yes to any of these, please make sure to include it in your PR.