### PR TITLE
Addon-storyshots: Add React as peer dependency 

### DIFF
--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -68,6 +68,7 @@
     "jest-vue-preprocessor": "^1.5.0"
   },
   "peerDependencies": {
+    "@storybook/react": "*",
     "@storybook/vue": "*",
     "jest-preset-angular": "*",
     "jest-vue-preprocessor": "*",


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

Issue: yarn v2 uses plug-n-play which enforces packages declaring their dependencies. Without this change, I get
```
    @storybook/addon-storyshots tried to access @storybook/react, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

    Required package: @storybook/react (via "@storybook/react")
    Required by: @storybook/addon-storyshots@virtual:dbf6fb739a2cd0ef0bbac1487a859a8cf75e2fac4b91f1e5e09c94189b803fa7487df4ab9dcb9afa086207ede70464fa7661bd9c744b19bf7998fc8208244079#npm:6.1.1 (via /Users/bchinn/leapyear/leapyear-delta/.yarn/$$virtual/@storybook-addon-storyshots-virtual-203a42d9b0/0/cache/@storybook-addon-storyshots-npm-6.1.1-9c5555024d-13556baf4c.zip/node_modules/@storybook/addon-storyshots/dist/frameworks/react/)
```

Current workaround is to add the following to `.yarnrc.yml`:
```yaml
packageExtensions:
  '@storybook/addon-storyshots@*':
    peerDependencies:
      '@storybook/react': '*'
```

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
