### PR TITLE
Update argtypes.md

### DIFF
--- a/docs/api/argtypes.md
+++ b/docs/api/argtypes.md
@@ -87,7 +87,7 @@ In particular, this would render a row with a modified description, a type displ
 
 <div class="aside">
 
-NOTE: Just as it happens with other properties (such as `args`), `argTypes` can be overridden in a single story.
+As it happens with other properties such as `args`, `argTypes` can be overridden in a single story.
 
 </div>
 

--- a/docs/api/argtypes.md
+++ b/docs/api/argtypes.md
@@ -85,6 +85,12 @@ These values--description, table.type, and controls.type--get merged over the de
 
 In particular, this would render a row with a modified description, a type display with a dropdown that shows the detail, and no control.
 
+<div class="aside">
+
+NOTE: Just as it happens with other properties (such as `args`), `argTypes` can be overridden in a single story.
+
+</div>
+
 #### Using argTypes in addons
 
 If you want to access the argTypes of the current component inside an addon, you can use the `useArgTypes` hook from the `@storybook/api` package:


### PR DESCRIPTION
As a user I miss to read that it is possible to override argTypes in a single story

Issue:

## What I did
Updated one documentation article

## How to test
Just added a NOTE in the .mdx

The documentation could be complemented with an example on how to override `argTypes` on a per-story basis such as:

```js
export default {
  title: 'Atoms/Tag',
  component: Tag,
  argTypes: {
    onClose: {
      control: {
        disable: true,
      },
    },
  },
  args: {
    closable: false,
  },
};

const Template = (args) => <Tag {...args}>Tag</Tag>;

export const Default = Template.bind({});

export const ColorPresets = Template.bind({});
ColorPresets.args = {
  color: 'magenta',
};
ColorPresets.argTypes = {
  color: {
    control: {
      type: 'select',
      options: [
        'magenta',
        'red',
        'volcano',
        'orange',
        'gold',
        'lime',
        'green',
        'cyan',
        'blue',
        'geekblue',
        'purple',
      ],
    },
  },
};

export const CustomColor = Template.bind({});
CustomColor.args = {
  color: '#ff5500',
};
CustomColor.argTypes = {
  color: {
    control: {
      type: 'color',
    },
  },
};
```