### PR TITLE
Broken link in documentation about DocsPage

### DIFF
--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -2,7 +2,7 @@
 title: 'DocsPage'
 ---
 
-When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/next/addons/docs/README.md), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
+When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/next/addons/docs/), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
 
 The best practice for docs is for each component to have its own set of documentation and stories.
 


### PR DESCRIPTION
Issue:

There is a broken link on the DocsPage docs [here](https://storybook.js.org/docs/react/writing-docs/docs-page).

This one:
![image](https://user-images.githubusercontent.com/263385/91638727-7e0d4880-e9df-11ea-9b5d-cfbc79ca249a.png)

## What I did
This behavior is a side effect of how the /frontpage repo processes .md file extensions to generate doc links. I changed the path to `https://github.com/storybookjs/storybook/blob/next/addons/docs/` which should fix this issue.


## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

