### PR TITLE
Correct globs in documentation

### DIFF
--- a/docs/snippets/common/storybook-main-default-setup.js.mdx
+++ b/docs/snippets/common/storybook-main-default-setup.js.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.js
 
 module.exports = {
-  stories: ['../src/**/*.stories.(js|mdx)'],
+  stories: ['../src/**/*.stories.@(js|mdx)'],
   addons: ['@storybook/addon-essentials']
 }
 ```


### PR DESCRIPTION


Issue:
Globs are not correct as it is listed here – https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#correct-globs-in-mainjs

## What I did
Updated documentation
