### PR TITLE
Fix typo in remote storybook example

### DIFF
--- a/docs/snippets/common/storybook-main-ref-remote.js.mdx
+++ b/docs/snippets/common/storybook-main-ref-remote.js.mdx
@@ -8,6 +8,6 @@ module.exports={
      title: "Storybook Design System",
      url: "https://5ccbc373887ca40020446347-yldsqjoxzb.chromatic.com"
    }
-  }`
+  }
 }
 ```


### PR DESCRIPTION
Issue:

## What I did

There was an extra quote in example code

## How to test

Visible in docs page: https://storybook.js.org/docs/react/workflows/storybook-composition

![image](https://user-images.githubusercontent.com/387794/93267161-98864680-f781-11ea-9db9-f9c896f6a4d8.png)

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
