### PR TITLE
Core: Fix webpack5 compatibility check for ProgressPlugin

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -172,6 +172,7 @@ const useProgressReporting = async (
     value = Math.max(newValue, value); // never go backwards
     const progress = { value, message: message.charAt(0).toUpperCase() + message.slice(1) };
     if (message === 'building') {
+      // arg3 undefined in webpack5
       const counts = arg3 && arg3.match(/(\d+)\/(\d+)/) || [];
       const complete = parseInt(counts[1], 10);
       const total = parseInt(counts[2], 10);

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -172,7 +172,7 @@ const useProgressReporting = async (
     value = Math.max(newValue, value); // never go backwards
     const progress = { value, message: message.charAt(0).toUpperCase() + message.slice(1) };
     if (message === 'building') {
-      const counts = arg3.match(/(\d+)\/(\d+)/) || [];
+      const counts = arg3 && arg3.match(/(\d+)\/(\d+)/) || [];
       const complete = parseInt(counts[1], 10);
       const total = parseInt(counts[2], 10);
       if (!Number.isNaN(complete) && !Number.isNaN(total)) {


### PR DESCRIPTION
Issue:
Webpack 5 ProgressPlugin only supplies 2 arguments to the handler. See https://github.com/webpack/webpack/blob/6394e2d1d87e82871e16945822b14fbfab954b71/lib/ProgressPlugin.js#L491-L494

This would make storybook compatible with webpack 5 again (at least from what I have seen so far).
