### PR TITLE
UI: Target only IE10/IE11 for our CSS vertical centering hack

### DIFF
--- a/lib/core/src/server/templates/base-preview-head.html
+++ b/lib/core/src/server/templates/base-preview-head.html
@@ -18,10 +18,12 @@
   }
 
   /* Vertical centering fix for IE11 */
-  .sb-show-main.sb-main-centered:after {
-    content: '';
-    min-height: inherit;
-    font-size: 0;
+  @media screen and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    .sb-show-main.sb-main-centered:after {
+      content: '';
+      min-height: inherit;
+      font-size: 0;
+    }
   }
 
   .sb-show-main.sb-main-fullscreen {


### PR DESCRIPTION
Issue: #13178

## What I did

Don't apply the hack everywhere, just for IE11.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
