### PR TITLE
Svelte: Fix duplicate story preview

### DIFF
--- a/addons/docs/src/frameworks/svelte/HOC.svelte
+++ b/addons/docs/src/frameworks/svelte/HOC.svelte
@@ -1,19 +1,7 @@
 <script>
-  import { onMount } from 'svelte';
-
   export let component;
   export let props;
-  let child;
-
-  const hash = `svelte mounter ${Math.floor(Math.random() * 100)}`;
-
-  onMount(() => {
-    child = new component({
-      target: document.getElementById(hash),
-      props,
-    });
-  });
 </script>
 
 <svelte:options accessors={true} />
-<div id={hash} />
+<svelte:component this={component} {...props}/>


### PR DESCRIPTION
Issue: #13662

## What I did

HOC doesn't destroy it child component. There is probably memory/resources leak related to this issue.

The fix is simple here: using <svelte:component/> instead of mounting manually the nested component.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
