### PR TITLE
Addon-docs: Reuse extractSource from source-loader

### DIFF
--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -1,14 +1,10 @@
 import { combineParameters } from '@storybook/client-api';
 import { StoryContext, Parameters } from '@storybook/addons';
-
-interface Location {
-  line: number;
-  col: number;
-}
+import { extractSource, LocationsMap } from '@storybook/source-loader';
 
 interface StorySource {
   source: string;
-  locationsMap: { [id: string]: { startBody: Location; endBody: Location } };
+  locationsMap: LocationsMap;
 }
 
 /**
@@ -24,23 +20,9 @@ const extract = (targetId: string, { source, locationsMap }: StorySource) => {
 
   const sanitizedStoryName = storyIdToSanitizedStoryName(targetId);
   const location = locationsMap[sanitizedStoryName];
-
-  const { startBody: start, endBody: end } = location;
   const lines = source.split('\n');
-  if (start.line === end.line && lines[start.line - 1] !== undefined) {
-    return lines[start.line - 1].substring(start.col, end.col);
-  }
-  // NOTE: storysource locations are 1-based not 0-based!
-  const startLine = lines[start.line - 1];
-  const endLine = lines[end.line - 1];
-  if (startLine === undefined || endLine === undefined) {
-    return source;
-  }
-  return [
-    startLine.substring(start.col),
-    ...lines.slice(start.line, end.line - 1),
-    endLine.substring(0, end.col),
-  ].join('\n');
+
+  return extractSource(location, lines);
 };
 
 export const enhanceSource = (context: StoryContext): Parameters => {

--- a/lib/source-loader/src/abstract-syntax-tree/generate-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/generate-helpers.js
@@ -9,6 +9,7 @@ import {
   popParametersObjectFromDefaultExport,
   findExportsMap as generateExportsMap,
 } from './traverse-helpers';
+import { extractSource } from '../extract-source';
 
 export function sanitizeSource(source) {
   return JSON.stringify(source)
@@ -174,27 +175,6 @@ export function generateSourcesInExportedParameters(source, ast, additionalParam
     return result;
   }
   return source;
-}
-
-/**
- * given a location, extract the text from the full source
- */
-function extractSource(location, lines) {
-  const { startBody: start, endBody: end } = location;
-  if (start.line === end.line && lines[start.line - 1] !== undefined) {
-    return lines[start.line - 1].substring(start.col, end.col);
-  }
-  // NOTE: storysource locations are 1-based not 0-based!
-  const startLine = lines[start.line - 1];
-  const endLine = lines[end.line - 1];
-  if (startLine === undefined || endLine === undefined) {
-    return null;
-  }
-  return [
-    startLine.substring(start.col),
-    ...lines.slice(start.line, end.line - 1),
-    endLine.substring(0, end.col),
-  ].join('\n');
 }
 
 function addStorySourceParameter(key, snippet) {

--- a/lib/source-loader/src/extract-source.ts
+++ b/lib/source-loader/src/extract-source.ts
@@ -1,0 +1,22 @@
+import type { SourceBlock } from './types';
+
+/**
+ * given a location, extract the text from the full source
+ */
+export function extractSource(location: SourceBlock, lines: string[]): string | null {
+  const { startBody: start, endBody: end } = location;
+  if (start.line === end.line && lines[start.line - 1] !== undefined) {
+    return lines[start.line - 1].substring(start.col, end.col);
+  }
+  // NOTE: storysource locations are 1-based not 0-based!
+  const startLine = lines[start.line - 1];
+  const endLine = lines[end.line - 1];
+  if (startLine === undefined || endLine === undefined) {
+    return null;
+  }
+  return [
+    startLine.substring(start.col),
+    ...lines.slice(start.line, end.line - 1),
+    endLine.substring(0, end.col),
+  ].join('\n');
+}

--- a/lib/source-loader/src/index.ts
+++ b/lib/source-loader/src/index.ts
@@ -4,3 +4,5 @@ import { transform } from './build';
 export default transform;
 
 export * from './types';
+
+export { extractSource } from './extract-source';

--- a/lib/source-loader/src/types.ts
+++ b/lib/source-loader/src/types.ts
@@ -4,6 +4,8 @@ export interface SourceLoc {
 }
 
 export interface SourceBlock {
+  startBody: SourceLoc;
+  endBody: SourceLoc;
   startLoc: SourceLoc;
   endLoc: SourceLoc;
 }


### PR DESCRIPTION
Issue: N/A

## What I did

While working on `source-loader` and `addon-docs`, I noticed duplication on how the source was being extracted. This came to my attention because changes I made in `source-loader` weren't reflected for static code in `addon-docs`.

This PR aligns the 2 source extraction methods.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, `enhanceSource.test.ts` already tests this logic.
- Does this need a new example in the kitchen sink apps? Nope
- Does this need an update to the documentation? Nope

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
