### PR TITLE
Addon-docs: Fix Vue source snippets for function attributes

### DIFF
--- a/addons/docs/src/frameworks/vue/sourceDecorator.test.ts
+++ b/addons/docs/src/frameworks/vue/sourceDecorator.test.ts
@@ -32,7 +32,7 @@ describe('vnodeToString', () => {
 
   it('attributes', () => {
     const MyComponent: ComponentOptions<any, any, any> = {
-      props: ['propA', 'propB', 'propC', 'propD', 'propE', 'propF', 'propG', 'propH'],
+      props: ['propA', 'propB', 'propC', 'propD', 'propE', 'propF', 'propG'],
       template: '<div/>',
     };
 
@@ -48,16 +48,14 @@ describe('vnodeToString', () => {
                 propC: null,
                 propD: {
                   foo: 'bar',
-                  bar: 'foo',
                 },
-                propE: 'propE',
-                propF: true,
-                propG() {
+                propE: true,
+                propF() {
                   const foo = 'bar';
 
                   return foo;
                 },
-                propH: undefined,
+                propG: undefined,
               },
             };
           },
@@ -65,7 +63,7 @@ describe('vnodeToString', () => {
         })
       )
     ).toMatchInlineSnapshot(
-      `<my-component propF propE="propE" :propD='{"foo":"bar","bar":"foo"}' :propC="null" :propB="1" propA="propA"/>`
+      `<my-component propE :propD='{"foo":"bar"}' :propC="null" :propB="1" propA="propA"/>`
     );
   });
 

--- a/addons/docs/src/frameworks/vue/sourceDecorator.test.ts
+++ b/addons/docs/src/frameworks/vue/sourceDecorator.test.ts
@@ -32,7 +32,7 @@ describe('vnodeToString', () => {
 
   it('attributes', () => {
     const MyComponent: ComponentOptions<any, any, any> = {
-      props: ['propA', 'propB', 'propC', 'propD'],
+      props: ['propA', 'propB', 'propC', 'propD', 'propE', 'propF', 'propG', 'propH'],
       template: '<div/>',
     };
 
@@ -48,7 +48,16 @@ describe('vnodeToString', () => {
                 propC: null,
                 propD: {
                   foo: 'bar',
+                  bar: 'foo',
                 },
+                propE: 'propE',
+                propF: true,
+                propG() {
+                  const foo = 'bar';
+
+                  return foo;
+                },
+                propH: undefined,
               },
             };
           },
@@ -56,7 +65,7 @@ describe('vnodeToString', () => {
         })
       )
     ).toMatchInlineSnapshot(
-      `<my-component :propD='{"foo":"bar"}' :propC="null" :propB="1" propA="propA"/>`
+      `<my-component propF propE="propE" :propD='{"foo":"bar","bar":"foo"}' :propC="null" :propB="1" propA="propA"/>`
     );
   });
 

--- a/addons/docs/src/frameworks/vue/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/vue/sourceDecorator.ts
@@ -123,7 +123,7 @@ export function vnodeToString(vnode: Vue.VNode): string {
 }
 
 function stringifyAttr(attrName: string, value?: any): string | null {
-  if (typeof value === 'undefined') {
+  if (typeof value === 'undefined' || typeof value === 'function') {
     return null;
   }
 


### PR DESCRIPTION
Followup to the excellent work done in #12812 by @pocka 

# What I did

The `sourceDecorator` currently throws an error if for some reason the value of an attribute is a function so I've added a simple check for the typeof the value:

```
Failed to generate dynamic story source: TypeError: Cannot read property 'includes' of undefined
```

I'm not sure what the underlying issue is that causes the type to be a function but it seems to be related to event handlers.

Here's some example code for a component/story (Not committed to the repo as it breaks storyshot tests) that causes the source to not be generated.

Example component:
```vue
<template>
  <div class="pagination">
    <button :disabled="isPreviousButtonDisabled" @click="previousPage">
      « Previous
    </button>

    <button :disabled="isNextButtonDisabled" @click="nextPage">
      Next »
    </button>
  </div>
</template>

<script>
export default {
  name: 'simple-pagination',
  props: {
    currentPage: {
      type: Number,
      required: true,
    },
    pageCount: {
      type: Number,
      required: true,
    },
  },
  computed: {
    isPreviousButtonDisabled() {
      return this.currentPage === 1;
    },
    isNextButtonDisabled() {
      return this.currentPage >= this.pageCount;
    },
  },
  methods: {
    nextPage() {
      this.$emit('next-page');
    },
    previousPage() {
      this.$emit('previous-page');
    },
  },
};
</script>
```

```js
import SimplePagination from './SimplePagination.vue';

export default {
  title: 'Components/Pagination/SimplePagination',
  component: SimplePagination,
  argTypes: {
    nextPage: { action: 'Next page' },
    previousPage: { action: 'Previous page' },
  },
  args: {
    currentPage: 2,
    pageCount: 3,
  },
};

const Template = (args, { argTypes }) => ({
  props: Object.keys(argTypes),
  components: { SimplePagination },
  template:
    '<simple-pagination @next-page="nextPage" @previous-page="previousPage" v-bind="$props" />',
});

export const Default = Template.bind({});
```

For some reason the value of the `@previous-page` attribute is being passed through as a function instead of just being undefined like `@next-page`:

```
 actionHandler() {
    var channel = _addons.addons.getChannel();

    var id = (0, _uuid.v4)();
    var minDepth = 5; // anything less is really just storybook internals

    for (var _len = argument…
```


## How to test

- Is this testable with Jest or Chromatic screenshots? yes
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR. ... done (`addons/docs/src/frameworks/vue/sourceDecorator.test.ts`)

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
