### PR TITLE
Fix docs for panelPosition / initialActive options

### DIFF
--- a/docs/configure/features-and-behavior.md
+++ b/docs/configure/features-and-behavior.md
@@ -21,12 +21,12 @@ The following table details how to use the API values:
 | **isFullscreen**      | Boolean       |Show story component as full screen                            |`false`                                         |
 | **showNav**           | Boolean       |Display panel that shows a list of stories                     |`true`                                          |
 | **showPanel**         | Boolean       |Display panel that shows addon configurations                  |`true`                                          |
-| **panelPosition**     | String/Object |Where to show the addon panel                                  |`bottom` or `{('bottom'|'right')}`              |
+| **panelPosition**     | String/Object |Where to show the addon panel                                  |`bottom` or `right`                             |
 | **sidebarAnimations** | Boolean       |Sidebar tree animations                                        |`true`                                          |
 | **enableShortcuts**   | Boolean       |Enable/disable shortcuts                                       |`true`                                          |
 | **isToolshown**       | String        |Show/hide tool bar                                             |`true`                                          |
 | **theme**             | Object        |Storybook Theme, see next section                              |`undefined`                                     |
 | **selectedPanel**     | String        |Id to select an addon panel                                    |`my-panel`                                      |
-| **initialActive**     | String        |Select the default active tab on Mobile.                       |`'sidebar'` or `{('sidebar'|'canvas'|'addons')}`|
+| **initialActive**     | String        |Select the default active tab on Mobile.                       |`sidebar` or `canvas` or `addons`             |
 | **showRoots**         | Boolean       |Display the top-level grouping as a "root" in the sidebar      |`false`                                         |
 


### PR DESCRIPTION
This fixes some formatting in the docs for the `panelPosition` and `initialActive` options. The broken formatting can be seen at https://storybook.js.org/docs/react/configure/features-and-behavior

<img width="830" alt="Screen Shot 2020-08-16 at 3 33 28 PM" src="https://user-images.githubusercontent.com/55398/90343439-0817e300-dfd6-11ea-96cc-20a5fbf69972.png">


Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
