### PR TITLE
Fixed typo in typescript documentation snippet

### DIFF
--- a/docs/snippets/react/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/react/list-story-with-subcomponents.ts.mdx
@@ -12,7 +12,7 @@ export default {
   title: 'List',
 } as Meta;
 
-export const Empty = Story<ListProps> = (args) => <List {...args} />;;
+export const Empty: Story<ListProps> = (args) => <List {...args} />;
 
 export const OneItem = (args) => (
   <List {...args}>


### PR DESCRIPTION
Issue:

## What I did
Fixed typo in `react-typescript` documentation snippet. (`list-story-with-subcomponents.ts.mdx`)

## How to test
N/A
