### PR TITLE
Addon-docs: Fix inline rendering for DOM nodes in HTML

### DIFF
--- a/addons/docs/src/frameworks/html/config.tsx
+++ b/addons/docs/src/frameworks/html/config.tsx
@@ -4,9 +4,13 @@ import { StoryFn } from '@storybook/addons';
 export const parameters = {
   docs: {
     inlineStories: true,
-    prepareForInline: (storyFn: StoryFn<string>) => (
-      // eslint-disable-next-line react/no-danger
-      <div dangerouslySetInnerHTML={{ __html: storyFn() }} />
-    ),
+    prepareForInline: (storyFn: StoryFn<string>) => {
+      const html = storyFn();
+      if (typeof html === 'string') {
+        // eslint-disable-next-line react/no-danger
+        return <div dangerouslySetInnerHTML={{ __html: html }} />;
+      }
+      return <div ref={(node) => (node ? node.appendChild(html) : null)} />;
+    },
   },
 };


### PR DESCRIPTION
Issue: #12138 

## What I did

Update HTML inline renderer to handle DOM nodes instead of just assuming HTML

## How to test

See the DocsPage `Demo/Button` story in `html-kitchen-sink` 
