### PR TITLE
Svelte: Fixes component name in docgen-loader

### DIFF
--- a/addons/docs/src/frameworks/svelte/svelte-docgen-loader.ts
+++ b/addons/docs/src/frameworks/svelte/svelte-docgen-loader.ts
@@ -1,6 +1,37 @@
 import svelteDoc from 'sveltedoc-parser';
-
+import dedent from 'ts-dedent';
 import * as path from 'path';
+
+// From https://github.com/sveltejs/svelte/blob/8db3e8d0297e052556f0b6dde310ef6e197b8d18/src/compiler/compile/utils/get_name_from_filename.ts
+// Copied because it is not exported from the compiler
+function getNameFromFilename(filename: string) {
+  if (!filename) return null;
+
+  const parts = filename.split(/[/\\]/).map(encodeURI);
+
+  if (parts.length > 1) {
+    const index_match = parts[parts.length - 1].match(/^index(\.\w+)/);
+    if (index_match) {
+      parts.pop();
+      parts[parts.length - 1] += index_match[1];
+    }
+  }
+
+  const base = parts
+    .pop()
+    .replace(/%/g, 'u')
+    .replace(/\.[^.]+$/, '')
+    .replace(/[^a-zA-Z_$0-9]+/g, '_')
+    .replace(/^_/, '')
+    .replace(/_$/, '')
+    .replace(/^(\d)/, '_$1');
+
+  if (!base) {
+    throw new Error(`Could not derive component name from file ${filename}`);
+  }
+
+  return base[0].toUpperCase() + base.slice(1);
+}
 
 /**
  * webpack loader for sveltedoc-parser
@@ -26,11 +57,12 @@ export default async function svelteDocgen(source: string) {
     // populate filename in docgen
     componentDoc.name = path.basename(file);
 
-    const componentName = path.parse(resource).name;
+    const componentName = getNameFromFilename(resource);
 
-    docgen = `
-    ${componentName}.__docgen = ${JSON.stringify(componentDoc)};
-  `;
+    docgen = dedent`
+
+              ${componentName}.__docgen = ${JSON.stringify(componentDoc)};
+              `;
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
Issue: #13742

## What I did

The Svelte component name was not correctly guessed for unusual files names.
I use now the function from svelte/compiler which generates the component name.
However, this function is not exported by Svelte, so I had to duplicate it in the loader.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
