### PR TITLE
Fix the link to the "advanced readme"

### DIFF
--- a/docs/writing-docs/introduction.md
+++ b/docs/writing-docs/introduction.md
@@ -19,4 +19,4 @@ You can also create free-form pages for each component using [MDX](./mdx.md), a 
 
 In both cases, you’ll use [Doc Blocks](./doc-blocks.md) as the building blocks to create full featured documentation.
 
-Docs is autoconfigured to work out of the box in most use cases. In some cases you may need or want to tweak the configuration. Read more about it in the [advanced readme](../../addons/docs/ADVANCED-README.md).
+Docs is autoconfigured to work out of the box in most use cases. In some cases you may need or want to tweak the configuration. Read more about it in the [readme](../../addons/docs/README.md).


### PR DESCRIPTION
## What I did

Read the documentation on how to write docs, find the link to a "advanced" readme -- and found the link to be pointing into nowhere. Looking through the history of the project it seems this file never existed, but it also looks like the "advanced" stuff here is simply the addon README.

## How to test

Check the link on https://storybook.js.org/docs/react/writing-docs/introduction at the end to work.