### PR TITLE
Add reference to Canvas isColumn props

### DIFF
--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -271,6 +271,8 @@ In MDX, `Canvas` is more flexible: in addition to the DocsPage behavior, it can 
 
 <!-- prettier-ignore-end -->
 
+By default, each story will display side by side (css block). You can display stories one above the other by adding `isColumn` property to the Canvas component.
+
 You can also place non-story content inside a `Canvas` block:
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
## What I did

I've noticed Canvas (and purPreview) block has a isColumn property. I find this props very useful when writing mdx.

Maybe this props should only be used internally, so feel free to reject the PR.