### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,21 +109,19 @@ yarn lint
 
 It can be immensely helpful to get feedback in your editor, if you're using VsCode, you should install the `eslint` plugin and configure it with these settings:
 
-```plaintext
-"eslint.autoFixOnSave": true,
-"eslint.packageManager": "yarn",
-"eslint.options": {
-  "cache": true,
-  "cacheLocation": ".cache/eslint",
-  "extensions": [".js", ".jsx", ".mjs", ".json", ".ts", ".tsx"]
-},
-"eslint.validate": [
-  "javascript",
-  "javascriptreact",
-  {"language": "typescript", "autoFix": true },
-  {"language": "typescriptreact", "autoFix": true }
-],
-"eslint.alwaysShowStatus": true
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.packageManager": "yarn",
+  "eslint.options": {
+    "cache": true,
+    "cacheLocation": ".cache/eslint",
+    "extensions": [".js", ".jsx", ".json", ".html", ".ts", ".tsx", ".mjs"]
+  },
+  "eslint.alwaysShowStatus": true
+}
 ```
 
 This should enable auto-fix for all source files, and give linting warnings and errors within your editor.


### PR DESCRIPTION
Issue:

## What I did

Update [vscode-eslint](https://github.com/Microsoft/vscode-eslint) config.

- Update `eslint.autoFixOnSave`
  > The old `eslint.autoFixOnSave` setting is now deprecated and can safely be removed.

- Remove `eslint.validate`
  > As soon as TypeScript is correctly configured inside ESLint, you no longer need additional configuration through VS Code's `eslint.validate` setting. The same is true for HTML and Vue.js files.

- Update `eslint.options`
  >     "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.json,.html,.ts,.tsx,.mjs --report-unused-disable-directives",

Maybe the `.vscode/settings.json` can be added to the project?

## How to test

- Does this need an update to the documentation? Yes

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
