### PR TITLE
Security update of sub dependency "prismjs"

### DIFF
--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -42,7 +42,7 @@
     "prettier": "~2.0.5",
     "prop-types": "^15.7.2",
     "react": "^16.9.17",
-    "react-syntax-highlighter": "^13.5.0",
+    "react-syntax-highlighter": "^13.5.1",
     "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## What I did
Upgrading to this version, we have access to a security bump that is being a warning in Dependabot

https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/package.json#L12

## How to test

Just check the yarn.lock file generated

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
