### PR TITLE
Core: Ensure node `name` does not contain leading/trailing whitespace

### DIFF
--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -205,6 +205,48 @@ describe('stories API', () => {
       });
     });
 
+    it('trims whitespace of group/component names (which originate from the kind)', () => {
+      const navigate = jest.fn();
+      const store = createMockStore();
+
+      const {
+        api: { setStories },
+      } = initStories({ store, navigate, provider });
+
+      setStories({
+        'design-system-some-component--my-story': {
+          kind: '  Design System  /  Some Component  ', // note the leading/trailing whitespace around each part of the path
+          name: '  My Story  ', // we only trim the path, so this will be kept as-is (it may intentionally have whitespace)
+          parameters,
+          path: 'design-system-some-component--my-story',
+          id: 'design-system-some-component--my-story',
+          args: {},
+        },
+      });
+
+      const { storiesHash: storedStoriesHash } = store.getState();
+
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(storedStoriesHash)).toEqual([
+        'design-system',
+        'design-system-some-component',
+        'design-system-some-component--my-story',
+      ]);
+      expect(storedStoriesHash['design-system']).toMatchObject({
+        isRoot: true,
+        name: 'Design System', // root name originates from `kind`, so it gets trimmed
+      });
+      expect(storedStoriesHash['design-system-some-component']).toMatchObject({
+        isComponent: true,
+        name: 'Some Component', // component name originates from `kind`, so it gets trimmed
+      });
+      expect(storedStoriesHash['design-system-some-component--my-story']).toMatchObject({
+        isLeaf: true,
+        kind: '  Design System  /  Some Component  ', // kind is kept as-is, because it may be used as identifier
+        name: '  My Story  ', // story name is kept as-is, because it's set directly on the story
+      });
+    });
+
     it('sets roots when showRoots = true', () => {
       const navigate = jest.fn();
       const store = createMockStore();

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -343,10 +343,8 @@ export default class StoryStore {
         'Cannot add a story when not configuring, see https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#story-store-immutable-outside-of-configuration'
       );
 
-    if (storyParameters) {
-      checkGlobals(storyParameters);
-      checkStorySort(storyParameters);
-    }
+    checkGlobals(storyParameters);
+    checkStorySort(storyParameters);
 
     const { _stories } = this;
 


### PR DESCRIPTION
Issue: #13251

## What I did

Primarily, this trims each part of the `title` (aka `kind`), after splitting it on `/`:

```js
const groups = kind.split('/').map((part) => part.trim());
```

The `.map(part => part.trim())` is what's added. Everything else in this PR is refactoring. I'll leave comments to clarify.

Pro tip: ignore whitespace changes when reviewing this 👍 

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, a unit test should be added.
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
