### PR TITLE
Add section for installing with React apps built without CRA

### DIFF
--- a/app/react/README.md
+++ b/app/react/README.md
@@ -27,6 +27,14 @@ Here are some featured storybooks that you can reference to see how Storybook wo
 - [Demo of React Dates](http://airbnb.io/react-dates/) - [source](https://github.com/airbnb/react-dates)
 - [Demo of React Native Web](https://necolas.github.io/react-native-web/docs/) - [source](https://github.com/necolas/react-native-web)
 
+## React Applications
+
+For React apps that are not built with Create React App, ReactDom is a required for Storybook to work with your project. Add it to your devDependencies if it is not a dependency in your project:
+
+```bash
+npm install react-dom --save-dev
+```
+
 ## Create React App
 
 Support for [Create React App](https://create-react-app.dev/) is handled by [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app).

--- a/app/react/README.md
+++ b/app/react/README.md
@@ -27,19 +27,13 @@ Here are some featured storybooks that you can reference to see how Storybook wo
 - [Demo of React Dates](http://airbnb.io/react-dates/) - [source](https://github.com/airbnb/react-dates)
 - [Demo of React Native Web](https://necolas.github.io/react-native-web/docs/) - [source](https://github.com/necolas/react-native-web)
 
-## React Applications
-
-For React apps that are not built with Create React App, ReactDom is a required for Storybook to work with your project. Add it to your devDependencies if it is not a dependency in your project:
-
-```bash
-npm install react-dom --save-dev
-```
-
 ## Create React App
 
 Support for [Create React App](https://create-react-app.dev/) is handled by [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app).
 
 This preset enables support for all Create React App features, including Sass/SCSS and TypeScript.
+
+If you're working on an app that was initialized manually (i.e., without the use of Create React App), ensure that your app has [react-dom](https://www.npmjs.com/package/react-dom) included as a dependency. Failing to do so can lead to unforeseen issues with Storybook and your project.
 
 ## Typescript
 


### PR DESCRIPTION
Issue: Playbook doesn't work in React projects without the ReactDom package listed as a dependency.

## What I did

In order to provide information on how to integrate the Playbook
module with a non-Create React App application I updated the 
React `README.md` document with the required steps.

It shouldn't be necessary to require `react-dom` as it isn't 
necessarily needed for a React project, but in most cases
will be used.

## How to test

This PR should not need to be tested, but the bug can be 
easily verified by spinning up a React project in webpack 
without ReactDom and then add Playbook to that project.

It will install but not run and throws errors about missing 
ReactDom from within the `playbook` project files.

## References
#9216 