### PR TITLE
Components: Add missing `regenerator-runtime` dependency

### DIFF
--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -55,6 +55,7 @@
     "react-popper-tooltip": "^3.1.1",
     "react-syntax-highlighter": "^13.5.3",
     "react-textarea-autosize": "^8.3.0",
+    "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -71,7 +71,7 @@ const cleanDirectory = async ({ cwd }: Options): Promise<void> => {
   await remove(cwd);
   await remove(path.join(siblingDir, 'node_modules'));
 
-  if (useYarn2PnP) {
+  if (useYarn2Pnp) {
     await shell.rm('-rf', [path.join(siblingDir, '.yarn'), path.join(siblingDir, '.yarnrc.yml')]);
   }
 };
@@ -103,7 +103,7 @@ const configureYarn2PnP = async ({ cwd }: Options) => {
 
 const generate = async ({ cwd, name, version, generator }: Options) => {
   let command = generator.replace(/{{name}}/g, name).replace(/{{version}}/g, version);
-  if (useYarn2PnP) {
+  if (useYarn2Pnp) {
     command = command.replace(/npx/g, `yarn dlx`);
   }
 
@@ -226,7 +226,7 @@ const runTests = async ({ name, version, ...rest }: Parameters) => {
   logger.log();
 
   if (!(await prepareDirectory(options))) {
-    if (useYarn2PnP) {
+    if (useYarn2Pnp) {
       await configureYarn2PnP({ ...options, cwd: siblingDir });
     }
 
@@ -322,7 +322,7 @@ program.option(
 program.parse(process.argv);
 
 const {
-  useYarn2PnP,
+  useYarn2Pnp,
   useLocalSbCli,
   clean: startWithCleanSlate,
   args: frameworkArgs,


### PR DESCRIPTION
Issue: #13830

## What I did

- Add missing `regenerator-runtime` dependency
- Fix a typo in the E2E, for a few weeks the Yarn 2 PnP E2E tests were simply not running with Yarn 2.

## How to test

- CI should be 🟢 
- The logs in `e2e-tests-yarn-2-pnp` should match Yarn 2 ones 