### PR TITLE
fix(mdx): Added a missing comma in `storybook-addon-toolbar-example.js.mdx`.

### DIFF
--- a/docs/snippets/common/storybook-addon-toolbar-example.js.mdx
+++ b/docs/snippets/common/storybook-addon-toolbar-example.js.mdx
@@ -7,7 +7,7 @@ import { Icons, IconButton } from '@storybook/components';
 
 addons.register("my/toolbar", () => {
   addons.add("my-toolbar-addon/toolbar", {
-    title: "Example Storybook toolbar"
+    title: "Example Storybook toolbar",
     //👇 Sets the type of UI element in Storybook
     type: types.TOOL,
     //👇 Shows the Toolbar UI element if either the Canvas or Docs tab is active


### PR DESCRIPTION
Issue: Added a missing comma in `storybook-addon-toolbar-example.js.mdx`.

## What I did

Added a missing comma in `storybook-addon-toolbar-example.js.mdx`.

## How to test

Just a comma, No testing required.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
