### PR TITLE
React: Allow Storybook packages to use React 17.x

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -45,7 +45,7 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "lodash": "^4.17.15",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-sizeme": "^2.5.2",
     "regenerator-runtime": "^0.13.3",

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.15",
     "polished": "^3.4.4",
     "prop-types": "^15.7.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-inspector": "^5.0.1",
     "regenerator-runtime": "^0.13.3",

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -41,7 +41,7 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1",

--- a/addons/controls/package.json
+++ b/addons/controls/package.json
@@ -37,7 +37,7 @@
     "@storybook/node-logger": "6.1.0-alpha.29",
     "@storybook/theming": "6.1.0-alpha.29",
     "core-js": "^3.0.1",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "ts-dedent": "^1.1.1"
   },

--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -39,7 +39,7 @@
     "@storybook/theming": "6.1.0-alpha.29",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3"
   },

--- a/addons/design-assets/package.json
+++ b/addons/design-assets/package.json
@@ -42,7 +42,7 @@
     "@storybook/theming": "6.1.0-alpha.29",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1",

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -72,7 +72,7 @@
     "lodash": "^4.17.15",
     "prettier": "~2.0.5",
     "prop-types": "^15.7.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-element-to-jsx-string": "^14.3.1",
     "react-is": "^16.12.0",

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -38,7 +38,7 @@
     "@storybook/api": "6.1.0-alpha.29",
     "@storybook/node-logger": "6.1.0-alpha.29",
     "core-js": "^3.0.1",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-is": "^16.8.0",
     "regenerator-runtime": "^0.13.3",

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -40,7 +40,7 @@
     "format-json": "^1.0.3",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-lifecycles-compat": "^3.0.4",
     "react-textarea-autosize": "^8.1.1",

--- a/addons/google-analytics/package.json
+++ b/addons/google-analytics/package.json
@@ -24,7 +24,7 @@
     "@storybook/core-events": "6.1.0-alpha.29",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-ga": "^2.5.7",
     "regenerator-runtime": "^0.13.3"

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -40,7 +40,7 @@
     "graphiql": "^0.17.5",
     "graphql": "^15.0.0",
     "prop-types": "^15.7.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "webpack": "^4.43.0"

--- a/addons/jest/package.json
+++ b/addons/jest/package.json
@@ -42,7 +42,7 @@
     "@storybook/theming": "6.1.0-alpha.29",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-sizeme": "^2.5.2",
     "regenerator-runtime": "^0.13.3",

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "qs": "^6.6.0",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-color": "^2.17.0",
     "react-dom": "^16.8.3",
     "react-lifecycles-compat": "^3.0.4",

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -39,7 +39,7 @@
     "global": "^4.3.2",
     "prop-types": "^15.7.2",
     "qs": "^6.6.0",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1"

--- a/addons/queryparams/package.json
+++ b/addons/queryparams/package.json
@@ -39,7 +39,7 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "qs": "^6.6.0",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "ts-dedent": "^1.1.1"

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -45,7 +45,7 @@
     "global": "^4.3.2",
     "jest-specific-snapshot": "^4.0.0",
     "pretty-format": "^26.4.0",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-test-renderer": "^16.8.3",
     "read-pkg-up": "^7.0.0",

--- a/addons/toolbars/package.json
+++ b/addons/toolbars/package.json
@@ -35,7 +35,7 @@
     "@storybook/client-api": "6.1.0-alpha.29",
     "@storybook/components": "6.1.0-alpha.29",
     "core-js": "^3.0.1",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3"
   },
   "publishConfig": {

--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -39,7 +39,7 @@
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
     "prop-types": "^15.7.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3"
   },

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -36,7 +36,7 @@
     "@storybook/theming": "6.1.0-alpha.29",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3"
   },

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -42,7 +42,7 @@
     "global": "^4.3.2",
     "lodash": "^4.17.15",
     "memoizerific": "^1.11.3",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "store2": "^2.7.1",

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15",
     "memoizerific": "^1.11.3",
     "qs": "^6.6.0",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "stable": "^0.1.8",

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -43,7 +43,7 @@
     "memoizerific": "^1.11.3",
     "overlayscrollbars": "^1.10.2",
     "polished": "^3.4.4",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-color": "^2.17.0",
     "react-dom": "^16.8.3",
     "react-popper-tooltip": "^3.1.0",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -112,7 +112,7 @@
     "pretty-hrtime": "^1.0.3",
     "qs": "^6.6.0",
     "raw-loader": "^4.0.1",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dev-utils": "^10.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",

--- a/lib/router/package.json
+++ b/lib/router/package.json
@@ -34,7 +34,7 @@
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
     "qs": "^6.6.0",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3"
   },
   "publishConfig": {

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -38,7 +38,7 @@
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.15",
     "prettier": "~2.0.5",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "regenerator-runtime": "^0.13.3",
     "source-map": "^0.7.3"

--- a/lib/theming/package.json
+++ b/lib/theming/package.json
@@ -38,7 +38,7 @@
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
     "polished": "^3.4.4",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "resolve-from": "^5.0.0",
     "ts-dedent": "^1.1.1"

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -51,7 +51,7 @@
     "memoizerific": "^1.11.3",
     "polished": "^3.4.4",
     "qs": "^6.6.0",
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3",
     "react-draggable": "^4.0.3",
     "react-helmet-async": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27905,7 +27905,7 @@ react@^15.4.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react@^16.8.3, react@^16.9.17:
+"react@^16.8.3 || ^17.0.0", react@^16.8.3, react@^16.9.17:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
Issue: #12408 

## What I did
This PR "unlocks" Storybook packages from the 16.x branch, meaning that during installation, npm/Yarn can dedupe and have only one React version installed.

## How to test
After installation, listing dependencies should now only show one version of React installed.
```sh
# npm
npm ls react

# Yarn
yarn list --pattern react
```