### PR TITLE
Preact: Keep the story state between rerenders

### DIFF
--- a/app/preact/src/client/preview/render.tsx
+++ b/app/preact/src/client/preview/render.tsx
@@ -39,7 +39,7 @@ export default function renderMain({
     return;
   }
 
-  // But forceRender means that it's the same story, so we want too keep the state in that case.
+  // But forceRender means that it's the same story, so we want to keep the state in that case.
   if (!forceRender) {
     preactRender(null);
   }

--- a/app/preact/src/client/preview/render.tsx
+++ b/app/preact/src/client/preview/render.tsx
@@ -18,7 +18,14 @@ function preactRender(element: StoryFnPreactReturnType | null): void {
   }
 }
 
-export default function renderMain({ storyFn, kind, name, showMain, showError }: RenderContext) {
+export default function renderMain({
+  storyFn,
+  kind,
+  name,
+  showMain,
+  showError,
+  forceRender,
+}: RenderContext) {
   const element = storyFn();
 
   if (!element) {
@@ -32,7 +39,10 @@ export default function renderMain({ storyFn, kind, name, showMain, showError }:
     return;
   }
 
-  preactRender(null);
+  // But forceRender means that it's the same story, so we want too keep the state in that case.
+  if (!forceRender) {
+    preactRender(null);
+  }
 
   showMain();
 


### PR DESCRIPTION
Issue: #12177

## What I did

With these changes, a Preact story will keep its state in between the rerenders, e.g. due to knob/control change. This will make Preact function similar to React.

## How to test

- Is this testable with Jest or Chromatic screenshots?

TODO

- Does this need a new example in the kitchen sink apps?

TODO

- Does this need an update to the documentation?

No: the `forceRender` is a normal Storybook mode and thus no new functionality has been enabled in this PR.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
