### PR TITLE
Core: Generate manager cache in smoke test, but don't use/clear any cache

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -413,14 +413,14 @@ export async function storybookDevServer(options: any) {
     startManager({ startTime, options, configType, outputDir, configDir, prebuiltDir })
       // TODO #13083 Restore this when compiling the preview is fast enough
       // .then((result) => {
-      //   if (!options.ci) openInBrowser(address);
+      //   if (!options.ci && !options.smokeTest) openInBrowser(address);
       //   return result;
       // })
       .catch(bailPreview),
   ]);
 
   // TODO #13083 Remove this when compiling the preview is fast enough
-  if (!options.ci) openInBrowser(networkAddress);
+  if (!options.ci && !options.smokeTest) openInBrowser(networkAddress);
 
   return { ...previewResult, ...managerResult, address, networkAddress };
 }

--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -237,18 +237,18 @@ const startManager = async ({
       logConfig('Manager webpack config', managerConfig);
     }
 
-    if (options.cache && !options.smokeTest) {
+    if (options.cache) {
       if (options.managerCache) {
         const [useCache, hasOutput] = await Promise.all([
           // must run even if outputDir doesn't exist, otherwise the 2nd run won't use cache
           useManagerCache(options.cache, managerConfig),
           pathExists(outputDir),
         ]);
-        if (useCache && hasOutput) {
+        if (useCache && hasOutput && !options.smokeTest) {
           logger.info('=> Using cached manager');
           managerConfig = null;
         }
-      } else if (await clearManagerCache(options.cache)) {
+      } else if (!options.smokeTest && (await clearManagerCache(options.cache))) {
         logger.info('=> Cleared cached manager config');
       }
     }


### PR DESCRIPTION
Issue: -
Discussion: https://github.com/storybookjs/storybook/discussions/13737

## What I did

When running with `--smoke-test`, currently no manager cache is used, created or cleared. However, sometimes it's beneficial to be able to prepare (generate) a cached manager without actually starting Storybook, for example when preparing a Docker image with embedded manager cache. This change makes `--smoke-test` cache the manager it built like normal, but won't use or clear any cache it finds as was intended in #13266.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
