### PR TITLE
React: Don't create a new story function on every render

### DIFF
--- a/app/react/src/client/preview/render.tsx
+++ b/app/react/src/client/preview/render.tsx
@@ -2,7 +2,7 @@ import { document, FRAMEWORK_OPTIONS } from 'global';
 import React, { Component, FunctionComponent, ReactElement, StrictMode, Fragment } from 'react';
 import ReactDOM from 'react-dom';
 
-import { RenderContext } from './types';
+import { StoryContext, RenderContext } from './types';
 
 const rootEl = document ? document.getElementById('root') : null;
 
@@ -46,17 +46,17 @@ class ErrorBoundary extends Component<{
 const Wrapper = FRAMEWORK_OPTIONS?.strictMode ? StrictMode : Fragment;
 
 export default async function renderMain({
-  storyFn,
+  storyContext,
+  unboundStoryFn,
   showMain,
   showException,
   forceRender,
 }: RenderContext) {
-  // storyFn has context bound in by now so can be treated as a function component with no args
-  const StoryFn = storyFn as FunctionComponent;
+  const Story = unboundStoryFn as FunctionComponent<StoryContext>;
 
   const content = (
     <ErrorBoundary showMain={showMain} showException={showException}>
-      <StoryFn />
+      <Story {...storyContext} />
     </ErrorBoundary>
   );
 

--- a/app/react/src/client/preview/types.ts
+++ b/app/react/src/client/preview/types.ts
@@ -2,6 +2,7 @@ import { ReactElement } from 'react';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 export { RenderContext } from '@storybook/client-api';
+export { StoryContext } from '@storybook/addons';
 
 export interface ShowErrorArgs {
   title: string;

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -102,12 +102,16 @@ export interface GetStorybookKind {
 
 // This really belongs in lib/core, but that depends on lib/ui which (dev) depends on app/react
 // which needs this type. So we put it here to avoid the circular dependency problem.
-export type RenderContext = StoreItem & {
+export type RenderContextWithoutStoryContext = StoreItem & {
   forceRender: boolean;
 
   showMain: () => void;
   showError: (error: { title: string; description: string }) => void;
   showException: (err: Error) => void;
+};
+
+export type RenderContext = RenderContextWithoutStoryContext & {
+  storyContext: StoryContext;
 };
 
 interface SBBaseType {

--- a/lib/core/src/client/preview/types.ts
+++ b/lib/core/src/client/preview/types.ts
@@ -1,4 +1,4 @@
-import { RenderContext } from '@storybook/client-api';
+import { RenderContext, RenderContextWithoutStoryContext } from '@storybook/client-api';
 
 export interface PreviewError {
   message?: string;
@@ -23,7 +23,7 @@ export interface RequireContext {
 export type LoaderFunction = () => void | any[];
 export type Loadable = RequireContext | RequireContext[] | LoaderFunction;
 
-export { RenderContext };
+export { RenderContext, RenderContextWithoutStoryContext };
 
 // The function used by a framework to render story to the DOM
 export type RenderStoryFunction = (context: RenderContext) => void;


### PR DESCRIPTION
This trips up React's reconciliation for re-using components.

Related to #12255