### PR TITLE
Source-loader: Fix default exports of type TSAsExpression

### DIFF
--- a/examples/react-ts/main.ts
+++ b/examples/react-ts/main.ts
@@ -3,7 +3,20 @@ import type { StorybookConfig } from '@storybook/core/types';
 module.exports = {
   stories: ['./src/*.stories.*'],
   logLevel: 'debug',
-  addons: ['@storybook/addon-essentials', '@storybook/addon-controls'],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-controls',
+    '@storybook/addon-storysource',
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        sourceLoaderOptions: {
+          parser: 'typescript',
+          injectStoryParameters: false,
+        },
+      },
+    },
+  ],
   typescript: {
     check: true,
     checkOptions: {},

--- a/examples/react-ts/src/button.stories.tsx
+++ b/examples/react-ts/src/button.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 import { Button } from './button';
 
-export default { component: Button, title: 'Examples / Button' };
+export default { component: Button, title: 'Examples / Button' } as Meta;
 
 export const WithArgs = (args: any) => <Button {...args} />;
 WithArgs.args = { label: 'With args' };

--- a/lib/source-loader/src/abstract-syntax-tree/traverse-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/traverse-helpers.js
@@ -208,12 +208,18 @@ export function popParametersObjectFromDefaultExport(source, ast) {
     enter: (node) => {
       patchNode(node);
 
+      const isDefaultExport = node.type === 'ExportDefaultDeclaration';
+      const isObjectExpression = node.declaration?.type === 'ObjectExpression';
+      const isTsAsExpression = node.declaration?.type === 'TSAsExpression';
+
+      const targetNode = isObjectExpression ? node.declaration : node.declaration?.expression;
+
       if (
-        node.type === 'ExportDefaultDeclaration' &&
-        node.declaration.type === 'ObjectExpression' &&
-        (node.declaration.properties || []).length
+        isDefaultExport &&
+        (isObjectExpression || isTsAsExpression) &&
+        (targetNode.properties || []).length
       ) {
-        const parametersProperty = node.declaration.properties.find(
+        const parametersProperty = targetNode.properties.find(
           (p) => p.key.name === 'parameters' && p.value.type === 'ObjectExpression'
         );
 
@@ -221,7 +227,7 @@ export function popParametersObjectFromDefaultExport(source, ast) {
         if (foundParametersProperty) {
           patchNode(parametersProperty.value);
         } else {
-          patchNode(node.declaration);
+          patchNode(targetNode);
         }
 
         splicedSource = parametersProperty
@@ -235,7 +241,7 @@ export function popParametersObjectFromDefaultExport(source, ast) {
 
         indexWhereToAppend = parametersProperty
           ? parametersProperty.value.start
-          : node.declaration.start + 1;
+          : targetNode.start + 1;
       }
     },
   });


### PR DESCRIPTION
Issue: #11994

## What I did

Added support for TypeScript `as <Type>` syntax:

<img width="1082" alt="Screen Shot 2020-08-17 at 11 00 40 PM" src="https://user-images.githubusercontent.com/1571918/90476061-988d1b00-e0dd-11ea-8305-e5b19d6c604e.png">

The logic for parsing story sourcecode is fairly surgical. The existing implementation was too strict to permit the  `TSAsExpression` type.

## How to test

- Is this testable with Jest or Chromatic screenshots? Unsure
- Does this need a new example in the kitchen sink apps? Unsure. I think this could be demoed in the existing `react-ts` example. (I have those changes locally & can push them. If this sounds good, let me know.)
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

Notes: this is my first PR-- open to any feedback! TIA.