### PR TITLE
CLI: Handle package versions in package strings for generators

### DIFF
--- a/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -8,6 +8,18 @@ import storybookPackagesVersions from '../versions.json';
 
 const logger = console;
 
+function getPackageDetails(pkg: string): [string, string?] {
+  const idx = pkg.lastIndexOf('@');
+  // If the only `@` is the first character, it is a scoped package
+  // If it isn't in the string, it will be -1
+  if (idx <= 0) {
+    return [pkg, undefined];
+  }
+  const packageName = pkg.slice(0, idx);
+  const packageVersion = pkg.slice(idx + 1);
+  return [packageName, packageVersion];
+}
+
 export abstract class JsPackageManager {
   public abstract readonly type: 'npm' | 'yarn1' | 'yarn2';
 
@@ -81,10 +93,7 @@ export abstract class JsPackageManager {
       const { packageJson } = options;
 
       const dependenciesMap = dependencies.reduce((acc, dep) => {
-        const idx = dep.lastIndexOf('@');
-        const packageName = dep.slice(0, idx);
-        const packageVersion = dep.slice(idx + 1);
-
+        const [packageName, packageVersion] = getPackageDetails(dep);
         return { ...acc, [packageName]: packageVersion };
       }, {});
 
@@ -115,13 +124,14 @@ export abstract class JsPackageManager {
   /**
    * Return an array of strings matching following format: `<package_name>@<package_latest_version>`
    *
-   * @param packageNames
+   * @param packages
    */
-  public getVersionedPackages(...packageNames: string[]): Promise<string[]> {
+  public getVersionedPackages(...packages: string[]): Promise<string[]> {
     return Promise.all(
-      packageNames.map(
-        async (packageName) => `${packageName}@${await this.getVersion(packageName)}`
-      )
+      packages.map(async (pkg) => {
+        const [packageName, packageVersion] = getPackageDetails(pkg);
+        return `${packageName}@${await this.getVersion(packageName, packageVersion)}`;
+      })
     );
   }
 


### PR DESCRIPTION
Issue: N/A

## What I did

Sometimes packages needed by generators might not be published on the `latest` tag, so the wrong version would be added to the package.json when using a generator.

An example of this is `vue-loader`, which publishes v16 (with Vue 3 support) on the `next` tag. Upon adding `vue-loader` to a generator, it would add v15 to the package.json.

This adds support for generators to request versions in the string, like so:

```js
baseGenerator(packageManager, npmOptions, options, 'vue3', {
    extraPackages: ['vue-loader@^16.0.0'],
});
```

## How to test

- Is this testable with Jest or Chromatic screenshots? The e2e tests will catch this once leveraged by a generator
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
