### PR TITLE
[Docs] Fix React workflows - mocking providers code sample syntax

### DIFF
--- a/docs/snippets/react/component-story-with-query.js.mdx
+++ b/docs/snippets/react/component-story-with-query.js.mdx
@@ -3,10 +3,10 @@
 
 import MyComponentThatHasAQuery, { MyQuery} from '../component-that-has-a-query';
 
-const Template=(args)=><MyComponentThatHasAQuery {...args}/>;
+const Template = (args) => <MyComponentThatHasAQuery {...args}/>;
 
-export const LoggedOut = () => Template.bind({});
-LoggedOut.parameters: {
+export const LoggedOut = Template.bind({});
+LoggedOut.parameters = {
   apolloClient: {
     mocks: [
       {

--- a/docs/snippets/react/component-story-with-query.js.mdx
+++ b/docs/snippets/react/component-story-with-query.js.mdx
@@ -21,5 +21,5 @@ LoggedOut.parameters = {
       },
     ],
   },
- };
+};
  ```


### PR DESCRIPTION
Issue: Invalid syntax in **Building Pages with Storybook -> Mocking Connected Components -> Mocking Providers** code sample may mislead users trying to adopt this pattern _(like me, earlier today)_.

https://storybook.js.org/docs/react/workflows/build-pages-with-storybook#mocking-providers

## What I did
- Replace invalid `LoggedOut.parameters: {...params}` syntax with `LoggedOut.parameters = {...params}`
- Update `Template.bind({});` syntax to match other examples

## How to test
Verify in documentation site, or by viewing MDX in Github.