### PR TITLE
Update installation documentation to troubleshoot issue where user is…

### DIFF
--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -27,7 +27,9 @@ title: 'Install Storybook'
 
 <summary><code>sb init</code> is not made for empty projects</summary>
 
-Storybook needs to be installed into a project that is already setup with a framework. It will not work on an empty project. There are many ways to bootstrap an app in a given framework including:
+Storybook needs to be installed into a project that is already setup with a framework. It will not work on an empty project. Make sure you are in the root directory of your project as well. For example: if you are using angular, run this command in the the directory that your angular.json is. 
+
+There are many ways to bootstrap an app in a given framework including:
 
 - 📦 [Create React App](https://reactjs.org/docs/create-a-new-react-app.html)
 - 📦 [Vue CLI](https://cli.vuejs.org/)


### PR DESCRIPTION
… unable to run the initial command when not on the root directory of their project

Credit: https://github.com/storybookjs/storybook/issues/10549#issuecomment-705536711

Making the user @glutengo's proposed solution.

Issue:

## What I did
Update installation documentation to troubleshoot issue where user cannot run the initial npx sb init command without being in the root directory of their project. If sb is added mid project this could be confusing. 

Please credit the author of this reply: https://github.com/storybookjs/storybook/issues/10549#issuecomment-705536711 for the solution and the proposed change. 

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
