### PR TITLE
Addon-docs: Export SourceContainer context

### DIFF
--- a/addons/docs/src/blocks/index.ts
+++ b/addons/docs/src/blocks/index.ts
@@ -14,6 +14,7 @@ export * from './Preview';
 export * from './Primary';
 export * from './Props';
 export * from './Source';
+export * from './SourceContainer';
 export * from './Stories';
 export * from './Story';
 export * from './Subheading';


### PR DESCRIPTION
Issue: #13113 

## What I did

This PR exports the `SourceContainer` module in the `addon-docs` module in order to make the Source Code of a Story accessible from outside the bundle.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
