### PR TITLE
CLI: Don't allow root directory as static dir

### DIFF
--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -29,6 +29,10 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
     throw new Error("Won't remove current directory. Check your outputDir!");
   }
 
+  if (options.staticDir?.includes('/')) {
+    throw new Error("Won't copy root directory. Check your staticDirs!");
+  }
+
   options.outputDir = path.isAbsolute(options.outputDir)
     ? options.outputDir
     : path.join(process.cwd(), options.outputDir);

--- a/lib/core-server/src/core-presets.test.ts
+++ b/lib/core-server/src/core-presets.test.ts
@@ -203,4 +203,21 @@ describe('dev cli flags', () => {
       );
     });
   });
+
+  describe('Invalid staticDir must throw: root directory /', () => {
+    const optionsWithInvalidStaticDir = {
+      ...cliOptions,
+      staticDir: ['/'],
+    };
+    beforeEach(() => {
+      jest.clearAllMocks();
+      cache.clear();
+    });
+    it('production mode', async () => {
+      expect.assertions(1);
+      await expect(buildStaticStandalone(optionsWithInvalidStaticDir)).rejects.toThrow(
+        "Won't copy root directory. Check your staticDirs!"
+      );
+    });
+  });
 });

--- a/lib/core-server/src/core-presets.test.ts
+++ b/lib/core-server/src/core-presets.test.ts
@@ -192,10 +192,7 @@ describe('dev cli flags', () => {
       ...cliOptions,
       outputDir,
     };
-    beforeEach(() => {
-      jest.clearAllMocks();
-      cache.clear();
-    });
+
     it('production mode', async () => {
       expect.assertions(1);
       await expect(buildStaticStandalone(optionsWithInvalidDir)).rejects.toThrow(
@@ -209,10 +206,7 @@ describe('dev cli flags', () => {
       ...cliOptions,
       staticDir: ['/'],
     };
-    beforeEach(() => {
-      jest.clearAllMocks();
-      cache.clear();
-    });
+
     it('production mode', async () => {
       expect.assertions(1);
       await expect(buildStaticStandalone(optionsWithInvalidStaticDir)).rejects.toThrow(


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13860

## Context
When a user builds `storybook` in `standalone` mode, exists the possibility to provide the root directory (`/`) as one of the static directories to copy from (probably by mistake). This ends up trying to copy the whole root directory which is an unexpected behavior.

## What I did
- When building statics standalone throws an error if the `staticDir` option provided contains the root directory: `/`.
- Added test coverage for invalid `staticDir` value
	- when it's root directory `/`

## How to test

- Is this testable with Jest or Chromatic screenshots? ✅

- Does this need a new example in the kitchen sink apps? I don't think so but since I'm lacking context on what's the scope of the examples I would like the feedback from a maintainer here.

- Does this need an update to the documentation? Checking existing `standalone.md` I don't think so but if you think this is an opportunity to add a disclaimer there, this PR can be used for it 😄 