### PR TITLE
UI: Fix display of custom brand image

### DIFF
--- a/lib/ui/src/components/sidebar/Brand.tsx
+++ b/lib/ui/src/components/sidebar/Brand.tsx
@@ -31,41 +31,28 @@ export const LogoLink = styled.a(({ theme }) => ({
   },
 }));
 
-export const Brand = withTheme(
-  ({
-    theme: {
-      brand: { title = 'Storybook', url = './', image },
-    },
-  }) => {
-    const targetValue = url === './' ? '' : '_blank';
-    if (image === undefined && url === null) {
-      return <StorybookLogoStyled alt={title} />;
-    }
-    if (image === undefined && url) {
-      return (
-        <LogoLink title={title} href={url} target={targetValue}>
-          <StorybookLogoStyled alt={title} />
-        </LogoLink>
-      );
-    }
-    if (image === null && url === null) {
-      return title;
-    }
-    if (image === null && url) {
-      return (
-        <LogoLink href={url} target={targetValue} dangerouslySetInnerHTML={{ __html: title }} />
-      );
-    }
-    if (image && url === null) {
-      return <Img src={image} alt={title} />;
-    }
-    if (image && url) {
-      return (
-        <LogoLink title={title} href={url} target={targetValue}>
-          <Img src={image} alt={title} />
-        </LogoLink>
-      );
-    }
-    return null;
+export const Brand = withTheme(({ theme }) => {
+  const { title = 'Storybook', url = './', image } = theme.brand;
+  const targetValue = url === './' ? '' : '_blank';
+
+  // When image is explicitly set to null, enable custom HTML support
+  if (image === null) {
+    if (title === null) return null;
+    // eslint-disable-next-line react/no-danger
+    if (!url) return <div dangerouslySetInnerHTML={{ __html: title }} />;
+    return <LogoLink href={url} target={targetValue} dangerouslySetInnerHTML={{ __html: title }} />;
   }
-);
+
+  const logo = image ? <Img src={image} alt={title} /> : <StorybookLogoStyled alt={title} />;
+
+  if (url) {
+    return (
+      <LogoLink title={title} href={url} target={targetValue}>
+        {logo}
+      </LogoLink>
+    );
+  }
+
+  // The wrapper div serves to prevent image misalignment
+  return <div>{logo}</div>;
+});

--- a/lib/ui/src/components/sidebar/Heading.stories.tsx
+++ b/lib/ui/src/components/sidebar/Heading.stories.tsx
@@ -131,3 +131,57 @@ export const customBrandImage = () => {
     </ThemeProvider>
   );
 };
+
+export const customBrandImageTall = () => {
+  const theme = useTheme() as Theme;
+  return (
+    <ThemeProvider
+      theme={{
+        ...theme,
+        brand: {
+          title: 'My Title',
+          url: 'https://example.com',
+          image: 'https://via.placeholder.com/100x150',
+        },
+      }}
+    >
+      <Heading menu={menuItems} />
+    </ThemeProvider>
+  );
+};
+
+export const customBrandImageUnsizedSVG = () => {
+  const theme = useTheme() as Theme;
+  return (
+    <ThemeProvider
+      theme={{
+        ...theme,
+        brand: {
+          title: 'My Title',
+          url: 'https://example.com',
+          image: 'https://s.cdpn.io/91525/potofgold.svg',
+        },
+      }}
+    >
+      <Heading menu={menuItems} />
+    </ThemeProvider>
+  );
+};
+
+export const noBrand = () => {
+  const theme = useTheme() as Theme;
+  return (
+    <ThemeProvider
+      theme={{
+        ...theme,
+        brand: {
+          title: null,
+          url: null,
+          image: null,
+        },
+      }}
+    >
+      <Heading menu={menuItems} />
+    </ThemeProvider>
+  );
+};

--- a/lib/ui/src/components/sidebar/Heading.tsx
+++ b/lib/ui/src/components/sidebar/Heading.tsx
@@ -13,7 +13,7 @@ const BrandArea = styled.div(({ theme }) => ({
   fontSize: theme.typography.size.s2,
   fontWeight: theme.typography.weight.bold,
   color: theme.color.defaultText,
-  marginRight: 40,
+  marginRight: 20,
   display: 'flex',
   width: '100%',
   alignItems: 'center',

--- a/lib/ui/src/components/sidebar/Heading.tsx
+++ b/lib/ui/src/components/sidebar/Heading.tsx
@@ -22,8 +22,8 @@ const BrandArea = styled.div(({ theme }) => ({
   '& > *': {
     maxWidth: '100%',
     height: 'auto',
-    width: 'auto',
     display: 'block',
+    flex: '1 1 auto',
   },
 }));
 


### PR DESCRIPTION
Issue: #13313

When supplying `theme.brandImage`, the image renders very small, effectively invisible:

![Screenshot of misrendered element](https://user-images.githubusercontent.com/486540/100801239-f3c0f000-33e4-11eb-9159-cf216e22ea23.png)

## What I did

The ([Brand](https://github.com/storybookjs/storybook/blob/next/lib/ui/src/components/sidebar/Heading.tsx#L45)) (which renders the selected element in the screenshot, above) is inside a flex container ([BrandArea](https://github.com/storybookjs/storybook/blob/next/lib/ui/src/components/sidebar/Heading.tsx#L17)), so I applied `flex: 1 1 auto` (and removed the now redundant `width: auto`) to BrandArea's immediate descendants to fill the available width. It was previously (implicitly) using the default of `flex: 0 1 auto`.

## How to test

- Is this testable with Jest or Chromatic screenshots? Not sure, probably
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
