### PR TITLE
Build: strengthen conditions under which Webpack stats are written in file

### DIFF
--- a/lib/core/src/server/build-dev.ts
+++ b/lib/core/src/server/build-dev.ts
@@ -218,11 +218,13 @@ function outputStartupInformation(options: {
   );
 }
 
-async function outputStats(previewStats: Stats, managerStats: Stats) {
+async function outputStats(previewStats: Stats | undefined, managerStats: Stats | undefined) {
   if (previewStats) {
     await writeStats('preview', previewStats);
   }
-  await writeStats('manager', managerStats);
+  if (managerStats) {
+    await writeStats('manager', managerStats);
+  }
   logger.info(
     `stats written to => ${chalk.cyan(resolvePathInStorybookCache('public/[name].json'))}`
   );
@@ -282,9 +284,9 @@ export async function buildDevStandalone(
 
     if (options.smokeTest) {
       await outputStats(previewStats, managerStats);
-      const managerWarnings = (managerStats as any).toJson().warnings.length > 0;
+      const managerWarnings = !!managerStats && managerStats.toJson().warnings.length > 0;
       const previewWarnings =
-        !options.ignorePreview && (previewStats as any).toJson().warnings.length > 0;
+        !options.ignorePreview && !!previewStats && previewStats.toJson().warnings.length > 0;
       process.exit(managerWarnings || previewWarnings ? 1 : 0);
       return;
     }

--- a/lib/core/src/server/build-dev.ts
+++ b/lib/core/src/server/build-dev.ts
@@ -25,11 +25,9 @@ const cache = Cache({
 });
 
 const writeStats = async (name: string, stats: Stats) => {
-  await fs.writeFile(
-    resolvePathInStorybookCache(`public/${name}-stats.json`),
-    JSON.stringify(stats.toJson(), null, 2),
-    'utf8'
-  );
+  const statsFilePath = resolvePathInStorybookCache(`public/${name}-stats.json`);
+  await fs.ensureFile(statsFilePath);
+  await fs.writeFile(statsFilePath, JSON.stringify(stats.toJson(), null, 2), 'utf8');
 };
 
 const getFreePort = (port: number) =>

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -258,7 +258,7 @@ const startManager = async ({
   }
 
   if (!managerConfig) {
-    return { managerStats: {}, managerTotalTime: [0, 0] } as ManagerResult;
+    return { managerTotalTime: [0, 0] };
   }
 
   const compiler = webpack(managerConfig);
@@ -311,7 +311,7 @@ const startPreview = async ({
   outputDir,
 }: any): Promise<PreviewResult> => {
   if (options.ignorePreview) {
-    return { previewStats: {}, previewTotalTime: [0, 0] } as PreviewResult;
+    return { previewTotalTime: [0, 0] };
   }
 
   const previewConfig = await loadConfig({

--- a/lib/core/src/server/types.ts
+++ b/lib/core/src/server/types.ts
@@ -94,12 +94,12 @@ export interface ReleaseNotesData {
 }
 
 export interface PreviewResult {
-  previewStats: Stats;
+  previewStats?: Stats;
   previewTotalTime: [number, number];
 }
 
 export interface ManagerResult {
-  managerStats: Stats;
+  managerStats?: Stats;
   managerTotalTime: [number, number];
 }
 


### PR DESCRIPTION
Issue: `CLI Tests` CI job is failing for a few days/weeks because in some cases we are trying to output some undefined Webpack stats in a file, inside a potentially non-existing directory.

## What I did

 - Ensure the directory used to output Webpack stats exists before writing files in it.
 - Strengthen the types and checks before trying to write anything in files.

## How to test

 - `CLI Tests`  CI job should be back to 🟢  