### PR TITLE
Source-loader: Generate sourcemaps

### DIFF
--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -40,7 +40,8 @@
     "prettier": "~2.0.5",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "regenerator-runtime": "^0.13.3"
+    "regenerator-runtime": "^0.13.3",
+    "source-map": "^0.7.3"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/source-loader/src/build.js
+++ b/lib/source-loader/src/build.js
@@ -1,24 +1,63 @@
+import { SourceMapConsumer, SourceNode } from 'source-map';
+
 import { readStory } from './dependencies-lookup/readAsObject';
 
-export function transform(inputSource) {
-  return readStory(this, inputSource).then((sourceObject) => {
+export async function transform(inputSource, inputSourceMap) {
+  const callback = this.async();
+
+  try {
+    const sourceObject = await readStory(this, inputSource);
     // if source-loader had trouble parsing the story exports, return the original story
     // example is
     // const myStory = () => xxx
     // export { myStory }
     if (!sourceObject.source || sourceObject.source.length === 0) {
-      return inputSource;
+      callback(null, inputSource, inputSourceMap);
+      return;
     }
 
     const { source, sourceJson, addsMap } = sourceObject;
+
+    // Use the SourceNode to produce the code. Given that the source mapping here is trivial it's easier to just
+    // always build a sourcemap rather than to have two different code paths.
+    let sourceNode;
+    if (inputSourceMap) {
+      // The inputSourceMap here should be a SourceMapGenerator, or just a plain source map JSON object.
+      sourceNode = await SourceMapConsumer.with(
+        JSON.stringify(inputSourceMap),
+        null,
+        (consumer) => {
+          return SourceNode.fromStringWithSourceMap(source, consumer);
+        }
+      );
+    } else {
+      // Build an identity sourcemap. Note that "source" is already potentially differing from "inputSource"
+      // due to other loaders, so while we need to use "source" for the source node contents to generate the correct
+      // code, we still want to use "inputSource" as the source content.
+      sourceNode = new SourceNode();
+      sourceNode.add(
+        source
+          .split(/\n/)
+          .map((line, index) => new SourceNode(index + 1, 0, this.resourcePath, `${line}\n`))
+      );
+
+      sourceNode.setSourceContent(this.resourcePath, inputSource);
+    }
+
+    // Prepend the preamble
     const preamble = `
       /* eslint-disable */
       // @ts-nocheck
       // @ts-ignore
       var __STORY__ = ${sourceJson};
       // @ts-ignore
-      var __LOCATIONS_MAP__ = ${JSON.stringify(addsMap)};
-    `;
-    return `${preamble}\n${source}`;
-  });
+      var __LOCATIONS_MAP__ = ${JSON.stringify(addsMap)};`;
+    sourceNode.prepend(`${preamble}\n`);
+
+    // Generate the code and the source map for the next loader
+    const { code, map } = sourceNode.toStringWithSourceMap();
+    callback(null, code, map);
+  } catch (e) {
+    callback(e);
+  }
 }


### PR DESCRIPTION
## What I did

I wanted to debug my stories, ideally in Visual Studio Code with the chrome debugger. Unfortunately setting breakpoints didn't work, they seemed to be "off" by a few lines.

I looked through the sourcemap options, and even though webpack is configured to produce some, it seems that for the storybook itself there were none. Looking through the config I found the source-loader, and saw that it doesn't produce sourcemaps.

## How to test

- Is this testable with Jest or Chromatic screenshots?

Chromatic screenshots: I guess not, as this isn't really a visual change.
Jest: Maybe one could test that running the `transform()` function invokes the callback with the source map, and that that sourcemap is a proper SourceMapGenerator as per webpack loader API (see <https://webpack.js.org/api/loaders/#thiscallback>).

The code does get exercised by the `build-storybook` tests.

- Does this need a new example in the kitchen sink apps?

Probably not: too trivial.

- Does this need an update to the documentation?

This might be needed, in the sense that the source-loader _still_ ignores the source map setting, and simply always produces one. Given that that producing is trivial (identity map + prepend some lines) the impact here should be ignorable though.

Attached a screenshot of a session, to note here is that the displayed source is breaking exactly at the spot it should, and that the preamble and other generated code aren't visible.
![screen-storybook-sourcemap](https://user-images.githubusercontent.com/1210641/91424223-cc90da80-e859-11ea-8a92-e1e4df16cb17.png)
