### PR TITLE
Add missing curly brace for actions property in the Button story example

### DIFF
--- a/docs/snippets/common/button-story-action-event-handle.js.mdx
+++ b/docs/snippets/common/button-story-action-event-handle.js.mdx
@@ -6,6 +6,7 @@ export default {
   parameters: {
     actions: {
       handles: ['mouseover', 'click .btn']
+    }
   }
 };
 


### PR DESCRIPTION
Issue:

Minor typographical error in the actions addon documentation

## What I did

Added a missing `}`