### PR TITLE
Addon-docs: Fix story description to only show when expanded

### DIFF
--- a/addons/docs/src/blocks/DocsStory.tsx
+++ b/addons/docs/src/blocks/DocsStory.tsx
@@ -22,13 +22,18 @@ export const DocsStory: FunctionComponent<DocsStoryProps> = ({
   name,
   expanded = true,
   withToolbar = false,
-  parameters,
+  parameters = {},
 }) => {
-  let description = expanded && parameters?.docs?.description?.story;
-  if (!description) {
-    description = parameters?.docs?.storyDescription;
-    if (description) warnStoryDescription();
+  let description;
+  const { docs } = parameters;
+  if (expanded && docs) {
+    description = docs.description?.story;
+    if (!description) {
+      description = docs.storyDescription;
+      if (description) warnStoryDescription();
+    }
   }
+
   const subheading = expanded && name;
 
   return (


### PR DESCRIPTION
Issue: #12397 

## What I did

Fixed a small bug where the `docs.storyDescription` parameter was showing even when the story was not expanded

## How to test

Add a primary story with a `docs.storyDescription`, before & after. Did not add to the repo since `storyDescription` is deprecated.