### PR TITLE
CLI: Add try/catch on readFileAsJson to improve error message

### DIFF
--- a/lib/cli/src/helpers.ts
+++ b/lib/cli/src/helpers.ts
@@ -32,10 +32,10 @@ export function readFileAsJson(jsonPath: string, allowComments?: boolean) {
 
   try {
     return JSON.parse(jsonContent);
-  } catch(e) {
-    throw new Error('Invalid json on file: ' + filePath);
+  } catch (e) {
+    console.error(chalk.red(`Invalid json on file: ${filePath}`));
+    throw e;
   }
-
 }
 
 export const writeFileAsJson = (jsonPath: string, content: unknown) => {

--- a/lib/cli/src/helpers.ts
+++ b/lib/cli/src/helpers.ts
@@ -29,7 +29,13 @@ export function readFileAsJson(jsonPath: string, allowComments?: boolean) {
 
   const fileContent = fs.readFileSync(filePath, 'utf8');
   const jsonContent = allowComments ? stripJsonComments(fileContent) : fileContent;
-  return JSON.parse(jsonContent);
+
+  try {
+    return JSON.parse(jsonContent);
+  } catch(e) {
+    throw new Error('Invalid json on file: ' + filePath);
+  }
+
 }
 
 export const writeFileAsJson = (jsonPath: string, content: unknown) => {

--- a/lib/cli/src/helpers.ts
+++ b/lib/cli/src/helpers.ts
@@ -33,7 +33,7 @@ export function readFileAsJson(jsonPath: string, allowComments?: boolean) {
   try {
     return JSON.parse(jsonContent);
   } catch (e) {
-    console.error(chalk.red(`Invalid json on file: ${filePath}`));
+    logger.error(chalk.red(`Invalid json in file: ${filePath}`));
     throw e;
   }
 }


### PR DESCRIPTION
Issue:
When running `npx sb init` in an angular project, one json file was wrong (with a trailing comma) and it took me too much time to figure out which json file was wrong.
<img width="1174" alt="Screen Shot 2021-01-26 at 10 18 26" src="https://user-images.githubusercontent.com/649219/105849970-dd3bad00-5fbf-11eb-9f51-b4a3298bcb95.png">

## What I did
Added try/catch wrapping the `JSON.parse` to improve error message and the user be aware which json file is wrong

## How to test
My test case is having a tsconfig.app.json with a wrong json in the file. In an angular project, the command `npx sb init` reads about 3 json files ( among `angular.json`, `tsconfig.json` and `tsconfig.app.json` )

