### PR TITLE
Fix indents/line breaks in code exmaples

### DIFF
--- a/docs/snippets/angular/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/angular/button-story-component-args-primary.ts.mdx
@@ -6,9 +6,8 @@ import Button from './button.component';
 export default {
   title: "Button",
   component: Button,
-   argTypes: {
+  argTypes: {
     backgroundColor: { control: 'color' },
-  
   },
   args: {
     // Now all Button stories will be primary.

--- a/docs/snippets/react/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.js.mdx
@@ -7,7 +7,7 @@ import Button from './Button';
 export default {
   title: "Button",
   component: Button,
-   argTypes: {
+  argTypes: {
     backgroundColor: { control: 'color' },
   },
   args: {

--- a/docs/snippets/react/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.ts.mdx
@@ -8,9 +8,8 @@ import Button from './Button';
 export default {
   title: "Button",
   component: Button,
-   argTypes: {
+  argTypes: {
     backgroundColor: { control: 'color' },
-  
   },
   args: {
     // Now all Button stories will be primary.


### PR DESCRIPTION
Issue:

I found two small issues in the code examples on the docs.

- Unnecessary white space before `argTypes: {` 
- Unnecessary link break after `backgroundColor: { control: 'color' },` 

![image](https://user-images.githubusercontent.com/5466341/90965693-778b4800-e498-11ea-9322-35145d8bcbeb.png)


## What I did

Fixed the above issues.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
