### PR TITLE
Storyshots: Fix compatibility for jest-preset-angular 8.3+

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/angular/loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/angular/loader.ts
@@ -17,7 +17,11 @@ function setupAngularJestPreset() {
   // is running inside jest -  one of the things that `jest-preset-angular/build/setupJest` does is
   // extending the `window.Reflect` with all the needed metadata functions, that are required
   // for emission of the TS decorations like 'design:paramtypes'
-  jest.requireActual('jest-preset-angular/build/setup-jest');
+  try {
+    jest.requireActual('jest-preset-angular/build/setupJest');
+  } catch(e) {
+    jest.requireActual('jest-preset-angular/build/setup-jest');
+  }
 }
 
 function test(options: StoryshotsOptions): boolean {

--- a/addons/storyshots/storyshots-core/src/frameworks/angular/loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/angular/loader.ts
@@ -17,7 +17,7 @@ function setupAngularJestPreset() {
   // is running inside jest -  one of the things that `jest-preset-angular/build/setupJest` does is
   // extending the `window.Reflect` with all the needed metadata functions, that are required
   // for emission of the TS decorations like 'design:paramtypes'
-  jest.requireActual('jest-preset-angular/build/setupJest');
+  jest.requireActual('jest-preset-angular/build/setup-jest');
 }
 
 function test(options: StoryshotsOptions): boolean {


### PR DESCRIPTION
## What I did

resolving issue: https://github.com/storybookjs/storybook/issues/12392 by requiring the appropriate file name

## How to test

Use storyshots with Angular framework and make sure there is "jest-preset-angular": "^8.3.0" in dependencies.
running jest shouldn't fail

