### PR TITLE
Addon-knobs: Fix uncontrolled to controlled warning for booleans

### DIFF
--- a/addons/knobs/src/components/types/Boolean.tsx
+++ b/addons/knobs/src/components/types/Boolean.tsx
@@ -35,7 +35,7 @@ const BooleanType: FunctionComponent<BooleanTypeProps> & {
     name={knob.name}
     type="checkbox"
     onChange={(e) => onChange(e.target.checked)}
-    checked={knob.value}
+    checked={knob.value || false}
   />
 );
 


### PR DESCRIPTION
Same as #12322 to fix knob addon

## What I did

- [x] Fixed warning


