### PR TITLE
Update badge-story-starter-example.mdx.mdx

### DIFF
--- a/docs/snippets/common/badge-story-starter-example.mdx.mdx
+++ b/docs/snippets/common/badge-story-starter-example.mdx.mdx
@@ -19,17 +19,17 @@ Let's define a story for our `Badge` component:
 
 We can drop it in a `Canvas` to get a code snippet:
 
-<Canvas>
+<Preview>
   <Story name="negative">
     <Badge status="negative">Negative</Badge>
   </Story>
-</Canvas>
+</Preview>
 
 We can even preview multiple stories in a block. This
 gets rendered as a group, but defines individual stories
 with unique URLs and isolated snapshot tests.
 
-<Canvas>
+<Preview>
   <Story name="warning">
     <Badge status="warning">Warning</Badge>
   </Story>
@@ -45,5 +45,5 @@ with unique URLs and isolated snapshot tests.
       with icon
     </Badge>
   </Story>
-</Canvas>
+</Preview>
 ```


### PR DESCRIPTION
I stumbled on this while setting up storybook docs and it took me way too long to understand what the problem is.

Canvas does not exist anymore and should be called Preview

Issue:

Wrong instructions, import is for `Preview` but the component used is `<Canvas>`

## What I did

Updated documentation