### PR TITLE
Added an alternative solution to disable a prop control in docs

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -250,6 +250,15 @@ Resulting in the following change in Storybook UI:
   />
 </video>
 
+The previous example also removed the prop documentation from the table. In some cases this is fine, however sometimes you might want to still render the prop documentation but without a control. The following example illustrates how:
+
+<CodeSnippets
+  paths={[
+    'common/component-story-disable-controls-alt.js.mdx',
+    'common/component-story-disable-controls-alt.mdx.mdx'
+  ]}
+/>
+
 <div class="aside">
 
  As with other Storybook properties, such as [decorators](../writing-stories/decorators.md) the same principle can also be applied at a story-level for more granular cases.

--- a/docs/snippets/common/component-story-disable-controls-alt.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-alt.js.mdx
@@ -1,0 +1,16 @@
+```js
+// YourComponent.stories.js
+
+import { YourComponent } from './your-component'
+
+export default {
+  component: YourComponent,
+  title:'My Story',
+  argTypes:{
+    // foo is the property we want to remove from the UI
+    foo:{
+      control:false
+    }
+  }
+};
+```

--- a/docs/snippets/common/component-story-disable-controls-alt.mdx.mdx
+++ b/docs/snippets/common/component-story-disable-controls-alt.mdx.mdx
@@ -1,0 +1,23 @@
+```md
+<!--- YourComponent.stories.mdx -->
+
+import { Meta,Story, Canvas } from '@storybook/addon-docs/blocks';
+
+import { YourComponent } from './your-component'
+
+<Meta 
+  title='My Story' 
+  argTypes={{
+    foo:{
+      control: false
+    }
+  }} />
+
+export const Template = (args) => <YourComponent {...args} />
+
+<Canvas>
+  <Story name="My Story" args={{ foo: 'bar'}}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+```


### PR DESCRIPTION
Issue:

## What I did

Added to docs an alternative solution to disable a prop control without removing the prop documentation.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
