### PR TITLE
Angular: Make CLI templates compatible with TS strict mode

### DIFF
--- a/lib/cli/src/frameworks/angular/button.component.ts
+++ b/lib/cli/src/frameworks/angular/button.component.ts
@@ -17,13 +17,13 @@ export default class ButtonComponent {
    * Is this the principal call to action on the page?
    */
   @Input()
-  primary: boolean;
+  primary = false;
 
   /**
    * What background color to use
    */
   @Input()
-  backgroundColor: string;
+  backgroundColor?: string;
 
   /**
    * How large should the button be?
@@ -37,7 +37,7 @@ export default class ButtonComponent {
    * @required
    */
   @Input()
-  label: string;
+  label = 'Button';
 
   /**
    * Optional click handler

--- a/lib/cli/src/frameworks/angular/header.component.ts
+++ b/lib/cli/src/frameworks/angular/header.component.ts
@@ -50,7 +50,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 })
 export default class HeaderComponent {
   @Input()
-  user = null;
+  user: unknown = null;
 
   @Output()
   onLogin = new EventEmitter<Event>();

--- a/lib/cli/src/frameworks/angular/page.component.ts
+++ b/lib/cli/src/frameworks/angular/page.component.ts
@@ -63,7 +63,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 })
 export default class PageComponent {
   @Input()
-  user = null;
+  user: unknown = null;
 
   @Output()
   onLogin = new EventEmitter<Event>();

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -17,7 +17,7 @@ const baseAngular: Parameters = {
   version: 'latest',
   generator: [
     `yarn add @angular/cli@{{version}} --no-lockfile --non-interactive --silent --no-progress`,
-    `npx ng new {{name}}-{{version}} --routing=true --minimal=true --style=scss --skipInstall=true`,
+    `npx ng new {{name}}-{{version}} --routing=true --minimal=true --style=scss --skipInstall=true --strict`,
   ].join(' && '),
   additionalDeps: ['react', 'react-dom'],
 };


### PR DESCRIPTION
Issue: #12070

## What I did

 - More and more devs are using TS strict mode as it's advocated by TS team. So we should generate Angular project in E2E tests with strict mode activated.
 - Fix typing errors in strict mode.

## How to test

- CI should be green, especially example-v2 for Angular.
