### PR TITLE
Addon-docs/Vue3: Attach app context from preview to inline stories

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -127,6 +127,7 @@
     "@babel/core": "^7.11.5",
     "@storybook/angular": "6.2.0-alpha.25",
     "@storybook/vue": "6.2.0-alpha.25",
+    "@storybook/vue3": "6.2.0-alpha.25",
     "babel-loader": "^8.0.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
@@ -139,6 +140,9 @@
       "optional": true
     },
     "@storybook/vue": {
+      "optional": true
+    },
+    "@storybook/vue3": {
       "optional": true
     },
     "react": {

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -76,7 +76,7 @@ export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
     if (typeof renderedJSX.props.children === 'undefined') {
       logger.warn('Not enough children to skip elements.');
 
-      if (typeof Type === 'function' && Type.name === '') {
+      if (typeof renderedJSX.type === 'function' && renderedJSX.type.name === '') {
         renderedJSX = <Type {...renderedJSX.props} />;
       }
     } else if (typeof renderedJSX.props.children === 'function') {

--- a/addons/docs/src/frameworks/vue3/prepareForInline.ts
+++ b/addons/docs/src/frameworks/vue3/prepareForInline.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as Vue from 'vue';
 import { StoryFn, StoryContext } from '@storybook/addons';
+import { app } from '@storybook/vue3';
 
 // This is cast as `any` to workaround type errors caused by Vue 2 types
 const { render, h } = Vue as any;
@@ -8,7 +9,13 @@ const { render, h } = Vue as any;
 export const prepareForInline = (storyFn: StoryFn, { args }: StoryContext) => {
   const component = storyFn();
 
+  const vnode = h(component, args);
+  // By attaching the app context from `@storybook/vue3` to the vnode
+  // like this, these stoeis are able to access any app config stuff
+  // the end-user set inside `.storybook/preview.js`
+  vnode.appContext = app._context; // eslint-disable-line no-underscore-dangle
+
   return React.createElement('div', {
-    ref: (node?: HTMLDivElement): void => (node ? render(h(component, args), node) : null),
+    ref: (node?: HTMLDivElement): void => (node ? render(vnode, node) : null),
   });
 };

--- a/examples/vue-3-cli/.storybook/preview.ts
+++ b/examples/vue-3-cli/.storybook/preview.ts
@@ -1,4 +1,9 @@
-import { Parameters, Decorators } from '@storybook/vue3';
+import { Parameters, Decorators, app } from '@storybook/vue3';
+// @ts-ignore
+import Button from '../src/stories/Button.vue';
+
+// This adds a component that can be used globally in stories
+app.component('GlobalButton', Button);
 
 export const parameters: Parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/examples/vue-3-cli/src/stories/GlobalUsage.stories.js
+++ b/examples/vue-3-cli/src/stories/GlobalUsage.stories.js
@@ -1,0 +1,36 @@
+import GlobalUsage from './GlobalUsage.vue';
+
+export default {
+  title: 'Example/Global Components',
+  component: GlobalUsage,
+  argTypes: {},
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { GlobalUsage },
+  template: '<global-usage v-bind="$props" />',
+});
+
+export const Primary = Template.bind({});
+Primary.args = {
+  primary: true,
+  label: 'Globally Defined',
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  label: 'Globally Defined',
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  size: 'large',
+  label: 'Globally Defined',
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  size: 'small',
+  label: 'Globally Defined',
+};

--- a/examples/vue-3-cli/src/stories/GlobalUsage.vue
+++ b/examples/vue-3-cli/src/stories/GlobalUsage.vue
@@ -1,0 +1,3 @@
+<template>
+  <global-button v-bind="$props" />
+</template>


### PR DESCRIPTION
Issue: #13883

## What I did

I figured out how to attach an "app" context to a Vue 3 vnode that is rendered inline inside addon-docs. This solves the issue linked above. I'm unsure how this affects Vue 3 internals, but it seems to work in the example I added.

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ✅ Added to the vue-3-cli example
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
