### PR TITLE
Updated docs/theming.md to have correct links to Storybook Docs

### DIFF
--- a/docs/configure/theming.md
+++ b/docs/configure/theming.md
@@ -32,7 +32,7 @@ When setting a theme, set a full theme object. The theme is replaced, not combin
 
 ## Theming docs
 
-[Storybook Docs](../writing-docs) uses the same theme system as Storybook’s UI, but is themed independently from the main UI.
+[Storybook Docs](../writing-docs/introduction) uses the same theme system as Storybook’s UI, but is themed independently from the main UI.
 
 Supposing you have a Storybook theme defined for the main UI in [`.storybook/manager.js`](./overview.md#configure-story-rendering):
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12067

## What I did
Fixed the URL to the Storybook Docs section

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storybookjs/storybook/12068)
<!-- Reviewable:end -->
