### PR TITLE
implement PoC for Angular docs with typedoc

### DIFF
--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -1,4 +1,4 @@
-import { extractArgTypes, extractComponentDescription } from './compodoc';
+import { extractArgTypes, extractComponentDescription } from './typedoc';
 
 export const parameters = {
   docs: {

--- a/addons/docs/src/frameworks/angular/index.ts
+++ b/addons/docs/src/frameworks/angular/index.ts
@@ -1,1 +1,1 @@
-export * from './compodoc';
+export * from './typedoc';

--- a/addons/docs/src/frameworks/angular/typedoc.ts
+++ b/addons/docs/src/frameworks/angular/typedoc.ts
@@ -1,0 +1,241 @@
+import { ArgTypes } from '@storybook/addons';
+import { logger } from '@storybook/client-logger';
+import { JSONOutput } from 'typedoc';
+import { Component, Directive } from './types';
+
+let typedocJson: JSONOutput.ProjectReflection;
+
+export function setTypedocJson(typedocConfig: object) {
+  assertTypedocJson(typedocConfig);
+  typedocJson = typedocConfig;
+}
+export function getTypedocJson() {
+  return typedocJson;
+}
+
+export function assertTypedocJson(
+  typedocConfig: object
+): asserts typedocConfig is JSONOutput.ProjectReflection {
+  if (
+    typedocConfig &&
+    'id' in typedocConfig &&
+    'kind' in typedocConfig &&
+    'name' in typedocConfig &&
+    'flags' in typedocConfig
+  ) {
+    return;
+  }
+
+  throw new Error('Invalid typedoc configuation.');
+}
+
+export function assertDirective(directive: Function): asserts directive is Component | Directive {
+  if (!directive.name) {
+    throw new Error(`Invalid directive ${directive}.`);
+  }
+}
+
+const cache = new Map<string, JSONOutput.DeclarationReflection>();
+function findReflectionByProperty(
+  key: keyof JSONOutput.DeclarationReflection,
+  value: unknown,
+  reflection: JSONOutput.DeclarationReflection = typedocJson
+): JSONOutput.DeclarationReflection | null {
+  if (reflection[key] === value) {
+    return reflection;
+  }
+
+  if (!reflection.children) {
+    return null;
+  }
+
+  const memoized = cache.get(key + value);
+
+  if (memoized) {
+    return memoized;
+  }
+
+  for (let i = 0; i < reflection.children.length; i += 1) {
+    const found = findReflectionByProperty(key, value, reflection.children[i]);
+
+    if (found !== null) {
+      cache.set(key + value, found);
+      return found;
+    }
+  }
+
+  return null;
+}
+const findReflectionByName = (name: string) => findReflectionByProperty('name', name);
+const findReflectionById = (id: number) => findReflectionByProperty('id', id);
+
+function getReflectionData(
+  component: Component | Directive
+): JSONOutput.DeclarationReflection | null {
+  if (!component) {
+    return null;
+  }
+
+  assertDirective(component);
+
+  const { name } = component;
+  const metadata = findReflectionByName(name);
+
+  if (metadata === null) {
+    logger.warn(`${name} not found in typedoc JSON.`);
+  }
+
+  return metadata;
+}
+
+const isUnionType = (typedocType: JSONOutput.SomeType): typedocType is JSONOutput.UnionType =>
+  typedocType.type === 'union';
+const isIntrinsicType = (
+  typedocType: JSONOutput.SomeType
+): typedocType is JSONOutput.IntrinsicType => typedocType.type === 'intrinsic';
+const isReferenceType = (
+  typedocType: JSONOutput.SomeType
+): typedocType is JSONOutput.ReferenceType => typedocType.type === 'reference';
+const isArrayType = (typedocType: JSONOutput.SomeType): typedocType is JSONOutput.ArrayType =>
+  typedocType.type === 'array';
+function extractType(
+  reflection: JSONOutput.DeclarationReflection
+): { name: string; value?: unknown } {
+  const typedocType = reflection?.type;
+
+  if (reflection.kindString === 'Accessor') {
+    return extractType(reflection.setSignature[0].parameters![0]);
+  }
+
+  if (!typedocType) {
+    return { name: null };
+  }
+
+  if (isUnionType(typedocType)) {
+    return {
+      name: 'enum',
+      value: typedocType.types.map((type: JSONOutput.StringLiteralType) => type.value),
+    };
+  }
+
+  if (isIntrinsicType(typedocType)) {
+    return typedocType;
+  }
+
+  if (isReferenceType(typedocType)) {
+    return extractType(findReflectionById(typedocType.id));
+  }
+
+  if (isArrayType(typedocType)) {
+    return { name: `${(typedocType.elementType as any).name}[]` };
+  }
+
+  return { name: 'string' };
+}
+
+function coerceDefaultValue(value: string) {
+  switch (value) {
+    case 'false':
+      return false;
+    case 'true':
+      return true;
+    default:
+  }
+
+  return value?.split('"').join('');
+}
+
+const isInput = (reflection: JSONOutput.DeclarationReflection) =>
+  reflection.decorators?.some((d) => d.name === 'Input');
+function mapReflectionToTableCategory(reflection: JSONOutput.DeclarationReflection) {
+  if (reflection.kindString === 'Property' || reflection.kindString === 'Accessor') {
+    if (!reflection.decorators) {
+      return 'properties';
+    }
+
+    const angularDecorators = <const>[
+      'Input',
+      'Output',
+      'ViewChild',
+      'ViewChildren',
+      'ContentChild',
+      'ContentChildren',
+    ];
+    const sections: Record<typeof angularDecorators[number], string> = {
+      Input: 'inputs',
+      Output: 'outputs',
+      ViewChild: 'view child',
+      ViewChildren: 'view children',
+      ContentChild: 'content child',
+      ContentChildren: 'content children',
+    };
+
+    const decorator = reflection.decorators
+      .map((d) => d.name)
+      .find((name: typeof angularDecorators[number]): name is typeof angularDecorators[number] =>
+        angularDecorators.includes(name)
+      );
+
+    if (decorator) {
+      return sections[decorator];
+    }
+
+    return 'properties';
+  }
+
+  if (reflection.kindString === 'Method') {
+    return 'methods';
+  }
+
+  return '';
+}
+
+function extractArgTypesFromReflection(
+  componentReflaction: JSONOutput.DeclarationReflection
+): ArgTypes {
+  return componentReflaction.children.reduce<ArgTypes>(
+    (argTypes, reflection: JSONOutput.DeclarationReflection) => {
+      return {
+        ...argTypes,
+        [reflection.name]: {
+          name: reflection.name,
+          description:
+            reflection.comment?.shortText ?? reflection.signatures?.[0].comment?.shortText,
+          defaultValue: coerceDefaultValue(
+            (reflection as JSONOutput.ParameterReflection).defaultValue
+          ),
+          type: isInput(reflection) ? extractType(reflection) : { name: 'void' },
+          table: {
+            category: mapReflectionToTableCategory(reflection),
+            type: {
+              // TODO: Should split the extractType to two functions, one providing rendering type and another readable type
+              // e.g. Union as enum rendered type and TS union representation for readable type.
+              summary: (reflection as any).type?.name ?? extractType(reflection).name,
+              required: !reflection.flags.isOptional,
+            },
+          },
+        },
+      };
+    },
+    {}
+  );
+}
+
+export function extractArgTypes(component: Component | Directive): ArgTypes {
+  const reflection = getReflectionData(component);
+
+  if (reflection === null) {
+    return null;
+  }
+
+  return extractArgTypesFromReflection(reflection);
+}
+
+export function extractComponentDescription(component: Component | Directive) {
+  const reflection = getReflectionData(component);
+  const comment = reflection?.comment;
+  const shortText = comment?.shortText ?? '';
+  const text = comment?.text ?? '';
+
+  return `${shortText}\n\n${text}`;
+}

--- a/addons/docs/src/frameworks/angular/types.ts
+++ b/addons/docs/src/frameworks/angular/types.ts
@@ -43,7 +43,7 @@ export interface Pipe {
   rawdescription?: string;
 }
 
-export interface Directive {
+export interface Directive extends Function {
   name: string;
   type: 'directive' | 'component';
   propertiesClass: Property[];

--- a/examples/angular-cli/.storybook/preview.ts
+++ b/examples/angular-cli/.storybook/preview.ts
@@ -1,18 +1,9 @@
-import { addParameters, addDecorator } from '@storybook/angular';
-import { setCompodocJson } from '@storybook/addon-docs/angular';
+import { addParameters } from '@storybook/angular';
+import { setTypedocJson } from '@storybook/addon-docs/angular';
 import addCssWarning from '../src/cssWarning';
-
-// @ts-ignore
-// eslint-disable-next-line import/extensions, import/no-unresolved
 import docJson from '../documentation.json';
-// remove ButtonComponent to test #12009
-const filtered = !docJson?.components
-  ? docJson
-  : {
-      ...docJson,
-      components: docJson.components.filter((c) => c.name !== 'ButtonComponent'),
-    };
-setCompodocJson(filtered);
+
+setTypedocJson(docJson);
 
 addCssWarning();
 

--- a/examples/angular-cli/package.json
+++ b/examples/angular-cli/package.json
@@ -12,7 +12,9 @@
     "ng": "ng",
     "start": "ng serve",
     "storybook": "yarn storybook:prebuild && start-storybook -p 9008 -s src/assets",
+    "storybook-typedoc": "yarn storybook:prebuild-typedoc && start-storybook -p 9008 -s src/assets",
     "storybook:prebuild": "yarn test:generate-output && yarn docs:json",
+    "storybook:prebuild-typedoc": "yarn test:generate-output && yarn typedoc",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:generate-output": "jest --json --config=jest.addon-config.js --outputFile=addon-jest.testresults.json || true",
@@ -62,6 +64,7 @@
     "jest-preset-angular": "^8.2.0",
     "protractor": "~7.0.0",
     "ts-node": "^8.10.2",
+    "typedoc": "^0.19.2",
     "typescript": "^3.9.3"
   },
   "storybook": {

--- a/examples/angular-cli/typedoc.json
+++ b/examples/angular-cli/typedoc.json
@@ -1,0 +1,8 @@
+{
+  "inputFiles": ["./src"],
+  "mode": "modules",
+  "exclude": ["**/node_modules/**", "**/*+(.spec|.e2e|.stories).ts", "./src/karma.ts", "./src/polyfills.ts"],
+  "excludePrivate": true,
+  "includes": "./src/",
+  "json": "documentation.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16140,6 +16140,16 @@ fs-extra@^9.0.0, fs-extra@^9.0.x:
     jsonfile "^6.0.1"
     universalify "^1.0.0"
 
+fs-extra@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
+  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-merger@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.1.0.tgz#f30f74f6c70b2ff7333ec074f3d2f22298152f3b"
@@ -17298,6 +17308,11 @@ highlight.js@^10.1.1, highlight.js@~10.1.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.1.2.tgz#c20db951ba1c22c055010648dfffd7b2a968e00c"
   integrity sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==
+
+highlight.js@^10.2.0:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.2.1.tgz#09784fe2e95612abbefd510948945d4fe6fa9668"
+  integrity sha512-A+sckVPIb9zQTUydC9lpRX1qRFO/N0OKEh0NwIr65ckvWA/oMY8v9P3+kGRK3w2ULSh9E8v5MszXafodQ6039g==
 
 highlight.js@^9.6.0:
   version "9.18.1"
@@ -22245,6 +22260,11 @@ lodash@4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-symbols@3.0.0, log-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
@@ -22403,6 +22423,11 @@ lunr-mutable-indexes@2.3.2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.8.tgz#a8b89c31f30b5a044b97d2d28e2da191b6ba2072"
   integrity sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==
+
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -22608,6 +22633,11 @@ marked@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
   integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
+
+marked@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.0.tgz#7221ce2395fa6cf6d722e6f2871a32d3513c85ca"
+  integrity sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==
 
 marko-starter-generic-server@^1.1.0:
   version "1.1.0"
@@ -32250,6 +32280,28 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typedoc-default-themes@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
+  integrity sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==
+
+typedoc@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
+  integrity sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==
+  dependencies:
+    fs-extra "^9.0.1"
+    handlebars "^4.7.6"
+    highlight.js "^10.2.0"
+    lodash "^4.17.20"
+    lunr "^2.3.9"
+    marked "^1.1.1"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    semver "^7.3.2"
+    shelljs "^0.8.4"
+    typedoc-default-themes "^0.11.4"
 
 typescript@2.9.1:
   version "2.9.1"


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12689

## What I did

Created a PoC for Angular CLI application using `typedoc` instead of `compodoc` in addon-docs.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
