### PR TITLE
CLI: Fix import of Button in react mdx template

### DIFF
--- a/lib/cli/src/generators/REACT/template-mdx/stories/1-Button.stories.mdx
+++ b/lib/cli/src/generators/REACT/template-mdx/stories/1-Button.stories.mdx
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, Story } from '@storybook/addon-docs/blocks';
-import Button from './Button';
+import { Button } from './Button';
 
 <Meta title="Docs/Button" component={Button} />
 

--- a/lib/cli/src/generators/REACT_SCRIPTS/template-mdx/stories/1-Button.stories.mdx
+++ b/lib/cli/src/generators/REACT_SCRIPTS/template-mdx/stories/1-Button.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import Button from './Button';
+import { Button } from './Button';
 
 <Meta title="Docs/Button" component={Button} />
 

--- a/lib/cli/src/generators/WEBPACK_REACT/template-mdx/stories/1-Button.stories.mdx
+++ b/lib/cli/src/generators/WEBPACK_REACT/template-mdx/stories/1-Button.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import Button from './Button';
+import { Button } from './Button';
 
 <Meta title="Docs/Button" component={Button} />
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12253

## What I did

Fixed import of Button in react mdx example

## How to test

1. Follow directions in https://github.com/storybookjs/storybook/issues/12253 to reproduce error
2. Replace the generated `1-Button.stories.mdx` with the version in this PR
3. Confirm that the error has been fixed.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
