### PR TITLE
Add GitLab UI to list of component libraries

### DIFF
--- a/docs/get-started/examples.md
+++ b/docs/get-started/examples.md
@@ -44,6 +44,7 @@ Learn how leading teams build design systems.
 - [AppNexus Lucid](https://appnexus.github.io/lucid/?path=/docs/documentation-introduction--introduction)
 - [AnyVision UI](http://storybook.anyvision.co/)
 - [Skyscanner Backpack](https://backpack.github.io/storybook/)
+- [GitLab UI](https://gitlab-org.gitlab.io/gitlab-ui)
 <!-- 
 NOTE for contributors: This is a curated list. Here's what qualifies:
 - Design system or component library


### PR DESCRIPTION
## What I did

Added a link to [GitLab UI](https://gitlab-org.gitlab.io/gitlab-ui) to the [curated list of component libraries](https://storybook.js.org/docs/react/get-started/examples).

## Why

I believe GitLab UI meets all of the follow criteria mentioned in this file's comments:

- [x] _Design system or component library_
   - Storybook is [GitLab's primary medium](https://about.gitlab.com/handbook/engineering/ux/ux-resources/designers-guide-to-contributing-ui-changes-in-gitlab/#contributing-to-gitlab-ui-component-system) for developing and demoing Vue components used in GitLab
- [x] _Used in production by a medium/large company or large open source community (Grommet, Chakra)_
   - GitLab currently has [1304 team members](https://about.gitlab.com/company/team/) and [3,333 contributors](http://contributors.gitlab.com/)
- [x] _Must have greater than 20+ contributors OR 1k+ GitHub stars OR show exceptional use of SB features_
   - GitLab UI has [over 100 contributors](https://gitlab.com/gitlab-org/gitlab-ui/-/graphs/master)