### PR TITLE
Core/CLI: Update ShellJS dep version

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -57,7 +57,7 @@
     "json5": "^2.1.1",
     "leven": "^3.1.0",
     "puppeteer-core": "^2.0.0",
-    "shelljs": "^0.8.3",
+    "shelljs": "^0.8.4",
     "strip-json-comments": "^3.0.1",
     "update-notifier": "^4.0.0"
   },

--- a/lib/cli/test/fixtures/sfc_vue/package.json
+++ b/lib/cli/test/fixtures/sfc_vue/package.json
@@ -43,7 +43,7 @@
     "optimize-css-assets-webpack-plugin": "^2.0.0",
     "ora": "^3.2.0",
     "rimraf": "^2.6.3",
-    "shelljs": "^0.8.3",
+    "shelljs": "^0.8.4",
     "url-loader": "^1.1.2",
     "vue-loader": "15.7.0",
     "vue-style-loader": "^4.1.2",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -118,7 +118,7 @@
     "regenerator-runtime": "^0.13.3",
     "resolve-from": "^5.0.0",
     "serve-favicon": "^2.5.0",
-    "shelljs": "^0.8.3",
+    "shelljs": "^0.8.4",
     "stable": "^0.1.8",
     "style-loader": "^1.2.1",
     "terser-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12793

## What I did

I updated all ShellJS dependencies from 0.8.3 to 0.8.4 to solve the circular dependency errors.

## How to test

I'm not sure how to reproduce it consistently.
However I linked the @storybook/core package in my local project and didn't had the errors when running storybook.
