### PR TITLE
Add Grafana UI to design systems list

### DIFF
--- a/docs/get-started/examples.md
+++ b/docs/get-started/examples.md
@@ -48,6 +48,7 @@ Learn how leading teams build design systems.
 - [AnyVision UI](http://storybook.anyvision.co/)
 - [Skyscanner Backpack](https://backpack.github.io/storybook/)
 - [GitLab UI](https://gitlab-org.gitlab.io/gitlab-ui)
+- [Grafana UI](https://developers.grafana.com/ui/latest/index.html)
 - [PX Blue](https://pxblue-components.github.io/)
 - [Audi](https://react.ui.audi/)
 


### PR DESCRIPTION
## What I did

Added Grafana UI to Design systems examples. I think Grafana fulfills the criteria to be on that list, but I'm also biased. Grafana UI is used by the Grafana core team and is a basis for all the plugin developers. It is a tool for the Grafana community, and the Storybook has been greatly appreciated by the teams working with plugins and UI development. I think it is a prime example of how Storybook can help with open source development and make it easier for people to contribute.