### PR TITLE
Fix typo in parameters.md

### DIFF
--- a/docs/writing-stories/parameters.md
+++ b/docs/writing-stories/parameters.md
@@ -79,4 +79,4 @@ The way the global, component and story parameters are combined is:
 
 The merging of parameters is important. It means it is possible to override a single specific sub-parameter on a per-story basis but still retain the majority of the parameters defined globally.
 
-If you are defining an API that relies on parameters (e..g an [**addon**](../api/addons.md)) it is a good idea to take this behavior into account.
+If you are defining an API that relies on parameters (e.g. an [**addon**](../api/addons.md)) it is a good idea to take this behavior into account.


### PR DESCRIPTION
"e.g." instead of "e..g"

Issue:

## What I did

FIxed a typo in parameters documentation (parameters.md)

## How to test

- Is this testable with Jest or Chromatic screenshots?

No -- documentation only.

- Does this need a new example in the kitchen sink apps?

No -- documentation only

- Does this need an update to the documentation?

No -- it updates the documentation
