### PR TITLE
Vue 3: Add example for overriding args/props

### DIFF
--- a/examples/vue-3-cli/src/stories/OverrideArgs.stories.js
+++ b/examples/vue-3-cli/src/stories/OverrideArgs.stories.js
@@ -1,0 +1,43 @@
+import OverrideArgs from './OverrideArgs.vue';
+
+// Emulate something that isn't serializable
+const icons = {
+  Primary: {
+    template: '<span>Primary Icon</span>',
+  },
+  Secondary: {
+    template: '<span>Secondary Icon</span>',
+  },
+};
+
+export default {
+  title: 'Example/Override Args',
+  component: OverrideArgs,
+  argTypes: {
+    // To show that other props are passed through
+    backgroundColor: { control: 'color' },
+    icon: {
+      control: {
+        type: 'select',
+        options: Object.keys(icons),
+      },
+      defaultValue: 'Primary',
+    },
+  },
+};
+
+const Template = (args, { argTypes }) => {
+  return {
+    props: Object.keys(argTypes),
+    components: { OverrideArgs },
+    template: '<override-args v-bind="$props" :icon="icon" />',
+    setup(props) {
+      return {
+        icon: icons[props.icon],
+      };
+    },
+  };
+};
+
+export const TestOne = Template.bind({});
+export const TestTwo = Template.bind({});

--- a/examples/vue-3-cli/src/stories/OverrideArgs.vue
+++ b/examples/vue-3-cli/src/stories/OverrideArgs.vue
@@ -1,0 +1,41 @@
+<template>
+  <button type="button" :class="classes" :style="style">
+    <!-- You can use <component /> with `:is` when passing a component as a prop -->
+    <component :is="icon" />
+  </button>
+</template>
+
+<script lang="typescript">
+import './button.css';
+import { h, computed, reactive } from 'vue';
+
+export default {
+  name: 'override-args',
+
+  props: {
+    icon: {
+      type: Object,
+      required: true,
+    },
+
+    backgroundColor: {
+      type: String
+    },
+  },
+
+  // @ts-ignore
+  setup(props, { emit }) {
+    const classes = {
+      'storybook-button': true,
+      'storybook-button--primary': true,
+      'storybook-button--large': true,
+    };
+    const style = computed(() => ({
+      backgroundColor: props.backgroundColor,
+    }));
+
+    // Notice that `icon` prop component is still passed through even though it isn't mapped
+    return { classes, style, }
+  },
+};
+</script>


### PR DESCRIPTION
Issue: #13861

## What I did

I added an example to the kitchen sink for Vue 3 that shows how args/props should be overridden. This is primarily to avoid people trying to mutate the args, which aren't cloned by storybook and result in a really weird state (as seen in the linked issue) if people do any mutation.

They can't be cloned in the 6.x release cycle because it could be a breaking change for some consumers that were unaware of this.

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ✅ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
