### PR TITLE
Build: Exclude more files from transpilation, generate versions with preval, and enable deepscan in workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deepscan.enable": true
+}

--- a/addons/a11y/tsconfig.json
+++ b/addons/a11y/tsconfig.json
@@ -11,5 +11,12 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/__tests__/**/*"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/actions/tsconfig.json
+++ b/addons/actions/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env", "jest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/__tests__/**/*", "src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/backgrounds/tsconfig.json
+++ b/addons/backgrounds/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/controls/tsconfig.json
+++ b/addons/controls/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env", "jest", "node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/cssresources/tsconfig.json
+++ b/addons/cssresources/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/design-assets/tsconfig.json
+++ b/addons/design-assets/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/docs/tsconfig.json
+++ b/addons/docs/tsconfig.json
@@ -5,5 +5,11 @@
     "types": ["webpack-env", "jest", "node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/essentials/tsconfig.json
+++ b/addons/essentials/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env", "jest", "node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/events/tsconfig.json
+++ b/addons/events/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/google-analytics/tsconfig.json
+++ b/addons/google-analytics/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/graphql/tsconfig.json
+++ b/addons/graphql/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/jest/tsconfig.json
+++ b/addons/jest/tsconfig.json
@@ -4,6 +4,15 @@
     "rootDir": "./src",
     "types": ["webpack-env", "jest"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/__tests__/**/*"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/knobs/tsconfig.json
+++ b/addons/knobs/tsconfig.json
@@ -7,5 +7,12 @@
     "noUnusedLocals": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/__tests__/**/*"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/links/tsconfig.json
+++ b/addons/links/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/queryparams/tsconfig.json
+++ b/addons/queryparams/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/storysource/tsconfig.json
+++ b/addons/storysource/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/toolbars/tsconfig.json
+++ b/addons/toolbars/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env", "jest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/viewport/tsconfig.json
+++ b/addons/viewport/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/addons/tsconfig.json
+++ b/lib/addons/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/**.test.ts"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -31,8 +31,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "prepare": "node ./scripts/generateVersion.js && node ../../scripts/prepare.js",
-    "postversion": "node ./scripts/generateVersion.js"
+    "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
     "@reach/router": "^1.3.4",
@@ -59,6 +58,7 @@
     "@types/lodash": "^4.14.167",
     "@types/semver": "^7.3.4",
     "flush-promises": "^1.0.2",
+    "preval.macro": "^5.0.0",
     "qs": "^6.9.5"
   },
   "peerDependencies": {

--- a/lib/api/scripts/generateVersion.js
+++ b/lib/api/scripts/generateVersion.js
@@ -1,9 +1,0 @@
-const fs = require('fs');
-const path = require('path');
-
-const output = (version) => `export const version = '${version}';\n`;
-
-const text = fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8');
-const json = JSON.parse(text);
-
-fs.writeFileSync(path.join(__dirname, '../src/version.ts'), output(json.version), 'utf8');

--- a/lib/api/src/version.ts
+++ b/lib/api/src/version.ts
@@ -1,1 +1,11 @@
-export const version = '6.2.0-alpha.18';
+/* eslint-disable import/no-extraneous-dependencies */
+// @ts-ignore
+import preval from 'preval.macro';
+
+export const version = preval`
+  const fs = require('fs-extra');
+  const path = require('path');
+  const { version } = require(path.join(__dirname, '..', 'package.json'));
+
+  module.exports = version;
+` as string;

--- a/lib/api/tsconfig.json
+++ b/lib/api/tsconfig.json
@@ -4,5 +4,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/channel-postmessage/tsconfig.json
+++ b/lib/channel-postmessage/tsconfig.json
@@ -4,5 +4,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/channel-websocket/tsconfig.json
+++ b/lib/channel-websocket/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/channels/tsconfig.json
+++ b/lib/channels/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/**.test.ts"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/cli/tsconfig.json
+++ b/lib/cli/tsconfig.json
@@ -13,5 +13,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/template*", "src/frameworks/**/*"]
+  "exclude": ["src/**/template*", "**/*.test.*", "src/frameworks/**/*"]
 }

--- a/lib/client-api/tsconfig.json
+++ b/lib/client-api/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/client-logger/tsconfig.json
+++ b/lib/client-logger/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/components/tsconfig.json
+++ b/lib/components/tsconfig.json
@@ -10,7 +10,11 @@
     "src/**/*"
   ],
   "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
     "src/**/__tests__/**/*",
-    "src/**/*.stories.*"
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/core-events/tsconfig.json
+++ b/lib/core-events/tsconfig.json
@@ -4,5 +4,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/core/tsconfig.json
+++ b/lib/core/tsconfig.json
@@ -4,6 +4,13 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*", "typings.d.ts"],
-  "exclude": ["src/**.test.ts"],
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ],
   "files": ["./typings.d.ts"]
 }

--- a/lib/node-logger/tsconfig.json
+++ b/lib/node-logger/tsconfig.json
@@ -4,5 +4,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/router/tsconfig.json
+++ b/lib/router/tsconfig.json
@@ -7,7 +7,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/tests/**/*",
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/source-loader/tsconfig.json
+++ b/lib/source-loader/tsconfig.json
@@ -8,7 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/tests/**/*",
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/theming/tsconfig.json
+++ b/lib/theming/tsconfig.json
@@ -7,6 +7,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/ui/tsconfig.json
+++ b/lib/ui/tsconfig.json
@@ -7,5 +7,10 @@
     "lib": ["ESNext", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.*", "src/__tests__/**/*", "src/**/*.stories.*"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8021,6 +8021,15 @@ babel-plugin-polyfill-corejs3@^0.0.7:
     "@babel/helper-define-polyfill-provider" "^0.0.5"
     core-js-compat "^3.7.0"
 
+babel-plugin-preval@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-preval/-/babel-plugin-preval-5.0.0.tgz#6cabb947ecc241664966e1f99eb56a3b4bb63d1e"
+  integrity sha512-8DqJq6/LPUjSZ0Qq6bVIFpsj2flCEE0Cbnbut9TvGU6jP9g3dOWEXtQ/sdvsA9d6souza8eNGh04WRXpuH9ThA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    babel-plugin-macros "^2.8.0"
+    require-from-string "^2.0.2"
+
 babel-plugin-react-docgen@^4.1.0, babel-plugin-react-docgen@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-4.2.1.tgz#7cc8e2f94e8dc057a06e953162f0810e4e72257b"
@@ -25973,6 +25982,13 @@ prettyjson@^1.2.1:
   dependencies:
     colors "^1.1.2"
     minimist "^1.2.0"
+
+preval.macro@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/preval.macro/-/preval.macro-5.0.0.tgz#bb9e0e0cd06aee094dd84eed89851b5a7337cc2f"
+  integrity sha512-+OZRqZYx1pjZ7H5Jis8bPFXkiT7lwA46UzAT4IjuzFVKwkJK+TwIx1TCqrqNCf8U3e5O12mEJEz1BXslkCLWfQ==
+  dependencies:
+    babel-plugin-preval "^5.0.0"
 
 printf@^0.5.1:
   version "0.5.3"


### PR DESCRIPTION
Issue: #11220

## What I did

I recreated #11220 by rebasing and splitting up the commits a bit. I didn't include the node 8 -> 10 changes because I want to do that in a separate PR.

## How to test

- Is this testable with Jest or Chromatic screenshots? Should affect all tests
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
