### PR TITLE
docs: how to use the addons in an Angular component

### DIFF
--- a/docs/addons/writing-addons.md
+++ b/docs/addons/writing-addons.md
@@ -183,6 +183,7 @@ When Storybook was initialized it provided a small set of examples stories. Chan
 <CodeSnippets
   paths={[
     'react/button-story-with-addon-example.js.mdx',
+    'angular/button-story-with-addon-example.ts.mdx',
   ]}
 />
 

--- a/docs/snippets/angular/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/angular/button-story-with-addon-example.ts.mdx
@@ -1,0 +1,15 @@
+```ts
+// Button.stories.ts
+
+import Button from './button.component';
+
+export default {
+  title: 'Button',
+  component: Button,
+  parameters: {
+    myAddon: {
+      data: 'this data is passed to the addon',
+    },
+  },
+};
+```


### PR DESCRIPTION
## What I did

I worked a bit with the addons and I liked that feature a lot. While the code snippet for this part was missing in the Angular documentation I decided to add it. 

## How to test

1. Follow the instructions of this [doc](https://storybook.js.org/docs/angular/addons/writing-addons) and create a panel addon. Make sure to follow all the steps up to "Using the addon with a story" (without this).
2. Create a root level `preset.js`. [(details here)](https://storybook.js.org/docs/angular/addons/writing-addons#root-level-presetjs)
2. Create an Angular application and init a storybook
3. In the `.storybook/main.js` add in the `addons` array property the absolute path of the add addon of step 1

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
