### PR TITLE
Core: Fix async keyword that breaks hermes

### DIFF
--- a/lib/channel-websocket/src/index.ts
+++ b/lib/channel-websocket/src/index.ts
@@ -11,7 +11,7 @@ interface WebsocketTransportArgs {
 
 interface CreateChannelArgs {
   url: string;
-  async: boolean;
+  useAsync: boolean;
   onError: OnError;
 }
 
@@ -73,7 +73,7 @@ export class WebsocketTransport {
   }
 }
 
-export default function createChannel({ url, async, onError }: CreateChannelArgs) {
+export default function createChannel({ url, useAsync, onError }: CreateChannelArgs) {
   const transport = new WebsocketTransport({ url, onError });
-  return new Channel({ transport, async });
+  return new Channel({ transport, useAsync });
 }

--- a/lib/channels/src/index.test.ts
+++ b/lib/channels/src/index.test.ts
@@ -33,7 +33,7 @@ describe('Channel', () => {
     });
 
     it('should set isAsync to true if passed as an argument', () => {
-      channel = new Channel({ async: true });
+      channel = new Channel({ useAsync: true });
       expect(channel.isAsync).toBeTruthy();
     });
   });
@@ -110,8 +110,8 @@ describe('Channel', () => {
       expect(sendSpy.mock.calls[0][1]).toEqual({ depth: 1 });
     });
 
-    it('should use setImmediate if async is true', () => {
-      channel = new Channel({ async: true, transport });
+    it('should use setImmediate if useAsync is true', () => {
+      channel = new Channel({ useAsync: true, transport });
       channel.addListener('event1', jest.fn());
     });
   });

--- a/lib/channels/src/index.ts
+++ b/lib/channels/src/index.ts
@@ -24,7 +24,7 @@ interface EventsKeyValue {
 
 interface ChannelArgs {
   transport?: ChannelTransport;
-  async?: boolean;
+  useAsync?: boolean;
 }
 
 const generateRandomId = () => {
@@ -43,8 +43,8 @@ export class Channel {
 
   private readonly transport: ChannelTransport;
 
-  constructor({ transport, async = false }: ChannelArgs = {}) {
-    this.isAsync = async;
+  constructor({ transport, useAsync = false }: ChannelArgs = {}) {
+    this.isAsync = useAsync;
     if (transport) {
       this.transport = transport;
       this.transport.setHandler((event) => this.handleEvent(event));


### PR DESCRIPTION
We have been having weird issues witch react-native once we enabled Hermes.

We finally managed to figure out what it was by running:

```
 curl 'http://localhost:8081/index.bundle?platform=android&dev=true&minify=false' > bundle.js
 node_modules/hermes-engine/osx-bin/hermesc bundle.js -emit-binary -out bundle.hbc
```
Thanks you @kyle-ssg (https://github.com/facebook/hermes/issues/298#issuecomment-663999190)

This builds a bundle for android and then runs it through the hermes compiler.

We can then see that we get syntax errors because of the [websocket lib](https://github.com/storybookjs/storybook/blob/next/lib/channel-websocket/src/index.ts#L78)

I think it's because of the `async`keyword..

By renaming async to useAsync, we mitigated these issues and could properly run our app on android with hermes enabled.

have tested storybook + hermes locally and works great with this PR applied.