### PR TITLE
Chore: (Docs) Adjustments to controls and writing stories docs.

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -147,6 +147,18 @@ As they can be complex cases:
 
 <!-- prettier-ignore-end -->
 
+Use customized options: 
+
+<!-- <!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/component-story-custom-args-complex-object.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
 Or even with certain types of elements, such as icons:
 
 <!-- prettier-ignore-start -->

--- a/docs/snippets/common/component-story-custom-args-complex-object.js.mdx
+++ b/docs/snippets/common/component-story-custom-args-complex-object.js.mdx
@@ -1,0 +1,22 @@
+```js
+// YourComponent.stories.js | YourComponent.stories.ts
+
+import { YourComponent } from './your-component';
+
+export default {
+  component: YourComponent,
+  title: 'A complex case with a complex options object',
+  //👇 Creates specific argTypes with options
+  argTypes: {
+    someProp: {
+      control: {
+        type: 'select',
+        options: {
+          label1: { item1: true, item2: 1 },
+          'label 2 with spaces': { item1: false, item2: 3 },
+        },
+      },
+    },
+  },
+};
+```

--- a/docs/snippets/react/button-story.with-hooks.js.mdx
+++ b/docs/snippets/react/button-story.with-hooks.js.mdx
@@ -5,8 +5,11 @@ import React, { useState } from 'react';
 
 import { Button } from './Button';
 
+/*
+* Example Button story with React Hooks.
+* See note below related to this example.
+*/
 export const Primary = () => {
-
   // Sets the hooks for both the label and primary props
   const [value, setValue] = useState('Secondary');
   const [isPrimary, setIsPrimary] = useState(false);

--- a/docs/snippets/react/button-story.with-hooks.js.mdx
+++ b/docs/snippets/react/button-story.with-hooks.js.mdx
@@ -1,0 +1,23 @@
+```js
+// Button.stories.js | Button.stories.ts
+
+import React, { useState } from 'react';
+
+import { Button } from './Button';
+
+export const Primary = () => {
+
+  // Sets the hooks for both the label and primary props
+  const [value, setValue] = useState('Secondary');
+  const [isPrimary, setIsPrimary] = useState(false);
+
+  // Sets a click handler to change the label's value
+  const handleOnChange = () => {
+    if (!isPrimary) {
+      setIsPrimary(true);
+      setValue('Primary');
+    }
+  };
+  return <Button primary={isPrimary} onClick={handleOnChange} label={value} />;
+};
+```

--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -49,6 +49,7 @@ Use the _named_ exports of a CSF file to define your component’s stories. We r
   paths={[
     'react/button-story.js.mdx',
     'react/button-story.ts.mdx',
+    'react/button-story.with-hooks.js.mdx',
     'vue/button-story.js.mdx',
     'angular/button-story.ts.mdx',
     'svelte/button-story.js.mdx',

--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -58,6 +58,12 @@ Use the _named_ exports of a CSF file to define your component’s stories. We r
 
 <!-- prettier-ignore-end -->
 
+<div class="aside">
+
+💡 <strong>Note</strong>: Using framework specific elements such as [React Hooks](https://reactjs.org/docs/hooks-intro.html) alongside your stories is a perfectly valid approach, but should be used as an advanced use case. We <strong>recommend</strong> using [args](./args.md) as much as possible when writing your own stories.
+
+</div>
+
 ### Rename stories
 
 You can rename any particular story you need. For instance to give it a clearer name. Here's how you can change the name of the `Primary` story:


### PR DESCRIPTION
With this pull request the documentation is adjusted to include examples on how to use React hooks within a story. But also how to further extend controls and argTypes.

Closes #13056

What was done:
- The page `writing-stories/introduction` was updated to include example with hooks.
- The page `essential/controls` was updated to include another example further expanding how to fully customize controls with argTypes.

Feel free to provide feedback