### PR TITLE
CLI: Fix handling of version ranges in dependency checks

### DIFF
--- a/lib/cli/src/project_types.ts
+++ b/lib/cli/src/project_types.ts
@@ -1,4 +1,14 @@
-import { lt, gte } from '@storybook/semver';
+import { validRange, minVersion } from '@storybook/semver';
+
+function ltMajor(versionRange: string, major: number) {
+  // Uses validRange to avoid a throw from minVersion if an invalid range gets passed
+  return validRange(versionRange) && minVersion(versionRange).major < major;
+}
+
+function eqMajor(versionRange: string, major: number) {
+  // Uses validRange to avoid a throw from minVersion if an invalid range gets passed
+  return validRange(versionRange) && minVersion(versionRange).major === major;
+}
 
 // Should match @storybook/<framework>
 export type SupportedFrameworks =
@@ -118,8 +128,8 @@ export const supportedTemplates: TemplateConfiguration[] = [
     // The Vue template only works with Vue or Nuxt under v3
     // In a future update, a new Vue3 template will be added
     dependencies: {
-      vue: (version) => lt(version, '3.0.0'),
-      nuxt: (version) => lt(version, '3.0.0'),
+      vue: (versionRange) => ltMajor(versionRange, 3),
+      nuxt: (versionRange) => ltMajor(versionRange, 3),
     },
     matcherFunction: ({ dependencies }) => {
       return dependencies.some(Boolean);
@@ -249,9 +259,9 @@ export const unsupportedTemplate: TemplateConfiguration = {
   preset: ProjectType.UNSUPPORTED,
   dependencies: {
     // TODO(blaine): Remove when we support Vue 3
-    vue: (version) => version === 'next' || gte(version, '3.0.0'),
+    vue: (versionRange) => versionRange === 'next' || eqMajor(versionRange, 3),
     // TODO(blaine): Remove when we support Vue 3
-    nuxt: (version) => gte(version, '3.0.0'),
+    nuxt: (versionRange) => eqMajor(versionRange, 3),
   },
   matcherFunction: ({ dependencies }) => {
     return dependencies.some(Boolean);


### PR DESCRIPTION
Issue: N/A

## What I did

Fixed an issue where version ranges caused issues with the code I added in #13738 - I switched to using `validRange` and `minVersion` to do the comparisons.

## How to test

- Is this testable with Jest or Chromatic screenshots? e2e tests caught it
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
