### PR TITLE
Fix broken link in writing-stories/decorator

### DIFF
--- a/docs/writing-stories/decorators.md
+++ b/docs/writing-stories/decorators.md
@@ -85,7 +85,7 @@ To define a decorator for all stories of a component, use the `decorators` key o
 
 ## Global decorators
 
-We can also set a decorator for **all stories** via the `decorators` export of your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering.md) file (this is the file where you configure all stories):
+We can also set a decorator for **all stories** via the `decorators` export of your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering) file (this is the file where you configure all stories):
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
## Issue:
The `.storybook/preview.js` link in [this section](https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators) was broken as the anchor also had a `.md` extension

## What I did
Removed the `.md` extension after the anchor in link

## How to test
Visit the decorators page and use the link


- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
