### PR TITLE
Args: Prefer react runtime default values

### DIFF
--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -7,17 +7,22 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
     const { rows } = extractProps(component);
     if (rows) {
       return rows.reduce((acc: ArgTypes, row: PropDef) => {
-        const { type, sbType, defaultValue: defaultSummary, jsDocTags, required } = row;
+        const { name, type, sbType, defaultValue: defaultSummary, jsDocTags, required } = row;
+
         let defaultValue;
-        const defaultValueString =
-          defaultSummary && (defaultSummary.detail || defaultSummary.summary);
-        try {
-          if (defaultValueString) {
-            // eslint-disable-next-line no-new-func
-            defaultValue = Function(`"use strict";return (${defaultValueString})`)();
-          }
-          // eslint-disable-next-line no-empty
-        } catch {}
+        if (component.defaultProps) {
+          defaultValue = component.defaultProps[name];
+        } else {
+          const defaultValueString =
+            defaultSummary && (defaultSummary.detail || defaultSummary.summary);
+          try {
+            if (defaultValueString) {
+              // eslint-disable-next-line no-new-func
+              defaultValue = Function(`"use strict";return (${defaultValueString})`)();
+            }
+            // eslint-disable-next-line no-empty
+          } catch {}
+        }
 
         acc[row.name] = {
           ...row,


### PR DESCRIPTION
Issue: #12635

Telescoping on https://github.com/storybookjs/storybook/pull/13919

## What I did

Start by using the *actual* default prop as the default arg value. Only try unreliable eval-ing of the table summary if we don't have access to that.

## How to test

- Is this testable with Jest or Chromatic screenshots?

Yep, see affected stories

- Does this need a new example in the kitchen sink apps?

No

- Does this need an update to the documentation?

Not sure.