### PR TITLE
Core: Add `prefix` customization for navigation items

### DIFF
--- a/examples/official-storybook/manager.js
+++ b/examples/official-storybook/manager.js
@@ -1,9 +1,18 @@
+import React from 'react';
 import { addons } from '@storybook/addons';
-import { themes } from '@storybook/theming';
-
+import { themes, styled } from '@storybook/theming';
+import { Icons } from '@storybook/components';
 import addHeadWarning from './head-warning';
 
 addHeadWarning('manager-head-not-loaded', 'Manager head not loaded');
+
+const PrefixIcon = styled(Icons)(({ theme }) => ({
+  marginRight: 8,
+  fontSize: 'inherit',
+  height: '1em',
+  width: '1em',
+  display: 'inline',
+}));
 
 addons.setConfig({
   theme: themes.light, // { base: 'dark', brandTitle: 'Storybook!' },
@@ -14,5 +23,11 @@ addons.setConfig({
     graphiql: {
       hidden: true,
     },
+  },
+  storyPrefix: {
+    addons: <PrefixIcon icon="power" />,
+    'addons-a11y': <PrefixIcon icon="certificate" />,
+    'addons-a11y-basebutton': <PrefixIcon icon="calendar" />,
+    'addons-a11y-basebutton--default': <PrefixIcon icon="star" />,
   },
 });

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 import { sanitize } from '@storybook/csf';
@@ -19,6 +20,7 @@ export interface Root {
   isComponent: false;
   isRoot: true;
   isLeaf: false;
+  prefix?: React.ReactNode;
 }
 
 export interface Group {
@@ -31,6 +33,7 @@ export interface Group {
   isComponent: boolean;
   isRoot: false;
   isLeaf: false;
+  prefix?: React.ReactNode;
   // MDX docs-only stories are "Group" type
   parameters?: {
     docsOnly?: boolean;
@@ -49,6 +52,7 @@ export interface Story {
   isComponent: boolean;
   isRoot: false;
   isLeaf: true;
+  prefix?: React.ReactNode;
   parameters?: {
     fileName: string;
     options: {
@@ -67,6 +71,7 @@ export interface StoryInput {
   refId?: string;
   kind: StoryKind;
   children: string[];
+  prefix?: React.ReactNode;
   parameters: {
     fileName: string;
     options: {
@@ -148,11 +153,11 @@ export const transformStoriesRawToStoriesHash = (
     .filter(Boolean)
     .some(({ kind }) => kind.match(/\.|\|/));
 
+  const { showRoots, storyPrefix = {} } = provider.getConfig();
   const storiesHashOutOfOrder = Object.values(input)
     .filter(Boolean)
     .reduce((acc, item) => {
       const { kind, parameters } = item;
-      const { showRoots } = provider.getConfig();
 
       const setShowRoots = typeof showRoots !== 'undefined';
       if (anyKindMatchesOldHierarchySeparators && !setShowRoots) {
@@ -197,6 +202,7 @@ export const transformStoriesRawToStoriesHash = (
               isComponent: false,
               isLeaf: false,
               isRoot: true,
+              prefix: storyPrefix[id],
             };
             return soFar.concat([result]);
           }
@@ -209,6 +215,7 @@ export const transformStoriesRawToStoriesHash = (
             isComponent: false,
             isLeaf: false,
             isRoot: false,
+            prefix: storyPrefix[id],
             parameters: {
               docsOnly: parameters?.docsOnly,
               viewMode: parameters?.viewMode,
@@ -236,6 +243,7 @@ export const transformStoriesRawToStoriesHash = (
         isLeaf: true,
         isComponent: false,
         isRoot: false,
+        prefix: storyPrefix[item.id],
       };
       acc[item.id] = story;
 

--- a/lib/ui/src/components/sidebar/RefBlocks.tsx
+++ b/lib/ui/src/components/sidebar/RefBlocks.tsx
@@ -327,9 +327,12 @@ export const ContentBlock: FunctionComponent<{
         </Section>
       ) : null}
 
-      {roots.map(({ id, name, children }) => (
+      {roots.map(({ id, name, children, prefix }) => (
         <Section data-title={name} key={id}>
-          <RootHeading className="sidebar-subheading">{name}</RootHeading>
+          <RootHeading className="sidebar-subheading">
+            {prefix}
+            {name}
+          </RootHeading>
           {children.map((child) => (
             <Tree
               key={child}

--- a/lib/ui/src/components/sidebar/Tree/ListItem.tsx
+++ b/lib/ui/src/components/sidebar/Tree/ListItem.tsx
@@ -118,6 +118,7 @@ export type ListItemProps = ComponentProps<typeof Item> & {
   kind: string;
   refId?: string;
   depth: number;
+  prefix?: React.ReactNode;
 };
 
 export const ListItem: FunctionComponent<ListItemProps> = ({
@@ -131,6 +132,7 @@ export const ListItem: FunctionComponent<ListItemProps> = ({
   isSelected = false,
   className,
   depth,
+  prefix,
   ...props
 }) => {
   let iconName: ComponentProps<typeof Icons>['icon'];
@@ -155,6 +157,7 @@ export const ListItem: FunctionComponent<ListItemProps> = ({
         <Expander className="sidebar-expander" depth={depth} isExpanded={isExpanded} />
       ) : null}
       <Icon className="sidebar-svg-icon" icon={iconName} isSelected={isSelected} />
+      {prefix}
       <span>{name}</span>
     </Item>
   );


### PR DESCRIPTION
Issue: Lack of capability to add elements to
- sidebar subheadings (most important one in my opinion)
- sidebar items 
   - folder
   - component
   - story

This PR aims as a proposal for this and basis of discussions

![image](https://user-images.githubusercontent.com/599163/93688960-58e59480-faca-11ea-9c3f-0d4724ac7e03.png)

- Should we keep double icons when prefix is set ?
- Should it be called prefix ?
