### PR TITLE
Fix flaky color rendering

### DIFF
--- a/lib/components/src/bar/button.tsx
+++ b/lib/components/src/bar/button.tsx
@@ -64,7 +64,7 @@ export const TabButton = styled(ButtonOrLink, { shouldForwardProp: isPropValid }
           borderBottomColor: theme.barSelectedColor,
         }
       : {
-          color: textColor || 'inherit',
+          color: textColor || theme.color.mediumdark,
           borderBottomColor: 'transparent',
         }
 );


### PR DESCRIPTION
Issue: -

## What I did

This should fix the [flaky text color rendering](https://www.chromatic.com/test?appId=5a375b97f4b14f0020b0cda3&id=60148cecb5cbbe00215f0156) in Chromatic for the iframe zoom stories.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, should stop being flaky now and always render `mediumdark` rather than black text.
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
