### PR TITLE
Fix syntax error in docs on DocsPage

### DIFF
--- a/docs/snippets/common/storybook-preview-disable-docspage.js.mdx
+++ b/docs/snippets/common/storybook-preview-disable-docspage.js.mdx
@@ -1,5 +1,5 @@
 ```js
 // .storybook/preview.js
 
-export const parameters { docs: { page: null } });
+export const parameters = { docs: { page: null } };
 ```


### PR DESCRIPTION
Issue:

## What I did

Just noticed that the code snippet causes a syntax error. This PR fixes it.

![image](https://user-images.githubusercontent.com/5466341/97033035-b38e6800-1530-11eb-98b2-830f356b4c23.png)
https://storybook.js.org/docs/react/writing-docs/docs-page#global-level