### PR TITLE
React: Don't add FastRefresh if already enabled

### DIFF
--- a/app/react/src/server/framework-preset-react.ts
+++ b/app/react/src/server/framework-preset-react.ts
@@ -65,7 +65,7 @@ export async function webpackFinal(config: Configuration, options: StorybookOpti
   const hasReactRefresh = config.plugins.find((p) => p.constructor.name === 'ReactRefreshPlugin');
 
   if (hasReactRefresh) {
-    logger.warn("=> React refresh is already set. You don't need do set the option");
+    logger.warn("=> React refresh is already set. You don't need to set the option");
     return config;
   }
 

--- a/app/react/src/server/framework-preset-react.ts
+++ b/app/react/src/server/framework-preset-react.ts
@@ -18,7 +18,10 @@ export async function babel(config: TransformOptions, options: StorybookOptions)
 
   return {
     ...config,
-    plugins: [require.resolve('react-refresh/babel'), ...(config.plugins || [])],
+    plugins: [
+      [require.resolve('react-refresh/babel'), {}, 'storybook-react-refresh'],
+      ...(config.plugins || []),
+    ],
   };
 }
 const storybookReactDirName = path.dirname(require.resolve('@storybook/react/package.json'));
@@ -58,8 +61,16 @@ export async function webpackFinal(config: Configuration, options: StorybookOpti
   if (!fastRefreshEnabled) {
     return config;
   }
+  // matches the name of the plugin in CRA.
+  const hasReactRefresh = config.plugins.find((p) => p.constructor.name === 'ReactRefreshPlugin');
+
+  if (hasReactRefresh) {
+    logger.warn("=> React refresh is already set. You don't need do set the option");
+    return config;
+  }
 
   logger.info('=> Using React fast refresh');
+
   return {
     ...config,
     plugins: [...(config.plugins || []), new ReactRefreshWebpackPlugin()],


### PR DESCRIPTION
Issue: #13248

## What I did
- Name babel plugin
- Remove plugin if already set (I don't like how I removed it, any better ideas ? @mrmckeb WDYT ?)

## How to test

- CRA with fastRefresh enabled