### PR TITLE
Chore: update wording in the @storybook/addons advanced readme

### DIFF
--- a/addons/actions/ADVANCED.md
+++ b/addons/actions/ADVANCED.md
@@ -8,7 +8,7 @@ This document describes the pre-6.0 usage of the addon, and as such is no longer
 
 Import the `action` function and use it to create actions handlers. When creating action handlers, provide a **name** to make it easier to identify.
 
-> _Note: Make sure NOT to use reserved words as function names. [issues#29](https://github.com/storybookjs/storybook-addon-actions/issues/29#issuecomment-288274794)_
+> _Note: If you haven't migrated to version 6.0 and you're using this addon, you'll have to be extra careful with the choice of the function's name. As some of them are reserved words for Storybook and they might lead into unexpected errors._
 
 ```js
 import { action } from '@storybook/addon-actions';

--- a/addons/actions/ADVANCED.md
+++ b/addons/actions/ADVANCED.md
@@ -8,7 +8,7 @@ This document describes the pre-6.0 usage of the addon, and as such is no longer
 
 Import the `action` function and use it to create actions handlers. When creating action handlers, provide a **name** to make it easier to identify.
 
-> _Note: If you haven't migrated to version 6.0 and you're using this addon, you'll have to be extra careful with the choice of the function's name. As some of them are reserved words for Storybook and they might lead into unexpected errors._
+> _Note: Be mindful of the choice of the function's name. Avoid using Javascript reserved words such as **default** or **if**, as they will lead into unexpected errors._
 
 ```js
 import { action } from '@storybook/addon-actions';


### PR DESCRIPTION
With this pull request the issue #12753 is addressed and can be closed.

What was done:
- The [advanced readme](https://github.com/storybookjs/storybook/blob/next/addons/actions/ADVANCED.md) was updated to prevent a 404 in the documentation. 

I've checked and the repo isn't around. It was probably merged into the storybook repo with a previous release. And with that the issues for the said repo are not present anymore.

Feel free to provide feedback