### PR TITLE
CLI: Add `--legacy-peer-deps` for NPM7 install

### DIFF
--- a/lib/cli/src/js-package-manager/NPMProxy.test.ts
+++ b/lib/cli/src/js-package-manager/NPMProxy.test.ts
@@ -22,26 +22,56 @@ describe('NPM Proxy', () => {
   });
 
   describe('installDependencies', () => {
-    it('should run `npm install`', () => {
-      const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('');
+    describe('npm6', () => {
+      it('should run `npm install`', () => {
+        const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('6.0.0');
 
-      npmProxy.installDependencies();
+        npmProxy.installDependencies();
 
-      expect(executeCommandSpy).toHaveBeenCalledWith('npm', ['install'], expect.any(String));
+        expect(executeCommandSpy).toHaveBeenLastCalledWith('npm', ['install'], expect.any(String));
+      });
+    });
+    describe('npm7', () => {
+      it('should run `npm install --legacy-peer-deps`', () => {
+        const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('7.1.0');
+
+        npmProxy.installDependencies();
+
+        expect(executeCommandSpy).toHaveBeenLastCalledWith(
+          'npm',
+          ['install', '--legacy-peer-deps'],
+          expect.any(String)
+        );
+      });
     });
   });
 
   describe('addDependencies', () => {
-    it('with devDep it should run `npm install -D @storybook/addons`', () => {
-      const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('');
+    describe('npm6', () => {
+      it('with devDep it should run `npm install -D @storybook/addons`', () => {
+        const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('6.0.0');
 
-      npmProxy.addDependencies({ installAsDevDependencies: true }, ['@storybook/addons']);
+        npmProxy.addDependencies({ installAsDevDependencies: true }, ['@storybook/addons']);
 
-      expect(executeCommandSpy).toHaveBeenCalledWith(
-        'npm',
-        ['install', '-D', '@storybook/addons'],
-        expect.any(String)
-      );
+        expect(executeCommandSpy).toHaveBeenLastCalledWith(
+          'npm',
+          ['install', '-D', '@storybook/addons'],
+          expect.any(String)
+        );
+      });
+    });
+    describe('npm7', () => {
+      it('with devDep it should run `npm install -D @storybook/addons`', () => {
+        const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('7.0.0');
+
+        npmProxy.addDependencies({ installAsDevDependencies: true }, ['@storybook/addons']);
+
+        expect(executeCommandSpy).toHaveBeenLastCalledWith(
+          'npm',
+          ['install', '--legacy-peer-deps', '-D', '@storybook/addons'],
+          expect.any(String)
+        );
+      });
     });
   });
 

--- a/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -1,7 +1,10 @@
+import semver from '@storybook/semver';
 import { JsPackageManager } from './JsPackageManager';
 
 export class NPMProxy extends JsPackageManager {
   readonly type = 'npm';
+
+  installArgs: string[] | undefined;
 
   initPackageJson() {
     return this.executeCommand('npm', ['init', '-y']);
@@ -15,8 +18,18 @@ export class NPMProxy extends JsPackageManager {
     return `npm run ${command}`;
   }
 
+  getInstallArgs(): string[] {
+    if (!this.installArgs) {
+      const version = this.executeCommand('npm', ['--version']);
+      this.installArgs = semver.gte(version, '7.0.0')
+        ? ['--legacy-peer-deps', 'install']
+        : ['install'];
+    }
+    return this.installArgs;
+  }
+
   protected runInstall(): void {
-    this.executeCommand('npm', ['install'], 'inherit');
+    this.executeCommand('npm', this.getInstallArgs(), 'inherit');
   }
 
   protected runAddDeps(dependencies: string[], installAsDevDependencies: boolean): void {
@@ -26,7 +39,7 @@ export class NPMProxy extends JsPackageManager {
       args = ['-D', ...args];
     }
 
-    this.executeCommand('npm', ['install', ...args], 'inherit');
+    this.executeCommand('npm', [...this.getInstallArgs(), ...args], 'inherit');
   }
 
   protected runGetVersions<T extends boolean>(

--- a/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -22,7 +22,7 @@ export class NPMProxy extends JsPackageManager {
     if (!this.installArgs) {
       const version = this.executeCommand('npm', ['--version']);
       this.installArgs = semver.gte(version, '7.0.0')
-        ? ['--legacy-peer-deps', 'install']
+        ? ['install', '--legacy-peer-deps']
         : ['install'];
     }
     return this.installArgs;


### PR DESCRIPTION
Issue: #12983

## What I did

Add `--legacy-peer-deps` for NPM7 installs

## How to test

See attached unit tests

I also tested it end-to-end in a sample app:

```
  580  npm init @vitejs/app
  581  cd vite-project/
  582  ~/projects/baseline/storybook/lib/cli/bin/index.js init
```