### PR TITLE
Chore: (Docs) Adjusts instructions for yarn/npm.

### DIFF
--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -21,9 +21,7 @@ npm install --save-dev @storybook/addon-essentials
 ```
 
 <div class="aside">
-  
-If you're using <a href="https://yarnpkg.com/">yarn</a>, you'll need to adjust the command accordingly.
-
+💡 <strong>Note</strong>: If you're using <a href="https://yarnpkg.com/">yarn</a> as a package manager, you'll need to adjust the command accordingly. 
 </div>
 
 Update your Storybook configuration (in `.storybook/main.js`) to include the essentials addon.

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -47,9 +47,16 @@ The command above will make the following changes to your local environment:
 
 Depending on your framework, first build your app and then check that everything worked by running:
 
-```shell
-npm run storybook
-```
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-run-dev.npm.js.mdx',
+    'common/storybook-run-dev.yarn.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
 
 It will start Storybook locally and output the address. Depending on your system configuration, it will automatically open the address in a new browser tab and you'll be greeted by a welcome screen.
 

--- a/docs/snippets/common/storybook-run-dev.npm.js.mdx
+++ b/docs/snippets/common/storybook-run-dev.npm.js.mdx
@@ -1,0 +1,4 @@
+```shell
+# Starts Storybook in development mode
+npm run storybook
+```

--- a/docs/snippets/common/storybook-run-dev.yarn.js.mdx
+++ b/docs/snippets/common/storybook-run-dev.yarn.js.mdx
@@ -1,0 +1,4 @@
+```shell
+# Starts Storybook in development mode
+yarn storybook
+```

--- a/docs/workflows/faq.md
+++ b/docs/workflows/faq.md
@@ -12,6 +12,10 @@ Create React App does not allow providing options to Jest in your `package.json`
 npm test -- --coverage --collectCoverageFrom='["src/**/*.{js,jsx}","!src/**/stories/*"]'
 ```
 
+<div class="aside">
+💡 <strong>Note</strong>: If you're using <a href="https://yarnpkg.com/">yarn</a> as a package manager, you'll need to adjust the command accordingly. 
+</div>
+
 ### I see `ReferenceError: React is not defined` when using storybooks with Next.js
 
 Next automatically defines `React` for all of your files via a babel plugin. You must define `React` for JSX to work. You can solve this either by:

--- a/docs/workflows/publish-storybook.md
+++ b/docs/workflows/publish-storybook.md
@@ -19,7 +19,7 @@ npm run build-storybook -- -o ./path/to/build
 ```
 
 <div class="aside">
-💡 <strong>Note</strong>: Be careful when running the  <code>build-storybook</code> in with the <code>-o</code> flag as you might unknowingly overwrite essential files and folders. For instance <strong>avoid</strong> running <code>build-storybook -o ./</code> as this will replace the root project contents with the output of the command. 
+💡 <strong>Note</strong>: Be careful when running the <code>build-storybook</code> command with the <code>-o</code> flag as you might unknowingly overwrite essential files and folders. For instance <strong>avoid</strong> running <code>build-storybook -o ./</code> as this will replace the root project contents with the output of the command. 
 </div>
 
 Storybook will create a static web application at the path you specify. This can be served by any web server. Try it out locally by running:

--- a/docs/workflows/snapshot-testing.md
+++ b/docs/workflows/snapshot-testing.md
@@ -14,6 +14,10 @@ Install the addon. **Make sure** the version of Storyshots and your project’s 
 npm i -D @storybook/addon-storyshots
 ```
 
+<div class="aside">
+💡 <strong>Note</strong>: If you're using <a href="https://yarnpkg.com/">yarn</a> as a package manager, you'll need to adjust the command accordingly. 
+</div>
+
 Configure Storyshots by adding the following test file to your project:
 
 <!-- prettier-ignore-start -->
@@ -63,6 +67,11 @@ You'll need to include the `@storybook/addon-storyshots-puppeteer` and `puppetee
 ```shell
 npm i -D @storybook/addon-storyshots-puppeteer puppeteer
 ```
+
+<div class="aside">
+💡 <strong>Note</strong>: If you're using <a href="https://yarnpkg.com/">yarn</a> as a package manager, you'll need to adjust the command accordingly. 
+</div>
+
 
 Then you'll need to change your `storybook.test.js` file to the following:
 


### PR DESCRIPTION
With this pull request the install page was updated to a reference on how to run Storybook based on the package manager. Amongst other small tweaks.


What was done:
- Created 2 snippets for both yarn and npm for the install page.
- Adjusted the page accordingly
- Polished the workflows page.
- Adjusted the docs with references for yarn case.


Feel free to provide feedback