### PR TITLE
Core: Fix typing of dev CLI options

### DIFF
--- a/lib/core/src/server/cli/dev.ts
+++ b/lib/core/src/server/cli/dev.ts
@@ -5,7 +5,7 @@ import { parseList, getEnvConfig, checkDeprecatedFlags } from './utils';
 
 export interface DevCliOptions {
   port?: number;
-  host?: number;
+  host?: string;
   staticDir?: string[];
   configDir?: string;
   https?: boolean;


### PR DESCRIPTION
## What I did

The mistake was spotted in https://github.com/storybookjs/storybook/commit/13947884387fec650bab8ebdcd7b11a00cf01607#r45325210

I fixed the type by setting `host` to `string`

## How to test

- Build should be ok