### PR TITLE
Addon-docs: Fix ArgsTable union type handling in Vue/TS

### DIFF
--- a/addons/docs/src/lib/docgen/extractDocgenProps.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.ts
@@ -33,9 +33,10 @@ export const extractComponentSectionArray = (docgenSection: any) => {
   const typeSystem = getTypeSystem(docgenSection[0]);
   const createPropDef = getPropDefFactory(typeSystem);
 
-  return docgenSection
-    .map((item: any) => extractProp(item.name, item, typeSystem, createPropDef))
-    .filter(Boolean);
+  return docgenSection.map((item: any) => {
+    const sanitizedItem = { ...item, value: item.elements };
+    return extractProp(sanitizedItem.name, sanitizedItem, typeSystem, createPropDef);
+  });
 };
 
 export const extractComponentSectionObject = (docgenSection: any) => {


### PR DESCRIPTION
Issue: #11944

## What I did

In the `addon-docs`, the `vue-docgen-api` has an entry `elements` for `union` types but the expected entry (with the same content) is `value`.

This fix sanitizes the data within the specific `vue-docgen-api` hook `extractComponentSectionArray` so that the `item` we throw into `extractProp()` contains the expected object 😊 

## How to test

- Build a Vue/TS component with a union type (or use  https://github.com/HerrBertling/nuxt-ts-storybook-docs-issue )
- Have it break in the current setup
- Use this fix => works™ :rocket:
