### PR TITLE
Fixed typo: changed yarn install to yarn add

### DIFF
--- a/docs/configure/theming.md
+++ b/docs/configure/theming.md
@@ -13,7 +13,7 @@ Storybook includes two themes that look good out of the box: "normal" (a light t
 Make sure you have installed [`@storybook/addons`](https://www.npmjs.com/package/@storybook/addons) and [`@storybook/theming`](https://www.npmjs.com/package/@storybook/theming) packages.
 
 ```sh
-yarn install --dev @storybook/addons @storybook/theming
+yarn add --dev @storybook/addons @storybook/theming
 ```
 
 As an example, you can tell Storybook to use the "dark" theme by modifying [`.storybook/manager.js`](./overview.md#configure-story-rendering):


### PR DESCRIPTION
Issue:

## What I did
Changed `yarn install` to `yarn add`

## How to test
 
Run `yarn add @storybook/addons @storybook/theming`
- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
