### PR TITLE
Dependencies: Swap postcss-loader for fork version

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -50,7 +50,7 @@
     "fork-ts-checker-webpack-plugin": "^4.1.6",
     "global": "^4.4.0",
     "postcss": "^7.0.35",
-    "postcss-loader": "^4.1.0",
+    "postcss-loader": "npm:@phated/postcss-loader@4.2.0-phated.1",
     "raw-loader": "^4.0.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -118,7 +118,7 @@
     "pnp-webpack-plugin": "1.6.4",
     "postcss": "^7.0.35",
     "postcss-flexbugs-fixes": "^4.2.1",
-    "postcss-loader": "^4.1.0",
+    "postcss-loader": "npm:@phated/postcss-loader@4.2.0-phated.1",
     "pretty-hrtime": "^1.0.3",
     "prompts": "^2.4.0",
     "qs": "^6.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25103,10 +25103,10 @@ postcss-loader@4.0.4:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-postcss-loader@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-4.1.0.tgz#4647a6c8dad3cb6b253fbfaa21d62201086f6e39"
-  integrity sha512-vbCkP70F3Q9PIk6d47aBwjqAMI4LfkXCoyxj+7NPNuVIwfTGdzv2KVQes59/RuxMniIgsYQCFSY42P3+ykJfaw==
+"postcss-loader@npm:@phated/postcss-loader@4.2.0-phated.1":
+  version "4.2.0-phated.1"
+  resolved "https://registry.yarnpkg.com/@phated/postcss-loader/-/postcss-loader-4.2.0-phated.1.tgz#ee6ab970a18454d81997b1be6e7812e987d3c803"
+  integrity sha512-qi3bdLXb7CgjjBFY/WuHQ2M4V+nh4gJdymc7OyRsnq5rWlYxskyWag8X0Brv0qUc2RQqsEWZRpdGAnqESLCM8Q==
   dependencies:
     cosmiconfig "^7.0.0"
     klona "^2.0.4"


### PR DESCRIPTION
Issue: Ref #12668 

## What I did

As part of the multi-phased work to support PostCSS 8, I needed to fork the postcss-loader and add a feature that allows a custom `postcss` factory to be passed as an option.

I submitted the feature as a [PR upstream](https://github.com/webpack-contrib/postcss-loader/pull/511), but they indicated in https://github.com/webpack-contrib/postcss-loader/issues/510 that this feature was out-of-scope and wouldn't be accepted.

I believe we can rely on my published fork for the duration of 6.x and deprecate relying implicitly on our direct PostCSS dependency. In 7.0, we can require that PostCSS be installed as a peerDep and switch back to the upstream loader.

The last part of this phased transition will be converting the PostCSS stuff to an addon, but I wanted to start depending on this fork ASAP if it won't make it into upstream.

## How to test

- Is this testable with Jest or Chromatic screenshots? postcss-loader is used in html-kitchen-sink and angular example.
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
