### PR TITLE
Addon-storyshots: Add support for Vue 3

### DIFF
--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -210,6 +210,29 @@ module.exports = {
 };
 ```
 
+### Configure Jest for Vue 3
+
+StoryShots addon for Vue is dependent on [vue-jest v5](https://www.npmjs.com/package/vue-jest/v/5.0.0-alpha.8), but
+[doesn't](#deps-issue) install it, so you need to install it separately.
+
+```sh
+yarn add vue-jest@5.0.0-alpha.8
+```
+
+If you already use Jest for testing your vue app - probably you already have the needed jest configuration.
+Anyway you can add these lines to your jest config:
+
+```js
+module.exports = {
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest',
+    '.*\\.(vue)$': '<rootDir>/node_modules/vue-jest',
+  },
+  transformIgnorePatterns: ['/node_modules/(?!(@storybook/.*\\.vue$))'],
+  moduleFileExtensions: ['vue', 'js', 'jsx', 'json', 'node'],
+};
+```
+
 ### Configure Jest for Preact
 
 StoryShots addon for Preact is dependent on [preact-render-to-json](https://github.com/nathancahill/preact-render-to-json), but

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -61,30 +61,37 @@
     "@storybook/addon-docs": "6.2.0-alpha.23",
     "@storybook/angular": "6.2.0-alpha.23",
     "@storybook/react": "6.2.0-alpha.23",
+    "@storybook/vue3": "6.2.0-alpha.23",
     "babel-loader": "^8.2.2",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.6.1",
     "jest-emotion": "^10.0.32",
     "jest-preset-angular": "^8.3.2",
     "jest-vue-preprocessor": "^1.7.1",
-    "rxjs": "^6.6.3"
+    "rxjs": "^6.6.3",
+    "vue-jest": "^5.0.0-alpha.8"
   },
   "peerDependencies": {
     "@storybook/angular": "*",
     "@storybook/react": "*",
     "@storybook/vue": "*",
+    "@storybook/vue3": "*",
     "jest-preset-angular": "*",
     "jest-vue-preprocessor": "*",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
     "rxjs": "*",
-    "vue": "*"
+    "vue": "*",
+    "vue-jest": "*"
   },
   "peerDependenciesMeta": {
     "@storybook/angular": {
       "optional": true
     },
     "@storybook/vue": {
+      "optional": true
+    },
+    "@storybook/vue3": {
       "optional": true
     },
     "jest-preset-angular": {
@@ -103,6 +110,9 @@
       "optional": true
     },
     "vue": {
+      "optional": true
+    },
+    "vue-jest": {
       "optional": true
     }
   },

--- a/addons/storyshots/storyshots-core/src/frameworks/SupportedFramework.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/SupportedFramework.ts
@@ -7,5 +7,6 @@ export type SupportedFramework =
   | 'react-native'
   | 'svelte'
   | 'vue'
+  | 'vue3'
   | 'web-components'
   | 'rax';

--- a/addons/storyshots/storyshots-core/src/frameworks/vue3/loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/vue3/loader.ts
@@ -1,0 +1,33 @@
+import global from 'global';
+import hasDependency from '../hasDependency';
+import configure from '../configure';
+import { Loader } from '../Loader';
+import { StoryshotsOptions } from '../../api/StoryshotsOptions';
+
+function test(options: StoryshotsOptions): boolean {
+  return options.framework === 'vue3' || (!options.framework && hasDependency('@storybook/vue3'));
+}
+
+function load(options: StoryshotsOptions) {
+  global.STORYBOOK_ENV = 'vue3';
+
+  const storybook = jest.requireActual('@storybook/vue3');
+
+  configure({ ...options, storybook });
+
+  return {
+    framework: 'vue3' as const,
+    renderTree: jest.requireActual('./renderTree').default,
+    renderShallowTree: () => {
+      throw new Error('Shallow renderer is not supported for Vue 3');
+    },
+    storybook,
+  };
+}
+
+const vueLoader: Loader = {
+  load,
+  test,
+};
+
+export default vueLoader;

--- a/addons/storyshots/storyshots-core/src/frameworks/vue3/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/vue3/renderTree.ts
@@ -2,6 +2,7 @@ import * as Vue from 'vue';
 import { document } from 'global';
 import dedent from 'ts-dedent';
 
+// This is cast as `any` to workaround type errors caused by Vue 2 types
 const { render, h } = Vue as any;
 
 function getRenderedTree(story: any) {

--- a/addons/storyshots/storyshots-core/src/frameworks/vue3/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/vue3/renderTree.ts
@@ -1,0 +1,30 @@
+import * as Vue from 'vue';
+import { document } from 'global';
+import dedent from 'ts-dedent';
+
+const { render, h } = Vue as any;
+
+function getRenderedTree(story: any) {
+  const component = story.render();
+
+  const vnode = h(component, story.args);
+
+  // Vue 3's Jest renderer throws if all of the required props aren't specified
+  // So we try/catch and warn the user if they forgot to specify one in their args
+  try {
+    render(vnode, document.createElement('div'));
+  } catch (err) {
+    // Jest throws an error when you call `console.error`
+    // eslint-disable-next-line no-console
+    console.error(
+      dedent`
+        Storyshots encountered an error while rendering Vue 3 story: ${story.id}
+        Did you remember to define every prop you are using in the story?
+      `
+    );
+  }
+
+  return vnode.el;
+}
+
+export default getRenderedTree;

--- a/examples/vue-3-cli/jest.config.js
+++ b/examples/vue-3-cli/jest.config.js
@@ -1,0 +1,11 @@
+const config = require('../../jest.config');
+
+module.exports = {
+  ...config,
+  roots: [__dirname],
+  transform: {
+    ...config.transform,
+    '.*\\.(vue)$': require.resolve('vue-jest'),
+  },
+  moduleFileExtensions: [...config.moduleFileExtensions, 'vue'],
+};

--- a/examples/vue-3-cli/package.json
+++ b/examples/vue-3-cli/package.json
@@ -17,6 +17,7 @@
     "@storybook/addon-actions": "6.2.0-alpha.23",
     "@storybook/addon-essentials": "6.2.0-alpha.23",
     "@storybook/addon-links": "6.2.0-alpha.23",
+    "@storybook/addon-storyshots": "6.2.0-alpha.23",
     "@storybook/vue3": "6.2.0-alpha.23",
     "@vue/cli-plugin-babel": "~4.5.0",
     "@vue/cli-plugin-typescript": "~4.5.0",
@@ -24,6 +25,7 @@
     "@vue/compiler-sfc": "^3.0.0",
     "babel-loader": "^8.2.2",
     "typescript": "~3.9.3",
+    "vue-jest": "^5.0.0-alpha.8",
     "vue-loader": "^16.1.2"
   }
 }

--- a/examples/vue-3-cli/src/stories/Button.vue
+++ b/examples/vue-3-cli/src/stories/Button.vue
@@ -2,7 +2,7 @@
   <button type="button" :class="classes" @click="onClick" :style="style">{{ label }}</button>
 </template>
 
-<script>
+<script lang="typescript">
 import './button.css';
 import { reactive, computed } from 'vue';
 
@@ -32,7 +32,7 @@ export default {
 
   emits: ['click'],
 
-  setup(props, { emit }) {
+  setup(props: any, { emit }: any) {
     props = reactive(props);
     return {
       classes: computed(() => ({

--- a/examples/vue-3-cli/src/stories/Button.vue
+++ b/examples/vue-3-cli/src/stories/Button.vue
@@ -32,7 +32,8 @@ export default {
 
   emits: ['click'],
 
-  setup(props: any, { emit }: any) {
+  // @ts-ignore
+  setup(props, { emit }) {
     props = reactive(props);
     return {
       classes: computed(() => ({

--- a/examples/vue-3-cli/src/stories/Header.stories.js
+++ b/examples/vue-3-cli/src/stories/Header.stories.js
@@ -17,4 +17,6 @@ LoggedIn.args = {
 };
 
 export const LoggedOut = Template.bind({});
-LoggedOut.args = {};
+LoggedOut.args = {
+  user: null,
+};

--- a/examples/vue-3-cli/src/stories/Header.vue
+++ b/examples/vue-3-cli/src/stories/Header.vue
@@ -29,7 +29,7 @@
   </header>
 </template>
 
-<script>
+<script lang="typescript">
 import './header.css';
 import MyButton from './Button.vue';
 

--- a/examples/vue-3-cli/src/stories/Page.stories.js
+++ b/examples/vue-3-cli/src/stories/Page.stories.js
@@ -6,8 +6,10 @@ export default {
   component: MyPage,
 };
 
-const Template = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
+// If your props are optional and don't always exist in argTypes,
+// you can specify them explicitly as you normally specify props
+const Template = () => ({
+  props: ['user'],
   components: { MyPage },
   template: '<my-page :user="user" />',
 });
@@ -18,6 +20,4 @@ LoggedIn.args = {
 };
 
 export const LoggedOut = Template.bind({});
-LoggedOut.args = {
-  ...HeaderStories.LoggedOut.args,
-};
+LoggedOut.args = {};

--- a/examples/vue-3-cli/src/stories/Page.vue
+++ b/examples/vue-3-cli/src/stories/Page.vue
@@ -58,7 +58,7 @@
   </article>
 </template>
 
-<script>
+<script lang="typescript">
 import './page.css';
 import MyHeader from './Header.vue';
 

--- a/examples/vue-3-cli/src/stories/Page.vue
+++ b/examples/vue-3-cli/src/stories/Page.vue
@@ -70,6 +70,7 @@ export default {
   props: {
     user: {
       type: Object,
+      required: false,
     },
   },
 

--- a/examples/vue-3-cli/src/stories/__snapshots__/Button.stories.storyshot
+++ b/examples/vue-3-cli/src/stories/__snapshots__/Button.stories.storyshot
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Example/Button Large 1`] = `
+<button
+  class="storybook-button storybook-button--secondary storybook-button--large"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`Storyshots Example/Button Primary 1`] = `
+<button
+  class="storybook-button storybook-button--primary storybook-button--medium"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`Storyshots Example/Button Secondary 1`] = `
+<button
+  class="storybook-button storybook-button--secondary storybook-button--medium"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`Storyshots Example/Button Small 1`] = `
+<button
+  class="storybook-button storybook-button--secondary storybook-button--small"
+  type="button"
+>
+  Button
+</button>
+`;

--- a/examples/vue-3-cli/src/stories/__snapshots__/Header.stories.storyshot
+++ b/examples/vue-3-cli/src/stories/__snapshots__/Header.stories.storyshot
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Example/Header Logged In 1`] = `
+<header>
+  <div
+    class="wrapper"
+  >
+    <div>
+      <svg
+        height="32"
+        viewBox="0 0 32 32"
+        width="32"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
+            fill="#FFF"
+          />
+          <path
+            d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
+            fill="#555AB9"
+          />
+          <path
+            d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
+            fill="#91BAF8"
+          />
+        </g>
+      </svg>
+      <h1>
+        Acme
+      </h1>
+    </div>
+    <div>
+      <button
+        class="storybook-button storybook-button--secondary storybook-button--small"
+        type="button"
+      >
+        Log out
+      </button>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+  </div>
+</header>
+`;
+
+exports[`Storyshots Example/Header Logged Out 1`] = `
+<header>
+  <div
+    class="wrapper"
+  >
+    <div>
+      <svg
+        height="32"
+        viewBox="0 0 32 32"
+        width="32"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
+            fill="#FFF"
+          />
+          <path
+            d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
+            fill="#555AB9"
+          />
+          <path
+            d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
+            fill="#91BAF8"
+          />
+        </g>
+      </svg>
+      <h1>
+        Acme
+      </h1>
+    </div>
+    <div>
+      <!--v-if-->
+      <button
+        class="storybook-button storybook-button--secondary storybook-button--small"
+        type="button"
+      >
+        Log in
+      </button>
+      <button
+        class="storybook-button storybook-button--primary storybook-button--small"
+        type="button"
+      >
+        Sign up
+      </button>
+    </div>
+  </div>
+</header>
+`;

--- a/examples/vue-3-cli/src/stories/__snapshots__/Page.stories.storyshot
+++ b/examples/vue-3-cli/src/stories/__snapshots__/Page.stories.storyshot
@@ -1,0 +1,258 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Example/Page Logged In 1`] = `
+<article>
+  <header>
+    <div
+      class="wrapper"
+    >
+      <div>
+        <svg
+          height="32"
+          viewBox="0 0 32 32"
+          width="32"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fill-rule="evenodd"
+          >
+            <path
+              d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
+              fill="#FFF"
+            />
+            <path
+              d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
+              fill="#555AB9"
+            />
+            <path
+              d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
+              fill="#91BAF8"
+            />
+          </g>
+        </svg>
+        <h1>
+          Acme
+        </h1>
+      </div>
+      <div>
+        <button
+          class="storybook-button storybook-button--secondary storybook-button--small"
+          type="button"
+        >
+          Log out
+        </button>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </div>
+  </header>
+  <section>
+    <h2>
+      Pages in Storybook
+    </h2>
+    <p>
+       We recommend building UIs with a 
+      <a
+        href="https://componentdriven.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <strong>
+          component-driven
+        </strong>
+      </a>
+       process starting with atomic components and ending with pages. 
+    </p>
+    <p>
+       Render pages with mock data. This makes it easy to build and review page states without needing to navigate to them in your app. Here are some handy patterns for managing page data in Storybook: 
+    </p>
+    <ul>
+      <li>
+         Use a higher-level connected component. Storybook helps you compose such data from the "args" of child component stories 
+      </li>
+      <li>
+         Assemble data in the page component from your services. You can mock these services out using Storybook. 
+      </li>
+    </ul>
+    <p>
+       Get a guided tutorial on component-driven development at 
+      <a
+        href="https://www.learnstorybook.com"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Learn Storybook
+      </a>
+       . Read more in the 
+      <a
+        href="https://storybook.js.org/docs"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        docs
+      </a>
+       . 
+    </p>
+    <div
+      class="tip-wrapper"
+    >
+      <span
+        class="tip"
+      >
+        Tip
+      </span>
+       Adjust the width of the canvas with the 
+      <svg
+        height="10"
+        viewBox="0 0 12 12"
+        width="10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            d="M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0 01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0 010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z"
+            fill="#999"
+            id="a"
+          />
+        </g>
+      </svg>
+       Viewports addon in the toolbar 
+    </div>
+  </section>
+</article>
+`;
+
+exports[`Storyshots Example/Page Logged Out 1`] = `
+<article>
+  <header>
+    <div
+      class="wrapper"
+    >
+      <div>
+        <svg
+          height="32"
+          viewBox="0 0 32 32"
+          width="32"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fill-rule="evenodd"
+          >
+            <path
+              d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
+              fill="#FFF"
+            />
+            <path
+              d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
+              fill="#555AB9"
+            />
+            <path
+              d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
+              fill="#91BAF8"
+            />
+          </g>
+        </svg>
+        <h1>
+          Acme
+        </h1>
+      </div>
+      <div>
+        <!--v-if-->
+        <button
+          class="storybook-button storybook-button--secondary storybook-button--small"
+          type="button"
+        >
+          Log in
+        </button>
+        <button
+          class="storybook-button storybook-button--primary storybook-button--small"
+          type="button"
+        >
+          Sign up
+        </button>
+      </div>
+    </div>
+  </header>
+  <section>
+    <h2>
+      Pages in Storybook
+    </h2>
+    <p>
+       We recommend building UIs with a 
+      <a
+        href="https://componentdriven.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <strong>
+          component-driven
+        </strong>
+      </a>
+       process starting with atomic components and ending with pages. 
+    </p>
+    <p>
+       Render pages with mock data. This makes it easy to build and review page states without needing to navigate to them in your app. Here are some handy patterns for managing page data in Storybook: 
+    </p>
+    <ul>
+      <li>
+         Use a higher-level connected component. Storybook helps you compose such data from the "args" of child component stories 
+      </li>
+      <li>
+         Assemble data in the page component from your services. You can mock these services out using Storybook. 
+      </li>
+    </ul>
+    <p>
+       Get a guided tutorial on component-driven development at 
+      <a
+        href="https://www.learnstorybook.com"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Learn Storybook
+      </a>
+       . Read more in the 
+      <a
+        href="https://storybook.js.org/docs"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        docs
+      </a>
+       . 
+    </p>
+    <div
+      class="tip-wrapper"
+    >
+      <span
+        class="tip"
+      >
+        Tip
+      </span>
+       Adjust the width of the canvas with the 
+      <svg
+        height="10"
+        viewBox="0 0 12 12"
+        width="10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            d="M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0 01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0 010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z"
+            fill="#999"
+            id="a"
+          />
+        </g>
+      </svg>
+       Viewports addon in the toolbar 
+    </div>
+  </section>
+</article>
+`;

--- a/examples/vue-3-cli/tsconfig.json
+++ b/examples/vue-3-cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "esnext",
+    "module": "commonjs",
     "strict": true,
     "jsx": "preserve",
     "importHelpers": true,

--- a/examples/vue-3-cli/vuethreeshots.test.js
+++ b/examples/vue-3-cli/vuethreeshots.test.js
@@ -1,0 +1,9 @@
+import path from 'path';
+import initStoryshots, { multiSnapshotWithOptions } from '@storybook/addon-storyshots';
+
+initStoryshots({
+  framework: 'vue3',
+  configPath: path.join(__dirname, '.storybook'),
+  integrityOptions: { cwd: path.join(__dirname, 'src', 'stories') },
+  test: multiSnapshotWithOptions(),
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,9 @@ module.exports = {
     '<rootDir>/examples/angular-cli',
     '<rootDir>/examples/preact-kitchen-sink',
     '<rootDir>/examples/rax-kitchen-sink',
+    // This is explicitly commented out because having vue 2 & 3 in the
+    // dependency graph makes it impossible to run storyshots on both examples
+    // '<rootDir>/examples/vue-3-cli',
   ],
   roots: [
     '<rootDir>/addons',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5607,6 +5607,16 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/strip-bom@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"
+  integrity sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=
+
+"@types/strip-json-comments@0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
+  integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
+
 "@types/symlink-or-copy@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#4151a81b4052c80bc2becbae09f3a9ec010a9c7a"
@@ -12012,7 +12022,7 @@ css.escape@^1.5.1:
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@^2.0.0, css@^2.2.1, css@^2.2.4:
+css@^2.0.0, css@^2.1.0, css@^2.2.1, css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -15221,6 +15231,13 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+extract-from-css@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/extract-from-css/-/extract-from-css-0.4.4.tgz#1ea7df2e7c7c6eb9922fa08e8adaea486f6f8f92"
+  integrity sha1-HqffLnx8brmSL6COitrqSG9vj5I=
+  dependencies:
+    css "^2.1.0"
 
 extract-stack@^2.0.0:
   version "2.0.0"
@@ -30603,7 +30620,7 @@ strip-json-comments@1.0.x:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
   integrity sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=
 
-strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.0, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -31891,6 +31908,16 @@ tsconfig-paths@^3.4.0, tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tsconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-7.0.0.tgz#84538875a4dc216e5c4a5432b3a4dec3d54e91b7"
+  integrity sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==
+  dependencies:
+    "@types/strip-bom" "^3.0.0"
+    "@types/strip-json-comments" "0.0.30"
+    strip-bom "^3.0.0"
+    strip-json-comments "^2.0.0"
+
 tslib@2.1.0, tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
@@ -33048,6 +33075,17 @@ vue-inbrowser-compiler-utils@^4.33.6:
   integrity sha512-g9ErL/xuTtRAdT6+VmzR4Lqxlw4hpH7ObEBGk8VGQgNqdcs9Pza8AMzlns160IGzQw4sI8gvvbYEPeZ54Z5OfA==
   dependencies:
     camelcase "^5.3.1"
+
+vue-jest@^5.0.0-alpha.8:
+  version "5.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-5.0.0-alpha.8.tgz#45b12335dbb73c9ab8309f1e24b2fc8781d519f9"
+  integrity sha512-4FqH69T6X6rOglrEui/mDWvOTGB9ammmCXLVdS4s524D4Emx8fBC4sKAPFAUZfbWpYh/7i7xWoPwF4agfyGWwA==
+  dependencies:
+    "@babel/plugin-transform-modules-commonjs" "^7.2.0"
+    chalk "^2.1.0"
+    convert-source-map "^1.6.0"
+    extract-from-css "^0.4.4"
+    tsconfig "^7.0.0"
 
 "vue-loader-v16@npm:vue-loader@^16.1.0", vue-loader@^16.0.0, vue-loader@^16.1.2:
   version "16.1.2"


### PR DESCRIPTION
Issue: Follow up to #13775

## What I did

I added support for Vue 3 in `addon-storyshots`. Additionally, I added some more stuff to the `vue-3-cli` example that makes it easier to try out the storyshots stuff.

As you can see, I was able to successfully generate the snapshots with storyshots, but those can't run during a normal test run because of all the troubles I've been encountering with having Vue 2 and Vue 3 in the dependency tree of this monorepo.

## How to test

- Is this testable with Jest or Chromatic screenshots? Generated but not run on normal test runs
- Does this need a new example in the kitchen sink apps? Added
- Does this need an update to the documentation? Updated the README for storyshots

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
