### PR TITLE
CI: Remove generic cache key from Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ jobs:
           name: Restore Yarn cache
           keys:
             - build-yarn-cache-v4--{{ checksum "yarn.lock" }}
-            - build-yarn-cache-v4--
       - run:
           name: Install dependencies
           command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
@@ -118,7 +117,6 @@ jobs:
           name: Restore Yarn cache
           keys:
             - install-examples-deps-yarn-cache-v4--{{ checksum "yarn.lock" }}
-            - install-examples-deps-yarn-cache-v4--
       - run:
           name: Install dependencies
           command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn


### PR DESCRIPTION
Issue: N/A

## What I did

While investigating my CI failures, I noticed that an old cache was being pulled (in the same fashion as #13752) - we should only use a cache in CI if it matches the lockfile in the project, otherwise this can cause flakiness in the tests.

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
