### PR TITLE
Fix incorrect component reference in angular-cli example

### DIFF
--- a/examples/angular-cli/src/stories/addon-docs.stories.mdx
+++ b/examples/angular-cli/src/stories/addon-docs.stories.mdx
@@ -79,7 +79,7 @@ Let's add another one. The UI updates automatically as you'd expect.
 
 We can automatically generate props tables from Angular components:
 
-<ArgsTable of={DocsButtonComponent} />
+<ArgsTable of={DocButtonComponent} />
 
 ## More info
 


### PR DESCRIPTION
## What I did
Fixed a typo

## How to test

- Is this testable with Jest or Chromatic screenshots? Not sure
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

## Screenshot
### The online version
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/13592559/99570741-3fa47b80-2987-11eb-844f-baf9300e03a1.png">

### Local with fix
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/13592559/99570558-f6ecc280-2986-11eb-869d-2df700499327.png">