### PR TITLE
Core: Improve handling of --static-dir option

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -91,7 +91,7 @@ async function useStatics(router: any, options: { staticDir?: string[] }) {
 
         if (!(await pathExists(dirpath))) {
           logger.warn(`Failed to load static files, no such directory: ${dirpath}`);
-          logger.warn(`Check your \`-s\` or \`--static-dir\` option for start-storybook.`);
+          logger.warn(`You should create this directory, or omit the -s (--static-dir) option.`);
           return;
         }
 


### PR DESCRIPTION
Issue: #13196

## What I did

This only warns if a --static-dir cannot be found, rather than error and exit. It also makes it a little more robust, so the `dirname:location` syntax is more intuitive to use.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
