### PR TITLE
Addon-docs: Fix scroll bug on page nav

### DIFF
--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -75,11 +75,11 @@ export const DocsContainer: FunctionComponent<DocsContainerProps> = ({ context, 
         setTimeout(() => {
           scrollToElement(scrollTarget, 'start');
         }, 200);
+      } else if (docsWrapperRef.current) {
+        setTimeout(() => {
+          scrollToElement(docsWrapperRef.current, 'start');
+        }, 200);
       }
-      // Handles scroll when element is undefined
-      setTimeout(() => {
-        scrollToElement(docsWrapperRef.current, 'start');
-      }, 200);
     }
   }, [storyId]);
 

--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -89,7 +89,7 @@ export const DocsContainer: FunctionComponent<DocsContainerProps> = ({ context, 
         <ThemeProvider theme={theme}>
           <MDXProvider components={allComponents}>
             <DocsWrapper className="sbdocs sbdocs-wrapper" ref={docsWrapperRef}>
-              <DocsContent className="sbdocs sbdocs-content">poop{children}</DocsContent>
+              <DocsContent className="sbdocs sbdocs-content">{children}</DocsContent>
             </DocsWrapper>
           </MDXProvider>
         </ThemeProvider>

--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -34,6 +34,7 @@ const warnOptionsTheme = deprecate(
 );
 
 export const DocsContainer: FunctionComponent<DocsContainerProps> = ({ context, children }) => {
+  const docsWrapperRef = React.useRef<HTMLDivElement | null>(null);
   const { id: storyId = null, parameters = {} } = context || {};
   const { options = {}, docs = {} } = parameters;
   let themeVars = docs.theme;
@@ -75,6 +76,10 @@ export const DocsContainer: FunctionComponent<DocsContainerProps> = ({ context, 
           scrollToElement(scrollTarget, 'start');
         }, 200);
       }
+      // Handles scroll when element is undefined
+      setTimeout(() => {
+        scrollToElement(docsWrapperRef.current, 'start');
+      }, 200);
     }
   }, [storyId]);
 
@@ -83,8 +88,8 @@ export const DocsContainer: FunctionComponent<DocsContainerProps> = ({ context, 
       <SourceContainer>
         <ThemeProvider theme={theme}>
           <MDXProvider components={allComponents}>
-            <DocsWrapper className="sbdocs sbdocs-wrapper">
-              <DocsContent className="sbdocs sbdocs-content">{children}</DocsContent>
+            <DocsWrapper className="sbdocs sbdocs-wrapper" ref={docsWrapperRef}>
+              <DocsContent className="sbdocs sbdocs-content">poop{children}</DocsContent>
             </DocsWrapper>
           </MDXProvider>
         </ThemeProvider>


### PR DESCRIPTION
Issue: #12497

## What I did
Investigated why the scroll behavior wasn't working as expected in #12497 .

```
const element =
  document.getElementById(anchorBlockIdFromId(storyId)) ||
  document.getElementById(storyBlockIdFromId(storyId));
 ```

`element` above is `undefined` so `scrollToElement()` was never being called. 

The approach I took was to add a ref to `<DocsWrapper />` to serve as a fail-safe and always scroll if `element` is `undefined`. 

Other potential solutions: There may be a solution involved with how `anchorBlockIdFromId()` and `storyBlockIdFromId()` are finding `storyId`. It's possible that when creating stories with MDX, these ids aren't being created so that these functions can find them. Happy to investigate further if warranted. 

## How to test

- Is this testable with Jest or Chromatic screenshots? no / unsure.
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
