### PR TITLE
Remind to add a new script for running storybook

### DIFF
--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -46,7 +46,19 @@ The command above will make the following changes to your local environment:
 - 🛠 Add the default Storybook configuration.
 - 📝 Add some boilerplate stories to get you started.
 
-Depending on your framework, first build your app and then check that everything worked by running:
+Depending on your framework, first build your app and then check that everything worked. Add a script into a package.json:
+
+```javascript
+{
+  "scripts": {
+    # ...
+    "storybook": "start-storybook -p 9001",
+    # ...
+  }
+}
+```
+
+Then, run:
 
 ```shell
 npm run storybook


### PR DESCRIPTION
Every time, all new users of storybook stuck at here. Please, add some instruction to adding a script for running npm run storybook.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
