### PR TITLE
docs: Update code snippets on Stories for multiple components

### DIFF
--- a/docs/snippets/react/list-story-template.ts.mdx
+++ b/docs/snippets/react/list-story-template.ts.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { List, ListProps } from './List';
-import { ListItem, ListItemProps} from './ListItem';
+import { ListItem, ListItemProps } from './ListItem';
 import { Unchecked } from './ListItem.stories';
 
 const ListTemplate = ({ items, ...args }) => (

--- a/docs/snippets/react/list-story-unchecked.ts.mdx
+++ b/docs/snippets/react/list-story-unchecked.ts.mdx
@@ -2,7 +2,7 @@
 // List.stories.tsx
 
 import React from 'react';
-import { List, ListProps} from './List';
+import { List, ListProps } from './List';
 // Instead of importing the ListItem, we import its stories
 import { Unchecked } from './ListItem.stories';
 

--- a/docs/snippets/react/list-story-with-unchecked-children.js.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.js.mdx
@@ -2,6 +2,8 @@
 // List.stories.js
 
 import React from 'react';
+import List from './List';
+import { Unchecked } from './ListItem.stories';
 
 const Template = (args) => <List {...args} />;
 

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -1,10 +1,14 @@
+```ts
 // List.stories.tsx
 
 import React from 'react';
 import { List } from './List';
 import { Unchecked } from './ListItem.stories';
 
+const Template = (args) => <List {...args} />;
+
 export const OneItem = Template.bind({});
 OneItem.args = {
   children: <Unchecked {...Unchecked.args} />,
 };
+```

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -5,7 +5,7 @@ import React from 'react';
 import { List } from './List';
 import { Unchecked } from './ListItem.stories';
 
-const Template = (args) => <List {...args} />;
+const Template: Story<ListProps> = (args) => <List {...args} />;
 
 export const OneItem = Template.bind({});
 OneItem.args = {

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -1,0 +1,10 @@
+// List.stories.tsx
+
+import React from 'react';
+import { List } from './List';
+import { Unchecked } from './ListItem.stories';
+
+export const OneItem = Template.bind({});
+OneItem.args = {
+  children: <Unchecked {...Unchecked.args} />,
+};

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -2,7 +2,7 @@
 // List.stories.tsx
 
 import React from 'react';
-import { List } from './List';
+import { List, ListProps } from './List';
 import { Unchecked } from './ListItem.stories';
 
 const Template: Story<ListProps> = (args) => <List {...args} />;

--- a/docs/workflows/stories-for-multiple-components.md
+++ b/docs/workflows/stories-for-multiple-components.md
@@ -55,6 +55,7 @@ One way we improve that situation is by pulling the rendered subcomponent out in
 <CodeSnippets
   paths={[
     'react/list-story-with-unchecked-children.js.mdx',
+    'react/list-story-with-unchecked-children.ts.mdx',
   ]}
 />
 


### PR DESCRIPTION
I just thought I'd contribute a bit to the docs: https://storybook.js.org/docs/react/workflows/stories-for-multiple-components

## What I did
- Add a TypeScript code snippet in the `Using children as an arg` section
- Add missing imports of the JavaSript code snippet in the `Using children as an arg` section
- Fix minor formatting issues in other code snippets

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
