### PR TITLE
Addon-docs: Introduce undefined filtering to jsxDecorator

### DIFF
--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -32,14 +32,14 @@ describe('renderJsx', () => {
   });
   it('undefined values', () => {
     expect(renderJsx(<div className={undefined}>hello</div>, {})).toMatchInlineSnapshot(`
-      <div className={undefined}>
+      <div>
         hello
       </div>
     `);
   });
   it('null values', () => {
     expect(renderJsx(<div className={null}>hello</div>, {})).toMatchInlineSnapshot(`
-      <div className={null}>
+      <div>
         hello
       </div>
     `);

--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -30,6 +30,20 @@ describe('renderJsx', () => {
       </div>
     `);
   });
+  it('undefined values', () => {
+    expect(renderJsx(<div className={undefined}>hello</div>, {})).toMatchInlineSnapshot(`
+      <div className={undefined}>
+        hello
+      </div>
+    `);
+  });
+  it('null values', () => {
+    expect(renderJsx(<div className={null}>hello</div>, {})).toMatchInlineSnapshot(`
+      <div className={null}>
+        hello
+      </div>
+    `);
+  });
   it('large objects', () => {
     const obj: Record<string, string> = {};
     range(20).forEach((i) => {

--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -39,7 +39,7 @@ describe('renderJsx', () => {
   });
   it('null values', () => {
     expect(renderJsx(<div className={null}>hello</div>, {})).toMatchInlineSnapshot(`
-      <div>
+      <div className={null}>
         hello
       </div>
     `);

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -90,7 +90,7 @@ export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
       : {};
 
   const filterDefaults = {
-    filterProps: (value: any, key: string): boolean => value != null,
+    filterProps: (value: any, key: string): boolean => value !== undefined,
   };
 
   const opts = {

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -8,7 +8,7 @@ import { logger } from '@storybook/client-logger';
 
 import { SourceType, SNIPPET_RENDERED } from '../../shared';
 
-interface JSXOptions {
+type JSXOptions = Options & {
   /** How many wrappers to skip when rendering the jsx */
   skip?: number;
   /** Whether to show the function in the jsx tab */
@@ -21,7 +21,7 @@ interface JSXOptions {
   onBeforeRender?(dom: string): string;
   /** A function ran after a story is rendered (prefer this over `onBeforeRender`) */
   transformSource?(dom: string, context?: StoryContext): string;
-}
+};
 
 /** Run the user supplied onBeforeRender function if it exists */
 const applyBeforeRender = (domString: string, options: JSXOptions) => {
@@ -84,14 +84,20 @@ export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
     }
   }
 
-  const opts =
+  const displayNameDefaults =
     typeof options.displayName === 'string'
-      ? {
-          ...options,
-          showFunctions: true,
-          displayName: () => options.displayName,
-        }
-      : options;
+      ? { showFunctions: true, displayName: () => options.displayName }
+      : {};
+
+  const filterDefaults = {
+    filterProps: (value: any, key: string): boolean => value != null,
+  };
+
+  const opts = {
+    ...displayNameDefaults,
+    ...filterDefaults,
+    ...options,
+  };
 
   const result = React.Children.map(code, (c) => {
     // @ts-ignore FIXME: workaround react-element-to-jsx-string

--- a/addons/docs/src/typings.d.ts
+++ b/addons/docs/src/typings.d.ts
@@ -8,16 +8,6 @@ declare module 'require-from-string';
 declare module 'styled-components';
 declare module 'acorn-jsx';
 
-declare module 'react-element-to-jsx-string' {
-  export interface Options {
-    showFunctions?: boolean;
-    displayName?(): string;
-    tabStop?: number;
-  }
-
-  export default function render(element: React.ReactNode, options: Options): string;
-}
-
 declare module 'sveltedoc-parser' {
   export function parse(options: any): Promise<any>;
 }


### PR DESCRIPTION
Issue: #11976

## What I did

While working on some private storybook stuff, I noticed that JSX source generated by Controls would include undefined values after args were reset. I then checked to make sure this was happening in the public Storybook Design System docs (screenshots below).

I think this a really weird default behavior, so I added a default filterProps in the `jsxDecorator` to filter any null or undefined values from the JSX output.

In addition, I cleaned up the TypeScript types because the `react-element-to-jsx-string` library now provides its own types.

<img width="1042" alt="Screen Shot 2020-09-02 at 6 26 55 PM" src="https://user-images.githubusercontent.com/992373/92061901-42121480-ed4c-11ea-9f73-cbe96d028920.png">
<img width="1034" alt="Screen Shot 2020-09-02 at 6 27 00 PM" src="https://user-images.githubusercontent.com/992373/92061903-43dbd800-ed4c-11ea-8a9f-efd528e898de.png">


## How to test

- Is this testable with Jest or Chromatic screenshots? Yep, added some tests for it.
- Does this need a new example in the kitchen sink apps? I don't think so.
- Does this need an update to the documentation? Not sure, let me know!

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
