### PR TITLE
Composition: Rename `disabled` parameter => `disable`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@
   - [6.1 deprecations](#61-deprecations)
     - [Deprecated onBeforeRender](#deprecated-onbeforerender)
     - [Deprecated grid parameter](#deprecated-grid-parameter)
+    - [Deprecated package-composition disabled parameter](#deprecated-package-composition-disabled-parameter)
 - [From version 5.3.x to 6.0.x](#from-version-53x-to-60x)
   - [Hoisted CSF annotations](#hoisted-csf-annotations)
   - [Zero config typescript](#zero-config-typescript)
@@ -173,6 +174,12 @@ Basic.parameters: {
   }
 },
 ```
+
+#### Deprecated package-composition disabled parameter
+
+Like [Deprecated disabled parameter](#deprecated-disabled-parameter). The `disabled` parameter has been deprecated, please use `disable` instead.
+
+For more information, see the [the related documentation](https://storybook.js.org/docs/react/workflows/package-composition#configuring).
 
 ## From version 5.3.x to 6.0.x
 

--- a/docs/snippets/common/storybook-main-disable-refs.js.mdx
+++ b/docs/snippets/common/storybook-main-disable-refs.js.mdx
@@ -4,6 +4,6 @@
 module.exports = {
   // your Storybook configuration
   refs: {
-    'package-name': { disabled: true }
+    'package-name': { disable: true }
 }
 ```

--- a/docs/snippets/common/storybook-main-disable-refs.js.mdx
+++ b/docs/snippets/common/storybook-main-disable-refs.js.mdx
@@ -4,6 +4,6 @@
 module.exports = {
   // your Storybook configuration
   refs: {
-    'package-name': { disable: true }
+    'package-name': { disabled: true }
 }
 ```

--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -3,6 +3,8 @@ import fs from 'fs-extra';
 import findUp from 'find-up';
 import resolveFrom from 'resolve-from';
 import fetch from 'node-fetch';
+import deprecate from 'util-deprecate';
+import dedent from 'ts-dedent';
 
 import { logger } from '@storybook/node-logger';
 
@@ -55,6 +57,15 @@ const toTitle = (input) => {
   return `${result.substring(0, 1).toUpperCase()}${result.substring(1)}`.trim();
 };
 
+const deprecatedDefinedRefDisabled = deprecate(
+  () => {},
+  dedent`
+    Deprecated parameter: disabled => disable
+
+    https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-package-composition-disabled-parameter
+  `
+);
+
 async function getManagerWebpackConfig(options, presets) {
   const typescriptOptions = await presets.apply('typescript', { ...typeScriptDefaults }, options);
   const babelOptions = await presets.apply('babel', {}, { ...options, typescriptOptions });
@@ -78,7 +89,13 @@ async function getManagerWebpackConfig(options, presets) {
 
   if (definedRefs) {
     Object.entries(definedRefs).forEach(([key, value]) => {
-      if (value?.disabled) {
+      const { disable, disabled } = value;
+
+      if (disable || disabled) {
+        if (disabled) {
+          deprecatedDefinedRefDisabled();
+        }
+
         delete refs[key.toLowerCase()];
         return;
       }
@@ -96,6 +113,7 @@ async function getManagerWebpackConfig(options, presets) {
       };
     });
   }
+
   if (autoRefs || definedRefs) {
     entries.push(path.resolve(path.join(options.configDir, `generated-refs.js`)));
 


### PR DESCRIPTION
Issue:

https://storybook.js.org/docs/react/workflows/package-composition#configuring

After checking the source: https://github.com/storybookjs/storybook/blob/next/lib/core/src/server/manager/manager-config.js#L81, this should be a typo.

## What I did

~~Change `disable` to `disabled`.~~

Deprecate the `disabled` parameter.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
