### PR TITLE
docs: fix args definition in How to write stories

### DIFF
--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -4,7 +4,7 @@ title: 'How to write stories'
 
 A story captures the rendered state of a UI component. It’s a function that returns a component’s state given a set of arguments.
 
-Storybook uses the generic term arguments (args for short) when talking about React’s `props`, Vue’s `slots`, Angular’s `@input`, and other similar concepts.
+Storybook uses the generic term arguments (args for short) when talking about React’s `props`, Vue’s `props`, Angular’s `@Input`, and other similar concepts.
 
 ## Where to put stories
 


### PR DESCRIPTION
## What I did

I changed the definition of arguments in How to write stories. Because [slots](https://v3.vuejs.org/guide/component-slots.html) is something completely different from [props](https://v3.vuejs.org/guide/component-props.html#prop-types) in Vue.js and it might confuse less experienced developers.

I also changed Angular's `@Input` to match the actual syntax in Angular components (title case).