### PR TITLE
Toolbar: fix link in Readme

### DIFF
--- a/addons/toolbars/README.md
+++ b/addons/toolbars/README.md
@@ -40,6 +40,6 @@ The primary difference between the two packages is that `addon-toolbars` makes u
 
 - **Standardization**. Args are built into Storybook in 6.x. Since `addon-toolbars` is based on args, you don't need to learn any addon-specific APIs to use it.
 
-- **Ergonomics**. Global args are easy to consume [in stories](#consuming-global-args-from-within-a-story), in [Storybook Docs](https://github.com/storybookjs/storybook/tree/master/addons/docs), or even in other addons.
+- **Ergonomics**. Global args are easy to consume [in stories](https://storybook.js.org/docs/react/essentials/toolbars-and-globals#consuming-globals-from-within-a-story), in [Storybook Docs](https://github.com/storybookjs/storybook/tree/master/addons/docs), or even in other addons.
 
 * **Framework compatibility**. Args are completely framework-independent, so `addon-toolbars` is compatible with React, Vue, Angular, etc. out of the box with no framework logic needed in the addon.


### PR DESCRIPTION
## What I did

In the README.md of `@storybook/addon-toolbar`,`consuming-global-args-from-within-a-story` section was removed in 0b6173e36b3973c4607496e6e5e85ecd465fad3c but there was still a link on it so I updated it to redirect to the related section in the official doc: https://storybook.js.org/docs/react/essentials/toolbars-and-globals#consuming-globals-from-within-a-story