### PR TITLE
Fix broken link to jest addon docs

### DIFF
--- a/docs/workflows/snapshot-testing.md
+++ b/docs/workflows/snapshot-testing.md
@@ -40,7 +40,7 @@ npx test storybook.test.js
 
 <div class="aside">
 
-If you are loading stories via `.storybook/preview.js` and `require.context()`, you will need to follow some extra steps to ensure Jest finds them. Read more in the [addon documentation](../../addons/storyshots-core/README.md#configure-your-app-for-jest).
+If you are loading stories via `.storybook/preview.js` and `require.context()`, you will need to follow some extra steps to ensure Jest finds them. Read more in the [addon documentation](../../addons/jest/README.md).
 
 </div>
 

--- a/docs/workflows/snapshot-testing.md
+++ b/docs/workflows/snapshot-testing.md
@@ -40,7 +40,7 @@ npx test storybook.test.js
 
 <div class="aside">
 
-If you are loading stories via `.storybook/preview.js` and `require.context()`, you will need to follow some extra steps to ensure Jest finds them. Read more in the [addon documentation](../../addons/jest/README.md).
+If you are loading stories via `.storybook/preview.js` and `require.context()`, you will need to follow some extra steps to ensure Jest finds them. Read more in the [addon documentation](../../addons/storyshots/storyshots-core/README.md#configure-your-app-for-jest/README.md).
 
 </div>
 


### PR DESCRIPTION
Issue:
Broken link in documentation.

## What I did
Fix the link.

## How to test
Click fixed link, see it takes you to the right place. Click old link, note it does not work.