### PR TITLE
Source-loader: Export extract-source in its own entry point

### DIFF
--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -1,6 +1,6 @@
 import { combineParameters } from '@storybook/client-api';
 import { StoryContext, Parameters } from '@storybook/addons';
-import { extractSource, LocationsMap } from '@storybook/source-loader';
+import { extractSource, LocationsMap } from '@storybook/source-loader/extract-source';
 
 interface StorySource {
   source: string;

--- a/addons/storysource/src/StoryPanel.tsx
+++ b/addons/storysource/src/StoryPanel.tsx
@@ -9,7 +9,7 @@ import {
   createSyntaxHighlighterElement,
 } from '@storybook/components';
 
-import { SourceBlock, LocationsMap } from '@storybook/source-loader';
+import { SourceBlock, LocationsMap } from '@storybook/source-loader/extract-source';
 import { Story } from '@storybook/api/dist/lib/stories';
 
 const StyledStoryLink = styled(Link)<{ to: string; key: string }>(({ theme }) => ({

--- a/lib/source-loader/extract-source.d.ts
+++ b/lib/source-loader/extract-source.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/extract-source.d';

--- a/lib/source-loader/extract-source.js
+++ b/lib/source-loader/extract-source.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/extract-source');

--- a/lib/source-loader/src/extract-source.ts
+++ b/lib/source-loader/src/extract-source.ts
@@ -1,5 +1,7 @@
 import type { SourceBlock } from './types';
 
+export * from './types';
+
 /**
  * given a location, extract the text from the full source
  */

--- a/lib/source-loader/src/index.ts
+++ b/lib/source-loader/src/index.ts
@@ -2,7 +2,3 @@
 import { transform } from './build';
 
 export default transform;
-
-export * from './types';
-
-export { extractSource } from './extract-source';


### PR DESCRIPTION
Issue: Alternative to #12422

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
