### PR TITLE
Perf: Bundle only required syntax highlighter languages

### DIFF
--- a/addons/docs/blocks.d.ts
+++ b/addons/docs/blocks.d.ts
@@ -1,2 +1,2 @@
 export { ColorPalette, ColorItem, IconGallery, IconItem, Typeset } from '@storybook/components';
-export * from './dist/blocks/index.d';
+export * from './dist/ts3.9/blocks/index.d';

--- a/addons/storysource/src/StoryPanel.tsx
+++ b/addons/storysource/src/StoryPanel.tsx
@@ -8,7 +8,7 @@ import {
   SyntaxHighlighterRendererProps,
 } from '@storybook/components';
 
-// @ts-ignore
+// @ts-expect-error Typedefs don't currently expose `createElement` even though it exists
 import { createElement as createSyntaxHighlighterElement } from 'react-syntax-highlighter';
 
 import { SourceBlock, LocationsMap } from '@storybook/source-loader';

--- a/addons/storysource/src/StoryPanel.tsx
+++ b/addons/storysource/src/StoryPanel.tsx
@@ -6,8 +6,10 @@ import {
   SyntaxHighlighter,
   SyntaxHighlighterProps,
   SyntaxHighlighterRendererProps,
-  createSyntaxHighlighterElement,
 } from '@storybook/components';
+
+// @ts-ignore
+import { createElement as createSyntaxHighlighterElement } from 'react-syntax-highlighter';
 
 import { SourceBlock, LocationsMap } from '@storybook/source-loader';
 

--- a/lib/components/src/index.ts
+++ b/lib/components/src/index.ts
@@ -10,7 +10,6 @@ export type {
   SyntaxHighlighterProps,
   SyntaxHighlighterRendererProps,
 } from './syntaxhighlighter/syntaxhighlighter-types';
-export { createSyntaxHighlighterElement } from './syntaxhighlighter/syntaxhighlighter-types';
 export { SyntaxHighlighter } from './syntaxhighlighter/lazy-syntaxhighlighter';
 
 // UI

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter-types.ts
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter-types.ts
@@ -1,8 +1,5 @@
 import React from 'react';
 
-// @ts-ignore
-export { createElement as createSyntaxHighlighterElement } from 'react-syntax-highlighter';
-
 export interface SyntaxHighlighterRendererProps {
   rows: any[];
   stylesheet: string;

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -5,30 +5,31 @@ import { navigator, window } from 'global';
 import memoize from 'memoizerific';
 
 // @ts-ignore
-import jsx from 'react-syntax-highlighter/dist/cjs/languages/prism/jsx';
+import jsx from 'react-syntax-highlighter/dist/esm/languages/prism/jsx';
 // @ts-ignore
-import bash from 'react-syntax-highlighter/dist/cjs/languages/prism/bash';
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
 // @ts-ignore
-import css from 'react-syntax-highlighter/dist/cjs/languages/prism/css';
+import css from 'react-syntax-highlighter/dist/esm/languages/prism/css';
 // @ts-ignore
-import jsExtras from 'react-syntax-highlighter/dist/cjs/languages/prism/js-extras';
+import jsExtras from 'react-syntax-highlighter/dist/esm/languages/prism/js-extras';
 // @ts-ignore
-import json from 'react-syntax-highlighter/dist/cjs/languages/prism/json';
+import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
 // @ts-ignore
-import graphql from 'react-syntax-highlighter/dist/cjs/languages/prism/graphql';
+import graphql from 'react-syntax-highlighter/dist/esm/languages/prism/graphql';
 // @ts-ignore
-import html from 'react-syntax-highlighter/dist/cjs/languages/prism/markup';
+import html from 'react-syntax-highlighter/dist/esm/languages/prism/markup';
 // @ts-ignore
-import md from 'react-syntax-highlighter/dist/cjs/languages/prism/markdown';
+import md from 'react-syntax-highlighter/dist/esm/languages/prism/markdown';
 // @ts-ignore
-import yml from 'react-syntax-highlighter/dist/cjs/languages/prism/yaml';
+import yml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml';
 // @ts-ignore
-import tsx from 'react-syntax-highlighter/dist/cjs/languages/prism/tsx';
+import tsx from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
 // @ts-ignore
-import typescript from 'react-syntax-highlighter/dist/cjs/languages/prism/typescript';
+import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
 
 // @ts-ignore
-import ReactSyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/prism-light';
+import ReactSyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
+
 import { ActionBar } from '../ActionBar/ActionBar';
 import { ScrollArea } from '../ScrollArea/ScrollArea';
 


### PR DESCRIPTION
Issue: -

## What I did

Avoid bundling all supported syntax highlighter languages for addon-docs, but rather just the ones we need. This shaves off close to 2 MB from the preview vendor bundle.

This telescopes off `add/analyser-addon` because it uses the addon to calculate bundle sizes.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
