### PR TITLE
Addon-docs: Apply transformSource to any SourceType

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -81,12 +81,12 @@ const getSnippet = (snippet: string, storyContext?: StoryContext): string => {
 
   // if user has explicitly set this as dynamic, use snippet
   if (type === SourceType.DYNAMIC) {
-    return snippet;
+    return parameters.docs?.transformSource?.(snippet, storyContext) || snippet;
   }
 
   // if this is an args story and there's a snippet
   if (type === SourceType.AUTO && snippet && isArgsStory) {
-    return snippet;
+    return parameters.docs?.transformSource?.(snippet, storyContext) || snippet;
   }
 
   // otherwise, use the source code logic

--- a/examples/official-storybook/stories/addon-docs/transform-source.stories.js
+++ b/examples/official-storybook/stories/addon-docs/transform-source.stories.js
@@ -11,15 +11,15 @@ export default {
 
 export const code = () => 'StoryType "CODE" story which has source transformed';
 code.parameters = {
-  docs: { source: { type: 'CODE' } },
+  docs: { source: { type: 'code' } },
 };
 
 export const dynamic = () => 'StoryType "DYNAMIC" story which has source transformed';
 dynamic.parameters = {
-  docs: { source: { type: 'DYMANIC' } },
+  docs: { source: { type: 'dynamic' } },
 };
 
 export const auto = () => 'StoryType "AUTO" story which has source transformed';
 dynamic.parameters = {
-  docs: { source: { type: 'AUTO' } },
+  docs: { source: { type: 'auto' } },
 };

--- a/examples/official-storybook/stories/addon-docs/transform-source.stories.js
+++ b/examples/official-storybook/stories/addon-docs/transform-source.stories.js
@@ -21,5 +21,5 @@ dynamic.parameters = {
 
 export const auto = () => 'StoryType "AUTO" story which has source transformed';
 dynamic.parameters = {
-  docs: { storySource: 'AUTO', source: { type: 'AUTO' } },
+  docs: { source: { type: 'AUTO' } },
 };

--- a/examples/official-storybook/stories/addon-docs/transform-source.stories.js
+++ b/examples/official-storybook/stories/addon-docs/transform-source.stories.js
@@ -1,0 +1,25 @@
+export default {
+  title: 'Addons/Docs/transformSource',
+  parameters: {
+    docs: {
+      transformSource(src, ctx) {
+        return `// We transformed this!\n const example = ${src};`;
+      },
+    },
+  },
+};
+
+export const code = () => 'StoryType "CODE" story which has source transformed';
+code.parameters = {
+  docs: { source: { type: 'CODE' } },
+};
+
+export const dynamic = () => 'StoryType "DYNAMIC" story which has source transformed';
+dynamic.parameters = {
+  docs: { source: { type: 'DYMANIC' } },
+};
+
+export const auto = () => 'StoryType "AUTO" story which has source transformed';
+dynamic.parameters = {
+  docs: { storySource: 'AUTO', source: { type: 'AUTO' } },
+};


### PR DESCRIPTION
Issue: N/A

## What I did

I made the `transformSource` function (if specified) apply to all `SourceType` snippets.

While trying to modify the snippets produced for `SourceType.DYNAMIC`, I noticed that the `transformSource` option was only being applied to `SourceType.CODE` snippets. This seems to be due to it being called inside `enhanceSource`, but the `SourceType` refactoring came after, so I think it got missed in the shuffle.

## How to test

- Is this testable with Jest or Chromatic screenshots? I don't think so, I see some other refactors that can happen with enhanceSource and then things can be tested together.
- Does this need a new example in the kitchen sink apps? I believe the kitchen sink app will get these through it's `transformSource` config.
- Does this need an update to the documentation? Nope, the recipe actually makes it sound like this is globally called already.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
