### PR TITLE
Fixed minor grammar error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 </p>
 
 [Storybook](https://storybook.js.org) is a development environment for UI components.
-It allows you to browse a component library, view the different states of each component, and interactively develop and test components. Find out more at https://storybook.js.org.
+It allows you to browse a component library, view different states of each component, and interactively develop and test components. Find out more at https://storybook.js.org.
 
 <center>
   <img src="https://raw.githubusercontent.com/storybookjs/storybook/master/media/storybook-intro.gif" width="100%" />


### PR DESCRIPTION
Fixed grammar error with incorrect "the". 
The definite article "the" is used before both singular and plural nouns when the noun is specific. The current case wasn't a specific one.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
