### PR TITLE
Angular: Support Angular 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,8 @@ jobs:
       - restore_cache:
           name: Restore Yarn cache
           keys:
-            - build-yarn-cache-v1--{{ checksum "yarn.lock" }}
-            - build-yarn-cache-v1--
+            - build-yarn-cache-v2--{{ checksum "yarn.lock" }}
+            - build-yarn-cache-v2--
       - run:
           name: Install dependencies
           command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
@@ -51,7 +51,7 @@ jobs:
           command: yarn bootstrap --core
       - save_cache:
           name: Save Yarn cache
-          key: build-yarn-cache-v1--{{ checksum "yarn.lock" }}
+          key: build-yarn-cache-v2--{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
       - persist_to_workspace:
@@ -70,14 +70,14 @@ jobs:
       - restore_cache:
           name: Restore Yarn cache
           keys:
-            - install-examples-deps-yarn-cache-v1--{{ checksum "yarn.lock" }}
-            - install-examples-deps-yarn-cache-v1--
+            - install-examples-deps-yarn-cache-v2--{{ checksum "yarn.lock" }}
+            - install-examples-deps-yarn-cache-v2--
       - run:
           name: Install dependencies
           command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
       - save_cache:
           name: Save Yarn cache
-          key: install-examples-deps-yarn-cache-v1--{{ checksum "yarn.lock" }}
+          key: install-examples-deps-yarn-cache-v2--{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
       - persist_to_workspace:
@@ -97,14 +97,14 @@ jobs:
       - restore_cache:
           name: Restore Yarn cache
           keys:
-            - install-e2e-deps-yarn-cache-v1--{{ checksum "yarn.lock" }}
-            - install-e2e-deps-yarn-cache-v1--
+            - install-e2e-deps-yarn-cache-v2--{{ checksum "yarn.lock" }}
+            - install-e2e-deps-yarn-cache-v2--
       - run:
           name: Install dependencies
           command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
       - save_cache:
           name: Save Yarn cache
-          key: install-e2e-deps-yarn-cache-v1--{{ checksum "yarn.lock" }}
+          key: install-e2e-deps-yarn-cache-v2--{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
       - persist_to_workspace:
@@ -358,10 +358,6 @@ jobs:
     executor: sb_node
     steps:
       - checkout
-      - restore_cache:
-          name: Restore core dependencies cache
-          keys:
-            - core-dependencies-v5-{{ checksum "yarn.lock" }}
       - run:
           name: Install dependencies
           command: yarn bootstrap --install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ executors:
 jobs:
   build:
     executor:
-      class: large
+      class: medium
       name: sb_node
     steps:
       - checkout
@@ -63,7 +63,7 @@ jobs:
             - lib
   install-examples-deps:
     executor:
-      class: large
+      class: medium
       name: sb_node
     steps:
       - checkout
@@ -87,7 +87,7 @@ jobs:
             - node_modules
   install-e2e-deps:
     executor:
-      class: large
+      class: medium
       name: sb_node
     steps:
       - checkout
@@ -138,7 +138,7 @@ jobs:
             yarn packtracker
   examples:
     executor:
-      class: large
+      class: medium
       name: sb_node
     parallelism: 11
     steps:
@@ -155,7 +155,7 @@ jobs:
             - built-storybooks
   publish:
     executor:
-      class: large
+      class: medium
       name: sb_node
     steps:
       - checkout
@@ -170,7 +170,7 @@ jobs:
             - .verdaccio-cache
   examples-v2:
     executor:
-      class: large
+      class: medium
       name: sb_node
     working_directory: /tmp/storybook
     parallelism: 10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,38 +231,6 @@ jobs:
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress
-  examples-v2-angular:
-    executor:
-      class: medium
-      name: sb_node_12
-    working_directory: /tmp/storybook
-    parallelism: 2
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Running local registry
-          command: yarn local-registry --port 6000 --open
-          background: true
-      - run:
-          name: Wait for registry
-          command: yarn wait-on http://localhost:6000
-      - run:
-          name: Set registry
-          command: yarn config set registry http://localhost:6000/
-      - run:
-          name: Test local registry
-          command: yarn info @storybook/core
-      - run:
-          name: Install Cypress binary
-          command: yarn cypress install
-      - run:
-          name: Run e2e tests
-          command: yarn test:e2e-framework angular@latest angular@v9-lts
-      - store_artifacts:
-          path: /tmp/storybook/cypress
-          destination: cypress
   examples-v2-yarn-2:
     executor:
       class: medium
@@ -476,9 +444,6 @@ workflows:
             - install-e2e-deps
             - build
       - examples-v2:
-          requires:
-            - publish
-      - examples-v2-angular:
           requires:
             - publish
       - examples-v2-yarn-2:

--- a/app/angular/src/server/angular-cli_utils.ts
+++ b/app/angular/src/server/angular-cli_utils.ts
@@ -8,13 +8,27 @@ import {
   Path,
   getSystemPath,
 } from '@angular-devkit/core';
-import {
-  getCommonConfig,
-  getStylesConfig,
-} from '@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs';
 import { logger } from '@storybook/node-logger';
 
 import { RuleSetRule, Configuration } from 'webpack';
+
+// We need to dynamically require theses functions as they are not part of the public api and so their paths
+// aren't the same in all versions of Angular
+let angularWebpackConfig: {
+  getCommonConfig: (config: unknown) => Configuration;
+  getStylesConfig: (config: unknown) => Configuration;
+};
+try {
+  // First we look for webpack config according to directory structure of Angular 11
+  // eslint-disable-next-line global-require
+  angularWebpackConfig = require('@angular-devkit/build-angular/src/webpack/configs');
+} catch (e) {
+  // We fallback on directory structure of Angular 10 (and below)
+  // eslint-disable-next-line global-require
+  angularWebpackConfig = require('@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs');
+}
+
+const { getCommonConfig, getStylesConfig } = angularWebpackConfig;
 
 function isDirectory(assetPath: string) {
   try {

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -21,36 +21,10 @@ const baseAngular: Parameters = {
   ].join(' && '),
 };
 
-// export const angularv6: Parameters = {
-//   ...baseAngular,
-//   version: 'v6-lts',
-//   additionalDeps: [...baseAngular.additionalDeps, 'core-js'],
-// };
-
-// TODO: enable back when typings issues are resolved
-// export const angularv7: Parameters = {
-//   ...baseAngular,
-//   version: 'v7-lts',
-//   additionalDeps: [...baseAngular.additionalDeps, 'core-js'],
-// };
-
-// export const angularv8: Parameters = {
-//   ...baseAngular,
-//   version: 'v8-lts',
-//   additionalDeps: [...baseAngular.additionalDeps, 'core-js'],
-// };
-
-export const angularv9: Parameters = {
-  ...baseAngular,
-  version: 'v9-lts',
-  additionalDeps: ['core-js'],
-};
-
 export const angularv10: Parameters = {
   ...baseAngular,
   // There is no `v10-lts` tag for now, to update as soon as one is published
   version: 'v10',
-  additionalDeps: ['core-js'],
 };
 
 export const angular: Parameters = baseAngular;

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -46,6 +46,13 @@ export const angularv9: Parameters = {
   additionalDeps: ['core-js'],
 };
 
+export const angularv10: Parameters = {
+  ...baseAngular,
+  // There is no `v10-lts` tag for now, to update as soon as one is published
+  version: 'v10',
+  additionalDeps: ['core-js'],
+};
+
 export const angular: Parameters = baseAngular;
 
 // TODO: not working yet, help needed

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -363,11 +363,6 @@ if (frameworkArgs.length > 0) {
   //   Because it is telling Yarn to use version 2
   delete e2eConfigs.yarn_2_cra;
 
-  // FIXME: Angular tests need to be explicitly run because they require Node 12.17+
-  // See https://github.com/storybookjs/storybook/issues/12735
-  delete e2eConfigs.angularv9;
-  delete e2eConfigs.angular;
-
   // CRA Bench is a special case of E2E tests, it requires Node 12 as `@storybook/bench` is using `@hapi/hapi@19.2.0`
   // which itself need Node 12.
   delete e2eConfigs.cra_bench;


### PR DESCRIPTION
Issue: #13093

## What I did

Some part of the Angular CLI webpack config has moved between Angular 10- and Angular 11. 
So we now dynamically require them from Angular 11 paths and fallback to the ones of Angular 10-.

I also: 
 - added an E2E config for Angular 10 as `latest` is now Angular 11
 - move back all Angular E2E tests to classic CircleCI executors as they rework with Node 10 (https://github.com/storybookjs/storybook/issues/12735)

## How to test

- Angular E2E tests should be 🟢  on CI and no error should be thrown in the logs anymore
