### PR TITLE
Core: Fix template script tag support

### DIFF
--- a/lib/client-api/src/simulate-pageload.ts
+++ b/lib/client-api/src/simulate-pageload.ts
@@ -82,15 +82,17 @@ export function simulatePageLoad($container: any) {
       const typeAttr = $script.getAttribute('type');
 
       // only run script tags without the type attribute
-      // or with a javascript mime attribute value
-      if (!typeAttr || !runScriptTypes.includes(typeAttr)) {
+      // or with a javascript mime attribute value from the list
+      if (!typeAttr || runScriptTypes.includes(typeAttr)) {
         scriptsToExecute.push((callback: any) => insertScript($script, callback, $scriptsRoot));
       }
     });
 
     // insert the script tags sequentially
     // to preserve execution order
-    insertScriptsSequentially(scriptsToExecute, simulateDOMContentLoaded, undefined);
+    if (scriptsToExecute.length) {
+      insertScriptsSequentially(scriptsToExecute, simulateDOMContentLoaded, undefined);
+    }
   } else {
     simulateDOMContentLoaded();
   }


### PR DESCRIPTION
Issue: #13270

## What I did
Fixed the support for script tag in templates. Take only defined script tags by type, not all.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
