### PR TITLE
Build: Move all the `yarn install` in the `build` CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,6 @@ jobs:
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
-      - run:
-          name: Remove examples
-          command: rm -rf examples/
       - restore_cache:
           name: Restore Yarn cache
           keys:
@@ -102,60 +99,12 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - examples
+            - node_modules
             - addons
             - dev-kits
             - app
             - lib
-  install-examples-deps:
-    executor:
-      class: medium
-      name: sb_node_10_classic
-    steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: '--depth 1 --verbose'
-      - restore_cache:
-          name: Restore Yarn cache
-          keys:
-            - install-examples-deps-yarn-cache-v4--{{ checksum "yarn.lock" }}
-      - run:
-          name: Install dependencies
-          command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
-      - save_cache:
-          name: Save Yarn cache
-          key: install-examples-deps-yarn-cache-v4--{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-      - persist_to_workspace:
-          root: .
-          paths:
-            - examples
-            - node_modules
-  install-e2e-deps:
-    executor:
-      class: small
-      name: sb_node_10_classic
-    steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: '--depth 1 --verbose'
-      - run:
-          name: Keep only root package
-          command: rm -rf examples/ && rm -rf addons/ && rm -rf app/ && rm -rf lib/
-      - restore_cache:
-          name: Restore cached node_modules
-          keys:
-            - install-e2e-deps-node_modules-cache-v1--{{ checksum "yarn.lock" }}
-      - run:
-          name: Install dependencies if cache wasn't hit
-          command: "[ ! -d \"node_modules/\" ] && yarn install --frozen-lockfile || echo \"Skipping yarn install\""
-      - save_cache:
-          name: Save node_modules
-          key: install-e2e-deps-node_modules-cache-v1--{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
-      - persist_to_workspace:
-          root: .
-          paths:
-            - node_modules
   chromatic:
     executor: sb_node_10_browsers
     parallelism: 4
@@ -512,30 +461,23 @@ workflows:
   test:
     jobs:
       - build
-      - install-e2e-deps
-      - install-examples-deps
       - lint:
           requires:
-            - install-examples-deps
             - build
       - examples:
           requires:
-            - install-examples-deps
             - build
       - e2e-tests-examples:
           requires:
             - examples
       - smoke-tests:
           requires:
-            - install-examples-deps
             - build
       - packtracker:
           requires:
-            - install-examples-deps
             - build
       - unit-tests:
           requires:
-            - install-examples-deps
             - build
       - coverage:
           requires:
@@ -545,7 +487,6 @@ workflows:
             - examples
       - publish:
           requires:
-            - install-e2e-deps
             - build
       - e2e-tests-node-10:
           requires:

--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -50,9 +50,9 @@ const startVerdaccio = (port: number) => {
       setTimeout(() => {
         if (!resolved) {
           resolved = true;
-          rej(new Error(`TIMEOUT - verdaccio didn't start within 60s`));
+          rej(new Error(`TIMEOUT - verdaccio didn't start within 10s`));
         }
-      }, 60000);
+      }, 10000);
     }),
   ]);
 };


### PR DESCRIPTION
Applying https://github.com/storybookjs/storybook/pull/13559 step by step to not face gigantic conflicts or issues with the webpack 4/5 works.

## What I did

All the different `install` steps have been merged in the `build` CircleCI job to avoid some hoisting issue faced when upgrading to Yarn 2.

I also reduced the verdaccio startup timeout because it looks like the publish job is waiting for the timeout to end before exiting 🤔 

Before:
![image](https://user-images.githubusercontent.com/4112568/107613894-8b468880-6c49-11eb-9b94-e579a4f928cd.png)

After: 
![image](https://user-images.githubusercontent.com/4112568/107614964-9bf7fe00-6c4b-11eb-8d91-229bf4f6ca27.png)



## How to test

Check CircleCI run