### PR TITLE
Typescript: Fix qs import in @storybook/client-api

### DIFF
--- a/lib/client-api/src/queryparams.ts
+++ b/lib/client-api/src/queryparams.ts
@@ -1,10 +1,10 @@
 import { document } from 'global';
-import qs from 'qs';
+import { parse } from 'qs';
 
 export const getQueryParams = () => {
   // document.location is not defined in react-native
   if (document && document.location && document.location.search) {
-    return qs.parse(document.location.search, { ignoreQueryPrefix: true });
+    return parse(document.location.search, { ignoreQueryPrefix: true });
   }
   return {};
 };


### PR DESCRIPTION
Issue: storybookjs/storybook#13496

## What I did
Explicitly importing `parse` from `qs` in `lib/client-api/src/queryparams.ts`

## How to test

Compile a typescript project using storybook as a dependency at this branch, with `allowSyntheticDefaultImports` set to false. You should not run in to the error described in the issue.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
