### PR TITLE
React: Make @babel/core an optional peer dependency

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -67,6 +67,11 @@
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },
+  "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=8.0.0"
   },


### PR DESCRIPTION
It seems that `@babel/core` is only used in two locations in the `react` app:

```
storybook/app/react/src/server/framework-preset-react-docgen.ts:import type { TransformOptions } from '@babel/core';
storybook/app/react/src/server/framework-preset-react.ts:import { TransformOptions } from '@babel/core';
```

Both of those only import types from `@babel/core` (and only in the server files, which don't seem to be publicly exposed), making it at best an optional peer dep (I think you could remove it altogether, but I haven't investigated to that effect).

## What I did

Used `peerDependenciesMeta` to mark the peer dep as optional.

## How to test

n/a