### PR TITLE
Add Story type to example

### DIFF
--- a/docs/snippets/react/button-story-with-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-args.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import { Story } from '@storybook/react';
+import { Story } from '@storybook/react/types-6-0';
 
 const Template: Story<ButtonProps> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/button-story-with-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-args.ts.mdx
@@ -1,6 +1,8 @@
 ```ts
 // Button.stories.ts
 
+import { Story } from '@storybook/react';
+
 const Template: Story<ButtonProps> = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});


### PR DESCRIPTION
Issue: the example does not tell where to import `Story` from.

## What I did

Added the import.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
