### PR TITLE
Addon-controls: Add include/exclude configuration options

### DIFF
--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import React, { FC, useContext, useEffect, useState, useCallback } from 'react';
 import mapValues from 'lodash/mapValues';
-import pickBy from 'lodash/pickBy';
 import {
   ArgsTable as PureArgsTable,
   ArgsTableProps as PureArgsTableProps,
@@ -10,7 +9,7 @@ import {
   TabbedArgsTable,
 } from '@storybook/components';
 import { Args } from '@storybook/addons';
-import { StoryStore } from '@storybook/client-api';
+import { StoryStore, filterArgTypes, PropDescriptor } from '@storybook/client-api';
 import Events from '@storybook/core-events';
 
 import { DocsContext, DocsContextProps } from './DocsContext';
@@ -18,8 +17,6 @@ import { Component, CURRENT_SELECTION, PRIMARY_STORY } from './types';
 import { getComponentName, getDocsStories } from './utils';
 import { ArgTypesExtractor } from '../lib/docgen/types';
 import { lookupStoryId } from './Story';
-
-type PropDescriptor = string[] | RegExp;
 
 interface BaseProps {
   include?: PropDescriptor;
@@ -71,22 +68,6 @@ const useArgs = (
     [storyId]
   );
   return [args, updateArgs, resetArgs];
-};
-
-const matches = (name: string, descriptor: PropDescriptor) =>
-  Array.isArray(descriptor) ? descriptor.includes(name) : name.match(descriptor);
-
-const filterArgTypes = (argTypes: ArgTypes, include?: PropDescriptor, exclude?: PropDescriptor) => {
-  if (!include && !exclude) {
-    return argTypes;
-  }
-  return (
-    argTypes &&
-    pickBy(argTypes, (argType, key) => {
-      const name = argType.name || key;
-      return (!include || matches(name, include)) && (!exclude || !matches(name, exclude));
-    })
-  );
 };
 
 export const extractComponentArgTypes = (

--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -232,7 +232,7 @@ And here's what the resulting UI looks like:
 
 ### Disable controls for specific properties
 
-Asides from the features already documented here. Controls can also be disabled for individual properties.
+Aside from the features already documented here, Controls can also be disabled for individual properties.
 
 Suppose you want to disable Controls for a property called `foo` in a component's story. The following example illustrates how:
 
@@ -259,10 +259,10 @@ Resulting in the following change in Storybook UI:
 The previous example also removed the prop documentation from the table. In some cases this is fine, however sometimes you might want to still render the prop documentation but without a control. The following example illustrates how:
 
 <CodeSnippets
-  paths={[
-    'common/component-story-disable-controls-alt.js.mdx',
-    'common/component-story-disable-controls-alt.mdx.mdx'
-  ]}
+paths={[
+'common/component-story-disable-controls-alt.js.mdx',
+'common/component-story-disable-controls-alt.mdx.mdx'
+]}
 />
 
 <div class="aside">
@@ -281,6 +281,25 @@ If you don't plan to handle the control args inside your Story, you can remove t
   paths={[
     'common/button-story-hide-nocontrols-warning.js.mdx',
   ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+## Filtering controls
+
+In some cases, you may want to either only present a few controls in the controls panel, or present all controls except a small set.
+
+To make this possible, you can use optional `include` and `exclude` configuration fields in the `controls` parameter, which can be set to either an array of strings, or a regular expression.
+
+Consider the following story snippets:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+paths={[
+'common/component-story-disable-controls-regex.js.mdx',
+'common/component-story-disable-controls-regex.mdx.mdx'
+]}
 />
 
 <!-- prettier-ignore-end -->

--- a/docs/snippets/common/component-story-disable-controls-regex.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-regex.js.mdx
@@ -1,0 +1,15 @@
+```js
+// YourComponent.stories.js | YourComponent.stories.ts
+
+ArrayInclude = Template.bind({})
+ArrayInclude.parameters = { controls: { include: ['foo', 'bar'] } };
+
+RegexInclude = Template.bind({})
+RegexInclude.parameters = { controls: { include: /^hello*/ } };
+
+ArrayExclude = Template.bind({})
+ArrayExclude.parameters = { controls: { exclude: ['foo', 'bar'] } };
+
+RegexExclude = Template.bind({})
+RegexExclude.parameters = { controls: { exclude: /^hello*/ } };
+```

--- a/docs/snippets/common/component-story-disable-controls-regex.mdx.mdx
+++ b/docs/snippets/common/component-story-disable-controls-regex.mdx.mdx
@@ -1,0 +1,18 @@
+```md
+<!--- YourComponent.stories.mdx -->
+<Story name="Array Include" parameters={{ controls: { include: ['foo', 'bar'] } }}>
+  {Template.bind({})}
+</Story>
+
+<Story name="Regex Include" parameters={{ controls: { include: /^hello*/ } }}>
+  {Template.bind({})}
+</Story>
+
+<Story name="Array Exclude" parameters={{ controls: { exclude: ['foo', 'bar'] } }}>
+  {Template.bind({})}
+</Story>
+
+<Story name="Regex Exclude" parameters={{ controls: { exclude: /^hello*/ } }}>
+  {Template.bind({})}
+</Story>
+```

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -10,6 +10,7 @@ export default {
     somethingElse: { control: 'object', name: 'Something Else' },
     imageUrls: { control: { type: 'file', accept: '.png' }, name: 'Image Urls' },
   },
+  parameters: { chromatic: { disable: true } },
 };
 
 const Template = (args) => <Button {...args} />;
@@ -19,6 +20,7 @@ Basic.args = {
   children: 'basic',
   somethingElse: { a: 2 },
 };
+Basic.parameters = { chromatic: { disable: false } };
 
 export const Action = Template.bind({});
 Action.args = {

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -50,3 +50,46 @@ CyclicArgs.args = {
 CyclicArgs.parameters = {
   chromatic: { disable: true },
 };
+
+export const FilteredWithInclude = Template.bind({});
+FilteredWithInclude.parameters = {
+  controls: {
+    include: ['Children'],
+  },
+};
+
+export const FilteredWithIncludeRegex = Template.bind({});
+FilteredWithIncludeRegex.args = {
+  helloWorld: 1,
+  helloPlanet: 1,
+  byeWorld: 1,
+};
+FilteredWithIncludeRegex.parameters = {
+  controls: {
+    include: /hello*/,
+  },
+};
+
+export const FilteredWithExclude = Template.bind({});
+FilteredWithExclude.args = {
+  helloWorld: 1,
+  helloPlanet: 1,
+  byeWorld: 1,
+};
+FilteredWithExclude.parameters = {
+  controls: {
+    exclude: ['helloPlanet', 'helloWorld'],
+  },
+};
+
+export const FilteredWithExcludeRegex = Template.bind({});
+FilteredWithExcludeRegex.args = {
+  helloWorld: 1,
+  helloPlanet: 1,
+  byeWorld: 1,
+};
+FilteredWithExcludeRegex.parameters = {
+  controls: {
+    exclude: /hello*/,
+  },
+};

--- a/lib/client-api/src/filterArgTypes.ts
+++ b/lib/client-api/src/filterArgTypes.ts
@@ -1,0 +1,24 @@
+import type { ArgTypes } from '@storybook/addons';
+import pickBy from 'lodash/pickBy';
+
+export type PropDescriptor = string[] | RegExp;
+
+const matches = (name: string, descriptor: PropDescriptor) =>
+  Array.isArray(descriptor) ? descriptor.includes(name) : name.match(descriptor);
+
+export const filterArgTypes = (
+  argTypes: ArgTypes,
+  include?: PropDescriptor,
+  exclude?: PropDescriptor
+) => {
+  if (!include && !exclude) {
+    return argTypes;
+  }
+  return (
+    argTypes &&
+    pickBy(argTypes, (argType, key) => {
+      const name = argType.name || key;
+      return (!include || matches(name, include)) && (!exclude || !matches(name, exclude));
+    })
+  );
+};

--- a/lib/client-api/src/index.ts
+++ b/lib/client-api/src/index.ts
@@ -13,26 +13,29 @@ import { simulatePageLoad, simulateDOMContentLoaded } from './simulate-pageload'
 
 import { getQueryParams, getQueryParam } from './queryparams';
 
+import { filterArgTypes, PropDescriptor } from './filterArgTypes';
+
 export * from './hooks';
 export * from './types';
 export * from './parameters';
-
 // FIXME: for react-argtypes.stories; remove on refactor
 export * from './inferControls';
 
 export {
-  ClientApi,
-  addDecorator,
-  addParameters,
-  addLoader,
   addArgTypesEnhancer,
+  addDecorator,
+  addLoader,
+  addParameters,
+  ClientApi,
   combineParameters,
-  StoryStore,
   ConfigApi,
   defaultDecorateStory,
-  pathToId,
-  getQueryParams,
+  filterArgTypes,
   getQueryParam,
-  simulatePageLoad,
+  getQueryParams,
+  pathToId,
+  PropDescriptor,
   simulateDOMContentLoaded,
+  simulatePageLoad,
+  StoryStore,
 };

--- a/lib/client-api/src/inferControls.ts
+++ b/lib/client-api/src/inferControls.ts
@@ -2,11 +2,7 @@ import mapValues from 'lodash/mapValues';
 import { ArgType } from '@storybook/addons';
 import { SBEnumType, ArgTypesEnhancer } from './types';
 import { combineParameters } from './parameters';
-
-type ControlsConfig = {
-  include?: string[];
-  exclude?: string[];
-};
+import { filterArgTypes } from './filterArgTypes';
 
 const inferControl = (argType: ArgType): any => {
   const { type } = argType;
@@ -47,36 +43,16 @@ const inferControl = (argType: ArgType): any => {
   }
 };
 
-const includeExcludeCheck = (key: string, { include, exclude }: ControlsConfig) => {
-  if (include && exclude) {
-    throw new Error(
-      `Addon-controls: found both "include" and "exclude" keys in parameter. You should use only one of them.`
-    );
-  }
-
-  if (include && include.length) {
-    return include.indexOf(key) !== -1;
-  }
-
-  if (exclude && exclude.length) {
-    return exclude.indexOf(key) === -1;
-  }
-
-  return true;
-};
-
 export const inferControls: ArgTypesEnhancer = (context) => {
-  const { __isArgsStory, argTypes, controls: controlsConfig } = context.parameters;
+  const { __isArgsStory, argTypes, controls: controlsConfig = {} } = context.parameters;
   if (!__isArgsStory) return argTypes;
 
-  let filteredArgTypes = argTypes;
-  if (controlsConfig.include || controlsConfig.exclude) {
-    filteredArgTypes = argTypes.filter((name: string) => includeExcludeCheck(name, controlsConfig));
-  }
+  const filteredArgTypes = filterArgTypes(argTypes, controlsConfig.include, controlsConfig.exclude);
 
-  const withControls = mapValues(filteredArgTypes, (argType, name) => {
+  const withControls = mapValues(filteredArgTypes, (argType) => {
     const control = argType && argType.type && inferControl(argType);
     return control ? { control } : undefined;
   });
+
   return combineParameters(withControls, filteredArgTypes);
 };


### PR DESCRIPTION
Issue: #11638

## What I did

This PR adds the ability to hide/show controls by using `include` or `exclude` configuration:

```
ArrayInclude = Template.bind({})
ArrayInclude.parameters = { controls: { include: ['foo', 'bar'] } };

RegexInclude = Template.bind({})
RegexInclude.parameters = { controls: { include: /^hello*/ } };

ArrayExclude = Template.bind({})
ArrayExclude.parameters = { controls: { exclude: ['foo', 'bar'] } };

RegexExclude = Template.bind({})
RegexExclude.parameters = { controls: { exclude: /^hello*/ } };
```

## How to test

1 - checkout the branch
2 - `yarn bootstrap`
3 - run `yarn start`
4 - play around with `examples/official-storybook/stories/addon-controls.stories.tsx`