### PR TITLE
Chore: (Docs) Removes references to --no-dll flag 

### DIFF
--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -42,16 +42,6 @@ Usage: start-storybook [options]
 Usage: build-storybook [options]
 ```
 
-<details>
-
-    <summary><h4>Troubleshooting routing issues with Storybook 6.0</h4></summary>
-
-    If you are building your Storybook and you encounter an issue where you cannot change the route in the sidebar, try building Storybook with the `--no-dll` flag and see if it solves the problem. If so, adjust your `build-storybook` script accordingly to include this flag. We would like to point out that your build process will run slower than usual when using this flag.
-
-    If you want, you can take a look at the following <a href="https://github.com/storybookjs/storybook/issues/11958"> issue </a> to get an in depth description of what is currently happening with your built Storybook.
-
-</details>
-
 | Options                        | Description                                                                                                                                     | Example                                     |
 | ------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------ |
 | -h, --help                     | Output usage information                                                                                                                        | `build-storybook --help`                    |

--- a/docs/workflows/publish-storybook.md
+++ b/docs/workflows/publish-storybook.md
@@ -28,12 +28,6 @@ Storybook will create a static web application at the path you specify. This can
 npx http-server ./path/to/build
 ```
 
-<details>
-    <summary><h4>Troubleshooting routing issues with Storybook 6.0</h4></summary>
-
-    After you've built your Storybook following the instructions outlined above, you encounter an issue where you cannot change the route in the sidebar, try building your Storybook with the `--no-dll` flag and see if it solves the problem. If so adjust your `build-storybook` script accordingly to include this flag. Be advised that the build process will run slower than usual.
-</details>
-
 <div class="aside">
 
 Asides from the `-o` flag, you can also include other flags to build Storybook, for instance if you're using [Docs](../writing-docs/introduction.md), you can append the `--docs` flag and Storybook will build your [MDX](../writing-docs/mdx.md) and [CSF](../writing-stories/introduction.md#component-story-format) stories into a rich and interactive documentation.


### PR DESCRIPTION
With this pull request the references to the usage of --no-dll flag as a means to solve routing issues when building Storybook are removed. 

What was done:
- Publish Storybook and Cli options page was updated to remove the reference to the --no-dll flag as a means to solve routing issues when building Storybook as the issue is now fixed with a recent release.

