### PR TITLE
Update instructions to configure toolbar menus

### DIFF
--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -12,7 +12,25 @@ When the globals change, the story re-renders and the decorators rerun with the 
 
 ## Global types and the toolbar annotation
 
-Storybook has a simple, declarative syntax for configuring toolbar menus. In your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering), you can add your own toolbars by creating `globalTypes` with a `toolbar` annotation:
+Storybook has a simple, declarative syntax for configuring toolbar menus. First, install `@storybook/addon-toolbars`:
+
+```
+npm i -D @storybook/addon-toolbars
+```
+
+And register the addon in your `.storybook/main.js` file:
+
+```
+module.exports = {
+  stories: [...],
+  addons: [
+    '@storybook/addon-toolbars'
+  ],
+};
+
+```
+
+Then, in your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering), you can add your own toolbars by creating `globalTypes` with a `toolbar` annotation:
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
Add instructions to install and register @storybook/addon-toolbars before configuring custom toolbar menus.

Issue:

The instructions to add custom toolbar menus did not mention the fact that `@storybook/addon-toolbars` needs to be installed and registered before a custom toolbar icon can be added. Without this step, the icon would never appear on the toolbar.

## What I did

Updated the text to include instructions to install and register `@storybook/addon-toolbars` before declaring `globalTypes`.

## How to test

n/a