### PR TITLE
(docs): include in the what's a story documentation an Angular snippet

### DIFF
--- a/docs/get-started/whats-a-story.md
+++ b/docs/get-started/whats-a-story.md
@@ -17,6 +17,7 @@ Let’s start with the `Button` component. A story is a function that describes 
     'react/button-story.js.mdx',
     'react/button-story.ts.mdx',
     'react/button-story.mdx.mdx',
+    'angular/button-story.ts.mdx',
   ]}
 />
 


### PR DESCRIPTION
Issue: NA

## What I did

A minor PR in the docs. 
I re-used a snippet we already had which shows in the "[what's a story page](https://storybook.js.org/docs/angular/get-started/whats-a-story)" a button story

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
