### PR TITLE
Correct Paramaters section

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -111,7 +111,7 @@ The Controls addon can be configured in two ways:
 
 ### Annotation
 
-As shown above, you can configure individual controls with the “control" annotation in the [argTypes](../api/argtypes) field of either a component or story.
+As shown above, you can configure individual controls with the `control` annotation in the [argTypes](../api/argtypes) field of either a component or story.
 
 Here is the full list of available controls you can use:
 
@@ -168,9 +168,9 @@ If you don't provide a specific one, it defaults to the number control type.
 
 ### Parameters
 
-Controls supports the following configuration [parameters](../writing-stories/parameters.md), either globally or on a per-story basis:
+[Parameters](../writing-stories/parameters.md) support the following control configurations, either globally or on a story.
 
-## Show full documentation for each property
+#### Show full documentation for each property
 
 Since Controls is built on the same engine as Storybook Docs, it can also show property documentation alongside your controls using the expanded parameter (defaults to false). This means you embed a complete [ArgsTable](../writing-docs/doc-blocks.md#argstable) doc block in the controls pane. The description and default value rendering can be [customized](#fully-custom-args) in the same way as the doc block.
 
@@ -190,9 +190,9 @@ And here's what the resulting UI looks like:
 
 ![Controls addon expanded](./addon-controls-expanded.png)
 
-## Hide NoControls warning
+#### Hide NoControls warning
 
-If you don't plan to handle the control args inside your Story, you can remove the warning with:
+If you don't plan to handle the control args inside your Story, you can remove the warning with the `controls.hideNoControlsWarning` parameter field.  You can hide the warning on a story using the `parameters` object like so:
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
Issue:
Parameters section hierarchy is inconsistent and other minor edits required.

## What I did
- Made some corrections to the heading hierarchy for the *Parameters* section. I hope it does not conflict with any docs style guidance on level 4 headings.
- *Hide NoControls warning* snippet was incorrect, so it took me a while to understand as a new user. I fixed the [snippet here](https://github.com/storybookjs/storybook/blob/next/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx) but I don't think it will hurt to make this paragraph more explicit.
- Grammatical fix in Annotation

## How to test

- Is this testable with Jest or Chromatic screenshots? Not sure
- Does this need a new example in the kitchen sink apps? Not sure
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
