### PR TITLE
Angular: Fix storyData handling on module update

### DIFF
--- a/app/angular/src/client/preview/angular/helpers.ts
+++ b/app/angular/src/client/preview/angular/helpers.ts
@@ -18,13 +18,12 @@ declare global {
 
 let platform: any = null;
 let promises: Promise<NgModuleRef<any>>[] = [];
+let storyData = new ReplaySubject(1);
 
 const moduleClass = class DynamicModule {};
 const componentClass = class DynamicComponent {};
 
 type DynamicComponentType = typeof componentClass;
-
-const storyData = new ReplaySubject(1);
 
 const getModule = (
   declarations: (Type<any> | any[])[],
@@ -33,6 +32,9 @@ const getModule = (
   data: StoryFnAngularReturnType,
   moduleMetadata: NgModuleMetadata
 ) => {
+  // Complete last ReplaySubject and create a new one for the current module
+  storyData.complete();
+  storyData = new ReplaySubject(1);
   storyData.next(data);
 
   const moduleMeta = {


### PR DESCRIPTION
Issue: na 

To reproduce the error simply go in the angular demo on one of the [simple components](https://storybookjs.netlify.app/angular-cli/?path=/story/custom-style--default-story) 
and change for this [one  "custom/ngmodel/custom ControlValueAccessor" ](https://storybookjs.netlify.app/angular-cli/?path=/story/custom-ngmodel--custom-control-value-accessor)
You will see this error in the console :
![image](https://user-images.githubusercontent.com/4974420/98420368-50034f00-2087-11eb-8107-b805bbcfe464.png)


## What I did

As the ReplaySubject did not refresh when changing the component
storyData.next has a side effect on the old component before it was
destroyed. So, it received the storyData of the new component

Now storyData is unique to each module

## How to test

- Is this testable with Jest or Chromatic screenshots? 
> not simply I think
- Does this need a new example in the kitchen sink apps?
> no
- Does this need an update to the documentation?
> no

If your answer is yes to any of these, please make sure to include it in your PR.

