### PR TITLE
Addon-docs/Vue3: Resolve vue3 package for addon-docs preset

### DIFF
--- a/addons/docs/src/frameworks/vue3/preset.ts
+++ b/addons/docs/src/frameworks/vue3/preset.ts
@@ -1,7 +1,7 @@
 export function webpackFinal(webpackConfig: any = {}, options: any = {}) {
   webpackConfig.module.rules.push({
     test: /\.vue$/,
-    loader: require.resolve('vue-docgen-loader', { paths: [require.resolve('@storybook/vue')] }),
+    loader: require.resolve('vue-docgen-loader', { paths: [require.resolve('@storybook/vue3')] }),
     enforce: 'post',
     options: {
       docgenOptions: {


### PR DESCRIPTION
Issue: Pointed out at https://github.com/storybookjs/storybook/pull/13809#issuecomment-773667516

## What I did

I fixed a copy-paste issue with the vue 3 code in addon-docs.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
