### PR TITLE
Addon-backgrounds: Fix grid offset always using default value

### DIFF
--- a/addons/backgrounds/src/decorators/withGrid.ts
+++ b/addons/backgrounds/src/decorators/withGrid.ts
@@ -33,8 +33,8 @@ export const withGrid = (StoryFn: StoryFunction, context: StoryContext) => {
   const isLayoutPadded = parameters.layout === undefined || parameters.layout === 'padded';
   // 16px offset in the grid to account for padded layout
   const defaultOffset = isLayoutPadded ? 16 : 0;
-  const offsetX = gridParameters.offsetX || isInDocs ? 20 : defaultOffset;
-  const offsetY = gridParameters.offsetY || isInDocs ? 20 : defaultOffset;
+  const offsetX = gridParameters.offsetX ?? (isInDocs ? 20 : defaultOffset);
+  const offsetY = gridParameters.offsetY ?? (isInDocs ? 20 : defaultOffset);
 
   const gridStyles = useMemo(() => {
     const selector =


### PR DESCRIPTION
## What I did

- Fix falsy value check to allow zero values in offsetX and offsetY parameters
- Fix default value fallback conditional logic

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
