### PR TITLE
docs: fix typo in migration docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -159,7 +159,7 @@ Basic.decorators = [ ... ];
 2. Similar to React's `displayName`, `propTypes`, `defaultProps` annotations
 3. We're introducing a new feature, [Storybook Args](https://docs.google.com/document/d/1Mhp1UFRCKCsN8pjlfPdz8ZdisgjNXeMXpXvGoALjxYM/edit?usp=sharing), where the new syntax will be significantly more ergonomic
 
-To help you upgrade your stories, we've crated a codemod:
+To help you upgrade your stories, we've created a codemod:
 
 ```
 npx @storybook/cli@next migrate csf-hoist-story-annotations --glob="**/*.stories.js"


### PR DESCRIPTION
Issue: fix typo in migration documentation

## What I did

Fixed a small typo in the docs

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? It's an update to the docs.

If your answer is yes to any of these, please make sure to include it in your PR.