### PR TITLE
Relative link to docs broken

### DIFF
--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -2,7 +2,7 @@
 title: 'DocsPage'
 ---
 
-When you install [Storybook Docs](../../addons/docs/README.md), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
+When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/master/addons/docs/README.md), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
 
 The best practice for docs is for each component to have its own set of documentation and stories.
 


### PR DESCRIPTION
The link to Storybook docs was relative, which on [the production site](https://storybook.js.org/docs/react/writing-docs/docs-page) links to the **next** branch, instead of the **master**.

Old link using relative:
`https://github.com/storybookjs/storybook/blob/next/addons/docs/README`

New link:
`https://github.com/storybookjs/storybook/blob/master/addons/docs/README.md`

Not sure if there's a way to use the relative link and have it point to master instead of next? But for now, hard-coded link will definitely work.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
