### PR TITLE
UI: Add a 'main' role to the Main component for a11y

### DIFF
--- a/lib/ui/src/components/layout/container.tsx
+++ b/lib/ui/src/components/layout/container.tsx
@@ -120,7 +120,7 @@ export const Main: FunctionComponent<{ isFullscreen: boolean; position: CSSPrope
   position = undefined,
   ...props
 }) => (
-  <Pane style={position} top {...props}>
+  <Pane style={position} top {...props} role="main">
     <Paper isFullscreen={isFullscreen}>{children}</Paper>
   </Pane>
 );


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13794

## What I did
Added a `role="main"` to the Main functional component

## How to test

Install and run the `axe` plug-in in Chrome. Observe that the error regarding a main landmark is resolved after this PR is added.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
