### PR TITLE
[docs] Update wording in writing-stories/args

### DIFF
--- a/docs/writing-stories/args.md
+++ b/docs/writing-stories/args.md
@@ -6,7 +6,7 @@ A story is a component with a set of arguments (props, slots, inputs, etc). “A
 
 When an arg’s value is changed, the component re-renders, allowing you to interact with components in Storybook’s UI via addons that affect args.
 
-Learn how and why to write stories with args [here](./introduction.md#using-args) section. For details on how args work, read on.
+Learn how and why to write stories in [the introduction](./introduction.md#using-args). For details on how args work, read on.
 
 ## Args object
 


### PR DESCRIPTION
Issue:

Wording was slightly odd after 7a0203f9bab0bc8b1434ad37d0a3765c573bf21b. Without the link, it read

> Learn how to write stories with args here section.

## What I did

Updated, so now it reads

> Learn how to write stories with args in the introduction.

## How to test

n/a

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
