### PR TITLE
Addon-controls: Fix "docs before controls" warning

### DIFF
--- a/addons/controls/src/preset/ensureDocsBeforeControls.ts
+++ b/addons/controls/src/preset/ensureDocsBeforeControls.ts
@@ -36,7 +36,7 @@ export const ensureDocsBeforeControls = (configDir: string) => {
     }
     if (!verifyDocsBeforeControls(main.addons)) {
       logger.warn(dedent`
-        Expected '@storybook/addon-docs' (or essentials) to be listed before '@storybook/addon-controls'. Check your main.js?
+        Expected '@storybook/addon-docs' to be listed before '@storybook/addon-controls' (or '@storybook/addon-essentials'). Check your main.js?
         
         https://github.com/storybookjs/storybook/issues/11442
       `);


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/11442

`docs` should be before `controls` or `essentials`, not `docs` or `essentials` before `controls`

## What I did
Change the phrasing of the WARN message to make it clearer how to get rid of it.

## How to test
Output only, no need to test this.
