### PR TITLE
Fixed hyperlink formatting

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -48,7 +48,7 @@ MyNonCheckedStory.parameters = {
 ## Parameters
 
 For more customizability use parameters to configure [aXe options](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure).
-You can override these options [at story level too](https://storybook.js.org/docs/react/configure/features-and-behavior#per-story-options.
+You can override these options [at story level too](https://storybook.js.org/docs/react/configure/features-and-behavior#per-story-options).
 
 ```js
 import React from 'react';


### PR DESCRIPTION
Issue:

## What I did
Hyperlink was not correctly formatted in `addons/a11y/README.md`

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
