### PR TITLE
Disable instant-on manager for now

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -374,12 +374,16 @@ export async function storybookDevServer(options: any) {
   const [previewResult, managerResult] = await Promise.all([
     startPreview({ startTime, options, configType, outputDir }),
     startManager({ startTime, options, configType, outputDir, configDir, prebuiltDir })
-      .then((result) => {
-        if (!options.ci) openInBrowser(address);
-        return result;
-      })
+      // TODO #13083 Restore this when compiling the preview is fast enough
+      // .then((result) => {
+      //   if (!options.ci) openInBrowser(address);
+      //   return result;
+      // })
       .catch(bailPreview),
   ]);
+
+  // TODO #13083 Remove this when compiling the preview is fast enough
+  if (!options.ci) openInBrowser(address);
 
   return { ...previewResult, ...managerResult, address, networkAddress };
 }


### PR DESCRIPTION
Issue: #13077

## What I did

Instead of opening the browser as soon as the manager is done, open it when both the preview and manager are done.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
