### PR TITLE
Core: Fix falsey default args handling

### DIFF
--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -8,10 +8,16 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
     if (rows) {
       return rows.reduce((acc: ArgTypes, row: PropDef) => {
         const { type, sbType, defaultValue: defaultSummary, jsDocTags, required } = row;
-        let defaultValue = defaultSummary && (defaultSummary.detail || defaultSummary.summary);
+        let defaultValue;
+
+        if (defaultSummary) {
+          defaultValue = defaultSummary.detail || defaultSummary.summary;
+        }
         try {
-          // eslint-disable-next-line no-eval
-          defaultValue = eval(defaultValue);
+          if (defaultValue) {
+            // eslint-disable-next-line no-eval
+            defaultValue = eval(defaultValue);
+          }
           // eslint-disable-next-line no-empty
         } catch {}
 

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -187,11 +187,12 @@ describe('preview.story_store', () => {
           arg3: { defaultValue: { complex: { object: ['type'] } } },
           arg4: {},
           arg5: {},
+          arg6: { defaultValue: 0 }, // See https://github.com/storybookjs/storybook/issues/12767
         },
         args: {
           arg2: 3,
           arg4: 'foo',
-          arg6: false,
+          arg7: false,
         },
       });
       expect(store.getRawStory('a', '1').args).toEqual({
@@ -199,7 +200,8 @@ describe('preview.story_store', () => {
         arg2: 3,
         arg3: { complex: { object: ['type'] } },
         arg4: 'foo',
-        arg6: false,
+        arg6: 0,
+        arg7: false,
       });
     });
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -457,7 +457,9 @@ export default class StoryStore {
     const defaultArgs: Args = Object.entries(
       argTypes as Record<string, { defaultValue: any }>
     ).reduce((acc, [arg, { defaultValue }]) => {
-      if (defaultValue) acc[arg] = defaultValue;
+      if (typeof defaultValue !== 'undefined') {
+        acc[arg] = defaultValue;
+      }
       return acc;
     }, {} as Args);
 


### PR DESCRIPTION
Issue: #12767

## What I did

Check if default value is `undefined`, rather than falsey before excluding it.

## How to test

- Is this testable with Jest or Chromatic screenshots?

Yes, see test

- Does this need a new example in the kitchen sink apps? 

I think probably not. I don't think these things are picked up by chromatic anyway so don't end up being very useful to have edge cases, unless they are hard to reproduce.
