### PR TITLE
Replace slack broken link with community

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
     <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
   </a>
   <a href="https://storybook.js.org/community/">
-    <img src="https://img.shields.io/badge/storybook-community-join.svg" alt="Storybook Community" />
+    <img src="https://img.shields.io/badge/community-join-4BC424.svg" alt="Storybook Community" />
   </a>
   <a href="#backers">
     <img src="https://opencollective.com/storybook/backers/badge.svg" alt="Backers on Open Collective" />

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
   <a href="https://discord.gg/sMFvFsG">
     <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
   </a>
-  <a href="https://now-examples-slackin-rrirkqohko.now.sh/">
-    <img src="https://now-examples-slackin-rrirkqohko.now.sh/badge.svg?logo=slack" alt="Storybook Slack" />
+  <a href="https://storybook.js.org/community/">
+    <img src="https://img.shields.io/badge/storybook-community-join.svg" alt="Storybook Community" />
   </a>
   <a href="#backers">
     <img src="https://opencollective.com/storybook/backers/badge.svg" alt="Backers on Open Collective" />


### PR DESCRIPTION
Issue:

## What I did
Replace slack legacy broken link to storybook community

## How to test
before:
![Screenshot 2020-08-21 at 12 00 29](https://user-images.githubusercontent.com/12380196/90872901-f489c500-e3a5-11ea-8f5d-b98562963028.png)

with PR changes:
![Screenshot 2020-08-21 at 11 52 46](https://user-images.githubusercontent.com/12380196/90872917-fce20000-e3a5-11ea-8b7f-ee5a88167b05.png)
