### PR TITLE
SyntaxHighlighter: Safely access clipboard on global.navigator

### DIFF
--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -54,7 +54,7 @@ const themedSyntax = memoize(2)((theme) =>
 
 let copyToClipboard: (text: string) => Promise<void>;
 
-if (navigator.clipboard) {
+if (navigator?.clipboard) {
   copyToClipboard = (text: string) => navigator.clipboard.writeText(text);
 } else {
   copyToClipboard = async (text: string) => {


### PR DESCRIPTION
Issue: None; discussed in Discord first

```ts
if (navigator.clipboard) {
  copyToClipboard = (text: string) => navigator.clipboard.writeText(text);
} else {
  // ...
}
```

In my admittedly convoluted project (details: https://github.com/storybookjs/storybook/pull/12959#discussion_r548662757), I get an error about not being able to access `clipboard` on `undefined`, because `navigator` (expectedly) is not available in the environment in which it is executed.

## What I did

Use optional chaining to safely access `clipboard` on `global.navigator`

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

## Questions

A [quick search](https://github.com/search?q=%22from+global%22+repo%3Astorybookjs%2Fstorybook&type=Code&ref=advsearch&l=&l=) shows that there may be other instances of unsafe global access. Let me know if this PR should attempt to address these, too.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
