### PR TITLE
CLI: Add core-js to Preact generator

### DIFF
--- a/lib/cli/src/generators/PREACT/index.ts
+++ b/lib/cli/src/generators/PREACT/index.ts
@@ -1,7 +1,9 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'preact');
+  baseGenerator(packageManager, npmOptions, options, 'preact', {
+    extraPackages: ['core-js'],
+  });
 };
 
 export default generator;


### PR DESCRIPTION
Issue: #13104

## What I did

I added core-js to the generator of preact, which solved the problem I had.

## How to test

I did **not** test that, because I didn't knew how.

This PR is linked to the following Issue: #13104 

I used the following example: [ANGULAR fix](https://github.com/storybookjs/storybook/blob/next/lib/cli/src/generators/ANGULAR/index.ts#L35)

@shilman Sorry I not experienced enough to Test such a bit application. I need some guidance for that.