### PR TITLE
docs: add vue/page-story.js

### DIFF
--- a/docs/snippets/vue/page-story.js.mdx
+++ b/docs/snippets/vue/page-story.js.mdx
@@ -1,0 +1,21 @@
+```js
+// Page.stories.js
+
+import Page from './Page.vue';
+import * as HeaderStories from './Header.stories';
+
+export default {
+  title: 'Page',
+};
+
+const Template = (args, { argTypes }) => ({
+  components: { Page },
+  props: Object.keys(argTypes),
+  template: '<page v-bind="$props" />',
+});
+
+export const LoggedIn = Template.bind({});
+LoggedIn.args = {
+  ...HeaderStories.LoggedIn.args,
+};
+```

--- a/docs/writing-stories/args.md
+++ b/docs/writing-stories/args.md
@@ -88,7 +88,8 @@ Args are useful when writing stories for composite components that are assembled
   paths={[
     'react/page-story.js.mdx',
     'react/page-story.ts.mdx',
-    'angular/page-story.ts.mdx'
+    'angular/page-story.ts.mdx',
+    'vue/page-story.js.mdx'
   ]}
 />
 


### PR DESCRIPTION
Issue:

## What I did
Currently we are displaying the react version of the page-story because we don't have a vue specific example. 

![Screenshot 2020-10-18 at 23 10 18](https://user-images.githubusercontent.com/1810031/96385934-71170500-1197-11eb-9875-9b3fd82bbf68.png)

In this pull request I add the equivalent script for the Vue docs.


## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
