### PR TITLE
Updating to reflect yarn command

### DIFF
--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -49,13 +49,10 @@ In your terminal run the following command:
 
 ```shell
 npm install --save-dev @storybook/addon-essentials
+
+# if you're using yarn
+yarn add -D @storybook/addon-essentials
 ```
-
-<div class="aside">
-  
-If you're using <a href="https://yarnpkg.com/">yarn</a>, you'll need to adjust the command accordingly.
-
-</div>
 
 Update your Storybook configuration (in `.storybook/main.js`) to include the essentials addon.
 


### PR DESCRIPTION
Issue: No direct issue

## What I did

While updating storybook and adding Essentials Add-On I realized that the comment to change yarn command accordingly is more than just putting that command into the example.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? Yes

I'm not sure what kind of Test is necessary when documentation is updated.
