### PR TITLE
Core: Dedupe default ArgTypes enhancers

### DIFF
--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import createChannel from '@storybook/channel-postmessage';
 import { toId } from '@storybook/csf';
 import addons, { mockChannel } from '@storybook/addons';
@@ -704,6 +705,23 @@ describe('preview.story_store', () => {
         expect.objectContaining({ parameters: { __isArgsStory: false, argTypes: { e: 'f' } } })
       );
       expect(store.getRawStory('a', '1').parameters.argTypes).toEqual({ e: 'f', c: 'd' });
+    });
+
+    it('adds user and default enhancers', () => {
+      const store = new StoryStore({ channel });
+      expect(store._argTypesEnhancers.length).toBe(1);
+
+      const enhancer = () => ({});
+      store.addArgTypesEnhancer(enhancer);
+      expect(store._argTypesEnhancers.length).toBe(2);
+
+      store.startConfiguring();
+      expect(store._argTypesEnhancers.length).toBe(4);
+
+      addStoryToStore(store, 'a', '1', () => 0);
+      addStoryToStore(store, 'a', '2', () => 0);
+      store.finishConfiguring();
+      expect(store._argTypesEnhancers.length).toBe(4);
     });
   });
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -165,6 +165,10 @@ export default class StoryStore {
 
   startConfiguring() {
     this._configuring = true;
+
+    // run these at the end
+    this._argTypesEnhancers.push(inferArgTypes);
+    this._argTypesEnhancers.push(inferControls);
   }
 
   storeGlobals() {
@@ -386,9 +390,6 @@ export default class StoryStore {
     const { passArgsFirst = true } = combinedParameters;
     const __isArgsStory = passArgsFirst && original.length > 0;
 
-    // run at the end
-    this._argTypesEnhancers.push(inferArgTypes);
-    this._argTypesEnhancers.push(inferControls);
     const { argTypes = {} } = this._argTypesEnhancers.reduce(
       (accumulatedParameters: Parameters, enhancer) => ({
         ...accumulatedParameters,


### PR DESCRIPTION
Issue: N/A

## What I did

Duplicate ArgType enhancers were getting added for every story. This dedupes them, which should improve loading performance.

## How to test

See attached tests
