### PR TITLE
Search UX improvements

### DIFF
--- a/lib/ui/src/components/sidebar/Search.stories.tsx
+++ b/lib/ui/src/components/sidebar/Search.stories.tsx
@@ -37,9 +37,9 @@ export const FilledIn = () => (
 
 export const LastViewed = () => (
   <Search {...baseProps} lastViewed={lastViewed}>
-    {({ inputValue, results, getMenuProps, getItemProps, highlightedIndex }) => (
+    {({ query, results, getMenuProps, getItemProps, highlightedIndex }) => (
       <SearchResults
-        isSearching={!!inputValue}
+        query={query}
         results={results}
         getMenuProps={getMenuProps}
         getItemProps={getItemProps}

--- a/lib/ui/src/components/sidebar/Search.tsx
+++ b/lib/ui/src/components/sidebar/Search.tsx
@@ -222,34 +222,64 @@ export const Search: FunctionComponent<{
 
   const stateReducer = useCallback(
     (state: DownshiftState<DownshiftItem>, changes: StateChangeOptions<DownshiftItem>) => {
-      const { blurInput, clickItem, keyDownEnter, keyDownEscape } = Downshift.stateChangeTypes;
-      const { type, inputValue, selectedItem = {} } = changes;
-      if (type === blurInput) return {};
-      if (type === keyDownEscape) {
-        inputRef.current.blur();
-        showAllComponents(false);
-        return { inputValue: '' };
-      }
-      if (type === clickItem || type === keyDownEnter) {
-        if (isSearchResult(selectedItem)) {
-          const { id, refId } = selectedItem.item;
-          selectStory(id, refId);
-          return { isOpen: false };
+      switch (changes.type) {
+        case Downshift.stateChangeTypes.blurInput: {
+          return {
+            ...changes,
+            // Prevent clearing the input on blur
+            inputValue: state.inputValue,
+            // Return to the tree view after selecting an item
+            isOpen: state.inputValue && !state.selectedItem,
+            selectedItem: null,
+          };
         }
-        if (isExpandType(selectedItem)) {
-          selectedItem.showAll();
+
+        case Downshift.stateChangeTypes.mouseUp: {
+          // Prevent clearing the input on refocus
           return {};
         }
-        if (isClearType(selectedItem)) {
-          selectedItem.clearLastViewed();
+
+        case Downshift.stateChangeTypes.keyDownEscape: {
+          if (state.inputValue) {
+            // Clear the inputValue, but don't return to the tree view
+            return { ...changes, inputValue: '', isOpen: true, selectedItem: null };
+          }
+          // When pressing escape a second time, blur the input and return to the tree view
           inputRef.current.blur();
-          return { isOpen: false };
+          return { ...changes, isOpen: false, selectedItem: null };
         }
+
+        case Downshift.stateChangeTypes.clickItem:
+        case Downshift.stateChangeTypes.keyDownEnter: {
+          if (isSearchResult(changes.selectedItem)) {
+            const { id, refId } = changes.selectedItem.item;
+            selectStory(id, refId);
+            // Return to the tree view, but keep the input value
+            return { ...changes, inputValue: state.inputValue, isOpen: false };
+          }
+          if (isExpandType(changes.selectedItem)) {
+            changes.selectedItem.showAll();
+            // Downshift should completely ignore this
+            return {};
+          }
+          if (isClearType(changes.selectedItem)) {
+            changes.selectedItem.clearLastViewed();
+            inputRef.current.blur();
+            // Nothing to see anymore, so return to the tree view
+            return { isOpen: false };
+          }
+          return changes;
+        }
+
+        case Downshift.stateChangeTypes.changeInput: {
+          // Reset the "show more" state whenever the input changes
+          showAllComponents(false);
+          return changes;
+        }
+
+        default:
+          return changes;
       }
-      if (inputValue === '') {
-        showAllComponents(false);
-      }
-      return changes;
     },
     [inputRef, selectStory, showAllComponents]
   );
@@ -263,6 +293,7 @@ export const Search: FunctionComponent<{
     >
       {({
         isOpen,
+        openMenu,
         inputValue,
         clearSelection,
         getInputProps,
@@ -302,7 +333,10 @@ export const Search: FunctionComponent<{
           required: true,
           type: 'search',
           placeholder: inputPlaceholder,
-          onFocus: () => setPlaceholder('Type to find...'),
+          onFocus: () => {
+            openMenu();
+            setPlaceholder('Type to find...');
+          },
           onBlur: () => setPlaceholder('Find components'),
         });
 

--- a/lib/ui/src/components/sidebar/Search.tsx
+++ b/lib/ui/src/components/sidebar/Search.tsx
@@ -21,7 +21,7 @@ import {
 } from './types';
 import { searchItem } from './utils';
 
-const DEFAULT_MAX_SEARCH_RESULTS = 20;
+const DEFAULT_MAX_SEARCH_RESULTS = 200;
 
 const options = {
   shouldSort: true,

--- a/lib/ui/src/components/sidebar/Search.tsx
+++ b/lib/ui/src/components/sidebar/Search.tsx
@@ -234,7 +234,7 @@ export const Search: FunctionComponent<{
         if (isSearchResult(selectedItem)) {
           const { id, refId } = selectedItem.item;
           selectStory(id, refId);
-          return { inputValue: '' };
+          return { isOpen: false };
         }
         if (isExpandType(selectedItem)) {
           selectedItem.showAll();
@@ -242,7 +242,8 @@ export const Search: FunctionComponent<{
         }
         if (isClearType(selectedItem)) {
           selectedItem.clearLastViewed();
-          return {};
+          inputRef.current.blur();
+          return { isOpen: false };
         }
       }
       if (inputValue === '') {
@@ -257,12 +258,11 @@ export const Search: FunctionComponent<{
     <Downshift<DownshiftItem>
       initialInputValue={initialQuery}
       stateReducer={stateReducer}
-      itemToString={(result) => {
-        // @ts-ignore
-        return result?.item?.name || '';
-      }}
+      // @ts-ignore
+      itemToString={(result) => result?.item?.name || ''}
     >
       {({
+        isOpen,
         inputValue,
         clearSelection,
         getInputProps,
@@ -317,9 +317,9 @@ export const Search: FunctionComponent<{
             </SearchField>
             <FocusContainer tabIndex={0} id="storybook-explorer-menu">
               {children({
-                inputValue: input,
+                query: input,
                 results,
-                inputHasFocus: document.activeElement === inputRef.current,
+                isBrowsing: !isOpen && document.activeElement !== inputRef.current,
                 getMenuProps,
                 getItemProps,
                 highlightedIndex,

--- a/lib/ui/src/components/sidebar/Search.tsx
+++ b/lib/ui/src/components/sidebar/Search.tsx
@@ -21,7 +21,7 @@ import {
 } from './types';
 import { searchItem } from './utils';
 
-const DEFAULT_MAX_SEARCH_RESULTS = 200;
+const DEFAULT_MAX_SEARCH_RESULTS = 50;
 
 const options = {
   shouldSort: true,

--- a/lib/ui/src/components/sidebar/SearchResults.stories.tsx
+++ b/lib/ui/src/components/sidebar/SearchResults.stories.tsx
@@ -59,14 +59,14 @@ const recents = stories
 const passKey = (props: any = {}) => ({ key: props.key });
 
 const searching = {
-  isSearching: true,
+  query: 'query',
   results,
   getMenuProps: passKey,
   getItemProps: passKey,
   highlightedIndex: 0,
 };
 const lastViewed = {
-  isSearching: false,
+  query: '',
   results: recents,
   getMenuProps: passKey,
   getItemProps: passKey,

--- a/lib/ui/src/components/sidebar/SearchResults.tsx
+++ b/lib/ui/src/components/sidebar/SearchResults.tsx
@@ -120,15 +120,15 @@ const Result: FunctionComponent<
 });
 
 export const SearchResults: FunctionComponent<{
-  isSearching: boolean;
+  query: string;
   results: DownshiftItem[];
   getMenuProps: ControllerStateAndHelpers<DownshiftItem>['getMenuProps'];
   getItemProps: ControllerStateAndHelpers<DownshiftItem>['getItemProps'];
   highlightedIndex: number | null;
-}> = React.memo(({ isSearching, results, getMenuProps, getItemProps, highlightedIndex }) => {
+}> = React.memo(({ query, results, getMenuProps, getItemProps, highlightedIndex }) => {
   return (
     <ResultsList {...getMenuProps()}>
-      {results.length > 0 && !isSearching && (
+      {results.length > 0 && !query && (
         <li>
           <RootNode>Recently opened</RootNode>
         </li>

--- a/lib/ui/src/components/sidebar/Sidebar.tsx
+++ b/lib/ui/src/components/sidebar/Sidebar.tsx
@@ -119,26 +119,15 @@ export const Sidebar: FunctionComponent<SidebarProps> = React.memo(
               enableShortcuts={enableShortcuts}
               {...lastViewed}
             >
-              {({
-                inputValue,
-                inputHasFocus,
-                results,
-                getMenuProps,
-                getItemProps,
-                highlightedIndex,
-              }) => (
-                <Swap condition={!!(inputHasFocus || inputValue)}>
+              {({ query, results, isBrowsing, getMenuProps, getItemProps, highlightedIndex }) => (
+                <Swap condition={isBrowsing}>
+                  <Explorer dataset={dataset} selected={selected} isBrowsing={isBrowsing} />
                   <SearchResults
-                    isSearching={!!inputValue}
+                    query={query}
                     results={results}
                     getMenuProps={getMenuProps}
                     getItemProps={getItemProps}
                     highlightedIndex={highlightedIndex}
-                  />
-                  <Explorer
-                    dataset={dataset}
-                    selected={selected}
-                    isBrowsing={!inputHasFocus && !inputValue}
                   />
                 </Swap>
               )}

--- a/lib/ui/src/components/sidebar/types.ts
+++ b/lib/ui/src/components/sidebar/types.ts
@@ -58,9 +58,9 @@ export type SearchResult = Fuse.FuseResultWithMatches<SearchItem> &
 export type DownshiftItem = SearchResult | ExpandType | ClearType;
 
 export type SearchChildrenFn = (args: {
-  inputValue: string;
+  query: string;
   results: DownshiftItem[];
-  inputHasFocus: boolean;
+  isBrowsing: boolean;
   getMenuProps: ControllerStateAndHelpers<DownshiftItem>['getMenuProps'];
   getItemProps: ControllerStateAndHelpers<DownshiftItem>['getItemProps'];
   highlightedIndex: number | null;

--- a/lib/ui/src/components/sidebar/types.ts
+++ b/lib/ui/src/components/sidebar/types.ts
@@ -31,13 +31,13 @@ export interface Match {
 }
 
 export function isClearType(x: any): x is ClearType {
-  return !!x.clearLastViewed;
+  return !!(x && x.clearLastViewed);
 }
 export function isExpandType(x: any): x is ExpandType {
-  return !!x.showAll;
+  return !!(x && x.showAll);
 }
 export function isSearchResult(x: any): x is SearchResult {
-  return !!x.item;
+  return !!(x && x.item);
 }
 
 export interface ClearType {


### PR DESCRIPTION
Issue: #12714

## What I did

1. Preserve the search query when selecting a search result, so that re-focusing the search will restore the previous list of results so one can easily select the next result.
2. Updated search to show 200 results before the "Show more" appears. This makes it unlikely to ever appear in a sensible query, but still guards against performance issues when searching for a single letter.
3. Hide the history panel (i.e. show the tree) when clearing history.

## How to test

- Search for something that yields multiple results.
- Select a result. This should open the story and close the search pane.
- Focus the search again (or press `/`). This should restore the previous search query and results list.
- Press down + enter to quickly select the next result.
- Focus the search and press Escape to clear the query and results. You can also click the (x) in the search field.
