### PR TITLE
Move @types/webpack-env to devDependencies

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -42,7 +42,6 @@
     "@storybook/node-logger": "6.1.0-alpha.14",
     "@storybook/semver": "^7.3.2",
     "@svgr/webpack": "^5.4.0",
-    "@types/webpack-env": "^1.15.2",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-named-asset-import": "^0.3.1",
     "babel-plugin-react-docgen": "^4.1.0",
@@ -62,7 +61,8 @@
   "devDependencies": {
     "@storybook/client-api": "6.1.0-alpha.14",
     "@types/node": "^14.0.10",
-    "@types/webpack": "^4.41.12"
+    "@types/webpack": "^4.41.12",
+    "@types/webpack-env": "^1.15.2"
   },
   "peerDependencies": {
     "@babel/core": "^7.11.5"


### PR DESCRIPTION
Issue: `@types/webpack-env` is incorrectly in the `dependencies` of `@storybook/react`.

## What I did

Moved to `devDependencies`

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
