### PR TITLE
resolve core-js to storybook's version

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -47,6 +47,10 @@ const storybookPaths = [
   {}
 );
 
+const coreJsPaths = {
+  'core-js': path.dirname(resolveFrom(__dirname, 'core-js/package.json'))
+};
+
 try {
   reactPaths.react = path.dirname(resolveFrom(process.cwd(), 'react/package.json'));
   reactPaths['react-dom'] = path.dirname(resolveFrom(process.cwd(), 'react-dom/package.json'));
@@ -186,6 +190,7 @@ export default async ({
         ...themingPaths,
         ...storybookPaths,
         ...reactPaths,
+        ...coreJsPaths,
       },
 
       plugins: [


### PR DESCRIPTION
This is just a draft to show where the problem lies.

Fixes #11255.

### What is the issue?

Basically, somewhere down the line we use core-js inside storybook (presumably to polyfill everything as a catch-all?).

When we bundle the JS to be executed in storybook's iframe, we take the user's sources and our own so we can effectively join up storybook's utils/controls/etc with the user's stories. 

The problem begins if the user has their own core-js installed (not necessarily as a direct dependency). 

Take the following imaginary *dependency* structure:

```
- some-dependency
-- core-js@2
- @storybook/html
-- core-js@3
```

assume this resulted in the following *directory* structure:

```
node_modules
- /core-js (2.x)
- some-dependency
-- /core-js (DEDUPED, 2.x)
- /@storybook
-- /html
--- /core-js (3.x)
```

This now means the `core-js` at top level is 2.x NOT 3.x, which is not the one we want.

Now, when we create our bundle, we will execute webpack in the USER's directory, _not_ webpack's directory. This means the core-js we resolve will be the top-level one: 2.x, the _wrong version_.

### Possible Solution

From looking at the code, i can see you've in fact encountered this before but from a different point of view: resolving storybook's own modules from outside storybook's directory. 

So here i've just done the exact same thing, i have forcefully aliased core-js to the one webpack installs.

### Problems / Questions

* If someone genuinely depends on another corejs in their own code, that will probably be broken instead now as we will be forcing it to resolve a version different to what is in their package
* Where on earth is core-js being pulled in? for my own sanity this would be nice to learn, i have absolutely no idea because of how dynamic all this stuff is. its all good us 'fixing' it, but we really should understand why we have the problem in the first place (why we have core-js)
* it feels like we're fixing one part of a wider issue... who knows what other dependencies we have that could clash in the same way, literally any dependency we pull in will probably have this issue

cc @ndelangen @shilman 