### PR TITLE
Core: Disable Docs DLL by default

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -39,7 +39,7 @@ function createBabelOptions({ babelOptions, mdxBabelOptions, configureJSX }: Bab
 }
 
 export const webpackDlls = (dlls: string[], options: any) => {
-  return options.dll ? [...dlls, './sb_dll/storybook_docs_dll.js'] : [];
+  return options.docsDll ? [...dlls, './sb_dll/storybook_docs_dll.js'] : [];
 };
 
 export function webpack(webpackConfig: any = {}, options: any = {}) {
@@ -143,7 +143,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
     },
   };
 
-  if (options.dll) {
+  if (options.docsDll) {
     result.plugins.push(
       new DllReferencePlugin({
         context,

--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -27,7 +27,8 @@ Usage: start-storybook [options]
 | --smoke-test                   | Exit after successful start                                                                                                                    | `start-storybook --smoke-test`                  |
 | --ci                           | CI mode (skip interactive prompts, don't open browser)                                                                                         | `start-storybook --ci`                          |
 | --quiet                        | Suppress verbose build output                                                                                                                  | `start-storybook --quiet`                       |
-| --no-dll                       | Do not use dll reference                                                                                                                       | `start-storybook --no-dll`                      |
+| --no-dll                       | Do not use UI dll reference                                                                                                                    | `start-storybook --no-dll`                      |
+| --docs-dll                     | Use the Docs dll reference (legacy)                                                                                                            | `start-storybook --docs-dll`                    |
 | --debug-webpack                | Display final webpack configurations for debugging purposes                                                                                    | `start-storybook --debug-webpack`               |
 | --docs                         | Starts Storybook in documentation mode. Learn more about it in [here](../writing-docs/build-documentation.md#preview-storybooks-documentation) | `start-storybook --docs`                        |
 
@@ -47,6 +48,7 @@ Usage: build-storybook [options]
 | -w, --watch                    | Enables watch mode                                                                                                                              | `build-storybook -w`                        |
 | --loglevel [level]             | Controls level of logging during build. Can be one of: [silly, verbose, info (default), warn, error, silent]                                    | `build-storybook --loglevel warn`           |
 | --quiet                        | Suppress verbose build output                                                                                                                   | `build-storybook --quiet`                   |
-| --no-dll                       | Do not use dll reference                                                                                                                        | `build-storybook --no-dll`                  |
+| --no-dll                       | Do not use UI dll reference                                                                                                                     | `build-storybook --no-dll`                  |
+| --docs-dll                     | Use Docs dll reference (legacy)                                                                                                                 | `build-storybook --docs-dll`                |
 | --debug-webpack                | Display final webpack configurations for debugging purposes                                                                                     | `build-storybook --debug-webpack`           |
 | --docs                         | Builds Storybook in documentation mode. Learn more about it in [here](../writing-docs/build-documentation.md#publish-storybooks-documentation)) | `build-storybook --docs`                    |

--- a/lib/core/src/server/cli/dev.js
+++ b/lib/core/src/server/cli/dev.js
@@ -33,7 +33,8 @@ async function getCLI(packageJson) {
       'Suppress automatic redirects to the release notes after upgrading',
       true
     )
-    .option('--no-dll', 'Do not use dll reference')
+    .option('--no-dll', 'Do not use UI dll reference')
+    .option('--docs-dll', 'Use Docs dll reference (legacy)')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(
       '--preview-url [string]',

--- a/lib/core/src/server/cli/prod.js
+++ b/lib/core/src/server/cli/prod.js
@@ -14,7 +14,8 @@ function getCLI(packageJson) {
     .option('-w, --watch', 'Enable watch mode')
     .option('--quiet', 'Suppress verbose build output')
     .option('--loglevel [level]', 'Control level of logging during build')
-    .option('--no-dll', 'Do not use dll reference')
+    .option('--no-dll', 'Do not use UI dll reference (legacy)')
+    .option('--docs-dll', 'Use Docs dll reference')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option(
       '--preview-url [string]',


### PR DESCRIPTION
Issue: #12408 #10982 #12016

## What I did

Storybook 6.0 has two Webpack DLLs: the UI DLL that runs in the manager, the Docs DLL that runs in the preview with user code. This PR disables the Docs DLL by default because it's causing lots of version conflicts, e.g. React 17, core-js, etc. in exchange for some performance improvements.

This PR disables the docs DLL by default since the current out of box experience for Storybook is broken now that React 17 has landed.

There are a few implications:
1. Startup time for the preview will be marginally slower if you use addon-docs. We'll be working hard to get this perf back in other ways.
2. Because the Docs DLL screws up with dependency resolution, it's possible that you were using a different version of a library that you weren't expecting, and this change 

This is technically a breaking change, but if you want to restore the old behavior you can run `start-storybook` or `build-storybook` with the `--docs-dll` flag to restore the old behavior.

Soon in 6.1 we will attempt to remove all DLLs entirely #12637 and will be working to fix the corresponding performance issues in other ways.

## How to test

TBD
