### PR TITLE
Addon-docs: Change 2nd argument of transformSource to the storyContext

### DIFF
--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -270,7 +270,7 @@ Alternatively, you can provide a function in the `docs.transformSource` paramete
 const SOURCE_REGEX = /^\(\) => `(.*)`$/;
 export const parameters = {
   docs: {
-    transformSource: (src, storyId) => {
+    transformSource: (src, storyContext) => {
       const match = SOURCE_REGEX.exec(src);
       return match ? match[1] : src;
     },

--- a/addons/docs/src/blocks/enhanceSource.test.ts
+++ b/addons/docs/src/blocks/enhanceSource.test.ts
@@ -11,8 +11,6 @@ const emptyContext: StoryContext = {
   parameters: {},
 };
 
-const transformSource = (src?: string) => (src ? `formatted: ${src}` : 'no src');
-
 describe('addon-docs enhanceSource', () => {
   describe('no source loaded', () => {
     const baseContext = emptyContext;
@@ -20,14 +18,16 @@ describe('addon-docs enhanceSource', () => {
       expect(enhanceSource(baseContext)).toBeNull();
     });
     it('transformSource', () => {
+      const transformSource = (src?: string) => (src ? `formatted: ${src}` : 'no src');
       const parameters = { ...baseContext.parameters, docs: { transformSource } };
       expect(enhanceSource({ ...baseContext, parameters })).toBeNull();
     });
   });
   describe('custom/mdx source loaded', () => {
+    const source = 'storySource.source';
     const baseContext = {
       ...emptyContext,
-      parameters: { storySource: { source: 'storySource.source' } },
+      parameters: { storySource: { source } },
     };
     it('no transformSource', () => {
       expect(enhanceSource(baseContext)).toEqual({
@@ -35,10 +35,18 @@ describe('addon-docs enhanceSource', () => {
       });
     });
     it('transformSource', () => {
+      const transformSource = (src?: string) => (src ? `formatted: ${src}` : 'no src');
       const parameters = { ...baseContext.parameters, docs: { transformSource } };
       expect(enhanceSource({ ...baseContext, parameters }).docs.source).toEqual({
         code: 'formatted: storySource.source',
       });
+    });
+    it('receives context as 2nd argument', () => {
+      const transformSource = jest.fn();
+      const parameters = { ...baseContext.parameters, docs: { transformSource } };
+      const context = { ...baseContext, parameters };
+      enhanceSource(context);
+      expect(transformSource).toHaveBeenCalledWith(source, context);
     });
   });
   describe('storysource source loaded w/ locationsMap', () => {
@@ -57,10 +65,18 @@ describe('addon-docs enhanceSource', () => {
       expect(enhanceSource(baseContext)).toEqual({ docs: { source: { code: 'Source' } } });
     });
     it('transformSource', () => {
+      const transformSource = (src?: string) => (src ? `formatted: ${src}` : 'no src');
       const parameters = { ...baseContext.parameters, docs: { transformSource } };
       expect(enhanceSource({ ...baseContext, parameters }).docs.source).toEqual({
         code: 'formatted: Source',
       });
+    });
+    it('receives context as 2nd argument', () => {
+      const transformSource = jest.fn();
+      const parameters = { ...baseContext.parameters, docs: { transformSource } };
+      const context = { ...baseContext, parameters };
+      enhanceSource(context);
+      expect(transformSource).toHaveBeenCalledWith('Source', context);
     });
   });
   describe('custom docs.source provided', () => {
@@ -75,6 +91,7 @@ describe('addon-docs enhanceSource', () => {
       expect(enhanceSource(baseContext)).toBeNull();
     });
     it('transformSource', () => {
+      const transformSource = (src?: string) => (src ? `formatted: ${src}` : 'no src');
       const { source } = baseContext.parameters.docs;
       const parameters = { ...baseContext.parameters, docs: { source, transformSource } };
       expect(enhanceSource({ ...baseContext, parameters })).toBeNull();

--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -54,7 +54,7 @@ export const enhanceSource = (context: StoryContext): Parameters => {
   }
 
   const input = extract(id, storySource);
-  const code = transformSource ? transformSource(input, id) : input;
+  const code = transformSource ? transformSource(input, context) : input;
 
   return { docs: combineParameters(docs, { source: { code } }) };
 };


### PR DESCRIPTION
Issue: N/A

## What I did

Similar to #12178, the `transformSource` method option in `addon-docs` was receiving the storyId instead of the entire context.

This is slightly breaking because it changes the 2nd argument to be the entire context instead of just the story `id`. However, I think this is okay because an end-user can destructure the story `id` from the context, and the 2nd parameter also was only documented in one recipe and not tested at all.

This will also bring the `transformSource` method inline with the definition in #12178.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, added jest tests
- Does this need a new example in the kitchen sink apps? No; however, I'll be able to expand on this work in the future to add a cool example to the kitchen sink!
- Does this need an update to the documentation? Updated the recipe.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
