### PR TITLE
docs: import from theming module to support esm

### DIFF
--- a/docs/snippets/common/storybook-theme-example-variables.ts.mdx
+++ b/docs/snippets/common/storybook-theme-example-variables.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // .storybook/YourTheme.js
 
-import { create } from '@storybook/theming/create';
+import { create } from '@storybook/theming';
 
 export default create({
   base: 'light',

--- a/docs/snippets/common/your-theme.js.mdx
+++ b/docs/snippets/common/your-theme.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // .storybook/YourTheme.js
 
-import { create } from '@storybook/theming/create';
+import { create } from '@storybook/theming';
 
 export default create({
   base: 'light',

--- a/examples/cra-kitchen-sink/.storybook/manager.js
+++ b/examples/cra-kitchen-sink/.storybook/manager.js
@@ -1,4 +1,4 @@
-import { create } from '@storybook/theming/create';
+import { create } from '@storybook/theming';
 import { addons } from '@storybook/addons';
 
 addons.setConfig({

--- a/examples/cra-react15/.storybook/manager.js
+++ b/examples/cra-react15/.storybook/manager.js
@@ -1,4 +1,4 @@
-import { create } from '@storybook/theming/create';
+import { create } from '@storybook/theming';
 import { addons } from '@storybook/addons';
 
 addons.setConfig({

--- a/examples/rax-kitchen-sink/.storybook/manager.js
+++ b/examples/rax-kitchen-sink/.storybook/manager.js
@@ -1,5 +1,5 @@
 import { addons } from '@storybook/addons';
-import { create } from '@storybook/theming/create';
+import { create } from '@storybook/theming';
 
 const theme = create({
   base: 'light',


### PR DESCRIPTION
Issue: #13718

## What I did

In #13718, some users were having issues with the theming docs because they tried to import from `@storybook/theming/create` but the `create` method is exported from the main file, too. I'm not sure of the reason for this "re-export", but I switched it to using the main file for better typescript and ESM support.

Does anyone know why there's that extra export file?

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ✅ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
