### PR TITLE
Exclude node_modules by default for react-docgen-typescript-plugin

### DIFF
--- a/lib/core/src/server/config/defaults.ts
+++ b/lib/core/src/server/config/defaults.ts
@@ -1,5 +1,6 @@
 export const typeScriptDefaults = {
   check: false,
+  exclude: 'node_modules',
   reactDocgen: 'react-docgen-typescript',
   reactDocgenTypescriptOptions: {
     shouldExtractLiteralValuesFromEnum: true,

--- a/lib/core/src/server/config/defaults.ts
+++ b/lib/core/src/server/config/defaults.ts
@@ -1,6 +1,6 @@
 export const typeScriptDefaults = {
   check: false,
-  exclude: 'node_modules',
+  exclude: ['node_modules'],
   reactDocgen: 'react-docgen-typescript',
   reactDocgenTypescriptOptions: {
     shouldExtractLiteralValuesFromEnum: true,


### PR DESCRIPTION
Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
