### PR TITLE
CLI: Disable DLL by default in template

### DIFF
--- a/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -187,13 +187,14 @@ export abstract class JsPackageManager {
     preCommand?: string;
   }) {
     const sbPort = options?.port ?? 6006;
+    const noDll = '--no-dll';
     const storybookCmd = options?.staticFolder
-      ? `start-storybook -p ${sbPort} -s ${options.staticFolder}`
-      : `start-storybook -p ${sbPort}`;
+      ? `start-storybook -p ${sbPort} -s ${options.staticFolder} ${noDll}`
+      : `start-storybook -p ${sbPort} ${noDll}`;
 
     const buildStorybookCmd = options?.staticFolder
-      ? `build-storybook -s ${options.staticFolder}`
-      : 'build-storybook';
+      ? `build-storybook -s ${options.staticFolder} ${noDll}`
+      : `build-storybook ${noDll}`;
 
     const preCommand = options.preCommand ? this.getRunCommand(options.preCommand) : undefined;
     this.addScripts({


### PR DESCRIPTION
Issue: N/A

## What I did

Disable Webpack DLLs by default in the CLI template

The DLLs are causing numerous issues (#12408 #12881 #11904) and we are getting rid of them in 6.1 #12637 

This is a temporary fix so that new users don't encounter these problems after installing Storybook for the first time.

It comes at a performance cost which is that Storybook's "manager" UI is about 2x slower to build.

## How to test

CI tests
