### PR TITLE
Storyshots Puppeteer: Fix support for over 1 assertions in async tests

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/src/imageSnapshot.ts
+++ b/addons/storyshots/storyshots-puppeteer/src/imageSnapshot.ts
@@ -11,6 +11,7 @@ export const imageSnapshot = (customConfig: Partial<ImageSnapshotConfig> = {}) =
   return puppeteerTest({
     ...config,
     async testBody(page, options) {
+      expect.hasAssertions();
       const element = await beforeScreenshot(page, options);
       const image = await (element || page).screenshot(getScreenshotOptions(options));
       await afterScreenshot({ image, context: options.context });

--- a/addons/storyshots/storyshots-puppeteer/src/imageSnapshot.ts
+++ b/addons/storyshots/storyshots-puppeteer/src/imageSnapshot.ts
@@ -11,7 +11,6 @@ export const imageSnapshot = (customConfig: Partial<ImageSnapshotConfig> = {}) =
   return puppeteerTest({
     ...config,
     async testBody(page, options) {
-      expect.assertions(1);
       const element = await beforeScreenshot(page, options);
       const image = await (element || page).screenshot(getScreenshotOptions(options));
       await afterScreenshot({ image, context: options.context });


### PR DESCRIPTION
## What I did
I wanna do more assertions in the test like this.
https://jestjs.io/docs/en/asynchronous#callbacks

maybe this assertions should be in the test code and not in the runtime code.
