### PR TITLE
Addon-docs: Use theme text color header anchors

### DIFF
--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -132,6 +132,8 @@ const OcticonAnchor = styled.a(() => ({
   float: 'left',
   paddingRight: '4px',
   marginLeft: '-20px',
+  // Allow the theme's text color to override the default link color.
+  color: 'inherit',
 }));
 
 interface HeaderWithOcticonAnchorProps {
@@ -164,7 +166,14 @@ const HeaderWithOcticonAnchor: FC<HeaderWithOcticonAnchorProps> = ({
           }
         }}
       >
-        <svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+        <svg
+          viewBox="0 0 16 16"
+          version="1.1"
+          width="16"
+          height="16"
+          aria-hidden="true"
+          fill="currentColor"
+        >
           <path
             fillRule="evenodd"
             d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"


### PR DESCRIPTION
Issue: None that I could find.

## What I did

Without this change, the anchor images in Storybook Docs always render in `#000`, which means they can be very hard to see in dark themes. This PR changes them to render using the theme's text color, which is a reasonable guarantee of sufficient contrast.

Some before-and-after screenshots from `examples/cra-kitchen-sink`, with theme changes as indicated:

|                     | Before | After |
|---------------------|--------|-------|
| Default light theme | <img width="197" alt="before-default-light" src="https://user-images.githubusercontent.com/537241/103257569-91f19880-4946-11eb-819e-dddf782a6284.png"> | <img width="190" alt="after-default-light" src="https://user-images.githubusercontent.com/537241/103257578-9e75f100-4946-11eb-95d7-00e74816bb20.png"> |
| Custom light theme  | <img width="191" alt="before-custom-light" src="https://user-images.githubusercontent.com/537241/103257583-a6ce2c00-4946-11eb-8d9f-0a6416f90107.png"> | <img width="187" alt="after-custom-light" src="https://user-images.githubusercontent.com/537241/103257590-acc40d00-4946-11eb-9fef-105f3ba3173b.png"> |
| Default dark theme  | <img width="191" alt="before-default-dark" src="https://user-images.githubusercontent.com/537241/103257604-b8173880-4946-11eb-8155-0a904d30fede.png"> | <img width="193" alt="after-default-dark" src="https://user-images.githubusercontent.com/537241/103257610-bd748300-4946-11eb-9180-72e2306ffd2a.png"> |
| Custom dark theme 1 | <img width="195" alt="before-custom-dark-1" src="https://user-images.githubusercontent.com/537241/103257619-c49b9100-4946-11eb-81c7-d9d201e0cd87.png"> | <img width="196" alt="after-custom-dark-1" src="https://user-images.githubusercontent.com/537241/103257622-c9604500-4946-11eb-8763-105576a3a206.png"> |
| Custom dark theme 2 | <img width="197" alt="before-custom-dark-2" src="https://user-images.githubusercontent.com/537241/103257625-cfeebc80-4946-11eb-8fd6-bc03aa4c25f5.png"> | <img width="193" alt="after-custom-dark-2" src="https://user-images.githubusercontent.com/537241/103257635-d4b37080-4946-11eb-823b-a7f742c5250a.png"> |


## How to test

- Is this testable with Jest or Chromatic screenshots? I don't think so, since the icon only appears on hover, but I could be wrong. I'm happy to add a test for this if y'all would like, but I'll need some pointers since I was unable to run the image snapshot tests following the instructions at https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md#cra-kitchen-sink---image-snapshots-using-storyshots.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
