### PR TITLE
Core: Only apply `express.json()` middleware to /runtime-error route

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -281,10 +281,11 @@ const startManager = async ({
     next();
   });
 
-  router.post('/runtime-error', (request, response) => {
+  // Used to report back any client-side (runtime) errors
+  router.post('/runtime-error', express.json(), (request, response) => {
     if (request.body?.error) {
       logger.error('Runtime error! Check your browser console.');
-      logger.error(request.body.error.stack || request.body.message);
+      logger.error(request.body.error.stack || request.body.message || request.body);
       if (request.body.origin === 'manager') clearManagerCache(options.cache);
     }
     response.sendStatus(200);
@@ -372,9 +373,6 @@ export async function storybookDevServer(options: any) {
   if (typeof options.extendServer === 'function') {
     options.extendServer(server);
   }
-
-  // Used to report back any client-side (runtime) errors
-  app.use(express.json());
 
   app.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
Issue: #13268

## What I did

This moves the `express.json()` middleware from application global to just the route handler for `/runtime-error`.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
