### PR TITLE
CLI: Don't try to add packages that are already installed

### DIFF
--- a/lib/cli/src/generators/baseGenerator.ts
+++ b/lib/cli/src/generators/baseGenerator.ts
@@ -2,7 +2,7 @@ import { NpmOptions } from '../NpmOptions';
 import { StoryFormat, SupportedLanguage, SupportedFrameworks } from '../project_types';
 import { getBabelDependencies, copyComponents } from '../helpers';
 import { configure } from './configure';
-import { JsPackageManager } from '../js-package-manager';
+import { getPackageDetails, JsPackageManager } from '../js-package-manager';
 
 export type GeneratorOptions = {
   language: SupportedLanguage;
@@ -64,13 +64,21 @@ export async function baseGenerator(
   const yarn2Dependencies =
     packageManager.type === 'yarn2' ? ['@storybook/addon-docs', '@mdx-js/react'] : [];
 
+  const packageJson = packageManager.retrievePackageJson();
+  const installedDependencies = new Set(Object.keys(packageJson.dependencies));
+
   const packages = [
     `@storybook/${framework}`,
     ...addonPackages,
     ...extraPackages,
     ...extraAddons,
     ...yarn2Dependencies,
-  ].filter(Boolean);
+  ]
+    .filter(Boolean)
+    .filter(
+      (packageToInstall) => !installedDependencies.has(getPackageDetails(packageToInstall)[0])
+    );
+
   const versionedPackages = await packageManager.getVersionedPackages(...packages);
 
   configure(framework, [...addons, ...extraAddons]);
@@ -78,7 +86,6 @@ export async function baseGenerator(
     copyComponents(framework, language);
   }
 
-  const packageJson = packageManager.retrievePackageJson();
   const babelDependencies = addBabel ? await getBabelDependencies(packageManager, packageJson) : [];
   packageManager.addDependencies({ ...npmOptions, packageJson }, [
     ...versionedPackages,

--- a/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -8,7 +8,13 @@ import storybookPackagesVersions from '../versions.json';
 
 const logger = console;
 
-function getPackageDetails(pkg: string): [string, string?] {
+/**
+ * Extract package name and version from input
+ *
+ * @param pkg A string like `@storybook/cli`, `react` or `react@^16`
+ * @return A tuple of 2 elements: [packageName, packageVersion]
+ */
+export function getPackageDetails(pkg: string): [string, string?] {
   const idx = pkg.lastIndexOf('@');
   // If the only `@` is the first character, it is a scoped package
   // If it isn't in the string, it will be -1


### PR DESCRIPTION
Applying https://github.com/storybookjs/storybook/pull/13559 step by step to not face gigantic conflicts or issues with the webpack 4/5 works.

## What I did

Previously for some framework, the Storybook CLI was installing extra dependencies (listed in the generator of each framework, [for instance for rax](https://github.com/storybookjs/storybook/blob/3b6a06aaa10ae72e84215d1e706a093058fc5f67/lib/cli/src/generators/RAX/index.ts#L22)) but, in some case, some were already present in the user's project. 

It doesn't cause any issue with NPM/Yarn, I guess they are just updating the version 🤷🏻 . But, reasonably from my point of view, Yarn 2 is throwing an error: 
> Usage Error: Package "XXXXXX" is already listed as a regular dependency - remove the -D,-P flags or remove it from your dependencies first

To fix that I added a filter before adding the extra dependencies to remove all the already installed ones. 

## How to test

- CI should be green (especially the e2e extended test suite)