### PR TITLE
fix: Vue 3 override args kitchen sink story

### DIFF
--- a/examples/vue-3-cli/src/stories/OverrideArgs.stories.js
+++ b/examples/vue-3-cli/src/stories/OverrideArgs.stories.js
@@ -30,11 +30,9 @@ const Template = (args, { argTypes }) => {
   return {
     props: Object.keys(argTypes),
     components: { OverrideArgs },
-    template: '<override-args v-bind="$props" :icon="icon" />',
-    setup(props) {
-      return {
-        icon: icons[props.icon],
-      };
+    template: '<override-args v-bind="$props" />',
+    setup(props, context) {
+      context.props.icon = icons[context.props.icon];
     },
   };
 };


### PR DESCRIPTION
Issue: #13861 #13920

## What I did

Changed the Vue 3 kitchen sink example Override Args, as the existing example could be mistaken for passing a reactive value back from setup. It also removes the need to adjust the template to receive a 2nd icon value (from `$props` and `icon`) and removes the possibility that Vue implementation could pass a string through with `$props.icon` when an object is expected.

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.
