### PR TITLE
Maintenance: Configure Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "group:allNonMajor"
+  ],
+  "prHourlyLimit": 1,
+  "prConcurrentLimit": 1,
+  // Custom ignore paths to include our `examples/` directory
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
+  "enabledManagers": [
+    "npm"
+  ],
+  // Ignore release notes for non-breaking changes
+  "fetchReleaseNotes": false,
+  // Always bump minor/patch to latest
+  "rangeStrategy": "bump",
+  "major": {
+    // Replace ranges when there is a major
+    "rangeStrategy": "replace",
+    // Get us the release notes for breaking changes
+    "fetchReleaseNotes": true
+  },
+  "packageRules": [
+    // Leave peerDependencies and engines alone
+    {
+      "depTypeList": [
+        "peerDependencies",
+        "engines"
+      ],
+      "enabled": false
+    },
+    // Handle patch updates under 0.1.0 as potentially breaking
+    // Workaround for https://github.com/renovatebot/renovate/issues/3588
+    {
+      "managers": [
+        "npm"
+      ],
+      "matchCurrentVersion": "<0.1.0",
+      "rangeStrategy": "replace",
+      "groupName": "maybe breaking patch updates",
+      "groupSlug": "maybe-breaking-patch",
+      // Get us the release notes for potentially breaking changes
+      "fetchReleaseNotes": true
+    },
+    // Handle minor updates under 1.0.0 as potentially breaking
+    // Workaround for https://github.com/renovatebot/renovate/issues/3588
+    {
+      "managers": [
+        "npm"
+      ],
+      "matchCurrentVersion": "<1.0.0 >=0.1.0",
+      "minor": {
+        "rangeStrategy": "replace",
+        "groupName": "maybe breaking minor updates",
+        "groupSlug": "maybe-breaking-minor",
+        // Get us the release notes for potentially breaking changes
+        "fetchReleaseNotes": true
+      }
+    },
+    // Group Storybook's linter configs together
+    {
+      "packageNames": [
+        "@storybook/eslint-config-storybook",
+        "@storybook/linter-config"
+      ],
+      "groupName": "storybook linting"
+    },
+    // Group Puppeteer packages together
+    {
+      "packagePatterns": [
+        "^puppeteer",
+        "^@types/puppeteer"
+      ],
+      "groupName": "puppeteer"
+    },
+    // Group Acorn packages together
+    {
+      "packagePatterns": [
+        "^acorn"
+      ],
+      "groupName": "acorn"
+    },
+    // Group React packages together
+    {
+      "packageNames": [
+        "react",
+        "@types/react",
+        "react-dom",
+        "@types/react-dom"
+      ],
+      "groupName": "react"
+    }
+  ],
+  // Simplifies the PR body
+  "prBodyTemplate": "{{{table}}}{{{notes}}}{{{changelogs}}}",
+  "prBodyColumns": [
+    "Package",
+    "Change"
+  ],
+  // https://docs.renovatebot.com/merge-confidence/#enabling-and-disabling
+  "ignorePresets": [
+    "github>whitesource/merge-confidence:beta"
+  ]
+}


### PR DESCRIPTION
Issue: N/A

## What I did

I added some configuration that makes it easy to run the `renovate` CLI tool against Storybook!

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
