### PR TITLE
CLI: Fix opening localhost in browser by default

### DIFF
--- a/lib/core/src/server/dev-server.ts
+++ b/lib/core/src/server/dev-server.ts
@@ -420,7 +420,7 @@ export async function storybookDevServer(options: any) {
   ]);
 
   // TODO #13083 Remove this when compiling the preview is fast enough
-  if (!options.ci && !options.smokeTest) openInBrowser(networkAddress);
+  if (!options.ci && !options.smokeTest) openInBrowser(host ? networkAddress : address);
 
   return { ...previewResult, ...managerResult, address, networkAddress };
 }


### PR DESCRIPTION
Issue: #13707 #13619

Fix an issue where host is preferred for openInBrowser when host is undefined from #13521.\

PR #13521 set opening as the `host` to default, however if the `host` option arg is not provided then it should open `localhost` in browser instead of the host IP

## What I did

Introduced a check to restore the expected feature of opening `localhost` if the `host` option is not provided. If `host` is truthy then open `networkAddress` in browser, otherwise open `address` in browser.

## How to test

Advice welcomed on how to test the `openInBrowser` feature specifically. Tests are currently failing due to broken or missing deps in the `next` branch.