### PR TITLE
CLI: Fix not printing managerTotalTime when using cached manager

### DIFF
--- a/lib/core/src/server/build-dev.ts
+++ b/lib/core/src/server/build-dev.ts
@@ -153,8 +153,8 @@ function outputStartupInformation(options: {
   version: string;
   address: string;
   networkAddress: string;
-  managerTotalTime: [number, number];
-  previewTotalTime: [number, number];
+  managerTotalTime?: [number, number];
+  previewTotalTime?: [number, number];
 }) {
   const {
     updateInfo,
@@ -283,10 +283,9 @@ export async function buildDevStandalone(
 
     if (options.smokeTest) {
       await outputStats(previewStats, managerStats);
-      const managerWarnings = (managerStats as any).toJson().warnings.length > 0;
-      const previewWarnings =
-        !options.ignorePreview && (previewStats as any).toJson().warnings.length > 0;
-      process.exit(managerWarnings || previewWarnings ? 1 : 0);
+      const hasManagerWarnings = managerStats && (managerStats as any).toJson().warnings.length > 0;
+      const hasPreviewWarnings = previewStats && (previewStats as any).toJson().warnings.length > 0;
+      process.exit(hasManagerWarnings || (hasPreviewWarnings && !options.ignorePreview) ? 1 : 0);
       return;
     }
 

--- a/lib/core/src/server/build-dev.ts
+++ b/lib/core/src/server/build-dev.ts
@@ -283,8 +283,8 @@ export async function buildDevStandalone(
 
     if (options.smokeTest) {
       await outputStats(previewStats, managerStats);
-      const hasManagerWarnings = managerStats && (managerStats as any).toJson().warnings.length > 0;
-      const hasPreviewWarnings = previewStats && (previewStats as any).toJson().warnings.length > 0;
+      const hasManagerWarnings = managerStats && managerStats.toJson().warnings.length > 0;
+      const hasPreviewWarnings = previewStats && previewStats.toJson().warnings.length > 0;
       process.exit(hasManagerWarnings || (hasPreviewWarnings && !options.ignorePreview) ? 1 : 0);
       return;
     }

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -258,7 +258,7 @@ const startManager = async ({
   }
 
   if (!managerConfig) {
-    return { managerStats: null, managerTotalTime: [0, 0] } as ManagerResult;
+    return {} as ManagerResult;
   }
 
   const compiler = webpack(managerConfig);
@@ -311,7 +311,7 @@ const startPreview = async ({
   outputDir,
 }: any): Promise<PreviewResult> => {
   if (options.ignorePreview) {
-    return { previewStats: null, previewTotalTime: [0, 0] } as PreviewResult;
+    return {} as PreviewResult;
   }
 
   const previewConfig = await loadConfig({

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -258,7 +258,7 @@ const startManager = async ({
   }
 
   if (!managerConfig) {
-    return {} as ManagerResult;
+    return {};
   }
 
   const compiler = webpack(managerConfig);
@@ -311,7 +311,7 @@ const startPreview = async ({
   outputDir,
 }: any): Promise<PreviewResult> => {
   if (options.ignorePreview) {
-    return {} as PreviewResult;
+    return {};
   }
 
   const previewConfig = await loadConfig({

--- a/lib/core/src/server/types.ts
+++ b/lib/core/src/server/types.ts
@@ -94,13 +94,13 @@ export interface ReleaseNotesData {
 }
 
 export interface PreviewResult {
-  previewStats: Stats;
-  previewTotalTime: [number, number];
+  previewStats?: Stats;
+  previewTotalTime?: [number, number];
 }
 
 export interface ManagerResult {
-  managerStats: Stats;
-  managerTotalTime: [number, number];
+  managerStats?: Stats;
+  managerTotalTime?: [number, number];
 }
 
 // TODO: this is a generic interface that we can share across multiple SB packages (like @storybook/cli)


### PR DESCRIPTION
Issue: #13292

## What I did

I simply made this data optional, so it will be falsy again and thus not print the manager time. See issue for info.

<img width="404" alt="Screenshot 2020-11-26 at 14 27 41" src="https://user-images.githubusercontent.com/321738/100356460-8df2f380-2ff3-11eb-8f9e-e1e97f5f3a2f.png">

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
