### PR TITLE
UI: Don't listen for progress updates in static builds

### DIFF
--- a/lib/core/src/server/manager/manager-webpack.config.js
+++ b/lib/core/src/server/manager/manager-webpack.config.js
@@ -85,6 +85,7 @@ export default async ({
           version,
           dlls: uiDll ? ['./sb_dll/storybook_ui_dll.js'] : [],
           globals: {
+            CONFIG_TYPE: configType,
             LOGLEVEL: logLevel,
             VERSIONCHECK: JSON.stringify(versionCheck),
             RELEASE_NOTES_DATA: JSON.stringify(releaseNotesData),


### PR DESCRIPTION
Fix for the prebuilt manager. This ensures we don't try to fetch /progress on static builds, because we won't have a backend there.