### PR TITLE
documentation: improve readme with example of rendering with React Testling Library

### DIFF
--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -295,6 +295,42 @@ initStoryshots({
 });
 ```
 
+### Using a custom renderer
+
+By design, [`react-test-renderer` doesn't use a browser environment or JSDOM](https://github.com/facebook/react/issues/20589). Because of this difference, some stories might render in your browser, but not in Storyshots. If you encounter this problem, you may want to switch for an higher level renderer such as `mount` from Enzyme or `render` from React Testing Library.
+
+#### Example with React Testing Library
+
+```js
+import initStoryshots from "@storybook/addon-storyshots";
+import { render } from "@testing-library/react";
+
+const reactTestingLibrarySerializer = {
+  print: (val, serialize, indent) => serialize(val.container.firstChild),
+  test: val => val && val.hasOwnProperty("container")
+};
+
+initStoryshots({
+  renderer: render,
+  snapshotSerializers: [reactTestingLibrarySerializer]
+});
+
+```
+
+#### Example with Enzyme
+
+```js
+import initStoryshots from '@storybook/addon-storyshots';
+import { mount } from 'enzyme';
+
+initStoryshots({
+  renderer: mount,
+});
+```
+
+If you are using enzyme, you need to make sure jest knows how to serialize rendered components.
+For that, you can pass an enzyme-compatible snapshotSerializer (like [enzyme-to-json](https://github.com/adriantoine/enzyme-to-json), [jest-serializer-enzyme](https://github.com/rogeliog/jest-serializer-enzyme) etc.) with the `snapshotSerializer` option (see below).
+
 ### StoryShots for async rendered components
 
 You can make use of [Jest done callback](https://jestjs.io/docs/en/asynchronous) to test components that render asynchronously. This callback is passed as param to test method passed to `initStoryshots(...)` when the `asyncJest` option is given as true.
@@ -551,17 +587,6 @@ This may be necessary if you want to use React features that are not supported b
 such as **ref** or **Portals**.
 Note that setting `test` overrides `renderer`.
 
-```js
-import initStoryshots from '@storybook/addon-storyshots';
-import { mount } from 'enzyme';
-
-initStoryshots({
-  renderer: mount,
-});
-```
-
-If you are using enzyme, you need to make sure jest knows how to serialize rendered components.
-For that, you can pass an enzyme-compatible snapshotSerializer (like [enzyme-to-json](https://github.com/adriantoine/enzyme-to-json), [jest-serializer-enzyme](https://github.com/rogeliog/jest-serializer-enzyme) etc.) with the `snapshotSerializer` option (see below).
 
 ### `snapshotSerializers`
 


### PR DESCRIPTION
Issue:

## What I did
Update doc to add an example of rendering with React Testing Library renderer.

## Before merging

I am not sure the usage of the serializer is clear here. I don't remember ever setting a snapshot serializer at Jest level, so I think we can assume that either:
- the user havent set any serializer, so we should add it already into the Enzyme example (it's already done in the React Testing example)
- the user have set a serializer at Jest level, so they are smart enough to remove it from storyshot config if they don't need it
- anyway I suppose this is not problem to set it again in storyshots if you have it at Jest level ?

Also I got the code from this SO answer: https://stackoverflow.com/questions/52029273/using-react-testing-library-with-storyshots, how can I give credit to the original poster?

## How to test
This is a doc update.
<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
