### PR TITLE
Addon-docs: Add transformSource for jsxDecorator, deprecated onBeforeRender

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,8 @@
 <h1>Migration</h1>
 
+- [From version 6.0.x to 6.1.0](#from-version-60x-to-610)
+  - [6.1 deprecations](#61-deprecations)
+    - [Deprecated onBeforeRender](#deprecated-onbeforerender)
 - [From version 5.3.x to 6.0.x](#from-version-53x-to-60x)
   - [Hoisted CSF annotations](#hoisted-csf-annotations)
   - [Zero config typescript](#zero-config-typescript)
@@ -49,7 +52,6 @@
     - [Deprecated clearDecorators](#deprecated-cleardecorators)
     - [Deprecated configure](#deprecated-configure)
     - [Deprecated support for duplicate kinds](#deprecated-support-for-duplicate-kinds)
-    - [Deprecated onBeforeRender](#deprecated-onbeforerender)
 - [From version 5.2.x to 5.3.x](#from-version-52x-to-53x)
   - [To main.js configuration](#to-mainjs-configuration)
     - [Using main.js](#using-mainjs)
@@ -128,6 +130,16 @@
   - [Webpack upgrade](#webpack-upgrade)
   - [Packages renaming](#packages-renaming)
   - [Deprecated embedded addons](#deprecated-embedded-addons)
+
+## From version 6.0.x to 6.1.0
+
+### 6.1 deprecations
+
+#### Deprecated onBeforeRender
+
+The `@storybook/addon-docs` previously accepted a `jsx` option called `onBeforeRender`, which was unfortunately named as it was called after the render.
+
+We've renamed it `transformSource` and also allowed it to receive the `StoryContext` in case source rendering requires additional information.
 
 ## From version 5.3.x to 6.0.x
 
@@ -798,12 +810,6 @@ export * from './Bar3.stories'
 
 export const SomeStory = () => ...;
 ```
-
-#### Deprecated onBeforeRender
-
-The `@storybook/addon-docs` previously accepted a `jsx` option called `onBeforeRender`, which was unfortunately named as it was called after the render.
-
-We've renamed it `transformSource` and also allowed it to receive the `StoryContext` in case source rendering requires additional information.
 
 ## From version 5.2.x to 5.3.x
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,6 +49,7 @@
     - [Deprecated clearDecorators](#deprecated-cleardecorators)
     - [Deprecated configure](#deprecated-configure)
     - [Deprecated support for duplicate kinds](#deprecated-support-for-duplicate-kinds)
+    - [Deprecated onBeforeRender](#deprecated-onbeforerender)
 - [From version 5.2.x to 5.3.x](#from-version-52x-to-53x)
   - [To main.js configuration](#to-mainjs-configuration)
     - [Using main.js](#using-mainjs)
@@ -797,6 +798,12 @@ export * from './Bar3.stories'
 
 export const SomeStory = () => ...;
 ```
+
+#### Deprecated onBeforeRender
+
+The `@storybook/addon-docs` previously accepted a `jsx` option called `onBeforeRender`, which was unfortunately named as it was called after the render.
+
+We've renamed it `transformSource` and also allowed it to receive the `StoryContext` in case source rendering requires additional information.
 
 ## From version 5.2.x to 5.3.x
 

--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -129,4 +129,26 @@ describe('jsxDecorator', () => {
     jsxDecorator(storyFn, context);
     expect(mockChannel.emit).not.toHaveBeenCalled();
   });
+
+  it('allows the snippet output to be modified by onBeforeRender', () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const onBeforeRender = (dom) => `<p>${dom}</p>`;
+    const jsx = { onBeforeRender };
+    const context = makeContext('args', { __isArgsStory: true, jsx }, {});
+    jsxDecorator(storyFn, context);
+    expect(mockChannel.emit).toHaveBeenCalledWith(
+      SNIPPET_RENDERED,
+      'jsx-test--args',
+      '<p><div>\n  args story\n</div></p>'
+    );
+  });
+
+  it('provides the story context to onBeforeRender', () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const onBeforeRender = jest.fn();
+    const jsx = { onBeforeRender };
+    const context = makeContext('args', { __isArgsStory: true, jsx }, {});
+    jsxDecorator(storyFn, context);
+    expect(onBeforeRender).toHaveBeenCalledWith('<div>\n  args story\n</div>', context);
+  });
 });

--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -130,6 +130,7 @@ describe('jsxDecorator', () => {
     expect(mockChannel.emit).not.toHaveBeenCalled();
   });
 
+  // This is deprecated, but still test it
   it('allows the snippet output to be modified by onBeforeRender', () => {
     const storyFn = (args: any) => <div>args story</div>;
     const onBeforeRender = (dom: string) => `<p>${dom}</p>`;
@@ -143,12 +144,25 @@ describe('jsxDecorator', () => {
     );
   });
 
-  it('provides the story context to onBeforeRender', () => {
+  it('allows the snippet output to be modified by transformSource', () => {
     const storyFn = (args: any) => <div>args story</div>;
-    const onBeforeRender = jest.fn();
-    const jsx = { onBeforeRender };
+    const transformSource = (dom: string) => `<p>${dom}</p>`;
+    const jsx = { transformSource };
     const context = makeContext('args', { __isArgsStory: true, jsx }, {});
     jsxDecorator(storyFn, context);
-    expect(onBeforeRender).toHaveBeenCalledWith('<div>\n  args story\n</div>', context);
+    expect(mockChannel.emit).toHaveBeenCalledWith(
+      SNIPPET_RENDERED,
+      'jsx-test--args',
+      '<p><div>\n  args story\n</div></p>'
+    );
+  });
+
+  it('provides the story context to transformSource', () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const transformSource = jest.fn();
+    const jsx = { transformSource };
+    const context = makeContext('args', { __isArgsStory: true, jsx }, {});
+    jsxDecorator(storyFn, context);
+    expect(transformSource).toHaveBeenCalledWith('<div>\n  args story\n</div>', context);
   });
 });

--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -132,7 +132,7 @@ describe('jsxDecorator', () => {
 
   it('allows the snippet output to be modified by onBeforeRender', () => {
     const storyFn = (args: any) => <div>args story</div>;
-    const onBeforeRender = (dom) => `<p>${dom}</p>`;
+    const onBeforeRender = (dom: string) => `<p>${dom}</p>`;
     const jsx = { onBeforeRender };
     const context = makeContext('args', { __isArgsStory: true, jsx }, {});
     jsxDecorator(storyFn, context);

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -16,16 +16,16 @@ interface JSXOptions {
   /** Override the display name used for a component */
   displayName?: string | Options['displayName'];
   /** A function ran before the story is rendered */
-  onBeforeRender?(dom: string): string;
+  onBeforeRender?(dom: string, context?: StoryContext): string;
 }
 
 /** Run the user supplied onBeforeRender function if it exists */
-const applyBeforeRender = (domString: string, options: JSXOptions) => {
+const applyBeforeRender = (domString: string, options: JSXOptions, context?: StoryContext) => {
   if (typeof options.onBeforeRender !== 'function') {
     return domString;
   }
 
-  return options.onBeforeRender(domString);
+  return options.onBeforeRender(domString, context);
 };
 
 /** Apply the users parameters and render the jsx for a story */
@@ -74,7 +74,7 @@ export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
   const result = React.Children.map(code, (c) => {
     // @ts-ignore FIXME: workaround react-element-to-jsx-string
     const child = typeof c === 'number' ? c.toString() : c;
-    let string = applyBeforeRender(reactElementToJSXString(child, opts as Options), options);
+    let string = reactElementToJSXString(child, opts as Options);
     const matches = string.match(/\S+=\\"([^"]*)\\"/g);
 
     if (matches) {
@@ -128,7 +128,7 @@ export const jsxDecorator = (storyFn: any, context: StoryContext) => {
   let jsx = '';
   const rendered = renderJsx(story, options);
   if (rendered) {
-    jsx = rendered;
+    jsx = applyBeforeRender(rendered, options, context);
   }
 
   channel.emit(SNIPPET_RENDERED, (context || {}).id, jsx);


### PR DESCRIPTION
Issue: N/A

## What I did
I modified where `onBeforeRender` was called and threaded the story context into that method. This can help users modify the snippet by pulling data that might be on story parameters or somewhere else in the context.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, Jest
- Does this need a new example in the kitchen sink apps? I don't this so.
- Does this need an update to the documentation? It isn't mentioned in the docs currently.

If your answer is yes to any of these, please make sure to include it in your PR. ✅ 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
