### PR TITLE
Build: Fix bootstrap reset command

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -32,9 +32,9 @@
     "versions.json"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/prepare.js && node -r esm ./scripts/generate-sb-packages-versions.js",
+    "prepare": "node ../../scripts/prepare.js && node ./scripts/generate-sb-packages-versions.js",
     "test": "cd test && ./run_tests.sh",
-    "postversion": "node -r esm ./scripts/generate-sb-packages-versions.js"
+    "postversion": "node ./scripts/generate-sb-packages-versions.js"
   },
   "dependencies": {
     "@babel/core": "^7.12.3",

--- a/lib/cli/scripts/generate-sb-packages-versions.js
+++ b/lib/cli/scripts/generate-sb-packages-versions.js
@@ -1,6 +1,6 @@
-import { writeJson, readJson } from 'fs-extra';
-import path from 'path';
-import globby from 'globby';
+const { writeJson, readJson } = require('fs-extra');
+const path = require('path');
+const globby = require('globby');
 
 const rootDirectory = path.join(__dirname, '..', '..', '..');
 


### PR DESCRIPTION
Issue: N/A

When running `yarn bootstrap --reset --core`, this consistently fails:


```
lerna ERR! yarn run prepare stderr:
/Users/shilman/projects/baseline/storybook/lib/cli/scripts/generate-sb-packages-versions.js:1
import { writeJson, readJson } from 'fs-extra';
```

The error doesn't make any sense since it's being run with `-r esm`, but this fixes it.
