### PR TITLE
Composition: Append index to ref indicator links

### DIFF
--- a/lib/ui/src/components/sidebar/RefIndicator.tsx
+++ b/lib/ui/src/components/sidebar/RefIndicator.tsx
@@ -235,7 +235,7 @@ const ReadyMessage: FunctionComponent<{
   componentCount: number;
   leafCount: number;
 }> = ({ url, componentCount, leafCount }) => (
-  <Message href={url} target="_blank">
+  <Message href={url.replace(/\/?$/, '/index.html')} target="_blank">
     <BlueIcon icon="globe" />
     <div>
       <MessageTitle>View external Storybook</MessageTitle>
@@ -284,7 +284,7 @@ const ReadDocsMessage: FunctionComponent = () => (
 );
 
 const ErrorOccurredMessage: FunctionComponent<{ url: string }> = ({ url }) => (
-  <Message href={url} target="_blank">
+  <Message href={url.replace(/\/?$/, '/index.html')} target="_blank">
     <RedIcon icon="alert" />
     <div>
       <MessageTitle>Something went wrong</MessageTitle>
@@ -294,7 +294,7 @@ const ErrorOccurredMessage: FunctionComponent<{ url: string }> = ({ url }) => (
 );
 
 const LoadingMessage: FunctionComponent<{ url: string }> = ({ url }) => (
-  <Message href={url} target="_blank">
+  <Message href={url.replace(/\/?$/, '/index.html')} target="_blank">
     <BlueIcon icon="time" />
     <div>
       <MessageTitle>Please wait</MessageTitle>


### PR DESCRIPTION
Issue: #12659

## What I did

Appended `index.html` to links in the ref indicator flyout – in order to support storybook apps nested in a URL directory (e.g. `domain.com/mystorybookapp/index.html`)

## How to test

- Is this testable with Jest or Chromatic screenshots? **No?**
- Does this need a new example in the kitchen sink apps? **No**
- Does this need an update to the documentation? **No**