### PR TITLE
Mithril: Add Mithril v2.0.0 to peer dependencies

### DIFF
--- a/app/mithril/package.json
+++ b/app/mithril/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@babel/core": "*",
-    "mithril": "^1.1.6",
+    "mithril": "^1.1.6 || ^2.0.0",
     "react": "*",
     "react-dom": "*"
   },


### PR DESCRIPTION
Issue: #11742

This will prevent the error when doing an npm install: `npm WARN @storybook/mithril@6.0.16 requires a peer of mithril@^1.1.6 but none is installed. You must install peer dependencies yourself.`

## What I did

Added support for v2 of Mithril

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
