### PR TITLE
Fix the doc about disabling addons per story

### DIFF
--- a/docs/snippets/react/button-story-disable-addon.js.mdx
+++ b/docs/snippets/react/button-story-disable-addon.js.mdx
@@ -6,7 +6,7 @@ import React from 'react';
 export default {
   title: 'Button',
   parameters: {
-    myAddon: { disable: true },
+    myAddon: { disabled: true },
   },
 };
 ```


### PR DESCRIPTION
Same than #12159 but for the doc rather than the migration guide.