### PR TITLE
React: Improve ArgTypes type definition

### DIFF
--- a/examples/react-ts/src/button.stories.tsx
+++ b/examples/react-ts/src/button.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Meta } from '@storybook/react/types-6-0';
-import { Button } from './button';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { Button, ButtonProps } from './button';
 
 export default { component: Button, title: 'Examples / Button' } as Meta;
 
-export const WithArgs = (args: any) => <Button {...args} />;
-WithArgs.args = { label: 'With args' };
+export const WithArgs: Story<ButtonProps> = (args) => <Button {...args} />;
+WithArgs.args = { label: 'With args', backgroundColor: '#FAFAFA' };
+WithArgs.argTypes = { backgroundColor: { control: 'color' } };
 export const Basic = () => <Button label="Click me" />;

--- a/examples/react-ts/src/button.tsx
+++ b/examples/react-ts/src/button.tsx
@@ -5,10 +5,14 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * A label to show on the button
    */
   label: string;
+  /**
+   * What background color to use
+   */
+  backgroundColor?: string;
 }
 
-export const Button = ({ label = 'Hello', ...props }: ButtonProps) => (
-  <button type="button" {...props}>
+export const Button = ({ label = 'Hello', backgroundColor, ...props }: ButtonProps) => (
+  <button type="button" style={{ backgroundColor }} {...props}>
     {label}
   </button>
 );

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -42,9 +42,9 @@ export interface ArgType {
   [key: string]: any;
 }
 
-export interface ArgTypes {
-  [key: string]: ArgType;
-}
+export type ArgTypes<TArgs = any> = {
+  [K in keyof Partial<TArgs>]: ArgType;
+};
 
 export interface StoryIdentifier {
   id: StoryId;
@@ -169,7 +169,7 @@ export interface Annotations<Args, StoryFnReturnType> {
    * ArgTypes encode basic metadata for args, such as `name`, `description`, `defaultValue` for an arg. These get automatically filled in by Storybook Docs.
    * @see [Control annotations](https://github.com/storybookjs/storybook/blob/91e9dee33faa8eff0b342a366845de7100415367/addons/controls/README.md#control-annotations)
    */
-  argTypes?: ArgTypes;
+  argTypes?: ArgTypes<Args>;
 
   /**
    * Custom metadata for a story.


### PR DESCRIPTION
Issue:

The `argTypes` property in the `Annotations<Args>` type definition is not checked such that it matches the `Args` type parameter.

## What I did

Updated the `ArgTypes` type definition such that it is generic and its keys are restricted to the keys of the object specified in its type parameter.

## How to test

- Is this testable with Jest or Chromatic screenshots? **No**
- Does this need a new example in the kitchen sink apps? **No**
- Does this need an update to the documentation?  **No**
