### PR TITLE
Add layout option "none" to remove inline styles from body

### DIFF
--- a/examples/official-storybook/stories/core/layout.stories.js
+++ b/examples/official-storybook/stories/core/layout.stories.js
@@ -29,5 +29,8 @@ CenteredBlock.parameters = { layout: 'centered' };
 export const CenteredInline = () => <Box display="inline-block">centered</Box>;
 CenteredInline.parameters = { layout: 'centered' };
 
+export const None = () => <Box>none</Box>;
+CenteredInline.parameters = { layout: 'none' };
+
 export const Invalid = () => <Box>invalid layout value</Box>;
 Invalid.parameters = { layout: '!invalid!' };

--- a/lib/core/src/client/preview/StoryRenderer.tsx
+++ b/lib/core/src/client/preview/StoryRenderer.tsx
@@ -47,6 +47,7 @@ const layouts = {
     alignItems: 'initial',
     minHeight: 'initial',
   },
+  none: {},
 } as const;
 
 const classes = {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12434

## What I did

Added "none" as a Layout option in StoryRenderer.tsx and updated Official Storybook stories to include None in layouts

I looked at this PR to try to understand why so many inline styles are added in the first place: https://github.com/storybookjs/storybook/pull/10643

This "none" option may not be sufficient as-is to unset other layouts if styles are always merged somewhere else downstream.