### PR TITLE
IE11: Transpile prettier down to ES5

### DIFF
--- a/lib/core-common/src/utils/es6Transpiler.ts
+++ b/lib/core-common/src/utils/es6Transpiler.ts
@@ -17,7 +17,7 @@ export const es6Transpiler: () => RuleSetRule = () => {
     return (
       !!nodeModulesThatNeedToBeParsedBecauseTheyExposeES6.find((p) => input.includes(p)) ||
       !!input.match(
-        /[\\/]node_modules[\\/](@storybook\/node-logger|are-you-es5|better-opn|boxen|chalk|commander|find-cache-dir|find-up|fs-extra|json5|node-fetch|pkg-dir|resolve-from|semver|highlight.js)/
+        /[\\/]node_modules[\\/](@storybook\/node-logger|are-you-es5|better-opn|boxen|chalk|commander|find-cache-dir|find-up|fs-extra|json5|node-fetch|pkg-dir|prettier|resolve-from|semver|highlight.js)/
       )
     );
   };


### PR DESCRIPTION
Issue: #13562

## What I did

Transpile prettier down to ES5.

```sh
# before
% cat storybook-static/vendors\~main.8a58097e4d6c098e5f67.bundle.js | grep -o "=>" | wc -l
719

# after
% cat storybook-static/vendors\~main.7c1566541e1e1392bebb.bundle.js | grep -o "=>" | wc -l
16
```

All of the remaining 16 `=>`s are in regexp literals or string literals (checked manually).

NOTE: I'm not sure what label is appropriate so just added `bug` and `ie11` labels

## How to test

- Is this testable with Jest or Chromatic screenshots? ... No
- Does this need a new example in the kitchen sink apps? ... No
- Does this need an update to the documentation? ... No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
