### PR TITLE
Preact: Add CSF types

### DIFF
--- a/app/preact/src/client/index.ts
+++ b/app/preact/src/client/index.ts
@@ -8,3 +8,5 @@ export {
   forceReRender,
   raw,
 } from './preview';
+
+export * from './preview/types-6-0';

--- a/app/preact/src/client/preview/types-6-0.ts
+++ b/app/preact/src/client/preview/types-6-0.ts
@@ -1,0 +1,24 @@
+import { AnyComponent } from 'preact';
+import { Args as DefaultArgs, Annotations, BaseMeta, BaseStory } from '@storybook/addons';
+import { StoryFnPreactReturnType } from './types';
+
+export { Args, ArgTypes, Parameters, StoryContext } from '@storybook/addons';
+
+type PreactComponent = AnyComponent<any, any>;
+type PreactReturnType = StoryFnPreactReturnType;
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export type Meta<Args = DefaultArgs> = BaseMeta<PreactComponent> &
+  Annotations<Args, PreactReturnType>;
+
+/**
+ * Story function that represents a component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<Args = DefaultArgs> = BaseStory<Args, PreactReturnType> &
+  Annotations<Args, PreactReturnType>;

--- a/app/preact/types-6-0.d.ts
+++ b/app/preact/types-6-0.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/ts3.9/client/preview/types-6-0.d';


### PR DESCRIPTION
Issue: #11845 (for Preact)

## What I did

I effectively copied the changes made in [the Vue PR](https://github.com/storybookjs/storybook/pull/12037/files) (except for the example change) to the app/preact folder with some minor name and import changes to make it fit for Preact.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? Not sure, tbh. I can add a Button.ts to examples/preact-kitchen-sink if desired, I believe.
- Does this need an update to the documentation? Not sure, but I don't think so.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
