### PR TITLE
CLI: Fix stories path in Introduction.stories.mdx

### DIFF
--- a/lib/cli/src/frameworks/common/Introduction.stories.mdx
+++ b/lib/cli/src/frameworks/common/Introduction.stories.mdx
@@ -120,7 +120,7 @@ Storybook helps you build UI components in isolation from your app's business lo
 That makes it easy to develop hard-to-reach states. Save these UI states as **stories** to revisit during development, testing, or QA.
 
 Browse example stories now by navigating to them in the sidebar.
-View their code in the `src/storybook-examples` directory to learn how they work.
+View their code in the `src/stories` directory to learn how they work.
 We recommend building UIs with a [**component-driven**](https://componentdriven.org) process starting with atomic components and ending with pages.
 
 <div className="subheading">Configure</div>
@@ -203,5 +203,5 @@ We recommend building UIs with a [**component-driven**](https://componentdriven.
 
 <div className="tip-wrapper">
   <span className="tip">Tip</span>Edit the Markdown in{' '}
-  <code>src/storybook-examples/welcome.mdx</code>
+  <code>src/stories/Introduction.stories.mdx</code>
 </div>


### PR DESCRIPTION
## What I did

The path where Storybook generates the boilerplate changed from `storybook-examples` to `stories` in https://github.com/storybookjs/storybook/blob/next/lib/cli/src/helpers.ts#L209-L214 but wasn't updated in the `Introduction.stories.mdx` (which also happens to correspond with the old `welcome.mdx` file that doesn't exist anymore).

With this change, we can prevent people from getting confused by not finding the `storybook-examples`
folder.

## How to test

- Is this testable with Jest or Chromatic screenshots? **No**
- Does this need a new example in the kitchen sink apps? **No**
- Does this need an update to the documentation? **No**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
