### PR TITLE
Fix Vue prop defaults for objects/arrays. #12634

### DIFF
--- a/addons/docs/src/frameworks/vue/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue/extractArgTypes.ts
@@ -17,10 +17,17 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
     props.forEach(({ propDef, docgenInfo, jsDocTags }) => {
       const { name, type, description, defaultValue: defaultSummary, required } = propDef;
       const sbType = section === 'props' ? convert(docgenInfo) : { name: 'void' };
-      let defaultValue = defaultSummary && (defaultSummary.detail || defaultSummary.summary);
+      let defaultValue: any = defaultSummary && (defaultSummary.detail || defaultSummary.summary);
       try {
         // eslint-disable-next-line no-eval
         defaultValue = eval(defaultValue);
+        // B/c Vue requires that Object/Array defaults be supplied as factory functions.
+        if (
+          typeof defaultValue === 'function' &&
+          ['object', 'array', 'other'].includes(sbType.name)
+        ) {
+          defaultValue = defaultValue();
+        }
         // eslint-disable-next-line no-empty
       } catch {}
 

--- a/examples/vue-kitchen-sink/src/stories/Button.vue
+++ b/examples/vue-kitchen-sink/src/stories/Button.vue
@@ -2,7 +2,7 @@
   <button
     class="button"
     :style="{ color, borderColor: color }"
-    :class="{ rounded }"
+    :class="computedClasses"
     @click="onClick"
     @dblclick="onDoubleClick"
   >
@@ -20,9 +20,25 @@
         type: Boolean,
         default: false,
       },
+      corners: {
+        type: [Boolean, Array],
+        default: () => [false, false, false, false],
+      },
       color: {
         type: String,
         default: '#42b983'
+      }
+    },
+
+    computed: {
+      computedClasses() {
+        return {
+          rounded: this.rounded,
+          'rounded-top-left': this.corners[0],
+          'rounded-top-right': this.corners[1],
+          'rounded-bottom-right': this.corners[2],
+          'rounded-bottom-left': this.corners[3],
+        }
       }
     },
 
@@ -50,6 +66,18 @@
 <style>
 .rounded {
   border-radius: 5px;
+}
+.rounded-top-left {
+  border-top-left-radius: 5px;
+}
+.rounded-top-right {
+  border-top-right-radius: 5px;
+}
+.rounded-bottom-right {
+  border-bottom-right-radius: 5px;
+}
+.rounded-bottom-left {
+  border-bottom-left-radius: 5px;
 }
 
 .button {

--- a/examples/vue-kitchen-sink/src/stories/components/button.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/components/button.stories.js
@@ -11,7 +11,7 @@ export default {
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { MyButton },
-  template: '<my-button :color="color" :rounded="rounded">{{label}}</my-button>',
+  template: '<my-button :color="color" :rounded="rounded" :corners="corners">{{label}}</my-button>',
 });
 
 export const Rounded = Template.bind({});
@@ -26,4 +26,12 @@ Square.args = {
   rounded: false,
   color: '#00f',
   label: 'A Button with square edges',
+};
+
+export const Varied = Template.bind({});
+Varied.args = {
+  rounded: false,
+  corners: [true, false, true, false],
+  color: '#00f',
+  label: 'A Button with varied edges',
 };


### PR DESCRIPTION
Issue: #12634 

## What I did
Added a check for whether or not an object/array prop's default value is a factory function, as prescribed by the Vue docs. See #12634 for more details. I also added a story to `vue-kitchen-sink` for testing. I'm not altogether sure how to add a Jest test for the `extractArgTypes` function, since I don't feel I fully understand its usage, but am willing to try with some guidance.

Also note that I included `'other'` among the types I'm checking against. I tried to restrict this to just `'object'` and `'array'`, but there is a peculiarity in how docgen works, where if the component's type is specified as `[Boolean, Array]`, it gets classified as `'other'`. Sorry, that's not a great explanation, but I'm happy to discuss further if it's of concern.

## How to test
See the new `Varied` story in `examples/vue-kitchen-sink/src/stories/components/button.stories.js`. Previously, this would have produced a warning and broken the component, as described in #12634.

- Is this testable with Jest or Chromatic screenshots?
Maybe?
- Does this need a new example in the kitchen sink apps?
One is provided.
- Does this need an update to the documentation?
No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
