### PR TITLE
CLI: Add safe check for eslint overrides

### DIFF
--- a/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -209,7 +209,7 @@ export abstract class JsPackageManager {
       eslintConfig: {
         ...packageJson.eslintConfig,
         overrides: [
-          ...(packageJson.eslintConfig.overrides || []),
+          ...(packageJson.eslintConfig?.overrides || []),
           {
             files: ['**/*.stories.*'],
             rules: {


### PR DESCRIPTION
Issue:
When running `npx sb@next init` in a CRA project and the project does not contain `eslintConfig.overrides` in package.json, the CLI throws an error:
![image](https://user-images.githubusercontent.com/1671563/105576593-2eeff780-5d74-11eb-8e74-cc1a0c4d5114.png)

## What I did

Add a safe check so that won't happen again

## How to test

- Checkout this branch
- Create a project without eslintConfig.overrides
- Run local cli
