### PR TITLE
docs: remove reference to `configure()`

### DIFF
--- a/docs/writing-stories/naming-components-and-hierarchy.md
+++ b/docs/writing-stories/naming-components-and-hierarchy.md
@@ -111,4 +111,4 @@ Which would result in this story ordering:
 7. `Components` and `Components/*` stories
 8. All other stories
 
-Note that the `order` option is independent of the `method` option; stories are sorted first by the `order` array and then by either the `method: 'alphabetical'` or the default `configure()` import order.
+Note that the `order` option is independent of the `method` option; stories are sorted first by the `order` array and then by the `method: 'alphabetical'`.


### PR DESCRIPTION
Issue:

## What I did

Removed reference to deprecated function `configure()`

## How to test

- Is this testable with Jest or Chromatic screenshots? :man_shrugging: 
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? it is an update to documentation

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
