### PR TITLE
Get rid of mentioning the no-dll flag in Workflow FAQ

### DIFF
--- a/docs/workflows/faq.md
+++ b/docs/workflows/faq.md
@@ -115,10 +115,6 @@ For now the addons you're using in a composed Storybook will not work.
 
 We're working on overcoming this limitation, soon you'll be able to use them  as if you working with a non composed Storybook.
 
-### Why i'm getting errors with react-popper and Storybook?
-
-If you're using the `react-popper` in your own project and you're experiencing issues with Storybook. You can solve them by adding the `--no-dll` command line flag. Take a look at the [cli options page](../api/cli-options.md) to see how you can use the flag in your project.
-
 ### Which community addons are compatible with the latest version of Storybook?
 
 Starting with Storybook version 6.0 we've introduced some great features aimed at streamlining your development workflow.


### PR DESCRIPTION
Issue: this flag was deprecated in 6.1 https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-dll-flags.

## What I did
I updated the documentation.

## How to test

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
