### PR TITLE
UI: Fix overflow scrolling on layout:centered

### DIFF
--- a/examples/official-storybook/stories/core/layout.stories.js
+++ b/examples/official-storybook/stories/core/layout.stories.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 // eslint-disable-next-line react/prop-types
-const Box = ({ children, display = 'block' }) => (
-  <div style={{ display, border: '2px solid #FF4785', padding: 10 }}>{children}</div>
+const Box = ({ children, display = 'block', width, height }) => (
+  <div style={{ display, border: '2px solid #FF4785', padding: 10, width, height }}>{children}</div>
 );
 
 export default {
@@ -28,6 +28,12 @@ CenteredBlock.parameters = { layout: 'centered' };
 
 export const CenteredInline = () => <Box display="inline-block">centered</Box>;
 CenteredInline.parameters = { layout: 'centered' };
+
+export const CenteredTall = () => <Box height="120vh">centered tall</Box>;
+CenteredTall.parameters = { layout: 'centered' };
+
+export const CenteredWide = () => <Box width="120vw">centered wide</Box>;
+CenteredWide.parameters = { layout: 'centered' };
 
 export const None = () => <Box>none</Box>;
 None.parameters = { layout: 'none' };

--- a/lib/core/src/server/templates/base-preview-head.html
+++ b/lib/core/src/server/templates/base-preview-head.html
@@ -9,12 +9,16 @@
 
   .sb-show-main.sb-main-centered {
     margin: 0;
-    padding: 1rem;
     display: flex;
-    justify-content: center;
     align-items: center;
     min-height: 100vh;
+  }
+
+  .sb-show-main.sb-main-centered #root {
     box-sizing: border-box;
+    margin: auto;
+    padding: 1rem;
+    max-height: 100%; /* Hack for centering correctly in IE11 */
   }
 
   /* Vertical centering fix for IE11 */


### PR DESCRIPTION
Issue: #13157 

## What I did

Fix overflow scrolling when using `layout: "centered"` with content wider than the viewport.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, I added them.
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
