### PR TITLE
Doc: Update toolbars-and-globals.md

### DIFF
--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -98,7 +98,7 @@ Using the example above, you can modify any story to retrieve the **Locale** `gl
 
 <div class="aside">
 
-In Storybook 6.0, if you set the global option `passArgsFirst: false` for backwards compatibility, the story context is passed as the second argument:
+In Storybook 6.0, if you set the global option `passArgsFirst: false` for backwards compatibility, the story context is passed as the first argument:
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
Issue:
In storybook 6,  if you set the global option `passArgsFirst: false`, context should be passed as the **first** argument

## What I did
change typo `second argument` to `first argument`

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
