### PR TITLE
Addon-docs: Add missing types for Story doc block

### DIFF
--- a/addons/docs/src/blocks/Meta.tsx
+++ b/addons/docs/src/blocks/Meta.tsx
@@ -1,22 +1,13 @@
 import React, { FC, useContext } from 'react';
 import { document } from 'global';
-import { Args, ArgTypes, Parameters } from '@storybook/addons';
+import { Annotations, Args, BaseMeta } from '@storybook/addons';
 import { Anchor } from './Anchor';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { getDocsStories } from './utils';
 import { Component } from './types';
 
-type Decorator = (...args: any) => any;
-
-interface MetaProps {
-  title: string;
-  component?: Component;
-  subcomponents?: Record<string, Component>;
-  decorators?: [Decorator];
-  parameters?: Parameters;
-  args?: Args;
-  argTypes?: ArgTypes;
-}
+type MetaProps = BaseMeta<Component> &
+  Omit<Annotations<Args, any>, 'includeStories' | 'excludeStories'>;
 
 function getFirstStoryId(docsContext: DocsContextProps): string {
   const stories = getDocsStories(docsContext);

--- a/addons/docs/src/blocks/Meta.tsx
+++ b/addons/docs/src/blocks/Meta.tsx
@@ -1,13 +1,12 @@
 import React, { FC, useContext } from 'react';
 import { document } from 'global';
-import { Annotations, Args, BaseMeta } from '@storybook/addons';
+import { Args, BaseAnnotations, BaseMeta } from '@storybook/addons';
 import { Anchor } from './Anchor';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { getDocsStories } from './utils';
 import { Component } from './types';
 
-type MetaProps = BaseMeta<Component> &
-  Omit<Annotations<Args, any>, 'includeStories' | 'excludeStories'>;
+type MetaProps = BaseMeta<Component> & BaseAnnotations<Args, any>;
 
 function getFirstStoryId(docsContext: DocsContextProps): string {
   const stories = getDocsStories(docsContext);

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, ReactNode, ElementType, ComponentProps } from
 import { MDXProvider } from '@mdx-js/react';
 import { resetComponents, Story as PureStory } from '@storybook/components';
 import { toId, storyNameFromExport } from '@storybook/csf';
-import { Annotations, Args } from '@storybook/addons';
+import { Args, BaseAnnotations } from '@storybook/addons';
 import { CURRENT_SELECTION } from './types';
 
 import { DocsContext, DocsContextProps } from './DocsContext';
@@ -11,7 +11,7 @@ export const storyBlockIdFromId = (storyId: string) => `story--${storyId}`;
 
 type PureStoryProps = ComponentProps<typeof PureStory>;
 
-type CommonProps = Omit<Annotations<Args, any>, 'includeStories' | 'excludeStories'> & {
+type CommonProps = BaseAnnotations<Args, any> & {
   height?: string;
   inline?: boolean;
 };

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, ReactNode, ElementType, ComponentProps } from
 import { MDXProvider } from '@mdx-js/react';
 import { resetComponents, Story as PureStory } from '@storybook/components';
 import { toId, storyNameFromExport } from '@storybook/csf';
+import { Annotations, Args } from '@storybook/addons';
 import { CURRENT_SELECTION } from './types';
 
 import { DocsContext, DocsContextProps } from './DocsContext';
@@ -10,26 +11,26 @@ export const storyBlockIdFromId = (storyId: string) => `story--${storyId}`;
 
 type PureStoryProps = ComponentProps<typeof PureStory>;
 
-interface CommonProps {
+type CommonProps = Omit<Annotations<Args, any>, 'includeStories' | 'excludeStories'> & {
   height?: string;
   inline?: boolean;
-}
+};
 
 type StoryDefProps = {
   name: string;
   children: ReactNode;
-} & CommonProps;
+};
 
 type StoryRefProps = {
   id?: string;
-} & CommonProps;
+};
 
 type StoryImportProps = {
   name: string;
   story: ElementType;
-} & CommonProps;
+};
 
-export type StoryProps = StoryDefProps | StoryRefProps;
+export type StoryProps = (StoryDefProps | StoryRefProps | StoryImportProps) & CommonProps;
 
 export const lookupStoryId = (
   storyName: string,

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -112,7 +112,6 @@ function genStoryExport(ast, context) {
   }
 
   if (storyAttr) {
-    // NOTE: Maybe we should merge parameters for imported story
     return genImportStory(ast, storyAttr, storyName, context);
   }
 

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -112,6 +112,7 @@ function genStoryExport(ast, context) {
   }
 
   if (storyAttr) {
+    // NOTE: Maybe we should merge parameters for imported story
     return genImportStory(ast, storyAttr, storyName, context);
   }
 

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -163,7 +163,7 @@ export type BaseDecorators<StoryFnReturnType> = Array<
   (story: () => StoryFnReturnType, context: StoryContext) => StoryFnReturnType
 >;
 
-export interface Annotations<Args, StoryFnReturnType> {
+export interface BaseAnnotations<Args, StoryFnReturnType> {
   /**
    * Dynamic data that are provided (and possibly updated by) Storybook and its addons.
    * @see [Arg story inputs](https://github.com/storybookjs/storybook/blob/next/docs/src/pages/formats/component-story-format/index.md#args-story-inputs)
@@ -189,7 +189,10 @@ export interface Annotations<Args, StoryFnReturnType> {
    * @see [Decorators](https://storybook.js.org/docs/addons/introduction/#1-decorators)
    */
   decorators?: BaseDecorators<StoryFnReturnType>;
+}
 
+export interface Annotations<Args, StoryFnReturnType>
+  extends BaseAnnotations<Args, StoryFnReturnType> {
   /**
    * Used to only include certain named exports as stories. Useful when you want to have non-story exports such as mock data or ignore a few stories.
    * @example


### PR DESCRIPTION
Issue:

## What I did

Add missing types for `Story` docs block.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
