### PR TITLE
Fix(addon-docs): Correctly parse union types in Vue/TS

### DIFF
--- a/addons/docs/src/lib/docgen/extractDocgenProps.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.ts
@@ -34,7 +34,10 @@ export const extractComponentSectionArray = (docgenSection: any) => {
   const createPropDef = getPropDefFactory(typeSystem);
 
   return docgenSection
-    .map((item: any) => extractProp(item.name, item, typeSystem, createPropDef))
+    .map((item: any) => {
+      const sanitizedItem = { ...item, value: item.elements };
+      return extractProp(sanitizedItem.name, sanitizedItem, typeSystem, createPropDef);
+    })
     .filter(Boolean);
 };
 

--- a/docs/snippets/vue/button-story-default-export-with-component.js.mdx
+++ b/docs/snippets/vue/button-story-default-export-with-component.js.mdx
@@ -1,0 +1,10 @@
+```js
+// Button.stories.js
+
+import Button from './Button.vue'
+
+export default {
+  title: 'Components/Button',
+  component: Button,
+}
+```

--- a/docs/snippets/vue/button-story-rename-story.js.mdx
+++ b/docs/snippets/vue/button-story-rename-story.js.mdx
@@ -1,0 +1,15 @@
+```js
+import BaseButton from './BaseButton.vue'
+
+export default {
+  title: 'Components/BaseButton',
+  component: BaseButton,
+}
+
+export const Primary = () => ({
+ components: { BaseButton },
+ template: `<base-button variant="primary" size="medium">Button</button>`,
+})
+
+Primary.storyName='I am the primary';
+```

--- a/docs/snippets/vue/button-story-using-args.js.mdx
+++ b/docs/snippets/vue/button-story-using-args.js.mdx
@@ -1,0 +1,25 @@
+```js
+// Button.stories.js
+import BaseButton from './BaseButton.vue'
+
+export default {
+  title: 'BaseButton',
+  component: BaseButton,
+}
+
+const Template = (args) => ({
+  props: Object.keys(args),
+  components: { BaseButton },
+  template: `<base-button :variant="variant" :size="size" />`,
+})
+
+export const Primary = Template.bind({})
+Primary.args = { variant: 'primary', size: 'medium' }
+
+export const Secondary = Template.bind({})
+Secondary.args = { ...Primary.args, variant: 'secondary' }
+
+export const Text = Template.bind({})
+Text.args = { ...Primary.args, variant: 'text' }
+
+```

--- a/docs/snippets/vue/button-story-with-emojis.js.mdx
+++ b/docs/snippets/vue/button-story-with-emojis.js.mdx
@@ -1,0 +1,23 @@
+```ts
+import BaseButton from './BaseButton.vue'
+
+export default {
+  title: 'Components/BaseButton',
+  component: BaseButton,
+}
+
+export const Primary = () => ({
+ components: { BaseButton },
+ template: `<base-button variant="primary" size="medium">Button</button>`,
+})
+
+export const Secondary = () => ({
+ components: { BaseButton },
+ template: `<base-button variant="secondary" size="medium">Button</button>`,
+})
+
+export const Text = () => ({
+ components: { BaseButton },
+ template: `<base-button variant="text" size="medium">Button</button>`,
+})
+```

--- a/docs/snippets/vue/button-story.js.mdx
+++ b/docs/snippets/vue/button-story.js.mdx
@@ -1,0 +1,13 @@
+```js
+import BaseButton from './BaseButton.vue'
+
+export default {
+  title: 'Components/BaseButton',
+  component: BaseButton,
+}
+
+export const Primary = () => ({
+ components: { BaseButton },
+ template: `<base-button variant="primary" size="medium">Button</button>`,
+})
+```

--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -32,6 +32,7 @@ The default export metadata controls how Storybook lists your stories and provid
     'react/button-story-default-export-with-component.js.mdx',
     'react/button-story-default-export-with-component.ts.mdx',
     'angular/button-story-default-export-with-component.ts.mdx',
+    'vue/button-story-default-export-with-component.js.mdx',
   ]}
 />
 
@@ -48,6 +49,7 @@ Use the named exports of a CSF file to define your componentâ€™s stories. Hereâ€
     'react/button-story.js.mdx',
     'react/button-story.ts.mdx',
     'angular/button-story.ts.mdx',
+    'vue/button-story.js.mdx',
   ]}
 />
 
@@ -64,6 +66,7 @@ You can rename any particular story you need. For instance to give it a more cle
     'react/button-story-rename-story.js.mdx',
     'react/button-story-rename-story.ts.mdx',
     'angular/button-story-rename-story.ts.mdx',
+    'vue/button-story-rename-story.ts.mdx',
   ]}
 />
 
@@ -82,6 +85,7 @@ A story is a function that describes how to render a component. You can have mul
     'react/button-story-with-emojis.js.mdx',
     'react/button-story-with-emojis.ts.mdx',
     'angular/button-story-with-emojis.ts.mdx',
+    'vue/button-story-with-emojis.ts.mdx',
   ]}
 />
 


### PR DESCRIPTION
Issue: #11944

## What I did

In the `addon-docs`, the `vue-docgen-api` has an entry `elements` for `union` types but the expected entry (with the same content) is `value`.

This fix sanitizes the data within the specific `vue-docgen-api` hook `extractComponentSectionArray` so that the `item` we throw into `extractProp()` contains the expected object 😊 

## How to test

- Build a Vue/TS component with a union type (or use  https://github.com/HerrBertling/nuxt-ts-storybook-docs-issue )
- Have it break in the current setup
- Use this fix => works™ :rocket:

closes #11944