### PR TITLE
Addon-viewport: Fill entire iframe width with drop shadow

### DIFF
--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -205,8 +205,7 @@ export const ViewportTool: FunctionComponent = memo(
                   transition: 'width .3s, height .3s',
                   position: 'relative',
                   border: `1px solid black`,
-                  boxShadow:
-                    '0 0 100px 1000px rgba(0,0,0,0.5), 0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08)',
+                  boxShadow: '0 0 100px 100vw rgba(0,0,0,0.5)',
 
                   ...styles,
                 },


### PR DESCRIPTION
Issue: When using addon-viewports in high resolution monitors, you can notice a weird looking background, like this:

(2048 x 1152)
![image](https://user-images.githubusercontent.com/1671563/96923656-e5141e80-14b1-11eb-973b-c7073195ffad.png)

(3840 x 2160)
![image](https://user-images.githubusercontent.com/1671563/96923699-f3623a80-14b1-11eb-8fa2-e3998ad412dc.png)

This can be seen in any [live storybook](https://next--storybookjs.netlify.app/official-storybook/?path=/story/addons-a11y-basebutton--default).


## What I did
Set the drop shadow to take full width instead of 1000px, so it will always fill everything:
![image](https://user-images.githubusercontent.com/1671563/96923749-037a1a00-14b2-11eb-8fc6-db0f7e8b3c01.png)

## How to test

Run Storybook, enable viewports and either emulate a higher resolution monitor or check it in a high resolution monitor like 4k.