### PR TITLE
Addon-docs: Fix Vue ArgsTable sanitizing of item.type.elements to item.type.value

### DIFF
--- a/addons/docs/src/lib/docgen/extractDocgenProps.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.ts
@@ -35,7 +35,7 @@ export const extractComponentSectionArray = (docgenSection: any) => {
 
   return docgenSection.map((item: any) => {
     let sanitizedItem = item;
-    if (item?.type?.elements) {
+    if (item.type?.elements) {
       sanitizedItem = {
         ...item,
         type: {

--- a/addons/docs/src/lib/docgen/extractDocgenProps.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.ts
@@ -35,7 +35,7 @@ export const extractComponentSectionArray = (docgenSection: any) => {
 
   return docgenSection.map((item: any) => {
     let sanitizedItem = item;
-    if (item.type.elements) {
+    if (item?.type?.elements) {
       sanitizedItem = {
         ...item,
         type: {

--- a/addons/docs/src/lib/docgen/extractDocgenProps.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.ts
@@ -34,7 +34,16 @@ export const extractComponentSectionArray = (docgenSection: any) => {
   const createPropDef = getPropDefFactory(typeSystem);
 
   return docgenSection.map((item: any) => {
-    const sanitizedItem = { ...item, value: item.elements };
+    let sanitizedItem = item;
+    if (item.type.elements) {
+      sanitizedItem = {
+        ...item,
+        type: {
+          ...item.type,
+          value: item.type.elements,
+        },
+      };
+    }
     return extractProp(sanitizedItem.name, sanitizedItem, typeSystem, createPropDef);
   });
 };


### PR DESCRIPTION
Issue #11944

which now only happens if the elements entry is present
and also is applied at the correct nesting level of the
item object.

## What I did

I swear the fix in https://github.com/storybookjs/storybook/pull/12158 worked on my machine. Should have tested it with more components, sorry 😓  This definitely works now, because my fully fledged project storybook with > 50 stories works with this correct nesting.

@shilman I guess you were right to catch this case via `if` after all 😅 