### PR TITLE
Replace "ES7" with "ES2017"

### DIFF
--- a/app/web-components/README.md
+++ b/app/web-components/README.md
@@ -52,9 +52,9 @@ if (module.hot) {
 
 # Setup es6/7 dependencies
 
-By default storybook only works with precompiled es5 code but as most web components themselves and their libs are distributed as es7 you will need to manually mark those packages as "needs transpilation".
+By default storybook only works with precompiled ES5 code but as most web components themselves and their libs are distributed as ES2017 you will need to manually mark those packages as "needs transpilation".
 
-For example if you have a library called `my-library` which is in es7 then you can add it like so
+For example if you have a library called `my-library` which is in ES2017 then you can add it like so
 
 ```js
 // .storybook/main.js


### PR DESCRIPTION
There is no such thing as "ES7". Presumably the author meant ES2016, but many web components libraries / bas classes use async functions which would make them ES2017.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
