### PR TITLE
Components: Add graphql support to SyntaxHighlighter

### DIFF
--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.stories.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.stories.tsx
@@ -84,8 +84,8 @@ storiesOf('Basics/SyntaxHighlighter', module)
   ))
   .add('graphql', () => (
     <SyntaxHighlighter language="graphql" copyable={false}>
-      {`query HeroNameAndFriends {
-          hero {
+      {`query HeroNameAndFriends($episode: Episode) {
+          hero(episode: $episode) {
             name
             friends {
               name

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.stories.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.stories.tsx
@@ -82,6 +82,19 @@ storiesOf('Basics/SyntaxHighlighter', module)
       `}
     </SyntaxHighlighter>
   ))
+  .add('graphql', () => (
+    <SyntaxHighlighter language="graphql" copyable={false}>
+      {`query HeroNameAndFriends {
+          hero {
+            name
+            friends {
+              name
+            }
+          }
+        }
+      `}
+    </SyntaxHighlighter>
+  ))
   .add('unsupported', () => (
     <SyntaxHighlighter language="C#" bordered copyable>
       {`

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -8,6 +8,7 @@ import jsx from 'react-syntax-highlighter/dist/cjs/languages/prism/jsx';
 import bash from 'react-syntax-highlighter/dist/cjs/languages/prism/bash';
 import css from 'react-syntax-highlighter/dist/cjs/languages/prism/css';
 import json from 'react-syntax-highlighter/dist/cjs/languages/prism/json';
+import graphql from 'react-syntax-highlighter/dist/cjs/languages/prism/graphql';
 import html from 'react-syntax-highlighter/dist/cjs/languages/prism/markup';
 import md from 'react-syntax-highlighter/dist/cjs/languages/prism/markdown';
 import yml from 'react-syntax-highlighter/dist/cjs/languages/prism/yaml';
@@ -33,6 +34,7 @@ ReactSyntaxHighlighter.registerLanguage('css', css);
 ReactSyntaxHighlighter.registerLanguage('html', html);
 ReactSyntaxHighlighter.registerLanguage('tsx', tsx);
 ReactSyntaxHighlighter.registerLanguage('typescript', typescript);
+ReactSyntaxHighlighter.registerLanguage('graphql', graphql);
 
 const themedSyntax = memoize(2)((theme) =>
   Object.entries(theme.code || {}).reduce((acc, [key, val]) => ({ ...acc, [`* .${key}`]: val }), {})


### PR DESCRIPTION
## Background
I am currently working on an addon to display metadata about Apollo-connected components, building on the approach referenced in these docs: https://storybook.js.org/docs/react/workflows/build-pages-with-storybook#mocking-providers

This add-on leverages the `SyntaxHighlighter` Storybook component, but `graphql` highlighting is not exposed through the component library. As closely coupled Graphql integration becomes more common in React component development, it would be nice to treat this as a first-class language option.

_(No issue, but I can file one if this requires further discussion)_

## What I did
- Add `graphql` syntax highlighting to Storybook `SyntaxHighlighter` component
- Add new Story example

## How to test

- `yarn storybook`
- Navigate to new Story example under **Basics -> SyntaxHighlighter**
- Or directly: http://localhost:9011/?path=/story/basics-syntaxhighlighter--graphql

![SB-gql](https://user-images.githubusercontent.com/428636/92268015-a6011e00-eeaf-11ea-8565-90b9f258878c.png)

