### PR TITLE
CLI/Vue 2: install vue-loader upon init of vue 2 storybook

### DIFF
--- a/lib/cli/src/generators/VUE/index.ts
+++ b/lib/cli/src/generators/VUE/index.ts
@@ -1,7 +1,9 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'vue');
+  baseGenerator(packageManager, npmOptions, options, 'vue', {
+    extraPackages: ['vue-loader@^15.7.0'],
+  });
 };
 
 export default generator;


### PR DESCRIPTION
Issue: #14011

## What I did

**I'm not sure if we should do this or not.**

Essentially, the `@storybook/vue` package has a peerDep on `vue-loader` and errors if someone doesn't install it (as was noted in the linked issue). It seems that some versions of the Vue CLI don't use webpack and don't install this dependency, so we could specify this as an `extraPackages` so it is always installed by `sb init`. Thoughts?

## How to test

- Is this testable with Jest or Chromatic screenshots? ❌ 
- Does this need a new example in the kitchen sink apps? ❌ 
- Does this need an update to the documentation? ❌ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
