### PR TITLE
Parallel StoryShots

### DIFF
--- a/addons/storyshots/storyshots-parallel/.gitignore
+++ b/addons/storyshots/storyshots-parallel/.gitignore
@@ -1,0 +1,1 @@
+__image_snapshots__

--- a/addons/storyshots/storyshots-parallel/package.json
+++ b/addons/storyshots/storyshots-parallel/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@storybook/addon-storyshots-parallel",
+  "version": "6.1.0-alpha.9",
+  "private": true,
+  "scripts": {
+    "example": "STORYBOOK_URL=http://localhost:8001/html-kitchen-sink CONCURRENCY=5 jest --forceExit --env '<rootDir>/src/jest-env.js' src/example.test.js"
+  },
+  "dependencies": {
+    "playwright": "^1.3.0",
+    "jest-image-snapshot": "^4.0.2",
+    "p-all": "^3.0.0"
+  }
+}

--- a/addons/storyshots/storyshots-parallel/package.json
+++ b/addons/storyshots/storyshots-parallel/package.json
@@ -3,7 +3,8 @@
   "version": "6.1.0-alpha.9",
   "private": true,
   "scripts": {
-    "example": "STORYBOOK_URL=http://localhost:8001/html-kitchen-sink CONCURRENCY=5 jest --forceExit --env '<rootDir>/src/jest-env.js' src/example.test.js"
+    "example": "STORYBOOK_URL=http://localhost:8001/html-kitchen-sink CONCURRENCY=5 jest --forceExit --env '<rootDir>/dist/jest-env.js' example.test",
+    "prepare": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "playwright": "^1.3.0",

--- a/addons/storyshots/storyshots-parallel/src/example.test.js
+++ b/addons/storyshots/storyshots-parallel/src/example.test.js
@@ -1,0 +1,47 @@
+const pAll = require('p-all');
+const { toMatchImageSnapshot } = require('jest-image-snapshot');
+
+expect.extend({ toMatchImageSnapshot });
+
+const renderScreenshot = async (url) => {
+  const page = await global.browser.newPage();
+  page.on('dialog', async (dialog) => {
+    await dialog.dismiss();
+  });
+  await page.goto(url);
+  const data = await page.screenshot({ fullPage: true });
+  await page.close();
+  return data;
+};
+
+const renderStories = async (stories) => {
+  const screenshotTasks = stories.map((story) => async () => {
+    console.log(`Rendering screenshot for story "${story.name}"`);
+    const image = await renderScreenshot(`${process.env.STORYBOOK_URL}/iframe.html?id=${story.id}`);
+    return { ...story, image };
+  });
+
+  const storyshots = await pAll(screenshotTasks, {
+    concurrency: Number(process.env.CONCURRENCY),
+  });
+
+  return storyshots;
+};
+
+describe('Storyshots', () => {
+  let storyshots;
+
+  const stories = global.stories;
+
+  beforeAll(async () => {
+    storyshots = await renderStories(stories);
+  }, 120000);
+
+  stories.forEach((story) => {
+    test(`Snapshot ${story.name}`, () => {
+      const { image } = storyshots.find(({ id }) => id === story.id);
+      console.log({ image });
+      expect(image).toMatchImageSnapshot();
+    });
+  });
+});

--- a/addons/storyshots/storyshots-parallel/src/example.test.js
+++ b/addons/storyshots/storyshots-parallel/src/example.test.js
@@ -1,46 +1,23 @@
-const pAll = require('p-all');
 const { toMatchImageSnapshot } = require('jest-image-snapshot');
+const { screenshotUrls } = require('../dist/screenshot');
 
 expect.extend({ toMatchImageSnapshot });
 
-const renderScreenshot = async (url) => {
-  const page = await global.browser.newPage();
-  page.on('dialog', async (dialog) => {
-    await dialog.dismiss();
-  });
-  await page.goto(url);
-  const data = await page.screenshot({ fullPage: true });
-  await page.close();
-  return data;
-};
-
-const renderStories = async (stories) => {
-  const screenshotTasks = stories.map((story) => async () => {
-    console.log(`Rendering screenshot for story "${story.name}"`);
-    const image = await renderScreenshot(`${process.env.STORYBOOK_URL}/iframe.html?id=${story.id}`);
-    return { ...story, image };
-  });
-
-  const storyshots = await pAll(screenshotTasks, {
-    concurrency: Number(process.env.CONCURRENCY),
-  });
-
-  return storyshots;
-};
-
 describe('Storyshots', () => {
   let storyshots;
-
-  const stories = global.stories;
+  const { stories, browser } = global;
 
   beforeAll(async () => {
-    storyshots = await renderStories(stories);
+    storyshots = await screenshotUrls(
+      browser,
+      stories.map((s) => s.url),
+      { concurrency: Number(process.env.CONCURRENCY) }
+    );
   }, 120000);
 
   stories.forEach((story) => {
     test(`Snapshot ${story.name}`, () => {
-      const { image } = storyshots.find(({ id }) => id === story.id);
-      console.log({ image });
+      const { image } = storyshots.find(({ url }) => url === story.url);
       expect(image).toMatchImageSnapshot();
     });
   });

--- a/addons/storyshots/storyshots-parallel/src/jest-env.js
+++ b/addons/storyshots/storyshots-parallel/src/jest-env.js
@@ -1,0 +1,35 @@
+const puppeteer = require('puppeteer');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const NodeEnvironment = require('jest-environment-node');
+
+const getStorybookData = async (browser, url) => {
+  const page = await browser.newPage();
+  await page.goto(`${url}/iframe.html`);
+  await page.waitForFunction(
+    'window.__STORYBOOK_STORY_STORE__ && window.__STORYBOOK_STORY_STORE__.extract && window.__STORYBOOK_STORY_STORE__.extract()'
+  );
+
+  return JSON.parse(
+    await page.evaluate(async () => {
+      // eslint-disable-next-line no-undef
+      return JSON.stringify(window.__STORYBOOK_STORY_STORE__.getStoriesJsonData(), null, 2);
+    })
+  );
+};
+
+class CustomEnvironment extends NodeEnvironment {
+  async setup() {
+    await super.setup();
+    const browser = await puppeteer.launch();
+    const storybookData = await getStorybookData(browser, process.env.STORYBOOK_URL);
+    this.global.stories = Object.values(storybookData.stories);
+    this.global.browser = browser;
+  }
+
+  async teardown() {
+    await this.global.browser.close();
+    await super.teardown();
+  }
+}
+
+module.exports = CustomEnvironment;

--- a/addons/storyshots/storyshots-parallel/src/screenshot.ts
+++ b/addons/storyshots/storyshots-parallel/src/screenshot.ts
@@ -1,0 +1,27 @@
+import pAll from 'p-all';
+import { Browser } from 'puppeteer';
+
+export const renderScreenshot = async (browser: Browser, url: string) => {
+  const page = await browser.newPage();
+  page.on('dialog', async (dialog) => {
+    await dialog.dismiss();
+  });
+  await page.goto(url, { waitUntil: 'networkidle0' });
+  const image = await page.screenshot({ fullPage: true });
+  await page.close();
+  return image;
+};
+
+export const screenshotUrls = async (
+  browser: Browser,
+  urls: string[],
+  { concurrency = 5 }: { concurrency?: number }
+) => {
+  const tasks = urls.map((url, index) => async () => {
+    console.log(`Rendering screenshot ${index}/${urls.length}: ${url}`);
+    const image = await renderScreenshot(browser, url);
+    return { url, image };
+  });
+
+  return pAll(tasks, { concurrency });
+};

--- a/addons/storyshots/storyshots-parallel/tsconfig.json
+++ b/addons/storyshots/storyshots-parallel/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "target": "es2019",
     "rootDir": "./src",
     "types": ["node"],
     "declaration": true

--- a/addons/storyshots/storyshots-parallel/tsconfig.json
+++ b/addons/storyshots/storyshots-parallel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "types": ["node"],
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
(Note: this isn't meant to be merged, only to show an idea. If the approach looks good, I might convert this into a proper PR and/or addon.)

I'm experimenting with an alternative implementation for StoryShots. On a simple project with 14 React stories, using a dual-core i5, it brings run time from ~100 seconds to ~20 seconds.

To test-drive it:

```sh
yarn serve-storybooks
cd addon/storyshots/storyshots-parallel
yarn prepare && yarn example
```

By default it runs against the HTML Kitchen Sink Storybook. Change `STORYBOOK_URL` in `package.json` to run it against a different Storybook, and `CONCURRENCY` to tell it how many stories should be rendered concurrently.

It saves time by doing two things differently from current StoryShots:

- retrieve the list of stories via HTTP (like `sb extract`) instead of running the Storybook project
- pre-render stories in parallel as part the test suite's `beforeAll`, and only do image comparison in tests, instead of doing both in tests (which have to run sequentially)

In detail:

1. In `jest-env.ts`, create a custom Jest env to initialize the browser and retrieve the list of stories. (Why not do that in the suite's `beforeAll`? Because defining tests depends on knowing the stories, but stories are retrieved asynchronously and Jest tests must be defined asynchronously.)
2. In `example.test.js / describe`, define tests based on the list of stories
3. In `example.test.js / beforeAll`, render all stories with the specified concurrency
4. In `example.test.js / <dynamically generated test>`, compare screenshot to previous snapshot

What I don't like: since the bulk of the work is done inside `beforeAll`, a rather long timeout must be set for it; and all screenshots are kept in memory. Probably both can be addressed by creating a suite for each Storybook "folder" ("Controls" in "Controls/Basic"), each with its own `beforeAll`.

A nice side effect is that the test suite can run completely independently of the Storybook project.
