### PR TITLE
Webpack5: Fix progress plugin version conflict

### DIFF
--- a/lib/builder-webpack4/src/presets/custom-webpack-preset.ts
+++ b/lib/builder-webpack4/src/presets/custom-webpack-preset.ts
@@ -21,6 +21,6 @@ export async function webpack(config: any, options: any) {
     return customConfig({ config: finalDefaultConfig, mode: configType });
   }
 
-  logger.info('=> Using default Webpack setup');
+  logger.info('=> Using default Webpack4 setup');
   return finalDefaultConfig;
 }

--- a/lib/builder-webpack5/src/index.ts
+++ b/lib/builder-webpack5/src/index.ts
@@ -35,12 +35,7 @@ export const executor = {
   get: webpack,
 };
 
-export const start: WebpackBuilder['start'] = async ({
-  startTime,
-  options,
-  useProgressReporting,
-  router,
-}) => {
+export const start: WebpackBuilder['start'] = async ({ startTime, options, router }) => {
   const config = await getConfig(options);
   const compiler = executor.get(config);
   if (!compiler) {
@@ -57,7 +52,7 @@ export const start: WebpackBuilder['start'] = async ({
     };
   }
 
-  await useProgressReporting(compiler, options, startTime);
+  // FIXME: await useProgressReporting(compiler, options, startTime);
 
   const middlewareOptions: Parameters<typeof webpackDevMiddleware>[1] = {
     publicPath: config.output?.publicPath as string,

--- a/lib/builder-webpack5/src/presets/custom-webpack-preset.ts
+++ b/lib/builder-webpack5/src/presets/custom-webpack-preset.ts
@@ -30,6 +30,6 @@ export async function webpack(config: Configuration, options: Options) {
     return customConfig({ config: finalDefaultConfig, mode: configType });
   }
 
-  logger.info('=> Using default Webpack setup');
+  logger.info('=> Using default Webpack5 setup');
   return finalDefaultConfig;
 }


### PR DESCRIPTION
Issue: #14006

## What I did

Hacked around a progress plugin version conflict by simply not using the progress plugin in the webpack5 builder.

Here is the dependency tree of Storybook

```
        /-------------------------------------------- \
       /                  / -------------------------- \
      /------------------/--------------\               \
     /                  /                \               \
core-server -> builder-webpack4 -----> core-common ----> webpack4
  \                                          /
   ----------> builder-webpack5 (optional) -/
                    \
                     ---> webpack5
```

So when `builder-webpack5` calls into `core-common` it's mixing `webpack4` and `webpack5`. This needs a refactor, but for now, just commenting out the call to fix the issue at hand and get people unblocked.

self-merging @tooppaaa @ndelangen 

## How to test

```
cd examples/react-ts
# edit to use `webpack5` builder
yarn storybook
```