### PR TITLE
Dependencies: Swap back to upstream postcss-loader

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -50,7 +50,7 @@
     "fork-ts-checker-webpack-plugin": "^4.1.6",
     "global": "^4.4.0",
     "postcss": "^7.0.35",
-    "postcss-loader": "npm:@phated/postcss-loader@4.2.0-phated.1",
+    "postcss-loader": "^4.2.0",
     "raw-loader": "^4.0.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -118,7 +118,7 @@
     "pnp-webpack-plugin": "1.6.4",
     "postcss": "^7.0.35",
     "postcss-flexbugs-fixes": "^4.2.1",
-    "postcss-loader": "npm:@phated/postcss-loader@4.2.0-phated.1",
+    "postcss-loader": "^4.2.0",
     "pretty-hrtime": "^1.0.3",
     "prompts": "^2.4.0",
     "qs": "^6.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25088,16 +25088,16 @@ postcss-loader@4.0.4:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-"postcss-loader@npm:@phated/postcss-loader@4.2.0-phated.1":
-  version "4.2.0-phated.1"
-  resolved "https://registry.yarnpkg.com/@phated/postcss-loader/-/postcss-loader-4.2.0-phated.1.tgz#ee6ab970a18454d81997b1be6e7812e987d3c803"
-  integrity sha512-qi3bdLXb7CgjjBFY/WuHQ2M4V+nh4gJdymc7OyRsnq5rWlYxskyWag8X0Brv0qUc2RQqsEWZRpdGAnqESLCM8Q==
+postcss-loader@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-4.2.0.tgz#f6993ea3e0f46600fb3ee49bbd010448123a7db4"
+  integrity sha512-mqgScxHqbiz1yxbnNcPdKYo/6aVt+XExURmEbQlviFVWogDbM4AJ0A/B+ZBpYsJrTRxKw7HyRazg9x0Q9SWwLA==
   dependencies:
     cosmiconfig "^7.0.0"
     klona "^2.0.4"
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.3.4"
 
 postcss-logical@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Issue: N/A

## What I did

I swapped back to the upstream postcss-loader since they landed and released my PR.

## How to test

- Is this testable with Jest or Chromatic screenshots? It is hooked up to the angular and html examples
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
