### PR TITLE
Update MIGRATION.md

### DIFF
--- a/.ci/danger/dangerfile.ts
+++ b/.ci/danger/dangerfile.ts
@@ -1,7 +1,7 @@
 import { fail, danger } from 'danger';
 import { execSync } from 'child_process';
 
-execSync('npm install lodash');
+execSync('yarn install lodash');
 
 const flatten = require('lodash/flatten');
 const intersection = require('lodash/intersection');

--- a/.ci/danger/dangerfile.ts
+++ b/.ci/danger/dangerfile.ts
@@ -1,7 +1,7 @@
 import { fail, danger } from 'danger';
 import { execSync } from 'child_process';
 
-execSync('yarn install lodash');
+execSync('yarn add lodash');
 
 const flatten = require('lodash/flatten');
 const intersection = require('lodash/intersection');

--- a/.ci/danger/dangerfile.ts
+++ b/.ci/danger/dangerfile.ts
@@ -1,7 +1,7 @@
 import { fail, danger } from 'danger';
 import { execSync } from 'child_process';
 
-execSync('yarn add lodash');
+execSync('yarn add lodash -W');
 
 const flatten = require('lodash/flatten');
 const intersection = require('lodash/intersection');

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -220,7 +220,7 @@ Earlier versions of Storybook used Webpack DLLs as a performance crutch. In 6.1,
 
 #### Deprecated storyFn
 
-Each item in the story store contains a field called `storyFn`, which is a fully decorated story that's applied to the denormalized story parameters. Starting in 6.0 we've stopped using this API internally, and have replaced it with a new field called `unboundStoryFn` which, unlike `storyFn`, must passed a story context, typically produced by `applyLoaders`;
+Each item in the story store contains a field called `storyFn`, which is a fully decorated story that's applied to the denormalized story parameters. Starting in 6.0 we've stopped using this API internally, and have replaced it with a new field called `unboundStoryFn` which, unlike `storyFn`, must be passed a story context, typically produced by `applyLoaders`;
 
 Before:
 


### PR DESCRIPTION
Fixes the grammatical error. It should be "must be passed a story context" as opposed to "must passed a story context".