### PR TITLE
Core: Clear manager cache on runtime error

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -282,8 +282,14 @@ const startManager = async ({
   router.use(middleware);
 
   const managerStats: Stats = await new Promise((resolve) => middleware.waitUntilValid(resolve));
-  if (!managerStats) throw new Error('no stats after building manager');
-  if (managerStats.hasErrors()) throw managerStats;
+  if (!managerStats) {
+    await clearManagerCache(options.cache);
+    throw new Error('no stats after building manager');
+  }
+  if (managerStats.hasErrors()) {
+    await clearManagerCache(options.cache);
+    throw managerStats;
+  }
   return { managerStats, managerTotalTime: process.hrtime(startTime) };
 };
 

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -16,6 +16,7 @@ import webpackHotMiddleware from 'webpack-hot-middleware';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { NextHandleFunction } from 'connect';
+import { FileSystemCache } from 'file-system-cache';
 import { getMiddleware } from './utils/middleware';
 import { logConfig } from './logConfig';
 import loadConfig from './config';
@@ -196,6 +197,23 @@ const useProgressReporting = async (
   new ProgressPlugin({ handler, modulesCount }).apply(compiler);
 };
 
+const useManagerCache = async (fsc: FileSystemCache, managerConfig: webpack.Configuration) => {
+  // Drop the `cache` property because it'll change as a result of writing to the cache.
+  const { cache: _, ...baseConfig } = managerConfig;
+  const configString = stringify(baseConfig);
+  const cachedConfig = await fsc.get('managerConfig');
+  await fsc.set('managerConfig', configString);
+  return configString === cachedConfig;
+};
+
+const clearManagerCache = async (fsc: FileSystemCache) => {
+  if (fsc.fileExists('managerConfig')) {
+    await fsc.remove('managerConfig');
+    return true;
+  }
+  return false;
+};
+
 const startManager = async ({
   startTime,
   options,
@@ -222,31 +240,28 @@ const startManager = async ({
 
     if (options.cache) {
       if (options.managerCache) {
-        // Drop the `cache` property because it'll change as a result of writing to the cache.
-        const { cache: _, ...baseConfig } = managerConfig;
-        const configString = stringify(baseConfig);
-        const cachedConfig = await options.cache.get('managerConfig');
-        options.cache.set('managerConfig', configString);
-        if (configString === cachedConfig && (await pathExists(outputDir))) {
+        const [useCache, hasOutput] = await Promise.all([
+          // must run even if outputDir doesn't exist, otherwise the 2nd run won't use cache
+          useManagerCache(options.cache, managerConfig),
+          pathExists(outputDir),
+        ]);
+        if (useCache && hasOutput) {
           logger.info('=> Using cached manager');
           managerConfig = null;
         }
-      } else {
-        logger.info('=> Removing cached managerConfig');
-        options.cache.remove('managerConfig');
+      } else if (await clearManagerCache(options.cache)) {
+        logger.info('=> Cleared cached manager config');
       }
     }
   }
 
   if (!managerConfig) {
-    // FIXME: This object containing default values should match ManagerResult
-    // @ts-ignore
-    return { managerStats: {}, managerTotalTime: 0 } as ManagerResult;
+    return { managerStats: {}, managerTotalTime: [0, 0] } as ManagerResult;
   }
 
   const compiler = webpack(managerConfig);
   const middleware = webpackDevMiddleware(compiler, {
-    publicPath: managerConfig.output.publicPath,
+    publicPath: managerConfig.output?.publicPath,
     writeToDisk: true,
     watchOptions: {
       aggregateTimeout: 2000,
@@ -267,7 +282,7 @@ const startManager = async ({
   router.use(middleware);
 
   const managerStats: Stats = await new Promise((resolve) => middleware.waitUntilValid(resolve));
-  if (!managerStats) throw new Error('no stats after building preview');
+  if (!managerStats) throw new Error('no stats after building manager');
   if (managerStats.hasErrors()) throw managerStats;
   return { managerStats, managerTotalTime: process.hrtime(startTime) };
 };
@@ -279,9 +294,7 @@ const startPreview = async ({
   outputDir,
 }: any): Promise<PreviewResult> => {
   if (options.ignorePreview) {
-    // FIXME: This object containing default values should match PreviewResult
-    // @ts-ignore
-    return { previewStats: {}, previewTotalTime: 0 } as PreviewResult;
+    return { previewStats: {}, previewTotalTime: [0, 0] } as PreviewResult;
   }
 
   const previewConfig = await loadConfig({

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -280,9 +280,11 @@ const startManager = async ({
   });
 
   router.post('/runtime-error', (request, response) => {
-    logger.error('Runtime error! Check your browser console.');
-    logger.error(request.body.error.stack || request.body.message);
-    if (request.body.origin === 'manager') clearManagerCache(options.cache);
+    if (request.body?.error) {
+      logger.error('Runtime error! Check your browser console.');
+      logger.error(request.body.error.stack || request.body.message);
+      if (request.body.origin === 'manager') clearManagerCache(options.cache);
+    }
     response.sendStatus(200);
   });
 

--- a/lib/core/src/server/templates/base-manager-head.html
+++ b/lib/core/src/server/templates/base-manager-head.html
@@ -23,4 +23,15 @@
     // eslint-disable-next-line no-console
     console.warn('unable to connect to top frame for connecting dev tools');
   }
+
+  window.onerror = function onerror(message, source, line, column, err) {
+    if (window.CONFIG_TYPE !== 'DEVELOPMENT') return;
+    // eslint-disable-next-line no-var, vars-on-top
+    var error = { message: err.message, name: err.name, stack: err.stack };
+    window.fetch('/runtime-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, source, line, column, error, origin: 'manager' }),
+    });
+  };
 </script>

--- a/lib/core/src/server/templates/base-preview-head.html
+++ b/lib/core/src/server/templates/base-preview-head.html
@@ -107,4 +107,15 @@
     // eslint-disable-next-line no-console
     console.warn('unable to connect to top frame for connecting dev tools');
   }
+
+  window.onerror = function onerror(message, source, line, column, err) {
+    if (window.CONFIG_TYPE !== 'DEVELOPMENT') return;
+    // eslint-disable-next-line no-var, vars-on-top
+    var error = { message: err.message, name: err.name, stack: err.stack };
+    window.fetch('/runtime-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, source, line, column, error, origin: 'preview' }),
+    });
+  };
 </script>

--- a/lib/core/src/typings.d.ts
+++ b/lib/core/src/typings.d.ts
@@ -5,6 +5,32 @@ declare module 'lazy-universal-dotenv';
 declare module 'pnp-webpack-plugin';
 declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
-declare module 'file-system-cache';
 declare module 'better-opn';
 declare module '@storybook/ui';
+
+declare module 'file-system-cache' {
+  export interface Options {
+    basePath?: string;
+    ns?: string | string[];
+    extension?: string;
+  }
+
+  export declare class FileSystemCache {
+    constructor(options: Options);
+    path(key: string): string;
+    fileExists(key: string): Promise<boolean>;
+    ensureBasePath(): Promise<void>;
+    get(key: string, defaultValue?: any): Promise<any | typeof defaultValue>;
+    getSync(key: string, defaultValue?: any): any | typeof defaultValue;
+    set(key: string, value: any): Promise<{ path: string }>
+    setSync(key: string, value: any): this;
+    remove(key: string): Promise<void>;
+    clear(): Promise<void>;
+    save(): Promise<{ paths: string[] }>;
+    load(): Promise<{ files: Array<{ path: string, value: any }> }>;
+  }
+
+  function create(options: Options): FileSystemCache;
+
+  export = create;
+}


### PR DESCRIPTION
Issues: #13199 #13209

## What I did

This reports back any runtime (console) errors from the browser to the dev server, and clears the manager cache if there's a runtime error originating from the manager UI.

This also includes some smaller tweaks and fixes, including one for the `TypeError: Cannot read property 'publicPath' of undefined` error reported in #13209.

<img width="600" alt="Screenshot 2020-11-23 at 20 13 46" src="https://user-images.githubusercontent.com/321738/100004887-708e1180-2dc8-11eb-9bda-b3c879a9c76f.png">

<img width="989" alt="Screenshot 2020-11-23 at 20 04 51" src="https://user-images.githubusercontent.com/321738/100004015-2ce6d800-2dc7-11eb-8964-2133bbceeebe.png">

## How to test

Run `start-storybook` to make sure the manager UI is cached. Then throw an error at the end of `manager.js` and restart Storybook. Note that it will used the cached manager and therefore is not broken. Now start again with `--no-manager-cache`. Note that the UI is now broken (white screen) with a runtime error in the browser console. Also note that the CLI will now show the browser error in your terminal. Finally, `start-storybook` again without the `--no-manager-cache` flag, so it'll build cache. Then exit and run it again. Note it will _not_ have a cached manager this time, because it got cleared when the runtime error occurred.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
