### PR TITLE
Improve docs for loading fonts locally

### DIFF
--- a/docs/configure/images-and-assets.md
+++ b/docs/configure/images-and-assets.md
@@ -1,8 +1,8 @@
 ---
-title: 'Images and assets'
+title: 'Images, fonts, and assets'
 ---
 
-Components often rely on images, videos, and other assets to render as the user expects. There are many ways to use these assets in your story files.
+Components often rely on images, videos, fonts, and other assets to render as the user expects. There are many ways to use these assets in your story files.
 
 ### Import assets into stories
 
@@ -22,7 +22,7 @@ Afterwards you can use any asset in your stories:
 
 ### Serving static files via Storybook
 
-We recommend serving static files via Storybook to ensure that your components always have the assets they need to load.
+We recommend serving static files via Storybook to ensure that your components always have the assets they need to load. This technique is recommended for assets that your component's often use like logos, fonts, and icons.
 
 Configure a directory (or a list of directories) where your assets live when starting Storybook. Use the`-s` flag in your npm script like so:
 

--- a/docs/configure/images-and-assets.md
+++ b/docs/configure/images-and-assets.md
@@ -22,7 +22,7 @@ Afterwards you can use any asset in your stories:
 
 ### Serving static files via Storybook
 
-We recommend serving static files via Storybook to ensure that your components always have the assets they need to load. This technique is recommended for assets that your component's often use like logos, fonts, and icons.
+We recommend serving static files via Storybook to ensure that your components always have the assets they need to load. This technique is recommended for assets that your components often use like logos, fonts, and icons.
 
 Configure a directory (or a list of directories) where your assets live when starting Storybook. Use the`-s` flag in your npm script like so:
 

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -97,14 +97,21 @@ If you have global imported styles, create a file called [`.storybook/preview.js
 </details>
 
 <details>
-  <summary>Add external CSS or fonts in the &lt;head&gt;</summary>
+  <summary>Add external CSS or webfonts in the &lt;head&gt;</summary>
 
-Alternatively if you want to inject a CSS link tag to the `<head>` directly (or some other resource like a font link), you can use [`.storybook/preview-head.html`](../configure/story-rendering.md#adding-to-&#60head&#62) to add arbitrary HTML.
+Alternatively, if you want to inject a CSS link tag to the `<head>` directly (or some other resource like a webfont link), you can use [`.storybook/preview-head.html`](../configure/story-rendering.md#adding-to-&#60head&#62) to add arbitrary HTML.
+
+</details>
+
+<details>
+  <summary>Load fonts or images from a local directory</summary>
+
+If you're referencing fonts or images from a local directory, you'll need to configure the Storybook script to [serve the static files](../configure/images-and-assets).
 
 </details>
 
 ## Load assets and resources
 
-If you want to link to static files in your project or stories (e.g. `/fonts/XYZ.woff`), use the `-s path/to/folder` to specify a static folder to serve from when you start up Storybook. To do so, edit the `storybook` and `build-storybook` scripts in `package.json`.
+If you want to [link to static files](../configure/images-and-assets) in your project or stories (e.g. `/fonts/XYZ.woff`), use the `-s path/to/folder` to specify a static folder to serve from when you start up Storybook. To do so, edit the `storybook` and `build-storybook` scripts in `package.json`.
 
 We recommend serving external resources and assets requested in your components statically with Storybook. This ensures that assets are always available to your stories.

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -112,6 +112,6 @@ If you're referencing fonts or images from a local directory, you'll need to con
 
 ## Load assets and resources
 
-If you want to [link to static files](../configure/images-and-assets) in your project or stories (e.g. `/fonts/XYZ.woff`), use the `-s path/to/folder` to specify a static folder to serve from when you start up Storybook. To do so, edit the `storybook` and `build-storybook` scripts in `package.json`.
+If you want to [link to static files](../configure/images-and-assets.md) in your project or stories (e.g. `/fonts/XYZ.woff`), use the `-s path/to/folder` to specify a static folder to serve from when you start up Storybook. To do so, edit the `storybook` and `build-storybook` scripts in `package.json`.
 
 We recommend serving external resources and assets requested in your components statically with Storybook. This ensures that assets are always available to your stories.


### PR DESCRIPTION
Issue: na

## What I did
Improve docs for loading fonts from a static directory. This was a stumbling block for a [user in Discord](https://discord.com/channels/486522875931656193/501692020226654208/789646850008285195). 


## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

