### PR TITLE
Storyshots: Fix missing `done` attribute on type definition

### DIFF
--- a/addons/storyshots/storyshots-core/src/api/StoryshotsOptions.ts
+++ b/addons/storyshots/storyshots-core/src/api/StoryshotsOptions.ts
@@ -11,6 +11,7 @@ export interface TestMethodOptions {
   stories2snapsConverter: Stories2SnapsConverter;
   snapshotFileName: string;
   options: any;
+  done?: () => void;
 }
 
 export interface StoryshotsTestMethod {


### PR DESCRIPTION
Issue:

## What I did

Added missing type definition - https://github.com/storybookjs/storybook/blob/master/addons/storyshots/storyshots-core/src/api/snapshotsTestsTemplate.ts#L16

## How to test

N/A

