### PR TITLE
Documentation: add `transcludeMarkdown` option in addon-docs

### DIFF
--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -165,7 +165,7 @@ The `configureJSX` option is useful when you're writing your docs in MDX and you
 
 `sourceLoaderOptions` is an object for configuring `@storybook/source-loader`. When set to `null` it tells docs not to run the `source-loader` at all, which can be used as an optimization, or if you're already using `source-loader` in your `main.js`.
 
-The `transcludeMarkdown` option enable mdx files to import `.md` files and render them as a component. Example:
+The `transcludeMarkdown` option enable mdx files to import `.md` files and render them as a component.
 ```mdx
 import { Meta } from '@storybook/addon-docs/blocks';
 import Changelog from '../CHANGELOG.md';

--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -154,6 +154,7 @@ module.exports = {
         configureJSX: true,
         babelOptions: {},
         sourceLoaderOptions: null,
+        transcludeMarkdown: true,
       },
     },
   ],
@@ -163,6 +164,16 @@ module.exports = {
 The `configureJSX` option is useful when you're writing your docs in MDX and your project's babel config isn't already set up to handle JSX files. `babelOptions` is a way to further configure the babel processor when you're using `configureJSX`.
 
 `sourceLoaderOptions` is an object for configuring `@storybook/source-loader`. When set to `null` it tells docs not to run the `source-loader` at all, which can be used as an optimization, or if you're already using `source-loader` in your `main.js`.
+
+The `transcludeMarkdown` option enable mdx files to import `.md` files and render them as a component. Example:
+```mdx
+import { Meta } from '@storybook/addon-docs/blocks';
+import Changelog from '../CHANGELOG.md';
+
+<Meta title="Changelog" />
+
+<Changelog />
+```
 
 ## Manual configuration
 

--- a/addons/docs/README.md
+++ b/addons/docs/README.md
@@ -165,7 +165,7 @@ The `configureJSX` option is useful when you're writing your docs in MDX and you
 
 `sourceLoaderOptions` is an object for configuring `@storybook/source-loader`. When set to `null` it tells docs not to run the `source-loader` at all, which can be used as an optimization, or if you're already using `source-loader` in your `main.js`.
 
-The `transcludeMarkdown` option enable mdx files to import `.md` files and render them as a component.
+The `transcludeMarkdown` option enables mdx files to import `.md` files and render them as a component.
 ```mdx
 import { Meta } from '@storybook/addon-docs/blocks';
 import Changelog from '../CHANGELOG.md';


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/11981
Fixing PR: https://github.com/storybookjs/storybook/pull/11334

What I did
Type: documentation
Add documentation for `transcludeMarkdown` addon-docs option

## How to test
No testing needed