### PR TITLE
Fix broken link in cli readme

### DIFF
--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -53,4 +53,4 @@ If the CLI cannot detect your project type, it will ask you. You can also force 
 npx -p @storybook/cli sb init --type <type>
 ```
 
-Where type is one of the project types defined in [project_types.js](https://github.com/storybookjs/storybook/blob/master/lib/cli/lib/project_types.js)
+Where type is one of the project types defined in [project_types.js](https://github.com/storybookjs/storybook/blob/next/lib/cli/src/project_types.ts)


### PR DESCRIPTION
Issue:

## What I did

Change a link in cli readme, that was broken.

## How to test

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
