### PR TITLE
UI: Fix page title for non-alpha chars

### DIFF
--- a/examples/official-storybook/stories/core/unicode.stories.js
+++ b/examples/official-storybook/stories/core/unicode.stories.js
@@ -5,3 +5,5 @@ storiesOf('Core/Unicode', module)
   .add('😀', () => <p>❤️</p>)
   .add('Кнопки', () => <p>нормальный</p>)
   .add('바보', () => <p>🤷🏻‍♂️</p>);
+
+storiesOf('Core/Unicode/Primário', module).add('😀', () => <p>❤️</p>);

--- a/lib/ui/src/containers/preview.tsx
+++ b/lib/ui/src/containers/preview.tsx
@@ -7,7 +7,7 @@ import { Preview } from '../components/preview/preview';
 
 export type Item = StoriesHash[keyof StoriesHash];
 
-const splitTitleAddExtraSpace = (input: string) => input.split('/').join(' / ');
+const splitTitleAddExtraSpace = (input: string) => input.split('/').join(' / ').replace(/\s\s/, ' ');
 
 const getDescription = (item: Item) => {
   if (isRoot(item)) {

--- a/lib/ui/src/containers/preview.tsx
+++ b/lib/ui/src/containers/preview.tsx
@@ -7,12 +7,7 @@ import { Preview } from '../components/preview/preview';
 
 export type Item = StoriesHash[keyof StoriesHash];
 
-const nonAlphanumSpace = /[^a-z0-9 ]/gi;
-const doubleSpace = /\s\s/gi;
-const replacer = (match: string) => ` ${match} `;
-
-const addExtraWhiteSpace = (input: string) =>
-  input.replace(nonAlphanumSpace, replacer).replace(doubleSpace, ' ');
+const splitTitleAddExtraSpace = (input: string) => input.split('/').join(' / ');
 
 const getDescription = (item: Item) => {
   if (isRoot(item)) {
@@ -23,7 +18,7 @@ const getDescription = (item: Item) => {
   }
   if (isStory(item)) {
     const { kind, name } = item;
-    return kind && name ? addExtraWhiteSpace(`${kind} - ${name} ⋅ Storybook`) : 'Storybook';
+    return kind && name ? splitTitleAddExtraSpace(`${kind} - ${name} ⋅ Storybook`) : 'Storybook';
   }
 
   return 'Storybook';


### PR DESCRIPTION
Issue: #12534 - The regular expression used to build the page title only accounted for characters without diacritics. When any character with special glyphs were inserted in the title, the characters were considered as the splitting characters and white spaces where inserted before and after the character, as it was doing with `/`.

## What I did

Refactored the function to only use JS `split` and `join` string functions.

## How to test

Just add a component title with any special character (examples: `éàô`). Follow the example below:
```jsx
export default {
  title: 'Botões/Primário/Quiça',
  component: Button,
  parameters: {
    ...
  },
};
```

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
