### PR TITLE
Fixes smoke-test on svelte-kitchen-sink

### DIFF
--- a/examples/svelte-kitchen-sink/src/stories/__snapshots__/argstable.stories.storyshot
+++ b/examples/svelte-kitchen-sink/src/stories/__snapshots__/argstable.stories.storyshot
@@ -5,7 +5,13 @@ exports[`Storyshots Args Table Args Table 1`] = `
   class="storybook-snapshot-container"
 >
   <pre>
-    {}
+    {
+  "string": "string",
+  "number": 0,
+  "unionstr": "a",
+  "unionnumeric": 1,
+  "required": ""
+}
   </pre>
    
   <div />

--- a/examples/svelte-kitchen-sink/src/stories/views/ArgsTableView.svelte
+++ b/examples/svelte-kitchen-sink/src/stories/views/ArgsTableView.svelte
@@ -37,10 +37,21 @@
          */
         dispatch('change', "some value");
     }
+
+    $: preview = {
+        string,
+        number,
+        fun,
+        unionstr,
+        unionnumeric,
+        union,
+        required,
+        unknown,
+    }
     
 </script>
 
-<pre on:click={onClick}>{JSON.stringify($$props, null, '  ')}</pre>
+<pre on:click={onClick}>{JSON.stringify(preview, null, '  ')}</pre>
 
 <!-- 
     User has clicked this element


### PR DESCRIPTION
Issue: svelte-kitchen-sink smoke-test fails because of the warnings in the argstable story.

## What I did

I have fixed the warning in this stories.
It's probably a bug in the svelte compiler because this warning should be disabled when $$props is used, but i'll check that later.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
