### PR TITLE
Components: Add missing `regenerator-runtime` dependency

### DIFF
--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -47,6 +47,7 @@
     "react-popper-tooltip": "^3.1.1",
     "react-syntax-highlighter": "^13.5.0",
     "react-textarea-autosize": "^8.1.1",
+    "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue: #13830

Applying https://github.com/storybookjs/storybook/pull/13916 to `master`

## What I did

- Add missing regenerator-runtime dependency

## How to test
 - `ci/circleci: examples-v2-yarn-2` should be 🟢
