### PR TITLE
Composition: Verify refs in node

### DIFF
--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -136,17 +136,20 @@ export const init: ModuleFn = ({ store, provider, fullAPI }, { runCheck = true }
     },
     checkRef: async (ref) => {
       const { id, url, version, type } = ref;
+      const isPublic = type === 'server-checked';
 
       const loadedData: { error?: Error; stories?: StoriesRaw; loginUrl?: string } = {};
       const query = version ? `?version=${version}` : '';
 
       const [included, omitted] = await allSettled([
-        fetch(`${url}/stories.json${query}`, {
-          headers: {
-            Accept: 'application/json',
-          },
-          credentials: 'include',
-        }),
+        isPublic
+          ? Promise.resolve(false)
+          : fetch(`${url}/stories.json${query}`, {
+              headers: {
+                Accept: 'application/json',
+              },
+              credentials: 'include',
+            }),
         fetch(`${url}/stories.json${query}`, {
           headers: {
             Accept: 'application/json',
@@ -164,7 +167,7 @@ export const init: ModuleFn = ({ store, provider, fullAPI }, { runCheck = true }
         return {};
       };
 
-      if (!included && !omitted && type !== 'server-checked') {
+      if (!included && !omitted && !isPublic) {
         loadedData.error = {
           message: dedent`
             Error: Loading of ref failed

--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -44,16 +44,13 @@ export interface ComposedRef {
   ready?: boolean;
   error?: any;
 }
-export interface ComposedRefUpdate {
-  title?: string;
-  type?: 'auto-inject' | 'unknown' | 'lazy' | 'server-checked';
-  stories?: StoriesHash;
-  versions?: Versions;
-  loginUrl?: string;
-  version?: string;
-  ready?: boolean;
-  error?: any;
-}
+
+export type ComposedRefUpdate = Partial<
+  Pick<
+    ComposedRef,
+    'title' | 'type' | 'stories' | 'versions' | 'loginUrl' | 'version' | 'ready' | 'error'
+  >
+>;
 
 export type Refs = Record<string, ComposedRef>;
 export type RefId = string;

--- a/lib/api/src/tests/refs.test.js
+++ b/lib/api/src/tests/refs.test.js
@@ -155,13 +155,6 @@ describe('Refs API', () => {
               },
             },
           ],
-          Array [
-            "https://example.com/iframe.html",
-            Object {
-              "credentials": "omit",
-              "mode": "no-cors",
-            },
-          ],
         ]
       `);
     });
@@ -198,13 +191,6 @@ describe('Refs API', () => {
               "headers": Object {
                 "Accept": "application/json",
               },
-            },
-          ],
-          Array [
-            "https://example.com/iframe.html?version=2.1.3-rc.2",
-            Object {
-              "credentials": "omit",
-              "mode": "no-cors",
             },
           ],
         ]
@@ -260,13 +246,6 @@ describe('Refs API', () => {
               "headers": Object {
                 "Accept": "application/json",
               },
-            },
-          ],
-          Array [
-            "https://example.com/iframe.html",
-            Object {
-              "credentials": "omit",
-              "mode": "no-cors",
             },
           ],
         ]
@@ -353,13 +332,6 @@ describe('Refs API', () => {
             },
           ],
           Array [
-            "https://example.com/iframe.html",
-            Object {
-              "credentials": "omit",
-              "mode": "no-cors",
-            },
-          ],
-          Array [
             "https://example.com/metadata.json",
             Object {
               "cache": "no-cache",
@@ -443,13 +415,6 @@ describe('Refs API', () => {
               "headers": Object {
                 "Accept": "application/json",
               },
-            },
-          ],
-          Array [
-            "https://example.com/iframe.html",
-            Object {
-              "credentials": "omit",
-              "mode": "no-cors",
             },
           ],
           Array [
@@ -540,13 +505,6 @@ describe('Refs API', () => {
             },
           ],
           Array [
-            "https://example.com/iframe.html",
-            Object {
-              "credentials": "omit",
-              "mode": "no-cors",
-            },
-          ],
-          Array [
             "https://example.com/metadata.json",
             Object {
               "cache": "no-cache",
@@ -592,12 +550,6 @@ describe('Refs API', () => {
           },
         },
         {
-          ok: false,
-          response: async () => {
-            throw new Error('Failed to fetch');
-          },
-        },
-        {
           ok: true,
           response: async () => {
             throw new Error('not ok');
@@ -615,6 +567,7 @@ describe('Refs API', () => {
         id: 'fake',
         url: 'https://example.com',
         title: 'Fake',
+        type: 'server-checked',
       });
 
       expect(fetch.mock.calls).toMatchInlineSnapshot(`
@@ -622,26 +575,10 @@ describe('Refs API', () => {
           Array [
             "https://example.com/stories.json",
             Object {
-              "credentials": "include",
-              "headers": Object {
-                "Accept": "application/json",
-              },
-            },
-          ],
-          Array [
-            "https://example.com/stories.json",
-            Object {
               "credentials": "omit",
               "headers": Object {
                 "Accept": "application/json",
               },
-            },
-          ],
-          Array [
-            "https://example.com/iframe.html",
-            Object {
-              "credentials": "omit",
-              "mode": "no-cors",
             },
           ],
         ]

--- a/lib/api/src/tests/refs.test.js
+++ b/lib/api/src/tests/refs.test.js
@@ -146,15 +146,6 @@ describe('Refs API', () => {
               },
             },
           ],
-          Array [
-            "https://example.com/stories.json",
-            Object {
-              "credentials": "omit",
-              "headers": Object {
-                "Accept": "application/json",
-              },
-            },
-          ],
         ]
       `);
     });
@@ -179,15 +170,6 @@ describe('Refs API', () => {
             "https://example.com/stories.json?version=2.1.3-rc.2",
             Object {
               "credentials": "include",
-              "headers": Object {
-                "Accept": "application/json",
-              },
-            },
-          ],
-          Array [
-            "https://example.com/stories.json?version=2.1.3-rc.2",
-            Object {
-              "credentials": "omit",
               "headers": Object {
                 "Accept": "application/json",
               },
@@ -234,15 +216,6 @@ describe('Refs API', () => {
             "https://example.com/stories.json",
             Object {
               "credentials": "include",
-              "headers": Object {
-                "Accept": "application/json",
-              },
-            },
-          ],
-          Array [
-            "https://example.com/stories.json",
-            Object {
-              "credentials": "omit",
               "headers": Object {
                 "Accept": "application/json",
               },
@@ -317,15 +290,6 @@ describe('Refs API', () => {
             "https://example.com/stories.json",
             Object {
               "credentials": "include",
-              "headers": Object {
-                "Accept": "application/json",
-              },
-            },
-          ],
-          Array [
-            "https://example.com/stories.json",
-            Object {
-              "credentials": "omit",
               "headers": Object {
                 "Accept": "application/json",
               },
@@ -408,25 +372,6 @@ describe('Refs API', () => {
               },
             },
           ],
-          Array [
-            "https://example.com/stories.json",
-            Object {
-              "credentials": "omit",
-              "headers": Object {
-                "Accept": "application/json",
-              },
-            },
-          ],
-          Array [
-            "https://example.com/metadata.json",
-            Object {
-              "cache": "no-cache",
-              "credentials": "omit",
-              "headers": Object {
-                "Accept": "application/json",
-              },
-            },
-          ],
         ]
       `);
 
@@ -434,9 +379,18 @@ describe('Refs API', () => {
         Object {
           "refs": Object {
             "fake": Object {
-              "error": undefined,
+              "error": Object {
+                "message": "Error: Loading of ref failed
+          at fetch (lib/api/src/modules/refs.ts)
+
+        URL: https://example.com
+
+        We weren't able to load the above URL,
+        it's possible a CORS error happened.
+
+        Please check your dev-tools network tab.",
+              },
               "id": "fake",
-              "loginUrl": "https://example.com/login",
               "ready": false,
               "stories": undefined,
               "title": "Fake",
@@ -490,15 +444,6 @@ describe('Refs API', () => {
             "https://example.com/stories.json",
             Object {
               "credentials": "include",
-              "headers": Object {
-                "Accept": "application/json",
-              },
-            },
-          ],
-          Array [
-            "https://example.com/stories.json",
-            Object {
-              "credentials": "omit",
               "headers": Object {
                 "Accept": "application/json",
               },
@@ -613,12 +558,6 @@ describe('Refs API', () => {
           },
         },
         {
-          ok: false,
-          response: async () => {
-            throw new Error('Failed to fetch');
-          },
-        },
-        {
           ok: true,
           response: async () => {
             throw new Error('not ok');
@@ -651,9 +590,10 @@ describe('Refs API', () => {
             },
           ],
           Array [
-            "https://example.com/stories.json",
+            "https://example.com/metadata.json",
             Object {
-              "credentials": "omit",
+              "cache": "no-cache",
+              "credentials": "include",
               "headers": Object {
                 "Accept": "application/json",
               },
@@ -666,17 +606,7 @@ describe('Refs API', () => {
         Object {
           "refs": Object {
             "fake": Object {
-              "error": Object {
-                "message": "Error: Loading of ref failed
-          at fetch (lib/api/src/modules/refs.ts)
-
-        URL: https://example.com
-
-        We weren't able to load the above URL,
-        it's possible a CORS error happened.
-
-        Please check your dev-tools network tab.",
-              },
+              "error": [Error: not ok],
               "id": "fake",
               "ready": false,
               "stories": undefined,

--- a/lib/api/src/tests/refs.test.js
+++ b/lib/api/src/tests/refs.test.js
@@ -538,7 +538,7 @@ describe('Refs API', () => {
       `);
     });
 
-    it('checks refs (cors)', async () => {
+    it('checks refs (serverside-success)', async () => {
       // given
       const { api } = initRefs({ provider, store }, { runCheck: false });
 
@@ -589,6 +589,94 @@ describe('Refs API', () => {
           "refs": Object {
             "fake": Object {
               "error": undefined,
+              "id": "fake",
+              "ready": false,
+              "stories": undefined,
+              "title": "Fake",
+              "type": "auto-inject",
+              "url": "https://example.com",
+            },
+          },
+        }
+      `);
+    });
+
+    it('checks refs (serverside-fail)', async () => {
+      // given
+      const { api } = initRefs({ provider, store }, { runCheck: false });
+
+      setupResponses(
+        {
+          ok: false,
+          response: async () => {
+            throw new Error('Failed to fetch');
+          },
+        },
+        {
+          ok: false,
+          response: async () => {
+            throw new Error('Failed to fetch');
+          },
+        },
+        {
+          ok: true,
+          response: async () => {
+            throw new Error('not ok');
+          },
+        },
+        {
+          ok: false,
+          response: async () => {
+            throw new Error('Failed to fetch');
+          },
+        }
+      );
+
+      await api.checkRef({
+        id: 'fake',
+        url: 'https://example.com',
+        title: 'Fake',
+        type: 'unknown',
+      });
+
+      expect(fetch.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            "https://example.com/stories.json",
+            Object {
+              "credentials": "include",
+              "headers": Object {
+                "Accept": "application/json",
+              },
+            },
+          ],
+          Array [
+            "https://example.com/stories.json",
+            Object {
+              "credentials": "omit",
+              "headers": Object {
+                "Accept": "application/json",
+              },
+            },
+          ],
+        ]
+      `);
+
+      expect(store.setState.mock.calls[0][0]).toMatchInlineSnapshot(`
+        Object {
+          "refs": Object {
+            "fake": Object {
+              "error": Object {
+                "message": "Error: Loading of ref failed
+          at fetch (lib/api/src/modules/refs.ts)
+
+        URL: https://example.com
+
+        We weren't able to load the above URL,
+        it's possible a CORS error happened.
+
+        Please check your dev-tools network tab.",
+              },
               "id": "fake",
               "ready": false,
               "stories": undefined,

--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import findUp from 'find-up';
 import resolveFrom from 'resolve-from';
+import fetch from 'node-fetch';
 
 import { logger } from '@storybook/node-logger';
 
@@ -91,6 +92,17 @@ async function getManagerWebpackConfig(options, presets) {
   }
   if (autoRefs || definedRefs) {
     entries.push(path.resolve(path.join(options.configDir, `generated-refs.js`)));
+
+    // verify the refs are publicly reachable, if they are not we'll require stories.json at runtime, otherwise the ref won't work
+    await Promise.all(
+      Object.entries(refs).map(async ([k, value]) => {
+        const { ok } = await fetch(`${value.url}/iframe.html`).catch((e) => ({
+          ok: false,
+        }));
+
+        refs[k] = { ...value, type: ok ? 'server-checked' : 'unknown' };
+      })
+    );
   }
 
   return presets.apply('managerWebpack', {}, { ...options, babelOptions, entries, refs });

--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -37,6 +37,12 @@ const getAutoRefs = async (options) => {
   return list.filter(Boolean);
 };
 
+const checkRef = (url) =>
+  fetch(`${url}/iframe.html`).then(
+    ({ ok }) => ok,
+    () => false
+  );
+
 const stripTrailingSlash = (url) => url.replace(/\/$/, '');
 
 const toTitle = (input) => {
@@ -96,9 +102,7 @@ async function getManagerWebpackConfig(options, presets) {
     // verify the refs are publicly reachable, if they are not we'll require stories.json at runtime, otherwise the ref won't work
     await Promise.all(
       Object.entries(refs).map(async ([k, value]) => {
-        const { ok } = await fetch(`${value.url}/iframe.html`).catch((e) => ({
-          ok: false,
-        }));
+        const ok = checkRef(value.url);
 
         refs[k] = { ...value, type: ok ? 'server-checked' : 'unknown' };
       })


### PR DESCRIPTION
Issue: #11892

## What I did

- ADD the type property from node
- ADD check in node to fetch the `iframe.html`
- REMOVE check for `iframe.html` in `lib/api/modules/refs`
- CHANGE `lib/api/modules/refs` to use the set type of a ref as a replacement for runtime checking `iframe.html`
- CHANGE `lib/api/modules/refs` to not request `stories.json` with credentials when the server-side fetch succeeded, because that means it's public.