### PR TITLE
Angular: Choose project used by Storybook

### DIFF
--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -73,7 +73,7 @@ export function getLeadingAngularCliProject(ngCliConfig: any) {
 
   let projectName;
   const firstProjectName = Object.keys(projects)[0];
-  const environmentProjectName = process.env.STORYBOOK_NAME;
+  const environmentProjectName = process.env.STORYBOOK_ANGULAR_PROJECT;
   if (environmentProjectName) {
     projectName = environmentProjectName;
   } else if (projects.storybook) {

--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -73,7 +73,10 @@ export function getLeadingAngularCliProject(ngCliConfig: any) {
 
   let projectName;
   const firstProjectName = Object.keys(projects)[0];
-  if (projects.storybook) {
+  const environmentProjectName = process.env.STORYBOOK_NAME;
+  if (environmentProjectName) {
+    projectName = environmentProjectName;
+  } else if (projects.storybook) {
     projectName = 'storybook';
   } else if (defaultProject && projects[defaultProject]) {
     projectName = defaultProject;


### PR DESCRIPTION
Issue: #8652 #10302 #11499 

Storybook always chooses a project from angular.json according to the following priority:

1. Verifies if there is a "storybook" project;
2. Verifies if a "defaultProject" is defined;
3. Chooses the first project on the list;

This causes problems in monorepos, as evidenced by the referenced issues.

## What I did

I added another condition before the 3 checks I mentioned. Basically, we now verify if there is an environment variable called "STORYBOOK_ANGULAR_PROJECT". If so, we use its value as the project name.

## How to test

Prepend an environment variable right before the command to start storybook. Example:

`STORYBOOK_ANGULAR_PROJECT=projectTest start-storybook -c .storybook`