### PR TITLE
Addon-docs: Fix line-height in Typeset

### DIFF
--- a/lib/components/src/blocks/Typeset.tsx
+++ b/lib/components/src/blocks/Typeset.tsx
@@ -60,7 +60,7 @@ export const Typeset: FunctionComponent<TypesetProps> = ({
             fontFamily,
             fontSize: size,
             fontWeight,
-            lineHeight: size,
+            lineHeight: `${size}px`,
           }}
         >
           {sampleText || 'Was he a beast if music could move him so?'}


### PR DESCRIPTION
lineHeight css property should include px, otherwise it will act as a multiplier

Issue:

<img width="1030" alt="Screenshot 2020-10-01 at 19 02 21" src="https://user-images.githubusercontent.com/5922147/94846215-af32cb80-0418-11eb-8522-e06209aeee6a.png">


## What I did
Change value passed to the lineHeight CSS Property to be a string with px

## How to test

Running storybook using the Typeset component from Addon-docs.

