### PR TITLE
Add Missing Vue Code Snippet in Get Started Setup Storybook section

### DIFF
--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -13,6 +13,7 @@ Pick a simple component from your project, like a Button, and write a `.stories.
     'react/your-component.js.mdx',
     'react/your-component.ts.mdx',
     'angular/your-component.ts.mdx',
+    'vue/your-component.js.mdx',
   ]}
 />
 

--- a/docs/snippets/vue/your-component.js.mdx
+++ b/docs/snippets/vue/your-component.js.mdx
@@ -1,0 +1,21 @@
+```js
+// YourComponent.stories.js
+import YourComponent from "./YourComponent.vue";
+
+// This default export determines where your story goes in the story list
+export default {
+  title: "YourComponent",
+  component: YourComponent,
+};
+
+const Template = (args) => ({
+  components: { YourComponent },
+  template: "<your-component/>",
+});
+
+export const Primary = Template.bind({});
+Primary.args = {
+  /* the args you need here will depend on your component */
+};
+
+```


### PR DESCRIPTION
The Vue Docs Get Started Setup Storybook section are missing the code snippet for an example and default to React instead

## What I did
Made a Vue Component example for YourComponent and added it to the markdown 
