### PR TITLE
Core: CSS modules support out of the box

### DIFF
--- a/lib/core/src/server/preview/base-webpack.config.js
+++ b/lib/core/src/server/preview/base-webpack.config.js
@@ -57,6 +57,7 @@ export async function createDefaultWebpackConfig(storybookBaseConfig, options) {
               loader: require.resolve('css-loader'),
               options: {
                 importLoaders: 1,
+                modules: true,
               },
             },
             {


### PR DESCRIPTION
Issue: #11961

## What I did

Added support css modules out of the box, because I think css modules now standart de-facto

## How to test

- Write story with components with css modules
