### PR TITLE
CLI: Change suggested upgrade command to sb@latest

### DIFF
--- a/lib/core/src/server/build-dev.js
+++ b/lib/core/src/server/build-dev.js
@@ -212,7 +212,7 @@ function createUpdateMessage(updateInfo, version) {
 
   try {
     const suffix = semver.prerelease(updateInfo.data.latest.version) ? '--prerelease' : '';
-    const upgradeCommand = `npx sb@next upgrade ${suffix}`.trim();
+    const upgradeCommand = `npx sb@latest upgrade ${suffix}`.trim();
     updateMessage =
       updateInfo.success && semver.lt(version, updateInfo.data.latest.version)
         ? dedent`


### PR DESCRIPTION
Issue:

## What I did
Fix upgradeCommant from @next to @latest
## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

I found the upgrade warning, but the next version is in alpha. so i could think i cannot install the pre-release version. we need to upgrade to stable / latest release. 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
