### PR TITLE
Composition: Fix incorrect ref type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Sidebar: Better search, keyboard shortcuts, and "recently viewed" ([#12601](https://github.com/storybookjs/storybook/pull/12601))
 - Source-loader: Generate sourcemaps ([#12277](https://github.com/storybookjs/storybook/pull/12277))
-- Core: Add apng support ([#12639](https://github.com/storybookjs/storybook/pull/12639))
+- Core: Add APNG support ([#12639](https://github.com/storybookjs/storybook/pull/12639))
 
 ### Bug Fixes
 

--- a/lib/core/src/server/manager/manager-config.js
+++ b/lib/core/src/server/manager/manager-config.js
@@ -120,7 +120,7 @@ async function getManagerWebpackConfig(options, presets) {
     // verify the refs are publicly reachable, if they are not we'll require stories.json at runtime, otherwise the ref won't work
     await Promise.all(
       Object.entries(refs).map(async ([k, value]) => {
-        const ok = checkRef(value.url);
+        const ok = await checkRef(value.url);
 
         refs[k] = { ...value, type: ok ? 'server-checked' : 'unknown' };
       })


### PR DESCRIPTION
Issue: #12708 

## What I did

Added `await` to ensure `ok` is set with the fulfilled value of the promise from `checkRef`.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
