### PR TITLE
Core: Add viewMode to StoryContext

### DIFF
--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -59,6 +59,7 @@ export type StoryContext = StoryIdentifier & {
   argTypes: ArgTypes;
   globals: Args;
   hooks?: HooksContext;
+  viewMode?: ViewMode;
 };
 
 export interface WrapperSettings {

--- a/lib/client-api/README.md
+++ b/lib/client-api/README.md
@@ -12,6 +12,7 @@ Each story is loaded via the `.add()` API and contains the follow attributes, wh
 - `parameters` - static data about the story, see below.
 - `args` - dynamic inputs to the story, see below.
 - `hooks` - listeners that will rerun when the story changes or is unmounted, see `@storybook/addons`.
+- `viewMode` - property that tells if the story is being rendered in Canvas or Docs tab. Values are `story` for canvas and `docs` for docs.
 
 ## Parameters
 

--- a/lib/client-api/src/decorators.test.ts
+++ b/lib/client-api/src/decorators.test.ts
@@ -7,9 +7,10 @@ function makeContext(input: Record<string, any>): StoryContext {
     id: 'id',
     kind: 'kind',
     name: 'name',
+    viewMode: 'story',
     parameters: {},
     ...input,
-  };
+  } as StoryContext;
 }
 
 describe('client-api.decorators', () => {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -406,6 +406,7 @@ export default class StoryStore {
         args: _stories[id].args,
         argTypes,
         globals: this._globals,
+        viewMode: this._selection?.viewMode,
       });
 
     // Pull out parameters.args.$ || .argTypes.$.defaultValue into initialArgs


### PR DESCRIPTION
Issue: #8474 Part of #12368

## What I did
Add `viewMode` to the context object (second parameter in decorators) so that users can apply conditional code in their decorators depending if the story is either on canvas or docs.. but most importantly it's ground work for certain addons to take advantage of it, such as the backgrounds addon.

## How to test

1 - Go to any story (e.g. `addon-a11y/base-button.stories.js`) and apply the following decorator:
```js
decorators: [
    (StoryFn, context) => {
      console.log({ viewMode: context.viewMode });
      return <StoryFn />;
    },
],
```

2 - Run `yarn start`
3 - Check if the viewMode is present.


*The viewMode is always `story` for the iframed stories such as in angular.