### PR TITLE
Addon-docs: Include Vue methods in ArgsTable

### DIFF
--- a/addons/docs/src/frameworks/vue/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue/extractArgTypes.ts
@@ -3,7 +3,7 @@ import { ArgTypesExtractor, hasDocgen, extractComponentProps } from '../../lib/d
 import { convert } from '../../lib/convert';
 import { trimQuotes } from '../../lib/convert/utils';
 
-const SECTIONS = ['props', 'events', 'slots'];
+const SECTIONS = ['props', 'events', 'slots', 'methods'];
 
 const trim = (val: any) => (val && typeof val === 'string' ? trimQuotes(val) : val);
 


### PR DESCRIPTION
Issue: Methods not shown use ArgsTable with vue framework( https://github.com/storybookjs/storybook/issues/13105)

## add SECTION Methods

## test in node_modules: change file content as same as in PR（node_modules\@storybook\addon-docs\dist\frameworks\vue\extractArgTypes.js），and it worked in my project

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
