### PR TITLE
Build: Do not recompile packages in publish step of the CI

### DIFF
--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -108,7 +108,7 @@ const publish = (packages: { name: string; location: string }[], url: string) =>
         () =>
           new Promise((res, rej) => {
             logger.log(`🛫 publishing ${name} (${location})`);
-            const command = `cd ${location} && npm publish --registry ${url} --force --access restricted`;
+            const command = `cd ${location} && npm publish --registry ${url} --force --access restricted --ignore-scripts`;
             exec(command, (e) => {
               if (e) {
                 rej(e);


### PR DESCRIPTION
## What I did

Do not recompile packages before publishing with the `run-registry` script. It will:
 - 🚓  ensure that the outputs of the build step are really used
 - 🚀  speed up the publish step on CI ~a lot~ a bit

## How to test
 
 - CI should still be 🟢  and the duration of the `publish` step should decrease ~a lot~ a bit