### PR TITLE
Core: Fix preview URL dropped hashes

### DIFF
--- a/lib/core/src/client/preview/url.test.ts
+++ b/lib/core/src/client/preview/url.test.ts
@@ -42,6 +42,16 @@ describe('url', () => {
         'pathname?foo=bar&id=story--id&viewMode=story'
       );
     });
+    it('should ignore + keep hashes', () => {
+      document.location.search = 'foo=bar&selectedStory=selStory&selectedKind=selKind';
+      document.location.hash = '#foobar';
+      setPath({ storyId: 'story--id', viewMode: 'story' });
+      expect(history.replaceState).toHaveBeenCalledWith(
+        {},
+        '',
+        'pathname?foo=bar&id=story--id&viewMode=story#foobar'
+      );
+    });
   });
 
   describe('parseQueryParameters', () => {

--- a/lib/core/src/client/preview/url.ts
+++ b/lib/core/src/client/preview/url.ts
@@ -19,14 +19,15 @@ export const setPath = (selection?: StoreSelection) => {
   }
 
   const { storyId, viewMode }: { storyId: StoryId; viewMode: ViewMode } = selection;
-  const { path, selectedKind, selectedStory, ...rest } = qs.parse(document.location.search, {
+  const { search, hash } = document.location;
+  const { path, selectedKind, selectedStory, ...rest } = qs.parse(search, {
     ignoreQueryPrefix: true,
   });
   const newPath = `${document.location.pathname}?${qs.stringify({
     ...rest,
     id: storyId,
     viewMode,
-  })}`;
+  })}${hash || ''}`;
   history.replaceState({}, '', newPath);
 };
 


### PR DESCRIPTION
Issue #13273

## What I did

Ensure we don't drop hashes when changing preview URLs (we don't use them)

## How to test

There's a test.

Also try browsing to say http://localhost:9011/iframe.html?id=addons-a11y-basebutton--delayed-render#hash in official-storybook.