### PR TITLE
Storyshots: Add missing vue peer dependencies

### DIFF
--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -63,6 +63,8 @@
     "jest-vue-preprocessor": "^1.5.0"
   },
   "peerDependencies": {
+    "@storybook/vue": "*",
+    "vue": "*",
     "jest-preset-angular": "*",
     "jest-vue-preprocessor": "*"
   },
@@ -71,6 +73,12 @@
       "optional": true
     },
     "jest-vue-preprocessor": {
+      "optional": true
+    },
+    "@storybook/vue": {
+      "optional": true
+    },
+    "vue": {
       "optional": true
     }
   },

--- a/addons/storyshots/storyshots-core/src/frameworks/vue/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/vue/renderTree.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import Vue from 'vue';
 
 // this is defined in @storybook/vue but not exported,


### PR DESCRIPTION
`@storybook/addon-storyshots` is trying to use `vue` and `@storybook/vue` without declaring them as dependencies

## What I did

Added them as optional peer dependencies

## How to test

Try to use `@storybook/addon-storyshots` with vue in a Yarn PnP project