### PR TITLE
Core: Use fs-extra emptyDir so build works on docker volume

### DIFF
--- a/lib/core/src/server/build-static.ts
+++ b/lib/core/src/server/build-static.ts
@@ -180,7 +180,7 @@ export async function buildStaticStandalone(options: any) {
 
   logger.info(chalk`=> Cleaning outputDir: {cyan ${outputDir}}`);
   if (outputDir === '/') throw new Error("Won't remove directory '/'. Check your outputDir!");
-  await fs.remove(outputDir);
+  await fs.emptyDir(outputDir);
 
   await cpy(defaultFavIcon, outputDir);
   await copyAllStaticFiles(staticDir, outputDir);


### PR DESCRIPTION
Issue:
When using a docker volume as an output directory, the build process fails with the following error:

```
[2020-12-17T18:59:46Z] info @storybook/react v6.1.11
--
  | [2020-12-17T18:59:46Z] info
  | [2020-12-17T18:59:46Z] info => Cleaning outputDir /js-tests/rp-storybook-upgrade-test
  | [2020-12-17T18:59:46Z] ERR! Error: EBUSY: resource busy or locked, rmdir '/js-tests/rp-storybook-upgrade-test'
  | [2020-12-17T18:59:46Z] ERR!  [Error: EBUSY: resource busy or locked, rmdir '/js-tests/rp-storybook-upgrade-test'] {
  | [2020-12-17T18:59:46Z] ERR!   stack: "Error: EBUSY: resource busy or locked, rmdir '/js-tests/rp-storybook-upgrade-test'",
  | [2020-12-17T18:59:46Z] ERR!   errno: -16,
  | [2020-12-17T18:59:46Z] ERR!   code: 'EBUSY',
  | [2020-12-17T18:59:46Z] ERR!   syscall: 'rmdir',
  | [2020-12-17T18:59:46Z] ERR!   path: '/js-tests/rp-storybook-upgrade-test'
  | [2020-12-17T18:59:46Z] ERR! }

```

## What I did
I updated the directory removal to use `fs-extra`'s `.emptyDir` instead of `.remove` which empties a folder instead of removing it.

I believe this should be considered for a 6.1.x patch since this bug breaks CI for 6.1.x if that outputDir is a docker volume.

Related issue: https://github.com/storybookjs/storybook/issues/13168

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
