### PR TITLE
Misc: clean dependencies in apps and addons

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -52,6 +52,8 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "lodash": "^4.17.15",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-sizeme": "^2.5.2",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0",
@@ -60,18 +62,6 @@
   "devDependencies": {
     "@testing-library/react": "^10.0.4",
     "@types/webpack-env": "^1.15.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -47,6 +47,8 @@
     "lodash": "^4.17.15",
     "polished": "^3.4.4",
     "prop-types": "^15.7.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-inspector": "^5.0.1",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0",
@@ -56,18 +58,6 @@
   "devDependencies": {
     "@types/lodash": "^4.14.150",
     "@types/webpack-env": "^1.15.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -48,24 +48,14 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.15.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/controls/package.json
+++ b/addons/controls/package.json
@@ -37,19 +37,9 @@
     "@storybook/node-logger": "6.2.0-alpha.6",
     "@storybook/theming": "6.2.0-alpha.6",
     "core-js": "^3.0.1",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "ts-dedent": "^2.0.0"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -46,22 +46,12 @@
     "@storybook/theming": "6.2.0-alpha.6",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.15.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/design-assets/package.json
+++ b/addons/design-assets/package.json
@@ -49,21 +49,11 @@
     "@storybook/theming": "6.2.0-alpha.6",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0",
     "use-image": "^1.0.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -80,6 +80,8 @@
     "lodash": "^4.17.15",
     "prettier": "~2.0.5",
     "prop-types": "^15.7.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-element-to-jsx-string": "^14.3.1",
     "regenerator-runtime": "^0.13.7",
     "remark-external-links": "^6.0.0",
@@ -125,20 +127,12 @@
     "@babel/core": "^7.11.5",
     "@storybook/vue": "6.2.0-alpha.6",
     "babel-loader": "^8.0.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0",
     "sveltedoc-parser": "^3.0.4",
     "vue": "^2.6.10",
     "webpack": ">=4"
   },
   "peerDependenciesMeta": {
     "@storybook/vue": {
-      "optional": true
-    },
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
       "optional": true
     },
     "sveltedoc-parser": {

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -45,6 +45,8 @@
     "@storybook/api": "6.2.0-alpha.6",
     "@storybook/node-logger": "6.2.0-alpha.6",
     "core-js": "^3.0.1",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0"
   },
@@ -58,18 +60,10 @@
     "@babel/core": "^7.9.6",
     "@storybook/vue": "6.2.0-alpha.6",
     "babel-loader": "^8.0.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0",
     "webpack": ">=4"
   },
   "peerDependenciesMeta": {
     "@storybook/vue": {
-      "optional": true
-    },
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
       "optional": true
     },
     "webpack": {

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -47,24 +47,14 @@
     "format-json": "^1.0.3",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-lifecycles-compat": "^3.0.4",
     "react-textarea-autosize": "^8.1.1",
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.15.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/google-analytics/package.json
+++ b/addons/google-analytics/package.json
@@ -24,20 +24,10 @@
     "@storybook/core-events": "6.2.0-alpha.6",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-ga": "^2.5.7",
     "regenerator-runtime": "^0.13.7"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -47,20 +47,10 @@
     "graphiql": "^0.17.5",
     "graphql": "^15.0.0",
     "prop-types": "^15.7.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7",
     "webpack": "^4.44.2"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/jest/package.json
+++ b/addons/jest/package.json
@@ -49,24 +49,14 @@
     "@storybook/theming": "6.2.0-alpha.6",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-sizeme": "^2.5.2",
     "regenerator-runtime": "^0.13.7",
     "upath": "^1.1.0"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.15.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -51,7 +51,9 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "qs": "^6.6.0",
+    "react": "16.13.1",
     "react-color": "^2.17.0",
+    "react-dom": "16.13.1",
     "react-lifecycles-compat": "^3.0.4",
     "react-select": "^3.0.8",
     "regenerator-runtime": "^0.13.7"
@@ -64,18 +66,6 @@
     "@types/react-select": "^3.0.12",
     "@types/webpack-env": "^1.15.3",
     "enzyme": "^3.11.0"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -46,23 +46,13 @@
     "global": "^4.3.2",
     "prop-types": "^15.7.2",
     "qs": "^6.6.0",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.15.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/queryparams/package.json
+++ b/addons/queryparams/package.json
@@ -46,23 +46,13 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2",
     "qs": "^6.6.0",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.15.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -52,6 +52,8 @@
     "global": "^4.3.2",
     "jest-specific-snapshot": "^4.0.0",
     "pretty-format": "^26.4.0",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-test-renderer": "^16.8.0 || ^17.0.0",
     "read-pkg-up": "^7.0.0",
     "regenerator-runtime": "^0.13.7",
@@ -72,8 +74,6 @@
     "@storybook/vue": "*",
     "jest-preset-angular": "*",
     "jest-vue-preprocessor": "*",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0",
     "vue": "*"
   },
   "peerDependenciesMeta": {
@@ -84,12 +84,6 @@
       "optional": true
     },
     "jest-vue-preprocessor": {
-      "optional": true
-    },
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
       "optional": true
     },
     "vue": {

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -48,24 +48,14 @@
     "loader-utils": "^2.0.0",
     "prettier": "~2.0.5",
     "prop-types": "^15.7.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-syntax-highlighter": "^13.5.0",
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
     "@types/react": "^16.9.27",
     "@types/react-syntax-highlighter": "^11.0.4"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/addons/toolbars/package.json
+++ b/addons/toolbars/package.json
@@ -34,19 +34,9 @@
     "@storybook/api": "6.2.0-alpha.6",
     "@storybook/client-api": "6.2.0-alpha.6",
     "@storybook/components": "6.2.0-alpha.6",
-    "core-js": "^3.0.1"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
+    "core-js": "^3.0.1",
+    "react": "16.13.1",
+    "react-dom": "16.13.1"
   },
   "publishConfig": {
     "access": "public"

--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -46,19 +46,9 @@
     "global": "^4.3.2",
     "memoizerific": "^1.11.3",
     "prop-types": "^15.7.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7"
-  },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "react-dom": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -74,7 +74,10 @@
     "@types/jest": "^25.1.1",
     "jest": "^26.0.0",
     "jest-preset-angular": "^8.3.2",
-    "ts-jest": "^26.4.4"
+    "rxjs": "^6.6.3",
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.1.2",
+    "zone.js": "^0.11.3"
   },
   "peerDependencies": {
     "@angular-devkit/build-angular": ">=0.8.9",
@@ -86,7 +89,6 @@
     "@angular/forms": ">=6.0.0",
     "@angular/platform-browser": ">=6.0.0",
     "@angular/platform-browser-dynamic": ">=6.0.0",
-    "@babel/core": "*",
     "rxjs": "^6.0.0",
     "typescript": "^3.4.0 || >=4.0.0",
     "zone.js": "^0.8.29 || ^0.9.0 || ^0.10.0 || ^0.11.0"

--- a/app/aurelia/package.json
+++ b/app/aurelia/package.json
@@ -31,10 +31,12 @@
     "@storybook/addons": "6.2.0-alpha.6",
     "@storybook/core": "6.2.0-alpha.6",
     "@storybook/node-logger": "6.2.0-alpha.6",
+    "core-js": "^3.0.1",
     "fork-ts-checker-webpack-plugin": "^4.0.3",
     "global": "^4.3.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "regenerator-runtime": "^0.13.7",
     "ts-loader": "^6.0.1",
     "url-loader": "^4.1.0",
     "webpack": "^4.44.2"
@@ -55,7 +57,8 @@
     "webpack": "^4.44.2"
   },
   "peerDependencies": {
-    "aurelia": "*"
+    "aurelia": "*",
+    "typescript": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/app/ember/package.json
+++ b/app/ember/package.json
@@ -48,7 +48,6 @@
     "ts-dedent": "^2.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "babel-plugin-ember-modules-api-polyfill": "^2.12.0",
     "babel-plugin-htmlbars-inline-precompile": "2 || 3",
     "ember-source": "^3.16.0"

--- a/app/html/package.json
+++ b/app/html/package.json
@@ -53,9 +53,6 @@
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0"
   },
-  "peerDependencies": {
-    "@babel/core": "*"
-  },
   "engines": {
     "node": ">=8.0.0"
   },

--- a/app/marionette/package.json
+++ b/app/marionette/package.json
@@ -29,16 +29,16 @@
     "common-tags": "^1.8.0",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
-    "html-loader": "^1.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
-    "backbone.marionette": "*"
+    "backbone": "^1.4.0",
+    "backbone.marionette": "^4.1.3",
+    "underscore": "^1.12.0"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "backbone": "*",
     "backbone.marionette": "*",
     "underscore": "*"

--- a/app/marko/package.json
+++ b/app/marko/package.json
@@ -51,7 +51,6 @@
     "ts-dedent": "^2.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "marko": "^4.15.2 || ^5.0.0-next || ^5",
     "webpack": "^4.44.2"
   },

--- a/app/mithril/package.json
+++ b/app/mithril/package.json
@@ -41,10 +41,10 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
-    "@babel/core": "^7.12.3",
     "@babel/plugin-transform-react-jsx": "^7.12.1",
     "@storybook/addons": "6.2.0-alpha.6",
     "@storybook/core": "6.2.0-alpha.6",
+    "@types/babel__core": "^7.1.12",
     "@types/mithril": "^2.0.0",
     "@types/webpack-env": "^1.15.3",
     "core-js": "^3.0.1",
@@ -58,7 +58,6 @@
     "mithril": "^1.1.6"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "mithril": "^1.1.6 || ^2.0.0"
   },
   "engines": {

--- a/app/mithril/src/server/framework-preset-mithril.ts
+++ b/app/mithril/src/server/framework-preset-mithril.ts
@@ -1,4 +1,4 @@
-import { TransformOptions } from '@babel/core';
+import type { TransformOptions } from '@babel/core';
 
 export function babelDefault(config: TransformOptions) {
   return {

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -44,6 +44,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.1",
     "@storybook/addons": "6.2.0-alpha.6",
     "@storybook/core": "6.2.0-alpha.6",
+    "@types/babel__core": "^7.1.12",
     "@types/webpack-env": "^1.15.3",
     "core-js": "^3.0.1",
     "global": "^4.3.2",
@@ -56,7 +57,6 @@
     "preact": "^10.4.0"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "preact": "^8.0.0||^10.0.0"
   },
   "engines": {

--- a/app/preact/src/server/framework-preset-preact.ts
+++ b/app/preact/src/server/framework-preset-preact.ts
@@ -1,4 +1,4 @@
-import { TransformOptions } from '@babel/core';
+import type { TransformOptions } from '@babel/core';
 
 export function babelDefault(config: TransformOptions) {
   return {

--- a/app/rax/package.json
+++ b/app/rax/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@storybook/core": "6.2.0-alpha.6",
+    "@types/babel__core": "^7.1.12",
     "babel-preset-rax": "^1.0.0-beta.0",
     "core-js": "^3.0.1",
     "driver-dom": "^2.0.0",
@@ -55,7 +56,6 @@
     "rax": "^1.1.0"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "rax": "^0.4.0 || ^1.0.0"
   },
   "publishConfig": {

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -52,6 +52,7 @@
     "@storybook/core": "6.2.0-alpha.6",
     "@storybook/node-logger": "6.2.0-alpha.6",
     "@storybook/semver": "^7.3.2",
+    "@types/babel__core": "^7.1.12",
     "@types/webpack-env": "^1.15.3",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-named-asset-import": "^0.3.1",
@@ -68,20 +69,18 @@
     "webpack": "^4.44.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.12.9",
     "@storybook/client-api": "6.2.0-alpha.6",
     "@types/node": "^14.0.10",
     "@types/prompts": "^2.0.0",
-    "@types/webpack": "^4.41.24"
+    "@types/webpack": "^4.41.24",
+    "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "@babel/core": "^7.11.5",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
-    "@babel/core": {
-      "optional": true
-    },
     "typescript": {
       "optional": true
     }

--- a/app/react/src/server/framework-preset-react.ts
+++ b/app/react/src/server/framework-preset-react.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { TransformOptions } from '@babel/core';
+import type { TransformOptions } from '@babel/core';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import type { Configuration } from 'webpack';
 

--- a/app/riot/package.json
+++ b/app/riot/package.json
@@ -51,13 +51,12 @@
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.12.1",
-    "@babel/preset-env": "^7.12.1",
-    "@babel/preset-flow": "^7.12.1",
-    "@babel/preset-react": "^7.12.1"
+    "riot": "^3.13.2",
+    "riot-compiler": "^3.6.0",
+    "riot-hot-reload": "^1.0.0",
+    "riot-tag-loader": "^2.1.0"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "riot": "^3.0.0 || ^4.0.0",
     "riot-compiler": "^3.5.1 || ^4.0.0",
     "riot-hot-reload": "^1.0.0",

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -57,7 +57,6 @@
     "svelte-loader": "^2.13.4"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "svelte": "^3.1.0",
     "svelte-loader": "^2.9.1"
   },

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -58,12 +58,12 @@
   "devDependencies": {
     "@types/node": "^14.0.10",
     "@types/webpack": "^4.41.24",
+    "css-loader": "^3.6.0",
     "vue": "^2.6.8",
     "vue-loader": "^15.7.0",
     "vue-template-compiler": "^2.6.8"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "babel-loader": "^7.0.0 || ^8.0.0",
     "css-loader": "*",
     "ts-loader": "^6.2.2",

--- a/app/web-components/src/client/preview/types.ts
+++ b/app/web-components/src/client/preview/types.ts
@@ -1,7 +1,6 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { TemplateResult, SVGTemplateResult } from 'lit-element';
+import type { TemplateResult, SVGTemplateResult } from 'lit-html';
 
-export { RenderContext } from '@storybook/core';
+export type { RenderContext } from '@storybook/core';
 
 export type StoryFnHtmlReturnType = string | Node | TemplateResult | SVGTemplateResult;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,27 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.12.9":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.10.tgz#b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd"
+  integrity sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.10"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.5"
+    "@babel/parser" "^7.12.10"
+    "@babel/template" "^7.12.7"
+    "@babel/traverse" "^7.12.10"
+    "@babel/types" "^7.12.10"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.1.tgz#0d70be32bdaa03d7c51c8597dda76e0df1f15468"
@@ -620,6 +641,15 @@
   integrity sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
   dependencies:
     "@babel/types" "^7.12.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.10.tgz#2b188fc329fb8e4f762181703beffc0fe6df3460"
+  integrity sha512-6mCdfhWgmqLdtTkhXjnIz0LcdVCd26wS2JXRtj2XY0u5klDsXBREA/pG5NVOuVnF2LUrBGNFtQkIqqTbblg0ww==
+  dependencies:
+    "@babel/types" "^7.12.10"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -860,6 +890,11 @@
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
   integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
+
+"@babel/parser@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.10.tgz#824600d59e96aea26a5a2af5a9d812af05c3ae81"
+  integrity sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.12.1", "@babel/plugin-proposal-async-generator-functions@^7.2.0", "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.12.1"
@@ -2014,10 +2049,34 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.10.tgz#2d1f4041e8bf42ea099e5b2dc48d6a594c00017a"
+  integrity sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.10"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.10"
+    "@babel/types" "^7.12.10"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.3.4", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.0", "@babel/types@^7.5.5", "@babel/types@^7.6.0", "@babel/types@^7.6.1", "@babel/types@^7.6.3", "@babel/types@^7.7.0", "@babel/types@^7.7.2", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.6":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13"
   integrity sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.10.tgz#7965e4a7260b26f09c56bcfcb0498af1f6d9b260"
+  integrity sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -4406,7 +4465,7 @@
     "@types/browserslist" "*"
     postcss "7.x.x"
 
-"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.0", "@types/babel__core@^7.1.7":
+"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.0", "@types/babel__core@^7.1.12", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
   integrity sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==
@@ -8386,7 +8445,7 @@ babylon@^6.18.0:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
-backbone.marionette@*:
+backbone.marionette@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/backbone.marionette/-/backbone.marionette-4.1.3.tgz#4b8646a880acc82941d65e4794b01fa24ba106c6"
   integrity sha512-8alY/p90UCMzOetMzVUl7+Y7riQktbKa44FKoehlToBUOzfTJqeDIJ62QxddE/H0zIvG9Iw2mMqRvqxvYRwOog==
@@ -8398,7 +8457,7 @@ backbone.radio@^2.0.0:
   resolved "https://registry.yarnpkg.com/backbone.radio/-/backbone.radio-2.0.0.tgz#bbe8672b373e313f99f36d2fbcf583fe77d04f42"
   integrity sha1-u+hnKzc+MT+Z820vvPWD/nfQT0I=
 
-backbone@^1.1.2:
+backbone@^1.1.2, backbone@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
   integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
@@ -11662,7 +11721,7 @@ css-loader@4.3.0:
     schema-utils "^2.7.1"
     semver "^7.3.2"
 
-css-loader@^3.0.0, css-loader@^3.4.2, css-loader@^3.5.3:
+css-loader@^3.0.0, css-loader@^3.4.2, css-loader@^3.5.3, css-loader@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.6.0.tgz#2e4b2c7e6e2d27f8c8f28f61bffcd2e6c91ef645"
   integrity sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==
@@ -28774,7 +28833,7 @@ riot-cli@^4.0.2:
     riot-compiler "^3.5.1"
     rollup "^0.57.1"
 
-riot-compiler@^3.5.1, riot-compiler@^3.5.2:
+riot-compiler@^3.5.1, riot-compiler@^3.5.2, riot-compiler@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/riot-compiler/-/riot-compiler-3.6.0.tgz#f65428cf25b940098e35ea9c8357ca91cae10280"
   integrity sha512-P2MVj0T9ox0EFPTSSHJIAaBe6/fCnKln76BtPK6ezAlBW2+qKCDzzvkj3gwFvGEG1dYUHa2jQ/O6+FZNNe8CYw==
@@ -28815,7 +28874,7 @@ riot-tmpl@^3.0.8:
   dependencies:
     eslint-config-riot "^1.0.0"
 
-riot@^3.13.0, riot@^3.3.1:
+riot@^3.13.0, riot@^3.13.2, riot@^3.3.1:
   version "3.13.2"
   resolved "https://registry.yarnpkg.com/riot/-/riot-3.13.2.tgz#3f5fb86b0d2b864bdcc959b7f86e2f4c2f696726"
   integrity sha512-L4WFJEhbTA0deDoZ1XxoVw7Tf96+xYc06aQ+4QM+IkYClD6mZ7E/9zN3Rd48uYMBvHQfHtbPvR0KEiu3pJyI2A==
@@ -32041,7 +32100,7 @@ typescript@4.0.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
-typescript@^3.2.4, typescript@^3.8.3, typescript@^3.9.3:
+typescript@^3.2.4, typescript@^3.8.3, typescript@^3.9.3, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
@@ -32050,6 +32109,11 @@ typescript@^4.0.3, typescript@^4.0.5, typescript@^4.1.0-dev.20200804:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+
+typescript@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 ua-parser-js@^0.7.18:
   version "0.7.22"
@@ -32135,7 +32199,7 @@ underscore.string@^3.2.2, underscore.string@~3.3.4:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
-underscore@>=1.8.3:
+underscore@>=1.8.3, underscore@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.0.tgz#4814940551fc80587cef7840d1ebb0f16453be97"
   integrity sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ==


### PR DESCRIPTION
Issue: #13194 
Plus, follow up on my comment from #13329

## What I did

 - Clean regular/dev/peer dependencies for every apps
 - Move `react` and `react-dom` to a regular dependency, one more time! For details, see https://github.com/storybookjs/storybook/issues/13194

![One More Time](https://media.giphy.com/media/54ZSJMeNkaNsA/giphy.gif)

## How to test

- CI should be 🟢  + E2E extended test suite
- There should be no `unmeet peer dependency` warnings in e2e jobs (threw for storybook packages)