### PR TITLE
Build: reduce job parallelism to 4 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             - node_modules
   chromatic:
     executor: sb_node
-    parallelism: 11
+    parallelism: 4
     steps:
       - checkout
       - attach_workspace:
@@ -140,7 +140,7 @@ jobs:
     executor:
       class: medium
       name: sb_node
-    parallelism: 11
+    parallelism: 4
     steps:
       - checkout
       - attach_workspace:
@@ -173,7 +173,7 @@ jobs:
       class: medium
       name: sb_node
     working_directory: /tmp/storybook
-    parallelism: 10
+    parallelism: 4
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
Issue: We are currently facing some billing issues for CircleCI so we are back on the "classic" open source plan. The latter doesn't allow us to use massive parallelism as we are doing in `examples`, `examples-v2` etc jobs. 

These jobs are not started with less parallelism, they are just not ran at all:

![image](https://user-images.githubusercontent.com/4112568/99300900-7c6c5780-284d-11eb-9b02-5bfc096e5ba4.png)

And doesn't appear in PR checks 😱 

## What I did

Reduce job parallelism to 4 as a workaround to still have all CI jobs ran.

## How to test
 - All CI jobs should be back in the game