### PR TITLE
Addon-a11y: Add blurred vision effect

### DIFF
--- a/addons/a11y/src/components/VisionDeficiency.tsx
+++ b/addons/a11y/src/components/VisionDeficiency.tsx
@@ -7,6 +7,7 @@ import { Filters } from './ColorFilters';
 const iframeId = 'storybook-preview-iframe';
 
 const baseList = [
+  'blurred vision',
   'protanopia',
   'protanomaly',
   'deuteranopia',
@@ -23,6 +24,9 @@ type Filter = typeof baseList[number] | null;
 const getFilter = (filter: Filter) => {
   if (!filter) {
     return 'none';
+  }
+  if (filter === 'blurred vision') {
+    return 'blur(2px)';
   }
   if (filter === 'mono') {
     return 'grayscale(100%)';
@@ -87,7 +91,7 @@ const getColorList = (active: Filter, set: (i: Filter) => void): Link[] => [
   })),
 ];
 
-export const ColorBlindness: FunctionComponent = () => {
+export const VisionDeficiency: FunctionComponent = () => {
   const [filter, setFilter] = useState<Filter>(null);
 
   return (
@@ -114,7 +118,7 @@ export const ColorBlindness: FunctionComponent = () => {
         closeOnClick
         onDoubleClick={() => setFilter(null)}
       >
-        <IconButton key="filter" active={!!filter} title="Color Blindness Emulation">
+        <IconButton key="filter" active={!!filter} title="Vision Deficiency Emulation">
           <Icons icon="mirror" />
         </IconButton>
       </WithTooltip>

--- a/addons/a11y/src/register.tsx
+++ b/addons/a11y/src/register.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addons, types } from '@storybook/addons';
 import { ADDON_ID, PANEL_ID, PARAM_KEY } from './constants';
-import { ColorBlindness } from './components/ColorBlindness';
+import { VisionDeficiency } from './components/VisionDeficiency';
 import { A11YPanel } from './components/A11YPanel';
 import { A11yContextProvider } from './components/A11yContext';
 
@@ -10,7 +10,7 @@ addons.register(ADDON_ID, () => {
     title: '',
     type: types.TOOL,
     match: ({ viewMode }) => viewMode === 'story',
-    render: () => <ColorBlindness />,
+    render: () => <VisionDeficiency />,
   });
 
   addons.add(PANEL_ID, {


### PR DESCRIPTION
Issue: #12730

## What I did
Added support for blurred vision effect as part of the color blindless emulation in addon-a11y. Also, because the filters do more than color blindness now, I renamed the file from ColorBlindness to VisionDeficiency and the tooltip title to "Vision Deficiency Emulation". Also the tooltip option from "Reset color filter" to "Reset filter" (this was done after I recorded the video below).

You can see it in action by checking this video: https://streamable.com/tty7bk
![image](https://user-images.githubusercontent.com/1671563/95662308-46450500-0b36-11eb-9e89-1e99547ea3a5.png)

## How to test

- Is this testable with Jest or Chromatic screenshots?
Not applicable I believe
- Does this need a new example in the kitchen sink apps?
Nope
- Does this need an update to the documentation?
Would be nice to have a better section on the README explaining the existing options, unfortunately there's nothing there yet. I could assist on improving it.

## Attention!

If by any chance someone somewhere is using cypress to test a component in storybook with addon-a11y, which might be a really slight chance, and they happen to use this selector: `cy.get('[title="Color Blindness Emulation"]')` it will break because now the tooltip has a different title. I don't think this will happen but it's important to note in the PR :)