### PR TITLE
Chore: Increase node version minimums to 10.13

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -103,7 +103,7 @@
     }
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/ember/package.json
+++ b/app/ember/package.json
@@ -55,7 +55,7 @@
     "ember-source": "^3.16.0"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/html/package.json
+++ b/app/html/package.json
@@ -58,7 +58,7 @@
     "@babel/core": "*"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/marionette/package.json
+++ b/app/marionette/package.json
@@ -56,7 +56,7 @@
     "underscore": "*"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/marko/package.json
+++ b/app/marko/package.json
@@ -58,7 +58,7 @@
     "webpack": "^4.44.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/mithril/package.json
+++ b/app/mithril/package.json
@@ -63,7 +63,7 @@
     "mithril": "^1.1.6 || ^2.0.0"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -61,7 +61,7 @@
     "preact": "^8.0.0||^10.0.0"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -85,7 +85,7 @@
     }
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/riot/package.json
+++ b/app/riot/package.json
@@ -68,7 +68,7 @@
     "webpack": "*"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -60,7 +60,7 @@
     "fs-extra": "^9.0.1"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -63,7 +63,7 @@
     "svelte-loader": "^2.9.1"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -73,7 +73,7 @@
     "vue-template-compiler": "^2.6.8"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -68,7 +68,7 @@
     "lit-html": "^1.0.0"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/cli/.babelrc.json
+++ b/lib/cli/.babelrc.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": 8
+          "node": 10
         },
         "useBuiltIns": "usage",
         "corejs": "3"

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "verdaccio-auth-memory": "^9.7.2"
   },
   "engines": {
-    "node": ">=8.10.0",
+    "node": ">=10.13.0",
     "yarn": ">=1.3.2"
   },
   "collective": {


### PR DESCRIPTION
Issue: #8207

## What I did

In #8207, the storybook CI was changed to only be node 10+ but the engine fields weren't changed to reflect that supported version range. I've updated all the engine references to be >=10.13 (which is when recursive mkdir was added) to be inline with the CI test matrix.

Additionally, node 8 is no longer LTS after Jan 1, 2021.

I also updated the babel settings to target node 10 (plucked from #11220).

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
