### PR TITLE
Addon-docs: Angular empty string now infers to "string" instead of "void"

### DIFF
--- a/addons/docs/src/frameworks/angular/compodoc.test.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.test.ts
@@ -12,6 +12,7 @@ describe('extractType', () => {
   describe('with compodoc type', () => {
     it.each([
       ['string', { name: 'string' }],
+      ['', { name: 'string' }],
       ['boolean', { name: 'boolean' }],
       ['number', { name: 'number' }],
       ['object', { name: 'object' }],

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -109,7 +109,7 @@ const displaySignature = (item: Method): string => {
 
 const extractTypeFromValue = (defaultValue: any) => {
   const valueType = typeof defaultValue;
-  return defaultValue || valueType === 'boolean' ? valueType : null;
+  return defaultValue || valueType === 'boolean' || valueType === 'string' ? valueType : null;
 };
 
 const extractEnumValues = (compodocType: any) => {


### PR DESCRIPTION
Issue: #12986

## What I did
- I added a test for an empty string to make sure it's covered: `['', { name: 'string' }]` 
- I fixed the `extractTypeFromValue` function to verify that when `valueType == string` it will infer a string



## How to test

Test is added. Should be covered now. For testing if the issue is fixed please refer to the description in the issue.
