### PR TITLE
Addon-essentials: Log info on config override

### DIFF
--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -27,7 +27,7 @@ export function addons(options: PresetOptions = {}) {
       return name?.startsWith(addon);
     });
     if (existingAddon) {
-      logger.warn(`Found existing addon ${JSON.stringify(existingAddon)}, skipping.`);
+      logger.info(`Found existing addon ${JSON.stringify(existingAddon)}, skipping.`);
     }
     return !!existingAddon;
   };


### PR DESCRIPTION
Issue: #12169 

## What I did

Use "info" instead of "warn" when a user overrides the default config for an essential addon. This is the recommended way to override, so it should not trigger a warning.

## How to test

N/A