### PR TITLE
Addon-controls: Default to radio control for small enums

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -96,7 +96,7 @@ Up until now, we only used auto-generated controls based on the component we're 
 
 By default, Storybook will add controls for all args that:
 
-- It infers from the component definition [if your framework supports it](https://github.com/storybookjs/storybook/blob/next/addons/controls/README.md#framework-support).
+- It infers from the component definition [if your framework supports it](../api/frameworks-feature-support.md).
 
 - Appear in the list of args for your story.
 
@@ -145,7 +145,9 @@ If you need to customize a control to use a enum data type in your story, for in
 <!-- prettier-ignore-end -->
 
 <div class="aside">
-If you don't provide a specific one, it defaults to select control type.
+If you don't provide a specific one, it defaults to:
+- a radio type for enums with 5 or less elements
+- a select control type with more than 5 elements
 </div>
 
 If you need to customize a control for a number data type in your story, you can do it like so:
@@ -161,7 +163,7 @@ If you need to customize a control for a number data type in your story, you can
 <!-- prettier-ignore-end -->
 
 <div class="aside">
-If you don't provide a specific one, it defaults to  number control type.
+If you don't provide a specific one, it defaults to the number control type.
 </div>
 
 ### Parameters

--- a/lib/client-api/src/inferControls.ts
+++ b/lib/client-api/src/inferControls.ts
@@ -28,6 +28,9 @@ const inferControl = (argType: ArgType): any => {
       return { type: 'number' };
     case 'enum': {
       const { value } = type as SBEnumType;
+      if (value?.length <= 5) {
+        return { type: 'radio', options: value };
+      }
       return { type: 'select', options: value };
     }
     case 'function':


### PR DESCRIPTION
Issue: N/A

## What I did

I wanted to propose this and see what others thought.

I changed the default inferred control for an enum to be a radio input for any enum that is 5 elements or less. I think radio inputs are a more natural default, but they get unwieldy with large enums. I just picked 5 randomly but could see it being adjusted.

Anyway, what do you think? If this makes sense, I can update the docs and stuff.

Edit: Oh, I forgot my screenshot from the `cra-ts-essentials` storybook!

<img width="1019" alt="Screen Shot 2020-09-09 at 3 29 45 PM" src="https://user-images.githubusercontent.com/992373/92663387-f7494d00-f2b5-11ea-8a26-4c36d2d4502d.png">


## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
