### PR TITLE
Add install instructions for upgraders

### DIFF
--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -11,6 +11,27 @@ A major strength of Storybook are [addons](/addons/) that extend Storybook’s U
 - [Backgrounds](./backgrounds.md)
 - [Toolbars & globals](./toolbars-and-globals.md)
 
+<details>
+<summary>Upgraders may need to install and configure essential addons manually.</summary>
+
+Install the addon-essentials package from `npm`.
+
+```shell
+npm install --save-dev @storybook/addon-essentials
+```
+
+Then configure Storybook to use it by modifying the `main.js` configuration file.
+
+```js
+// .storybook/main.js
+
+module.exports = {
+  stories: ['../my-project/src/components/*.@(js|md)'],
+  addons: ['@storybook/addon-essentials'],
+};
+```
+</details>
+
 ### Configuration
 
 Essentials is "zero config”, it comes with a recommended configuration out of the box.

--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -11,26 +11,6 @@ A major strength of Storybook are [addons](/addons/) that extend Storybook’s U
 - [Backgrounds](./backgrounds.md)
 - [Toolbars & globals](./toolbars-and-globals.md)
 
-<details>
-<summary>Upgraders may need to install and configure essential addons manually.</summary>
-
-Install the addon-essentials package from `npm`.
-
-```shell
-npm install --save-dev @storybook/addon-essentials
-```
-
-Then configure Storybook to use it by modifying the `main.js` configuration file.
-
-```js
-// .storybook/main.js
-
-module.exports = {
-  addons: ['@storybook/addon-essentials'],
-};
-```
-</details>
-
 ### Configuration
 
 Essentials is "zero config”, it comes with a recommended configuration out of the box.
@@ -60,3 +40,27 @@ As an example, if the background addon wasn't necessary to your work, you would 
 You can use the following keys for each individual addon: `actions`, `backgrounds`, `controls`, `docs`, `viewport`, `toolbars`.
 
 </div>
+
+### Upgrading from previous versions
+
+If you're upgrading from a previous Storybook version, you will need to add the `@storybook/addon-essentials` package manually.
+
+In your terminal run the following command:
+
+```shell
+npm install --save-dev @storybook/addon-essentials
+```
+
+<div class="aside">
+  
+If you're using <a href="https://yarnpkg.com/">yarn</a>, you'll need to adjust the command accordingly.
+
+</div>
+
+Update your Storybook configuration (in `.storybook/main.js`) to include the essentials addon.
+
+```js
+module.exports = {
+  addons: ['@storybook/addon-essentials'],
+};
+```

--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -26,7 +26,6 @@ Then configure Storybook to use it by modifying the `main.js` configuration file
 // .storybook/main.js
 
 module.exports = {
-  stories: ['../my-project/src/components/*.@(js|md)'],
   addons: ['@storybook/addon-essentials'],
 };
 ```


### PR DESCRIPTION
Issue: Documentation for essential addons was incomplete for some upgraders

## What I did

I wrote out the details that were missing for me when I tried using these essential addons. Included instructions on what to install and how to update the `main.js` configuration file.

## How to test

This is a documentation update only, so all existing tests should maintain their current state after merging this change in.
