### PR TITLE
Update addon controls readme from incorrect syntax

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -180,7 +180,7 @@ Here's the MDX equivalent:
 
 ```jsx
 import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Button } from './Button'
+import { Button } from './Button';
 
 <Meta title="Button" component={Button} argTypes={{ background: { control: 'color' } }} />
 

--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -179,7 +179,7 @@ Basic.args = { label: 'hello', background: '#ff0' };
 Here's the MDX equivalent:
 
 ```jsx
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story } from '@storybook/addon-docs/blocks';
 import { Button } from './Button'
 
 <Meta title="Button" component={Button} argTypes={{ background: { control: 'color' } }} />

--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -179,16 +179,16 @@ Basic.args = { label: 'hello', background: '#ff0' };
 Here's the MDX equivalent:
 
 ```jsx
-import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Button } from './Button';
+import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Button } from './Button'
 
-<Meta title="Button" component={Button} argTypes={{ background: { control: 'color' } }} />;
+<Meta title="Button" component={Button} argTypes={{ background: { control: 'color' } }} />
 
-export const Template = (args) => <Button {...args} />;
+export const Template = (args) => <Button {...args} />
 
 <Story name="Basic" args={{ label: 'hello', background: '#ff0' }}>
   {Template.bind({})}
-</Story>;
+</Story>
 ```
 
 For more info, see a full [Controls example in MDX for Vue](https://raw.githubusercontent.com/storybookjs/storybook/next/examples/vue-kitchen-sink/src/stories/addon-controls.stories.mdx).


### PR DESCRIPTION
Having semi-colons at the end of JSX causes SyntaxError compilation issues.

Issue:

I copied the existing example for a new SB setup to tryout v6 and had a confusing issue: semi-colons seem to be fine for JS statements in MDX, but having semi-colons at the end of JSX causes this error:
```
WARNING in ./src/stories/Button.stories.mdx
Module build failed (from ./node_modules/@mdx-js/loader/index.js):
SyntaxError: Unexpected token (6:8)
```
And the story will cease to appear in storybook.

## What I did
I have removed all semi-colons from the MDX example. I believe removing them all for consistency makes sense, but you could leave the `import` and `export` ones if you like (just ask me to change those back).

