### PR TITLE
Addon-controls: Add JSON tree editor for Object args

### DIFF
--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -11,25 +11,42 @@ export default {
   },
 };
 
+const DEFAULT_NESTED_OBJECT = { a: 4, b: { c: 'hello', d: [1, 2, 3] } };
+
 const Template = (args) => <Button {...args} />;
 
 export const Basic = Template.bind({});
 Basic.args = {
   children: 'basic',
-  somethingElse: { a: 2 },
+  somethingElse: DEFAULT_NESTED_OBJECT,
 };
 
 export const Action = Template.bind({});
 Action.args = {
   children: 'hmmm',
   type: 'action',
-  somethingElse: { a: 4 },
+  somethingElse: DEFAULT_NESTED_OBJECT,
 };
 
 export const CustomControls = Template.bind({});
+CustomControls.args = {
+  children: 'hmmm',
+  type: 'action',
+  somethingElse: DEFAULT_NESTED_OBJECT,
+};
+
 CustomControls.argTypes = {
   children: { table: { disable: true } },
   type: { control: { disable: true } },
+  somethingElse: {
+    control: {
+      type: 'object',
+      collapsed: true,
+      displayObjectSize: false,
+      displayDataTypes: false,
+      // See src/controls/types:ObjectConfig for all options
+    },
+  },
 };
 
 export const NoArgs = () => <Button>no args</Button>;

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -46,6 +46,7 @@
     "react": "^16.8.3",
     "react-color": "^2.17.0",
     "react-dom": "^16.8.3",
+    "react-json-view": "^1.19.1",
     "react-popper-tooltip": "^3.1.0",
     "react-syntax-highlighter": "^13.5.0",
     "react-textarea-autosize": "^8.1.1",

--- a/lib/components/src/controls/Object.tsx
+++ b/lib/components/src/controls/Object.tsx
@@ -24,6 +24,7 @@ export const ObjectControl: FC<ObjectProps> = ({
   enableClipboard = true,
   displayObjectSize = true,
   displayDataTypes = true,
+  sortKeys = false,
 }) => {
   const handleChange = useCallback(
     (payload: InteractionProps) => {
@@ -51,6 +52,7 @@ export const ObjectControl: FC<ObjectProps> = ({
         enableClipboard={enableClipboard}
         displayObjectSize={displayObjectSize}
         displayDataTypes={displayDataTypes}
+        sortKeys={sortKeys}
       />
     </Wrapper>
   );

--- a/lib/components/src/controls/types.ts
+++ b/lib/components/src/controls/types.ts
@@ -37,7 +37,61 @@ export interface NumberConfig {
 export type RangeConfig = NumberConfig;
 
 export type ObjectValue = any;
-export interface ObjectConfig {}
+export interface ObjectConfig {
+  /**
+   * Style of expand/collapse icons. Accepted values are "circle", triangle" or "square".
+   *
+   * Default: {}
+   */
+  iconStyle?: 'circle' | 'triangle' | 'square';
+  /**
+   * Set the indent-width for nested objects.
+   *
+   * Default: 4
+   */
+  indentWidth?: number;
+  /**
+   * When set to true, all nodes will be collapsed by default.
+   * Use an integer value to collapse at a particular depth.
+   *
+   * Default: false
+   */
+  collapsed?: boolean | number;
+  /**
+   * When an integer value is assigned, strings will be cut off at that length.
+   * Collapsed strings are followed by an ellipsis.
+   * String content can be expanded and collapsed by clicking on the string value.
+   *
+   * Default: false
+   */
+  collapseStringsAfterLength?: number | false;
+  /**
+   * When an integer value is assigned, arrays will be displayed in groups by count of the value.
+   * Groups are displayed with brakcet notation and can be expanded and collapsed by clickong on the brackets.
+   *
+   * Default: 100
+   */
+  groupArraysAfterLength?: number;
+  /**
+   * When prop is not false, the user can copy objects and arrays to clipboard by clicking on the clipboard icon.
+   * Copy callbacks are supported.
+   *
+   * Default: true
+   */
+  enableClipboard?: boolean;
+  /**
+   * When set to true, objects and arrays are labeled with size.
+   *
+   * Default: true
+   */
+  displayObjectSize?: boolean;
+  /**
+   * When set to true, data type labels prefix values.
+   *
+   * Default: true
+   */
+  displayDataTypes?: boolean;
+}
 
 export type OptionsSingleSelection = any;
 export type OptionsMultiSelection = any[];

--- a/lib/components/src/controls/types.ts
+++ b/lib/components/src/controls/types.ts
@@ -91,6 +91,12 @@ export interface ObjectConfig {
    * Default: true
    */
   displayDataTypes?: boolean;
+  /**
+   * Set to true to sort object keys.
+   *
+   * Default: false
+   */
+  sortKeys?: boolean;
 }
 
 export type OptionsSingleSelection = any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8874,6 +8874,11 @@ base-x@^3.0.7:
   dependencies:
     safe-buffer "^5.0.1"
 
+base16@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base16/-/base16-1.0.0.tgz#e297f60d7ec1014a7a971a39ebc8a98c0b681e70"
+  integrity sha1-4pf2DX7BAUp6lxo568ipjAtoHnA=
+
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
@@ -15497,7 +15502,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs@^0.8.1, fbjs@^0.8.9:
+fbemitter@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fbemitter/-/fbemitter-2.1.1.tgz#523e14fdaf5248805bb02f62efc33be703f51865"
+  integrity sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=
+  dependencies:
+    fbjs "^0.8.4"
+
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -15847,6 +15859,14 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+flux@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/flux/-/flux-3.1.3.tgz#d23bed515a79a22d933ab53ab4ada19d05b2f08a"
+  integrity sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=
+  dependencies:
+    fbemitter "^2.0.0"
+    fbjs "^0.8.0"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -21983,6 +22003,11 @@ lodash.clonedeep@^4.4.1, lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.curry@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
+  integrity sha1-JI42By7ekGUB11lmIAqG2riyMXA=
+
 lodash.debounce@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
@@ -22022,6 +22047,11 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.flow@^3.3.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
+  integrity sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=
 
 lodash.foreach@^4.5.0:
   version "4.5.0"
@@ -26828,6 +26858,11 @@ puppeteer@^2.0.0:
     rimraf "^2.6.1"
     ws "^6.1.0"
 
+pure-color@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
+  integrity sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4=
+
 purgecss@^1.4.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-1.4.2.tgz#67ab50cb4f5c163fcefde56002467c974e577f41"
@@ -27282,6 +27317,16 @@ react-app-polyfill@^1.0.1, react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
+react-base16-styling@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-base16-styling/-/react-base16-styling-0.6.0.tgz#ef2156d66cf4139695c8a167886cb69ea660792c"
+  integrity sha1-7yFW1mz0E5aVyKFniGy2nqZgeSw=
+  dependencies:
+    base16 "^1.0.0"
+    lodash.curry "^4.0.1"
+    lodash.flow "^3.3.0"
+    pure-color "^1.2.0"
+
 react-color@^2.17.0:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.18.1.tgz#2cda8cc8e06a9e2c52ad391a30ddad31972472f4"
@@ -27496,6 +27541,16 @@ react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-i
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-json-view@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/react-json-view/-/react-json-view-1.19.1.tgz#95d8e59e024f08a25e5dc8f076ae304eed97cf5c"
+  integrity sha512-u5e0XDLIs9Rj43vWkKvwL8G3JzvXSl6etuS5G42a8klMohZuYFQzSN6ri+/GiBptDqlrXPTdExJVU7x9rrlXhg==
+  dependencies:
+    flux "^3.1.3"
+    react-base16-styling "^0.6.0"
+    react-lifecycles-compat "^3.0.4"
+    react-textarea-autosize "^6.1.0"
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -27726,6 +27781,13 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.8.3:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
+
+react-textarea-autosize@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-6.1.0.tgz#df91387f8a8f22020b77e3833c09829d706a09a5"
+  integrity sha512-F6bI1dgib6fSvG8so1HuArPUv+iVEfPliuLWusLF+gAKz0FbB4jLrWUrTAeq1afnPT2c9toEZYUdz/y1uKMy4A==
+  dependencies:
+    prop-types "^15.6.0"
 
 react-textarea-autosize@^8.1.1:
   version "8.1.1"


### PR DESCRIPTION
Issue: #12599 

## What I did

- Replaced the existing text form control with the `react-json-view` lib (public demo here: https://mac-s-g.github.io/react-json-view/demo/dist/ )
- Updated `ObjectConfig` so that the user can customize the behavior of this control using all non-function props of the `ReactJSON` component
- Updated the `official-storybook` story about using add-controls
- Example GIF of the new controls in action: https://a.cl.ly/xQuAg4dy

Thanks to @yannbf for providing a guide to getting started and showing an example with using `knobs` [here](https://github.com/storybookjs/storybook/issues/12599#issuecomment-702425452). 

## How to test

- Is this testable with Jest or Chromatic screenshots?

It's possible, but I'm not sure that it's necessary.

- Does this need a new example in the kitchen sink apps?

We could, but I think updating the main storybook story may be sufficient, as this change should benefit most users without needing them to customize anything. 

- Does this need an update to the documentation?

We could document the `ObjectConfig` options on[this page](https://storybook.js.org/docs/react/essentials/controls#annotation).

 On the other hand, we could also keep this as an undocumented feature if we're not sure whether we want users to be customizing their controls to this level. Not documenting these properties officially gives us the flexibility to switch to other JSON tree components in the future, without fear that the new library may not support all of these options. 

## FAQ

- Why not some other JSON tree viewer library XYZ?
  - `react-json` was picked for its balance between features and bundle weight. See the options that were evaluated here: https://github.com/storybookjs/storybook/issues/12599#issuecomment-701097502 . Very open to trying other suggestions if you have recommendations.

- What terminal commands did you use that you might use again next time?

```bash
# to add a dependency scoped to 1 package (seems basic, but it took me a while to figure out the right scope as a new contributor)
yarn lerna add react-json-view --scope=@storybook/components

# to test locally
yarn build components --watch
yarn start
```

- Any modifications useful in dev that you didn't commit?

 1 change in `examples/official-storybook/main.ts` to speed up build time:

```js
{
stories: [
    './stories/**/addon-controls.stories.@(js|ts|tsx|mdx)',
  ]
 // ... rest
}
```