### PR TITLE
Documentation (Intro to Writing Docs) - Point to valid README link

### DIFF
--- a/docs/writing-docs/introduction.md
+++ b/docs/writing-docs/introduction.md
@@ -19,4 +19,4 @@ You can also create free-form pages for each component using [MDX](./mdx.md), a 
 
 In both cases, you’ll use [Doc Blocks](./doc-blocks.md) as the building blocks to create full featured documentation.
 
-Docs is autoconfigured to work out of the box in most use cases. In some cases you may need or want to tweak the configuration. Read more about it in the [advanced readme](../../addons/docs/ADVANCED-README.md).
+Docs is autoconfigured to work out of the box in most use cases. In some cases you may need or want to tweak the configuration. Read more about it in the [readme](../../addons/docs/README.md).


### PR DESCRIPTION
Issue:
Near the bottom of the [introduction to writing docs](https://storybook.js.org/docs/vue/writing-docs/introduction) page, the link to "[advanced readme](https://github.com/storybookjs/storybook/tree/master/addons/docs/ADVANCED-README.md)" doesn't exist any longer.

## What I did
- Pointed the link to the regular docs readme (`../../addons/docs/README.md`)
- Removed the word "advanced" from the link text

## How to test
I don't think this is testable with the current setup.
- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No - is is a docs update

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
