### PR TITLE
Core: Replace 'trash' with 'fs.remove'

### DIFF
--- a/examples/angular-cli/jest.config.js
+++ b/examples/angular-cli/jest.config.js
@@ -31,4 +31,5 @@ module.exports = {
     'jest-preset-angular/build/HTMLCommentSerializer.js',
   ],
   setupFilesAfterEnv: ['./jest-config/setup.ts'],
+  testPathIgnorePatterns: ['app.component.spec.ts'],
 };

--- a/examples/aurelia-kitchen-sink/package.json
+++ b/examples/aurelia-kitchen-sink/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "scripts": {
     "build": "rimraf dist && webpack --env production",
-    "build-storybook": "build-storybook -s dist",
+    "build-storybook": "yarn build && build-storybook -s dist",
     "now-build": "node ../../scripts/bootstrap --core && yarn run build-storybook --quiet",
     "start": "webpack-dev-server",
     "storybook": "start-storybook -p 9009 -s dist"

--- a/examples/rax-kitchen-sink/package.json
+++ b/examples/rax-kitchen-sink/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "build-scripts build",
-    "build-storybook": "build-storybook -s public",
+    "build-storybook": "build-storybook",
     "start": "build-scripts start",
     "storybook": "start-storybook -p 9009 -s public"
   },

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -122,7 +122,6 @@
     "style-loader": "^1.2.1",
     "telejson": "^5.0.2",
     "terser-webpack-plugin": "^3.0.0",
-    "trash": "^6.1.1",
     "ts-dedent": "^2.0.0",
     "unfetch": "^4.1.0",
     "url-loader": "^4.0.0",

--- a/lib/core/src/server/build-static.ts
+++ b/lib/core/src/server/build-static.ts
@@ -3,7 +3,6 @@ import fs from 'fs-extra';
 import path from 'path';
 import webpack from 'webpack';
 import shelljs from 'shelljs';
-import trash from 'trash';
 
 import { logger } from '@storybook/node-logger';
 
@@ -177,7 +176,8 @@ export async function buildStaticStandalone(options: any) {
   const defaultFavIcon = require.resolve('./public/favicon.ico');
 
   logger.info(`=> Cleaning outputDir ${outputDir}`);
-  await trash(outputDir, { glob: false });
+  if (outputDir === '/') throw new Error("Won't remove directory '/'. Check your outputDir!");
+  await fs.remove(outputDir);
 
   await cpy(defaultFavIcon, outputDir);
   await copyAllStaticFiles(staticDir, outputDir);

--- a/lib/core/src/server/build-static.ts
+++ b/lib/core/src/server/build-static.ts
@@ -106,8 +106,7 @@ async function copyAllStaticFiles(staticDir: any[] | undefined, outputDir: strin
         const [currentStaticDir, staticEndpoint] = dir.split(':').concat('/');
         const localStaticPath = path.resolve(currentStaticDir);
 
-        // @ts-ignore
-        if (await !fs.exists(localStaticPath)) {
+        if (!(await fs.pathExists(localStaticPath))) {
           logger.error(`Error: no such directory to load static files: ${localStaticPath}`);
           process.exit(-1);
         }


### PR DESCRIPTION
Issues: #13168 #13150

## What I did

This replaces the `trash` module, which has issues on Linux, with `remove` from `fs-extra`. I've also added a check to prevent accidentally removing `/`. There was also a logic mistake and a deprecated method which I fixed along the way.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
