### PR TITLE
docs (toolbars and globals): fixes an error in the documentation example

### DIFF
--- a/docs/snippets/common/my-component-story-use-globaltype.mdx.mdx
+++ b/docs/snippets/common/my-component-story-use-globaltype.mdx.mdx
@@ -8,14 +8,14 @@ export const getCaptionForLocale = (locale) => {
     case 'kr': return '안녕하세요!';
     case 'zh': return '你好!';
     default:
-      return 'Hello!',
+      return 'Hello!';
   }
 }
 
 <Story name="StoryWithLocale">
   {(args, { globals: { locale } }) => {
     const caption = getCaptionForLocale(locale);
-    return <>{caption}</>;
+    return `<p>${caption}</p>`;
   }}
 </Story>
 ```


### PR DESCRIPTION
Issue: #13602 

## What I did

When using the descriptive example in [Toolbars and Globals](https://storybook.js.org/docs/react/essentials/toolbars-and-globals) page as the following example:

```
export const getCaptionForLocale = (locale) => {
  switch(locale) {
    case 'es': return 'Hola!';
    case 'fr': return 'Bonjour!';
    case 'kr': return '안녕하세요!';
    case 'zh': return '你好!';
    default:
      return 'Hello!',
  }
}

<Story name="StoryWithLocale">
  {(args, { globals: { locale } }) => {
    const caption = getCaptionForLocale(locale);
    return <>{caption}</>;
  }}
</Story>
```
The errors below appear:
![Captura de tela de 2021-01-11 10-28-19](https://user-images.githubusercontent.com/17319734/104191550-6964a680-53fc-11eb-96ef-3c8055923f5c.png)
![Captura de tela de 2021-01-11 10-29-17](https://user-images.githubusercontent.com/17319734/104191570-6d90c400-53fc-11eb-84e4-97162af4b125.png)

## How to test
Use test instructions described in https://github.com/storybookjs/frontpage#docs-content .
