### PR TITLE
Addon-docs: Configure syntax highlighter language by story parameter

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -93,7 +93,7 @@ export const getSourceProps = (
   docsContext: DocsContextProps,
   sourceContext: SourceContextProps
 ): PureSourceProps => {
-  const { id: currentId } = docsContext;
+  const { id: currentId, parameters = {} } = docsContext;
 
   const codeProps = props as CodeProps;
   const singleProps = props as SingleSourceProps;
@@ -112,8 +112,13 @@ export const getSourceProps = (
       })
       .join('\n\n');
   }
+
+  const { docs: docsParameters = {} } = parameters;
+  const { source: sourceParameters = {} } = docsParameters;
+  const { language: docsLanguage = null } = sourceParameters;
+
   return source
-    ? { code: source, language: props.language || 'jsx', dark: props.dark || false }
+    ? { code: source, language: props.language || docsLanguage || 'jsx', dark: props.dark || false }
     : { error: SourceError.SOURCE_UNAVAILABLE };
 };
 

--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -8,6 +8,7 @@ export const parameters = {
     extractComponentDescription,
     source: {
       type: SourceType.DYNAMIC,
+      language: 'html',
     },
   },
 };

--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -214,7 +214,7 @@ Storybook Docs displays a story’s source code using the `Source` block. The sn
 
 In DocsPage, the `Source` block appears automatically within each story’s [Canvas](#canvas) block.
 
-To customize the source snippet that’s displayed for a story, set the `docs.source.code` parameter:
+To customize the source snippet that’s displayed for a story, set the `docs.source.code` and optionally the `docs.source.language` parameters:
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13839

## What I did

I added some code to fetch `language` from `parameters.docs.source.language`. Previously it defaulted to jsx, and was not really configurable on a global level. For Angular, HTML is a better fit than JSX

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, Chromatic should catch the change on Angular-cli example
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
