### PR TITLE
Fix the migration guide to disable addons through parameters

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -367,7 +367,7 @@ If you wish to selectively disable `knobs` checks for a subset of stories, you c
 export const MyNonCheckedStory = () => <SomeComponent />;
 MyNonCheckedStory.story = {
   parameters: {
-    knobs: { disable: true },
+    knobs: { disabled: true },
   },
 };
 ```
@@ -474,7 +474,7 @@ It's unclear and confusing what would happened if you did. If you want to disabl
 
 ```js
 export StoryOne = ...;
-StoryOne.story = { parameters: { addon: { disable: true } } };
+StoryOne.story = { parameters: { addon: { disabled: true } } };
 ```
 
 If you want to use a parameter for a subset of stories in a kind, simply use a variable to do so:


### PR DESCRIPTION
I followed the migration guide, and the disabling was not working. Then I diged in the code to find the implementation, and I found out that the doc uses the wrong name:
https://github.com/storybookjs/storybook/blob/1c972a2bc2b5bfd70c035da89fda8a4cd1b4899c/lib/api/src/modules/addons.ts#L107
