### PR TITLE
Chore: Fixes the doc block link to point at the correct api page

### DIFF
--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -65,7 +65,7 @@ To use the `ArgsTable` block in MDX, add the following:
 
 `ArgsTables` are automatically inferred from your components and stories, but sometimes it's useful to customize the results.
 
-`ArgsTables` are rendered from an internal data structure called [ArgTypes](../api/mdx.md#argtypes). When you declare a story's component metadata, Docs automatically extracts ArgTypes based on the component's properties.
+`ArgsTables` are rendered from an internal data structure called [ArgTypes](../api/argtypes.md). When you declare a story's component metadata, Docs automatically extracts ArgTypes based on the component's properties.
 
 You can customize what's shown in the `ArgsTable` by customizing the `ArgTypes` data. This is currently available for [DocsPage](./docs-page.md) and `<ArgsTable story="xxx">` construct, but not for the `<ArgsTable of={component} />` construct.
 


### PR DESCRIPTION
This pull request addresses and closes #12124.

What was done:
- The link in the writing docs section, doc block page was updated to point at the argtypes page in the api section.

Feel free to provide feedback