### PR TITLE
Chore: Addons docs missing info for supported and unsupported metadata property

### DIFF
--- a/docs/addons/addon-catalog.md
+++ b/docs/addons/addon-catalog.md
@@ -2,12 +2,6 @@
 title: 'Add to the addon catalog'
 ---
 
-<div class="aside">
-
-The addon catalog is in <strong>beta</strong>. Please [report any issues](https://github.com/storybookjs/frontpage/issues) you find.
-
-</div>
-
 Storybook addons are listed in the [catalog](/addons) and distributed via npm. The catalog is populated by querying npm's registry for Storybook-specific metadata in `package.json`.
 
 Add your addon to the catalog by publishing an npm package that follows these requirements:

--- a/docs/addons/addon-catalog.md
+++ b/docs/addons/addon-catalog.md
@@ -41,8 +41,22 @@ Customize your addon's appearance by adding the `storybook` property with the fo
 | ----------------------- | --------------------------------- | ------------------------------------- |
 | `displayName`           | Display name                      | Outline                               |
 | `icon`                  | Link to custom icon for the addon | https://yoursite.com/outline-icon.png |
-| `unsupportedFrameworks` | List of unsupported frameworks    | `["Vue"]`                             |
-| `supportedFrameworks`   | List of supported frameworks      | `["React", "Angular"]`                |
+| `unsupportedFrameworks` | List of unsupported frameworks    | `["vue"]`                             |
+| `supportedFrameworks`   | List of supported frameworks      | `["react", "angular"]`                |
+
+
+Use the table below as a reference when filling in the values for both the `supportedFrameworks` and `unsupportedFrameworks` metadata properties. 
+
+| react          | vue        | angular      |
+|----------------|------------|--------------|
+| web-components | ember      | html         |
+| mithril        | marko      | svelte       |
+| riot           | preact     | rax          |
+| aurelia        | marionette | react-native |
+
+<div class="aside">
+Note: Make sure to copy each item <strong>exactly</strong> as listed so that we can properly index your addon in our catalog.
+</div>
 
 ```json
 {


### PR DESCRIPTION
Based on a conversation with @winkerVSbecks the documentation was updated to include the information regarding the `supported` and ` unsupported` metadata property.

What was done:
- Included the list of values that should be used for each property.
- Adjusted the information's table to match the values documented.

@winkerVSbecks let me know if you're ok with this.

Feel free to provide feedback