### PR TITLE
Addon-docs: Lazy load iframes

### DIFF
--- a/lib/components/src/blocks/IFrame.tsx
+++ b/lib/components/src/blocks/IFrame.tsx
@@ -46,6 +46,6 @@ export class IFrame extends Component<IFrameProps> {
 
   render() {
     const { id, title, src, allowFullScreen, scale, ...rest } = this.props;
-    return <iframe id={id} title={title} src={src} allowFullScreen={allowFullScreen} {...rest} />;
+    return <iframe id={id} title={title} src={src} allowFullScreen={allowFullScreen} {...rest} loading="lazy"/>;
   }
 }

--- a/lib/components/src/blocks/IFrame.tsx
+++ b/lib/components/src/blocks/IFrame.tsx
@@ -46,6 +46,16 @@ export class IFrame extends Component<IFrameProps> {
 
   render() {
     const { id, title, src, allowFullScreen, scale, ...rest } = this.props;
-    return <iframe id={id} title={title} src={src} allowFullScreen={allowFullScreen} {...rest} loading="lazy"/>;
+    return (
+      <iframe
+        id={id}
+        title={title}
+        src={src}
+        allowFullScreen={allowFullScreen}
+        // @ts-ignore
+        loading="lazy"
+        {...rest}
+      />
+    );
   }
 }


### PR DESCRIPTION
Issue: #7455

## What I did
add the lazy loading attribute to the iframe component. When using a framework that puts stories in iframes, supporting browsers will improve performance by not loading the iframe until it is scrolled into view. 

## How to test
run the "angular-cli" storybook, and go to a page with multiple iframes like "controls/basic". If you wait a bit for the page to load, then scroll down to the bottom of the docs page, you should see the story load for the first time after you scroll.
