### PR TITLE
Grammar corrections

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -161,7 +161,7 @@ Please also file an issue if you need to opt out. We plan to remove the legacy r
 
 In 6.1 we introduced an unintentional breaking change to `addon-backgrounds`.
 
-The addon uses decorators which are set up automatically by a preset. The required preset is ignored if you register the addon in `main.js` withe the the `/register` entry point. This used to be valid in `v6.0.x` and earlier:
+The addon uses decorators which are set up automatically by a preset. The required preset is ignored if you register the addon in `main.js` with the `/register` entry point. This used to be valid in `v6.0.x` and earlier:
 ```js
 module.exports = {
   stories: ['../**/*.stories.js'],


### PR DESCRIPTION
withe the the => with the

Issue:
Documentation typo

## What I did
Corrected the typo (withe the the => with the)

## How to test
Not needed, simply updated documentation
