### PR TITLE
Build: Ensure consistency of Chromatic snapshots of Zoom stories

### DIFF
--- a/lib/components/src/Zoom/Zoom.stories.tsx
+++ b/lib/components/src/Zoom/Zoom.stories.tsx
@@ -9,6 +9,9 @@ export default {
       control: { type: 'range', min: 0.2, max: 30, step: 0.02 },
     },
   },
+  parameters: {
+    chromatic: { delay: 300 },
+  },
 };
 const EXAMPLE_ELEMENT = (
   <div


### PR DESCRIPTION
Issue: The zoom related stories look to take some time to be properly rendered, so the Chromatic snapshots aren't always the same causing some false positive changes in almost every PR.

## What I did

I followed Chromatic doc and added a small delay to ensure the rendering/zoom is done before taking the snapshot.
Details: https://www.chromatic.com/docs/delay

## How to test

- The snapshots of all the Zoom stories should be OK
- After this PR will be merged we shouldn't have false positive on these stories.