### PR TITLE
Addons: Move extract-source to storybook/addons public API

### DIFF
--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -1,6 +1,5 @@
 import { combineParameters } from '@storybook/client-api';
-import { StoryContext, Parameters } from '@storybook/addons';
-import { extractSource, LocationsMap } from '@storybook/source-loader';
+import { StoryContext, Parameters, extractSource, LocationsMap } from '@storybook/addons';
 
 interface StorySource {
   source: string;

--- a/lib/addons/src/public_api.ts
+++ b/lib/addons/src/public_api.ts
@@ -10,5 +10,6 @@ export * from './index';
 export * from './types';
 export * from './storybook-channel-mock';
 export * from './hooks';
+export * from './source';
 
 export default addons;

--- a/lib/addons/src/source.ts
+++ b/lib/addons/src/source.ts
@@ -1,4 +1,18 @@
-import type { SourceBlock } from './types';
+export interface SourceLoc {
+  line: number;
+  col: number;
+}
+
+export interface SourceBlock {
+  startBody: SourceLoc;
+  endBody: SourceLoc;
+  startLoc: SourceLoc;
+  endLoc: SourceLoc;
+}
+
+export interface LocationsMap {
+  [key: string]: SourceBlock;
+}
 
 /**
  * given a location, extract the text from the full source

--- a/lib/source-loader/src/abstract-syntax-tree/generate-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/generate-helpers.js
@@ -1,4 +1,5 @@
 import { storyNameFromExport, sanitize } from '@storybook/csf';
+import { extractSource } from '@storybook/addons';
 import mapKeys from 'lodash/mapKeys';
 import { patchNode } from './parse-helpers';
 import getParser from './parsers';
@@ -9,7 +10,6 @@ import {
   popParametersObjectFromDefaultExport,
   findExportsMap as generateExportsMap,
 } from './traverse-helpers';
-import { extractSource } from '../extract-source';
 
 export function sanitizeSource(source) {
   return JSON.stringify(source)

--- a/lib/source-loader/src/index.ts
+++ b/lib/source-loader/src/index.ts
@@ -4,5 +4,3 @@ import { transform } from './build';
 export default transform;
 
 export * from './types';
-
-export { extractSource } from './extract-source';

--- a/lib/source-loader/src/types.ts
+++ b/lib/source-loader/src/types.ts
@@ -1,15 +1,2 @@
-export interface SourceLoc {
-  line: number;
-  col: number;
-}
-
-export interface SourceBlock {
-  startBody: SourceLoc;
-  endBody: SourceLoc;
-  startLoc: SourceLoc;
-  endLoc: SourceLoc;
-}
-
-export interface LocationsMap {
-  [key: string]: SourceBlock;
-}
+// This file should eventually go away, but it remains inc ase someone needs these types
+export { SourceLoc, SourceBlock, LocationsMap } from '@storybook/addons';


### PR DESCRIPTION
Alternative to #12422

## What I did

I moved the `extractSource` method from `@storybook/source-loader` into the `public_api` of `@storybook/addons`. This avoids including all of source-loader in the bundle (which I thought would be DCE'd previously) for `addon-docs`.

I think this is a good solution because extracting the source might be something other addons want to do in the future, and this file can be expanded to include other source code-related utilities.

Sorry about exploding the bundle size in alpha.3, hopefully this solves it in a more scalable way!

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
