### PR TITLE
Angular: Create componentMetadata to override component's providers.

### DIFF
--- a/app/angular/src/client/index.ts
+++ b/app/angular/src/client/index.ts
@@ -13,7 +13,7 @@ export * from './preview/types-6-0';
 
 export { StoryFnAngularReturnType as IStory } from './preview/types';
 
-export { moduleMetadata, componentWrapperDecorator } from './preview/decorators';
+export { moduleMetadata, componentWrapperDecorator, componentMetadata } from './preview/decorators';
 
 if (module && module.hot && module.hot.decline) {
   module.hot.decline();

--- a/app/angular/src/client/preview/angular-beta/StorybookModule.ts
+++ b/app/angular/src/client/preview/angular-beta/StorybookModule.ts
@@ -8,7 +8,7 @@ import { ICollection, StoryFnAngularReturnType } from '../types';
 import { Parameters } from '../types-6-0';
 import { storyPropsProvider } from './StorybookProvider';
 import { isComponentAlreadyDeclaredInModules } from './utils/NgModulesAnalyzer';
-import { isDeclarable } from './utils/NgComponentAnalyzer';
+import { getComponentDecoratorMetadata, isDeclarable } from './utils/NgComponentAnalyzer';
 import { createStorybookWrapperComponent } from './StorybookWrapperComponent';
 import { computesTemplateFromComponent } from './ComputesTemplateFromComponent';
 
@@ -37,13 +37,23 @@ export const getStorybookModuleMetadata = (
   },
   storyProps$: Subject<ICollection>
 ): NgModule => {
-  const { component: storyComponent, props, styles, moduleMetadata = {} } = storyFnAngular;
+  const {
+    component: storyComponent,
+    props,
+    styles,
+    componentMetadata,
+    moduleMetadata = {},
+  } = storyFnAngular;
   let { template } = storyFnAngular;
 
   if (storyComponent) {
     deprecatedStoryComponentWarning();
   }
   const component = storyComponent ?? parameters.component;
+
+  if (componentMetadata) {
+    Object.assign(getComponentDecoratorMetadata(component), componentMetadata);
+  }
 
   if (!template && component) {
     template = computesTemplateFromComponent(component, props, '');

--- a/app/angular/src/client/preview/decorators.ts
+++ b/app/angular/src/client/preview/decorators.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { Type } from '@angular/core';
+import { Component, Type } from '@angular/core';
 import { DecoratorFunction, StoryContext } from '@storybook/addons';
 import { computesTemplateFromComponent } from './angular-beta/ComputesTemplateFromComponent';
 import { isComponent } from './angular-beta/utils/NgComponentAnalyzer';
@@ -25,6 +25,12 @@ export const moduleMetadata = (
       providers: [...(metadata.providers || []), ...(storyMetadata.providers || [])],
     },
   };
+};
+
+export const componentMetadata = (
+  metadata: Partial<Component>
+): DecoratorFunction<StoryFnAngularReturnType> => (storyFn) => {
+  return { ...storyFn(), componentMetadata: metadata };
 };
 
 export const componentWrapperDecorator = (

--- a/app/angular/src/client/preview/types.ts
+++ b/app/angular/src/client/preview/types.ts
@@ -1,3 +1,5 @@
+import { Component } from '@angular/core';
+
 export interface NgModuleMetadata {
   declarations?: any[];
   entryComponents?: any[];
@@ -26,6 +28,7 @@ export interface StoryFnAngularReturnType {
   /** @deprecated `propsMeta` story input is deprecated, and will be removed in Storybook 7.0. */
   propsMeta?: ICollection;
   moduleMetadata?: NgModuleMetadata;
+  componentMetadata?: Component;
   template?: string;
   styles?: string[];
 }

--- a/examples/angular-cli/src/stories/basics/component-with-provider/__snapshots__/di.component.stories.storyshot
+++ b/examples/angular-cli/src/stories/basics/component-with-provider/__snapshots__/di.component.stories.storyshot
@@ -22,7 +22,7 @@ exports[`Storyshots Basics / Component / With Provider inputs and inject depende
         ElementRef: {"nativeElement":{}}
       </div>
       <div>
-        TestToken: 123
+        TestToken: 321
       </div>
     </div>
   </storybook-di-component>
@@ -51,7 +51,7 @@ exports[`Storyshots Basics / Component / With Provider inputs and inject depende
         ElementRef: {"nativeElement":{}}
       </div>
       <div>
-        TestToken: 123
+        TestToken: 321
       </div>
     </div>
   </storybook-di-component>

--- a/examples/angular-cli/src/stories/basics/component-with-provider/di.component.stories.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-provider/di.component.stories.ts
@@ -1,8 +1,10 @@
-import { DiComponent } from './di.component';
+import { componentMetadata } from '@storybook/angular';
+import { DiComponent, TEST_TOKEN } from './di.component';
 
 export default {
   title: 'Basics / Component / With Provider',
   component: DiComponent,
+  decorators: [componentMetadata({ providers: [{ provide: TEST_TOKEN, useValue: 321 }] })],
 };
 
 export const InputsAndInjectDependencies = () => ({
@@ -23,3 +25,6 @@ InputsAndInjectDependenciesWithArgs.argTypes = {
 InputsAndInjectDependenciesWithArgs.args = {
   title: 'Component dependencies',
 };
+InputsAndInjectDependencies.decorators = [
+  componentMetadata({ providers: [{ provide: TEST_TOKEN, useValue: 42 }] }),
+];


### PR DESCRIPTION
Issue: It's not possible to override the providers (dependency injection) on the component level. Angular supports providers on the component level: https://angular.io/api/core/Directive#providers. In some cases it would be nice to override providers with mocked values.

## What I did

I created componentMetadata decorator that should be used like the moduleMetadata decorator to override providers declared on the component level. Of course you can also override the other metadata of the Angular component decorator.


### Sample usage:

Component:
```ts
@Component({
  selector: 'foo-component',
  templateUrl: './foo.component.html',
  providers: [{ provide: 'foo' , useValue: 'bar' }],
})
export class FooComponent {
}
```

Story:
```ts
export default {
  title: 'FooComponent with Mocked Provider',
  component: FooComponent,
  decorators: [componentMetadata({ providers: [{ provide: 'foo', useValue: '42' }] })],
};

const Template: Story<FooComponent> = (props) => ({
  props,
});

export const Default = Template.bind({});

// alternative declaration on the story
Default.decorators = [
  componentMetadata({ providers: [{ provide: 'foo', useValue: 42 }] }),
]
```

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
