### PR TITLE
Svelte: Fix async loaders in docs panel

### DIFF
--- a/addons/docs/src/frameworks/svelte/HOC.svelte
+++ b/addons/docs/src/frameworks/svelte/HOC.svelte
@@ -1,7 +1,8 @@
 <script>
-  export let storyFn;
-
-  let { Component: component, props } = storyFn();
+  export let storyContext;
+  export let unboundStoryFn;
+      
+  let { Component: component, props } = unboundStoryFn(storyContext);
 </script>
 
 <svelte:component this={component} {...props}/>

--- a/examples/svelte-kitchen-sink/src/stories/__snapshots__/loaders.stories.storyshot
+++ b/examples/svelte-kitchen-sink/src/stories/__snapshots__/loaders.stories.storyshot
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Async Loaders Async Loaders 1`] = `
+<section
+  class="storybook-snapshot-container"
+>
+  <button
+    class="button svelte-n2tx93 rounded"
+  >
+    <strong>
+      Round
+       corners
+    </strong>
+     
+    <br />
+     
+    
+     
+  </button>
+</section>
+`;

--- a/examples/svelte-kitchen-sink/src/stories/loaders.stories.js
+++ b/examples/svelte-kitchen-sink/src/stories/loaders.stories.js
@@ -1,0 +1,16 @@
+import Button from '../components/Button.svelte';
+
+export default {
+  title: 'Async Loaders',
+  component: Button,
+};
+
+export const AsyncLoaders = (args, { loaded: { text } = {} }) => ({
+  Component: Button,
+  props: {
+    ...args,
+    text,
+  },
+});
+
+AsyncLoaders.loaders = [async () => ({ text: 'asynchronous value' })];


### PR DESCRIPTION
Issue:

## What I did

Async loaders work in the preview panel, but not in the documentation panel. This PR fixes it.

However, this PR doesn' fix  tests with storyshot - it's another issue and there is already a PR for that.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? Done
- Does this need an update to the documentation? No
