### PR TITLE
Addon-actions: Normalize args

### DIFF
--- a/addons/actions/src/preview/__tests__/action.test.js
+++ b/addons/actions/src/preview/__tests__/action.test.js
@@ -16,7 +16,7 @@ describe('Action', () => {
 
     action('test-action')('one');
 
-    expect(getChannelData(channel)[0]).toEqual('one');
+    expect(getChannelData(channel)).toEqual('one');
   });
 
   it('with multiple arguments', () => {
@@ -46,7 +46,7 @@ describe('Depth config', () => {
       },
     });
 
-    expect(getChannelData(channel)[0]).toEqual({
+    expect(getChannelData(channel)).toEqual({
       root: {
         one: {
           two: 'foo',
@@ -76,7 +76,7 @@ describe('Depth config', () => {
       },
     });
 
-    expect(getChannelData(channel)[0]).toEqual({
+    expect(getChannelData(channel)).toEqual({
       root: {
         one: {
           two: {
@@ -111,7 +111,7 @@ describe('allowFunction config', () => {
       },
     });
 
-    expect(getChannelData(channel)[0]).toEqual({
+    expect(getChannelData(channel)).toEqual({
       root: {
         one: {
           a: 1,
@@ -140,7 +140,7 @@ describe('allowFunction config', () => {
       },
     });
 
-    expect(getChannelData(channel)[0]).toEqual({
+    expect(getChannelData(channel)).toEqual({
       root: {
         one: {
           a: 1,

--- a/addons/actions/src/preview/__tests__/actions.test.js
+++ b/addons/actions/src/preview/__tests__/actions.test.js
@@ -20,7 +20,7 @@ describe('Actions', () => {
     expect(Object.keys(actionsResult)).toEqual(['test-action']);
     actionsResult['test-action']('one');
 
-    expect(getChannelData(channel, 0)).toEqual({ name: 'test-action', args: ['one'] });
+    expect(getChannelData(channel, 0)).toEqual({ name: 'test-action', args: 'one' });
   });
 
   it('with multiple arguments', () => {
@@ -33,8 +33,8 @@ describe('Actions', () => {
     actionsResult['test-action']('one');
     actionsResult['test-action2']('two');
 
-    expect(getChannelData(channel, 0)).toEqual({ name: 'test-action', args: ['one'] });
-    expect(getChannelData(channel, 1)).toEqual({ name: 'test-action2', args: ['two'] });
+    expect(getChannelData(channel, 0)).toEqual({ name: 'test-action', args: 'one' });
+    expect(getChannelData(channel, 1)).toEqual({ name: 'test-action2', args: 'two' });
   });
 
   it('with multiple arguments + config', () => {
@@ -47,8 +47,8 @@ describe('Actions', () => {
     actionsResult['test-action']('one');
     actionsResult['test-action2']('two');
 
-    expect(getChannelData(channel, 0)).toEqual({ name: 'test-action', args: ['one'] });
-    expect(getChannelData(channel, 1)).toEqual({ name: 'test-action2', args: ['two'] });
+    expect(getChannelData(channel, 0)).toEqual({ name: 'test-action', args: 'one' });
+    expect(getChannelData(channel, 1)).toEqual({ name: 'test-action2', args: 'two' });
 
     expect(getChannelOptions(channel, 0).some).toEqual('config');
     expect(getChannelOptions(channel, 1).some).toEqual('config');
@@ -67,8 +67,8 @@ describe('Actions', () => {
     actionsResult['test-action']('one');
     actionsResult['test-action2']('two');
 
-    expect(getChannelData(channel, 0)).toEqual({ name: 'test action', args: ['one'] });
-    expect(getChannelData(channel, 1)).toEqual({ name: 'test action two', args: ['two'] });
+    expect(getChannelData(channel, 0)).toEqual({ name: 'test action', args: 'one' });
+    expect(getChannelData(channel, 1)).toEqual({ name: 'test action two', args: 'two' });
   });
 
   it('with first argument as array of arguments + config', () => {
@@ -81,8 +81,8 @@ describe('Actions', () => {
     actionsResult['test-action']('one');
     actionsResult['test-action2']('two');
 
-    expect(getChannelData(channel, 0)).toEqual({ name: 'test-action', args: ['one'] });
-    expect(getChannelData(channel, 1)).toEqual({ name: 'test-action2', args: ['two'] });
+    expect(getChannelData(channel, 0)).toEqual({ name: 'test-action', args: 'one' });
+    expect(getChannelData(channel, 1)).toEqual({ name: 'test-action2', args: 'two' });
 
     expect(getChannelOptions(channel, 0).some).toEqual('config');
     expect(getChannelOptions(channel, 1).some).toEqual('config');

--- a/addons/actions/src/preview/action.ts
+++ b/addons/actions/src/preview/action.ts
@@ -14,11 +14,12 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
     const channel = addons.getChannel();
     const id = uuidv4();
     const minDepth = 5; // anything less is really just storybook internals
+    const normalizedArgs = args.length > 1 ? args : args[0];
 
     const actionDisplayToEmit: ActionDisplay = {
       id,
       count: 0,
-      data: { name, args },
+      data: { name, args: normalizedArgs },
       options: {
         ...actionOptions,
         depth: minDepth + (actionOptions.depth || 3),


### PR DESCRIPTION
Issue: #7764

addon-action now will show results out of an array when it's not an array.

## What I did

I added treatment for the args received on addon-actions. Before, it was sending the args forward. Now, when it is only one argument, it will send the argument outside of an array.

Before:

![image](https://user-images.githubusercontent.com/5339165/104385347-60c2bc00-5533-11eb-9d0e-c0a3492c5c0e.png)

After: 

![image](https://user-images.githubusercontent.com/5339165/104385405-7637e600-5533-11eb-9d1e-82e10656fe4e.png)


## How to test

- Is this testable with Jest or Chromatic screenshots?
 I did update the tests
- Does this need a new example in the kitchen sink apps?
 No
- Does this need an update to the documentation?
 I don't think so.

If your answer is yes to any of these, please make sure to include it in your PR.

Thanks @yannbf for the guidance :D
