### PR TITLE
UI: Restrict layout styles to only apply to a rendered preview area

### DIFF
--- a/lib/core/src/server/templates/base-preview-head.html
+++ b/lib/core/src/server/templates/base-preview-head.html
@@ -7,7 +7,7 @@
     display: none;
   }
 
-  .sb-main-centered {
+  .sb-show-main.sb-main-centered {
     margin: 0;
     padding: 1rem;
     display: flex;
@@ -17,13 +17,13 @@
     box-sizing: border-box;
   }
 
-  .sb-main-fullscreen {
+  .sb-show-main.sb-main-fullscreen {
     margin: 0;
     padding: 0;
     display: block;
   }
 
-  .sb-main-padded {
+  .sb-show-main.sb-main-padded {
     margin: 0;
     padding: 1rem;
     display: block;


### PR DESCRIPTION
Issue: -

## What I did

I've bumped the specificity for the layout classes to only apply when the `sb-show-main` class is also present. This avoids an issue with the layout class somehow getting applied to the manager itself. I haven't seen that happen with the new class approach, but I've seen it happen with the old styles approach, with `body.style` getting set on the outer (manager) body.

## How to test

Not really testable, because I can't reproduce. This is a "better safe than sorry" tweak.

For those with access, this happened [here](https://5e5fcc0d6aa8bd00220faff4-vaajmccdlc.chromatic.com/?id=buttons--routing-choice-disabled&viewMode=story).

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
