### PR TITLE
Cleanup: Remove some references to dependency:update label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,7 +11,6 @@ exemptLabels:
   - 'needs review'
   - 'high priority'
   - 'good first issue'
-  - dependencies:update
 
 # Label to use when marking an issue as stale
 staleLabel: inactive

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,7 +24,6 @@ This document will document some of the processes that members of the documentat
 | components | |
 | core | |
 | decorators | |
-| dependencies:update | |
 | dependencies | |
 | discussion | |
 | do not merge | |

--- a/package.json
+++ b/package.json
@@ -231,8 +231,7 @@
   },
   "pr-log": {
     "skipLabels": [
-      "cleanup",
-      "doc-dependencies:update"
+      "cleanup"
     ],
     "validLabels": [
       [
@@ -254,10 +253,6 @@
       [
         "maintenance",
         "Maintenance"
-      ],
-      [
-        "dependencies:update",
-        "Dependency Upgrades"
       ],
       [
         "dependencies",


### PR DESCRIPTION
Issue: N/A

## What I did

As per discussion with @shilman - I removed the old references to `dependencies:update` label and migrated all those to `dependencies` label.

## How to test

- Is this testable with Jest or Chromatic screenshots? N/A
- Does this need a new example in the kitchen sink apps? N/A
- Does this need an update to the documentation? N/A

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
