### PR TITLE
Angular: Properly handle empty tsconfig compilerOptions

### DIFF
--- a/app/angular/src/server/angular-cli_config.ts
+++ b/app/angular/src/server/angular-cli_config.ts
@@ -36,9 +36,8 @@ function getTsConfigOptions(tsConfigPath: Path) {
 
   const tsConfig = JSON.parse(stripJsonComments(fs.readFileSync(tsConfigPath, 'utf8')));
 
-  const { baseUrl } = tsConfig.compilerOptions as CompilerOptions;
-
-  if (baseUrl) {
+  if (tsConfig.compilerOptions && tsConfig.compilerOptions.baseUrl) {
+    const { baseUrl } = tsConfig.compilerOptions as CompilerOptions;
     const tsConfigDirName = path.dirname(tsConfigPath);
     basicOptions.options.baseUrl = path.resolve(tsConfigDirName, baseUrl);
   }


### PR DESCRIPTION
Issue:

## What I did

Considered the case when `tsconfig` is extending another file and has an empty `compilerOptions`.

This avoid an exception like:

![image](https://user-images.githubusercontent.com/260185/104111848-55625d00-52b5-11eb-81fd-1114e9ded3aa.png)
