### PR TITLE
Correctly reference managerWebpack in preset docs

### DIFF
--- a/docs/api/writing-presets.md
+++ b/docs/api/writing-presets.md
@@ -64,7 +64,7 @@ For example, here is how Storybook automatically adopts `create-react-app`'s con
 
 - `webpack` is applied to the preview config after it has been initialized by storybook
 - `webpackFinal` is applied to the preview config after all user presets have been applied
-- `webpackManager` is applied to the manager config
+- `managerWebpack` is applied to the manager config
 
 ### Manager entries
 


### PR DESCRIPTION
## What I did

Searched the codebase for webpackManager and realized it was managerWebpack.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
