### PR TITLE
Build: Fix Yarn 2 E2E tests

### DIFF
--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -143,6 +143,9 @@ export const sfcVue: Parameters = {
   additionalDeps: [
     // TODO: remove when https://github.com/storybookjs/storybook/issues/11255 is solved
     'core-js',
+    // FIXME: We still have issue with react as peer/regular deps...
+    // For some details see: https://github.com/storybookjs/storybook/pull/13059/commits/8d4938bc4aef55e208a89f3547674c64ed39d3b3#r520101039
+    'react',
   ],
 };
 

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -89,10 +89,9 @@ const configureYarn2 = async ({ cwd }: Options) => {
     // Disable fallback mode to make sure everything is required correctly
     `yarn config set pnpFallbackMode none`,
     // Add package extensions
-    // https://github.com/casesandberg/reactcss/pull/153
-    `yarn config set "packageExtensions.reactcss@*.peerDependencies.react" "*"`,
-    // https://github.com/casesandberg/react-color/pull/746
-    `yarn config set "packageExtensions.react-color@*.peerDependencies.react" "*"`,
+    // https://github.com/facebook/create-react-app/pull/9872
+    `yarn config set "packageExtensions.react-scripts@*.peerDependencies.react" "*"`,
+    `yarn config set "packageExtensions.react-scripts@*.dependencies.@pmmmwh/react-refresh-webpack-plugin" "*"`,
   ].join(' && ');
   logger.info(`🎛 Configuring Yarn 2`);
   logger.debug(command);

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -79,6 +79,9 @@ const cleanDirectory = async ({ cwd }: Options): Promise<void> => {
 const configureYarn2 = async ({ cwd }: Options) => {
   const command = [
     `yarn set version berry`,
+    // See https://github.com/yarnpkg/berry/pull/2078
+    // As soon as a new version of Yarn is released remove next line
+    `yarn set version from sources --branch 2078`,
     // ⚠️ Need to set registry because Yarn 2 is not using the conf of Yarn 1
     `yarn config set npmScopes --json '{ "storybook": { "npmRegistryServer": "http://localhost:6000/" } }'`,
     // Some required magic to be able to fetch deps from local registry


### PR DESCRIPTION
## What I did

- use an unreleased version of Yarn 2 to fix the issue with fsevents patch
- update missing package extensions for Yarn 2 tests
- add react as additionalDeps in sfcVue E2E tests to tmp fix Yarn 2 E2E tests

## How to test

- CI job `example-v2-yarn-2` should be 🟢 