### PR TITLE
Addon-docs: Fix ArgsTable tab renamed to `Story` when using args

### DIFF
--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -170,9 +170,11 @@ export const StoryTable: FC<
     }
     storyArgTypes = filterArgTypes(storyArgTypes, include, exclude);
 
+    const mainLabel = getComponentName(component) || 'Story';
+
     // eslint-disable-next-line prefer-const
     let [args, updateArgs, resetArgs] = useArgs(storyId, storyStore);
-    let tabs = { Story: { rows: storyArgTypes, args, updateArgs, resetArgs } } as Record<
+    let tabs = { [mainLabel]: { rows: storyArgTypes, args, updateArgs, resetArgs } } as Record<
       string,
       PureArgsTableProps
     >;
@@ -188,7 +190,6 @@ export const StoryTable: FC<
     }
 
     if (component && (!storyHasArgsWithControls || showComponent)) {
-      const mainLabel = getComponentName(component);
       tabs = addComponentTabs(tabs, { [mainLabel]: component }, context, include, exclude);
     }
 


### PR DESCRIPTION
Issue: #12357

## What I did

Used component name for first tab of ArgsTable instead of hardcoded "Story" title

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
