### PR TITLE
feat(addon-viewport): editable width/height

### DIFF
--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -41,7 +41,8 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "regenerator-runtime": "^0.13.3"
+    "regenerator-runtime": "^0.13.3",
+    "use-debounce": "^5.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -102,7 +102,7 @@ const ActiveViewportSize = styled.div(() => ({
 const ActiveViewportNumericInput = styled(Form.NumericInput)(() => ({
   flexGrow: 0,
   alignSelf: 'center',
-  padding: '3px 10px',
+  padding: '2px 2px 2px 6px',
 }));
 
 const ActiveViewportIconButton = styled(IconButton)(() => ({

--- a/lib/components/src/form/form.stories.tsx
+++ b/lib/components/src/form/form.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { styled } from '@storybook/theming';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { Input, Button, Select, Textarea } from './input/input';
+import { Input, Button, Select, Textarea, NumericInput } from './input/input';
 import { Field } from './field/field';
 import { Spaced } from '../spaced/Spaced';
 
@@ -154,3 +154,63 @@ storiesOf('Basics/Form/Input', module)
       ))}
     </Spaced>
   ));
+
+storiesOf('Basics/Form/NumericInput', module)
+  .add('sizes', () => {
+    const [auto, setAuto] = useState(0);
+    const [flex, setFlex] = useState(0);
+    const [full, setFull] = useState(0);
+    const [content, setContent] = useState(0);
+    return (
+      <Spaced>
+        {[
+          { size: 'auto', value: auto, onChange: setAuto },
+          { size: 'flex', value: flex, onChange: setFlex },
+          { size: '100%', value: full, onChange: setFull },
+          { size: 'content', value: content, onChange: setContent },
+        ].map(({ size, value, onChange }) => (
+          <Flexed key={size} label={size}>
+            <NumericInput value={value} onChange={onChange} size={size} />
+          </Flexed>
+        ))}
+      </Spaced>
+    );
+  })
+  .add('validations', () => {
+    const [error, setError] = useState(0);
+    const [warn, setWarn] = useState(0);
+    const [validity, setValidity] = useState(0);
+    const [nullState, setNull] = useState(0);
+    return (
+      <Spaced>
+        {[
+          { valid: 'error', value: error, onChange: setError },
+          { valid: 'warn', value: warn, onChange: setWarn },
+          { valid: 'valid', value: validity, onChange: setValidity },
+          { valid: null, value: nullState, onChange: setNull },
+        ].map(({ valid, value, onChange }) => (
+          <Flexed key={valid} label={String(valid)}>
+            <NumericInput value={value} onChange={onChange} size="100%" valid={valid} />
+          </Flexed>
+        ))}
+      </Spaced>
+    );
+  })
+  .add('alignment', () => {
+    const [end, setEnd] = useState(0);
+    const [center, setCenter] = useState(0);
+    const [start, setStart] = useState(0);
+    return (
+      <Spaced>
+        {[
+          { align: 'end', value: end, onChange: setEnd },
+          { align: 'center', value: center, onChange: setCenter },
+          { align: 'start', value: start, onChange: setStart },
+        ].map(({ align, value, onChange }) => (
+          <Flexed key={align} label={align}>
+            <NumericInput value={value} onChange={onChange} size="100%" align={align} />
+          </Flexed>
+        ))}
+      </Spaced>
+    );
+  });

--- a/lib/components/src/form/index.tsx
+++ b/lib/components/src/form/index.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@storybook/theming';
 import { Field } from './field/field';
 // InputStyleProps import is for TS
-import { InputStyleProps, Input, Select, Textarea, Button } from './input/input';
+import { InputStyleProps, Input, Select, Textarea, Button, NumericInput } from './input/input';
 
 export const Form = Object.assign(
   styled.form({
@@ -14,5 +14,6 @@ export const Form = Object.assign(
     Select,
     Textarea,
     Button,
+    NumericInput,
   }
 );

--- a/lib/components/src/form/input/input.tsx
+++ b/lib/components/src/form/input/input.tsx
@@ -4,6 +4,7 @@ import React, {
   HTMLProps,
   SelectHTMLAttributes,
   ChangeEvent,
+  KeyboardEvent,
 } from 'react';
 import { styled, Theme, CSSObject } from '@storybook/theming';
 
@@ -201,6 +202,7 @@ const numericSizes = ({ value, size }: { value?: number; size?: NumericSizes }):
         width: `calc(${value ? value.toString().length : 1}ch + 20px)`,
         boxSizing: 'content-box',
         padding: '6px 10px',
+        // Override the default 32 as we are using content-box.
         minHeight: 20,
       };
     }
@@ -223,12 +225,30 @@ type NumericInputProps = Omit<HTMLProps<HTMLInputElement>, keyof NumericInputOwn
   NumericInputOwnProps;
 export const NumericInput = Object.assign(
   styled(
-    forwardRef<any, NumericInputProps>(({ size, valid, align, onChange, ...props }, ref) => {
-      const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-        onChange(parse(event.target.value));
-      };
-      return <input type="number" onChange={handleChange} {...props} ref={ref} />;
-    })
+    forwardRef<any, NumericInputProps>(
+      ({ size, valid, align, onChange, onKeyDown, ...props }, ref) => {
+        const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+          onChange(parse(event.target.value));
+        };
+        const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+          if (event.keyCode === 27) {
+            event.currentTarget.blur();
+          }
+          if (onKeyDown) {
+            onKeyDown(event);
+          }
+        };
+        return (
+          <input
+            type="number"
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            {...props}
+            ref={ref}
+          />
+        );
+      }
+    )
   )<NumericInputStyleProps>(
     styles,
     alignment,

--- a/lib/components/src/form/input/input.tsx
+++ b/lib/components/src/form/input/input.tsx
@@ -217,7 +217,7 @@ type NumericInputStyleProps = Omit<InputStyleProps, 'size'> & {
 type NumericInputOwnProps = {
   value?: number;
   defaultValue?: number;
-  onChange: (value: number) => number | void;
+  onChange: (value: number | '') => number | void;
 } & NumericInputStyleProps;
 type NumericInputProps = Omit<HTMLProps<HTMLInputElement>, keyof NumericInputOwnProps> &
   NumericInputOwnProps;

--- a/lib/components/src/form/input/input.tsx
+++ b/lib/components/src/form/input/input.tsx
@@ -1,4 +1,10 @@
-import React, { FunctionComponent, forwardRef, HTMLProps, SelectHTMLAttributes } from 'react';
+import React, {
+  FunctionComponent,
+  forwardRef,
+  HTMLProps,
+  SelectHTMLAttributes,
+  ChangeEvent,
+} from 'react';
 import { styled, Theme, CSSObject } from '@storybook/theming';
 
 import TextareaAutoResize, { TextareaAutosizeProps } from 'react-textarea-autosize';
@@ -57,7 +63,7 @@ export interface InputStyleProps {
   height?: number;
 }
 
-const sizes = ({ size }: { size?: Sizes }): CSSObject => {
+const sizes = ({ size }: Pick<InputStyleProps, 'size'>): CSSObject => {
   switch (size) {
     case '100%': {
       return { width: '100%' };
@@ -71,7 +77,7 @@ const sizes = ({ size }: { size?: Sizes }): CSSObject => {
     }
   }
 };
-const alignment = ({ align }: InputStyleProps): CSSObject => {
+const alignment = ({ align }: Pick<InputStyleProps, 'align'>): CSSObject => {
   switch (align) {
     case 'end': {
       return { textAlign: 'right' };
@@ -85,7 +91,10 @@ const alignment = ({ align }: InputStyleProps): CSSObject => {
     }
   }
 };
-const validation = ({ valid, theme }: { valid: ValidationStates; theme: Theme }): CSSObject => {
+const validation = ({
+  valid,
+  theme,
+}: Pick<InputStyleProps, 'valid'> & { valid: ValidationStates; theme: Theme }): CSSObject => {
   switch (valid) {
     case 'valid': {
       return { boxShadow: `${theme.color.positive} 0 0 0 1px inset !important` };
@@ -175,5 +184,61 @@ export const Button: FunctionComponent<any> = Object.assign(
   )),
   {
     displayName: 'Button',
+  }
+);
+
+export const parse = (value: string) => {
+  const result = parseFloat(value);
+  return Number.isNaN(result) ? '' : result;
+};
+
+type NumericSizes = Sizes | 'content';
+
+const numericSizes = ({ value, size }: { value?: number; size?: NumericSizes }): CSSObject => {
+  switch (size) {
+    case 'content': {
+      return {
+        width: `calc(${value ? value.toString().length : 1}ch + 20px)`,
+        boxSizing: 'content-box',
+        padding: '6px 10px',
+        minHeight: 20,
+      };
+    }
+    default: {
+      return sizes({ size });
+    }
+  }
+};
+
+type NumericInputStyleProps = Omit<InputStyleProps, 'size'> & {
+  size?: NumericSizes;
+};
+
+type NumericInputOwnProps = {
+  value?: number;
+  defaultValue?: number;
+  onChange: (value: number) => number | void;
+} & NumericInputStyleProps;
+type NumericInputProps = Omit<HTMLProps<HTMLInputElement>, keyof NumericInputOwnProps> &
+  NumericInputOwnProps;
+export const NumericInput = Object.assign(
+  styled(
+    forwardRef<any, NumericInputProps>(({ size, valid, align, onChange, ...props }, ref) => {
+      const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        onChange(parse(event.target.value));
+      };
+      return <input type="number" onChange={handleChange} {...props} ref={ref} />;
+    })
+  )<NumericInputStyleProps>(
+    styles,
+    alignment,
+    validation,
+    {
+      minHeight: 32,
+    },
+    numericSizes
+  ),
+  {
+    displayName: 'NumericInput',
   }
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -32904,6 +32904,11 @@ use-composed-ref@^1.0.0:
   dependencies:
     ts-essentials "^2.0.3"
 
+use-debounce@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-5.0.1.tgz#b11861bc63970bfc6fd8393a0a3cc3d7cb5944ce"
+  integrity sha512-YHzlVa7qKFRlrMpVRiStGWGE0lumwJiQPvsTMlatsIrck39ycyJkdf0npUYG5MJEVxaJQWwvpmePRYZb534upg==
+
 use-image@^1.0.3:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/use-image/-/use-image-1.0.5.tgz#51fa23fe705c3ad0d4ae3eca6cf636551c591693"


### PR DESCRIPTION
This is still a WIP.

Issue: #12586 

## What I did
- Added a NumericInput component to `@storybook/components`
- Used the new NumericInput in place of the width/height labels in the `@storybook/addon-viewport` toolbar.
- Adjusted the way styles are applied from the `@storybook/addon-viewport` plugin, to work with the new inputs.

## How to test

- Chromatic screenshots for the NumericInput.