### PR TITLE
Core: Add new layout style `none` and fix layout styles

### DIFF
--- a/examples/official-storybook/stories/core/layout.stories.js
+++ b/examples/official-storybook/stories/core/layout.stories.js
@@ -29,5 +29,8 @@ CenteredBlock.parameters = { layout: 'centered' };
 export const CenteredInline = () => <Box display="inline-block">centered</Box>;
 CenteredInline.parameters = { layout: 'centered' };
 
+export const None = () => <Box>none</Box>;
+None.parameters = { layout: 'none' };
+
 export const Invalid = () => <Box>invalid layout value</Box>;
 Invalid.parameters = { layout: '!invalid!' };

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -24,7 +24,8 @@ export type ViewMode = 'story' | 'docs';
 export interface Parameters {
   fileName?: string;
   options?: OptionsParameter;
-  layout?: 'centered' | 'fullscreen' | 'padded';
+  /** The layout property defines basic styles added to the preview body where the story is rendered. If you pass 'none', no styles are applied. */
+  layout?: 'centered' | 'fullscreen' | 'padded' | 'none';
   docsOnly?: boolean;
   [key: string]: any;
 }

--- a/lib/core/src/server/templates/base-preview-head.html
+++ b/lib/core/src/server/templates/base-preview-head.html
@@ -7,6 +7,28 @@
     display: none;
   }
 
+  .sb-main-centered {
+    margin: 0;
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    box-sizing: border-box;
+  }
+
+  .sb-main-fullscreen {
+    margin: 0;
+    padding: 0;
+    display: block;
+  }
+
+  .sb-main-padded {
+    margin: 0;
+    padding: 1rem;
+    display: block;
+  }
+
   .sb-wrapper {
     position: fixed;
     top: 0;


### PR DESCRIPTION
Issue: #12434 #12041

This PR: Removes the logic from adding styles on body element through styles attr. 
Adds a new option for layout: none.

## What I did
Added a new option for layouts called none, which won't apply any new style on preview body.
Moved the layouts styles from js to CSS.
Fixed CSS initials override.

## How to test

Change the layout property on story parameters to one of the available layouts:

example:
`None.parameters = { layout: 'none' };`


- Is this testable with Jest or Chromatic screenshots?
I don't think it will break any story.

- Does this need a new example in the kitchen sink apps?
It's added.

- Does this need an update to the documentation?
Yes, but I didn't find any docs related to available parameters.

If your answer is yes to any of these, please make sure to include it in your PR.

## Discussion
When the received layout is invalid, what should be the proper behaviour?
For now, it is showing a warning on the console with the invalid option and telling the available options. However, this solution also adds an `undefined` as a class on the body.

Thanks to @yannbf for the guidance :D

