### PR TITLE
Storyshots: Allow taking a screenshot of just a specific element

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -305,3 +305,16 @@ initStoryshots({
 ```
 
 `getScreenshotOptions` receives an object `{ context: {kind, story}, url}`. _kind_ is the kind of the story and the _story_ its name. _url_ is the URL the browser will use to screenshot.
+
+To create a screenshot of just a single element (with its children), rather than the page or current viewport, an ElementHandle can be returned from `beforeScreenshot`:
+```js
+import initStoryshots from '@storybook/addon-storyshots';
+import { imageSnapshot } from '@storybook/addon-storyshots-puppeteer';
+
+const beforeScreenshot = (page) => page.$('#root > *');
+
+initStoryshots({
+  suite: 'Image storyshots',
+  test: imageSnapshot({ storybookUrl: 'http://localhost:6006', beforeScreenshot }),
+});
+```

--- a/addons/storyshots/storyshots-puppeteer/src/config.ts
+++ b/addons/storyshots/storyshots-puppeteer/src/config.ts
@@ -1,5 +1,5 @@
 import { MatchImageSnapshotOptions } from 'jest-image-snapshot';
-import { Base64ScreenShotOptions, Browser, DirectNavigationOptions, Page } from 'puppeteer';
+import { Base64ScreenShotOptions, Browser, DirectNavigationOptions, Page, ElementHandle } from 'puppeteer';
 
 export interface Context {
   kind: string;
@@ -33,7 +33,7 @@ export interface PuppeteerTestConfig extends CommonConfig {
 export interface ImageSnapshotConfig extends CommonConfig {
   getMatchOptions: (options: Options) => MatchImageSnapshotOptions;
   getScreenshotOptions: (options: Options) => Base64ScreenShotOptions;
-  beforeScreenshot: (page: Page, options: Options) => void;
+  beforeScreenshot: (page: Page, options: Options) => void | ElementHandle;
   afterScreenshot: (options: { image: string; context: Context }) => void;
 }
 

--- a/addons/storyshots/storyshots-puppeteer/src/imageSnapshot.ts
+++ b/addons/storyshots/storyshots-puppeteer/src/imageSnapshot.ts
@@ -12,8 +12,8 @@ export const imageSnapshot = (customConfig: Partial<ImageSnapshotConfig> = {}) =
     ...config,
     async testBody(page, options) {
       expect.assertions(1);
-      await beforeScreenshot(page, options);
-      const image = await page.screenshot(getScreenshotOptions(options));
+      const element = await beforeScreenshot(page, options);
+      const image = await (element || page).screenshot(getScreenshotOptions(options));
       await afterScreenshot({ image, context: options.context });
       expect(image).toMatchImageSnapshot(getMatchOptions(options));
     },


### PR DESCRIPTION
I have a lot of very small React components, but the screenshots taken are of the entire viewport, which makes the files a lot larger than they need to be. Furthermore, it's much more difficult to see a 1 or 2 pixel difference on a file that's 600px wide, when the component itself is 50px wide.

## What I did
I added an optional return value to the `beforeScreenshot` function; whenever an ElementHandle is returned, it is used as the basis for the screenshot. This is _not_ a breaking change.

## How to test

- Is this testable with Jest or Chromatic screenshots?
Probably, but there were not any tests yet.

- Does this need a new example in the kitchen sink apps?
Don't think so.

- Does this need an update to the documentation?
Yes, and done.

<!--

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
