### PR TITLE
Adapt text from README for hide controls section

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -188,6 +188,29 @@ And here's what the resulting UI looks like:
 
 ![Controls addon expanded](./addon-controls-expanded.png)
 
+## Hide controls for certain fields on a particular story
+
+The `argTypes` annotation can be used to hide controls for a particular row, or even hide rows.
+
+Suppose you have a `Button` component with `borderWidth` and `label` properties (auto-generated or otherwise) and you want to hide the `borderWidth` row completely and disable controls for the `label` row on a specific story. Here's how you'd do that:
+
+```js
+import { Button } from 'button';
+
+export default {
+  title: 'Button',
+  component: Button,
+};
+
+export const CustomControls = (args) => <Button {...args} />;
+CustomControls.argTypes = {
+  borderWidth: { table: { disable: true } },
+  label: { control: { disable: true } },
+};
+```
+
+Like [story parameters](https://storybook.js.org/docs/react/writing-stories/parameters), `args` and `argTypes` annotations are hierarchically merged, so story-level annotations overwrite component-level annotations.
+
 ## Hide NoControls warning
 
 If you don't plan to handle the control args inside your Story, you can remove the warning with:


### PR DESCRIPTION
Issue: #12260

This PR addresses #12260. The [docs](https://storybook.js.org/docs/vue/essentials/controls) previously did not include instructions on how to disable controls for specified fields, but the information was available on a [README file](https://github.com/storybookjs/storybook/blob/next/addons/controls/README.md#how-can-i-disable-controls-for-certain-fields-on-a-particular-story).

## What I did
Adapted the [section of the README](https://github.com/storybookjs/storybook/blob/next/addons/controls/README.md#how-can-i-disable-controls-for-certain-fields-on-a-particular-story) file into a new section in the [Controls](https://storybook.js.org/docs/vue/essentials/controls) documentation.

I would also like to include documentation on how to disable controls for an entire story file, but I don't know how to do that! (And I figure it can be it's own PR.)

## How to test
This is an update to the docs. It should be reviewed for clarity, but I doubt any automated tests are applicable.
- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
