### PR TITLE
Fix code example

### DIFF
--- a/docs/snippets/common/component-story-mdx-story-by-name.mdx.mdx
+++ b/docs/snippets/common/component-story-mdx-story-by-name.mdx.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 export const Template = (args) => <Button {...args} />;
 
 <Story name="Basic" args={{ label: ‘hello’ }}>
-  {Template.bind({})
+  {Template.bind({})}
 </Story>
 
 ```


### PR DESCRIPTION
Issue:

Fixed a missing `}` in `docs/snippets/common/component-story-mdx-story-by-name.mdx.mdx` code example.