### PR TITLE
Show initial parent folder expanded, allow toggle current folder

### DIFF
--- a/lib/ui/src/components/sidebar/Tree/State.tsx
+++ b/lib/ui/src/components/sidebar/Tree/State.tsx
@@ -213,7 +213,9 @@ export const useDataset = (storiesHash: DataSet = {}, filter: string, storyId: s
     }
     return emptyInitial;
     // Parents are dependency relied upon for initial expanded
-  }, [dataset, parents]);
+    // Really just need to check if storyId is defined or not
+    // storyId is undefined on initial render. Always defined after
+  }, [dataset, typeof storyId === 'undefined']);
   const type: FilteredType = filter.length >= 2 ? 'filtered' : 'unfiltered';
   const { expandedSet, setExpanded } = useExpanded(type, initial.filtered, initial.unfiltered);
   const selectedSet = useSelected(dataset, storyId);

--- a/lib/ui/src/components/sidebar/Tree/State.tsx
+++ b/lib/ui/src/components/sidebar/Tree/State.tsx
@@ -198,9 +198,13 @@ export const useDataset = (storiesHash: DataSet = {}, filter: string, storyId: s
   // On initial render, without a storyId specified, parents is undefined
   const parents = useMemo(() => getParents(storyId, dataset), [dataset[storyId]]);
   const datasetKeys = useMemo(() => Object.keys(dataset), [dataset]);
+  // don't want initial to rerun on every parents change,
+  // only when parents goes from an empty array to one with length
+  const isEmptyParents = useMemo(() => parents.length === 0, [parents]);
   const initial = useMemo(() => {
-    // only want this to run on initial
-    if (datasetKeys.length) {
+    // parents is empty on initial render
+    // on second render, when the url redirects, this will be at least 1
+    if (datasetKeys.length && parents.length) {
       return Object.keys(dataset).reduce(
         (acc, k) => {
           acc.filtered[k] = true;
@@ -213,9 +217,8 @@ export const useDataset = (storiesHash: DataSet = {}, filter: string, storyId: s
     }
     return emptyInitial;
     // Parents are dependency relied upon for initial expanded
-    // Really just need to check if storyId is defined or not
-    // storyId is undefined on initial render. Always defined after
-  }, [dataset, typeof storyId === 'undefined']);
+    // don't want initial to run on every story change
+  }, [dataset, isEmptyParents]);
   const type: FilteredType = filter.length >= 2 ? 'filtered' : 'unfiltered';
   const { expandedSet, setExpanded } = useExpanded(type, initial.filtered, initial.unfiltered);
   const selectedSet = useSelected(dataset, storyId);

--- a/lib/ui/src/components/sidebar/Tree/State.tsx
+++ b/lib/ui/src/components/sidebar/Tree/State.tsx
@@ -218,7 +218,7 @@ export const useDataset = (storiesHash: DataSet = {}, filter: string, storyId: s
     return emptyInitial;
     // Parents are dependency relied upon for initial expanded
     // don't want initial to run on every story change
-  }, [dataset, isEmptyParents]);
+  }, [isEmptyParents]);
   const type: FilteredType = filter.length >= 2 ? 'filtered' : 'unfiltered';
   const { expandedSet, setExpanded } = useExpanded(type, initial.filtered, initial.unfiltered);
   const selectedSet = useSelected(dataset, storyId);

--- a/lib/ui/src/components/sidebar/Tree/State.tsx
+++ b/lib/ui/src/components/sidebar/Tree/State.tsx
@@ -195,9 +195,11 @@ export const useDataset = (storiesHash: DataSet = {}, filter: string, storyId: s
     }),
     []
   );
+  // On initial render, without a storyId specified, parents is undefined
   const parents = useMemo(() => getParents(storyId, dataset), [dataset[storyId]]);
   const datasetKeys = useMemo(() => Object.keys(dataset), [dataset]);
   const initial = useMemo(() => {
+    // only want this to run on initial
     if (datasetKeys.length) {
       return Object.keys(dataset).reduce(
         (acc, k) => {
@@ -210,7 +212,8 @@ export const useDataset = (storiesHash: DataSet = {}, filter: string, storyId: s
       );
     }
     return emptyInitial;
-  }, [dataset]);
+    // Parents are dependency relied upon for initial expanded
+  }, [dataset, parents]);
   const type: FilteredType = filter.length >= 2 ? 'filtered' : 'unfiltered';
   const { expandedSet, setExpanded } = useExpanded(type, initial.filtered, initial.unfiltered);
   const selectedSet = useSelected(dataset, storyId);


### PR DESCRIPTION
Issue: #11243

## Allow users to toggle current active folder

## How to test

Usecases 

1. When you toggle click your current folder that’s open, then it should toggle close. 
2. When you first open storybook with an active story, all of the parent folders of the first story should be expanded (or expand).

- Is this testable with Jest or Chromatic screenshots? First story should be expanded and there's e2e tests for this
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no


@shilman, so we've gotten the current folder toggle working. We're also showing the initial story expanded and its parents. One potential issue we've uncovered is using the keyboard shortcuts to go to the next story and auto-expand its parents (not sure about who uses this).

As a storybook user, I keep folders expanded for reference so that I can look back. 

Potentially thinking about pinning a storybook story to access deeply nested items. @ndelangen 

references https://github.com/storybookjs/storybook/issues/11065