### PR TITLE
Prevent default browser behavior when using certain keyboard shortcuts

### DIFF
--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -25,7 +25,7 @@ export interface SubAPI {
   restoreAllDefaultShortcuts(): Promise<Shortcuts>;
   restoreDefaultShortcut(action: Action): Promise<KeyCollection>;
   handleKeydownEvent(event: Event): void;
-  handleShortcutFeature(feature: Action, event: KeyboardEvent): void;
+  handleShortcutFeature(feature: Action, event?: KeyboardEvent): void;
 }
 export type KeyCollection = string[];
 

--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -205,13 +205,13 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
         }
 
         case 'nextComponent': {
-          event.preventDefault();
+          if (event) event.preventDefault();
           fullAPI.jumpToComponent(1);
           break;
         }
 
         case 'prevComponent': {
-          event.preventDefault();
+          if (event) event.preventDefault();
           fullAPI.jumpToComponent(-1);
           break;
         }
@@ -268,12 +268,12 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
           break;
         }
         case 'collapseAll': {
-          event.preventDefault();
+          if (event) event.preventDefault();
           fullAPI.collapseAll();
           break;
         }
         case 'expandAll': {
-          event.preventDefault();
+          if (event) event.preventDefault();
           fullAPI.expandAll();
           break;
         }

--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -25,7 +25,7 @@ export interface SubAPI {
   restoreAllDefaultShortcuts(): Promise<Shortcuts>;
   restoreDefaultShortcut(action: Action): Promise<KeyCollection>;
   handleKeydownEvent(event: Event): void;
-  handleShortcutFeature(feature: Action): void;
+  handleShortcutFeature(feature: Action, event: KeyboardEvent): void;
 }
 export type KeyCollection = string[];
 
@@ -122,11 +122,11 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
         shortcutMatchesShortcut(shortcut, shortcuts[feature])
       );
       if (matchedFeature) {
-        api.handleShortcutFeature(matchedFeature);
+        api.handleShortcutFeature(matchedFeature, event);
       }
     },
 
-    handleShortcutFeature(feature) {
+    handleShortcutFeature(feature, event) {
       const {
         layout: { isFullscreen, showNav, showPanel },
         ui: { enableShortcuts },
@@ -205,11 +205,13 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
         }
 
         case 'nextComponent': {
+          event.preventDefault();
           fullAPI.jumpToComponent(1);
           break;
         }
 
         case 'prevComponent': {
+          event.preventDefault();
           fullAPI.jumpToComponent(-1);
           break;
         }
@@ -266,10 +268,12 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
           break;
         }
         case 'collapseAll': {
+          event.preventDefault();
           fullAPI.collapseAll();
           break;
         }
         case 'expandAll': {
+          event.preventDefault();
           fullAPI.expandAll();
           break;
         }


### PR DESCRIPTION
Issue: #13040

## What I did

This fixes a conflict between default browser behavior and the sidebar's scrollToElement behavior when pressing option+down / option+up (or Windows equivalent).

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
