### PR TITLE
docs: reference the decorators in the introduction page

### DIFF
--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -182,6 +182,7 @@ A simple example is adding padding to a component’s stories. Accomplish this u
     'react/button-story-component-decorator.js.mdx',
     'react/button-story-component-decorator.ts.mdx',
     'vue/button-story-component-decorator.js.mdx',
+    'angular/button-story-component-decorator.ts.mdx',
   ]}
 />
 


### PR DESCRIPTION
Issue: N/A

## What I did
The decorators apart from the actual landing page, have also a reference on the introduction page which should also have an Angular example.

I included the `decorators` example in the [writing-stories/introduction](https://storybook.js.org/docs/angular/writing-stories/introduction) page.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
