### PR TITLE
Addon-docs: Remove leading pipe if using raw value for Flow union

### DIFF
--- a/addons/docs/src/lib/docgen/flow/createPropDef.test.ts
+++ b/addons/docs/src/lib/docgen/flow/createPropDef.test.ts
@@ -317,6 +317,32 @@ describe('type', () => {
     expect(type.summary).toBe('"minimum" | "maximum" | UserSize');
   });
 
+  it('removes a leading | if raw union value is used', () => {
+    const docgenInfo = createDocgenInfo({
+      flowType: {
+        name: 'union',
+        raw: '| "minimum" | "maximum" | UserSize',
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('"minimum" | "maximum" | UserSize');
+  });
+
+  it('even removes extra spaces after a leading | if raw union value is used', () => {
+    const docgenInfo = createDocgenInfo({
+      flowType: {
+        name: 'union',
+        raw: '|     "minimum" | "maximum" | UserSize',
+      },
+    });
+
+    const { type } = createFlowPropDef(PROP_NAME, docgenInfo);
+
+    expect(type.summary).toBe('"minimum" | "maximum" | UserSize');
+  });
+
   it('should support intersection', () => {
     const docgenInfo = createDocgenInfo({
       flowType: {

--- a/addons/docs/src/lib/docgen/flow/createType.ts
+++ b/addons/docs/src/lib/docgen/flow/createType.ts
@@ -40,7 +40,8 @@ function generateUnion({ name, raw, elements }: DocgenFlowUnionType): PropType {
   }
 
   if (raw != null) {
-    return createSummaryValue(raw);
+    // Flow Unions can be defined with or without a leading `|` character, so try to remove it.
+    return createSummaryValue(raw.replace(/^\|\s*/, ''));
   }
 
   return createSummaryValue(name);


### PR DESCRIPTION
Issue: N/A

## What I did

I ran into this issue prior to preferring `elements` in Flow's union type. In Flow, a Union can be specified with a leading `|` character, which results in an extra empty string value once processed by storybook. This removes that extra character if we don't have `elements` (for some reason) and must use the `raw` value.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yep, added a couple jest tests.
- Does this need a new example in the kitchen sink apps? Nope
- Does this need an update to the documentation? Nope

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
