### PR TITLE
Fix stray smart quotes on React snippet

### DIFF
--- a/docs/snippets/react/button-story-click-handler.js.mdx
+++ b/docs/snippets/react/button-story-click-handler.js.mdx
@@ -9,5 +9,5 @@ export default {
     title: 'Button',
     component: Button
 };
-export const Text = () => <Button label=’Hello’ onClick={action('clicked')} />;
+export const Text = () => <Button label='Hello' onClick={action('clicked')} />;
 ``` 


### PR DESCRIPTION
Issue: React code example uses smart quotes instead of apostrophes

This changes the example to use apostrophes so it can be copied and used directly.