### PR TITLE
Core: Fix Yarn monorepo compatibility 

### DIFF
--- a/app/react/src/server/framework-preset-cra.ts
+++ b/app/react/src/server/framework-preset-cra.ts
@@ -7,7 +7,7 @@ type Preset = string | { name: string };
 const checkForNewPreset = (presetsList: Preset[]) => {
   const hasNewPreset = presetsList.some((preset: Preset) => {
     const presetName = typeof preset === 'string' ? preset : preset.name;
-    return presetName === '@storybook/preset-create-react-app';
+    return presetName.includes('@storybook/preset-create-react-app');
   });
 
   if (!hasNewPreset) {

--- a/lib/core/src/server/presets.js
+++ b/lib/core/src/server/presets.js
@@ -69,7 +69,7 @@ export const resolveAddonName = (configDir, name) => {
     // eslint-disable-next-line no-empty
   } catch (err) {}
 
-  return { name, type: 'presets' };
+  return { name: resolveFrom(configDir, name), type: 'presets' };
 };
 
 const map = ({ configDir }) => (item) => {

--- a/lib/core/src/server/preview/base-webpack.config.js
+++ b/lib/core/src/server/preview/base-webpack.config.js
@@ -5,8 +5,8 @@ import { logger } from '@storybook/node-logger';
 
 export async function createDefaultWebpackConfig(storybookBaseConfig, options) {
   if (
-    options.presetsList.some(
-      (preset) => (preset.name || preset) === '@storybook/preset-create-react-app'
+    options.presetsList.some((preset) =>
+      (preset.name || preset).includes('@storybook/preset-create-react-app')
     )
   ) {
     return storybookBaseConfig;

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -83,6 +83,13 @@ const configureYarn2 = async ({ cwd }: Options) => {
     `yarn config set npmScopes --json '{ "storybook": { "npmRegistryServer": "http://localhost:6000/" } }'`,
     // Some required magic to be able to fetch deps from local registry
     `yarn config set unsafeHttpWhitelist --json '["localhost"]'`,
+    // Disable fallback mode to make sure everything is required correctly
+    `yarn config set pnpFallbackMode none`,
+    // Add package extensions
+    // https://github.com/casesandberg/reactcss/pull/153
+    `yarn config set "packageExtensions.reactcss@*.peerDependencies.react" "*"`,
+    // https://github.com/casesandberg/react-color/pull/746
+    `yarn config set "packageExtensions.react-color@*.peerDependencies.react" "*"`,
   ].join(' && ');
   logger.info(`🎛 Configuring Yarn 2`);
   logger.debug(command);


### PR DESCRIPTION
Follows https://github.com/storybookjs/storybook/pull/11753, I created a new branch as I can't push on @merceyz's fork.

## Issue

> Storybook doesn't work correctly in monorepos with both node_modules (Yarn 1/2) and PnP (Yarn 2) because it's trying to require the addons declared in .storybook/main.js from @storybook/core instead of requiring them on behalf of the config.

> The e2e tests currently pass because Yarn has a compatibility feature, called fallbackMode, that allows dependencies to require top-level dependencies without declaring them as their own. In a monorepo this fails as the top level no longer declares these dependencies, the workspace does, and under the node_modules linker, the addons are not guaranteed to be hoisted to the same level as @storybook/core.

## What I did

All credits go to @merceyz! And a big thanks to @ndelangen for the debugging hour we spend together 😃 

 - Disabled the fallbackMode to highlight the issue in the e2e tests: https://yarnpkg.com/configuration/yarnrc#pnpFallbackMode
 - Resolve presets relatively to configDir
 - Fix issue with preset name checks as they are now resolved path and no more simple names.

## How to test
 - Disable the fallback mode and try to use storybook in a PnP project
 - `example-v2-yarn2` has been updated to not use fallback mode, it should still be 🟢 

