### PR TITLE
Vue 3: Add example for reactive toolbar decorator

### DIFF
--- a/examples/vue-3-cli/.storybook/preview-head.html
+++ b/examples/vue-3-cli/.storybook/preview-head.html
@@ -1,0 +1,14 @@
+<style>
+  .light-theme {
+    --test: #ff0;
+  }
+
+  .dark-theme {
+    --test: #f00;
+  }
+
+  .theme {
+    background-color: var(--test);
+    padding: 1rem;
+  }
+</style>

--- a/examples/vue-3-cli/.storybook/preview.ts
+++ b/examples/vue-3-cli/.storybook/preview.ts
@@ -9,6 +9,22 @@ export const parameters: Parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
 };
 
+// A toolbar item to set a global theme
+export const globalTypes = {
+  theme: {
+    name: 'Theme',
+    description: 'Global theme for components',
+    defaultValue: 'light-theme',
+    toolbar: {
+      icon: 'paintbrush',
+      items: [
+        { value: 'light-theme', title: 'Light theme' },
+        { value: 'dark-theme', title: 'Dark theme' },
+      ],
+    },
+  },
+};
+
 export const decorators: Decorators = [
   () => ({
     template: '<div id="test-div"><story /></div>',

--- a/examples/vue-3-cli/src/stories/ThemeDecorator.stories.js
+++ b/examples/vue-3-cli/src/stories/ThemeDecorator.stories.js
@@ -1,0 +1,36 @@
+// Just going to use the Button component for this example
+import MyButton from './Button.vue';
+
+const withTheme = (Story, context) => {
+  return {
+    data() {
+      return {
+        theme: context.globals.theme,
+      };
+    },
+    template: `<div class="theme" :class="theme"><story /></div>`,
+  };
+};
+
+export default {
+  title: 'Example/Theme Decorator',
+  component: MyButton,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+    size: { control: { type: 'select', options: ['small', 'medium', 'large'] } },
+    onClick: {},
+  },
+  decorators: [withTheme],
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { MyButton },
+  template: '<my-button @click="onClick" v-bind="$props" />',
+});
+
+export const ButtonWithTheme = Template.bind({});
+ButtonWithTheme.args = {
+  primary: true,
+  label: 'Button',
+};


### PR DESCRIPTION
Issue: #12840 (for Vue 3)

## What I did

I added an example for the use-case described in the linked issue. It seems that it "just works" in the Vue 3 implementation, but it's good to have this in the example!

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ✅ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
