### PR TITLE
Addon-docs: Prefer flow's union elements over raw values

### DIFF
--- a/addons/docs/src/lib/docgen/flow/createPropDef.test.ts
+++ b/addons/docs/src/lib/docgen/flow/createPropDef.test.ts
@@ -269,6 +269,54 @@ describe('type', () => {
     expect(type.summary).toBe('number | string');
   });
 
+  it('should support nested union elements', () => {
+    const docgenInfo = createDocgenInfo({
+      flowType: {
+        name: 'union',
+        raw: '"minimum" | "maximum" | UserSize',
+        elements: [
+          {
+            name: 'literal',
+            value: '"minimum"',
+          },
+          {
+            name: 'literal',
+            value: '"maximum"',
+          },
+          {
+            name: 'union',
+            raw: 'string | number',
+            elements: [
+              {
+                name: 'number',
+              },
+              {
+                name: 'string',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('"minimum" | "maximum" | number | string');
+  });
+
+  it('uses raw union value if elements are missing', () => {
+    const docgenInfo = createDocgenInfo({
+      flowType: {
+        name: 'union',
+        raw: '"minimum" | "maximum" | UserSize',
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('"minimum" | "maximum" | UserSize');
+  });
+
   it('should support intersection', () => {
     const docgenInfo = createDocgenInfo({
       flowType: {

--- a/addons/docs/src/lib/docgen/flow/createType.ts
+++ b/addons/docs/src/lib/docgen/flow/createType.ts
@@ -7,17 +7,40 @@ enum FlowTypesType {
   SIGNATURE = 'signature',
 }
 
-interface DocgenFlowUnionType extends DocgenFlowType {
-  elements: { name: string; value: string }[];
+interface DocgenFlowUnionElement {
+  name: string;
+  value?: string;
+  elements?: DocgenFlowUnionElement[];
+  raw?: string;
 }
 
-function generateUnion({ name, raw, elements }: DocgenFlowUnionType): PropType {
-  if (raw != null) {
-    return createSummaryValue(raw);
+interface DocgenFlowUnionType extends DocgenFlowType {
+  elements: DocgenFlowUnionElement[];
+}
+
+function generateUnionElement({ name, value, elements, raw }: DocgenFlowUnionElement): string {
+  if (value != null) {
+    return value;
   }
 
   if (elements != null) {
-    return createSummaryValue(elements.map((x) => x.value).join(' | '));
+    return elements.map(generateUnionElement).join(' | ');
+  }
+
+  if (raw != null) {
+    return raw;
+  }
+
+  return name;
+}
+
+function generateUnion({ name, raw, elements }: DocgenFlowUnionType): PropType {
+  if (elements != null) {
+    return createSummaryValue(elements.map(generateUnionElement).join(' | '));
+  }
+
+  if (raw != null) {
+    return createSummaryValue(raw);
   }
 
   return createSummaryValue(name);


### PR DESCRIPTION
Issue: N/A

## What I did

I changed the generation of Flow's union type to prefer the `elements` over `raw` values because the `raw` value doesn't include fully resolved types (as demonstrated in the new tests I added).

## How to test

- Is this testable with Jest or Chromatic screenshots? Yep! Added Jest tests.
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
