### PR TITLE
Build: Improve angular e2e tests

### DIFF
--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -17,7 +17,7 @@ const baseAngular: Parameters = {
   version: 'latest',
   generator: [
     `yarn add @angular/cli@{{version}} --no-lockfile --non-interactive --silent --no-progress`,
-    `npx ng new {{name}}-{{version}} --routing=true --minimal=true --style=scss --skipInstall=true --strict`,
+    `yarn ng new {{name}}-{{version}} --routing=true --minimal=true --style=scss --skipInstall=true --strict`,
   ].join(' && '),
   additionalDeps: ['react', 'react-dom'],
 };

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -167,12 +167,10 @@ const addRequiredDeps = async ({ cwd, additionalDeps }: Options) => {
     if (additionalDeps && additionalDeps.length > 0) {
       await exec(`yarn add -D ${additionalDeps.join(' ')}`, {
         cwd,
-        silent: true,
       });
     } else {
       await exec(`yarn install`, {
         cwd,
-        silent: true,
       });
     }
   } catch (e) {


### PR DESCRIPTION
## What I did
  
 - Use yarn instead of `npx` to bootstrap angular e2e tests 
 - Display yarn install/add command output when running the E2E tests

## How to test

- CI should be 🟢  except Angular tests that are currently failing
- We should be able to see the cause of the issue in Angular tests:
> error @aduh95/viz.js@3.1.0: The engine "node" is incompatible with this module. Expected version "^12.17.0 || >=13.2.0". Got "12.16.2"
error Found incompatible module.