### PR TITLE
Fix comments in examples.md for MDX parser

### DIFF
--- a/docs/get-started/examples.md
+++ b/docs/get-started/examples.md
@@ -19,12 +19,15 @@ See how to build UIs using a [component driven](https://www.componentdriven.org/
 
 - [BBC Psammead](https://bbc.github.io/psammead/?path=/story/components-brand--without-brand-link)
 - [The Guardian](https://master--5dfcbf3012392c0020e7140b.chromatic.com)
-<!-- 
+
+<!--
+
 NOTE for contributors: This is a curated list. Here's what qualifies:
 - Website or app Storybook that illustrates how to build UIs from small components to pages
 - Used in production by a medium/large company or large open source community
 - Must be developed actively
-  -->
+
+-->
 
 ## Design systems and component libraries
 
@@ -45,9 +48,12 @@ Learn how leading teams build design systems.
 - [AnyVision UI](http://storybook.anyvision.co/)
 - [Skyscanner Backpack](https://backpack.github.io/storybook/)
 - [GitLab UI](https://gitlab-org.gitlab.io/gitlab-ui)
-<!-- 
+
+<!--
+
 NOTE for contributors: This is a curated list. Here's what qualifies:
 - Design system or component library
 - Used in production by a medium/large company or large open source community (Grommet, Chakra)
 - Must have greater than 20+ contributors OR 1k+ GitHub stars OR show exceptional use of SB features
-  -->
+
+-->


### PR DESCRIPTION
Issue: The MDX parser (which lives in the frontpage) is pretty strict about comments and typically needs some extra whitespace around comments to parse them correctly. There are some comments in `examples.md` that needed more whitespace.

## What I did

Added the necessary whitespace so that the MDX parser pulls in the comments without issue.


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
