### PR TITLE
Addon-docs: Tighten preset webpack pattern for mdx stories

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -97,7 +97,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
           ],
         },
         {
-          test: /\.(stories|story).mdx$/,
+          test: /\.(stories|story)\.mdx$/,
           use: [
             {
               loader: require.resolve('babel-loader'),
@@ -114,7 +114,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
         },
         {
           test: /\.mdx$/,
-          exclude: /\.(stories|story).mdx$/,
+          exclude: /\.(stories|story)\.mdx$/,
           use: [
             {
               loader: require.resolve('babel-loader'),


### PR DESCRIPTION
Issue: Slightly incorrect regexp for mdx stories

## What I did

Escaped dot symbol in regexp
