### PR TITLE
Addon-docs: Resolve vue-docgen-loader from @storybook/vue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
           command: yarn info @storybook/core
       - run:
           name: run e2e tests
-          command: yarn test:e2e-framework --use-yarn-2 cra
+          command: yarn test:e2e-framework --use-yarn-2 sfcVue cra
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -87,6 +87,7 @@
     "@emotion/core": "^10.0.20",
     "@emotion/styled": "^10.0.17",
     "@storybook/react": "6.1.0-alpha.8",
+    "@storybook/vue": "6.1.0-alpha.8",
     "@storybook/web-components": "6.1.0-alpha.8",
     "@types/cross-spawn": "^6.0.1",
     "@types/doctrine": "^0.0.3",
@@ -118,24 +119,20 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",
+    "@storybook/vue": "6.1.0-alpha.8",
     "babel-loader": "^8.0.0",
     "sveltedoc-parser": "^3.0.4",
     "vue": "^2.6.10",
-    "vue-docgen-api": "^4.29.1",
-    "vue-docgen-loader": "^1.5.0",
     "webpack": ">=4"
   },
   "peerDependenciesMeta": {
+    "@storybook/vue": {
+      "optional": true
+    },
     "sveltedoc-parser": {
       "optional": true
     },
     "vue": {
-      "optional": true
-    },
-    "vue-docgen-api": {
-      "optional": true
-    },
-    "vue-docgen-loader": {
       "optional": true
     },
     "webpack": {

--- a/addons/docs/src/frameworks/vue/preset.ts
+++ b/addons/docs/src/frameworks/vue/preset.ts
@@ -1,7 +1,7 @@
 export function webpackFinal(webpackConfig: any = {}, options: any = {}) {
   webpackConfig.module.rules.push({
     test: /\.vue$/,
-    loader: require.resolve('vue-docgen-loader'),
+    loader: require.resolve('vue-docgen-loader', { paths: [require.resolve('@storybook/vue')] }),
     enforce: 'post',
     options: {
       docgenOptions: {

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -45,16 +45,22 @@
     "ts-dedent": "^1.1.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.9.6",
     "@storybook/vue": "6.1.0-alpha.8",
     "@types/jest": "^25.1.1",
     "@types/webpack-env": "^1.15.2"
   },
   "peerDependencies": {
+    "@babel/core": "^7.9.6",
     "@storybook/vue": "6.1.0-alpha.8",
-    "babel-loader": "^8.0.0"
+    "babel-loader": "^8.0.0",
+    "webpack": ">=4"
   },
   "peerDependenciesMeta": {
     "@storybook/vue": {
+      "optional": true
+    },
+    "webpack": {
       "optional": true
     }
   },

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -45,11 +45,18 @@
     "ts-dedent": "^1.1.1"
   },
   "devDependencies": {
+    "@storybook/vue": "6.1.0-alpha.8",
     "@types/jest": "^25.1.1",
     "@types/webpack-env": "^1.15.2"
   },
   "peerDependencies": {
+    "@storybook/vue": "6.1.0-alpha.8",
     "babel-loader": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@storybook/vue": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -157,7 +157,13 @@ export const sfcVue: Parameters = {
   name: 'sfcVue',
   version: 'latest',
   generator: fromDeps('vue', 'vue-loader', 'vue-template-compiler'),
-  additionalDeps: ['react', 'react-dom'],
+  additionalDeps: [
+    'react',
+    'react-dom',
+    'webpack',
+    // TODO: remove when https://github.com/storybookjs/storybook/issues/11255 is solved
+    'core-js',
+  ],
 };
 
 export const svelte: Parameters = {


### PR DESCRIPTION
## Issue

`@storybook/addon-docs` is declaring `vue-docgen-api` and `vue-docgen-loader` as peer dependencies which means `@storybook/addon-essentials` needs to declare them as well, but this means that the user needs to provide them while what we're actually after is to load them from `@storybook/vue`.

Continuation of https://github.com/storybookjs/storybook/pull/11753 and https://github.com/storybookjs/storybook/pull/12383

## What I did

Changed the resolution to get the `vue-docgen-loader` from `@storybook/vue`

## How to test

The PnP e2e test has been updated and should be green