### PR TITLE
Update link to argTypes page

### DIFF
--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -75,7 +75,7 @@ NOTE: This API is experimental and may change outside of the typical semver rele
 
 </div>
 
-The API documentation of `ArgTypes` is detailed in a [separate section](../api/mdx.md#argtypes), but to control the description and default values, use the following fields:
+The API documentation of `ArgTypes` is detailed in a [separate section](../api/argtypes.md), but to control the description and default values, use the following fields:
 
 | Field                          |                                           Description                                            |
 | :----------------------------- | :----------------------------------------------------------------------------------------------: |


### PR DESCRIPTION
Issue:
Currently there is a link in the [Customizing section](https://storybook.js.org/docs/vue/writing-docs/doc-blocks#customizing) of the [Doc Blocks page](https://storybook.js.org/docs/vue/writing-docs/doc-blocks) which reads as though it will link to the argTypes API page ("The API documentation of ArgTypes is detailed in a separate section..."). However, the link leads to a non-existent anchor on the MDX page.

## What I did
Replaced the current link with a link to the [argTypes API page](https://storybook.js.org/docs/vue/api/argtypes).

## How to test
I don't think the link is testable by Jest or Chromatic.
