### PR TITLE
Core: Fix using cached manager on the 2nd run

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -222,7 +222,9 @@ const startManager = async ({
 
     if (options.cache) {
       if (options.managerCache) {
-        const configString = stringify(managerConfig);
+        // Drop the `cache` property because it'll change as a result of writing to the cache.
+        const { cache: _, ...baseConfig } = managerConfig;
+        const configString = stringify(baseConfig);
         const cachedConfig = await options.cache.get('managerConfig');
         options.cache.set('managerConfig', configString);
         if (configString === cachedConfig && (await pathExists(outputDir))) {
@@ -230,6 +232,7 @@ const startManager = async ({
           managerConfig = null;
         }
       } else {
+        logger.info('=> Removing cached managerConfig');
         options.cache.remove('managerConfig');
       }
     }


### PR DESCRIPTION
Issue: #13156

## What I did

This fixes the cache key matching to also work on the 2nd run, when we have a cached manager. It wasn't working because the cache key contained a `cache` prop which is different on the first run (before we have a cache), causing the cached manager to get ignored on the 2nd run.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
