### PR TITLE
UI: Fix search field styling in Safari 13

### DIFF
--- a/lib/ui/src/components/sidebar/Search.tsx
+++ b/lib/ui/src/components/sidebar/Search.tsx
@@ -71,6 +71,7 @@ const SearchField = styled.div(({ theme }) => ({
 }));
 
 const Input = styled.input(({ theme }) => ({
+  '-webkit-appearance': 'none',
   height: 28,
   paddingLeft: 28,
   paddingRight: 28,


### PR DESCRIPTION
Issue:

<img width="201" alt="image" src="https://user-images.githubusercontent.com/132554/98661666-de831380-239a-11eb-9718-4c0769cd8dfe.png">

(In Safari 13)

## What I did

Reset style

## How to test

Use official SB or view search stories in Saf 13