### PR TITLE
Update react-popper-tooltip and @popperjs/core for react17

### DIFF
--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -35,7 +35,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
-    "@popperjs/core": "^2.4.4",
+    "@popperjs/core": "^2.5.4",
     "@storybook/client-logger": "6.2.0-alpha.5",
     "@storybook/csf": "0.0.1",
     "@storybook/theming": "6.2.0-alpha.5",
@@ -51,7 +51,7 @@
     "overlayscrollbars": "^1.10.2",
     "polished": "^3.4.4",
     "react-color": "^2.17.0",
-    "react-popper-tooltip": "^3.1.0",
+    "react-popper-tooltip": "^3.1.1",
     "react-syntax-highlighter": "^13.5.0",
     "react-textarea-autosize": "^8.1.1",
     "ts-dedent": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4005,7 +4005,7 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.4.4", "@popperjs/core@^2.5.4":
+"@popperjs/core@^2.5.4":
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
   integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
@@ -5232,13 +5232,6 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/util-deprecate/-/util-deprecate-1.0.0.tgz#341d0815fe5a661b94e3ea738d182b4c359e3958"
   integrity sha512-I2vixiQ+mrmKxfdLNvaa766nulrMVDoUQiSQoNeTjFUNAt8klnMgDh3yy/bH/r275357q30ACOEUaxFOR8YVrA==
-
-"@types/webpack-bundle-analyzer@^3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz#bf2f3fd7f1fe6a71dff8968afeb12785d1ce737b"
-  integrity sha512-O4Dsmml4T+emssdk3t6/N1vwtYRx1VfWCx0Oph4jRY62DZGNOL9IAS6mSX0XG1LdZuFSX0g42DXj1otQuPXRGQ==
-  dependencies:
-    "@types/webpack" "*"
 
 "@types/webpack-dev-middleware@^3.7.2":
   version "3.7.2"
@@ -27226,7 +27219,7 @@ react-popper-tooltip@^2.11.1:
     "@babel/runtime" "^7.9.2"
     react-popper "^1.3.7"
 
-react-popper-tooltip@^3.1.0:
+react-popper-tooltip@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz#329569eb7b287008f04fcbddb6370452ad3f9eac"
   integrity sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==


### PR DESCRIPTION
Issue:
My projects use `react@17`.

`yarn install`
`warning @storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.0" has incorrect peer dependency "react-dom@^16.6.0".`

## What I did
Update dependancies.

x-refs

- https://github.com/mohsinulhaq/react-popper-tooltip/pull/100
- https://github.com/popperjs/popper-core/releases

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
