### PR TITLE
CLI: Add version matcher functions for framework detection

### DIFF
--- a/lib/cli/src/detect.test.ts
+++ b/lib/cli/src/detect.test.ts
@@ -316,23 +316,23 @@ describe('Detect', () => {
     });
 
     // TODO(blaine): Remove once Vue3 is supported
-    it(`UNDETECTED for Vue framework above version 3.0.0`, () => {
+    it(`UNSUPPORTED for Vue framework above version 3.0.0`, () => {
       const result = detectFrameworkPreset({
         dependencies: {
           vue: '3.0.0',
         },
       });
-      expect(result).toBe(ProjectType.UNDETECTED);
+      expect(result).toBe(ProjectType.UNSUPPORTED);
     });
 
     // TODO(blaine): Remove once Nuxt3 is supported
-    it(`UNDETECTED for Nuxt framework above version 3.0.0`, () => {
+    it(`UNSUPPORTED for Nuxt framework above version 3.0.0`, () => {
       const result = detectFrameworkPreset({
         dependencies: {
           nuxt: '3.0.0',
         },
       });
-      expect(result).toBe(ProjectType.UNDETECTED);
+      expect(result).toBe(ProjectType.UNSUPPORTED);
     });
 
     // TODO: The mocking in this test causes tests after it to fail

--- a/lib/cli/src/detect.test.ts
+++ b/lib/cli/src/detect.test.ts
@@ -315,6 +315,27 @@ describe('Detect', () => {
       expect(result).toBe(ProjectType.UNDETECTED);
     });
 
+    // TODO(blaine): Remove once Vue3 is supported
+    it(`UNDETECTED for Vue framework above version 3.0.0`, () => {
+      const result = detectFrameworkPreset({
+        dependencies: {
+          vue: '3.0.0',
+        },
+      });
+      expect(result).toBe(ProjectType.UNDETECTED);
+    });
+
+    // TODO(blaine): Remove once Nuxt3 is supported
+    it(`UNDETECTED for Nuxt framework above version 3.0.0`, () => {
+      const result = detectFrameworkPreset({
+        dependencies: {
+          nuxt: '3.0.0',
+        },
+      });
+      expect(result).toBe(ProjectType.UNDETECTED);
+    });
+
+    // TODO: The mocking in this test causes tests after it to fail
     it('REACT_SCRIPTS for custom react scripts config', () => {
       const forkedReactScriptsConfig = {
         '/node_modules/.bin/react-scripts': 'file content',

--- a/lib/cli/src/detect.ts
+++ b/lib/cli/src/detect.ts
@@ -12,13 +12,31 @@ import {
 import { getBowerJson } from './helpers';
 import { PackageJson, readPackageJson } from './js-package-manager';
 
-const hasDependency = (packageJson: PackageJson, name: string) => {
-  return !!packageJson.dependencies?.[name] || !!packageJson.devDependencies?.[name];
+const hasDependency = (
+  packageJson: PackageJson,
+  name: string,
+  matcher?: (version: string) => boolean
+) => {
+  const version = packageJson.dependencies?.[name] || packageJson.devDependencies?.[name];
+  if (version && typeof matcher === 'function') {
+    return matcher(version);
+  }
+  return !!version;
 };
 
-const hasPeerDependency = (packageJson: PackageJson, name: string) => {
-  return !!packageJson.peerDependencies?.[name];
+const hasPeerDependency = (
+  packageJson: PackageJson,
+  name: string,
+  matcher?: (version: string) => boolean
+) => {
+  const version = packageJson.peerDependencies?.[name];
+  if (version && typeof matcher === 'function') {
+    return matcher(version);
+  }
+  return !!version;
 };
+
+type SearchTuple = [string, (version: string) => boolean | undefined];
 
 const getFrameworkPreset = (
   packageJson: PackageJson,
@@ -32,12 +50,32 @@ const getFrameworkPreset = (
 
   const { preset, files, dependencies, peerDependencies, matcherFunction } = framework;
 
-  if (Array.isArray(dependencies) && dependencies.length > 0) {
-    matcher.dependencies = dependencies.map((name) => hasDependency(packageJson, name));
+  let dependencySearches = [] as SearchTuple[];
+  if (Array.isArray(dependencies)) {
+    dependencySearches = dependencies.map((name) => [name, undefined]);
+  } else if (typeof dependencies === 'object') {
+    dependencySearches = Object.entries(dependencies);
   }
 
-  if (Array.isArray(peerDependencies) && peerDependencies.length > 0) {
-    matcher.peerDependencies = peerDependencies.map((name) => hasPeerDependency(packageJson, name));
+  // Must check the length so the `[false]` isn't overwritten if `{ dependencies: [] }`
+  if (dependencySearches.length > 0) {
+    matcher.dependencies = dependencySearches.map(([name, matchFn]) =>
+      hasDependency(packageJson, name, matchFn)
+    );
+  }
+
+  let peerDependencySearches = [] as SearchTuple[];
+  if (Array.isArray(peerDependencies)) {
+    peerDependencySearches = peerDependencies.map((name) => [name, undefined]);
+  } else if (typeof peerDependencies === 'object') {
+    peerDependencySearches = Object.entries(peerDependencies);
+  }
+
+  // Must check the length so the `[false]` isn't overwritten if `{ peerDependencies: [] }`
+  if (peerDependencySearches.length > 0) {
+    matcher.peerDependencies = peerDependencySearches.map(([name, matchFn]) =>
+      hasPeerDependency(packageJson, name, matchFn)
+    );
   }
 
   if (Array.isArray(files) && files.length > 0) {

--- a/lib/cli/src/detect.ts
+++ b/lib/cli/src/detect.ts
@@ -8,6 +8,7 @@ import {
   SupportedLanguage,
   TemplateConfiguration,
   TemplateMatcher,
+  unsupportedTemplate,
 } from './project_types';
 import { getBowerJson } from './helpers';
 import { PackageJson, readPackageJson } from './js-package-manager';
@@ -86,7 +87,7 @@ const getFrameworkPreset = (
 };
 
 export function detectFrameworkPreset(packageJson = {}) {
-  const result = supportedTemplates.find((framework) => {
+  const result = [...supportedTemplates, unsupportedTemplate].find((framework) => {
     return getFrameworkPreset(packageJson, framework) !== null;
   });
 

--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -222,6 +222,17 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
           .then(commandLog('Adding Storybook support to your "Aurelia" app'))
           .then(end);
 
+      case ProjectType.UNSUPPORTED:
+        paddedLog(`We detected a project type that we don't support yet.`);
+        paddedLog(
+          `If you'd like your framework to be supported, please let use know about it at https://github.com/storybookjs/storybook/issues`
+        );
+
+        // Add a new line for the clear visibility.
+        logger.log();
+
+        return Promise.resolve();
+
       default:
         paddedLog(`We couldn't detect your project type. (code: ${projectType})`);
         paddedLog(

--- a/lib/cli/src/project_types.ts
+++ b/lib/cli/src/project_types.ts
@@ -1,4 +1,4 @@
-import { lt } from '@storybook/semver';
+import { lt, gte } from '@storybook/semver';
 
 // Should match @storybook/<framework>
 export type SupportedFrameworks =
@@ -21,6 +21,7 @@ export type SupportedFrameworks =
 
 export enum ProjectType {
   UNDETECTED = 'UNDETECTED',
+  UNSUPPORTED = 'UNSUPPORTED',
   REACT_SCRIPTS = 'REACT_SCRIPTS',
   METEOR = 'METEOR',
   REACT = 'REACT',
@@ -241,8 +242,25 @@ export const supportedTemplates: TemplateConfiguration[] = [
   },
 ];
 
+// A TemplateConfiguration that matches unsupported frameworks
+// Framework matchers can be added to this object to give
+// users an "Unsupported framework" message
+export const unsupportedTemplate: TemplateConfiguration = {
+  preset: ProjectType.UNSUPPORTED,
+  dependencies: {
+    // TODO(blaine): Remove when we support Vue 3
+    vue: (version) => version === 'next' || gte(version, '3.0.0'),
+    // TODO(blaine): Remove when we support Vue 3
+    nuxt: (version) => gte(version, '3.0.0'),
+  },
+  matcherFunction: ({ dependencies }) => {
+    return dependencies.some(Boolean);
+  },
+};
+
 const notInstallableProjectTypes: ProjectType[] = [
   ProjectType.UNDETECTED,
+  ProjectType.UNSUPPORTED,
   ProjectType.ALREADY_HAS_STORYBOOK,
   ProjectType.UPDATE_PACKAGE_ORGANIZATIONS,
 ];

--- a/lib/cli/src/project_types.ts
+++ b/lib/cli/src/project_types.ts
@@ -1,3 +1,5 @@
+import { lt } from '@storybook/semver';
+
 // Should match @storybook/<framework>
 export type SupportedFrameworks =
   | 'react'
@@ -82,8 +84,8 @@ export type TemplateMatcher = {
 export type TemplateConfiguration = {
   preset: ProjectType;
   /** will be checked both against dependencies and devDependencies */
-  dependencies?: string[];
-  peerDependencies?: string[];
+  dependencies?: string[] | { [dependency: string]: (version: string) => boolean };
+  peerDependencies?: string[] | { [dependency: string]: (version: string) => boolean };
   files?: string[];
   matcherFunction: (matcher: TemplateMatcher) => boolean;
 };
@@ -112,7 +114,12 @@ export const supportedTemplates: TemplateConfiguration[] = [
   },
   {
     preset: ProjectType.VUE,
-    dependencies: ['vue', 'nuxt'],
+    // The Vue template only works with Vue or Nuxt under v3
+    // In a future update, a new Vue3 template will be added
+    dependencies: {
+      vue: (version) => lt(version, '3.0.0'),
+      nuxt: (version) => lt(version, '3.0.0'),
+    },
     matcherFunction: ({ dependencies }) => {
       return dependencies.some(Boolean);
     },


### PR DESCRIPTION
Issue: N/A

## What I did

I added logic to the framework detection to support "matcher functions" in order to change the template based on the version of a framework. This work is necessary to have different templates between Vue/Nuxt v2 and Vue/Nuxt v3.

Additionally, I used these methods for the Vue/Nuxt preset that currently exists to ensure they are only matched for versions less than 3.0.0

## How to test

- Is this testable with Jest or Chromatic screenshots? ✅ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
