### PR TITLE
UI: Fix Escape key handling perf

### DIFF
--- a/lib/ui/src/components/sidebar/SearchResults.tsx
+++ b/lib/ui/src/components/sidebar/SearchResults.tsx
@@ -169,83 +169,101 @@ export const SearchResults: FunctionComponent<{
   getMenuProps: ControllerStateAndHelpers<DownshiftItem>['getMenuProps'];
   getItemProps: ControllerStateAndHelpers<DownshiftItem>['getItemProps'];
   highlightedIndex: number | null;
-}> = React.memo(({ query, results, closeMenu, getMenuProps, getItemProps, highlightedIndex }) => {
-  useEffect(() => {
-    const handleEscape = (event: KeyboardEvent) => {
-      const target = event.target as Element;
-      if (target?.id === 'storybook-explorer-searchfield') return; // handled by downshift
-      closeMenu();
-    };
-
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, []);
-
-  return (
-    <ResultsList {...getMenuProps()}>
-      {results.length > 0 && !query && (
-        <li>
-          <RootNode>Recently opened</RootNode>
-        </li>
-      )}
-      {results.length === 0 && query && (
-        <li>
-          <NoResults>
-            <strong>No components found</strong>
-            <br />
-            <small>Find components by name or path.</small>
-          </NoResults>
-        </li>
-      )}
-      {results.map((result: DownshiftItem, index) => {
-        if (isCloseType(result)) {
-          return (
-            <BackActionRow
-              {...result}
-              {...getItemProps({ key: index, index, item: result })}
-              isHighlighted={highlightedIndex === index}
-            >
-              <ActionIcon icon="arrowleft" />
-              <ActionLabel>Back to components</ActionLabel>
-              <ActionKey>ESC</ActionKey>
-            </BackActionRow>
-          );
+  isLoading?: boolean;
+  enableShortcuts?: boolean;
+}> = React.memo(
+  ({
+    query,
+    results,
+    closeMenu,
+    getMenuProps,
+    getItemProps,
+    highlightedIndex,
+    isLoading = false,
+    enableShortcuts = true,
+  }) => {
+    useEffect(() => {
+      const handleEscape = (event: KeyboardEvent) => {
+        if (!enableShortcuts || isLoading) return;
+        if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return;
+        if (event.key === 'Escape') {
+          const target = event.target as Element;
+          if (target?.id === 'storybook-explorer-searchfield') return; // handled by downshift
+          event.preventDefault();
+          closeMenu();
         }
-        if (isClearType(result)) {
-          return (
-            <ActionRow
-              {...result}
-              {...getItemProps({ key: index, index, item: result })}
-              isHighlighted={highlightedIndex === index}
-            >
-              <ActionIcon icon="trash" />
-              <ActionLabel>Clear history</ActionLabel>
-            </ActionRow>
-          );
-        }
-        if (isExpandType(result)) {
-          return (
-            <ActionRow
-              {...result}
-              {...getItemProps({ key: index, index, item: result })}
-              isHighlighted={highlightedIndex === index}
-            >
-              <ActionIcon icon="plus" />
-              <ActionLabel>Show {result.moreCount} more results</ActionLabel>
-            </ActionRow>
-          );
-        }
+      };
 
-        const { item } = result;
-        const key = `${item.refId}::${item.id}`;
-        return (
-          <Result
-            {...result}
-            {...getItemProps({ key, index, item: result })}
-            isHighlighted={highlightedIndex === index}
-          />
-        );
-      })}
-    </ResultsList>
-  );
-});
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }, [enableShortcuts, isLoading]);
+
+    return (
+      <ResultsList {...getMenuProps()}>
+        {results.length > 0 && !query && (
+          <li>
+            <RootNode>Recently opened</RootNode>
+          </li>
+        )}
+        {results.length === 0 && query && (
+          <li>
+            <NoResults>
+              <strong>No components found</strong>
+              <br />
+              <small>Find components by name or path.</small>
+            </NoResults>
+          </li>
+        )}
+        {results.map((result: DownshiftItem, index) => {
+          if (isCloseType(result)) {
+            return (
+              <BackActionRow
+                {...result}
+                {...getItemProps({ key: index, index, item: result })}
+                isHighlighted={highlightedIndex === index}
+              >
+                <ActionIcon icon="arrowleft" />
+                <ActionLabel>Back to components</ActionLabel>
+                <ActionKey>ESC</ActionKey>
+              </BackActionRow>
+            );
+          }
+          if (isClearType(result)) {
+            return (
+              <ActionRow
+                {...result}
+                {...getItemProps({ key: index, index, item: result })}
+                isHighlighted={highlightedIndex === index}
+              >
+                <ActionIcon icon="trash" />
+                <ActionLabel>Clear history</ActionLabel>
+              </ActionRow>
+            );
+          }
+          if (isExpandType(result)) {
+            return (
+              <ActionRow
+                {...result}
+                {...getItemProps({ key: index, index, item: result })}
+                isHighlighted={highlightedIndex === index}
+              >
+                <ActionIcon icon="plus" />
+                <ActionLabel>Show {result.moreCount} more results</ActionLabel>
+              </ActionRow>
+            );
+          }
+
+          const { item } = result;
+          const key = `${item.refId}::${item.id}`;
+          return (
+            <Result
+              {...result}
+              {...getItemProps({ key, index, item: result })}
+              isHighlighted={highlightedIndex === index}
+            />
+          );
+        })}
+      </ResultsList>
+    );
+  }
+);

--- a/lib/ui/src/components/sidebar/Sidebar.tsx
+++ b/lib/ui/src/components/sidebar/Sidebar.tsx
@@ -142,6 +142,8 @@ export const Sidebar: FunctionComponent<SidebarProps> = React.memo(
                     getMenuProps={getMenuProps}
                     getItemProps={getItemProps}
                     highlightedIndex={highlightedIndex}
+                    enableShortcuts={enableShortcuts}
+                    isLoading={isLoading}
                   />
                 </Swap>
               )}


### PR DESCRIPTION
# What I did

While I was profiling, I discovered this `keydown` listener isn't actually targeted specifically at `Escape` but executes for any key. It's not apparent but this causes the sidebar to return to the tree view when you click _any_ button while the search input doesn't have focus.

I recommend hiding whitespace changes when looking at the [diff](https://github.com/storybookjs/storybook/pull/13073/files?diff=split&w=1).

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
