### PR TITLE
Svelte: Add Slots and Events to the generated ArgsTable

### DIFF
--- a/addons/docs/src/frameworks/svelte/extractArgTypes.test.ts
+++ b/addons/docs/src/frameworks/svelte/extractArgTypes.test.ts
@@ -17,10 +17,16 @@ describe('Extracting Arguments', () => {
         function onClick(event) {
           rounded = !rounded;
 
+          /**
+           * Click Event 
+           */
           dispatch('click', event);
         }
 
         afterUpdate(() => {
+          /**
+           * After Update
+           */
           dispatch('afterUpdate');
         });
       </script>
@@ -47,7 +53,7 @@ describe('Extracting Arguments', () => {
         </strong>
         <br>
         {text}
-        <slot>
+        <slot {rounded}>
         </slot>
       </button>
     `);
@@ -60,6 +66,26 @@ describe('Extracting Arguments', () => {
 
     expect(results).toMatchInlineSnapshot(`
       Object {
+        "event_afterUpdate": Object {
+          "description": "After Update",
+          "name": "afterUpdate",
+          "table": Object {
+            "category": "events",
+          },
+          "type": Object {
+            "name": "void",
+          },
+        },
+        "event_click": Object {
+          "description": "Click Event",
+          "name": "click",
+          "table": Object {
+            "category": "events",
+          },
+          "type": Object {
+            "name": "void",
+          },
+        },
         "rounded": Object {
           "control": Object {
             "type": "boolean",
@@ -68,11 +94,30 @@ describe('Extracting Arguments', () => {
           "description": null,
           "name": "rounded",
           "table": Object {
+            "category": "properties",
             "defaultValue": Object {
               "summary": true,
             },
+            "type": Object {
+              "summary": "boolean",
+            },
           },
-          "type": Object {},
+          "type": Object {
+            "required": false,
+            "summary": "boolean",
+          },
+        },
+        "slot_default": Object {
+          "description": "Default Slot
+
+      \`{rounded}\`",
+          "name": "default",
+          "table": Object {
+            "category": "slots",
+          },
+          "type": Object {
+            "name": "void",
+          },
         },
         "text": Object {
           "control": Object {
@@ -82,11 +127,18 @@ describe('Extracting Arguments', () => {
           "description": null,
           "name": "text",
           "table": Object {
+            "category": "properties",
             "defaultValue": Object {
               "summary": "",
             },
+            "type": Object {
+              "summary": "string",
+            },
           },
-          "type": Object {},
+          "type": Object {
+            "required": false,
+            "summary": "string",
+          },
         },
       }
     `);

--- a/addons/docs/src/frameworks/svelte/sample/MockButton.svelte
+++ b/addons/docs/src/frameworks/svelte/sample/MockButton.svelte
@@ -8,10 +8,16 @@
   function onClick(event) {
     rounded = !rounded;
 
+    /**
+     * Click Event 
+     */
     dispatch('click', event);
   }
 
   afterUpdate(() => {
+    /**
+     * After Update
+     */
     dispatch('afterUpdate');
   });
 </script>
@@ -34,5 +40,6 @@
   <strong>{rounded ? 'Round' : 'Square'} corners</strong>
   <br />
   {text}
-  <slot />
+  <!-- Default Slot -->
+  <slot {rounded}/>
 </button>

--- a/examples/svelte-kitchen-sink/jest.config.js
+++ b/examples/svelte-kitchen-sink/jest.config.js
@@ -7,5 +7,8 @@ module.exports = {
     ...config.transform,
     '.*\\.(svelte)$': '<rootDir>/scripts/utils/jest-transform-svelte',
   },
+  moduleNameMapper: {
+    '!!raw-loader!.*': '<rootDir>/__mocks__/fileMock.js',
+  },
   moduleFileExtensions: [...config.moduleFileExtensions, 'svelte'],
 };

--- a/examples/svelte-kitchen-sink/src/stories/__snapshots__/argstable.stories.storyshot
+++ b/examples/svelte-kitchen-sink/src/stories/__snapshots__/argstable.stories.storyshot
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Args Table Args Table 1`] = `
+<section
+  class="storybook-snapshot-container"
+>
+  <pre>
+    {}
+  </pre>
+   
+  <div />
+   
+  <div />
+   
+   
+</section>
+`;

--- a/examples/svelte-kitchen-sink/src/stories/argstable.stories.js
+++ b/examples/svelte-kitchen-sink/src/stories/argstable.stories.js
@@ -1,0 +1,20 @@
+import ArgsTableView from './views/ArgsTableView.svelte';
+// eslint-disable-next-line
+import srcArgsTableView from '!!raw-loader!./views/ArgsTableView.svelte';
+
+export default {
+  title: 'Args Table',
+  component: ArgsTableView,
+};
+
+export const ArgsTable = (args) => ({
+  Component: ArgsTableView,
+  props: args,
+});
+ArgsTable.parameters = {
+  docs: {
+    source: {
+      code: srcArgsTableView,
+    },
+  },
+};

--- a/examples/svelte-kitchen-sink/src/stories/views/ArgsTableView.svelte
+++ b/examples/svelte-kitchen-sink/src/stories/views/ArgsTableView.svelte
@@ -1,0 +1,56 @@
+<script>
+    import { createEventDispatcher } from 'svelte';
+
+    const dispatch = createEventDispatcher();
+
+    export let string = 'string';
+    export let number = 0;
+    /**
+     * @type {(string) => string}
+     */
+    export let fun = (key) => '';
+    /**
+     * @type {'a'|'b'}
+     */
+    export let unionstr = 'a';
+
+     /**
+     * @type {0|1}
+     */
+     export let unionnumeric = 1;
+
+    /** @typedef {object} TypeA */
+    /** @typedef {number} TypeB */
+    /** @type {TypeA|TypeB}*/
+    export let union;
+
+    /**
+     * @required
+     */
+    export let required = '';
+
+    export let unknown;
+
+    function onClick() {
+        /**
+         * Event description 
+         */
+        dispatch('change', "some value");
+    }
+    
+</script>
+
+<pre on:click={onClick}>{JSON.stringify($$props, null, '  ')}</pre>
+
+<!-- 
+    User has clicked this element
+-->
+<div on:click/>
+
+<div on:click={() => /** Close description */ dispatch('close')}/>
+
+<!-- Default Slot -->
+<slot/>
+
+<!-- Slot for actions -->
+<slot name="actions" {required} value={string}/>


### PR DESCRIPTION
Issue: None

## What I did

Improvements on the generated ArgsTable with Svelte, like Vue : 3 sections, Properties, Events and Slots.

## How to test

- Is this testable with Jest or Chromatic screenshots? Done
- Does this need a new example in the kitchen sink apps? Done
- Does this need an update to the documentation? No
