### PR TITLE
CLI: only kill other processes on fail

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -104,7 +104,7 @@ function run() {
     selection = Promise.resolve(
       Object.keys(tasks)
         .map((key) => tasks[key])
-        .filter((item) => item.value === true)
+        .filter((item) => item.name !== 'watch' && item.value === true)
     );
   }
 
@@ -139,7 +139,8 @@ function run() {
             )}`;
             const watchTsc = `${baseWatchCommand}/utils/watch-tsc.js`;
             const watchBabel = `${baseWatchCommand}/utils/watch-babel.js`;
-            const command = `concurrently --kill-others "${watchTsc}" "${watchBabel}"`;
+            const command = `concurrently --kill-others-on-fail "${watchTsc}" "${watchBabel}"`;
+
             spawn(command);
           };
 


### PR DESCRIPTION
Issue: #13821

## What I did

The --watch command was using --kill-others with concurrently, which kills other processes in case any process fails **or succeeds**.

This PR changes it so that it will only kill other processes on failure. It also adds an extra filter to remove --watch in the lerna scope, as it should not be there.
 
## How to test

- yarn build addon-docs --watch (should not fail anymore)