### PR TITLE
DRAFT documentation for Next and serve

### DIFF
--- a/docs/configure/next.md
+++ b/docs/configure/next.md
@@ -1,0 +1,21 @@
+---
+title: 'Next/Vercel'
+---
+
+### Setup webpack
+
+Next is providing an addon for Storybook under the [@next/plugin-storybook](https://www.npmjs.com/package/@next/plugin-storybook) package.
+
+See [the official Storybook example in Next](https://github.com/vercel/next.js/tree/canary/examples/with-storybook) for usage.
+
+This plugin will automatically extend Storybook build step to behave similarly to Next. You will enjoy features such as [module path aliases](https://nextjs.org/docs/advanced-features/module-path-aliases) being computed directly based on your `tsconfig.json` or `jsconfig.json` `paths` configuration.
+
+### Serve static build with `serve`
+
+[`serve`](https://github.com/vercel/serve) is a micro-server for static websites. You can use it to serve the built version of your Storybook stories.
+
+```sh
+yarn build-storybook -s ./public
+yarn add -D serve
+yarn serve storybook-static
+```


### PR DESCRIPTION
Issue:

## What I did

Started to write a documentation for Next and more broadly Vercel tooling.

It is still draft for following reasons:
- Storybook preset need this PR to be really stabilized, it also includes a better `with-storybook` example : https://github.com/vercel/next.js/pull/18367
- ~~Storybook preset has been fixed on Next canary, at the time of writing it is not yet release though~~ Now released in Next 10
- ~~Therefore https://github.com/storybookjs/storybook/issues/11639 is still open~~ Done
- A PR is pending to demo serving storybook with serve: https://github.com/vercel/next.js/pull/18775
- Serve has some unexpected interaction with Storybook, see https://github.com/vercel/serve/issues/631
- I just threw a code snippet but did not create it with the `CodeSnippet` component as in other pages