### PR TITLE
UI: Fix lineheight in typeset component

### DIFF
--- a/lib/components/src/blocks/Typeset.tsx
+++ b/lib/components/src/blocks/Typeset.tsx
@@ -60,7 +60,7 @@ export const Typeset: FunctionComponent<TypesetProps> = ({
             fontFamily,
             fontSize: size,
             fontWeight,
-            lineHeight: size,
+            lineHeight: 1.2,
           }}
         >
           {sampleText || 'Was he a beast if music could move him so?'}


### PR DESCRIPTION
Issue: #12643 

## What I did
Set a reasonable line-height for the Typeset component. This fixes the regression that makes typeset look like this 👇
![image](https://user-images.githubusercontent.com/263385/99886773-23197500-2c0d-11eb-9553-6d340d5e5a93.png)


## How to test

- Is this testable with Jest or Chromatic screenshots? Yes. Go to Typeset component.
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

