### PR TITLE
Chore: Updates link for addons

### DIFF
--- a/lib/core-common/src/presets.ts
+++ b/lib/core-common/src/presets.ts
@@ -113,7 +113,7 @@ const map = ({ configDir }: InterPresetOptions) => (item: any) => {
     return resolveAddonName(configDir, name);
   } catch (err) {
     logger.error(
-      `Addon value should end in /register OR it should be a valid preset https://storybook.js.org/docs/presets/introduction/\n${item}`
+      `Addon value should end in /register OR it should be a valid preset https://storybook.js.org/docs/react/addons/writing-presets/\n${item}`
     );
   }
   return undefined;


### PR DESCRIPTION
With this pull request the link for the documentation regarding presets is updated to point at the right place. It was sending users to the old location in the documentation prior to the addons documentation restructure. 

It was reported by a community member [here](https://discord.com/channels/486522875931656193/549981762416017426/814016205199376404)

Feel free to provide feedback