### PR TITLE
Build: fix E2E tests and rework related CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,10 +172,6 @@ jobs:
     executor:
       class: large
       name: sb_node
-    docker:
-      - image: cypress/included:4.7.0
-        environment:
-          TERM: xterm
     working_directory: /tmp/storybook
     parallelism: 10
     steps:
@@ -195,6 +191,9 @@ jobs:
       - run:
           name: test local registry
           command: yarn info @storybook/core
+      - run:
+          name: Install Cypress binary
+          command: yarn cypress install
       - run:
           name: run e2e tests
           command: yarn test:e2e-framework
@@ -234,12 +233,10 @@ jobs:
           path: /tmp/storybook/cypress
           destination: cypress
   examples-v2-yarn-2:
-    docker:
-      - image: cypress/included:4.7.0
-        environment:
-          TERM: xterm
+    executor:
+      class: medium
+      name: sb_node
     working_directory: /tmp/storybook
-    # parallelism: 10
     steps:
       - checkout
       - attach_workspace:
@@ -257,6 +254,9 @@ jobs:
       - run:
           name: test local registry
           command: yarn info @storybook/core
+      - run:
+          name: Install Cypress binary
+          command: yarn cypress install
       - run:
           name: run e2e tests
           command: yarn test:e2e-framework --use-yarn-2 sfcVue cra

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,37 @@ jobs:
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress
+  examples-v2-cra-bench:
+    executor:
+      class: medium
+      name: sb_node_12
+    working_directory: /tmp/storybook
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Running local registry
+          command: yarn local-registry --port 6000 --open
+          background: true
+      - run:
+          name: Wait for registry
+          command: yarn wait-on http://localhost:6000
+      - run:
+          name: Set registry
+          command: yarn config set registry http://localhost:6000/
+      - run:
+          name: Test local registry
+          command: yarn info @storybook/core
+      - run:
+          name: Install Cypress binary
+          command: yarn cypress install
+      - run:
+          name: Run @storybook/bench on a CRA project
+          command: yarn test:e2e-framework cra_bench
+      - store_artifacts:
+          path: /tmp/storybook/cypress
+          destination: cypress
   examples-v2-angular:
     executor:
       class: medium
@@ -451,6 +482,9 @@ workflows:
           requires:
             - publish
       - examples-v2-yarn-2:
+          requires:
+            - publish
+      - examples-v2-cra-bench:
           requires:
             - publish
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,19 @@ executors:
         environment:
           NODE_OPTIONS: --max_old_space_size=4096
     resource_class: <<parameters.class>>
+  sb_node_12:
+    parameters:
+      class:
+        description: The Resource class
+        type: enum
+        enum: ['small', 'medium', 'large', 'xlarge']
+        default: 'medium'
+    working_directory: /tmp/storybook
+    docker:
+      - image: circleci/node:12-browsers
+        environment:
+          NODE_OPTIONS: --max_old_space_size=4096
+    resource_class: <<parameters.class>>
 
 jobs:
   build:
@@ -185,6 +198,38 @@ jobs:
       - run:
           name: run e2e tests
           command: yarn test:e2e-framework
+      - store_artifacts:
+          path: /tmp/storybook/cypress
+          destination: cypress
+  examples-v2-angular:
+    executor:
+      class: medium
+      name: sb_node_12
+    working_directory: /tmp/storybook
+    parallelism: 2
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Running local registry
+          command: yarn local-registry --port 6000 --open
+          background: true
+      - run:
+          name: Wait for registry
+          command: yarn wait-on http://localhost:6000
+      - run:
+          name: Set registry
+          command: yarn config set registry http://localhost:6000/
+      - run:
+          name: Test local registry
+          command: yarn info @storybook/core
+      - run:
+          name: Install Cypress binary
+          command: yarn cypress install
+      - run:
+          name: Run e2e tests
+          command: yarn test:e2e-framework angular@latest angular@v9-lts
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress
@@ -400,6 +445,9 @@ workflows:
             - install-e2e-deps
             - build
       - examples-v2:
+          requires:
+            - publish
+      - examples-v2-angular:
           requires:
             - publish
       - examples-v2-yarn-2:

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -164,7 +164,7 @@ export const sfcVue: Parameters = {
   additionalDeps: [
     'react',
     'react-dom',
-    'webpack',
+    'webpack@webpack-4',
     // TODO: remove when https://github.com/storybookjs/storybook/issues/11255 is solved
     'core-js',
   ],
@@ -194,7 +194,7 @@ export const web_components: Parameters = {
 export const webpack_react: Parameters = {
   name: 'webpack_react',
   version: 'latest',
-  generator: fromDeps('react', 'react-dom', 'webpack'),
+  generator: fromDeps('react', 'react-dom', 'webpack@webpack-4'),
 };
 
 export const react_in_yarn_workspace: Parameters = {

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -362,6 +362,11 @@ if (frameworkArgs.length > 0) {
   // FIXME: For now Yarn 2 E2E tests must be run by explicitly call `yarn test:e2e-framework yarn2Cra@latest`
   //   Because it is telling Yarn to use version 2
   delete e2eConfigs.yarn_2_cra;
+
+  // FIXME: Angular tests need to be explicitly run because they require Node 12.17+
+  // See https://github.com/storybookjs/storybook/issues/12735
+  delete e2eConfigs.angularv9;
+  delete e2eConfigs.angular;
 }
 
 const perform = () => {

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -367,6 +367,10 @@ if (frameworkArgs.length > 0) {
   // See https://github.com/storybookjs/storybook/issues/12735
   delete e2eConfigs.angularv9;
   delete e2eConfigs.angular;
+
+  // CRA Bench is a special case of E2E tests, it requires Node 12 as `@storybook/bench` is using `@hapi/hapi@19.2.0`
+  // which itself need Node 12.
+  delete e2eConfigs.cra_bench;
 }
 
 const perform = () => {


### PR DESCRIPTION
## What I did

 - Run Angular E2E tests on executors with the latest version of Node 12, workaround for https://github.com/storybookjs/storybook/issues/12735
 - Manually install Cypress to avoid using a docker image shipping its version of Node: We want all E2E tests to run against Node 10 but `cypress/included:4.7.0` docker image is based on Node 12.16.0.
 - Use Webpack 4 in `webpack_react` and `sfcVue` E2E tests as Webpack 5 is officially out for a few days but it looks like Storybook is not 100% compatible with it yet.
 - Extract `cra_bench` in a dedicated job, CRA Bench requires Node 12 (see https://github.com/storybookjs/bench/pull/2) and isn't a "true" E2E test so it makes sense to move it in a dedicated job.


## How to test

 - CI should now contain an `example-v2-angular` step
 - `example-v2-angular` step should be 🟢 
 - CI should be 🟢 