### PR TITLE
Core: Throw an error for invalid story format

### DIFF
--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -658,6 +658,18 @@ describe('preview.client_api', () => {
           expect(entry.stories[0].render()).toBe('story2');
         }
       });
+
+      it('should throw an error if story is in wrong format', () => {
+        const {
+          clientApi: { storiesOf },
+        } = getContext();
+
+        expect(() => {
+          storiesOf('kind', module).add('test', 'String that should be a function instead' as any);
+        }).toThrow(
+          'Cannot load story "test" in "kind" due to invalid format. Storybook expected a function but received string instead.'
+        );
+      });
     });
   });
 });

--- a/lib/client-api/src/client_api.ts
+++ b/lib/client-api/src/client_api.ts
@@ -206,6 +206,12 @@ export default class ClientApi {
         throw new Error(`Invalid or missing storyName provided for a "${kind}" story.`);
       }
 
+      if (typeof storyFn !== 'function') {
+        throw new Error(
+          `Cannot load story "${storyName}" in "${kind}" due to invalid format. Storybook expected a function but received ${typeof storyFn} instead.`
+        );
+      }
+
       if (!this._noStoryModuleAddMethodHotDispose && m && m.hot && m.hot.dispose) {
         m.hot.dispose(() => {
           const { _storyStore } = this;


### PR DESCRIPTION
Issue:
When mistakenly a user writes a story such as:
```jsx
export const Basic = <div>Hello</div>
```

rather than:
```jsx
export const Basic = () => <div>Hello</div>
```

Storybook fails with an error that is not very helpful:
![image](https://user-images.githubusercontent.com/1671563/105083408-24dca900-5a95-11eb-8c4d-a447744e6256.png)


## What I did

This PR adds a check in the client api that will break Storybook if the story received is not a function telling exactly which story is broken. It's a similar mechanism than the one that checks if `storyName` is not a string.

Here's how it looks like:
![image](https://user-images.githubusercontent.com/1671563/105084370-83eeed80-5a96-11eb-8623-dedade6c41c5.png)


I personally find it quite useful that Storybook breaks entirely because it tells the users that there is a critical error given that their stories are broken and it forces them to fix the problem right away.


## How to test

1 - check the branch
2 - `yarn build client-api`
3 - add this to any of the example stories:
```jsx
export const Basic = <div>Hello</div>
```
4 - run Storybook (e.g. `yarn start`)

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
