### PR TITLE
Examples page qualification

### DIFF
--- a/docs/get-started/examples.md
+++ b/docs/get-started/examples.md
@@ -19,6 +19,12 @@ See how to build UIs using a [component driven](https://www.componentdriven.org/
 
 - [BBC Psammead](https://bbc.github.io/psammead/?path=/story/components-brand--without-brand-link)
 - [The Guardian](https://master--5dfcbf3012392c0020e7140b.chromatic.com)
+<!-- 
+NOTE for contributors: This is a curated list. Here's what qualifies:
+- Website or app Storybook that illustrates how to build UIs from small components to pages
+- Used in production by a medium/large company or large open source community
+- Must be developed actively
+  -->
 
 ## Design systems and component libraries
 
@@ -38,3 +44,9 @@ Learn how leading teams build design systems.
 - [AppNexus Lucid](https://appnexus.github.io/lucid/?path=/docs/documentation-introduction--introduction)
 - [React Pakistan](https://react-pakistan.github.io/react-storybook-composed)
 - [AnyVision UI](http://storybook.anyvision.co/)
+<!-- 
+NOTE for contributors: This is a curated list. Here's what qualifies:
+- Design system or component library
+- Used in production by a medium/large company or large open source community (Grommet, Chakra)
+- Must have greater than 20+ contributors OR 1k+ GitHub stars OR show exceptional use of SB features
+  -->

--- a/docs/get-started/examples.md
+++ b/docs/get-started/examples.md
@@ -42,7 +42,6 @@ Learn how leading teams build design systems.
 - [Reaviz](https://reaviz.io/?path=/story/docs-intro--page)
 - [ShareGate Orbit](https://orbit.sharegate.design/?path=/docs/getting-started-packages--page)
 - [AppNexus Lucid](https://appnexus.github.io/lucid/?path=/docs/documentation-introduction--introduction)
-- [React Pakistan](https://react-pakistan.github.io/react-storybook-composed)
 - [AnyVision UI](http://storybook.anyvision.co/)
 <!-- 
 NOTE for contributors: This is a curated list. Here's what qualifies:


### PR DESCRIPTION
Issue:na

## What I did
I added qualification criteria for the Storybook examples page. 

When I created the examples page I only mentioned that these examples were a "curated" list. That's confusing because it doesn't give specifics about how the list is curated. 

The goal with the example page isn't to list every Storybook.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

