### PR TITLE
Make link to fork-ts-checker-webpack-plugin documentation point to v4

### DIFF
--- a/docs/configure/typescript.md
+++ b/docs/configure/typescript.md
@@ -6,7 +6,7 @@ Storybook has built-in Typescript support, so your Typescript project should wor
 
 ### Default configuration
 
-The base Typescript configuration uses [`babel-loader`](https://webpack.js.org/loaders/babel-loader/) for Typescript transpilation, and optionally [`fork-ts-checker-webpack-plugin`](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin) for checking.
+The base Typescript configuration uses [`babel-loader`](https://webpack.js.org/loaders/babel-loader/) for Typescript transpilation, and optionally [`fork-ts-checker-webpack-plugin`](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/v4.1.6/README.md#options) for checking.
 
 Each framework uses the base configuration unless otherwise specified:
 
@@ -30,9 +30,9 @@ The following code snippets shows the fields for you to use with TypeScript:
 
 <!-- prettier-ignore-end -->
 
-| Field                            | Framework | Description                                                                                   | Type                                                                          |
-| :------------------------------- | :-------- | :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
-| **check**                        | All       | Optionally run fork-ts-checker-webpack-plugin                                                 | boolean                                                                       |
-| **checkOptions**                 | All       | Options to pass to fork-ts-checker-webpack-plugin if it's enabled                             | [See docs](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin)      |
-| **reactDocgen**                  | React     | Which react docgen processor to run: `"react-docgen-typescript"`, `"react-docgen"`, `false`   | string or false                                                               |
-| **reactDocgenTypescriptOptions** | React     | Options to pass to react-docgen-typescript-plugin if react-docgen-typescript is enabled.      | [See docs](https://github.com/hipstersmoothie/react-docgen-typescript-plugin) |
+| Field                            | Framework | Description                                                                                 | Type                                                                                                   |
+| :------------------------------- | :-------- | :------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------- |
+| **check**                        | All       | Optionally run fork-ts-checker-webpack-plugin                                               | boolean                                                                                                |
+| **checkOptions**                 | All       | Options to pass to fork-ts-checker-webpack-plugin if it's enabled                           | [See docs](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/v4.1.6/README.md#options) |
+| **reactDocgen**                  | React     | Which react docgen processor to run: `"react-docgen-typescript"`, `"react-docgen"`, `false` | string or false                                                                                        |
+| **reactDocgenTypescriptOptions** | React     | Options to pass to react-docgen-typescript-plugin if react-docgen-typescript is enabled.    | [See docs](https://github.com/hipstersmoothie/react-docgen-typescript-plugin)                          |


### PR DESCRIPTION
Issue:#11804
> The "See docs" link in Storybook v6's TypeScript configuration guide points to the wrong version of `fork-ts-checker-Storybook v6's package.json declares "fork-ts-checker-webpack-plugin": "^4.1.4" [here](https://github.com/storybookjs/storybook/blob/next/lib/core/package.json#L94), but the link points to the most recent version, which is v5.0.14. Fork-TS-Checker's configuration changed from v4 -> v5, so the docs in question provide a configuration shape that is not compatible with the version used by Storybook.

## What I did
Updated documentation to point to the correct version of a dependency documentation

## How to test

- Is this testable with Jest or Chromatic screenshots? **No**
- Does this need a new example in the kitchen sink apps? **No**
- Does this need an update to the documentation? **No**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
