### PR TITLE
Addon-jest: Infer parameter from story filename if not provided

### DIFF
--- a/addons/jest/README.md
+++ b/addons/jest/README.md
@@ -128,6 +128,9 @@ defaultView.parameters = {
 };
 ```
 
+The jest parameter will default to inferring from your story file name if not provided. For example, if your story file is `MyComponent.stories.js`,
+then "MyComponent" will be used to find your test file results.
+
 ### Disabling
 
 You can disable the addon for a single story by setting the `jest` parameter to `{disable: true}`:

--- a/addons/jest/README.md
+++ b/addons/jest/README.md
@@ -129,7 +129,7 @@ defaultView.parameters = {
 ```
 
 The jest parameter will default to inferring from your story file name if not provided. For example, if your story file is `MyComponent.stories.js`,
-then "MyComponent" will be used to find your test file results.
+then "MyComponent" will be used to find your test file results. This currently doesn't work in production environments.
 
 ### Disabling
 

--- a/addons/jest/src/index.ts
+++ b/addons/jest/src/index.ts
@@ -1,10 +1,6 @@
-import addons, { Parameters } from '@storybook/addons';
+import addons from '@storybook/addons';
 import { normalize, sep } from 'upath';
-import { ADD_TESTS } from './shared';
-
-interface AddonParameters extends Parameters {
-  jest?: string | string[] | { disable: true };
-}
+import { ADD_TESTS, defineJestParameters } from './shared';
 
 const findTestResults = (
   testFiles: string[],
@@ -55,18 +51,10 @@ export const withTests = (userOptions: { results: any; filesExt?: string }) => {
 
   return (...args: any[]) => {
     const [storyFn, { kind, parameters = {} }] = args;
-    let { jest: testFiles } = parameters;
+    const testFiles = defineJestParameters(parameters);
 
-    if (typeof testFiles === 'string') {
-      testFiles = [testFiles];
-    }
-
-    if (testFiles && Array.isArray(testFiles)) {
+    if (testFiles !== null) {
       emitAddTests({ kind, story: storyFn, testFiles, options });
-    } else if (testFiles === undefined) {
-      const { fileName: filePath } = parameters;
-      const fileName = filePath.split('/').pop().split('.')[0];
-      emitAddTests({ kind, story: storyFn, testFiles: [fileName], options });
     }
 
     return storyFn();

--- a/addons/jest/src/index.ts
+++ b/addons/jest/src/index.ts
@@ -57,17 +57,13 @@ export const withTests = (userOptions: { results: any; filesExt?: string }) => {
     const [storyFn, { kind, parameters = {} }] = args;
     let { jest: testFiles } = parameters;
 
-    if (Object.prototype.hasOwnProperty.call(testFiles, 'disabled') && testFiles.disabled) {
-      return storyFn();
-    }
-
     if (typeof testFiles === 'string') {
       testFiles = [testFiles];
     }
 
     if (testFiles && Array.isArray(testFiles)) {
       emitAddTests({ kind, story: storyFn, testFiles, options });
-    } else {
+    } else if (testFiles === undefined) {
       const { fileName: filePath } = parameters;
       const fileName = filePath.split('/').pop().split('.')[0];
       emitAddTests({ kind, story: storyFn, testFiles: [fileName], options });

--- a/addons/jest/src/index.ts
+++ b/addons/jest/src/index.ts
@@ -57,12 +57,20 @@ export const withTests = (userOptions: { results: any; filesExt?: string }) => {
     const [storyFn, { kind, parameters = {} }] = args;
     let { jest: testFiles } = parameters;
 
+    if (Object.prototype.hasOwnProperty.call(testFiles, 'disabled') && testFiles.disabled) {
+      return storyFn();
+    }
+
     if (typeof testFiles === 'string') {
       testFiles = [testFiles];
     }
 
     if (testFiles && Array.isArray(testFiles)) {
       emitAddTests({ kind, story: storyFn, testFiles, options });
+    } else {
+      const { fileName: filePath } = parameters;
+      const fileName = filePath.split('/').pop().split('.')[0];
+      emitAddTests({ kind, story: storyFn, testFiles: [fileName], options });
     }
 
     return storyFn();

--- a/addons/jest/src/index.ts
+++ b/addons/jest/src/index.ts
@@ -1,6 +1,6 @@
 import addons from '@storybook/addons';
 import { normalize, sep } from 'upath';
-import { ADD_TESTS, defineJestParameters } from './shared';
+import { ADD_TESTS, defineJestParameter } from './shared';
 
 const findTestResults = (
   testFiles: string[],
@@ -51,7 +51,7 @@ export const withTests = (userOptions: { results: any; filesExt?: string }) => {
 
   return (...args: any[]) => {
     const [storyFn, { kind, parameters = {} }] = args;
-    const testFiles = defineJestParameters(parameters);
+    const testFiles = defineJestParameter(parameters);
 
     if (testFiles !== null) {
       emitAddTests({ kind, story: storyFn, testFiles, options });

--- a/addons/jest/src/shared.test.ts
+++ b/addons/jest/src/shared.test.ts
@@ -1,24 +1,24 @@
-import { defineJestParameters } from './shared';
+import { defineJestParameter } from './shared';
 
-describe('defineJestParameters', () => {
+describe('defineJestParameter', () => {
   test('infers from story file name if jest parameter is not provided', () => {
-    expect(defineJestParameters({ fileName: './stories/addon-jest.stories.js' })).toEqual([
+    expect(defineJestParameter({ fileName: './stories/addon-jest.stories.js' })).toEqual([
       'addon-jest',
     ]);
   });
 
   test('wraps string jest parameter with an array', () => {
-    expect(defineJestParameters({ jest: 'addon-jest' })).toEqual(['addon-jest']);
+    expect(defineJestParameter({ jest: 'addon-jest' })).toEqual(['addon-jest']);
   });
 
   test('returns as is if jest parameter is an array', () => {
-    expect(defineJestParameters({ jest: ['addon-jest', 'something-else'] })).toEqual([
+    expect(defineJestParameter({ jest: ['addon-jest', 'something-else'] })).toEqual([
       'addon-jest',
       'something-else',
     ]);
   });
 
   test('returns null if disabled option is passed to jest parameter', () => {
-    expect(defineJestParameters({ jest: { disabled: true } })).toEqual(null);
+    expect(defineJestParameter({ jest: { disabled: true } })).toEqual(null);
   });
 });

--- a/addons/jest/src/shared.test.ts
+++ b/addons/jest/src/shared.test.ts
@@ -19,6 +19,10 @@ describe('defineJestParameter', () => {
   });
 
   test('returns null if disabled option is passed to jest parameter', () => {
-    expect(defineJestParameter({ jest: { disabled: true } })).toEqual(null);
+    expect(defineJestParameter({ jest: { disabled: true } })).toBeNull();
+  });
+
+  test('returns null if no filename to infer from', () => {
+    expect(defineJestParameter({})).toBeNull();
   });
 });

--- a/addons/jest/src/shared.test.ts
+++ b/addons/jest/src/shared.test.ts
@@ -25,4 +25,9 @@ describe('defineJestParameter', () => {
   test('returns null if no filename to infer from', () => {
     expect(defineJestParameter({})).toBeNull();
   });
+
+  test('returns null if filename is a module ID that cannot be inferred from', () => {
+    // @ts-ignore
+    expect(defineJestParameter({ fileName: 1234 })).toBeNull();
+  });
 });

--- a/addons/jest/src/shared.test.ts
+++ b/addons/jest/src/shared.test.ts
@@ -1,0 +1,24 @@
+import { defineJestParameters } from './shared';
+
+describe('defineJestParameters', () => {
+  test('infers from story file name if jest parameter is not provided', () => {
+    expect(defineJestParameters({ fileName: './stories/addon-jest.stories.js' })).toEqual([
+      'addon-jest',
+    ]);
+  });
+
+  test('wraps string jest parameter with an array', () => {
+    expect(defineJestParameters({ jest: 'addon-jest' })).toEqual(['addon-jest']);
+  });
+
+  test('returns as is if jest parameter is an array', () => {
+    expect(defineJestParameters({ jest: ['addon-jest', 'something-else'] })).toEqual([
+      'addon-jest',
+      'something-else',
+    ]);
+  });
+
+  test('returns null if disabled option is passed to jest parameter', () => {
+    expect(defineJestParameters({ jest: { disabled: true } })).toEqual(null);
+  });
+});

--- a/addons/jest/src/shared.ts
+++ b/addons/jest/src/shared.ts
@@ -22,7 +22,7 @@ export function defineJestParameter(parameters: AddonParameters): string[] | nul
     return jest;
   }
 
-  if (jest === undefined) {
+  if (jest === undefined && filePath) {
     const fileName = filePath.split('/').pop().split('.')[0];
     return [fileName];
   }

--- a/addons/jest/src/shared.ts
+++ b/addons/jest/src/shared.ts
@@ -22,7 +22,7 @@ export function defineJestParameter(parameters: AddonParameters): string[] | nul
     return jest;
   }
 
-  if (jest === undefined && filePath) {
+  if (jest === undefined && typeof filePath === 'string') {
     const fileName = filePath.split('/').pop().split('.')[0];
     return [fileName];
   }

--- a/addons/jest/src/shared.ts
+++ b/addons/jest/src/shared.ts
@@ -8,7 +8,7 @@ export const PANEL_ID = `${ADDON_ID}/panel`;
 export const ADD_TESTS = `${ADDON_ID}/add_tests`;
 
 interface AddonParameters extends Parameters {
-  jest?: string | string[] | { disable: true } | null;
+  jest?: string | string[] | { disabled: true };
 }
 
 export function defineJestParameters(parameters: AddonParameters): string[] | null {

--- a/addons/jest/src/shared.ts
+++ b/addons/jest/src/shared.ts
@@ -14,8 +14,6 @@ interface AddonParameters extends Parameters {
 export function defineJestParameters(parameters: AddonParameters): string[] | null {
   const { jest, fileName: filePath } = parameters;
 
-  console.log(jest);
-
   if (typeof jest === 'string') {
     return [jest];
   }

--- a/addons/jest/src/shared.ts
+++ b/addons/jest/src/shared.ts
@@ -11,7 +11,7 @@ interface AddonParameters extends Parameters {
   jest?: string | string[] | { disabled: true };
 }
 
-export function defineJestParameters(parameters: AddonParameters): string[] | null {
+export function defineJestParameter(parameters: AddonParameters): string[] | null {
   const { jest, fileName: filePath } = parameters;
 
   if (typeof jest === 'string') {

--- a/addons/jest/src/shared.ts
+++ b/addons/jest/src/shared.ts
@@ -1,6 +1,33 @@
+import type { Parameters } from '@storybook/addons';
+
 // addons, panels and events get unique names using a prefix
 export const PARAM_KEY = 'test';
 export const ADDON_ID = 'storybookjs/test';
 export const PANEL_ID = `${ADDON_ID}/panel`;
 
 export const ADD_TESTS = `${ADDON_ID}/add_tests`;
+
+interface AddonParameters extends Parameters {
+  jest?: string | string[] | { disable: true } | null;
+}
+
+export function defineJestParameters(parameters: AddonParameters): string[] | null {
+  const { jest, fileName: filePath } = parameters;
+
+  console.log(jest);
+
+  if (typeof jest === 'string') {
+    return [jest];
+  }
+
+  if (jest && Array.isArray(jest)) {
+    return jest;
+  }
+
+  if (jest === undefined) {
+    const fileName = filePath.split('/').pop().split('.')[0];
+    return [fileName];
+  }
+
+  return null;
+}

--- a/addons/jest/tsconfig.json
+++ b/addons/jest/tsconfig.json
@@ -2,12 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "types": ["webpack-env"]
+    "types": ["webpack-env", "jest"]
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "src/__tests__/**/*"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__/**/*"]
 }

--- a/examples/official-storybook/stories/addon-jest.stories.js
+++ b/examples/official-storybook/stories/addon-jest.stories.js
@@ -10,3 +10,8 @@ export default {
 
 export const WithTests = () => <p>Hello</p>;
 WithTests.parameters = { jest: 'addon-jest' };
+
+export const WithInferredTests = () => <p>Inferred Tests</p>;
+
+export const DisabledTests = () => <p>Disabled Tests</p>;
+WithTests.parameters = { jest: { disabled: true } };

--- a/examples/official-storybook/stories/addon-jest.stories.js
+++ b/examples/official-storybook/stories/addon-jest.stories.js
@@ -14,4 +14,4 @@ WithTests.parameters = { jest: 'addon-jest' };
 export const WithInferredTests = () => <p>Inferred Tests</p>;
 
 export const DisabledTests = () => <p>Disabled Tests</p>;
-WithTests.parameters = { jest: { disabled: true } };
+DisabledTests.parameters = { jest: { disabled: true } };


### PR DESCRIPTION
Issue: #12084

## What I did
Added functionality to infer jest parameter from file name if not provided explicitly.

## How to test

- Is this testable with Jest or Chromatic screenshots? yes
- Does this need a new example in the kitchen sink apps? yes
- Does this need an update to the documentation? yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
