### PR TITLE
Addon-backgrounds: Respect user's reduced motion settings

### DIFF
--- a/addons/backgrounds/src/decorators/withBackground.ts
+++ b/addons/backgrounds/src/decorators/withBackground.ts
@@ -1,7 +1,12 @@
 import { StoryFn as StoryFunction, StoryContext, useMemo, useEffect } from '@storybook/addons';
 
 import { PARAM_KEY as BACKGROUNDS_PARAM_KEY } from '../constants';
-import { clearStyles, addBackgroundStyle, getBackgroundColorByName } from '../helpers';
+import {
+  clearStyles,
+  addBackgroundStyle,
+  getBackgroundColorByName,
+  isReduceMotionEnabled,
+} from '../helpers';
 
 export const withBackground = (StoryFn: StoryFunction, context: StoryContext) => {
   const { globals, parameters } = context;
@@ -29,10 +34,11 @@ export const withBackground = (StoryFn: StoryFunction, context: StoryContext) =>
     context.viewMode === 'docs' ? `#anchor--${context.id} .docs-story` : '.sb-show-main';
 
   const backgroundStyles = useMemo(() => {
+    const transitionStyle = 'transition: background-color 0.3s;';
     return `
       ${selector} {
         background: ${selectedBackgroundColor} !important;
-        transition: background-color 0.3s;
+        ${isReduceMotionEnabled() ? '' : transitionStyle}
       }
     `;
   }, [selectedBackgroundColor, selector]);

--- a/addons/backgrounds/src/helpers/index.ts
+++ b/addons/backgrounds/src/helpers/index.ts
@@ -5,7 +5,12 @@ import { logger } from '@storybook/client-logger';
 
 import { Background } from '../types';
 
-const { document } = global;
+const { document, window } = global;
+
+export const isReduceMotionEnabled = () => {
+  const prefersReduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  return prefersReduceMotion.matches;
+};
 
 export const getBackgroundColorByName = (
   currentSelectedValue: string,


### PR DESCRIPTION
Issue: #13612

## What I did
Addon backgrounds should respect the user's configuration, so it should disable the backgrounds transition animation when requested

![reducedMotion](https://user-images.githubusercontent.com/1671563/105524616-28b03b80-5ce0-11eb-9eb9-5fe9d06eadd9.gif)

## How to test
Open the chromatic build and toggle reduced motion to see if it has effect

If your answer is yes to any of these, please make sure to include it in your PR.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200539748475788/1200567521206880) by [Unito](https://www.unito.io)
