### PR TITLE
Core: Fix babel-loader path resolution

### DIFF
--- a/lib/core/src/server/preview/babel-loader-preview.js
+++ b/lib/core/src/server/preview/babel-loader-preview.js
@@ -5,7 +5,7 @@ export const createBabelLoader = (options, framework) => ({
   test: useBaseTsSupport(framework) ? /\.(mjs|tsx?|jsx?)$/ : /\.(mjs|jsx?)$/,
   use: [
     {
-      loader: 'babel-loader',
+      loader: require.resolve('babel-loader'),
       options,
     },
   ],


### PR DESCRIPTION
Issue:
**Resolving path to the babel for pnpm when running storybook**
## What I did
I tried to **_pnpm run storybook_** with  the **_main.js_** config without _**"@storybook/preset-create-react-app"**_
## How to test
- install create react app
- initialize storybook on it
- when your main.js config looks like mine:
<img width="1093" alt="Bildschirmfoto 2020-09-21 um 21 13 14" src="https://user-images.githubusercontent.com/7083484/93810958-b1926a00-fc4f-11ea-9e61-867eb10fd365.png">
- try to run storybook with pnpm
- you will get an error:
<img width="1680" alt="Bildschirmfoto 2020-09-21 um 21 12 50" src="https://user-images.githubusercontent.com/7083484/93811132-f9b18c80-fc4f-11ea-89a7-b82d31ce57da.png">

