### PR TITLE
Docs page, Update a link

### DIFF
--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -2,7 +2,7 @@
 title: 'DocsPage'
 ---
 
-When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/master/addons/docs/README.md), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
+When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/next/addons/docs/README.md), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
 
 The best practice for docs is for each component to have its own set of documentation and stories.
 


### PR DESCRIPTION
## Issue
In the first line in this page, there's a link to README.MD of docs addons. This link is currently pointing to: https://github.com/storybookjs/storybook/blob/master/addons/docs/README

While the updated link is:
https://github.com/storybookjs/storybook/blob/next/addons/docs/README.md

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
