### PR TITLE
Core: Pass framework options as global

### DIFF
--- a/lib/core/src/server/preview/iframe-webpack.config.js
+++ b/lib/core/src/server/preview/iframe-webpack.config.js
@@ -140,6 +140,7 @@ export default async ({
           version: packageJson.version,
           globals: {
             LOGLEVEL: logLevel,
+            FRAMEWORK_OPTIONS: frameworkOptions,
           },
           headHtmlSnippet: getPreviewHeadHtml(configDir, process.env),
           dlls,
@@ -158,7 +159,6 @@ export default async ({
       new DefinePlugin({
         'process.env': stringified,
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
-        FRAMEWORK_OPTIONS: frameworkOptions,
       }),
       isProd ? null : new WatchMissingNodeModulesPlugin(nodeModulesPaths),
       isProd ? null : new HotModuleReplacementPlugin(),


### PR DESCRIPTION
Issue: #12734 global vars not set

## What I did

use globals over define plugin
