### PR TITLE
Adjust addon titles and table of contents

### DIFF
--- a/docs/addons/addons-api.md
+++ b/docs/addons/addons-api.md
@@ -1,5 +1,5 @@
 ---
-title: 'Addons API'
+title: 'Addon API'
 ---
 
 ## Core Addon API

--- a/docs/addons/install-addons.md
+++ b/docs/addons/install-addons.md
@@ -1,5 +1,5 @@
 ---
-title: Install Storybook addons
+title: Install addons
 ---
 
 Storybook has [hundreds of reusable addons](/addons) that are packaged as NPM modules. Let's walk through how to extend Storybook by installing and registering addons.
@@ -34,18 +34,15 @@ Now when you run Storybook the accessibility testing addon will be enabled.
 
 ![Storybook addon installed and registered](./storybook-addon-installed-registered.png)
 
-
-### Using preset addons 
+### Using preset addons
 
 Storybook preset addons are grouped collections of specific `babel`,`webpack` and `addons` configurations for distinct use cases. Each one with it's own set of instructions. Preset addons have a three-step installation process: install, register and optionally configuration.
-
 
 For example, to use SCSS styling, run the following command to install the addon and the required dependencies:
 
 ```sh
 yarn add -D @storybook/preset-scss css-loader sass-loader style-loader
 ```
-
 
 Next, update [`.storybook/main.js`](../configure/overview.md#configure-story-rendering) to the following:
 
@@ -60,8 +57,6 @@ Next, update [`.storybook/main.js`](../configure/overview.md#configure-story-ren
 <!-- prettier-ignore-end -->
 
 Now when you run Storybook it will configure itself to use SCSS styling. No further configuration needed.
-
-
 
 #### Optional configuration
 

--- a/docs/addons/install-addons.md
+++ b/docs/addons/install-addons.md
@@ -27,7 +27,7 @@ Next, update [`.storybook/main.js`](../configure/overview.md#configure-story-ren
 <!-- prettier-ignore-end -->
 
 <div class="aside">
-Addons can also require additional addon-specific configuration found in their respective READMEs.
+Addons may also require addon-specific configuration. Read their respective READMEs.
 </div>
 
 Now when you run Storybook the accessibility testing addon will be enabled.
@@ -77,8 +77,8 @@ Consider the following example:
 
 <!-- prettier-ignore-end -->
 
-Now, when Storybook starts up, it will update webpack's CSS loader to use modules and adjust how styling is defined.
-
 <div class="aside">
-Each preset addon has its own options documented in their READMEs.
+Preset addons may also have addon-specific configuration. Read their respective READMEs.
 </div>
+
+Now, when Storybook starts up, it will update webpack's CSS loader to use modules and adjust how styling is defined.

--- a/docs/addons/introduction.md
+++ b/docs/addons/introduction.md
@@ -1,5 +1,5 @@
 ---
-title: 'Introduction to Storybook addons'
+title: 'Introduction to addons'
 ---
 
 Addons extend Storybook with features and integrations that are not built into the core. Most Storybook features are implemented as addons. For instance: [documentation](../writing-docs/introduction.md), [accessibility testing](https://github.com/storybookjs/storybook/tree/master/addons/a11y), [interactive controls](../essentials/controls.md), among others.
@@ -16,7 +16,7 @@ The **Manager** is the UI responsible for rendering the:
 - 🔍 Search
 - 🧭 Navigation
 - 🔗 Toolbars
-- 📦 Addons 
+- 📦 Addons
 
 The **Preview** area is an `iframe` where your stories are rendered.
 

--- a/docs/addons/introduction.md
+++ b/docs/addons/introduction.md
@@ -24,22 +24,18 @@ The **Preview** area is an `iframe` where your stories are rendered.
 
 Because both elements run in their own separate `iframes`, they use a communication channel to keep in synch. For example when you select a story in the Manager a event is dispatched across the channel notifying the Preview to render the story.
 
-### Anatomy of an addon
+## Anatomy of an addon
 
-Storybook addons allow you to extend what's already possible with Storybook, everything from the [interface](./addon-types.md) to the [API](./addons-api.md). Each one classified into two broader categories.
+Storybook addons allow you to extend what's already possible with Storybook, everything from the [user interface](./addon-types.md) to the [API](./addons-api.md). Each one classified into two broader categories.
 
-#### UI-based addons
+### UI-based addons
 
-This particular type of addons focuses mainly on the interface. Installing addons that fall into this category help you with your existing workflows. Good examples of this particular type are: [Controls](../essentials/controls.md), [Docs](../writing-docs/introduction.md) or the [Accessibility addon](https://github.com/storybookjs/storybook/tree/master/addons/a11y).
+[UI-based addons](./addon-types.md#ui-based-addons) focus on customizing Storybook's user interface to extend your development workflow. Examples of UI-based addons include: [Controls](../essentials/controls.md), [Docs](../writing-docs/introduction.md) and [Accessibility](https://github.com/storybookjs/storybook/tree/master/addons/a11y).
 
-<div class="aside">
-Read our <a href="./writing-addons">documentation</a> to learn more about creating addons.
-</div>
+[Learn how to write an addon »](./writing-addons)
 
-#### Preset addons
+### Preset addons
 
-This particular type of addons focuses on integrations. They are often used to integrate Storybook with other existing technologies. Good examples of this particular type are: [preset-scss](https://github.com/storybookjs/presets/tree/master/packages/preset-scss) and [preset-create-react-app](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app).
+[Preset addons](./addon-types.md#preset-addons) help you integrate Storybook with other technologies and libraries. Examples of preset addons are: [preset-scss](https://github.com/storybookjs/presets/tree/master/packages/preset-scss) and [preset-create-react-app](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app).
 
-<div class="aside">
-Read our <a href="./writing-presets">documentation</a> to learn more about preset addons.
-</div>
+[Learn how to write a preset addon »](./writing-presets)

--- a/docs/addons/writing-addons.md
+++ b/docs/addons/writing-addons.md
@@ -188,7 +188,7 @@ When Storybook was initialized it provided a small set of examples stories. Chan
 
 <!-- prettier-ignore-end -->
 
-After applying the changes to the story your Storybook UI will yield the following:
+After applying the changes to the story, the Storybook UI will show the following:
 
 <video autoPlay muted playsInline loop>
   <source

--- a/docs/addons/writing-addons.md
+++ b/docs/addons/writing-addons.md
@@ -1,5 +1,5 @@
 ---
-title: 'Write your own Storybook addon'
+title: 'Write an addon'
 ---
 
 One of Storybook's main features is its robust addon ecosystem. Use addons to enhance and extend your development workflow. This page shows you how to create your own addon.
@@ -16,19 +16,18 @@ For this example we're going to build a bare-bones addon which:
 
 We recommend a common addon file and directory structure for consistency.
 
-
-| Files/Directories | Description                       |
-|:------------------|:----------------------------------|
-| dist              | Transpiled directory for the addon|
-| src               | Source code for the addon         |
-| .babelrc.js       | Babel configuration               |
-| preset.js         | Addon entry point                 |
-| package.json      | Addon metadata information        |
-| README.md         | General information for the addon |
+| Files/Directories | Description                        |
+| :---------------- | :--------------------------------- |
+| dist              | Transpiled directory for the addon |
+| src               | Source code for the addon          |
+| .babelrc.js       | Babel configuration                |
+| preset.js         | Addon entry point                  |
+| package.json      | Addon metadata information         |
+| README.md         | General information for the addon  |
 
 ### Get started
 
-Open a new terminal and create a new directory called `my-addon`. Inside it run `npm init` to initialize a new node project. For your project's name choose `my-addon` and for entry point `dist/preset.js`. 
+Open a new terminal and create a new directory called `my-addon`. Inside it run `npm init` to initialize a new node project. For your project's name choose `my-addon` and for entry point `dist/preset.js`.
 
 Once you've gone through the prompts your `package.json` should look like:
 
@@ -38,15 +37,8 @@ Once you've gone through the prompts your `package.json` should look like:
   "version": "1.0.0",
   "description": "A barebones Storybook addon",
   "main": "dist/preset.js",
-  "files": [
-    "dist/**/*",
-    "README.md",
-    "*.js"
-  ],
-  "keywords": [
-    "storybook",
-    "addons"
-  ],
+  "files": ["dist/**/*", "README.md", "*.js"],
+  "keywords": ["storybook", "addons"],
   "author": "YourUsername",
   "license": "MIT"
 }
@@ -93,6 +85,7 @@ Change your `package.json` and add the following script to build the addon:
   }
 }
 ```
+
 <div class="aside">
 Running <code>yarn build</code> at this stage will output the code into the <code>dist</code> directory, transpiled into a ES5 module ready to be installed into any Storybook. 
 </div>
@@ -133,14 +126,13 @@ Now let’s add a panel to Storybook. Inside the `src` directory, create a new f
 
 <div class="aside">
 Make sure to include the <code>key</code> when you register the addon. This will prevent any issues when the addon renders.
-</div> 
+</div>
 
 Going over the code snippet in more detail. When Storybook starts up:
 
 1. It [registers](./addons-api.md#addonsregister) the addon
 2. [Adds](./addons-api.md#addonsadd) a new `panel` titled `My Addon` to the UI
 3. When selected, the `panel` renders the static `div` content
-
 
 ### Register the addon
 
@@ -164,7 +156,6 @@ Run `yarn storybook` and you should see something similar to:
 
 ![Storybook addon initial state](./addon-initial-state.png)
 
-
 ### Display story parameter
 
 Next, let’s replace the `MyPanel` component from above to show the parameter.
@@ -183,7 +174,6 @@ The new version is made smarter by [`useParameter`](./addons-api.md#useparameter
 
 The [addon API](./addons-api.md) provides hooks like this so all of that communication can happen behind the scenes. That means you can focus on your addon's functionality.
 
-
 ### Using the addon with a story
 
 When Storybook was initialized it provided a small set of examples stories. Change your `Button.stories.js` to the following:
@@ -197,7 +187,6 @@ When Storybook was initialized it provided a small set of examples stories. Chan
 />
 
 <!-- prettier-ignore-end -->
-
 
 After applying the changes to the story your Storybook UI will yield the following:
 
@@ -242,11 +231,10 @@ For example, check out [storybook-addon-outline](https://www.npmjs.com/package/s
 
 In the previous example, we introduced the structure of an addon, but barely scratched the surface of what addons can do.
 
-To dive deeper we recommend [Learn Storybook’s “creating addons”](https://www.learnstorybook.com/intro-to-storybook/react/en/creating-addons/) tutorial. It’s an excellent walkthrough that covers the same ground as the above introduction, but goes further and leads you through the full process of creating a realistic addon. 
+To dive deeper we recommend [Learn Storybook’s “creating addons”](https://www.learnstorybook.com/intro-to-storybook/react/en/creating-addons/) tutorial. It’s an excellent walkthrough that covers the same ground as the above introduction, but goes further and leads you through the full process of creating a realistic addon.
 
 [How to build a Storybook addon](https://www.chromatic.com/blog/how-to-build-a-storybook-addon/) shows you how to create a standalone addon in great detail.
 
 ### Dev kits
 
 To help you jumpstart the addon development, the Storybook maintainers created some [`dev-kits`](https://github.com/storybookjs/storybook/tree/next/dev-kits), use them as reference when building your next addon.
-

--- a/docs/addons/writing-presets.md
+++ b/docs/addons/writing-presets.md
@@ -1,5 +1,5 @@
 ---
-title: 'Write a Storybook preset addon'
+title: 'Write a preset addon'
 ---
 
 [Storybook preset addons](./addon-types.md#preset-addons) are grouped collections of `babel`, `webpack`, and `addons` configurations that support specific use cases in Storybook, such as typescript or MDX support.
@@ -202,6 +202,5 @@ and extract the configuration to a new file `./storybook/my-preset.js`:
 />
 
 <!-- prettier-ignore-end -->
-
 
 Place your `my-preset.js` file wherever you want, if you want to share it far and wide you'll want to make it its own package.

--- a/docs/toc.js
+++ b/docs/toc.js
@@ -322,32 +322,32 @@ module.exports = {
         },
         {
           pathSegment: 'install-addons',
-          title: 'Install addons',
+          title: 'Install',
           type: 'link',
         },
         {
           pathSegment: 'writing-addons',
-          title: 'Writing addons',
+          title: 'Write',
           type: 'link',
         },
         {
           pathSegment: 'writing-presets',
-          title: 'Writing preset addons',
+          title: 'Write a preset',
           type: 'link',
         },
         {
           pathSegment: 'addon-types',
-          title: 'Storybook addon types',
+          title: 'Types of addons',
           type: 'link',
         },
         {
           pathSegment: 'addon-knowledge-base',
-          title: 'Addons knowledge base',
+          title: 'Knowledge base',
           type: 'link',
         },
         {
           pathSegment: 'addons-api',
-          title: 'Addons API',
+          title: 'Addon API',
           type: 'link',
         },
       ],


### PR DESCRIPTION
Related PR: #13358 

@jonniebigodes can you check it out?

## What I did
- Removed repetition from table of contents for addons
- Removed repetition from addon doc titles

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No


