### PR TITLE
Build: Ensure consistency of Chromatic snapshots of Zoom stories

### DIFF
--- a/lib/components/src/Zoom/Zoom.stories.tsx
+++ b/lib/components/src/Zoom/Zoom.stories.tsx
@@ -10,7 +10,7 @@ export default {
     },
   },
   parameters: {
-    chromatic: { delay: 300 },
+    chromatic: { delay: 500, diffThreshold: 0.2 },
   },
 };
 const EXAMPLE_ELEMENT = (


### PR DESCRIPTION
## What I did

https://github.com/storybookjs/storybook/pull/13676 reduced the number of false-positive but it wasn't a perfect win. 
Currently, the snapshots are mainly failing due to minor changes in font color so I increase the diffThreshold and the delay before taking the snapshot hoping it will help to avoid false positive. 🤞🏻 


## How to test

- Merge and see 🤷🏻