### PR TITLE
Chore: Follow up on pr #12841

### DIFF
--- a/docs/configure/typescript.md
+++ b/docs/configure/typescript.md
@@ -58,3 +58,7 @@ Adjust the configuration as shown below and any third party props will be displa
 <!-- prettier-ignore-end -->
 
 Next time you restart your Storybook the extra props will also be in the UI.
+
+<div class="aside">
+If you run into an issue where the extra props aren't included, check how your component is being exported. If it's using a default export, change it to a named export and the extra props will be included as well.
+</div>


### PR DESCRIPTION
With this pull request the change introduced with #12841 is updated to include a note to inform the readers that if the inferred  props aren't included, it's required to change the way they are exporting their components in order to view the additional information.

Feel free to provide feedback