### PR TITLE
Svelte: Improved decorators

### DIFF
--- a/addons/docs/src/frameworks/svelte/HOC.svelte
+++ b/addons/docs/src/frameworks/svelte/HOC.svelte
@@ -1,7 +1,7 @@
 <script>
-  export let component;
-  export let props;
+  export let storyFn;
+
+  let { Component: component, props } = storyFn();
 </script>
 
-<svelte:options accessors={true} />
 <svelte:component this={component} {...props}/>

--- a/addons/docs/src/frameworks/svelte/prepareForInline.ts
+++ b/addons/docs/src/frameworks/svelte/prepareForInline.ts
@@ -1,22 +1,17 @@
-import { StoryFn, StoryContext } from '@storybook/addons';
+import { StoryFn } from '@storybook/addons';
 
 import React from 'react';
 
 // @ts-ignore
 import HOC from './HOC.svelte';
 
-export const prepareForInline = (storyFn: StoryFn, context: StoryContext) => {
-  // @ts-ignore
-  const story: { Component: any; props: any } = storyFn();
+export const prepareForInline = (storyFn: StoryFn) => {
   const el = React.useRef(null);
   React.useEffect(() => {
     const root = new HOC({
       target: el.current,
       props: {
-        component: story.Component,
-        context,
-        props: story.props,
-        slot: story.Component,
+        storyFn,
       },
     });
     return () => root.$destroy();

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -82,7 +82,8 @@
     "react-dom": "^16.8.0 || ^17.0.0",
     "rxjs": "*",
     "vue": "*",
-    "vue-jest": "*"
+    "vue-jest": "*",
+    "svelte": "*"
   },
   "peerDependenciesMeta": {
     "@storybook/angular": {

--- a/addons/storyshots/storyshots-core/src/frameworks/svelte/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/svelte/renderTree.ts
@@ -1,4 +1,5 @@
 import { document } from 'global';
+import { set_current_component } from 'svelte/internal';
 
 /**
  * Provides functionality to convert your raw story to the resulting markup.
@@ -12,6 +13,9 @@ import { document } from 'global';
  * i.e. ({ Component, data }).
  */
 function getRenderedTree(story: any) {
+  // allow setContext to work
+  set_current_component({ $$: { context: new Map() } });
+
   const { Component, props } = story.render();
 
   const DefaultCompatComponent = Component.default || Component;

--- a/app/svelte/src/client/preview/PreviewRender.svelte
+++ b/app/svelte/src/client/preview/PreviewRender.svelte
@@ -1,0 +1,37 @@
+<script>
+  import SlotDecorator from './SlotDecorator.svelte';
+  import dedent from 'ts-dedent';
+
+  export let name;
+  export let kind;
+  export let storyFn;
+  export let showError;
+
+  const {
+    /** @type {SvelteComponent} */
+    Component,
+    /** @type {any} */
+    props = {},
+    /** @type {{[string]: () => {}}} Attach svelte event handlers */
+    on,
+    Wrapper,
+    WrapperData = {},
+  } = storyFn(); 
+
+  if (!Component) {
+    showError({
+      title: `Expecting a Svelte component from the story: "${name}" of "${kind}".`,
+      description: dedent`
+        Did you forget to return the Svelte component configuration from the story?
+        Use "() => ({ Component: YourComponent, data: {} })"
+        when defining the story.
+      `,
+    });
+  }
+</script>
+<SlotDecorator
+  decorator={Wrapper}
+  decoratorProps={WrapperData}
+  component={Component}
+  props={props}
+  {on}/>

--- a/app/svelte/src/client/preview/SlotDecorator.svelte
+++ b/app/svelte/src/client/preview/SlotDecorator.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { onMount } from 'svelte';
+  export let decorator;
+  export let decoratorProps = {};
+  export let component;
+  export let props = {};
+  export let on;
+
+  let instance;
+  let decoratorInstance;
+
+  function getInstance() {
+    // instance can be undefined if a decorator doesn't have <slot/>
+    return instance || decoratorInstance;
+  }
+
+  if (on) {
+    // Attach svelte event listeners.
+    Object.keys(on).forEach((eventName) => {
+      onMount(() => getInstance().$on(eventName, on[eventName]));
+    });
+  }
+</script>
+{#if decorator}
+  <svelte:component this={decorator} {...decoratorProps} bind:this={decoratorInstance}>
+    <svelte:component this={component} {...props} bind:this={instance}/>
+  </svelte:component>
+{:else}
+  <svelte:component this={component} {...props} bind:this={instance}/>
+{/if}

--- a/app/svelte/src/client/preview/decorators.ts
+++ b/app/svelte/src/client/preview/decorators.ts
@@ -1,0 +1,100 @@
+import { StoryFn, DecoratorFunction, StoryContext } from '@storybook/addons';
+import SlotDecorator from './SlotDecorator.svelte';
+
+const defaultContext: StoryContext = {
+  id: 'unspecified',
+  name: 'unspecified',
+  kind: 'unspecified',
+  parameters: {},
+  args: {},
+  argTypes: {},
+  globals: {},
+};
+
+/**
+ * Check if an object is a svelte component.
+ * @param obj Object
+ */
+function isSvelteComponent(obj: any) {
+  return obj.prototype && obj.prototype.$destroy !== undefined;
+}
+
+/**
+ * Handle component loaded with esm or cjs.
+ * @param obj object
+ */
+function unWrap(obj: any) {
+  return obj && obj.default ? obj.default : obj;
+}
+
+/**
+ * Transform a story to be compatible with the PreviewRender component.
+ *
+ * - `() => MyComponent` is translated to `() => ({ Component: MyComponent })`
+ * - `() => ({})` is translated to `() => ({ Component: <from parameters.component> })`
+ * - A decorator component is wrapped with SlotDecorator. The decorated component is inject through
+ * a <slot/>
+ *
+ * @param context StoryContext
+ * @param story  the current story
+ * @param originalStory the story decorated by the current story
+ */
+function prepareStory(context: StoryContext, story: any, originalStory?: any) {
+  let result = unWrap(story);
+  if (isSvelteComponent(result)) {
+    // wrap the component
+    result = {
+      Component: result,
+    };
+  }
+
+  if (originalStory) {
+    // inject the new story as a wrapper of the original story
+    result = {
+      Component: SlotDecorator,
+      props: {
+        decorator: unWrap(result.Component),
+        decoratorProps: result.props,
+        component: unWrap(originalStory.Component),
+        props: originalStory.props,
+        on: originalStory.on,
+      },
+    };
+  } else {
+    let cpn = result.Component;
+    if (!cpn) {
+      // if the component is not defined, get it from parameters
+      cpn = context.parameters.component;
+    }
+    result.Component = unWrap(cpn);
+  }
+  return result;
+}
+
+export function decorateStory(storyFn: any, decorators: any[]) {
+  return decorators.reduce(
+    (previousStoryFn: StoryFn, decorator: DecoratorFunction) => (
+      context: StoryContext = defaultContext
+    ) => {
+      let story;
+      const decoratedStory = decorator(
+        ({ parameters, ...innerContext }: StoryContext = {} as StoryContext) => {
+          story = previousStoryFn({ ...context, ...innerContext });
+          return story;
+        },
+        context
+      );
+
+      if (!story) {
+        story = previousStoryFn(context);
+      }
+
+      if (!decoratedStory || decoratedStory === story) {
+        return story;
+      }
+
+      return prepareStory(context, decoratedStory, story);
+    },
+    (context: StoryContext) => prepareStory(context, storyFn(context))
+  );
+}

--- a/app/svelte/src/client/preview/index.ts
+++ b/app/svelte/src/client/preview/index.ts
@@ -1,9 +1,10 @@
 import { start } from '@storybook/core/client';
+import { decorateStory } from './decorators';
 
 import './globals';
 import render from './render';
 
-const { configure: coreConfigure, clientApi, forceReRender } = start(render);
+const { configure: coreConfigure, clientApi, forceReRender } = start(render, { decorateStory });
 
 export const {
   setAddon,

--- a/app/svelte/src/client/preview/render.ts
+++ b/app/svelte/src/client/preview/render.ts
@@ -1,7 +1,6 @@
-import { detach, insert, noop } from 'svelte/internal';
 import { document } from 'global';
-import dedent from 'ts-dedent';
-import { MountViewArgs, RenderContext } from './types';
+import { RenderContext } from './types';
+import PreviewRender from './PreviewRender.svelte';
 
 type Component = any;
 
@@ -15,104 +14,21 @@ function cleanUpPreviousStory() {
   previousComponent = null;
 }
 
-function createSlotFn(element: any) {
-  return [
-    function createSlot() {
-      return {
-        c: noop,
-        m: function mount(target: any, anchor: any) {
-          insert(target, element, anchor);
-        },
-        d: function destroy(detaching: boolean) {
-          if (detaching) {
-            detach(element);
-          }
-        },
-        l: noop,
-      };
-    },
-  ];
-}
-
-function createSlots(slots: Record<string, any>): Record<string, any> {
-  return Object.entries(slots).reduce((acc, [slotName, element]) => {
-    acc[slotName] = createSlotFn(element);
-    return acc;
-  }, {} as Record<string, any>);
-}
-
-function mountView({ Component, target, props, on, Wrapper, WrapperData }: MountViewArgs) {
-  let component: Component;
-
-  if (Wrapper) {
-    const fragment = document.createDocumentFragment();
-    component = new Component({ target: fragment, props });
-
-    const wrapper = new Wrapper({
-      target,
-      props: {
-        ...WrapperData,
-        $$slots: createSlots({ default: fragment }),
-        $$scope: {},
-      },
-    });
-    component.$on('destroy', () => {
-      wrapper.$destroy(true);
-    });
-  } else {
-    component = new Component({ target, props });
-  }
-
-  if (on) {
-    // Attach svelte event listeners.
-    Object.keys(on).forEach((eventName) => {
-      component.$on(eventName, on[eventName]);
-    });
-  }
-
-  previousComponent = component;
-}
-
 export default function render({ storyFn, kind, name, showMain, showError }: RenderContext) {
-  const {
-    /** @type {SvelteComponent} */
-    Component,
-    /** @type {any} */
-    props,
-    /** @type {{[string]: () => {}}} Attach svelte event handlers */
-    on,
-    Wrapper,
-    WrapperData,
-  } = storyFn();
-
   cleanUpPreviousStory();
-  const DefaultCompatComponent = Component ? Component.default || Component : undefined;
-  const DefaultCompatWrapper = Wrapper ? Wrapper.default || Wrapper : undefined;
-
-  if (!DefaultCompatComponent) {
-    showError({
-      title: `Expecting a Svelte component from the story: "${name}" of "${kind}".`,
-      description: dedent`
-        Did you forget to return the Svelte component configuration from the story?
-        Use "() => ({ Component: YourComponent, data: {} })"
-        when defining the story.
-      `,
-    });
-
-    return;
-  }
 
   const target = document.getElementById('root');
 
   target.innerHTML = '';
 
-  mountView({
-    Component: DefaultCompatComponent,
+  previousComponent = new PreviewRender({
     target,
-    props,
-    on,
-    Wrapper: DefaultCompatWrapper,
-    WrapperData,
+    props: {
+      storyFn,
+      name,
+      kind,
+      showError,
+    },
   });
 
   showMain();

--- a/app/svelte/src/typings.d.ts
+++ b/app/svelte/src/typings.d.ts
@@ -1,2 +1,3 @@
 declare module '@storybook/core/*';
 declare module 'global';
+declare module '*.svelte';

--- a/docs/snippets/svelte/button-group-story.js.mdx
+++ b/docs/snippets/svelte/button-group-story.js.mdx
@@ -10,7 +10,6 @@ export default {
 }
 
 const Template = (args) => ({
-  Component: ButtonGroup,
   props: args,
  });
 

--- a/docs/snippets/svelte/button-story-component-decorator.js.mdx
+++ b/docs/snippets/svelte/button-story-component-decorator.js.mdx
@@ -7,17 +7,7 @@ import MarginDecorator from './MarginDecorator.svelte';
 export default {
   title: "Button",
   component: Button,
-  decorators:  [(storyFn) => {
-    const story = storyFun();
-
-    return {
-      Component: MarginDecorator,
-      props: {
-        child: story.Component,
-        props: story.props,
-      },
-    }
-  }]
+  decorators:  [() => MarginDecorator],
 };
 
 // Your templates and stories here. 
@@ -28,20 +18,8 @@ export default {
 ```html
 <!-- MarginDecorator.svelte -->
 
-<!-- 
-  Read the Svelte documentation for special elements here: 
-  https://svelte.dev/tutorial/svelte-component 
--->
-
-<script>
-  // the component used in the story.
-  export let child;
-  // the props inherited from the component's story
-  export let props = {};
-</script>
-
 <div>
-  <svelte:component this={child} {...props}/>
+  <slot/>
 </div>
 
 <style>

--- a/docs/snippets/svelte/button-story-decorator.js.mdx
+++ b/docs/snippets/svelte/button-story-decorator.js.mdx
@@ -2,15 +2,5 @@
 // Button.stories.js
 
 export const Primary = …
-Primary.decorators = [(storyFn) => {
-    const story = storyFun();
-
-    return {
-      Component: MarginDecorator,
-      props: {
-        child: story.Component,
-        props: story.props,
-      },
-    }
-  }]
+Primary.decorators = [() => MarginDecorator]
 ```

--- a/docs/snippets/svelte/button-story.mdx.mdx
+++ b/docs/snippets/svelte/button-story.mdx.mdx
@@ -4,13 +4,12 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 import Button from './Button.svelte';
 
-<Meta title="Button" />
+<Meta title="Button" component={Button}/>
 
 # Button
 
 <Story name="Primary">
   {{
-    Component: Button,
     props: {
       primary: true,
       label: 'Button',

--- a/docs/snippets/svelte/page-story.js.mdx
+++ b/docs/snippets/svelte/page-story.js.mdx
@@ -9,7 +9,7 @@ export default {
   component: Page,
 };
 
-const Template = (args) => ({ Component: Page, props: args });
+const Template = (args) => ({ props: args });
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {

--- a/docs/snippets/svelte/storybook-preview-global-decorator.js.mdx
+++ b/docs/snippets/svelte/storybook-preview-global-decorator.js.mdx
@@ -3,16 +3,6 @@
 
 import MarginDecorator from './MarginDecorator.svelte';
 
-export const decorators = [(storyFn) => {
-    const story = storyFun();
-
-    return {
-      Component: MarginDecorator,
-      props: {
-        child: story.Component,
-        props: story.props
-      }
-    }
-  }];
+export const decorators = [() => MarginDecorator];
 
 ```

--- a/docs/snippets/svelte/your-component-with-decorator.js.mdx
+++ b/docs/snippets/svelte/your-component-with-decorator.js.mdx
@@ -6,17 +6,7 @@ import MarginDecorator from './MarginDecorator.svelte';
 
 export default {
   component: YourComponent,
-  decorators:  [(storyFn) => {
-    const story = storyFun();
-
-    return {
-      Component: MarginDecorator,
-      props: {
-        child: story.Component,
-        props: story.props
-      }
-    }
-  }]
+  decorators:  [() => MarginDecorator]
 };
 
 // Your templates and stories here. 
@@ -27,20 +17,8 @@ export default {
 ```html
 <!-- MarginDecorator.svelte -->
 
-<!-- 
-  Read the Svelte documentation for special elements here: 
-  https://svelte.dev/tutorial/svelte-component 
--->
-
-<script>
-  // the component used in the story.
-  export let child;
-  // the props inherited from the component's story
-  export let props = {};
-</script>
-
 <div>
-  <svelte:component this={child} {...props}/>
+  <slot/>
 </div>
 
 <style>

--- a/docs/snippets/svelte/your-component.js.mdx
+++ b/docs/snippets/svelte/your-component.js.mdx
@@ -10,7 +10,6 @@ export default {
 };
 
 const Template = (args) => ({
-  Component: YourComponent,
   props: args,
 });
 

--- a/examples/svelte-kitchen-sink/src/components/Context.svelte
+++ b/examples/svelte-kitchen-sink/src/components/Context.svelte
@@ -1,0 +1,9 @@
+<script>
+    import { getContext } from 'svelte';
+
+    let value = getContext('storybook/test') || 'No value';
+</script>
+
+<div on:click>
+    Value read from context: {value}
+</div>

--- a/examples/svelte-kitchen-sink/src/stories/BorderDecorator.svelte
+++ b/examples/svelte-kitchen-sink/src/stories/BorderDecorator.svelte
@@ -1,0 +1,15 @@
+<script>
+    export let color = 'red';
+</script>
+
+<div style="border-color: {color}">
+    <slot/>
+</div>
+
+<style>
+    div {
+        margin: 8px;
+        padding: 8px;
+        border: 1px solid red;
+    }
+</style>

--- a/examples/svelte-kitchen-sink/src/stories/__snapshots__/decorators.stories.storyshot
+++ b/examples/svelte-kitchen-sink/src/stories/__snapshots__/decorators.stories.storyshot
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Decorators Decorators 1`] = `
+<section
+  class="storybook-snapshot-container"
+>
+  <div
+    class="svelte-1gln52r"
+    style="border-color: blue;"
+  >
+    <div
+      class="svelte-1gln52r"
+      style="border-color: red;"
+    >
+      <div>
+        Value read from context: setted from decorator
+      </div>
+      
+    </div>
+    
+    
+    
+  </div>
+  
+  
+</section>
+`;

--- a/examples/svelte-kitchen-sink/src/stories/decorators.stories.js
+++ b/examples/svelte-kitchen-sink/src/stories/decorators.stories.js
@@ -1,0 +1,24 @@
+import { setContext } from 'svelte';
+import { action } from '@storybook/addon-actions';
+import Context from '../components/Context.svelte';
+import BorderDecorator from './BorderDecorator.svelte';
+
+export default {
+  title: 'Decorators',
+  component: Context,
+  decorators: [
+    () => BorderDecorator,
+    () => ({ Component: BorderDecorator, props: { color: 'blue' } }),
+  ],
+};
+
+export const Decorators = () => ({
+  on: {
+    click: action('I am logging in the actions tab'),
+  },
+});
+Decorators.decorators = [
+  () => {
+    setContext('storybook/test', 'setted from decorator');
+  },
+];


### PR DESCRIPTION
Issue: None

## What I did

Today, writing decorators for svelte is hard:
- A decorator must be a svelte component and the decorated story must be injected "by hand" with properties and a <svelte:component/>
- It's not possible to use svelte context

In a "svelte world", data is passed to child through context, and a decorator has children with a `<slot/>`

This PR allow to use a syntax closest to Svelte.

A decorator component can be declared as:

```
<!-- MarginDecorator.svelte -->
<div>
  <slot/>
</div>

<style>
  div { margin: 3em; }
</style>
``` 
And a decorator for this component is just `() => MarginDecorator`.

It's possible to use Svelte context with `() => { setContext('myKey', 'myValue') }`

Moreover, this PR:
- Implements #8673 : If a story doesn't define a component, then the parameters.component is used
- Remove dependencies to internal svelte implementation: the rendering is done through a real component

## How to test

- Is this testable with Jest or Chromatic screenshots? Done
- Does this need a new example in the kitchen sink apps? Done
- Does this need an update to the documentation? Done
