### PR TITLE
Addon-viewport: Add preset to fix windows import

### DIFF
--- a/addons/viewport/preset.js
+++ b/addons/viewport/preset.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/preset');

--- a/addons/viewport/register.js
+++ b/addons/viewport/register.js
@@ -1,3 +1,1 @@
-// NOTE: loading addons using this file is deprecated!
-// please use manager.js and preview.js files instead
 require('./dist/register');

--- a/addons/viewport/src/preset/index.ts
+++ b/addons/viewport/src/preset/index.ts
@@ -1,0 +1,3 @@
+export function managerEntries(entry: any[] = []) {
+  return [...entry, require.resolve('../register')];
+}


### PR DESCRIPTION
Issue: #12024

For windows users, addons that are missing preset are not loaded through essentials

## What I did

Add preset to viewport

## How to test

- https://www.microsoft.com/en-us/store/b/windows
