### PR TITLE
Addon-docs: Fix DocsPage scroll behavior

### DIFF
--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -65,13 +65,14 @@ export const DocsContainer: FunctionComponent<DocsContainerProps> = ({ context, 
         document.getElementById(storyBlockIdFromId(storyId));
       if (element) {
         const allStories = element.parentElement.querySelectorAll('[id|="anchor-"]');
-        let block = 'start';
+        let scrollTarget = element;
         if (allStories && allStories[0] === element) {
-          block = 'end'; // first story should be shown with the intro content above
+          // Include content above first story
+          scrollTarget = document.getElementById('docs-root');
         }
         // Introducing a delay to ensure scrolling works when it's a full refresh.
         setTimeout(() => {
-          scrollToElement(element, block);
+          scrollToElement(scrollTarget, 'start');
         }, 200);
       }
     }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12042

## What I did
Modified the scroll logic for first stories in the view

## How to test
I believe the most appropriate way to test this is just go simply go to http://localhost:9011/?path=/docs/docs-docspage--with-subtitle and verify that the view does not scroll (as opposed to the behavior described in the issue linked above).  You should also be able to click around on other stories within that group and go back and forth between the "Canvas" and "Docs" tab and have everything behave as expected.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
