### PR TITLE
Core: Fix `modulesCount` cache storage and retrieval

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -182,7 +182,7 @@ const useProgressReporting = async (
 
     if (value === 1) {
       if (options.cache) {
-        options.cache.set('modulesCount', totalModules);
+        options.cache.set('modulesCount', { modulesCount: totalModules });
       }
 
       if (!progress.message) {
@@ -192,7 +192,7 @@ const useProgressReporting = async (
     reportProgress(progress);
   };
 
-  const modulesCount = (await options.cache?.get('modulesCount')) || 1000;
+  const { modulesCount = 1000 } = (await options.cache?.get('modulesCount').catch(() => {})) || {};
   new ProgressPlugin({ handler, modulesCount }).apply(compiler);
 };
 


### PR DESCRIPTION
Issue: -

## What I did

Sometimes the disk cache can get corrupted leading to hard to debug errors. This fixes the `modulesCount` cache by ensuring we store a JSON object and by ignoring failed cache retrievals rather than throwing an error.

<img width="1122" alt="Screenshot 2020-12-11 at 11 15 35" src="https://user-images.githubusercontent.com/321738/101893724-68461c80-3ba5-11eb-9fb2-b2add232f1a4.png">

Arguably this is a problem in `file-system-cache`.

## How to test

Start Storybook, then empty (not remove) the files in `node_modules/.cache/storybook/dev-server`. Then start Storybook again. Previously this would throw an error. Should be fine now.

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
