### PR TITLE
UI: Add fullscreen mode to docs

### DIFF
--- a/lib/ui/src/components/preview/toolbar.tsx
+++ b/lib/ui/src/components/preview/toolbar.tsx
@@ -46,7 +46,7 @@ const fullScreenMapper = ({ api, state }: Combo) => ({
 
 export const fullScreenTool: Addon = {
   title: 'fullscreen',
-  match: (p) => p.viewMode === 'story',
+  match: (p) => ['story', 'docs'].includes(p.viewMode),
   render: () => (
     <Consumer filter={fullScreenMapper}>
       {({ toggle, value, shortcut }) => (


### PR DESCRIPTION
Issue: #12820 

## What I did

Show fullscreen toggle button on docs tab

## How to test

See `official-storybook` etc
