### PR TITLE
Addon-docs: Add converters between Flow types and storybook types

### DIFF
--- a/addons/docs/src/lib/convert/flow/convert.ts
+++ b/addons/docs/src/lib/convert/flow/convert.ts
@@ -1,0 +1,55 @@
+/* eslint-disable no-case-declarations */
+import { SBType } from '@storybook/client-api';
+import { FlowType, FlowSigType, FlowLiteralType } from './types';
+
+const isLiteral = (type: FlowType) => type.name === 'literal';
+const toEnumOption = (element: FlowLiteralType) => element.value.replace(/['|"]/g, '');
+
+const convertSig = (type: FlowSigType) => {
+  switch (type.type) {
+    case 'function':
+      return { name: 'function' };
+    case 'object':
+      const values: any = {};
+      type.signature.properties.forEach((prop) => {
+        values[prop.key] = convert(prop.value);
+      });
+      return {
+        name: 'object',
+        value: values,
+      };
+    default:
+      throw new Error(`Unknown: ${type}`);
+  }
+};
+
+export const convert = (type: FlowType): SBType | void => {
+  const { name, raw } = type;
+  const base: any = {};
+  if (typeof raw !== 'undefined') base.raw = raw;
+  switch (type.name) {
+    case 'literal':
+      return { ...base, name: 'other', value: type.value };
+    case 'string':
+    case 'number':
+    case 'symbol':
+    case 'boolean': {
+      return { ...base, name };
+    }
+    case 'Array': {
+      return { ...base, name: 'array', value: type.elements.map(convert) };
+    }
+    case 'signature':
+      return { ...base, ...convertSig(type) };
+    case 'union':
+      if (type.elements.every(isLiteral)) {
+        return { ...base, name: 'enum', value: type.elements.map(toEnumOption) };
+      }
+      return { ...base, name, value: type.elements.map(convert) };
+
+    case 'intersection':
+      return { ...base, name, value: type.elements.map(convert) };
+    default:
+      return { ...base, name: 'other', value: name };
+  }
+};

--- a/addons/docs/src/lib/convert/flow/index.ts
+++ b/addons/docs/src/lib/convert/flow/index.ts
@@ -1,0 +1,2 @@
+export * from './convert';
+export * from './types';

--- a/addons/docs/src/lib/convert/flow/types.ts
+++ b/addons/docs/src/lib/convert/flow/types.ts
@@ -1,0 +1,56 @@
+interface FlowBaseType {
+  name: string;
+  type?: string;
+  raw?: string;
+  required?: boolean;
+}
+
+type FlowArgType = FlowType;
+
+type FlowCombinationType = FlowBaseType & {
+  name: 'union' | 'intersection';
+  elements: FlowType[];
+};
+
+type FlowFuncSigType = FlowBaseType & {
+  name: 'signature';
+  type: 'function';
+  signature: {
+    arguments: FlowArgType[];
+    return: FlowType;
+  };
+};
+
+type FlowObjectSigType = FlowBaseType & {
+  name: 'signature';
+  type: 'object';
+  signature: {
+    properties: {
+      key: string;
+      value: FlowType;
+    }[];
+  };
+};
+
+type FlowScalarType = FlowBaseType & {
+  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol';
+};
+
+export type FlowLiteralType = FlowBaseType & {
+  name: 'literal';
+  value: string;
+};
+
+type FlowArrayType = FlowBaseType & {
+  name: 'Array';
+  elements: FlowType[];
+};
+
+export type FlowSigType = FlowObjectSigType | FlowFuncSigType;
+
+export type FlowType =
+  | FlowScalarType
+  | FlowLiteralType
+  | FlowCombinationType
+  | FlowSigType
+  | FlowArrayType;

--- a/addons/docs/src/lib/convert/index.ts
+++ b/addons/docs/src/lib/convert/index.ts
@@ -1,11 +1,13 @@
 import { DocgenInfo } from '../docgen/types';
 import { convert as tsConvert, TSType } from './typescript';
+import { convert as flowConvert, FlowType } from './flow';
 import { convert as propTypesConvert } from './proptypes';
 
 export const convert = (docgenInfo: DocgenInfo) => {
-  const { type, tsType } = docgenInfo;
+  const { type, tsType, flowType } = docgenInfo;
   if (type != null) return propTypesConvert(type);
   if (tsType != null) return tsConvert(tsType as TSType);
+  if (flowType != null) return flowConvert(flowType as FlowType);
 
   return null;
 };


### PR DESCRIPTION
Issue: N/A

## What I did

This adds initial support for supporting Flow types in the ArgsTable of addon-docs. I've been running this against a large Flow project and updating it as I come across patterns in the codebase, but I wanted to get something upstreamed that I can keep iterating on.

I'm noticing that TypeScript and PropTypes have jest snapshot testing, so I'm planning to add that coming up.

## How to test

- Is this testable with Jest or Chromatic screenshots? Coming Soon(tm)
- Does this need a new example in the kitchen sink apps? I'm wondering if it is time to start working on a flow storybook?
- Does this need an update to the documentation? Unsure

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
