### PR TITLE
Addon-docs: Fix CSF names importing in MDX

### DIFF
--- a/addons/docs/src/mdx/__testfixtures__/csf-imports.mdx
+++ b/addons/docs/src/mdx/__testfixtures__/csf-imports.mdx
@@ -1,4 +1,4 @@
-import { Story, Meta } from '@storybook/addon-docs/blocks';
+import { Story, Meta, Canvas } from '@storybook/addon-docs/blocks';
 import { Welcome, Button } from '@storybook/angular/demo';
 import * as MyStories from './My.stories';
 import { Other } from './Other.stories';
@@ -9,6 +9,8 @@ import { Other } from './Other.stories';
 
 <Story story={MyStories.Basic} />
 
-<Story story={Other} />
+<Canvas>
+  <Story story={Other} />
+</Canvas>
 
 <Story name="renamed" story={MyStories.Foo} />

--- a/addons/docs/src/mdx/__testfixtures__/csf-imports.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/csf-imports.output.snapshot
@@ -4,7 +4,7 @@ exports[`docs-mdx-compiler-plugin csf-imports.mdx 1`] = `
 "/* @jsx mdx */
 import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
 
-import { Story, Meta } from '@storybook/addon-docs/blocks';
+import { Story, Meta, Canvas } from '@storybook/addon-docs/blocks';
 import { Welcome, Button } from '@storybook/angular/demo';
 import * as MyStories from './My.stories';
 import { Other } from './Other.stories';
@@ -27,7 +27,9 @@ function MDXContent({ components, ...props }) {
       <Meta title=\\"MDX/CSF imports\\" mdxType=\\"Meta\\" />
       <h1>{\`Stories from CSF imports\`}</h1>
       <Story story={MyStories.Basic} name=\\"BasicStory\\" mdxType=\\"Story\\" />
-      <Story story={Other} name=\\"OtherStory\\" mdxType=\\"Story\\" />
+      <Canvas mdxType=\\"Canvas\\">
+        <Story story={Other} name=\\"OtherStory\\" mdxType=\\"Story\\" />
+      </Canvas>
       <Story name=\\"renamed\\" story={MyStories.Foo} mdxType=\\"Story\\" />
     </MDXLayout>
   );

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -249,7 +249,14 @@ function getExports(node, counter, options) {
     if (CANVAS_REGEX.exec(value)) {
       // Canvas/Preview, possibly containing multiple stories
       const ast = parser.parseExpression(value, { plugins: ['jsx'] });
-      return { stories: genCanvasExports(ast, counter) };
+
+      const canvasExports = genCanvasExports(ast, counter);
+
+      const { code } = generate(ast, {});
+      // eslint-disable-next-line no-param-reassign
+      node.value = code;
+
+      return { stories: canvasExports };
     }
     if (META_REGEX.exec(value)) {
       const ast = parser.parseExpression(value, { plugins: ['jsx'] });

--- a/examples/official-storybook/stories/addon-docs/csf-with-mdx-docs.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/csf-with-mdx-docs.stories.mdx
@@ -14,7 +14,7 @@ I can define a story with the function imported from CSF:
 <ArgsTable />
 
 <Canvas>
-  <Story name="basic" story={Csf.Basic} />
+  <Story story={Csf.Basic} />
 </Canvas>
 
 <Canvas>


### PR DESCRIPTION
Issue: #11794 

## What I did

Fixed the case where MDX story with embedded CSF is enclosed in a `<Canvas>`

## How to test

See attached unit test & story in `official-storybook`

Self-merging @tmeasday 