### PR TITLE
Components: Add additionalActions prop to Preview block

### DIFF
--- a/lib/components/src/blocks/Preview.stories.tsx
+++ b/lib/components/src/blocks/Preview.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { styled } from '@storybook/theming';
+import { window } from 'global';
 
 import { Spaced } from '../spaced/Spaced';
 import { Preview } from './Preview';
@@ -134,5 +135,21 @@ export const WithCenteredMulti = () => (
   <Preview withToolbar>
     <Story inline storyFn={buttonFn} title="story1" parameters={{ layout: 'centered' }} />
     <Story inline storyFn={buttonFn} title="story2" parameters={{ layout: 'centered' }} />
+  </Preview>
+);
+
+export const WithAdditionalActions = () => (
+  <Preview
+    additionalActions={[
+      {
+        title: 'Open on GitHub',
+        onClick: () => {
+          window.location.href =
+            'https://github.com/storybookjs/storybook/blob/next/lib/components/src/blocks/Preview.stories.tsx#L140-L147';
+        },
+      },
+    ]}
+  >
+    <Button secondary>Button 1</Button>
   </Preview>
 );

--- a/lib/components/src/blocks/Preview.tsx
+++ b/lib/components/src/blocks/Preview.tsx
@@ -15,6 +15,7 @@ export interface PreviewProps {
   isExpanded?: boolean;
   withToolbar?: boolean;
   className?: string;
+  additionalActions?: ActionItem[];
 }
 
 type layout = 'padded' | 'fullscreen' | 'centered';
@@ -179,6 +180,7 @@ const Preview: FunctionComponent<PreviewProps> = ({
   withSource,
   withToolbar = false,
   isExpanded = false,
+  additionalActions,
   className,
   ...props
 }) => {
@@ -186,6 +188,11 @@ const Preview: FunctionComponent<PreviewProps> = ({
   const { source, actionItem } = getSource(withSource, expanded, setExpanded);
   const [scale, setScale] = useState(1);
   const previewClasses = [className].concat(['sbdocs', 'sbdocs-preview']);
+
+  const defaultActionItems = withSource ? [actionItem] : [];
+  const actionItems = additionalActions
+    ? [...defaultActionItems, ...additionalActions]
+    : defaultActionItems;
 
   // @ts-ignore
   const layout = getLayout(Children.count(children) === 1 ? [children] : children);
@@ -220,7 +227,7 @@ const Preview: FunctionComponent<PreviewProps> = ({
               <div>{children}</div>
             )}
           </ChildrenContainer>
-          {withSource && <ActionBar actionItems={[actionItem]} />}
+          <ActionBar actionItems={actionItems} />
         </Relative>
       </ZoomContext.Provider>
       {withSource && source}


### PR DESCRIPTION
Issue: N/A

## What I did

This adds an `additionalActions` prop to the `Preview` component to specify additional items in the action bar. I also added a story to show how this can be used to add something like a button to "Open in GitHub". I was going to take a screenshot to attach, but I couldn't figure out the building for the official storybook.

## How to test

- Is this testable with Jest or Chromatic screenshots? I'm not sure.
- Does this need a new example in the kitchen sink apps? Added to the official storybook
- Does this need an update to the documentation? Don't think so.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
