### PR TITLE
Addon-actions: Change to override default values

### DIFF
--- a/addons/actions/src/preset/addArgs.test.ts
+++ b/addons/actions/src/preset/addArgs.test.ts
@@ -17,18 +17,17 @@ describe('actions parameter enhancers', () => {
       expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onFocus']);
     });
 
-    it('should prioritize pre-existing argTypes unless they are null', () => {
+    it('should override pre-existing argTypes', () => {
       const parameters = {
         ...baseParameters,
         argTypes: {
           onClick: { defaultValue: 'pre-existing value' },
-          onFocus: { defaultValue: null },
         },
       };
       const argTypes = inferActionsFromArgTypesRegex({ parameters } as StoryContext);
-      expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onFocus']);
-      expect(argTypes.onClick.defaultValue).toEqual('pre-existing value');
-      expect(argTypes.onFocus.defaultValue).not.toBeNull();
+      expect(withDefaultValue(argTypes)).toEqual(['onClick']);
+      expect(argTypes.onClick.defaultValue).not.toBeNull();
+      expect(argTypes.onClick.defaultValue).not.toEqual('pre-existing value');
     });
 
     it('should do nothing if actions are disabled', () => {
@@ -54,7 +53,7 @@ describe('actions parameter enhancers', () => {
       expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onBlur']);
     });
 
-    it('should prioritize pre-existing args', () => {
+    it('should override pre-existing args', () => {
       const parameters = {
         ...baseParameters,
         argTypes: {
@@ -64,7 +63,8 @@ describe('actions parameter enhancers', () => {
       };
       const argTypes = addActionsFromArgTypes({ parameters } as StoryContext);
       expect(withDefaultValue(argTypes)).toEqual(['onClick', 'onBlur']);
-      expect(argTypes.onClick.defaultValue).toEqual('pre-existing value');
+      expect(argTypes.onClick.defaultValue).not.toBeNull();
+      expect(argTypes.onClick.defaultValue).not.toEqual('pre-existing value');
     });
 
     it('should do nothing if actions are disabled', () => {

--- a/addons/actions/src/preset/addArgs.ts
+++ b/addons/actions/src/preset/addArgs.ts
@@ -23,7 +23,7 @@ export const inferActionsFromArgTypesRegex: ArgTypesEnhancer = (context) => {
     if (!argTypesRegex.test(name)) {
       return argType;
     }
-    return { ...argType, defaultValue: argType.defaultValue || action(name) };
+    return { ...argType, defaultValue: action(name) };
   });
 };
 
@@ -41,7 +41,7 @@ export const addActionsFromArgTypes: ArgTypesEnhancer = (context) => {
       return argType;
     }
     const message = typeof argType.action === 'string' ? argType.action : name;
-    return { ...argType, defaultValue: argType.defaultValue || action(message) };
+    return { ...argType, defaultValue: action(message) };
   });
 };
 


### PR DESCRIPTION
Issue: #12120

## What I did

Reverse current behaviour (to prefer the defaultValue) to instead prefer the action.

We think this can be considered a bugfix rather than a breaking change. Although the previous behaviour was intentional (all the way to having a test), it wasn't very well thought out, surprising to users, and AFAIK not documented anywhere.

## How to test

- Is this testable with Jest or Chromatic screenshots?

Yes see test