### PR TITLE
Addon-controls: Fix ensureDocsBeforeControls support for paths

### DIFF
--- a/addons/controls/src/preset/ensureDocsBeforeControls.test.ts
+++ b/addons/controls/src/preset/ensureDocsBeforeControls.test.ts
@@ -16,6 +16,7 @@ describe.each([
 
 describe.each([
   [['@storybook/addon-docs', '@storybook/addon-controls']],
+  [['@storybook/addon-docs', 'foo/node_modules/@storybook/addon-controls']],
   [[{ name: '@storybook/addon-docs' }, '@storybook/addon-controls']],
   [['@storybook/addon-essentials', '@storybook/addon-controls']],
   [['@storybook/addon-essentials']],

--- a/addons/controls/src/preset/ensureDocsBeforeControls.ts
+++ b/addons/controls/src/preset/ensureDocsBeforeControls.ts
@@ -8,7 +8,7 @@ type Entry = string | OptionsEntry;
 const findIndex = (addon: string, addons: Entry[]) =>
   addons.findIndex((entry) => {
     const name = (entry as OptionsEntry).name || (entry as string);
-    return name && name.startsWith(addon);
+    return name && name.includes(addon);
   });
 
 const indexOfAddonOrEssentials = (addon: string, addons: Entry[]) => {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13202

## What I did

Ensuring Docs is before Controls or Essentials even if the latter resolves as a sub-package.

## How to test

Run `yarn jest ensureDocsBeforeControls`