### PR TITLE
Essentials: Make controls tab show first

### DIFF
--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -34,7 +34,7 @@ export function addons(options: PresetOptions = {}) {
 
   const main = requireMain(options.configDir);
   return (
-    ['actions', 'docs', 'controls', 'backgrounds', 'viewport', 'toolbars']
+    ['docs', 'controls', 'actions', 'backgrounds', 'viewport', 'toolbars']
       .filter((key) => (options as any)[key] !== false)
       .map((key) => `@storybook/addon-${key}`)
       .filter((addon) => !checkInstalled(addon, main))


### PR DESCRIPTION
Issue: #12640 

## What I did

Make controls tab show first

## How to test

See `examples/cra-ts-essentials` 