### PR TITLE
Bump react-dogen-typescript-plugin to 0.6.2

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react-dev-utils": "^10.0.0",
-    "react-docgen-typescript-plugin": "^0.6.0",
+    "react-docgen-typescript-plugin": "^0.6.2",
     "react-refresh": "^0.8.3",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0",

--- a/examples/cra-ts-essentials/package.json
+++ b/examples/cra-ts-essentials/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@storybook/addon-essentials": "6.1.0-beta.5",
     "@storybook/addons": "6.1.0-beta.5",
-    "@storybook/preset-create-react-app": "^3.1.4",
+    "@storybook/preset-create-react-app": "^3.1.5",
     "@storybook/react": "6.1.0-beta.5"
   },
   "storybook": {

--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -40,7 +40,7 @@
     "@storybook/addon-knobs": "6.1.0-beta.5",
     "@storybook/addon-links": "6.1.0-beta.5",
     "@storybook/addons": "6.1.0-beta.5",
-    "@storybook/preset-create-react-app": "^3.1.4",
+    "@storybook/preset-create-react-app": "^3.1.5",
     "@storybook/react": "6.1.0-beta.5",
     "@types/enzyme": "^3.9.0",
     "enzyme": "^3.9.0",

--- a/lib/core/src/server/config/defaults.ts
+++ b/lib/core/src/server/config/defaults.ts
@@ -1,5 +1,6 @@
 export const typeScriptDefaults = {
   check: false,
+  // 'react-docgen' faster but produces lower quality typescript results
   reactDocgen: 'react-docgen-typescript',
   reactDocgenTypescriptOptions: {
     shouldExtractLiteralValuesFromEnum: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -28621,10 +28621,10 @@ react-docgen-typescript-plugin@^0.5.0:
     react-docgen-typescript-loader "^3.7.2"
     tslib "^2.0.0"
 
-react-docgen-typescript-plugin@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.6.0.tgz#fbb465dad3c5553d9300af19ba3763e9b5a80eee"
-  integrity sha512-RWAo/uC3+5BcOstK+YTZquIWq2EunGFVVxiU1cnJ3+XjylwVKlJ0nZ140IsngxGIH9H5KyFCObGJwKxOTpNCdw==
+react-docgen-typescript-plugin@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.6.2.tgz#c83305206c61d5c7e004eaf2dc4661367ddc105d"
+  integrity sha512-Orw0WKdJGAg5eMZGbEMw/rKonoxbi8epU6RJWTW3ukWuTarxckFXTltGvm8XADAWlBHak30KD71XThtJruxfTg==
   dependencies:
     debug "^4.1.1"
     endent "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5551,16 +5551,16 @@
     remark-lint "^7.0.0"
     remark-preset-lint-recommended "^4.0.0"
 
-"@storybook/preset-create-react-app@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@storybook/preset-create-react-app/-/preset-create-react-app-3.1.4.tgz#64bb674f69fe860ef1a4909e686775adf6c05fdd"
-  integrity sha512-VwzGCvv+HnEDXxSwF6ITRIZ4EaMhiMu1Mxrwm+nb49XTT2VME8VTzmbDjrdpZXPXUJrwLYmvqzaBT/qGZoMlgA==
+"@storybook/preset-create-react-app@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@storybook/preset-create-react-app/-/preset-create-react-app-3.1.5.tgz#af46c9d64c384980d458fe99c10dcbaa623f93fd"
+  integrity sha512-tzYcCRD5j22/HoDZ1tvsKaVnzyd4qqTE9sn3cx56Reb0XHcm4XkvG87jx0NvBGPCZrsThyBAtB3+XNxoFbI+9Q==
   dependencies:
     "@types/babel__core" "^7.1.7"
     "@types/webpack" "^4.41.13"
     babel-plugin-react-docgen "^4.1.0"
     pnp-webpack-plugin "^1.6.4"
-    react-docgen-typescript-plugin "^0.5.0"
+    react-docgen-typescript-plugin "^0.6.2"
     semver "^7.3.2"
 
 "@storybook/preset-scss@^1.0.2":
@@ -28608,18 +28608,6 @@ react-docgen-typescript-loader@^3.7.2:
     "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
     loader-utils "^1.2.3"
     react-docgen-typescript "^1.15.0"
-
-react-docgen-typescript-plugin@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.5.2.tgz#2b294d75ef3145c36303da82be5d447cb67dc0dc"
-  integrity sha512-NQfWyWLmzUnedkiN2nPDb6Nkm68ik6fqbC3UvgjqYSeZsbKijXUA4bmV6aU7qICOXdop9PevPdjEgJuAN0nNVQ==
-  dependencies:
-    debug "^4.1.1"
-    endent "^2.0.1"
-    micromatch "^4.0.2"
-    react-docgen-typescript "^1.20.1"
-    react-docgen-typescript-loader "^3.7.2"
-    tslib "^2.0.0"
 
 react-docgen-typescript-plugin@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
