### PR TITLE
Combine args with basic object spread semantics

### DIFF
--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -157,6 +157,26 @@ describe('preview.story_store', () => {
   });
 
   describe('args', () => {
+    it('composes component-level and story-level args, favoring story-level', () => {
+      const store = new StoryStore({ channel });
+      store.addKindMetadata('a', {
+        parameters: { args: { arg1: 1, arg2: 2, arg3: 3, arg4: { complex: 'object' } } },
+      });
+      addStoryToStore(store, 'a', '1', () => 0, {
+        args: {
+          arg1: 4,
+          arg2: undefined,
+          arg4: { other: 'object ' },
+        },
+      });
+      expect(store.getRawStory('a', '1').args).toEqual({
+        arg1: 4,
+        arg2: undefined,
+        arg3: 3,
+        arg4: { other: 'object ' },
+      });
+    });
+
     it('is initialized to the value stored in parameters.args[name] || parameters.argType[name].defaultValue', () => {
       const store = new StoryStore({ channel });
       addStoryToStore(store, 'a', '1', () => 0, {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -445,7 +445,10 @@ export default class StoryStore {
     };
 
     // Pull out parameters.args.$ || .argTypes.$.defaultValue into initialArgs
-    const passedArgs: Args = combinedParameters.args;
+    const passedArgs: Args = {
+      ...this._kinds[kind].parameters.args,
+      ...storyParameters.args,
+    };
     const defaultArgs: Args = Object.entries(
       argTypes as Record<string, { defaultValue: any }>
     ).reduce((acc, [arg, { defaultValue }]) => {


### PR DESCRIPTION
Fixes #12697

Issue: We (implicitly) used `combineParameters` to combine component & story-level args, which has complex object-combination semantics that I don't think we wanted.

## What I did

Just use object spread.

NOTE: this is technically a breaking change, fixing a bug. However people may be relying on that bug. Not sure what to do about that.

## How to test

There's a test.
