### PR TITLE
Fix PropDescriptor babel warnings

### DIFF
--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -9,7 +9,8 @@ import {
   TabbedArgsTable,
 } from '@storybook/components';
 import { Args } from '@storybook/addons';
-import { StoryStore, filterArgTypes, PropDescriptor } from '@storybook/client-api';
+import { StoryStore, filterArgTypes } from '@storybook/client-api';
+import type { PropDescriptor } from '@storybook/client-api';
 import Events from '@storybook/core-events';
 
 import { DocsContext, DocsContextProps } from './DocsContext';

--- a/lib/client-api/src/index.ts
+++ b/lib/client-api/src/index.ts
@@ -13,7 +13,8 @@ import { simulatePageLoad, simulateDOMContentLoaded } from './simulate-pageload'
 
 import { getQueryParams, getQueryParam } from './queryparams';
 
-import { filterArgTypes, PropDescriptor } from './filterArgTypes';
+import { filterArgTypes } from './filterArgTypes';
+import type { PropDescriptor } from './filterArgTypes';
 
 export * from './hooks';
 export * from './types';

--- a/lib/client-api/src/index.ts
+++ b/lib/client-api/src/index.ts
@@ -14,13 +14,14 @@ import { simulatePageLoad, simulateDOMContentLoaded } from './simulate-pageload'
 import { getQueryParams, getQueryParam } from './queryparams';
 
 import { filterArgTypes } from './filterArgTypes';
-import type { PropDescriptor } from './filterArgTypes';
 
 export * from './hooks';
 export * from './types';
 export * from './parameters';
 // FIXME: for react-argtypes.stories; remove on refactor
 export * from './inferControls';
+
+export type { PropDescriptor } from './filterArgTypes';
 
 export {
   addArgTypesEnhancer,
@@ -35,7 +36,6 @@ export {
   getQueryParam,
   getQueryParams,
   pathToId,
-  PropDescriptor,
   simulateDOMContentLoaded,
   simulatePageLoad,
   StoryStore,


### PR DESCRIPTION
Issue: N/A

## What I did

Split type import to fix the following babel warning on bootstrap:

```
WARN ./lib/client-api/dist/esm/index.js 15:0-263
WARN "export 'PropDescriptor' was not found in './filterArgTypes'
WARN     at HarmonyExportImportedSpecifierDependency._getErrors (/Users/shilman/projects/baseline/storybook/node_modules/webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency.js:395:11)
WARN     at HarmonyExportImportedSpecifierDependency.getWarnings (/Users/shilman/projects/baseline/storybook/node_modules/webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency.js:346:15)
WARN     at Compilation.reportDependencyErrorsAndWarnings (/Users/shilman/projects/baseline/storybook/node_modules/webpack/lib/Compilation.js:1454:24)
WARN     at /Users/shilman/projects/baseline/storybook/node_modules/webpack/lib/Compilation.js:1258:10
WARN     at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/shilman/projects/baseline/storybook/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:22:1)
WARN     at AsyncSeriesHook.lazyCompileHook (/Users/shilman/projects/baseline/storybook/node_modules/tapable/lib/Hook.js:154:20)
```

Self-merging @yannbf @gaetanmaisse 

## How to test

```
yarn bootstrap --core
```
