### PR TITLE
CI: Upgrade cache GH Action & remove fallback caches

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -12,13 +12,10 @@ jobs:
         node-version: '10.x'
     - uses: actions/checkout@v2
     - name: Cache node modules
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: node_modules
         key: build-v2-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          build-v2-${{ env.cache-name }}-
-          build-v2-
     - name: install, bootstrap
       run: |
         yarn bootstrap --core


### PR DESCRIPTION
Issue: N/A

## What I did

I'm noticing a bunch of failures on the "Unit Tests" GH Action. I believe this is because the cache action is fetching stale caches. I removed the "restore-keys" option so it only ever pulls a cache that matches the yarn.lock file.

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
