### PR TITLE
Addon-docs: Hide React default props in source block

### DIFF
--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 import React from 'react';
 import range from 'lodash/range';
+import PropTypes from 'prop-types';
 import addons, { StoryContext } from '@storybook/addons';
 import { renderJsx, jsxDecorator } from './jsxDecorator';
 import { SNIPPET_RENDERED } from '../../shared';
@@ -129,6 +130,27 @@ describe('renderJsx', () => {
       <MyMemoComponent>
         I'm memo!
       </MyMemoComponent>
+    `);
+  });
+
+  it('should not add default props to string if the prop value has not changed', () => {
+    const Container = ({ className, children }: { className: string; children: string }) => {
+      return <div className={className}>{children}</div>;
+    };
+
+    Container.propTypes = {
+      children: PropTypes.string.isRequired,
+      className: PropTypes.string,
+    };
+
+    Container.defaultProps = {
+      className: 'super-container',
+    };
+
+    expect(renderJsx(<Container>yo dude</Container>, {})).toMatchInlineSnapshot(`
+      <div>
+        yo dude
+      </div>
     `);
   });
 });

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -133,6 +133,7 @@ const defaultOpts = {
   skip: 0,
   showFunctions: false,
   enableBeautify: true,
+  showDefaultProps: false,
 };
 
 export const skipJsxRender = (context: StoryContext) => {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/11510

## What I did

Added option to not show default props on code preview when a component isn't overriding those values. In `jsxDecorator.tsx`, it is using the `reactElementToString` method from the [react-element-to-jsx-string](https://www.npmjs.com/package/react-element-to-jsx-string#reactelementtojsxstringreactelement-options) package. If you check their options, they accept a `showDefaultProps` property, which when set to `false` omits the default props in the JSX. This sets that to `false` so it doesn't show the default props by default.

## How to test

- Is this testable with Jest or Chromatic screenshots?
  Yes. I added a test case, but it looks like it is failing due to a snapshot. I'm not familiar with snapshots, so I could use some help there please.
- Does this need a new example in the kitchen sink apps?
  No
- Does this need an update to the documentation?
  Yeah I think so, but I'm struggling determining where that would be added the best. Any advice?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
