### PR TITLE
Components: Cleanup circular dependencies

### DIFF
--- a/lib/components/src/Zoom/ZoomElement.tsx
+++ b/lib/components/src/Zoom/ZoomElement.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { styled } from '@storybook/theming';
-import { browserSupportsCssZoom } from './Zoom';
+import { browserSupportsCssZoom } from './browserSupportsCssZoom';
 
 const ZoomElementWrapper = styled.div<{ scale: number; height: number }>(({ scale = 1, height }) =>
   browserSupportsCssZoom()

--- a/lib/components/src/Zoom/ZoomIFrame.tsx
+++ b/lib/components/src/Zoom/ZoomIFrame.tsx
@@ -1,5 +1,5 @@
 import { Component, ReactElement } from 'react';
-import { browserSupportsCssZoom } from './Zoom';
+import { browserSupportsCssZoom } from './browserSupportsCssZoom';
 
 export type IZoomIFrameProps = {
   scale: number;

--- a/lib/components/src/Zoom/browserSupportsCssZoom.ts
+++ b/lib/components/src/Zoom/browserSupportsCssZoom.ts
@@ -1,0 +1,9 @@
+import window from 'global';
+
+export function browserSupportsCssZoom(): boolean {
+  try {
+    return window.document.implementation.createHTMLDocument('').body.style.zoom !== undefined;
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
Issue: #13437

## What I did

Removed circular dependencies by moving `browserSupportsCssZoom` out of **ZoomElement.tsx** and **ZoomIFrame.tsx** 

## How to test
Run `npx madge --circular --extensions ts lib/components` and see no more circular dependencies.
