### PR TITLE
Essentials: Fix absolute config dir

### DIFF
--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -10,7 +10,10 @@ interface PresetOptions {
 
 const requireMain = (configDir: string) => {
   let main = {};
-  const mainFile = path.join(process.cwd(), configDir, 'main');
+  const absoluteConfigDir = path.isAbsolute(configDir)
+    ? configDir
+    : path.join(process.cwd(), configDir);
+  const mainFile = path.join(absoluteConfigDir, 'main');
   try {
     // eslint-disable-next-line global-require,import/no-dynamic-require
     main = require(mainFile);


### PR DESCRIPTION
Issue: #12872 

## What I did

Quick fix for nuxt-storybook integration, supporting absolute config dir path.

## How to test

N/A
