### PR TITLE
Fix copy for Docs

### DIFF
--- a/docs/writing-docs/introduction.md
+++ b/docs/writing-docs/introduction.md
@@ -13,7 +13,7 @@ Storybook gives you tools to expand this basic documentation with prose and layo
   />
 </video>
 
-Out of the box, Storybook ships with [DocsPage](./docs-page.md), a documentation template that lists all the stories for a component and associated metadata. It infers metadata values based on source code, types and JSDoc comments. [Customize](./docs-page.md#replacing-docspage) this page to create a new template if you have specific requirements.
+When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/master/addons/docs/README.md#installation), you can use [DocsPage](./docs-page.md), a documentation template that lists all the stories for a component and associated metadata. It infers metadata values based on source code, types and JSDoc comments. [Customize](./docs-page.md#replacing-docspage) this page to create a new template if you have specific requirements.
 
 You can also create free-form pages for each component using [MDX](./mdx.md), a format for simultaneously documenting components and writing stories.
 

--- a/docs/writing-docs/introduction.md
+++ b/docs/writing-docs/introduction.md
@@ -13,7 +13,9 @@ Storybook gives you tools to expand this basic documentation with prose and layo
   />
 </video>
 
-When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/master/addons/docs/README.md#installation), you can use [DocsPage](./docs-page.md), a documentation template that lists all the stories for a component and associated metadata. It infers metadata values based on source code, types and JSDoc comments. [Customize](./docs-page.md#replacing-docspage) this page to create a new template if you have specific requirements.
+If you're including Storybook in your project for the [first time](../get-started/install.md), we provide you with [DocsPage](./docs-page.md), a documentation template that lists all the stories for a component and associated metadata. It infers metadata values based on source code, types and JSDoc comments. If you need, you can customize this page to create your own custom template.
+
+If you're already using Storybook and you're **updating** to the latest release, we recommend that you install [@storybook/addon-essentials](https://www.npmjs.com/package/@storybook/addon-essentials), to include this and other great features into your project.
 
 You can also create free-form pages for each component using [MDX](./mdx.md), a format for simultaneously documenting components and writing stories.
 


### PR DESCRIPTION
The website state that DocsPage is available out of the box with Storybook. After upgrading to Storybook v6 in a recent project, I didn't have access to Docs, and had to install the addon separately. You can also see in the [next page](https://storybook.js.org/docs/react/writing-docs/docs-page) that it states you need to install Storybook Docs to get access to DocsPage (which is more accurate, albeit conflicting and confusing in it's present state).

I changed the copy from `Out of the box` to `When you install Storybook Docs` to clarify that the user does indeed need to install the addon to access the functionality.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
