### PR TITLE
Docs - fix configure overview babel and webpack links

### DIFF
--- a/docs/configure/overview.md
+++ b/docs/configure/overview.md
@@ -28,8 +28,8 @@ The `main.js` configuration file is a [preset](../api/presets.md) and as such ha
 
 - `stories` - a array of globs that indicates the [location of your story files](#configure-story-loading), relative to `main.js`.
 - `addons` - a list of the [addons](/addons) you are using.
-- `webpackFinal` - custom [webpack configuration](./integration.md#extending-storybooks-webpack-config).
-- `babel` - custom [babel configuration](./integration.md#babel).
+- `webpackFinal` - custom [webpack configuration](./webpack.md#extending-storybooks-webpack-config).
+- `babel` - custom [babel configuration](./babel.md).
 
 ## Configure story loading
 


### PR DESCRIPTION
Issue:

## What I did

Fixed two links leading to 404 in "Configure" overview docs.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no


