### PR TITLE
Bump webpack to 4.41.24

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^10.0.4",
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.150",
     "@types/uuid": "^7.0.3",
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -46,7 +46,7 @@
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -42,7 +42,7 @@
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -111,7 +111,7 @@
     "tmp": "^0.2.1",
     "tslib": "^2.0.0",
     "web-component-analyzer": "^1.0.3",
-    "webpack": "^4.33.0",
+    "webpack": "^4.44.2",
     "zone.js": "^0.10.2"
   },
   "peerDependencies": {

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.9.6",
     "@storybook/vue": "6.1.0-beta.2",
     "@types/jest": "^25.1.1",
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "@babel/core": "^7.9.6",

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -45,7 +45,7 @@
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -33,7 +33,7 @@
     "@babel/plugin-transform-classes": "^7.12.1",
     "@storybook/addons": "6.1.0-beta.2",
     "@storybook/api": "6.1.0-beta.2",
-    "@types/webpack": "^4.41.9",
+    "@types/webpack": "^4.41.24",
     "babel-loader": "^8.0.6",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
@@ -41,7 +41,7 @@
     "graphql": "^15.0.0",
     "prop-types": "^15.7.2",
     "regenerator-runtime": "^0.13.7",
-    "webpack": "^4.43.0"
+    "webpack": "^4.44.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/addons/jest/package.json
+++ b/addons/jest/package.json
@@ -47,7 +47,7 @@
     "upath": "^1.1.0"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -55,7 +55,7 @@
     "@types/react-color": "^3.0.1",
     "@types/react-lifecycles-compat": "^3.0.1",
     "@types/react-select": "^3.0.12",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "enzyme": "^3.11.0"
   },
   "peerDependencies": {

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -43,7 +43,7 @@
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/addons/queryparams/package.json
+++ b/addons/queryparams/package.json
@@ -43,7 +43,7 @@
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.2"
+    "@types/webpack-env": "^1.15.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -37,7 +37,7 @@
     "@storybook/addons": "6.1.0-beta.2",
     "@storybook/core": "6.1.0-beta.2",
     "@storybook/node-logger": "6.1.0-beta.2",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "autoprefixer": "^9.7.6",
     "core-js": "^3.0.1",
     "fork-ts-checker-webpack-plugin": "^4.0.3",
@@ -51,7 +51,7 @@
     "strip-json-comments": "^3.0.1",
     "ts-loader": "^6.0.1",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
-    "webpack": "^4.43.0"
+    "webpack": "^4.44.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.901.0",

--- a/app/aurelia/package.json
+++ b/app/aurelia/package.json
@@ -37,7 +37,7 @@
     "react-dom": "16.13.1",
     "ts-loader": "^6.0.1",
     "url-loader": "^4.1.0",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   },
   "devDependencies": {
     "@types/node": "^14.0.10",
@@ -52,7 +52,7 @@
     "sass-loader": "^8.0.0",
     "style-loader": "^0.23.0",
     "typescript": "^3.9.3",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   },
   "peerDependencies": {
     "aurelia": "*"

--- a/app/html/package.json
+++ b/app/html/package.json
@@ -37,7 +37,7 @@
     "@storybook/addons": "6.1.0-beta.2",
     "@storybook/client-api": "6.1.0-beta.2",
     "@storybook/core": "6.1.0-beta.2",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "html-loader": "^1.0.0",

--- a/app/marko/package.json
+++ b/app/marko/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@babel/core": "*",
     "marko": "^4.15.2 || ^5.0.0-next || ^5",
-    "webpack": "^4"
+    "webpack": "^4.44.2"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/app/mithril/package.json
+++ b/app/mithril/package.json
@@ -39,7 +39,7 @@
     "@storybook/addons": "6.1.0-beta.2",
     "@storybook/core": "6.1.0-beta.2",
     "@types/mithril": "^2.0.0",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "react": "16.13.1",

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -37,7 +37,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.1",
     "@storybook/addons": "6.1.0-beta.2",
     "@storybook/core": "6.1.0-beta.2",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "react": "16.13.1",

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -42,7 +42,7 @@
     "@storybook/node-logger": "6.1.0-beta.2",
     "@storybook/semver": "^7.3.2",
     "@svgr/webpack": "^5.4.0",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-named-asset-import": "^0.3.1",
     "babel-plugin-react-docgen": "^4.2.1",
@@ -55,12 +55,12 @@
     "react-refresh": "^0.8.3",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0",
-    "webpack": "^4.43.0"
+    "webpack": "^4.44.2"
   },
   "devDependencies": {
     "@storybook/client-api": "6.1.0-beta.2",
     "@types/node": "^14.0.10",
-    "@types/webpack": "^4.41.12"
+    "@types/webpack": "^4.41.24"
   },
   "peerDependencies": {
     "@babel/core": "^7.11.5",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -39,7 +39,7 @@
     "@storybook/client-api": "6.1.0-beta.2",
     "@storybook/core": "6.1.0-beta.2",
     "@storybook/node-logger": "6.1.0-beta.2",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "react": "16.13.1",

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -45,7 +45,7 @@
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "svelte": "^3.18.1",
     "svelte-loader": "^2.13.4"
   },

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@storybook/addons": "6.1.0-beta.2",
     "@storybook/core": "6.1.0-beta.2",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "react": "16.13.1",
@@ -46,11 +46,11 @@
     "ts-loader": "^6.2.2",
     "vue-docgen-api": "^4.33.1",
     "vue-docgen-loader": "^1.5.0",
-    "webpack": "^4.43.0"
+    "webpack": "^4.44.2"
   },
   "devDependencies": {
     "@types/node": "^14.0.10",
-    "@types/webpack": "^4.41.12",
+    "@types/webpack": "^4.41.24",
     "vue": "^2.6.8",
     "vue-loader": "^15.7.0",
     "vue-template-compiler": "^2.6.8"

--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -42,7 +42,7 @@
     "@storybook/addons": "6.1.0-beta.2",
     "@storybook/client-api": "6.1.0-beta.2",
     "@storybook/core": "6.1.0-beta.2",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "babel-plugin-bundled-import-meta": "^0.3.1",
     "core-js": "^3.0.1",
     "global": "^4.3.2",

--- a/examples/angular-cli/package.json
+++ b/examples/angular-cli/package.json
@@ -53,7 +53,7 @@
     "@types/core-js": "^2.5.0",
     "@types/jest": "^25.1.1",
     "@types/node": "^14.0.10",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "babel-plugin-require-context-hook": "^1.0.0",
     "global": "^4.3.2",
     "jasmine-core": "~3.5.0",

--- a/examples/aurelia-kitchen-sink/package.json
+++ b/examples/aurelia-kitchen-sink/package.json
@@ -45,6 +45,6 @@
     "style-loader": "^0.23.0",
     "ts-loader": "^6.0.0",
     "typescript": "^3.9.3",
-    "webpack": "^4.41.2"
+    "webpack": "^4.44.2"
   }
 }

--- a/examples/dev-kits/package.json
+++ b/examples/dev-kits/package.json
@@ -36,7 +36,7 @@
     "react-dom": "16.13.1",
     "ts-loader": "^6.2.0",
     "uuid": "^8.0.0",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   },
   "storybook": {
     "chromatic": {

--- a/examples/ember-cli/package.json
+++ b/examples/ember-cli/package.json
@@ -46,7 +46,7 @@
     "ember-resolver": "^7.0.0",
     "ember-source": "~3.19.0",
     "loader.js": "^4.2.3",
-    "webpack": "^4.43.0",
+    "webpack": "^4.44.2",
     "webpack-cli": "^3.3.0"
   },
   "engines": {

--- a/examples/marko-cli/package.json
+++ b/examples/marko-cli/package.json
@@ -31,7 +31,7 @@
     "@storybook/marko": "6.1.0-beta.2",
     "@storybook/source-loader": "6.1.0-beta.2",
     "prettier": "~2.0.5",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   },
   "storybook": {
     "chromatic": {

--- a/examples/mithril-kitchen-sink/package.json
+++ b/examples/mithril-kitchen-sink/package.json
@@ -21,7 +21,7 @@
     "@storybook/addons": "6.1.0-beta.2",
     "@storybook/mithril": "6.1.0-beta.2",
     "@storybook/source-loader": "6.1.0-beta.2",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   },
   "storybook": {
     "chromatic": {

--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -60,7 +60,7 @@
     "terser-webpack-plugin": "^3.0.0",
     "ts-loader": "^6.0.0",
     "uuid": "^8.0.0",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   },
   "peerDependencies": {
     "puppeteer": "^2.0.0 || ^3.0.0"

--- a/examples/preact-kitchen-sink/package.json
+++ b/examples/preact-kitchen-sink/package.json
@@ -32,7 +32,7 @@
     "preact-render-to-json": "^3.6.6",
     "raw-loader": "^4.0.1",
     "svg-url-loader": "^5.0.0",
-    "webpack": "^4.33.0",
+    "webpack": "^4.44.2",
     "webpack-dev-server": "^3.8.2"
   },
   "storybook": {

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -17,6 +17,6 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "typescript": "^3.9.3",
-    "webpack": "^4.43.0"
+    "webpack": "^4.44.2"
   }
 }

--- a/examples/riot-kitchen-sink/package.json
+++ b/examples/riot-kitchen-sink/package.json
@@ -32,7 +32,7 @@
     "raw-loader": "^4.0.1",
     "riot-tag-loader": "^2.1.0",
     "svg-url-loader": "^5.0.0",
-    "webpack": "^4.33.0",
+    "webpack": "^4.44.2",
     "webpack-dev-server": "^3.8.2"
   },
   "storybook": {

--- a/examples/vue-kitchen-sink/package.json
+++ b/examples/vue-kitchen-sink/package.json
@@ -35,7 +35,7 @@
     "svg-url-loader": "^5.0.0",
     "vue-loader": "^15.7.0",
     "vue-style-loader": "^4.1.2",
-    "webpack": "^4.33.0",
+    "webpack": "^4.44.2",
     "webpack-dev-server": "^3.8.2"
   },
   "storybook": {

--- a/lib/cli/test/fixtures/riot/package.json
+++ b/lib/cli/test/fixtures/riot/package.json
@@ -21,7 +21,7 @@
     "riot-hot-reload": "^1.0.0",
     "riot-tmpl": "^3.0.8",
     "style-loader": "^0.23.1",
-    "webpack": "^4.33.0",
+    "webpack": "^4.44.2",
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-cli": "^3.2.3"
   }

--- a/lib/cli/test/fixtures/sfc_vue/package.json
+++ b/lib/cli/test/fixtures/sfc_vue/package.json
@@ -48,7 +48,7 @@
     "vue-loader": "15.7.0",
     "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.6.8",
-    "webpack": "^4.33.0",
+    "webpack": "^4.44.2",
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-dev-middleware": "^3.6.0",
     "webpack-hot-middleware": "^2.24.3",

--- a/lib/cli/test/fixtures/webpack_react/package.json
+++ b/lib/cli/test/fixtures/webpack_react/package.json
@@ -16,6 +16,6 @@
     "@babel/preset-react": "7.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   }
 }

--- a/lib/cli/test/fixtures/webpack_react_frozen_lock/package.json
+++ b/lib/cli/test/fixtures/webpack_react_frozen_lock/package.json
@@ -16,6 +16,6 @@
     "@babel/preset-react": "7.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   }
 }

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -35,7 +35,7 @@
     "@storybook/core-events": "6.1.0-beta.2",
     "@storybook/csf": "0.0.1",
     "@types/qs": "^6.9.0",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack-env": "^1.15.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "lodash": "^4.17.15",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -127,7 +127,7 @@
     "unfetch": "^4.1.0",
     "url-loader": "^4.0.0",
     "util-deprecate": "^1.0.2",
-    "webpack": "^4.43.0",
+    "webpack": "^4.44.2",
     "webpack-dev-middleware": "^3.7.0",
     "webpack-filter-warnings-plugin": "^1.2.1",
     "webpack-hot-middleware": "^2.25.0",

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -69,7 +69,7 @@
     "enzyme": "^3.11.0",
     "flush-promises": "^1.0.2",
     "terser-webpack-plugin": "^3.0.0",
-    "webpack": "^4.33.0"
+    "webpack": "^4.44.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -129,8 +129,8 @@
     "@types/semver": "^7.1.0",
     "@types/serve-static": "^1.13.3",
     "@types/shelljs": "^0.8.7",
-    "@types/webpack": "^4.41.12",
-    "@types/webpack-env": "^1.15.2",
+    "@types/webpack": "^4.41.24",
+    "@types/webpack-env": "^1.15.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^26.0.0",
@@ -213,7 +213,7 @@
     "ts-node": "^8.10.2",
     "typescript": "^3.9.3",
     "wait-on": "^4.0.0",
-    "webpack": "^4.43.0",
+    "webpack": "^4.44.2",
     "window-size": "^1.1.1"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6711,10 +6711,15 @@
     "@types/serve-static" "*"
     "@types/webpack" "*"
 
-"@types/webpack-env@^1.15.1", "@types/webpack-env@^1.15.2":
+"@types/webpack-env@^1.15.1":
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.15.2.tgz#927997342bb9f4a5185a86e6579a0a18afc33b0a"
   integrity sha512-67ZgZpAlhIICIdfQrB5fnDvaKFcDxpKibxznfYRVAT4mQE41Dido/3Ty+E3xGBmTogc5+0Qb8tWhna+5B8z1iQ==
+
+"@types/webpack-env@^1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.15.3.tgz#fb602cd4c2f0b7c0fb857e922075fdf677d25d84"
+  integrity sha512-5oiXqR7kwDGZ6+gmzIO2lTC+QsriNuQXZDWNYRV3l2XRN/zmPgnC21DLSx2D05zvD8vnXW6qUg7JnXZ4I6qLVQ==
 
 "@types/webpack-hot-middleware@^2.25.3":
   version "2.25.3"
@@ -6752,10 +6757,22 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
-"@types/webpack@^4.41.12", "@types/webpack@^4.41.13", "@types/webpack@^4.41.8", "@types/webpack@^4.41.9":
+"@types/webpack@^4.41.13", "@types/webpack@^4.41.8":
   version "4.41.13"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.13.tgz#988d114c8913d039b8a0e0502a7fe4f1f84f3d5e"
   integrity sha512-RYmIHOWSxnTTa765N6jJBVE45pd2SYNblEYshVDduLw6RhocazNmRzE5/ytvBD8IkDMH6DI+bcrqxh8NILimBA==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    source-map "^0.6.0"
+
+"@types/webpack@^4.41.24":
+  version "4.41.24"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.24.tgz#75b664abe3d5bcfe54e64313ca3b43e498550422"
+  integrity sha512-1A0MXPwZiMOD3DPMuOKUKcpkdPo8Lq33UGggZ7xio6wJ/jV1dAu5cXDrOfGDnldUroPIRLsr/DT43/GqOA4RFQ==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"
@@ -11687,6 +11704,21 @@ chokidar@^1.4.3:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chokidar@^3.4.1:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
+  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -15098,6 +15130,15 @@ enhanced-resolve@4.1.1, enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0, enhanc
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz#2937e2b8066cd0fe7ce0990a98f0d71a35189f66"
   integrity sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.5.0"
+    tapable "^1.0.0"
+
+enhanced-resolve@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
+  integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
@@ -29212,6 +29253,13 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 readjson@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/readjson/-/readjson-2.0.1.tgz#1822964dfd0bc0b49c8f983c192a9dd5309eb9e1"
@@ -34724,6 +34772,17 @@ watchpack@^1.5.0, watchpack@^1.6.0, watchpack@^1.6.1:
     chokidar "^3.4.0"
     watchpack-chokidar2 "^2.0.0"
 
+watchpack@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.4.tgz#6e9da53b3c80bb2d6508188f5b200410866cd30b"
+  integrity sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    neo-async "^2.5.0"
+  optionalDependencies:
+    chokidar "^3.4.1"
+    watchpack-chokidar2 "^2.0.0"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -35102,7 +35161,7 @@ webpack@4.42.0:
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
 
-webpack@^4.0.0, webpack@^4.27.1, webpack@^4.33.0, webpack@^4.38.0, webpack@^4.41.2, webpack@^4.41.4, webpack@^4.43.0:
+webpack@^4.0.0, webpack@^4.27.1, webpack@^4.38.0, webpack@^4.41.4:
   version "4.43.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"
   integrity sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==
@@ -35129,6 +35188,35 @@ webpack@^4.0.0, webpack@^4.27.1, webpack@^4.33.0, webpack@^4.38.0, webpack@^4.41
     tapable "^1.1.3"
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.6.1"
+    webpack-sources "^1.4.1"
+
+webpack@^4.44.2:
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72"
+  integrity sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==
+  dependencies:
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/wasm-edit" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    acorn "^6.4.1"
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^4.3.0"
+    eslint-scope "^4.0.3"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.4.0"
+    loader-utils "^1.2.3"
+    memory-fs "^0.4.1"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.3"
+    neo-async "^2.6.1"
+    node-libs-browser "^2.2.1"
+    schema-utils "^1.0.0"
+    tapable "^1.1.3"
+    terser-webpack-plugin "^1.4.3"
+    watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
 websocket-driver@0.6.5:


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12425

## What I did
minor webpack upgrade

This is strictly not necessary! users should be able to use the any 4.x version of webpack. Storybook depends on webpack 4.x. npm should dedup the webpack packages if it can, and storybook will accept ^4.44.2 already.

This PR just forces the latest 4.x version of webpack unto users. Even if they have < 4.44 installed.