### PR TITLE
fix(docs): correct react viewport snippet's import

### DIFF
--- a/docs/snippets/react/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.js.mdx
@@ -2,6 +2,7 @@
 // MyComponent.stories.js
 
 import React from 'react';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 export default {
   title: 'Stories',
@@ -9,7 +10,7 @@ export default {
     // the viewports object from the Essentials addon
     viewport: {
       // the viewports you want to use
-      viewports: MINIMAL_VIEWPORTS,
+      viewports: INITIAL_VIEWPORTS,
       // your own default viewport
       defaultViewport: 'iphone6'
     },


### PR DESCRIPTION
Issue:
The `MINIMAL_VIEWPORTS` is no longer contain 'iphone6' and 'iphonex' in [code](https://github.com/storybookjs/storybook/blob/4f5ab9fe9e590da7b841ec37cb1bed8d6327ea4b/addons/viewport/src/defaults.ts). 

## What I did
1. Correct the value of `viewports`
2. add `import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';` for more clear example

## How to test

Docs fix

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
