### PR TITLE
Core: Load middleware.cjs if it exists

### DIFF
--- a/lib/core/src/server/utils/middleware.ts
+++ b/lib/core/src/server/utils/middleware.ts
@@ -1,9 +1,15 @@
 import path from 'path';
 import fs from 'fs';
 
+const fileExists = (basename: string) =>
+  ['.js', '.cjs'].reduce((found: string, ext: string) => {
+    const filename = `${basename}${ext}`;
+    return !found && fs.existsSync(filename) ? filename : found;
+  }, '');
+
 export function getMiddleware(configDir: string) {
-  const middlewarePath = path.resolve(configDir, 'middleware.js');
-  if (fs.existsSync(middlewarePath)) {
+  const middlewarePath = fileExists(path.resolve(configDir, 'middleware'));
+  if (middlewarePath) {
     let middlewareModule = require(middlewarePath); // eslint-disable-line
     if (middlewareModule.__esModule) { // eslint-disable-line
       middlewareModule = middlewareModule.default;


### PR DESCRIPTION
Issue:

For node packages of type module require can only be used from .cjs files.
This fix now searches for both files middleware.js and middleware.cjs. 
The first file found (if any) will be used.

## What I did

Adding a function which iterates over .js as well as .cjs files. The first found file is used.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

So far no tests are available for this file.
