### PR TITLE
Addon-docs: Fix missing line-height on TypeSet block

### DIFF
--- a/lib/components/src/blocks/Typeset.tsx
+++ b/lib/components/src/blocks/Typeset.tsx
@@ -60,6 +60,7 @@ export const Typeset: FunctionComponent<TypesetProps> = ({
             fontFamily,
             fontSize: size,
             fontWeight,
+            lineHeight: size,
           }}
         >
           {sampleText || 'Was he a beast if music could move him so?'}


### PR DESCRIPTION
Add `line-height` to `<TypeSet>` `<Sample>`. Fixes screenshot:
<img width="384" alt="Screen Shot 2020-08-19 at 13 26 16" src="https://user-images.githubusercontent.com/3968/90642546-cfc11080-e232-11ea-922d-7636966ef0cb.png">
