### PR TITLE
Lower z-index on "Show code" button

### DIFF
--- a/lib/components/src/ActionBar/ActionBar.tsx
+++ b/lib/components/src/ActionBar/ActionBar.tsx
@@ -9,7 +9,6 @@ const Container = styled.div<{}>(({ theme }) => ({
   maxWidth: '100%',
   display: 'flex',
   background: theme.background.content,
-  zIndex: 1,
 }));
 
 export const ActionButton = styled.button<{ disabled: boolean }>(

--- a/lib/components/src/ActionBar/ActionBar.tsx
+++ b/lib/components/src/ActionBar/ActionBar.tsx
@@ -9,6 +9,7 @@ const Container = styled.div<{}>(({ theme }) => ({
   maxWidth: '100%',
   display: 'flex',
   background: theme.background.content,
+  zIndex: 0,
 }));
 
 export const ActionButton = styled.button<{ disabled: boolean }>(


### PR DESCRIPTION
Issue:

## What I did
Removed set z-index from the div that wraps the "Show code" button in a story preview block. I don't wanna get into a fight with z-indeces anywhere - least of all within Storybook. My modals are rendered via portals which should be last in the DOM beating any z indeces; however, in Storybook, those portals are rendered within the preview block's iFrame, meaning they aren't rendered last.

### Before
![Screen Shot 2021-02-26 at 12 55 44 PM](https://user-images.githubusercontent.com/9523719/109354027-07d48c00-7832-11eb-82d3-81262bff057b.png)

### After
![Screen Shot 2021-02-26 at 12 55 32 PM](https://user-images.githubusercontent.com/9523719/109354050-0f943080-7832-11eb-9300-cc1bf0015c8e.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200539748475788/1200567473293920) by [Unito](https://www.unito.io)
