### PR TITLE
UI: Fix kebab-case CSS property error

### DIFF
--- a/lib/ui/src/components/sidebar/Search.tsx
+++ b/lib/ui/src/components/sidebar/Search.tsx
@@ -71,7 +71,7 @@ const SearchField = styled.div(({ theme }) => ({
 }));
 
 const Input = styled.input(({ theme }) => ({
-  '-webkit-appearance': 'none',
+  appearance: 'none',
   height: 28,
   paddingLeft: 28,
   paddingRight: 28,


### PR DESCRIPTION
This fixes an issue introduced in #13070:

<img width="565" alt="Screenshot 2020-11-11 at 17 44 05" src="https://user-images.githubusercontent.com/321738/98839178-8523ee80-2445-11eb-83ab-f19551ddd49f.png">

## What I did

Just use the `appearance` property without prefix and let Emotion handle the prefixing.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
