### PR TITLE
docs(vue-kitchen-sink): improve punctuation

### DIFF
--- a/examples/vue-kitchen-sink/src/stories/addon-docs.stories.mdx
+++ b/examples/vue-kitchen-sink/src/stories/addon-docs.stories.mdx
@@ -58,7 +58,7 @@ Let's add another one. The UI updates automatically as you'd expect.
 
 ## Longform docs
 
-And just like in the React, case we're generating long-form docs as we go.
+And—just like in the React case—we're generating long-form docs as we go.
 
 The primary difference is that for Vue Docs we generate an iframe per story, by default. If you prefer your stories to be rendered inline, see the next section.
 


### PR DESCRIPTION
Previous punctuation was confusing. I think this is how it was meant.

I hope the `—` characters is allowed!?!

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
