### PR TITLE
Addon-controls: Files control

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -119,7 +119,6 @@ As they can be complex cases:
 
 <!-- prettier-ignore-end -->
 
-
 Or even with certain types of elements, such as icons:
 
 <!-- prettier-ignore-start -->
@@ -150,6 +149,7 @@ Here is the full list of available controls you can use:
 | Data Type   | Control Type | Description                                                    |    Options     |
 | :---------- | :----------: | :------------------------------------------------------------- | :------------: |
 | **array**   |    array     | serialize array into a comma-separated string inside a textbox |   separator    |
+|             |     file     | a file input that gives you a array of urls                    |     accept     |
 | **boolean** |   boolean    | checkbox input                                                 |       -        |
 | **number**  |    number    | a numeric text box input                                       | min, max, step |
 |             |    range     | a range slider input                                           | min, max, step |
@@ -226,7 +226,7 @@ And here's what the resulting UI looks like:
 
 ### Disable controls for specific properties
 
-Asides from the features already documented here. Controls can also be disabled for individual properties. 
+Asides from the features already documented here. Controls can also be disabled for individual properties.
 
 Suppose you want to disable Controls for a property called `foo` in a component's story. The following example illustrates how:
 
@@ -252,7 +252,7 @@ Resulting in the following change in Storybook UI:
 
 <div class="aside">
 
- As with other Storybook properties, such as [decorators](../writing-stories/decorators.md) the same principle can also be applied at a story-level for more granular cases.
+As with other Storybook properties, such as [decorators](../writing-stories/decorators.md) the same principle can also be applied at a story-level for more granular cases.
 
 </div>
 

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -8,7 +8,7 @@ export default {
     children: { control: 'text', name: 'Children' },
     type: { control: 'text', name: 'Type' },
     somethingElse: { control: 'object', name: 'Something Else' },
-    imageUrls: { control: 'file', name: 'Image Urls' },
+    imageUrls: { control: { type: 'file', accept: '.doc' }, name: 'Image Urls' },
   },
 };
 
@@ -27,7 +27,7 @@ Action.args = {
   somethingElse: { a: 4 },
 };
 
-export const ImageFileControl = (args) => <img src={args.imageSrc[0]} alt="Your Example Story" />;
+export const ImageFileControl = (args) => <img src={args.imageUrls[0]} alt="Your Example Story" />;
 ImageFileControl.args = {
   imageUrls: ['http://placehold.it/350x150'],
 };

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -40,13 +40,13 @@ CustomControls.argTypes = {
 
 export const NoArgs = () => <Button>no args</Button>;
 
-// const hasCycle: any = {};
-// hasCycle.cycle = hasCycle;
+const hasCycle: any = {};
+hasCycle.cycle = hasCycle;
 
-// export const CyclicArgs = Template.bind({});
-// CyclicArgs.args = {
-//   hasCycle,
-// };
-// CyclicArgs.parameters = {
-//   chromatic: { disable: true },
-// };
+export const CyclicArgs = Template.bind({});
+CyclicArgs.args = {
+  hasCycle,
+};
+CyclicArgs.parameters = {
+  chromatic: { disable: true },
+};

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -27,9 +27,9 @@ Action.args = {
   somethingElse: { a: 4 },
 };
 
-export const ImageFileControl = (args) => <img src={args.imageSrc} alt="file control" />;
+export const ImageFileControl = (args) => <img src={args.imageSrc[0]} alt="file control" />;
 ImageFileControl.args = {
-  imageSrc: 'http://placehold.it/350x150',
+  imageSrc: ['http://placehold.it/350x150'],
 };
 
 export const CustomControls = Template.bind({});
@@ -40,13 +40,13 @@ CustomControls.argTypes = {
 
 export const NoArgs = () => <Button>no args</Button>;
 
-const hasCycle: any = {};
-hasCycle.cycle = hasCycle;
+// const hasCycle: any = {};
+// hasCycle.cycle = hasCycle;
 
-export const CyclicArgs = Template.bind({});
-CyclicArgs.args = {
-  hasCycle,
-};
-CyclicArgs.parameters = {
-  chromatic: { disable: true },
-};
+// export const CyclicArgs = Template.bind({});
+// CyclicArgs.args = {
+//   hasCycle,
+// };
+// CyclicArgs.parameters = {
+//   chromatic: { disable: true },
+// };

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -8,7 +8,7 @@ export default {
     children: { control: 'text', name: 'Children' },
     type: { control: 'text', name: 'Type' },
     somethingElse: { control: 'object', name: 'Something Else' },
-    imageUrls: { control: { type: 'file', accept: '.doc' }, name: 'Image Urls' },
+    imageUrls: { control: { type: 'file', accept: '.png' }, name: 'Image Urls' },
   },
 };
 

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -8,7 +8,7 @@ export default {
     children: { control: 'text', name: 'Children' },
     type: { control: 'text', name: 'Type' },
     somethingElse: { control: 'object', name: 'Something Else' },
-    imageSrc: { control: 'file', name: 'Image Src' },
+    imageUrls: { control: 'file', name: 'Image Urls' },
   },
 };
 
@@ -27,9 +27,9 @@ Action.args = {
   somethingElse: { a: 4 },
 };
 
-export const ImageFileControl = (args) => <img src={args.imageSrc[0]} alt="file control" />;
+export const ImageFileControl = (args) => <img src={args.imageSrc[0]} alt="Your Example Story" />;
 ImageFileControl.args = {
-  imageSrc: ['http://placehold.it/350x150'],
+  imageUrls: ['http://placehold.it/350x150'],
 };
 
 export const CustomControls = Template.bind({});

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -8,6 +8,7 @@ export default {
     children: { control: 'text', name: 'Children' },
     type: { control: 'text', name: 'Type' },
     somethingElse: { control: 'object', name: 'Something Else' },
+    imageSrc: { control: 'file', name: 'Image Src' },
   },
 };
 
@@ -24,6 +25,11 @@ Action.args = {
   children: 'hmmm',
   type: 'action',
   somethingElse: { a: 4 },
+};
+
+export const ImageFileControl = (args) => <img src={args.imageSrc} alt="file control" />;
+ImageFileControl.args = {
+  imageSrc: 'http://placehold.it/350x150',
 };
 
 export const CustomControls = Template.bind({});

--- a/lib/components/src/blocks/ArgsTable/ArgControl.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgControl.tsx
@@ -5,6 +5,7 @@ import {
   BooleanControl,
   ColorControl,
   DateControl,
+  FilesControl,
   NumberControl,
   ObjectControl,
   OptionsControl,
@@ -72,6 +73,8 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs }) => {
       return <RangeControl {...props} {...control} />;
     case 'text':
       return <TextControl {...props} {...control} />;
+    case 'file':
+      return <FilesControl {...props} {...control} />;
     default:
       return <NoControl />;
   }

--- a/lib/components/src/controls/Files.tsx
+++ b/lib/components/src/controls/Files.tsx
@@ -21,10 +21,10 @@ function fileReaderPromise(file: File) {
   });
 }
 
-const serialize = (): undefined => undefined;
-const deserialize = (): undefined => undefined;
+// const serialize = (): undefined => undefined;
+// const deserialize = (): undefined => undefined;
 
-const FilesControl: FunctionComponent<FilesControlProps> = ({ onChange, name, accept }) => (
+export const FilesControl: FunctionComponent<FilesControlProps> = ({ onChange, name, accept }) => (
   <FileInput
     type="file"
     name={name}
@@ -42,5 +42,3 @@ const FilesControl: FunctionComponent<FilesControlProps> = ({ onChange, name, ac
 FilesControl.defaultProps = {
   onChange: (value) => value,
 };
-
-export default FilesControl;

--- a/lib/components/src/controls/Files.tsx
+++ b/lib/components/src/controls/Files.tsx
@@ -1,4 +1,3 @@
-import { FileReader } from 'global';
 import React, { ChangeEvent, FunctionComponent } from 'react';
 import { styled } from '@storybook/theming';
 import { ControlProps } from './types';

--- a/lib/components/src/controls/Files.tsx
+++ b/lib/components/src/controls/Files.tsx
@@ -13,11 +13,11 @@ const FileInput = styled(Form.Input)({
   paddingTop: 12,
 });
 
-function fileReaderPromise(file: File) {
-  return new Promise<string>((resolve) => {
-    const fileReader = new FileReader();
-    fileReader.onload = (e: Event) => resolve((e.currentTarget as FileReader).result as string);
-    fileReader.readAsDataURL(file);
+function revokeOldUrls(urls: string[]) {
+  urls.forEach((url) => {
+    if (url.startsWith('blob:')) {
+      URL.revokeObjectURL(url);
+    }
   });
 }
 
@@ -25,20 +25,25 @@ export const FilesControl: FunctionComponent<FilesControlProps> = ({
   onChange,
   name,
   accept = 'image/*',
-}) => (
-  <FileInput
-    type="file"
-    name={name}
-    multiple
-    onChange={(e: ChangeEvent<HTMLInputElement>) => {
-      if (e.target.files) {
-        Promise.all(Array.from(e.target.files).map(fileReaderPromise)).then((result) => {
-          console.log('READ FILE RESULT', result);
-          onChange(result);
-        });
-      }
-    }}
-    accept={accept}
-    size="flex"
-  />
-);
+  value,
+}) => {
+  function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    if (!e.target.files) {
+      return;
+    }
+    const fileUrls = Array.from(e.target.files).map((file) => URL.createObjectURL(file));
+    onChange(fileUrls);
+    revokeOldUrls(value);
+  }
+
+  return (
+    <FileInput
+      type="file"
+      name={name}
+      multiple
+      onChange={handleFileChange}
+      accept={accept}
+      size="flex"
+    />
+  );
+};

--- a/lib/components/src/controls/Files.tsx
+++ b/lib/components/src/controls/Files.tsx
@@ -10,7 +10,7 @@ export interface FilesControlProps extends ControlProps<string[]> {
 }
 
 const FileInput = styled(Form.Input)({
-  paddingTop: 4,
+  paddingTop: 12,
 });
 
 function fileReaderPromise(file: File) {

--- a/lib/components/src/controls/Files.tsx
+++ b/lib/components/src/controls/Files.tsx
@@ -6,7 +6,7 @@ import { ControlProps } from './types';
 import { Form } from '../form';
 
 export interface FilesControlProps extends ControlProps<string[]> {
-  accept: string;
+  accept?: string;
 }
 
 const FileInput = styled(Form.Input)({
@@ -21,7 +21,11 @@ function fileReaderPromise(file: File) {
   });
 }
 
-export const FilesControl: FunctionComponent<FilesControlProps> = ({ onChange, name, accept }) => (
+export const FilesControl: FunctionComponent<FilesControlProps> = ({
+  onChange,
+  name,
+  accept = 'image/*',
+}) => (
   <FileInput
     type="file"
     name={name}

--- a/lib/components/src/controls/Files.tsx
+++ b/lib/components/src/controls/Files.tsx
@@ -21,9 +21,6 @@ function fileReaderPromise(file: File) {
   });
 }
 
-// const serialize = (): undefined => undefined;
-// const deserialize = (): undefined => undefined;
-
 export const FilesControl: FunctionComponent<FilesControlProps> = ({ onChange, name, accept }) => (
   <FileInput
     type="file"
@@ -31,14 +28,13 @@ export const FilesControl: FunctionComponent<FilesControlProps> = ({ onChange, n
     multiple
     onChange={(e: ChangeEvent<HTMLInputElement>) => {
       if (e.target.files) {
-        Promise.all(Array.from(e.target.files).map(fileReaderPromise)).then(onChange);
+        Promise.all(Array.from(e.target.files).map(fileReaderPromise)).then((result) => {
+          console.log('READ FILE RESULT', result);
+          onChange(result);
+        });
       }
     }}
     accept={accept}
     size="flex"
   />
 );
-
-FilesControl.defaultProps = {
-  onChange: (value) => value,
-};

--- a/lib/components/src/controls/Files.tsx
+++ b/lib/components/src/controls/Files.tsx
@@ -10,7 +10,7 @@ export interface FilesControlProps extends ControlProps<string[]> {
 }
 
 const FileInput = styled(Form.Input)({
-  paddingTop: 12,
+  padding: 10,
 });
 
 function revokeOldUrls(urls: string[]) {

--- a/lib/components/src/controls/Files.tsx
+++ b/lib/components/src/controls/Files.tsx
@@ -1,0 +1,46 @@
+import { FileReader } from 'global';
+import React, { ChangeEvent, FunctionComponent } from 'react';
+import { styled } from '@storybook/theming';
+import { ControlProps } from './types';
+
+import { Form } from '../form';
+
+export interface FilesControlProps extends ControlProps<string[]> {
+  accept: string;
+}
+
+const FileInput = styled(Form.Input)({
+  paddingTop: 4,
+});
+
+function fileReaderPromise(file: File) {
+  return new Promise<string>((resolve) => {
+    const fileReader = new FileReader();
+    fileReader.onload = (e: Event) => resolve((e.currentTarget as FileReader).result as string);
+    fileReader.readAsDataURL(file);
+  });
+}
+
+const serialize = (): undefined => undefined;
+const deserialize = (): undefined => undefined;
+
+const FilesControl: FunctionComponent<FilesControlProps> = ({ onChange, name, accept }) => (
+  <FileInput
+    type="file"
+    name={name}
+    multiple
+    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files) {
+        Promise.all(Array.from(e.target.files).map(fileReaderPromise)).then(onChange);
+      }
+    }}
+    accept={accept}
+    size="flex"
+  />
+);
+
+FilesControl.defaultProps = {
+  onChange: (value) => value,
+};
+
+export default FilesControl;

--- a/lib/components/src/controls/index.tsx
+++ b/lib/components/src/controls/index.tsx
@@ -20,3 +20,4 @@ export * from './options';
 export * from './Object';
 export * from './Range';
 export * from './Text';
+export * from './Files';


### PR DESCRIPTION
Issue: #13004

## What I did
Port over FilesControl component from knobs. Used `createObjectUrl()` instead of `FileReader.readAsDataURL()` as the latter was  slow and causing issues when dealing with larger files.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps? yes
- Does this need an update to the documentation? yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
