### PR TITLE
Core: Add frameworkPath to options to support custom frameworks

### DIFF
--- a/docs/api/new-frameworks.md
+++ b/docs/api/new-frameworks.md
@@ -76,6 +76,25 @@ The value of the `framework` option (in this case ‘vue’) is something that g
 
 The real meat of this file is the framework presets, and these are standard [Storybook presets](./addons.md#addon-presets) -- you can look at framework packages in the Storybook monorepo (e.g. [React](https://github.com/storybookjs/storybook/blob/next/app/react/src/server/options.ts), [Vue](https://github.com/storybookjs/storybook/blob/next/app/vue/src/server/options.ts), [Web Components](https://github.com/storybookjs/storybook/blob/next/app/web-components/src/server/options.ts)) to see examples of framework-specific customizations.
 
+When developing your own framework that is not published by storybook, you can pass the path to the framework location with the `frameworkPath` key:
+
+```ts
+// my-framework/src/server/options.ts
+
+const packageJson = require('../../package.json');
+
+export default {
+  packageJson,
+  framework: 'my-framework',
+  frameworkPath: '@my-framework/storybook',
+  frameworkPresets: [require.resolve('./framework-preset-my-framework.js')],
+};
+```
+
+Passing a relative path to `frameworkPath` is also possible, just keep in mind that these are resolved from the storybook config directory (`.storybook` by default). 
+
+Make sure the `frameworkPath` ends up at the `dist/client/index.js` file within your framework app.
+
 ## Configuring the client
 
 To configure the client, you must provide a framework specific render function. Before diving into the details, it’s important to understand how user-written stories relate to what is finally rendered on the screen.

--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -64,6 +64,7 @@ export default async ({
   packageJson,
   configType,
   framework,
+  frameworkPath,
   presets,
   typescriptOptions,
 }) => {
@@ -81,10 +82,12 @@ export default async ({
   const frameworkInitEntry = path.resolve(
     path.join(configDir, 'storybook-init-framework-entry.js')
   );
+  // Allows for custom frameworks that are not published under the @storybook namespace
+  const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
   const virtualModuleMapping = {
     // Ensure that the client API is initialized by the framework before any other iframe code
     // is loaded. That way our client-apis can assume the existence of the API+store
-    [frameworkInitEntry]: `import '@storybook/${framework}';`,
+    [frameworkInitEntry]: `import '${frameworkImportPath}';`,
   };
   entries.forEach((entryFilename) => {
     const match = entryFilename.match(/(.*)-generated-(config|other)-entry.js$/);
@@ -102,7 +105,7 @@ export default async ({
   });
   if (stories) {
     const storiesFilename = path.resolve(path.join(configDir, `generated-stories-entry.js`));
-    virtualModuleMapping[storiesFilename] = interpolate(storyTemplate, { framework })
+    virtualModuleMapping[storiesFilename] = interpolate(storyTemplate, { frameworkImportPath })
       // Make sure we also replace quotes for this one
       .replace("'{{stories}}'", stories.map(toRequireContextString).join(','));
   }

--- a/lib/core/src/server/preview/virtualModuleStory.template.js
+++ b/lib/core/src/server/preview/virtualModuleStory.template.js
@@ -1,3 +1,4 @@
-import { configure } from '@storybook/{{framework}}';
+/* eslint-disable import/no-unresolved */
+import { configure } from '{{frameworkImportPath}}';
 
 configure(['{{stories}}'], module, false);


### PR DESCRIPTION
Issue: #12075

## What I did
This addition allows an override of the hardcoded `@storybook/${framework}` import path in the (generated) preview code.

I tested these changes first in a separate project that would need this feature to work, by changing the node_modules.

I'm not sure if any of the automated tests cover the creation of custom frameworks, or running normal framework webpack builds at all, so I haven't run or included any tests.

## How to test

- Is this testable with Jest or Chromatic screenshots? - Don't think so
- Does this need a new example in the kitchen sink apps? - No
- Does this need an update to the documentation? - Yes, which I tried to provide in this PR

If your answer is yes to any of these, please make sure to include it in your PR. - Done

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
