### PR TITLE
Chore: Fix broken links in the documentation

### DIFF
--- a/docs/api/presets.md
+++ b/docs/api/presets.md
@@ -37,7 +37,7 @@ Then load it in the file `main.js` in your storybook folder (`.storybook` by def
 
 <!-- prettier-ignore-end -->
 
-That's it. When Storybook starts up, it will configure itself to use SCSS styling without any further configuration. For more information, see the SCSS preset [README](https://github.com/storybookjs/presets/blob/master/packages/preset-scss/README.md).
+That's it. When Storybook starts up, it will configure itself to use SCSS styling without any further configuration. For more information, see the SCSS preset [README](https://github.com/storybookjs/presets/blob/master/packages/preset-scss/).
 
 ## Preset configuration
 

--- a/docs/configure/story-rendering.md
+++ b/docs/configure/story-rendering.md
@@ -2,7 +2,7 @@
 title: 'Story rendering'
 ---
 
-In Storybook, your stories render in a special “preview” iframe (Canvas tab) inside the larger Storybook web application. The JavaScript build configuration of the preview is controlled by a [webpack](./integration.md#default-configuration) config, but you also may want to directly control the HTML that is rendered to help your stories render correctly.
+In Storybook, your stories render in a special “preview” iframe (Canvas tab) inside the larger Storybook web application. The JavaScript build configuration of the preview is controlled by a [webpack](./webpack.md) config, but you also may want to directly control the HTML that is rendered to help your stories render correctly.
 
 ## Adding to &#60;head&#62;
 

--- a/docs/configure/typescript.md
+++ b/docs/configure/typescript.md
@@ -6,7 +6,7 @@ Storybook has built-in Typescript support, so your Typescript project should wor
 
 ### Default configuration
 
-The base Typescript configuration uses [`babel-loader`](https://webpack.js.org/loaders/babel-loader/) for Typescript transpilation, and optionally [`fork-ts-checker-webpack-plugin`](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/v4.1.6/README.md#options) for checking.
+The base Typescript configuration uses [`babel-loader`](https://webpack.js.org/loaders/babel-loader/) for Typescript transpilation, and optionally <a href="https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/v4.1.6/README.md#options"><code>fork-ts-checker-webpack-plugin</code></a> for checking.
 
 Each framework uses the base configuration unless otherwise specified:
 
@@ -33,6 +33,6 @@ The following code snippets shows the fields for you to use with TypeScript:
 | Field                            | Framework | Description                                                                                 | Type                                                                                                   |
 | :------------------------------- | :-------- | :------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------- |
 | **check**                        | All       | Optionally run fork-ts-checker-webpack-plugin                                               | boolean                                                                                                |
-| **checkOptions**                 | All       | Options to pass to fork-ts-checker-webpack-plugin if it's enabled                           | [See docs](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/v4.1.6/README.md#options) |
+| **checkOptions**                 | All       | Options to pass to fork-ts-checker-webpack-plugin if it's enabled                           | <a href="https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/v4.1.6/README.md#options">See Docs</a> |
 | **reactDocgen**                  | React     | Which react docgen processor to run: `"react-docgen-typescript"`, `"react-docgen"`, `false` | string or false                                                                                        |
 | **reactDocgenTypescriptOptions** | React     | Options to pass to react-docgen-typescript-plugin if react-docgen-typescript is enabled.    | [See docs](https://github.com/hipstersmoothie/react-docgen-typescript-plugin)                          |

--- a/docs/frameworks.js
+++ b/docs/frameworks.js
@@ -72,7 +72,7 @@ module.exports = {
           unsupported: ['marko'],
         },
         {
-          name: 'query-params',
+          name: 'queryparams',
           unsupported: [],
         },
         {

--- a/docs/writing-docs/mdx.md
+++ b/docs/writing-docs/mdx.md
@@ -104,7 +104,7 @@ Typically, when you use Storybook MDX, you define stories in the MDX and documen
 
 If you don't define stories in your MDX, you can write MDX documentation and associate it with an existing story, or embed that MDX as its own documentation node in your Storybook's navigation.
 
-If you don't define a Meta, you can write Markdown and associate with an existing story. See ["CSF Stories with MDX Docs"](https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/recipes.md#csf-stories-with-mdx-docs).
+If you don't define a Meta, you can write Markdown and associate with an existing story. See ["CSF Stories with MDX Docs"](../../addons/docs/docs/recipes.md#csf-stories-with-mdx-docs).
 
 To get a "documentation-only story", in your UI, define a `<Meta>` as you normally would, but don't define any stories. It will show up in your UI as a documentation node:
 


### PR DESCRIPTION
With this pull request some broken links that still exist in the documentation are now fixed to the correct places.

What was done:
| Section      | Page                             | Item                                         | Notes                                                                                              |
|--------------|----------------------------------|----------------------------------------------|----------------------------------------------------------------------------------------------------|
| Writing Docs | MDX                              | CSF Stories with MDX Docs link               | Replaced with a relative link to avoid creation of a invalid URL to GitHub                         |
| Configure    | TypeScript                       | References to fork-ts-checker-webpack-plugin | Until version 5.x of the package is not added. The links to version 4.6 are now showing correctly. |
|              | Story Rendering                  | Link to webpack configuration page           | The link is now pointing to the proper page                                                        |
| API          | Presets                          | Link to SCSS preset readme                   | Link is now working properly                                                                       |
|              | Framework support for frameworks | Link to the queryparams addon                | When the reader clicks the addon link it will point to the proper location                         |

Feel free to provide feedback