### PR TITLE
fix(ui): use theme input color for search focus bg

### DIFF
--- a/lib/ui/src/components/sidebar/Search.tsx
+++ b/lib/ui/src/components/sidebar/Search.tsx
@@ -86,7 +86,7 @@ const Input = styled.input(({ theme }) => ({
   '&:focus, &:active': {
     outline: 0,
     borderColor: theme.color.secondary,
-    background: theme.barBg,
+    background: theme.input.background,
   },
   '&::placeholder': {
     color: theme.textMutedColor,


### PR DESCRIPTION
Issue: #13388

## What I did
I changed the `Search` component that is used in the sidebar to use the same color as `form/Input`, instead of the toolbar background color.

| Theme | Before | After |
|-|-|-|
| `light` | ![Screenshot 2021-02-02 at 15 34 25](https://user-images.githubusercontent.com/2328042/106633322-a0028c80-6576-11eb-84d2-e0f7af68225e.png) | ![Screenshot 2021-02-02 at 15 35 00](https://user-images.githubusercontent.com/2328042/106633316-9e38c900-6576-11eb-880e-1f6380e288ee.png) |
| `dark` | ![Screenshot 2021-02-02 at 15 34 32](https://user-images.githubusercontent.com/2328042/106633321-9f69f600-6576-11eb-8aef-ddc0fe6c766d.png) | ![Screenshot 2021-02-02 at 15 34 54](https://user-images.githubusercontent.com/2328042/106633320-9ed15f80-6576-11eb-8aaf-d96908eb78b5.png) |

## How to test

1. Create a custom theme with a `barBg` prop.
```
import {create} from '@storybook/theming/create';

const light = create({
  base: 'light',
  barBg: 'hotpink',
});

const dark = create({
  base: 'dark',
  barBg: 'hotpink',
});
```
2. Focus the `Search` component in the sidebar.

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
