### PR TITLE
Addon-docs: Fix spurious warnings

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -52,15 +52,9 @@ const getStoryContext = (storyId: StoryId, docsContext: DocsContextProps): Story
 
 const getStorySource = (storyId: StoryId, sourceContext: SourceContextProps): string => {
   const { sources } = sourceContext;
-
-  const source = sources?.[storyId];
-
-  if (!source) {
-    logger.warn(`Unable to find source for story ID '${storyId}'`);
-    return '';
-  }
-
-  return source;
+  // source rendering is async so source is unavailable at the start of the render cycle,
+  // so we fail gracefully here without warning
+  return sources?.[storyId] || '';
 };
 
 const getSnippet = (snippet: string, storyContext?: StoryContext): string => {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -77,6 +77,14 @@ const checkStorySort = (parameters: Parameters) => {
   if (options?.storySort) logger.error('The storySort option parameter can only be set globally');
 };
 
+const storyFnWarning = deprecate(
+  () => {},
+  dedent`
+  \`storyFn\` is deprecated and will be removed in Storybook 7.0.
+
+  https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-storyfn`
+);
+
 interface AllowUnsafeOption {
   allowUnsafe?: boolean;
 }
@@ -410,25 +418,20 @@ export default class StoryStore {
 
     const storyParametersWithArgTypes = { ...storyParameters, argTypes, __isArgsStory };
 
-    const storyFn: LegacyStoryFn = deprecate(
-      (runtimeContext: StoryContext) =>
-        getDecorated()({
-          ...identification,
-          ...runtimeContext,
-          // Calculate "combined" parameters at render time (NOTE: for perf we could just use combinedParameters from above?)
-          parameters: this.combineStoryParameters(storyParametersWithArgTypes, kind),
-          hooks,
-          args: _stories[id].args,
-          argTypes,
-          globals: this._globals,
-          viewMode: this._selection?.viewMode,
-        }),
-      dedent`
-        \`storyFn\` is deprecated and will be removed in Storybook 7.0.
-
-        https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-storyfn
-      `
-    );
+    const storyFn: LegacyStoryFn = (runtimeContext: StoryContext) => {
+      storyFnWarning();
+      return getDecorated()({
+        ...identification,
+        ...runtimeContext,
+        // Calculate "combined" parameters at render time (NOTE: for perf we could just use combinedParameters from above?)
+        parameters: this.combineStoryParameters(storyParametersWithArgTypes, kind),
+        hooks,
+        args: _stories[id].args,
+        argTypes,
+        globals: this._globals,
+        viewMode: this._selection?.viewMode,
+      });
+    };
 
     const unboundStoryFn: LegacyStoryFn = (context: StoryContext) => getDecorated()(context);
 


### PR DESCRIPTION
Issue: #13074

## What I did

- Removed a spurious source warning (see comment)
- Deduplicated `storyFn is deprecated warnings` on docs page

NOTE: Docs needs to be rearchitected to render async functions, so the warning is valid. @tmeasday it would be nice to get a fix in--maybe using React suspense?--but seems like a 6.2 change. WDYT?

## How to test

See `official-storybook`