### PR TITLE
Fix erroneous code snippet

### DIFF
--- a/docs/snippets/common/gizmo-story-controls-customization.js.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.js.mdx
@@ -5,7 +5,9 @@ export default {
   title: 'Gizmo',
   component: Gizmo,
   argTypes: {
-    width: { type: 'range', min: 400, max: 1200, step: 50 };
+    width: { 
+      control: { type: 'range', min: 400, max: 1200, step: 50 },
+    },
   },
 };
 ```


### PR DESCRIPTION
Came across this in the documentation (on [this page](https://storybook.js.org/docs/react/essentials/controls)) and noticed 2 issues with it:

1. it had a semicolon instead of a comma within the `argTypes` object
2. it was missing the `control` object, like in the code snippet before it

I've corrected both in this PR.