### PR TITLE
feat(addon-controls): support query parameters

### DIFF
--- a/addons/controls/src/components/ControlsPanel.tsx
+++ b/addons/controls/src/components/ControlsPanel.tsx
@@ -1,8 +1,18 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { ArgsTable, NoControlsWarning } from '@storybook/components';
 import { useArgs, useArgTypes, useParameter } from '@storybook/api';
+import { getQueryParams } from '@storybook/client-api';
 
 import { PARAM_KEY } from '../constants';
+
+const controlsValuesFromUrl: Record<string, string> = Object.entries(getQueryParams())
+  .filter((key) => {
+    return key[0]?.includes('control-');
+  })
+  .reduce((acc, [key, value]) => {
+    const argName = key.replace('control-', '');
+    return { ...acc, [argName]: value };
+  }, {});
 
 interface ControlsParameters {
   expanded?: boolean;
@@ -18,6 +28,13 @@ export const ControlsPanel: FC = () => {
     {}
   );
   const hasControls = Object.values(rows).filter((argType) => !!argType?.control).length > 0;
+
+  useEffect(() => {
+    if (Object.keys(controlsValuesFromUrl).length > 0) {
+      updateArgs(controlsValuesFromUrl);
+    }
+  }, []);
+
   return (
     <>
       {(hasControls && isArgsStory) || hideNoControlsWarning ? null : <NoControlsWarning />}

--- a/addons/controls/src/components/ControlsPanel.tsx
+++ b/addons/controls/src/components/ControlsPanel.tsx
@@ -1,5 +1,6 @@
-import React, { FC, useEffect } from 'react';
-import { ArgsTable, NoControlsWarning } from '@storybook/components';
+import React, { FC, useCallback, useEffect } from 'react';
+import copy from 'copy-to-clipboard';
+import { ActionBar, ArgsTable, NoControlsWarning } from '@storybook/components';
 import { useArgs, useArgTypes, useParameter } from '@storybook/api';
 import { getQueryParams } from '@storybook/client-api';
 
@@ -35,15 +36,29 @@ export const ControlsPanel: FC = () => {
     }
   }, []);
 
+  const copyArgs = useCallback(() => {
+    // const { location } = window.document;
+    // const query = qs.parse(location.search, { ignoreQueryPrefix: true });
+
+    Object.entries(args).forEach(([name, arg]) => {
+      console.log({ name, arg });
+      // query[`control-${name}`] = getKnobControl(knob.type).serialize(knob.value);
+    });
+    // copy(`${location.origin + location.pathname}?${qs.stringify(query, { encode: false })}`);
+  }, [args]);
+
+  const isControlsEnabled = hasControls && isArgsStory;
+
   return (
     <>
-      {(hasControls && isArgsStory) || hideNoControlsWarning ? null : <NoControlsWarning />}
+      {isControlsEnabled || hideNoControlsWarning ? null : <NoControlsWarning />}
       <ArgsTable
         {...{
           compact: !expanded && hasControls,
           rows,
           args,
           updateArgs,
+          copyArgs,
           resetArgs,
           inAddonPanel: true,
         }}

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
@@ -181,7 +181,7 @@ export const TableWrapper = styled.table<{ compact?: boolean; inAddonPanel?: boo
   })
 );
 
-const ResetButton = styled.button(({ theme }) => ({
+const UtilityButton = styled.button(({ theme }) => ({
   border: 0,
   borderRadius: '3em',
   cursor: 'pointer',
@@ -221,6 +221,12 @@ const ControlHeadingWrapper = styled.span({
   justifyContent: 'space-between',
 });
 
+const ControlButtons = styled.span({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '12px',
+});
+
 export enum ArgsTableError {
   NO_COMPONENT = 'No component found.',
   ARGS_UNSUPPORTED = 'Args unsupported. See Args documentation for your framework.',
@@ -229,6 +235,7 @@ export enum ArgsTableError {
 export interface ArgsTableRowProps {
   rows: ArgTypes;
   args?: Args;
+  copyArgs?: () => void;
   updateArgs?: (args: Args) => void;
   resetArgs?: (argNames?: string[]) => void;
   compact?: boolean;
@@ -302,6 +309,7 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     rows,
     args,
     updateArgs,
+    copyArgs,
     resetArgs,
     compact,
     inAddonPanel,
@@ -343,11 +351,18 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
               <th>
                 <ControlHeadingWrapper>
                   Control{' '}
-                  {resetArgs && (
-                    <ResetButton onClick={() => resetArgs()} title="Reset controls">
-                      <Icons icon="sync" aria-hidden />
-                    </ResetButton>
-                  )}
+                  <ControlButtons>
+                    {copyArgs && (
+                      <UtilityButton onClick={() => copyArgs()} title="Copy controls in url">
+                        <Icons icon="share" aria-hidden />
+                      </UtilityButton>
+                    )}
+                    {resetArgs && (
+                      <UtilityButton onClick={() => resetArgs()} title="Reset controls">
+                        <Icons icon="sync" aria-hidden />
+                      </UtilityButton>
+                    )}
+                  </ControlButtons>
                 </ControlHeadingWrapper>
               </th>
             ) : null}


### PR DESCRIPTION
Issue:

## What I did

Add support for query parameters so that users can enter URLs which will directly change the props, like it works in knobs.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
