### PR TITLE
docs: explain how to create stories for multiple components

### DIFF
--- a/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
@@ -1,0 +1,24 @@
+```ts
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
+import { ListItemComponent } from './list-item.component';
+import { ListComponent } from './list.component';
+
+export default {
+  title: 'List',
+  component: ListComponent,
+  subcomponents: { ListItemComponent },
+} as Meta;
+
+const Template: Story<ListComponent> = (args: ListComponent) => ({
+  component: ListComponent,
+  props: args,
+  moduleMetadata: {
+    declarations: [ListComponent, ListItemComponent],
+  },
+});
+
+export const OneItem = Template.bind({});
+OneItem.args = {
+  items: [ListItemComponent],
+};
+```

--- a/docs/workflows/stories-for-multiple-components.md
+++ b/docs/workflows/stories-for-multiple-components.md
@@ -10,6 +10,7 @@ It's useful to write stories that [render two or more components](../writing-sto
   paths={[
     'react/list-story-with-subcomponents.js.mdx',
     'react/list-story-with-subcomponents.ts.mdx',
+    'angular/list-story-with-subcomponents.ts.mdx',
   ]}
 />
 


### PR DESCRIPTION
Issue: N/A

## What I did
In this PR I explain how to create a story [for multiple components](https://storybook.js.org/docs/angular/workflows/stories-for-multiple-components) in Angular.

I tried also to create an example by re-using the stories like [this](http://localhost:8000/docs/angular/workflows/stories-for-multiple-components#reusing-subcomponent-stories), but it seems it requires more time than I expected. I hope on a new PR soon :) 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
