### PR TITLE
Fix writing-addons docs

### DIFF
--- a/docs/snippets/common/my-addon-storybook-registration.js.mdx
+++ b/docs/snippets/common/my-addon-storybook-registration.js.mdx
@@ -7,7 +7,7 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/preset-create-react-app",
-    "../src/preset.js" //👈 Our addon registered here
+    "../dist/preset.js" //👈 Our addon registered here
   ]
 }
 ```


### PR DESCRIPTION
Issue:
The `src` path throws a webpack error because it's expecting CJS but it's using ESM.

## What I did
Changed `src` to `dist` in docs.

## How to test
No testing needed; just a documentation fix.

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No. 
