### PR TITLE
Run benchmarks with no DLL

### DIFF
--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -204,6 +204,6 @@ export const cra_bench: Parameters = {
   generator: [
     'npx create-react-app@{{version}} {{name}}-{{version}}',
     'cd {{name}}-{{version}}',
-    "npx @storybook/bench 'npx sb init' --label cra",
+    "npx @storybook/bench 'npx sb init' --label cra --extra-flags '--no-dll'",
   ].join(' && '),
 };


### PR DESCRIPTION
Issue: #12637

## What I did

This PR simulates #12637 by simply running Storybook without DLLs
