### PR TITLE
Addon-controls: Update style of Boolean control

### DIFF
--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { styled } from '@storybook/theming';
-import { opacify, transparentize } from 'polished';
+import { opacify, transparentize, lighten } from 'polished';
 
 import { ControlProps, BooleanValue, BooleanConfig } from './types';
 
@@ -12,6 +12,8 @@ const Label = styled.label(({ theme }) => ({
   display: 'inline-block',
   position: 'relative',
   whiteSpace: 'nowrap',
+  background: `#d9d9d9`,
+  borderRadius: '3em',
 
   input: {
     appearance: 'none',
@@ -42,11 +44,9 @@ const Label = styled.label(({ theme }) => ({
     cursor: 'pointer',
     display: 'inline-block',
     padding: '8px 16px',
-    transition: 'all 150ms ease-out',
     userSelect: 'none',
     borderRadius: '3em',
 
-    boxShadow: `${opacify(0.05, theme.appBorderColor)} 0 0 0 1px inset`,
     color: transparentize(0.4, theme.color.defaultText),
     background: 'transparent',
 
@@ -70,8 +70,9 @@ const Label = styled.label(({ theme }) => ({
   },
 
   'input:checked ~ span:first-of-type, input:not(:checked) ~ span:last-of-type': {
-    background: `${opacify(0.05, theme.appBorderColor)}`,
-    boxShadow: `transparent 0 0 0 1px inset`,
+    background: 'white',
+    borderRadius: '3em',
+    boxShadow: `#d9d9d9 0 0 0 2px inset`,
     color: theme.color.defaultText,
   },
 }));

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -6,14 +6,14 @@ import { opacify, transparentize } from 'polished';
 import { ControlProps, BooleanValue, BooleanConfig } from './types';
 
 const Label = styled.label(({ theme }) => ({
-  lineHeight: '20px',
+  lineHeight: '18px',
   alignItems: 'center',
   marginBottom: 8,
   display: 'inline-block',
   position: 'relative',
-  whiteSpace: 'nowrap',
-  background: `#d9d9d9`,
+  background: `${opacify(0.05, theme.appBorderColor)}`,
   borderRadius: '3em',
+  padding: 1,
 
   input: {
     appearance: 'none',
@@ -36,14 +36,14 @@ const Label = styled.label(({ theme }) => ({
   },
 
   span: {
-    minWidth: 60,
     textAlign: 'center',
     fontSize: theme.typography.size.s1,
     fontWeight: theme.typography.weight.bold,
     lineHeight: '1',
     cursor: 'pointer',
     display: 'inline-block',
-    padding: '8px 16px',
+    padding: '7px 15px',
+    transition: 'all 100ms ease-out',
     userSelect: 'none',
     borderRadius: '3em',
 
@@ -60,20 +60,18 @@ const Label = styled.label(({ theme }) => ({
     },
 
     '&:first-of-type': {
-      borderTopRightRadius: 0,
-      borderBottomRightRadius: 0,
+      paddingRight: 8,
     },
     '&:last-of-type': {
-      borderTopLeftRadius: 0,
-      borderBottomLeftRadius: 0,
+      paddingLeft: 8,
     },
   },
 
   'input:checked ~ span:first-of-type, input:not(:checked) ~ span:last-of-type': {
-    background: 'white',
-    borderRadius: '3em',
-    boxShadow: `#d9d9d9 0 0 0 2px inset`,
+    background: theme.background.bar,
+    boxShadow: `${opacify(0.1, theme.appBorderColor)} 0 0 2px`,
     color: theme.color.defaultText,
+    padding: '7px 15px',
   },
 }));
 

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { styled } from '@storybook/theming';
-import { opacify, transparentize, lighten } from 'polished';
+import { opacify, transparentize } from 'polished';
 
 import { ControlProps, BooleanValue, BooleanConfig } from './types';
 

--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -11,6 +11,7 @@ const Label = styled.label(({ theme }) => ({
   marginBottom: 8,
   display: 'inline-block',
   position: 'relative',
+  whiteSpace: 'nowrap',
   background: `${opacify(0.05, theme.appBorderColor)}`,
   borderRadius: '3em',
   padding: 1,


### PR DESCRIPTION
Issue:
https://twitter.com/mattrothenberg/status/1306952200619466763?s=20

## What I did
Updated the visual style of the `Boolean` control to look more like @dizzyup's mockup.

<img width="336" alt="Screen Shot 2020-09-18 at 10 04 24 AM" src="https://user-images.githubusercontent.com/5148596/93613532-9c3ee680-f996-11ea-9b59-668fda1dd298.png">

@domyen I couldn't quite figure out how to get the gray colors to match up (since y'all are relying heavily on transparency + opacity to reduce the lightness of the base gray color). For the sake of expediency, I hard-coded a gray value of #d9d9d9.

