### PR TITLE
Core: Improve preset handling test coverage

### DIFF
--- a/lib/core/src/server/__snapshots__/angular-cli_manager-dev
+++ b/lib/core/src/server/__snapshots__/angular-cli_manager-dev
@@ -1,18 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager dev mode 1`] = `
+exports[`angular-cli manager dev mode 1`] = `
 Object {
   "entry": Array [
     "ROOT/lib/core/src/server/common/polyfills.ts",
     "ROOT/lib/core/src/client/manager/index.ts",
-    "ROOT/addons/actions/dist/esm/register.js",
-    "ROOT/addons/backgrounds/dist/esm/register.js",
-    "ROOT/addons/viewport/dist/esm/register.js",
-    "ROOT/addons/toolbars/dist/esm/register.js",
+    "ROOT/addons/docs/dist/esm/register.js",
     "ROOT/addons/controls/dist/esm/register.js",
     "ROOT/addons/storysource/dist/esm/register.js",
-    "ROOT/addons/docs/dist/esm/register.js",
-    "ROOT/examples/react-ts/generated-refs.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/links/dist/esm/register.js",
+    "ROOT/addons/knobs/dist/esm/register.js",
+    "ROOT/addons/jest/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/a11y/dist/esm/register.js",
+    "ROOT/addons/toolbars/dist/esm/register.js",
+    "ROOT/examples/angular-cli/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
   ],
   "module": Object {
     "rules": Array [

--- a/lib/core/src/server/__snapshots__/angular-cli_manager-prod
+++ b/lib/core/src/server/__snapshots__/angular-cli_manager-prod
@@ -1,0 +1,224 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`angular-cli manager production mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/storysource/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/links/dist/esm/register.js",
+    "ROOT/addons/knobs/dist/esm/register.js",
+    "ROOT/addons/jest/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/a11y/dist/esm/register.js",
+    "ROOT/addons/toolbars/dist/esm/register.js",
+    "ROOT/examples/angular-cli/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "query": Object {
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+    "DefinePlugin",
+    "BundleAnalyzerPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/angular-cli_preview-dev
+++ b/lib/core/src/server/__snapshots__/angular-cli_preview-dev
@@ -1,0 +1,544 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`angular-cli preview dev mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/server/preview/globals.ts",
+    "ROOT/examples/angular-cli/.storybook/storybook-init-framework-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/knobs/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-other-entry.js",
+    "ROOT/examples/angular-cli/.storybook/preview.ts-generated-config-entry.js",
+    "ROOT/examples/angular-cli/.storybook/generated-stories-entry.js",
+    "NODE_MODULES/webpack-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": "NODE_MODULES/",
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.md$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
+          },
+        ],
+      },
+      Object {
+        "include": "NODE_MODULES\\\\/acorn-jsx/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": "commonjs",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.(stories|story)\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "compilers": Array [
+                [Function],
+              ],
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "exclude": "/\\\\.(stories|story)\\\\.mdx$/",
+        "test": "/\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+        "options": Object {
+          "injectStoryParameters": true,
+          "inspectLocalDependencies": true,
+        },
+        "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+      Object {
+        "enforce": "pre",
+        "test": Array [
+          "/\\\\.stories\\\\.(jsx?$|tsx?$)/",
+        ],
+        "use": Array [
+          Object {
+            "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+            "options": undefined,
+          },
+        ],
+      },
+      Object {
+        "sideEffects": true,
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": [Function],
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "options": Object {
+          "esModule": false,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "FilterWarningsPlugin",
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "DefinePlugin",
+    "WatchMissingNodeModulesPlugin",
+    "HotModuleReplacementPlugin",
+    "CaseSensitivePathsPlugin",
+    "ProgressPlugin",
+    "DefinePlugin",
+    "DocgenPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/angular-cli_preview-prod
+++ b/lib/core/src/server/__snapshots__/angular-cli_preview-prod
@@ -1,20 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`preview dev mode 1`] = `
+exports[`angular-cli preview production mode 1`] = `
 Object {
   "entry": Array [
     "ROOT/lib/core/src/server/common/polyfills.ts",
     "ROOT/lib/core/src/server/preview/globals.ts",
-    "ROOT/examples/react-ts/storybook-init-framework-entry.js",
+    "ROOT/examples/angular-cli/.storybook/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/knobs/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
-    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
-    "ROOT/examples/react-ts/generated-stories-entry.js",
-    "NODE_MODULES/webpack-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined",
+    "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-other-entry.js",
+    "ROOT/examples/angular-cli/.storybook/preview.ts-generated-config-entry.js",
+    "ROOT/examples/angular-cli/.storybook/generated-stories-entry.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
   ],
   "module": Object {
     "rules": Array [
@@ -195,18 +213,6 @@ Object {
         "use": Array [
           Object {
             "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
-          },
-        ],
-      },
-      Object {
-        "enforce": "pre",
-        "test": Array [
-          "/\\\\.stories\\\\.(jsx?$|tsx?$)/",
-        ],
-        "use": Array [
-          Object {
-            "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
-            "options": undefined,
           },
         ],
       },
@@ -467,11 +473,22 @@ Object {
         "enforce": "pre",
         "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
         "options": Object {
-          "injectStoryParameters": false,
+          "injectStoryParameters": true,
           "inspectLocalDependencies": true,
-          "parser": "typescript",
         },
         "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+      Object {
+        "enforce": "pre",
+        "test": Array [
+          "/\\\\.stories\\\\.(jsx?$|tsx?$)/",
+        ],
+        "use": Array [
+          Object {
+            "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+            "options": undefined,
+          },
+        ],
       },
       Object {
         "sideEffects": true,
@@ -515,12 +532,9 @@ Object {
     "VirtualModulesPlugin",
     "HtmlWebpackPlugin",
     "DefinePlugin",
-    "WatchMissingNodeModulesPlugin",
-    "HotModuleReplacementPlugin",
     "CaseSensitivePathsPlugin",
     "ProgressPlugin",
     "DefinePlugin",
-    "ForkTsCheckerWebpackPlugin",
     "DocgenPlugin",
   ],
 }

--- a/lib/core/src/server/__snapshots__/cra-ts-essentials_manager-dev
+++ b/lib/core/src/server/__snapshots__/cra-ts-essentials_manager-dev
@@ -1,0 +1,218 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cra-ts-essentials manager dev mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/toolbars/dist/esm/register.js",
+    "ROOT/examples/cra-ts-essentials/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "query": Object {
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+    "DefinePlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/cra-ts-essentials_manager-prod
+++ b/lib/core/src/server/__snapshots__/cra-ts-essentials_manager-prod
@@ -1,0 +1,219 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cra-ts-essentials manager production mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/toolbars/dist/esm/register.js",
+    "ROOT/examples/cra-ts-essentials/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "query": Object {
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+    "DefinePlugin",
+    "BundleAnalyzerPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/cra-ts-essentials_preview-dev
+++ b/lib/core/src/server/__snapshots__/cra-ts-essentials_preview-dev
@@ -1,0 +1,439 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cra-ts-essentials preview dev mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/server/preview/globals.ts",
+    "ROOT/examples/cra-ts-essentials/.storybook/storybook-init-framework-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/examples/cra-ts-essentials/.storybook/preview.js-generated-config-entry.js",
+    "ROOT/examples/cra-ts-essentials/.storybook/generated-stories-entry.js",
+    "NODE_MODULES/webpack-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "test": "/\\\\.md$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
+          },
+        ],
+      },
+      Object {
+        "parser": Object {
+          "requireEnsure": false,
+        },
+      },
+      Object {
+        "enforce": "pre",
+        "include": Array [
+          "ROOT/src",
+          "ROOT/examples/cra-ts-essentials/.storybook",
+        ],
+        "test": "/\\\\.(js|mjs|jsx|ts|tsx)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/eslint-loader/dist/cjs.js",
+            "options": Object {
+              "baseConfig": Object {
+                "extends": Array [
+                  "NODE_MODULES/eslint-config-react-app/index.js",
+                ],
+              },
+              "cache": true,
+              "eslintPath": "NODE_MODULES/eslint/lib/api.js",
+              "formatter": "NODE_MODULES/react-dev-utils/eslintFormatter.js",
+              "ignore": false,
+              "resolvePluginsRelativeTo": "NODE_MODULES/react-scripts/config",
+              "useEslintrc": false,
+            },
+          },
+        ],
+      },
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+            "options": Object {
+              "limit": 10000,
+              "name": "static/media/[name].[hash:8].[ext]",
+            },
+            "test": Array [
+              "/\\\\.bmp$/",
+              "/\\\\.gif$/",
+              "/\\\\.jpe?g$/",
+              "/\\\\.png$/",
+            ],
+          },
+          Object {
+            "include": Array [
+              "ROOT/src",
+              "ROOT/examples/cra-ts-essentials/.storybook",
+            ],
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheCompression": false,
+              "cacheDirectory": true,
+              "cacheIdentifier": "development:babel-plugin-named-asset-import@0.3.7:babel-preset-react-app@9.1.2:react-dev-utils@10.2.1:react-scripts@3.4.4",
+              "compact": false,
+              "configFile": false,
+              "customize": "NODE_MODULES/babel-preset-react-app/webpack-overrides.js",
+              "extends": undefined,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                Array [
+                  "NODE_MODULES/babel-plugin-named-asset-import/index.js",
+                  Object {
+                    "loaderMap": Object {
+                      "svg": Object {
+                        "ReactComponent": "@svgr/webpack?-svgo,+titleProp,+ref![path]",
+                      },
+                    },
+                  },
+                ],
+              ],
+              "presets": Array [
+                "NODE_MODULES/babel-preset-react-app/index.js",
+              ],
+            },
+            "test": "/\\\\.(js|mjs|jsx|ts|tsx)$/",
+          },
+          Object {
+            "exclude": "/@babel(?:\\\\/|\\\\\\\\{1,2})runtime/",
+            "include": Array [
+              "ROOT/examples/cra-ts-essentials/.storybook",
+            ],
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheCompression": false,
+              "cacheDirectory": true,
+              "cacheIdentifier": "development:babel-plugin-named-asset-import@0.3.7:babel-preset-react-app@9.1.2:react-dev-utils@10.2.1:react-scripts@3.4.4",
+              "compact": false,
+              "configFile": false,
+              "inputSourceMap": true,
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/babel-preset-react-app/dependencies.js",
+                  Object {
+                    "helpers": true,
+                  },
+                ],
+              ],
+              "sourceMaps": true,
+            },
+            "test": "/\\\\.(js|mjs)$/",
+          },
+          Object {
+            "exclude": Array [
+              "/\\\\.module\\\\.css$/",
+              "/@storybook/",
+            ],
+            "include": undefined,
+            "sideEffects": true,
+            "test": "/\\\\.css$/",
+            "use": Array [
+              "NODE_MODULES/style-loader/index.js",
+              Object {
+                "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+                "options": Object {
+                  "importLoaders": 1,
+                  "sourceMap": false,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/postcss-loader/src/index.js",
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                  "sourceMap": false,
+                },
+              },
+            ],
+          },
+          Object {
+            "test": "/\\\\.module\\\\.css$/",
+            "use": Array [
+              "NODE_MODULES/style-loader/index.js",
+              Object {
+                "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+                "options": Object {
+                  "importLoaders": 1,
+                  "modules": Object {
+                    "getLocalIdent": [Function],
+                  },
+                  "sourceMap": false,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/postcss-loader/src/index.js",
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                  "sourceMap": false,
+                },
+              },
+            ],
+          },
+          Object {
+            "exclude": "/\\\\.module\\\\.(scss|sass)$/",
+            "sideEffects": true,
+            "test": "/\\\\.(scss|sass)$/",
+            "use": Array [
+              "NODE_MODULES/style-loader/index.js",
+              Object {
+                "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+                "options": Object {
+                  "importLoaders": 3,
+                  "sourceMap": false,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/postcss-loader/src/index.js",
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                  "sourceMap": false,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/resolve-url-loader/index.js",
+                "options": Object {
+                  "sourceMap": false,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/sass-loader/dist/cjs.js",
+                "options": Object {
+                  "sourceMap": true,
+                },
+              },
+            ],
+          },
+          Object {
+            "test": "/\\\\.module\\\\.(scss|sass)$/",
+            "use": Array [
+              "NODE_MODULES/style-loader/index.js",
+              Object {
+                "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+                "options": Object {
+                  "importLoaders": 3,
+                  "modules": Object {
+                    "getLocalIdent": [Function],
+                  },
+                  "sourceMap": false,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/postcss-loader/src/index.js",
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                  "sourceMap": false,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/resolve-url-loader/index.js",
+                "options": Object {
+                  "sourceMap": false,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/sass-loader/dist/cjs.js",
+                "options": Object {
+                  "sourceMap": true,
+                },
+              },
+            ],
+          },
+          Object {
+            "exclude": Array [
+              "/\\\\.(js|mjs|jsx|ts|tsx)$/",
+              "/\\\\.html$/",
+              "/\\\\.json$/",
+              "/\\\\.(ejs|md|mdx)$/",
+            ],
+            "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+            "options": Object {
+              "name": "static/media/[name].[hash:8].[ext]",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": "NODE_MODULES\\\\/acorn-jsx/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": "commonjs",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.(stories|story)\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [],
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "compilers": Array [
+                [Function],
+              ],
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "exclude": "/\\\\.(stories|story)\\\\.mdx$/",
+        "test": "/\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [],
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+        "options": Object {
+          "injectStoryParameters": true,
+          "inspectLocalDependencies": true,
+        },
+        "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "FilterWarningsPlugin",
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "DefinePlugin",
+    "WatchMissingNodeModulesPlugin",
+    "HotModuleReplacementPlugin",
+    "CaseSensitivePathsPlugin",
+    "ProgressPlugin",
+    "InterpolateHtmlPlugin",
+    "ModuleNotFoundPlugin",
+    "ManifestPlugin",
+    "IgnorePlugin",
+    "ForkTsCheckerWebpackPlugin",
+    "DocgenPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/cra-ts-essentials_preview-prod
+++ b/lib/core/src/server/__snapshots__/cra-ts-essentials_preview-prod
@@ -1,0 +1,459 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cra-ts-essentials preview production mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/server/preview/globals.ts",
+    "ROOT/examples/cra-ts-essentials/.storybook/storybook-init-framework-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/examples/cra-ts-essentials/.storybook/preview.js-generated-config-entry.js",
+    "ROOT/examples/cra-ts-essentials/.storybook/generated-stories-entry.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "test": "/\\\\.md$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
+          },
+        ],
+      },
+      Object {
+        "parser": Object {
+          "requireEnsure": false,
+        },
+      },
+      Object {
+        "enforce": "pre",
+        "include": Array [
+          "ROOT/src",
+          "ROOT/examples/cra-ts-essentials/.storybook",
+        ],
+        "test": "/\\\\.(js|mjs|jsx|ts|tsx)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/eslint-loader/dist/cjs.js",
+            "options": Object {
+              "baseConfig": Object {
+                "extends": Array [
+                  "NODE_MODULES/eslint-config-react-app/index.js",
+                ],
+              },
+              "cache": true,
+              "eslintPath": "NODE_MODULES/eslint/lib/api.js",
+              "formatter": "NODE_MODULES/react-dev-utils/eslintFormatter.js",
+              "ignore": false,
+              "resolvePluginsRelativeTo": "NODE_MODULES/react-scripts/config",
+              "useEslintrc": false,
+            },
+          },
+        ],
+      },
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+            "options": Object {
+              "limit": 10000,
+              "name": "static/media/[name].[hash:8].[ext]",
+            },
+            "test": Array [
+              "/\\\\.bmp$/",
+              "/\\\\.gif$/",
+              "/\\\\.jpe?g$/",
+              "/\\\\.png$/",
+            ],
+          },
+          Object {
+            "include": Array [
+              "ROOT/src",
+              "ROOT/examples/cra-ts-essentials/.storybook",
+            ],
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheCompression": false,
+              "cacheDirectory": true,
+              "cacheIdentifier": "production:babel-plugin-named-asset-import@0.3.7:babel-preset-react-app@9.1.2:react-dev-utils@10.2.1:react-scripts@3.4.4",
+              "compact": true,
+              "configFile": false,
+              "customize": "NODE_MODULES/babel-preset-react-app/webpack-overrides.js",
+              "extends": undefined,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                Array [
+                  "NODE_MODULES/babel-plugin-named-asset-import/index.js",
+                  Object {
+                    "loaderMap": Object {
+                      "svg": Object {
+                        "ReactComponent": "@svgr/webpack?-svgo,+titleProp,+ref![path]",
+                      },
+                    },
+                  },
+                ],
+              ],
+              "presets": Array [
+                "NODE_MODULES/babel-preset-react-app/index.js",
+              ],
+            },
+            "test": "/\\\\.(js|mjs|jsx|ts|tsx)$/",
+          },
+          Object {
+            "exclude": "/@babel(?:\\\\/|\\\\\\\\{1,2})runtime/",
+            "include": Array [
+              "ROOT/examples/cra-ts-essentials/.storybook",
+            ],
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheCompression": false,
+              "cacheDirectory": true,
+              "cacheIdentifier": "production:babel-plugin-named-asset-import@0.3.7:babel-preset-react-app@9.1.2:react-dev-utils@10.2.1:react-scripts@3.4.4",
+              "compact": false,
+              "configFile": false,
+              "inputSourceMap": true,
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/babel-preset-react-app/dependencies.js",
+                  Object {
+                    "helpers": true,
+                  },
+                ],
+              ],
+              "sourceMaps": true,
+            },
+            "test": "/\\\\.(js|mjs)$/",
+          },
+          Object {
+            "exclude": Array [
+              "/\\\\.module\\\\.css$/",
+              "/@storybook/",
+            ],
+            "include": undefined,
+            "sideEffects": true,
+            "test": "/\\\\.css$/",
+            "use": Array [
+              Object {
+                "loader": "NODE_MODULES/mini-css-extract-plugin/dist/loader.js",
+                "options": Object {
+                  "publicPath": "../../",
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+                "options": Object {
+                  "importLoaders": 1,
+                  "sourceMap": true,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/postcss-loader/src/index.js",
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                  "sourceMap": true,
+                },
+              },
+            ],
+          },
+          Object {
+            "test": "/\\\\.module\\\\.css$/",
+            "use": Array [
+              Object {
+                "loader": "NODE_MODULES/mini-css-extract-plugin/dist/loader.js",
+                "options": Object {
+                  "publicPath": "../../",
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+                "options": Object {
+                  "importLoaders": 1,
+                  "modules": Object {
+                    "getLocalIdent": [Function],
+                  },
+                  "sourceMap": true,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/postcss-loader/src/index.js",
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                  "sourceMap": true,
+                },
+              },
+            ],
+          },
+          Object {
+            "exclude": "/\\\\.module\\\\.(scss|sass)$/",
+            "sideEffects": true,
+            "test": "/\\\\.(scss|sass)$/",
+            "use": Array [
+              Object {
+                "loader": "NODE_MODULES/mini-css-extract-plugin/dist/loader.js",
+                "options": Object {
+                  "publicPath": "../../",
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+                "options": Object {
+                  "importLoaders": 3,
+                  "sourceMap": true,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/postcss-loader/src/index.js",
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                  "sourceMap": true,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/resolve-url-loader/index.js",
+                "options": Object {
+                  "sourceMap": true,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/sass-loader/dist/cjs.js",
+                "options": Object {
+                  "sourceMap": true,
+                },
+              },
+            ],
+          },
+          Object {
+            "test": "/\\\\.module\\\\.(scss|sass)$/",
+            "use": Array [
+              Object {
+                "loader": "NODE_MODULES/mini-css-extract-plugin/dist/loader.js",
+                "options": Object {
+                  "publicPath": "../../",
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+                "options": Object {
+                  "importLoaders": 3,
+                  "modules": Object {
+                    "getLocalIdent": [Function],
+                  },
+                  "sourceMap": true,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/postcss-loader/src/index.js",
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                  "sourceMap": true,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/resolve-url-loader/index.js",
+                "options": Object {
+                  "sourceMap": true,
+                },
+              },
+              Object {
+                "loader": "NODE_MODULES/sass-loader/dist/cjs.js",
+                "options": Object {
+                  "sourceMap": true,
+                },
+              },
+            ],
+          },
+          Object {
+            "exclude": Array [
+              "/\\\\.(js|mjs|jsx|ts|tsx)$/",
+              "/\\\\.html$/",
+              "/\\\\.json$/",
+              "/\\\\.(ejs|md|mdx)$/",
+            ],
+            "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+            "options": Object {
+              "name": "static/media/[name].[hash:8].[ext]",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": "NODE_MODULES\\\\/acorn-jsx/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": "commonjs",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.(stories|story)\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [],
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "compilers": Array [
+                [Function],
+              ],
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "exclude": "/\\\\.(stories|story)\\\\.mdx$/",
+        "test": "/\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [],
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+        "options": Object {
+          "injectStoryParameters": true,
+          "inspectLocalDependencies": true,
+        },
+        "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "FilterWarningsPlugin",
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "DefinePlugin",
+    "CaseSensitivePathsPlugin",
+    "ProgressPlugin",
+    "InlineChunkHtmlPlugin",
+    "InterpolateHtmlPlugin",
+    "ModuleNotFoundPlugin",
+    "MiniCssExtractPlugin",
+    "ManifestPlugin",
+    "IgnorePlugin",
+    "GenerateSW",
+    "ForkTsCheckerWebpackPlugin",
+    "DocgenPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/html-kitchen-sink_manager-dev
+++ b/lib/core/src/server/__snapshots__/html-kitchen-sink_manager-dev
@@ -1,18 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager production mode 1`] = `
+exports[`html-kitchen-sink manager dev mode 1`] = `
 Object {
   "entry": Array [
     "ROOT/lib/core/src/server/common/polyfills.ts",
     "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/a11y/dist/esm/register.js",
     "ROOT/addons/actions/dist/esm/register.js",
     "ROOT/addons/backgrounds/dist/esm/register.js",
-    "ROOT/addons/viewport/dist/esm/register.js",
-    "ROOT/addons/toolbars/dist/esm/register.js",
     "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/events/register.js",
+    "ROOT/addons/jest/register.js",
+    "ROOT/addons/knobs/dist/esm/register.js",
+    "ROOT/addons/links/dist/esm/register.js",
     "ROOT/addons/storysource/dist/esm/register.js",
-    "ROOT/addons/docs/dist/esm/register.js",
-    "ROOT/examples/react-ts/generated-refs.js",
+    "ROOT/addons/viewport/dist/esm/register.js",
+    "ROOT/examples/html-kitchen-sink/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
   ],
   "module": Object {
     "rules": Array [
@@ -199,7 +219,6 @@ Object {
     "CaseSensitivePathsPlugin",
     "DefinePlugin",
     "DefinePlugin",
-    "BundleAnalyzerPlugin",
   ],
 }
 `;

--- a/lib/core/src/server/__snapshots__/html-kitchen-sink_manager-prod
+++ b/lib/core/src/server/__snapshots__/html-kitchen-sink_manager-prod
@@ -1,0 +1,225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`html-kitchen-sink manager production mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/a11y/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/events/register.js",
+    "ROOT/addons/jest/register.js",
+    "ROOT/addons/knobs/dist/esm/register.js",
+    "ROOT/addons/links/dist/esm/register.js",
+    "ROOT/addons/storysource/dist/esm/register.js",
+    "ROOT/addons/viewport/dist/esm/register.js",
+    "ROOT/examples/html-kitchen-sink/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "query": Object {
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+    "DefinePlugin",
+    "BundleAnalyzerPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/html-kitchen-sink_preview-dev
+++ b/lib/core/src/server/__snapshots__/html-kitchen-sink_preview-dev
@@ -1,0 +1,546 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`html-kitchen-sink preview dev mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/server/preview/globals.ts",
+    "ROOT/examples/html-kitchen-sink/.storybook/storybook-init-framework-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/knobs/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/examples/html-kitchen-sink/.storybook/preview.js-generated-config-entry.js",
+    "ROOT/examples/html-kitchen-sink/.storybook/generated-stories-entry.js",
+    "NODE_MODULES/webpack-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": "NODE_MODULES/",
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.md$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
+          },
+        ],
+      },
+      Object {
+        "include": "NODE_MODULES\\\\/acorn-jsx/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": "commonjs",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.(stories|story)\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "compilers": Array [
+                [Function],
+              ],
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "exclude": "/\\\\.(stories|story)\\\\.mdx$/",
+        "test": "/\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+        "options": Object {
+          "injectStoryParameters": true,
+          "inspectLocalDependencies": true,
+        },
+        "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+      Object {
+        "sideEffects": true,
+        "test": "/\\\\.css$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/style-loader/dist/cjs.js",
+            "options": undefined,
+          },
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": undefined,
+          },
+          Object {
+            "loader": "NODE_MODULES/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "implementation": [Function],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "test": Array [
+          "/\\\\.stories\\\\.(jsx?$|tsx?$)/",
+        ],
+        "use": Array [
+          Object {
+            "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+            "options": undefined,
+          },
+        ],
+      },
+      Object {},
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "options": Object {
+          "esModule": false,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "FilterWarningsPlugin",
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "DefinePlugin",
+    "WatchMissingNodeModulesPlugin",
+    "HotModuleReplacementPlugin",
+    "CaseSensitivePathsPlugin",
+    "ProgressPlugin",
+    "DefinePlugin",
+    "DocgenPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/html-kitchen-sink_preview-prod
+++ b/lib/core/src/server/__snapshots__/html-kitchen-sink_preview-prod
@@ -1,19 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`preview production mode 1`] = `
+exports[`html-kitchen-sink preview production mode 1`] = `
 Object {
   "entry": Array [
     "ROOT/lib/core/src/server/common/polyfills.ts",
     "ROOT/lib/core/src/server/preview/globals.ts",
-    "ROOT/examples/react-ts/storybook-init-framework-entry.js",
+    "ROOT/examples/html-kitchen-sink/.storybook/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-other-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
     "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
-    "ROOT/examples/react-ts/generated-stories-entry.js",
+    "ROOT/addons/knobs/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/examples/html-kitchen-sink/.storybook/preview.js-generated-config-entry.js",
+    "ROOT/examples/html-kitchen-sink/.storybook/generated-stories-entry.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
   ],
   "module": Object {
     "rules": Array [
@@ -194,18 +213,6 @@ Object {
         "use": Array [
           Object {
             "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
-          },
-        ],
-      },
-      Object {
-        "enforce": "pre",
-        "test": Array [
-          "/\\\\.stories\\\\.(jsx?$|tsx?$)/",
-        ],
-        "use": Array [
-          Object {
-            "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
-            "options": undefined,
           },
         ],
       },
@@ -466,9 +473,8 @@ Object {
         "enforce": "pre",
         "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
         "options": Object {
-          "injectStoryParameters": false,
+          "injectStoryParameters": true,
           "inspectLocalDependencies": true,
-          "parser": "typescript",
         },
         "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
       },
@@ -476,21 +482,35 @@ Object {
         "sideEffects": true,
         "test": "/\\\\.css$/",
         "use": Array [
-          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/style-loader/dist/cjs.js",
+            "options": undefined,
+          },
           Object {
             "loader": "NODE_MODULES/css-loader/dist/cjs.js",
-            "options": Object {
-              "importLoaders": 1,
-            },
+            "options": undefined,
           },
           Object {
             "loader": "NODE_MODULES/postcss-loader/dist/cjs.js",
             "options": Object {
-              "postcssOptions": [Function],
+              "implementation": [Function],
             },
           },
         ],
       },
+      Object {
+        "enforce": "pre",
+        "test": Array [
+          "/\\\\.stories\\\\.(jsx?$|tsx?$)/",
+        ],
+        "use": Array [
+          Object {
+            "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+            "options": undefined,
+          },
+        ],
+      },
+      Object {},
       Object {
         "loader": "NODE_MODULES/file-loader/dist/cjs.js",
         "options": Object {
@@ -517,7 +537,6 @@ Object {
     "CaseSensitivePathsPlugin",
     "ProgressPlugin",
     "DefinePlugin",
-    "ForkTsCheckerWebpackPlugin",
     "DocgenPlugin",
   ],
 }

--- a/lib/core/src/server/__snapshots__/vue-3-cli_manager-dev
+++ b/lib/core/src/server/__snapshots__/vue-3-cli_manager-dev
@@ -1,0 +1,220 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`vue-3-cli manager dev mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/links/dist/esm/register.js",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/viewport/dist/esm/register.js",
+    "ROOT/addons/toolbars/dist/esm/register.js",
+    "ROOT/examples/vue-3-cli/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "query": Object {
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+    "DefinePlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/vue-3-cli_manager-prod
+++ b/lib/core/src/server/__snapshots__/vue-3-cli_manager-prod
@@ -1,0 +1,221 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`vue-3-cli manager production mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/links/dist/esm/register.js",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/viewport/dist/esm/register.js",
+    "ROOT/addons/toolbars/dist/esm/register.js",
+    "ROOT/examples/vue-3-cli/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "query": Object {
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+    "DefinePlugin",
+    "BundleAnalyzerPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/vue-3-cli_preview-dev
+++ b/lib/core/src/server/__snapshots__/vue-3-cli_preview-dev
@@ -1,0 +1,529 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`vue-3-cli preview dev mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/server/preview/globals.ts",
+    "ROOT/examples/vue-3-cli/.storybook/storybook-init-framework-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/examples/vue-3-cli/.storybook/preview.ts-generated-config-entry.js",
+    "ROOT/examples/vue-3-cli/.storybook/generated-stories-entry.js",
+    "NODE_MODULES/webpack-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": "NODE_MODULES/",
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.md$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
+          },
+        ],
+      },
+      Object {
+        "include": "NODE_MODULES\\\\/acorn-jsx/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": "commonjs",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.(stories|story)\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "compilers": Array [
+                [Function],
+              ],
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "exclude": "/\\\\.(stories|story)\\\\.mdx$/",
+        "test": "/\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+        "options": Object {
+          "injectStoryParameters": true,
+          "inspectLocalDependencies": true,
+        },
+        "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+      Object {
+        "sideEffects": true,
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": [Function],
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "options": Object {
+          "esModule": false,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "FilterWarningsPlugin",
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "DefinePlugin",
+    "WatchMissingNodeModulesPlugin",
+    "HotModuleReplacementPlugin",
+    "CaseSensitivePathsPlugin",
+    "ProgressPlugin",
+    "DefinePlugin",
+    "DocgenPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/vue-3-cli_preview-prod
+++ b/lib/core/src/server/__snapshots__/vue-3-cli_preview-prod
@@ -1,0 +1,526 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`vue-3-cli preview production mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/server/preview/globals.ts",
+    "ROOT/examples/vue-3-cli/.storybook/storybook-init-framework-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/examples/vue-3-cli/.storybook/preview.ts-generated-config-entry.js",
+    "ROOT/examples/vue-3-cli/.storybook/generated-stories-entry.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": "NODE_MODULES/",
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.md$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
+          },
+        ],
+      },
+      Object {
+        "include": "NODE_MODULES\\\\/acorn-jsx/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": "commonjs",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.(stories|story)\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "compilers": Array [
+                [Function],
+              ],
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "exclude": "/\\\\.(stories|story)\\\\.mdx$/",
+        "test": "/\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+        "options": Object {
+          "injectStoryParameters": true,
+          "inspectLocalDependencies": true,
+        },
+        "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+      Object {
+        "sideEffects": true,
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": [Function],
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "options": Object {
+          "esModule": false,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "FilterWarningsPlugin",
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "DefinePlugin",
+    "CaseSensitivePathsPlugin",
+    "ProgressPlugin",
+    "DefinePlugin",
+    "DocgenPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/web-components-kitchen-sink_manager-dev
+++ b/lib/core/src/server/__snapshots__/web-components-kitchen-sink_manager-dev
@@ -1,0 +1,222 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`web-components-kitchen-sink manager dev mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/a11y/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/knobs/dist/esm/register.js",
+    "ROOT/addons/links/dist/esm/register.js",
+    "ROOT/addons/storysource/dist/esm/register.js",
+    "ROOT/addons/viewport/dist/esm/register.js",
+    "ROOT/examples/web-components-kitchen-sink/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "query": Object {
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+    "DefinePlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/web-components-kitchen-sink_manager-prod
+++ b/lib/core/src/server/__snapshots__/web-components-kitchen-sink_manager-prod
@@ -1,0 +1,223 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`web-components-kitchen-sink manager production mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/client/manager/index.ts",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/a11y/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/knobs/dist/esm/register.js",
+    "ROOT/addons/links/dist/esm/register.js",
+    "ROOT/addons/storysource/dist/esm/register.js",
+    "ROOT/addons/viewport/dist/esm/register.js",
+    "ROOT/examples/web-components-kitchen-sink/.storybook/generated-refs.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "cache",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "query": Object {
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+    "DefinePlugin",
+    "BundleAnalyzerPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/web-components-kitchen-sink_preview-dev
+++ b/lib/core/src/server/__snapshots__/web-components-kitchen-sink_preview-dev
@@ -1,0 +1,543 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`web-components-kitchen-sink preview dev mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/server/preview/globals.ts",
+    "ROOT/examples/web-components-kitchen-sink/.storybook/storybook-init-framework-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/knobs/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/examples/web-components-kitchen-sink/.storybook/preview.js-generated-config-entry.js",
+    "NODE_MODULES/webpack-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": "NODE_MODULES/",
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.md$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
+          },
+        ],
+      },
+      Object {
+        "include": "NODE_MODULES\\\\/acorn-jsx/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": "commonjs",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.(stories|story)\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "compilers": Array [
+                [Function],
+              ],
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "exclude": "/\\\\.(stories|story)\\\\.mdx$/",
+        "test": "/\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+        "options": Object {
+          "injectStoryParameters": true,
+          "inspectLocalDependencies": true,
+        },
+        "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+      Object {
+        "enforce": "pre",
+        "test": Array [
+          "/\\\\.stories\\\\.(jsx?$|tsx?$)/",
+        ],
+        "use": Array [
+          Object {
+            "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+            "options": undefined,
+          },
+        ],
+      },
+      Object {
+        "sideEffects": true,
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": [Function],
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "options": Object {
+          "esModule": false,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "FilterWarningsPlugin",
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "DefinePlugin",
+    "WatchMissingNodeModulesPlugin",
+    "HotModuleReplacementPlugin",
+    "CaseSensitivePathsPlugin",
+    "ProgressPlugin",
+    "DefinePlugin",
+    "DocgenPlugin",
+  ],
+}
+`;

--- a/lib/core/src/server/__snapshots__/web-components-kitchen-sink_preview-prod
+++ b/lib/core/src/server/__snapshots__/web-components-kitchen-sink_preview-prod
@@ -1,0 +1,540 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`web-components-kitchen-sink preview production mode 1`] = `
+Object {
+  "entry": Array [
+    "ROOT/lib/core/src/server/common/polyfills.ts",
+    "ROOT/lib/core/src/server/preview/globals.ts",
+    "ROOT/examples/web-components-kitchen-sink/.storybook/storybook-init-framework-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js",
+    "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-other-entry.js",
+    "ROOT/addons/controls/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-other-entry.js",
+    "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "ROOT/addons/knobs/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-other-entry.js",
+    "ROOT/examples/web-components-kitchen-sink/.storybook/preview.js-generated-config-entry.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "optimization",
+    "performance",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": "NODE_MODULES/",
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.md$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/raw-loader/dist/cjs.js",
+          },
+        ],
+      },
+      Object {
+        "include": "NODE_MODULES\\\\/acorn-jsx/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "modules": "commonjs",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.(stories|story)\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "compilers": Array [
+                [Function],
+              ],
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "exclude": "/\\\\.(stories|story)\\\\.mdx$/",
+        "test": "/\\\\.mdx$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
+              "overrides": Array [
+                Object {
+                  "plugins": Array [
+                    Array [
+                      "NODE_MODULES/babel-plugin-react-docgen/lib/index.js",
+                      Object {
+                        "DOC_GEN_COLLECTION_NAME": "STORYBOOK_REACT_CLASSES",
+                      },
+                    ],
+                  ],
+                  "test": "/\\\\.(mjs|jsx?)$/",
+                },
+              ],
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "3.8.2",
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.js",
+                  Object {
+                    "autoLabel": true,
+                    "sourceMap": true,
+                  },
+                ],
+                "NODE_MODULES/babel-plugin-add-react-displayname/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-transform-react-jsx/lib/index.js",
+                  Object {
+                    "pragma": "React.createElement",
+                    "pragmaFrag": "React.Fragment",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/preset-react/lib/index.js",
+                  Object {
+                    "runtime": "automatic",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-flow/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/@mdx-js/loader/index.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "enforce": "pre",
+        "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+        "options": Object {
+          "injectStoryParameters": true,
+          "inspectLocalDependencies": true,
+        },
+        "test": "/\\\\.(stories|story)\\\\.[tj]sx?$/",
+      },
+      Object {
+        "enforce": "pre",
+        "test": Array [
+          "/\\\\.stories\\\\.(jsx?$|tsx?$)/",
+        ],
+        "use": Array [
+          Object {
+            "loader": "ROOT/lib/source-loader/dist/cjs/index.js",
+            "options": undefined,
+          },
+        ],
+      },
+      Object {
+        "sideEffects": true,
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+          Object {
+            "loader": "NODE_MODULES/postcss-loader/dist/cjs.js",
+            "options": Object {
+              "postcssOptions": [Function],
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "options": Object {
+          "esModule": false,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "query": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[hash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+    ],
+  },
+  "plugins": Array [
+    "FilterWarningsPlugin",
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "DefinePlugin",
+    "CaseSensitivePathsPlugin",
+    "ProgressPlugin",
+    "DefinePlugin",
+    "DocgenPlugin",
+  ],
+}
+`;


### PR DESCRIPTION
Issue: N/A

## What I did

Get more coverage for core presets handling code:
- more frameworks
- save the webpack config keys

## How to test

```
yarn test core-presets.test.ts
```