### PR TITLE
UI: Fix eject and copy URLs for composition

### DIFF
--- a/lib/ui/src/components/preview/tools/copy.tsx
+++ b/lib/ui/src/components/preview/tools/copy.tsx
@@ -1,3 +1,4 @@
+import { PREVIEW_URL } from 'global';
 import React from 'react';
 import copy from 'copy-to-clipboard';
 import { IconButton, Icons } from '@storybook/components';
@@ -11,9 +12,7 @@ const copyMapper = ({ state }: Combo) => {
 
   return {
     refId,
-    baseUrl: ref
-      ? `${ref.url}/iframe.html`
-      : `${state.location.origin + state.location.pathname}iframe.html`,
+    baseUrl: ref ? `${ref.url}/iframe.html` : (PREVIEW_URL as string) || 'iframe.html',
     storyId,
     queryParams: state.customQueryParams,
   };

--- a/lib/ui/src/components/preview/tools/eject.tsx
+++ b/lib/ui/src/components/preview/tools/eject.tsx
@@ -1,3 +1,4 @@
+import { PREVIEW_URL } from 'global';
 import React from 'react';
 import { IconButton, Icons } from '@storybook/components';
 import { Consumer, Combo } from '@storybook/api';
@@ -10,9 +11,7 @@ const ejectMapper = ({ state }: Combo) => {
 
   return {
     refId,
-    baseUrl: ref
-      ? `${ref.url}/iframe.html`
-      : `${state.location.origin + state.location.pathname}iframe.html`,
+    baseUrl: ref ? `${ref.url}/iframe.html` : (PREVIEW_URL as string) || 'iframe.html',
     storyId,
     queryParams: state.customQueryParams,
   };


### PR DESCRIPTION
Issue: #12162

## What I did

I changed the eject 7 copy feature so it has the correct url, same implementation as in the preview.

### how to test
- navigate to a storybook
- ensure there's `index.html` in manager
- click eject in toolbar

@davidhildering would you be able to review?