### PR TITLE
UI: Fix `disable` parameter to hide addon panel

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,6 +34,7 @@
   - [6.0 Addon API changes](#60-addon-api-changes)
     - [Consistent local addon paths in main.js](#consistent-local-addon-paths-in-mainjs)
     - [Deprecated setAddon](#deprecated-setaddon)
+    - [Deprecated disabled parameter](#deprecated-disabled-parameter)
     - [Actions addon uses parameters](#actions-addon-uses-parameters)
     - [Removed action decorator APIs](#removed-action-decorator-apis)
     - [Removed withA11y decorator](#removed-witha11y-decorator)
@@ -598,6 +599,22 @@ module.exports = { addons: ['./my-local-addon/register'] };
 We've deprecated the `setAddon` method of the `storiesOf` API and plan to remove it in 7.0.
 
 Since early versions, Storybook shipped with a `setAddon` API, which allows you to extend `storiesOf` with arbitrary code. We've removed this from all core addons long ago and recommend writing stories in [Component Story Format](https://medium.com/storybookjs/component-story-format-66f4c32366df) rather than using the internal Storybook API.
+
+#### Deprecated disabled parameter
+
+Starting in 6.0.17, we've renamed the `disabled` parameter to `disable` to resolve an inconsistency where `disabled` had been used to hide the addon panel, whereas `disable` had been used to disable an addon's execution. Since `disable` was much more widespread in the code, we standardized on that.
+
+So, for example:
+
+```
+Story.parameters = { actions: { disabled: true } }
+```
+
+Should be rewritten as:
+
+```
+Story.parameters = { actions: { disable: true } }
+```
 
 #### Actions addon uses parameters
 

--- a/lib/api/src/modules/addons.ts
+++ b/lib/api/src/modules/addons.ts
@@ -104,7 +104,12 @@ export const init: ModuleFn = ({ provider, store, fullAPI }) => {
       const filteredPanels: Collection = {};
       Object.entries(allPanels).forEach(([id, panel]) => {
         const { paramKey } = panel;
-        if (paramKey && parameters && parameters[paramKey] && parameters[paramKey].disabled) {
+        if (
+          paramKey &&
+          parameters &&
+          parameters[paramKey] &&
+          (parameters[paramKey].disabled || parameters[paramKey].disable)
+        ) {
           return;
         }
         filteredPanels[id] = panel;

--- a/lib/api/src/modules/addons.ts
+++ b/lib/api/src/modules/addons.ts
@@ -1,9 +1,20 @@
 import { ReactElement } from 'react';
-
 import { WindowLocation } from '@reach/router';
+import deprecate from 'util-deprecate';
+import dedent from 'ts-dedent';
+
 import { ModuleFn } from '../index';
 import { Options } from '../store';
 import { isStory } from '../lib/stories';
+
+const warnDisabledDeprecated = deprecate(
+  () => {},
+  dedent`
+    Use 'parameters.key.disable' instead of 'parameters.key.disabled'.
+    
+    https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-disabled-parameter
+  `
+);
 
 export type ViewMode = 'story' | 'info' | 'settings' | 'page' | undefined | string;
 
@@ -110,6 +121,9 @@ export const init: ModuleFn = ({ provider, store, fullAPI }) => {
           parameters[paramKey] &&
           (parameters[paramKey].disabled || parameters[paramKey].disable)
         ) {
+          if (parameters[paramKey].disabled) {
+            warnDisabledDeprecated();
+          }
           return;
         }
         filteredPanels[id] = panel;

--- a/lib/api/src/tests/addons.test.js
+++ b/lib/api/src/tests/addons.test.js
@@ -77,7 +77,7 @@ describe('Addons API', () => {
         [storyId]: {
           isLeaf: true,
           parameters: {
-            a11y: { disabled: true },
+            a11y: { disable: true },
           },
         },
       };

--- a/lib/ui/src/containers/panel.stories.tsx
+++ b/lib/ui/src/containers/panel.stories.tsx
@@ -8,6 +8,6 @@ export const AllAddons = () => <div>By default all addon panels are rendered</di
 export const FilteredAddons = () => <div>By default all addon panels are rendered</div>;
 
 FilteredAddons.parameters = {
-  a11y: { disabled: true },
-  actions: { disabled: true },
+  a11y: { disable: true },
+  actions: { disable: true },
 };


### PR DESCRIPTION
Issue: N/A

Alternative to #12159  #12161 that accepts `disable: true` in addition to `disabled: true` for hiding addon tabs per @ndelangen 's suggestion.

This is consistent with how we've documented disable and also consistent with how disabling addon decorators via parameters already works. See https://github.com/storybookjs/storybook/blob/master/lib/addons/src/make-decorator.ts#L21

## What I did

- [x] Support both `[key].disable` and `[key].disabled`.
- [x] Deprecated `disabled` for removal in 7.0
- [x] Documented migration and rationale

cc @stof @ndelangen @tmeasday @yannbf @jonniebigodes 

## How to test

See updated stories
