### PR TITLE
Build: Exclude all test and story files from transpilation

### DIFF
--- a/addons/a11y/tsconfig.json
+++ b/addons/a11y/tsconfig.json
@@ -11,5 +11,12 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/__tests__/**/*"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/actions/tsconfig.json
+++ b/addons/actions/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env", "jest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/__tests__/**/*", "src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/backgrounds/tsconfig.json
+++ b/addons/backgrounds/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/controls/tsconfig.json
+++ b/addons/controls/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env", "jest", "node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/cssresources/tsconfig.json
+++ b/addons/cssresources/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/design-assets/tsconfig.json
+++ b/addons/design-assets/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/docs/tsconfig.json
+++ b/addons/docs/tsconfig.json
@@ -5,5 +5,11 @@
     "types": ["webpack-env", "jest", "node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/essentials/tsconfig.json
+++ b/addons/essentials/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env", "jest", "node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/events/tsconfig.json
+++ b/addons/events/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/google-analytics/tsconfig.json
+++ b/addons/google-analytics/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/graphql/tsconfig.json
+++ b/addons/graphql/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/jest/tsconfig.json
+++ b/addons/jest/tsconfig.json
@@ -4,6 +4,15 @@
     "rootDir": "./src",
     "types": ["webpack-env", "jest"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/__tests__/**/*"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/knobs/tsconfig.json
+++ b/addons/knobs/tsconfig.json
@@ -7,5 +7,12 @@
     "noUnusedLocals": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/__tests__/**/*"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/links/tsconfig.json
+++ b/addons/links/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/queryparams/tsconfig.json
+++ b/addons/queryparams/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/storysource/tsconfig.json
+++ b/addons/storysource/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/addons/toolbars/tsconfig.json
+++ b/addons/toolbars/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env", "jest"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/addons/viewport/tsconfig.json
+++ b/addons/viewport/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/addons/tsconfig.json
+++ b/lib/addons/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/**.test.ts"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/api/tsconfig.json
+++ b/lib/api/tsconfig.json
@@ -4,5 +4,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/channel-postmessage/tsconfig.json
+++ b/lib/channel-postmessage/tsconfig.json
@@ -4,5 +4,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/channel-websocket/tsconfig.json
+++ b/lib/channel-websocket/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "rootDir": "./src"
   },
-  "include": [
-    "src/**/*.ts"
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/channels/tsconfig.json
+++ b/lib/channels/tsconfig.json
@@ -8,6 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/**.test.ts"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/cli/tsconfig.json
+++ b/lib/cli/tsconfig.json
@@ -13,5 +13,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/template*", "src/frameworks/**/*"]
+  "exclude": ["src/**/template*", "**/*.test.*", "src/frameworks/**/*"]
 }

--- a/lib/client-api/tsconfig.json
+++ b/lib/client-api/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["webpack-env"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/client-logger/tsconfig.json
+++ b/lib/client-logger/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/components/tsconfig.json
+++ b/lib/components/tsconfig.json
@@ -10,7 +10,11 @@
     "src/**/*"
   ],
   "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
     "src/**/__tests__/**/*",
-    "src/**/*.stories.*"
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/core-events/tsconfig.json
+++ b/lib/core-events/tsconfig.json
@@ -4,5 +4,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/core/tsconfig.json
+++ b/lib/core/tsconfig.json
@@ -4,6 +4,13 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*", "typings.d.ts"],
-  "exclude": ["src/**.test.ts"],
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ],
   "files": ["./typings.d.ts"]
 }

--- a/lib/node-logger/tsconfig.json
+++ b/lib/node-logger/tsconfig.json
@@ -4,5 +4,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**.test.ts"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
+  ]
 }

--- a/lib/router/tsconfig.json
+++ b/lib/router/tsconfig.json
@@ -7,7 +7,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/tests/**/*",
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/source-loader/tsconfig.json
+++ b/lib/source-loader/tsconfig.json
@@ -8,7 +8,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/tests/**/*",
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/theming/tsconfig.json
+++ b/lib/theming/tsconfig.json
@@ -7,6 +7,11 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/__tests__/**/*"
+    "src/**/*.test.*",
+    "src/**/tests/**/*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*",
+    "src/**/__testfixtures__/**"
   ]
 }

--- a/lib/ui/tsconfig.json
+++ b/lib/ui/tsconfig.json
@@ -7,5 +7,10 @@
     "lib": ["ESNext", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.*", "src/__tests__/**/*", "src/**/*.stories.*"]
+  "exclude": [
+    "src/**/*.test.*",
+    "src/**/__tests__/**/*",
+    "src/**/*.stories.*",
+    "src/**/*.mockdata.*"
+  ]
 }


### PR DESCRIPTION
Issue: #11220

## What I did

I split out the additional excludes from #11220 into a separate commit. One question that @shilman had was whether or not we could put these in the root config that the packages extend from instead of duplicating all the boilerplate.

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
