### PR TITLE
[manager] Change API to disable composition

### DIFF
--- a/docs/snippets/common/storybook-main-disable-refs.js.mdx
+++ b/docs/snippets/common/storybook-main-disable-refs.js.mdx
@@ -4,6 +4,6 @@
 module.exports = {
   // your Storybook configuration
   refs: {
-    'package-name': { disabled: true }
+    'package-name': { disable: true }
 }
 ```

--- a/docs/snippets/common/storybook-main-disable-refs.js.mdx
+++ b/docs/snippets/common/storybook-main-disable-refs.js.mdx
@@ -4,6 +4,6 @@
 module.exports = {
   // your Storybook configuration
   refs: {
-    'package-name': { disable: true }
+    'package-name': { disabled: true }
 }
 ```

--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -78,7 +78,7 @@ async function getManagerWebpackConfig(options, presets) {
 
   if (definedRefs) {
     Object.entries(definedRefs).forEach(([key, value]) => {
-      if (value?.disabled) {
+      if (value?.disable) {
         delete refs[key.toLowerCase()];
         return;
       }


### PR DESCRIPTION
Issue: [API to disable composition of a Storybook](https://storybook.js.org/docs/react/workflows/package-composition#configuring) is incorrect, as it uses `disabled` instead of `disable`.

## What I did

`refs[key].disabled` -> `refs[key].disable`

## How to test

Try to disable composition. Not sure if this needs tests, or how to test it.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
