### PR TITLE
Addon-docs: Fix MDX IDs from CSF imports

### DIFF
--- a/addons/docs/src/mdx/__testfixtures__/csf-imports.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/csf-imports.output.snapshot
@@ -26,9 +26,9 @@ function MDXContent({ components, ...props }) {
     <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
       <Meta title=\\"MDX/CSF imports\\" mdxType=\\"Meta\\" />
       <h1>{\`Stories from CSF imports\`}</h1>
-      <Story story={MyStories.Basic} name=\\"BasicStory\\" mdxType=\\"Story\\" />
+      <Story story={MyStories.Basic} name=\\"_Basic_\\" mdxType=\\"Story\\" />
       <Canvas mdxType=\\"Canvas\\">
-        <Story story={Other} name=\\"OtherStory\\" mdxType=\\"Story\\" />
+        <Story story={Other} name=\\"_Other_\\" mdxType=\\"Story\\" />
       </Canvas>
       <Story name=\\"renamed\\" story={MyStories.Foo} mdxType=\\"Story\\" />
     </MDXLayout>
@@ -37,23 +37,16 @@ function MDXContent({ components, ...props }) {
 
 MDXContent.isMDXComponent = true;
 
-export const BasicStory = MyStories.Basic;
+export const _Basic_ = MyStories.Basic;
 
-export const OtherStory = Other;
+export const _Other_ = Other;
 
-export const FooStory = MyStories.Foo;
-FooStory.storyName = 'renamed';
+export const _Foo_ = MyStories.Foo;
+_Foo_.storyName = 'renamed';
 
-const componentMeta = {
-  title: 'MDX/CSF imports',
-  includeStories: ['BasicStory', 'OtherStory', 'FooStory'],
-};
+const componentMeta = { title: 'MDX/CSF imports', includeStories: ['_Basic_', '_Other_', '_Foo_'] };
 
-const mdxStoryNameToKey = {
-  BasicStory: 'BasicStory',
-  OtherStory: 'OtherStory',
-  renamed: 'FooStory',
-};
+const mdxStoryNameToKey = { _Basic_: '_Basic_', _Other_: '_Other_', renamed: '_Foo_' };
 
 componentMeta.parameters = componentMeta.parameters || {};
 componentMeta.parameters.docs = {

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -44,7 +44,7 @@ function genAttribute(key, element) {
 function genImportStory(ast, storyDef, storyName, context) {
   const { code: story } = generate(storyDef.expression, {});
 
-  const storyKey = `${story.split('.').pop()}Story`;
+  const storyKey = `_${story.split('.').pop()}_`;
 
   const statements = [`export const ${storyKey} = ${story};`];
   if (storyName) {


### PR DESCRIPTION
Issue: #12143

This is technically a breaking change but I'd like to treat it as a bugfix since the feature is brand new.

## What I did

This is a cheap/hacky way to make sure that the variable is unique.

Consider the following MDX:

```md
import { foo } from './button.stories';

<Story story={foo} />
```

The compiler was generating the following code (simplified):

```
import { foo } from './button.stories';

// lots of MDX stuff omitted

export const fooStory = foo;
```

If I made the export named `foo`, it would collide with the import name and the generated code would be invalid. However, this modified the Story ID.

This PR modifies the generated code to be:

```
export const _foo_ = foo;
```

Which preserves the same ID.

## How to test

See attached snapshot & CSF imported MDX example in `official-storybook`.