### PR TITLE
Addon-docs: Fix Component description in Svelte

### DIFF
--- a/addons/docs/src/frameworks/svelte/config.ts
+++ b/addons/docs/src/frameworks/svelte/config.ts
@@ -1,5 +1,5 @@
 import { extractArgTypes } from './extractArgTypes';
-import { extractComponentDescription } from '../../lib/docgen';
+import { extractComponentDescription } from './extractComponentDescription';
 import { prepareForInline } from './prepareForInline';
 
 export const parameters = {

--- a/addons/docs/src/frameworks/svelte/extractComponentDescription.test.ts
+++ b/addons/docs/src/frameworks/svelte/extractComponentDescription.test.ts
@@ -1,0 +1,15 @@
+import { extractComponentDescription } from './extractComponentDescription';
+
+describe('extractComponentDescription', () => {
+  test('Extract from docgen', () => {
+    expect(extractComponentDescription({ __docgen: { description: 'a description' } })).toBe(
+      'a description'
+    );
+  });
+  test('Null Component', () => {
+    expect(extractComponentDescription(null)).toBeFalsy();
+  });
+  test('Missing docgen', () => {
+    expect(extractComponentDescription({})).toBeFalsy();
+  });
+});

--- a/addons/docs/src/frameworks/svelte/extractComponentDescription.ts
+++ b/addons/docs/src/frameworks/svelte/extractComponentDescription.ts
@@ -1,0 +1,10 @@
+import { Component } from '../../blocks/types';
+
+export function extractComponentDescription(component?: Component): string {
+  if (!component) {
+    return null;
+  }
+
+  const { __docgen = {} } = component;
+  return __docgen.description;
+}

--- a/examples/svelte-kitchen-sink/src/stories/views/ControlShowcaseView.svelte
+++ b/examples/svelte-kitchen-sink/src/stories/views/ControlShowcaseView.svelte
@@ -1,4 +1,8 @@
 <script>
+  /**
+   * Control Showcase
+   * @component
+   */
   import Button from '../../components/Button.svelte';
 
   /**


### PR DESCRIPTION
Issue: #13658

## What I did

The current implementation of `extractComponentDescription` doesn't handle correctly the generated docgen.
I have added a specific svelte version

## How to test

- Is this testable with Jest or Chromatic screenshots? Done
- Does this need a new example in the kitchen sink apps? Done
- Does this need an update to the documentation? No
