### PR TITLE
fix(docs): use html codes for triangle brackets

### DIFF
--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -96,7 +96,7 @@ If you have global imported styles, create a file called [`.storybook/preview.js
 </details>
 
 <details>
-  <summary>Add external CSS or fonts in the &#60head&#62</summary>
+  <summary>Add external CSS or fonts in the &lt;head&gt;</summary>
 
 Alternatively if you want to inject a CSS link tag to the `<head>` directly (or some other resource like a font link), you can use [`.storybook/preview-head.html`](../configure/story-rendering.md#adding-to-&#60head&#62) to add arbitrary HTML.
 


### PR DESCRIPTION
Issue:

## What I did
- Used `&lt;` instead of `&#60` so that `<` shows up correctly
- Same for `>`

## How to test
See https://storybook.js.org/docs/html/get-started/setup#render-component-styles