### PR TITLE
UI: Fix icon for addon panel orientation button

### DIFF
--- a/lib/ui/src/components/panel/panel.tsx
+++ b/lib/ui/src/components/panel/panel.tsx
@@ -72,7 +72,7 @@ const AddonPanel = React.memo<{
             onClick={actions.togglePosition}
             title={`Change addon orientation [${shortcutToHumanString(shortcuts.panelPosition)}]`}
           >
-            <Icons icon={panelPosition === 'bottom' ? 'bottombar' : 'sidebaralt'} />
+            <Icons icon={panelPosition === 'bottom' ? 'sidebaralt' : 'bottombar'} />
           </DesktopOnlyIconButton>
           <DesktopOnlyIconButton
             key="visibility"


### PR DESCRIPTION
## What I did
Changed the addon panel icon so that it shows what the orientation **_will be_** after re-orienting. This is based on new [research](https://www.nngroup.com/articles/state-switch-buttons/) from Nielsen. Thanks @ghengeveld!

**What it used to be:**
The addon panel's orientation icon displays the current orientation. For example, when it is on the bottom it shows the bottom icon. When it is on the side, it shows the sidebar icon.

Bottom icon
![image](https://user-images.githubusercontent.com/263385/98294381-df244000-1f7d-11eb-87dc-8f4ac084601c.png)

Sidebar icon
![image](https://user-images.githubusercontent.com/263385/98294418-eba89880-1f7d-11eb-8de5-40ce5ef87870.png)




## How to test

- Is this testable with Jest or Chromatic screenshots? Yes. See UI Tests PR check.
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

