### PR TITLE
Addon-docs: Add Methods to web components ArgsTable

### DIFF
--- a/addons/docs/src/frameworks/web-components/custom-elements.ts
+++ b/addons/docs/src/frameworks/web-components/custom-elements.ts
@@ -17,6 +17,7 @@ interface Tag {
   attributes?: TagItem[];
   properties?: TagItem[];
   events?: TagItem[];
+  methods?: TagItem[];
   slots?: TagItem[];
   cssProperties?: TagItem[];
 }
@@ -74,6 +75,7 @@ export const extractArgTypesFromElements = (tagName: string, customElements: Cus
       ...mapData(metaData.attributes, 'attributes'),
       ...mapData(metaData.properties, 'properties'),
       ...mapData(metaData.events, 'events'),
+      ...mapData(metaData.methods, 'methods'),
       ...mapData(metaData.slots, 'slots'),
       ...mapData(metaData.cssProperties, 'css'),
     }

--- a/examples/web-components-kitchen-sink/custom-elements.json
+++ b/examples/web-components-kitchen-sink/custom-elements.json
@@ -46,6 +46,12 @@
           "description": "Fires whenever it switches between front/back"
         }
       ],
+      "methods": [
+        {
+          "name": "testMethod",
+          "description": "Some web component frameworks like Stencil generate extra docs for methods. These are also displayed in the ArgsTable."
+        }
+      ],
       "slots": [
         {
           "name": "",


### PR DESCRIPTION
Issue: #12412

## What I did

Some web component frameworks like Stencil are able to generate documentation for public methods of web components.
These should be shown in the ArgsTable of Storybook next to Attributes, Events, Slots etc. but are currently missing.

I added 'methods' to the custom elements interface and extractor and also included a demo entry to the custom-elements.json file in the web components kitchen-sink to display the results.

## How to test

- run web components kitchen-sink and find the new Methods section in the ArgsTable

## Screenshot

![image](https://user-images.githubusercontent.com/306996/92464025-d822c080-f1cc-11ea-9e73-cba975528fe2.png)
