### PR TITLE
Fix copy of invalid glob warning

### DIFF
--- a/lib/core/src/server/preview/to-require-context.ts
+++ b/lib/core/src/server/preview/to-require-context.ts
@@ -9,7 +9,7 @@ const fixBadGlob = deprecate(
     return match.input.replace(match[1], `@${match[1]}`);
   },
   dedent`
-    You're specified an invalid glob, we've attempted to fix it, please ensure the glob you specify is a valid glob. See: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#correct-globs-in-mainjs
+    You have specified an invalid glob, we've attempted to fix it, please ensure that the glob you specify is valid. See: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#correct-globs-in-mainjs
   `
 );
 const detectBadGlob = (val: string) => {


### PR DESCRIPTION
Issue:

## What I did
I noticed while upgrading from Storybook 5 to 6 today that the warning message shown in the console when you've specified an invalid glob has a typo or grammar error. I corrected the typo and tweaked the copy to remove the third usage of the word "glob" to make it feel less wordy. 📝 

## How to test
Simple string update, no testing required.
