### PR TITLE
[Docs] Add Audi to examples page

### DIFF
--- a/docs/get-started/examples.md
+++ b/docs/get-started/examples.md
@@ -48,6 +48,7 @@ Learn how leading teams build design systems.
 - [AnyVision UI](http://storybook.anyvision.co/)
 - [Skyscanner Backpack](https://backpack.github.io/storybook/)
 - [GitLab UI](https://gitlab-org.gitlab.io/gitlab-ui)
+- [Audi](https://react.ui.audi/)
 
 <!--
 


### PR DESCRIPTION
## What I did
Link to the Audi design system that's powered by Storybook in our examples page.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no
