### PR TITLE
ArgsTable: Remove the "simple" detection for enum types

### DIFF
--- a/lib/components/src/blocks/ArgsTable/ArgValue.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgValue.tsx
@@ -141,7 +141,7 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
     const cannotBeSafelySplitted = /[(){}[\]<>]/.test(summaryAsString);
 
     if (cannotBeSafelySplitted) {
-      return <ArgText text={summaryAsString} simple={summaryAsString.includes('|')} />;
+      return <ArgText text={summaryAsString} />;
     }
 
     const summaryItems = getSummaryItems(summaryAsString);


### PR DESCRIPTION
Issue: Partial reversion of #11868

## What I did

While working on a very large storybook, I noticed that a subset of types weren't formatted correctly. For example, they had no background. They were really standing out from the rest of the system. These types often looked like `(arg1: string) => 'return1' | 'return2'`.

I traced it back to the `simple` option added in #11868 which added a check that is too simplistic for what it is trying to do. From what I understand, it was trying to avoid adding styling to complex unions, but it didn't consider a union-type value anywhere else in a signature.

My suggestion is to remove this check for now until a more sophisticated check is applied.

## How to test

- Is this testable with Jest or Chromatic screenshots? The previous PR said it added these?
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
