### PR TITLE
Added failing test for falsey default values

### DIFF
--- a/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
@@ -181,6 +181,41 @@ describe('enhanceArgTypes', () => {
         `);
       });
 
+      it('will fail with a falsey value if an arg isnt passed', () => {
+        expect(
+          enhance({
+            argType: { defaultValue: 0, control: { type: 'range', step: 50 } },
+            arg: undefined,
+            extractedArgTypes: { input: { name: 'input' } },
+          }).input
+        ).toMatchInlineSnapshot(`
+          {
+            "name": "input",
+            "defaultValue": 0,
+            "control": {
+              "type": "range",
+              "step": 50
+            }
+          }
+        `);
+        expect(
+          enhance({
+            argType: { defaultValue: false, control: { type: 'range', step: 50 } },
+            arg: undefined,
+            extractedArgTypes: { input: { name: 'input' } },
+          }).input
+        ).toMatchInlineSnapshot(`
+          {
+            "name": "input",
+            "defaultValue": false,
+            "control": {
+              "type": "range",
+              "step": 50
+            }
+          }
+        `);
+      });
+
       it('user-specified controls take precedence over inferred controls', () => {
         expect(
           enhance({


### PR DESCRIPTION
Issue:

When the default value for an argType is falsey, and no arg is provided, the arg shows as undefined in the args passed to the story.

## What I did

I added tests that should fail and highlight the issue

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
