### PR TITLE
Vue 3: Fix decorators and add more examples

### DIFF
--- a/app/vue3/src/client/preview/types-6-0.ts
+++ b/app/vue3/src/client/preview/types-6-0.ts
@@ -21,3 +21,5 @@ export type Meta<Args = DefaultArgs> = BaseMeta<VueComponent> & Annotations<Args
  */
 export type Story<Args = DefaultArgs> = BaseStory<Args, VueReturnType> &
   Annotations<Args, VueReturnType>;
+
+export type Decorators = Story['decorators'];

--- a/app/vue3/src/client/preview/types-6-0.ts
+++ b/app/vue3/src/client/preview/types-6-0.ts
@@ -4,7 +4,7 @@ import { StoryFnVueReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/addons';
 
-type VueComponent = ConcreteComponent;
+type VueComponent = ConcreteComponent<any>;
 type VueReturnType = StoryFnVueReturnType;
 
 /**

--- a/app/vue3/src/client/preview/types.ts
+++ b/app/vue3/src/client/preview/types.ts
@@ -7,7 +7,7 @@ export interface ShowErrorArgs {
   description: string;
 }
 
-export type StoryFnVueReturnType = ConcreteComponent;
+export type StoryFnVueReturnType = ConcreteComponent<any>;
 
 export interface IStorybookStory {
   name: string;

--- a/examples/vue-3-cli/.storybook/preview.js
+++ b/examples/vue-3-cli/.storybook/preview.js
@@ -1,3 +1,0 @@
-export const parameters = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
-};

--- a/examples/vue-3-cli/.storybook/preview.ts
+++ b/examples/vue-3-cli/.storybook/preview.ts
@@ -1,5 +1,11 @@
-import { Parameters } from '@storybook/vue3';
+import { Parameters, Decorators } from '@storybook/vue3';
 
 export const parameters: Parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
 };
+
+export const decorators: Decorators = [
+  () => ({
+    template: '<div id="test-div"><story /></div>',
+  }),
+];

--- a/examples/vue-3-cli/.storybook/preview.ts
+++ b/examples/vue-3-cli/.storybook/preview.ts
@@ -1,0 +1,5 @@
+import { Parameters } from '@storybook/vue3';
+
+export const parameters: Parameters = {
+  actions: { argTypesRegex: '^on[A-Z].*' },
+};

--- a/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
+++ b/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
@@ -1,0 +1,53 @@
+import { Story } from '@storybook/vue3';
+import { FunctionalComponent, h } from 'vue';
+import DynamicHeading, { Props } from './DynamicHeading';
+
+export default {
+  title: 'Example/DynamicHeading',
+  component: DynamicHeading,
+  argTypes: {
+    // Number type is detected, but we still want to constrain the range from 1-6
+    level: { control: { min: 1, max: 6 } },
+  },
+};
+
+/*
+  You can return a Vue 3 functional component from a Story.
+
+  Make sure to specify the `props` the component expects to receive!
+ */
+const Template: Story = (args, { argTypes }) => {
+  const component: FunctionalComponent<Props> = (props) => h(DynamicHeading, props, 'Hello World!');
+  component.props = Object.keys(argTypes);
+  return component;
+};
+
+export const One = Template.bind({});
+One.args = {
+  level: 1,
+};
+
+export const Two = Template.bind({});
+Two.args = {
+  level: 2,
+};
+
+export const Three = Template.bind({});
+Three.args = {
+  level: 3,
+};
+
+export const Four = Template.bind({});
+Four.args = {
+  level: 4,
+};
+
+export const Five = Template.bind({});
+Five.args = {
+  level: 5,
+};
+
+export const Six = Template.bind({});
+Six.args = {
+  level: 6,
+};

--- a/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
+++ b/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
@@ -7,7 +7,7 @@ export default {
   component: DynamicHeading,
   argTypes: {
     // Number type is detected, but we still want to constrain the range from 1-6
-    level: { control: { min: 1, max: 6 } },
+    level: { control: { type: 'range', min: 1, max: 6 } },
   },
   decorators: [
     (storyFn) => {

--- a/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
+++ b/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/vue3';
+import { Story, Meta } from '@storybook/vue3';
 import { FunctionalComponent, h } from 'vue';
 import DynamicHeading, { Props } from './DynamicHeading';
 
@@ -9,7 +9,7 @@ export default {
     // Number type is detected, but we still want to constrain the range from 1-6
     level: { control: { min: 1, max: 6 } },
   },
-};
+} as Meta;
 
 /*
   You can return a Vue 3 functional component from a Story.

--- a/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
+++ b/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
@@ -9,6 +9,16 @@ export default {
     // Number type is detected, but we still want to constrain the range from 1-6
     level: { control: { min: 1, max: 6 } },
   },
+  decorators: [
+    (storyFn) => {
+      // Call the `storyFn` to receive a component that Vue can render
+      const story = storyFn();
+      // Vue 3 "Functional" component as decorator
+      return () => {
+        return h('div', { style: 'border: 2px solid red' }, h(story));
+      };
+    },
+  ],
 } as Meta;
 
 /*
@@ -26,6 +36,26 @@ export const One = Template.bind({});
 One.args = {
   level: 1,
 };
+One.decorators = [
+  // Vue 3 "ComponentOptions" component as decorator
+  () => ({
+    // The `story` component is always injected into a decorator
+    template: '<div :style="{ color: activeColor }"><story /></div>',
+    data() {
+      // Story Args can be accessed on `this.props`
+      switch (this.props.level) {
+        case 1:
+          return { activeColor: 'purple' };
+        case 2:
+          return { activeColor: 'green' };
+        case 3:
+          return { activeColor: 'blue' };
+        default:
+          return { activeColor: 'unset' };
+      }
+    },
+  }),
+];
 
 export const Two = Template.bind({});
 Two.args = {

--- a/examples/vue-3-cli/src/stories/DynamicHeading.ts
+++ b/examples/vue-3-cli/src/stories/DynamicHeading.ts
@@ -1,0 +1,29 @@
+/*
+  Functional Vue 3 component
+  Inspired by https://v3.vuejs.org/guide/migration/functional-components.html#components-created-by-functions
+ */
+
+import { FunctionalComponent, h } from 'vue';
+
+export type Props = {
+  level: number;
+};
+
+export type Component = FunctionalComponent<Props>;
+
+const DynamicHeading: Component = (props, context) => {
+  return h(`h${props.level}`, context.attrs, context.slots);
+};
+
+/*
+  Props object definition is tied to the Props type used in FunctionalComponent<Props>
+
+  Try adding a prop that doesn't exist on the type...
+ */
+DynamicHeading.props = {
+  level: {
+    type: Number,
+  },
+};
+
+export default DynamicHeading;


### PR DESCRIPTION
Issue: Mentioned at https://github.com/storybookjs/storybook/issues/10654#issuecomment-774166287

## What I did

I fixed the way decorators were constructed for Vue 3 and added some examples to further exercise the TS types provided by the library. I also tested functional and object components for stories **and** decorators in the examples.

I didn't re-generate the storyshots because it is quite an ordeal to get working.

cc @LinusBorg - The issue seemed to be that we couldn't use the [`extends`](https://v3.vuejs.org/api/options-composition.html#extends) API to decorate stories. We had to instead normalize the functional components into an object and spread them with our additional logic. I'm not sure why this was the case, any thoughts?

cc @kayue - I added some examples for you to review. There is no need for you to specify the `components: { story }` in your decorators because it is automatically added for you.

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? Added a bunch fo Vue 3 example
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
