### PR TITLE
Core: Add catch to end process

### DIFF
--- a/lib/core/src/server/build-static.ts
+++ b/lib/core/src/server/build-static.ts
@@ -209,5 +209,8 @@ export function buildStatic({ packageJson, ...loadOptions }: any) {
     outputDir: loadOptions.outputDir || cliOptions.outputDir || './storybook-static',
     ignorePreview: !!cliOptions.previewUrl,
     docsMode: !!cliOptions.docs,
+  }).catch((e) => {
+    logger.error(e);
+    process.exit(1);
   });
 }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/10405

## What I did
- add a catch block to exit the process when building storybook failed