### PR TITLE
CLI: Fix storybook-deployer upgrade warning

### DIFF
--- a/lib/cli/src/upgrade.ts
+++ b/lib/cli/src/upgrade.ts
@@ -30,6 +30,7 @@ const excludeList = [
   '@storybook/addon-bench',
   '@storybook/addon-console',
   '@storybook/csf',
+  '@storybook/storybook-deployer',
 ];
 export const isCorePackage = (pkg: string) =>
   pkg.startsWith('@storybook/') &&


### PR DESCRIPTION
Issue: #13305 

## What I did

Add storybook-deployer to exclude list. Self-merging.


