### PR TITLE
Core: Don't use prebuilt or cached manager when running smoke test

### DIFF
--- a/lib/core/src/server/build-dev.ts
+++ b/lib/core/src/server/build-dev.ts
@@ -25,11 +25,9 @@ const cache = Cache({
 });
 
 const writeStats = async (name: string, stats: Stats) => {
-  await fs.writeFile(
-    resolvePathInStorybookCache(`public/${name}-stats.json`),
-    JSON.stringify(stats.toJson(), null, 2),
-    'utf8'
-  );
+  const filePath = resolvePathInStorybookCache(`public/${name}-stats.json`);
+  await fs.writeFile(filePath, JSON.stringify(stats.toJson(), null, 2), 'utf8');
+  return filePath;
 };
 
 const getFreePort = (port: number) =>
@@ -222,12 +220,13 @@ function outputStartupInformation(options: {
 
 async function outputStats(previewStats: Stats, managerStats: Stats) {
   if (previewStats) {
-    await writeStats('preview', previewStats);
+    const filePath = await writeStats('preview', previewStats);
+    logger.info(`=> preview stats written to ${chalk.cyan(filePath)}`);
   }
-  await writeStats('manager', managerStats);
-  logger.info(
-    `stats written to => ${chalk.cyan(resolvePathInStorybookCache('public/[name].json'))}`
-  );
+  if (managerStats) {
+    const filePath = await writeStats('manager', managerStats);
+    logger.info(`=> manager stats written to ${chalk.cyan(filePath)}`);
+  }
 }
 
 export async function buildDevStandalone(

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -258,7 +258,7 @@ const startManager = async ({
   }
 
   if (!managerConfig) {
-    return { managerStats: {}, managerTotalTime: [0, 0] } as ManagerResult;
+    return { managerStats: null, managerTotalTime: [0, 0] } as ManagerResult;
   }
 
   const compiler = webpack(managerConfig);
@@ -311,7 +311,7 @@ const startPreview = async ({
   outputDir,
 }: any): Promise<PreviewResult> => {
   if (options.ignorePreview) {
-    return { previewStats: {}, previewTotalTime: [0, 0] } as PreviewResult;
+    return { previewStats: null, previewTotalTime: [0, 0] } as PreviewResult;
   }
 
   const previewConfig = await loadConfig({

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -174,7 +174,7 @@ const useProgressReporting = async (
     const progress = { value, message: message.charAt(0).toUpperCase() + message.slice(1) };
     if (message === 'building') {
       // arg3 undefined in webpack5
-      const counts = arg3 && arg3.match(/(\d+)\/(\d+)/) || [];
+      const counts = (arg3 && arg3.match(/(\d+)\/(\d+)/)) || [];
       const complete = parseInt(counts[1], 10);
       const total = parseInt(counts[2], 10);
       if (!Number.isNaN(complete) && !Number.isNaN(total)) {
@@ -240,7 +240,7 @@ const startManager = async ({
       logConfig('Manager webpack config', managerConfig);
     }
 
-    if (options.cache) {
+    if (options.cache && !options.smokeTest) {
       if (options.managerCache) {
         const [useCache, hasOutput] = await Promise.all([
           // must run even if outputDir doesn't exist, otherwise the 2nd run won't use cache

--- a/lib/core/src/server/utils/prebuilt-manager.ts
+++ b/lib/core/src/server/utils/prebuilt-manager.ts
@@ -22,9 +22,9 @@ export const getPrebuiltDir = async ({
   options,
 }: {
   configDir: string;
-  options: { managerCache?: boolean };
+  options: { managerCache?: boolean; smokeTest?: boolean };
 }): Promise<string | false> => {
-  if (options.managerCache === false) return false;
+  if (options.managerCache === false || options.smokeTest) return false;
 
   const prebuiltDir = path.join(__dirname, '../../../prebuilt');
   const hasPrebuiltManager = await pathExists(path.join(prebuiltDir, 'index.html'));


### PR DESCRIPTION
Issue: #13262

## What I did

Ignore any prebuilt or cached manager when running with `--smoke-test`.
Additionally I improved some logging and made the related code a little more resilient.

## How to test

Run with `--smoke-test`. Note it will not use the prebuilt or cached manager. It will also not clear the cache, so running without `--smoke-test` afterwards will use a cached version as normal.

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
