### PR TITLE
UI: Fix loading UI when EventSource isn't defined

### DIFF
--- a/lib/components/src/Loader/Loader.tsx
+++ b/lib/components/src/Loader/Loader.tsx
@@ -158,7 +158,8 @@ export const Loader: FunctionComponent<ComponentProps<typeof PureLoader>> = (pro
 
   useEffect(() => {
     // Don't listen for progress updates in static builds
-    if (CONFIG_TYPE !== 'DEVELOPMENT') return undefined;
+    // Event source is not defined in IE 11
+    if (CONFIG_TYPE !== 'DEVELOPMENT' || !EventSource) return undefined;
 
     const eventSource = new EventSource('/progress');
     let lastProgress: Progress;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13088

## What I did

Prevent usage of EventSource (polyfills looks messy and it's IE11...)

## How to test

- Be bold and launch IE 11