### PR TITLE
Addon-docs: Move summary & detail equality check to createSummaryValue

### DIFF
--- a/addons/docs/src/frameworks/react/lib/defaultValues/createDefaultValue.ts
+++ b/addons/docs/src/frameworks/react/lib/defaultValues/createDefaultValue.ts
@@ -47,10 +47,7 @@ function generateElement(
         inferedType as InspectionIdentifiableInferedType
       );
 
-      return createSummaryValue(
-        prettyIdentifier,
-        prettyIdentifier !== defaultValue ? defaultValue : undefined
-      );
+      return createSummaryValue(prettyIdentifier, defaultValue);
     }
   }
 

--- a/addons/docs/src/frameworks/react/lib/defaultValues/createFromRawDefaultProp.ts
+++ b/addons/docs/src/frameworks/react/lib/defaultValues/createFromRawDefaultProp.ts
@@ -50,7 +50,7 @@ function generateReactObject(rawDefaultProp: any) {
   if (displayName != null) {
     const prettyIdentifier = getPrettyElementIdentifier(displayName);
 
-    return createSummaryValue(prettyIdentifier, prettyIdentifier !== jsx ? jsx : undefined);
+    return createSummaryValue(prettyIdentifier, jsx);
   }
 
   if (isString(type)) {

--- a/addons/docs/src/frameworks/react/propTypes/createType.ts
+++ b/addons/docs/src/frameworks/react/propTypes/createType.ts
@@ -381,7 +381,7 @@ export function createType(extractedProp: ExtractedProp): PropType {
           }
         }
 
-        return createSummaryValue(short, short !== full ? full : undefined);
+        return createSummaryValue(short, full);
       }
       case PropTypesType.FUNC: {
         const { short, full } = generateType(type, extractedProp);

--- a/addons/docs/src/lib/utils.test.ts
+++ b/addons/docs/src/lib/utils.test.ts
@@ -1,0 +1,20 @@
+import { createSummaryValue } from './utils';
+
+describe('createSummaryValue', () => {
+  it('creates an object with just summary if detail is not passed', () => {
+    const summary = 'boolean';
+    expect(createSummaryValue(summary)).toEqual({ summary });
+  });
+
+  it('creates an object with summary & detail if passed', () => {
+    const summary = 'MyType';
+    const detail = 'boolean | string';
+    expect(createSummaryValue(summary, detail)).toEqual({ summary, detail });
+  });
+
+  it('creates an object with just summary if details are equal', () => {
+    const summary = 'boolean';
+    const detail = 'boolean';
+    expect(createSummaryValue(summary, detail)).toEqual({ summary });
+  });
+});

--- a/addons/docs/src/lib/utils.ts
+++ b/addons/docs/src/lib/utils.ts
@@ -12,6 +12,9 @@ export function isTooLongForDefaultValueSummary(value: string): boolean {
 }
 
 export function createSummaryValue(summary: string, detail?: string): PropSummaryValue {
+  if (summary === detail) {
+    return { summary };
+  }
   return { summary, detail };
 }
 


### PR DESCRIPTION
Issue: N/A

## What I did

I moved the `summary` and `detail` equality comparison into the `createSummaryValue` utility function and cleaned up the call sites that were checking equality themselves. I also added Jest tests for this util method.

This also lays some groundwork for a bigger Flow related PR that I've been working on.

## How to test

- Is this testable with Jest or Chromatic screenshots? Jest, added a new test file!
- Does this need a new example in the kitchen sink apps? Nope
- Does this need an update to the documentation? Nope

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
