### PR TITLE
React: Fix fast refresh

### DIFF
--- a/app/react/src/server/framework-preset-react.test.ts
+++ b/app/react/src/server/framework-preset-react.test.ts
@@ -1,54 +1,96 @@
 import webpack from 'webpack';
+import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import * as preset from './framework-preset-react';
 import type { StorybookOptions } from './types';
 
+const mockApply = jest.fn();
+jest.mock('@pmmmwh/react-refresh-webpack-plugin', () => {
+  return jest.fn().mockImplementation(() => {
+    return { apply: mockApply };
+  });
+});
+
 describe('framework-preset-react', () => {
-  const babelLoaderPath = require.resolve('babel-loader');
   const reactRefreshPath = require.resolve('react-refresh/babel');
   const webpackConfigMock: webpack.Configuration = {
-    mode: 'development',
     plugins: [],
     module: {
       rules: [],
     },
   };
+  const babelConfigMock = {};
+
+  const storybookOptions: Partial<StorybookOptions> = {
+    configType: 'DEVELOPMENT',
+    presets: {
+      apply: async () => ({
+        fastRefresh: true,
+      }),
+    },
+    presetsList: [],
+  };
+
+  const storybookOptionsDisabledRefresh: Partial<StorybookOptions> = {
+    configType: 'DEVELOPMENT',
+    presets: {
+      apply: async () => ({
+        fastRefresh: false,
+      }),
+    },
+  };
+
+  describe('babel', () => {
+    it('should return a config with fast refresh plugin when fast refresh is enabled', async () => {
+      const config = await preset.babel(babelConfigMock, storybookOptions as StorybookOptions);
+
+      expect(config.plugins).toEqual([reactRefreshPath]);
+    });
+
+    it('should return unchanged config without fast refresh plugin when fast refresh is disabled', async () => {
+      const config = await preset.babel(
+        babelConfigMock,
+        storybookOptionsDisabledRefresh as StorybookOptions
+      );
+
+      expect(config).toEqual(babelConfigMock);
+    });
+
+    it('should return unchanged config without fast refresh plugin when mode is not development', async () => {
+      const config = await preset.babel(babelConfigMock, {
+        ...storybookOptions,
+        configType: 'PRODUCTION',
+      } as StorybookOptions);
+
+      expect(config).toEqual(babelConfigMock);
+    });
+  });
 
   describe('webpackFinal', () => {
-    it('should return a config with fast refresh plugin when fast refresh is enabled', () => {
-      const config = preset.webpackFinal(webpackConfigMock, {
-        reactOptions: { fastRefresh: true },
-      } as StorybookOptions);
+    it('should return a config with fast refresh plugin when fast refresh is enabled', async () => {
+      const config = await preset.webpackFinal(
+        webpackConfigMock,
+        storybookOptions as StorybookOptions
+      );
 
-      expect(config.module.rules).toEqual([
-        {
-          test: /\.[jt]sx?$/,
-          exclude: /node_modules/,
-          use: [
-            {
-              loader: babelLoaderPath,
-              options: {
-                plugins: [reactRefreshPath],
-              },
-            },
-          ],
-        },
-      ]);
+      expect(config.plugins).toEqual([new ReactRefreshWebpackPlugin()]);
     });
 
-    it('should not return a config with fast refresh plugin when fast refresh is disabled', () => {
-      const config = preset.webpackFinal(webpackConfigMock, {
-        reactOptions: { fastRefresh: false },
-      } as StorybookOptions);
+    it('should return unchanged config without fast refresh plugin when fast refresh is disabled', async () => {
+      const config = await preset.webpackFinal(
+        webpackConfigMock,
+        storybookOptionsDisabledRefresh as StorybookOptions
+      );
 
-      expect(config.module.rules).toEqual([]);
+      expect(config).toEqual(webpackConfigMock);
     });
 
-    it('should not return a config with fast refresh plugin when mode is not development', () => {
-      const config = preset.webpackFinal({ ...webpackConfigMock, mode: 'production' }, {
-        reactOptions: { fastRefresh: true },
+    it('should return unchanged config without fast refresh plugin when mode is not development', async () => {
+      const config = await preset.webpackFinal(webpackConfigMock, {
+        ...storybookOptions,
+        configType: 'PRODUCTION',
       } as StorybookOptions);
 
-      expect(config.module.rules).toEqual([]);
+      expect(config).toEqual(webpackConfigMock);
     });
   });
 });

--- a/examples/cra-kitchen-sink/.storybook/main.js
+++ b/examples/cra-kitchen-sink/.storybook/main.js
@@ -3,6 +3,9 @@ const path = require('path');
 module.exports = {
   stories: ['../src/stories/**/*.stories.@(js|mdx)'],
   logLevel: 'debug',
+  reactOptions: {
+    fastRefresh: true,
+  },
   addons: [
     '@storybook/preset-create-react-app',
     {

--- a/examples/cra-kitchen-sink/src/components/FastRefreshExample.js
+++ b/examples/cra-kitchen-sink/src/components/FastRefreshExample.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-export const Refresh = () => {
+export const FastRefreshExample = () => {
   const [value, setValue] = React.useState('abc');
   return (
     <>
       <input value={value} onChange={(event) => setValue(event.target.value)} />
-      <p>Change the input value then this text in the component.</p>
+      <p>Change the input value then this text in the component file.</p>
       <p>The state of the input should be kept.</p>
     </>
   );

--- a/examples/cra-kitchen-sink/src/stories/fast-refresh.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/fast-refresh.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { FastRefreshExample } from '../components/FastRefreshExample';
+
+export default {
+  title: 'React Fast Refresh',
+  component: FastRefreshExample,
+};
+
+export const Default = () => <FastRefreshExample />;

--- a/examples/official-storybook/stories/addon-docs/react-refresh.stories.js
+++ b/examples/official-storybook/stories/addon-docs/react-refresh.stories.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import { Refresh } from './react-refresh-example';
-
-export default {
-  title: 'Core/React Refresh',
-};
-
-export const Default = () => <Refresh />;

--- a/lib/core/types/index.ts
+++ b/lib/core/types/index.ts
@@ -40,6 +40,7 @@ export interface StorybookOptions {
   configType: 'DEVELOPMENT' | 'PRODUCTION';
   presetsList: Preset[];
   typescriptOptions: TypescriptOptions;
+  [key: string]: any;
 }
 
 /**

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -137,7 +137,11 @@ export const react_typescript: Parameters = {
 export const cra: Parameters = {
   name: 'cra',
   version: 'latest',
-  generator: 'npx create-react-app@{{version}} {{name}}-{{version}}',
+  generator: [
+    'npx create-react-app@{{version}} {{name}}-{{version}}',
+    'cd {{name}}-{{version}}',
+    'echo "FAST_REFRESH=true" > .env',
+  ].join(' && '),
 };
 
 export const cra_typescript: Parameters = {


### PR DESCRIPTION
## What I did
In 6.1 alpha, support for React fast refresh was added. Unfortunately the fast refresh config ended up adding a new babel-loader rather than integrating the rules with the existing loader. This PR fixes that by separating the webpack and babel work in the react preset.

The fast refresh example component + story was moved from official-storybook to cra-kitchen-sink, given that the official-storybook is deliberately removing the babel loader and adding a custom one.

## How to test
`yarn bootstrap`
`yarn --cwd examples/cra-kitchen-sink storybook` and tweak with either the reactOptions in main.js or add REACT_REFRESH=true then change to false in the `.env` file.