### PR TITLE
docs(MIGRATION): add preset information for addon-backgrounds in 6.1

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -144,7 +144,7 @@
 
 In 6.1 we introduced an unintentional breaking change to `addon-backgrounds`.
 
-The addon needs decorators which come in a preset. The needed preset is ignored if you import the addon like this in `main.js`:
+The addon uses decorators which are set up automatically by a preset. The required preset is ignored if you register the addon in `main.js` withe the the `/register` entry point. This used to be valid in `v6.0.x` and earlier:
 ```js
 module.exports = {
   stories: ['../**/*.stories.js'],

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -153,6 +153,7 @@ module.exports = {
 ```
 
 To fix it, just replace `@storybook/addon-backgrounds/register` with `@storybook/addon-backgrounds`:
+
 ```js
 module.exports = {
   stories: ['../**/*.stories.js'],

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,7 @@
 <h1>Migration</h1>
 
 - [From version 6.0.x to 6.1.0](#from-version-60x-to-610)
+  - [Addon-backgrounds preset](#addon-backgrounds-preset)
   - [Single story hoisting](#single-story-hoisting)
   - [6.1 deprecations](#61-deprecations)
     - [Deprecated DLL flags](#deprecated-dll-flags)
@@ -138,6 +139,26 @@
   - [Deprecated embedded addons](#deprecated-embedded-addons)
 
 ## From version 6.0.x to 6.1.0
+
+### Addon-backgrounds preset
+
+In 6.1 we there is an structural change in addon-backgrounds that ended up introducing an unintentional breaking change.
+
+The addon needs decorators which come in a preset. The needed preset is ignored if you import the addon like this in `main.js`:
+```js
+module.exports = {
+  stories: ['../**/*.stories.js'],
+  addons: ['@storybook/addon-backgrounds/register'],
+};
+```
+
+To fix it, just replace `@storybook/addon-backgrounds/register` with `@storybook/addon-backgrounds`:
+```js
+module.exports = {
+  stories: ['../**/*.stories.js'],
+  addons: ['@storybook/addon-backgrounds'],
+};
+```
 
 ### Single story hoisting
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -142,7 +142,7 @@
 
 ### Addon-backgrounds preset
 
-In 6.1 we there is an structural change in addon-backgrounds that ended up introducing an unintentional breaking change.
+In 6.1 we introduced an unintentional breaking change to `addon-backgrounds`.
 
 The addon needs decorators which come in a preset. The needed preset is ignored if you import the addon like this in `main.js`:
 ```js


### PR DESCRIPTION
Issue: #13173

## What I did
Update on MIGRATION to add information over the unintentional breaking change caused in addon-backgrounds from #12368
