### PR TITLE
Chore: (Docs) Adjusts layout parameter documentation

### DIFF
--- a/docs/configure/story-layout.md
+++ b/docs/configure/story-layout.md
@@ -2,7 +2,9 @@
 title: 'Story layout'
 ---
 
-The `layout` [global parameter](../writing-stories/parameters.md) allows you to configure how stories are positioned in Storybook's Canvas tab. 
+The `layout` [parameter](../writing-stories/parameters.md) allows you to configure how stories are positioned in Storybook's Canvas tab. 
+
+## Global layout
 
 You can add the parameter to your [`./storybook/preview.js`](./overview.md#configure-story-rendering), like so:
 
@@ -23,5 +25,34 @@ In the example above, Storybook will center all stories in the UI. `layout` acce
 - `centered`: center the component horizontally and vertically in the Canvas
 - `fullscreen`: allow the component to expand to the full width and height of the Canvas
 - `padded`: Add extra padding around the component
+
+## Component layout
+
+You can also set it at a component level like so:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-component-layout-param.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+## Story layout
+
+Or even apply it to specific stories like so:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-story-layout-param.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
 
 If you want to use your own styles, or require a more granular approach we recommend using [decorators](../writing-stories/decorators.md) instead.

--- a/docs/configure/story-layout.md
+++ b/docs/configure/story-layout.md
@@ -53,6 +53,3 @@ Or even apply it to specific stories like so:
 />
 
 <!-- prettier-ignore-end -->
-
-
-If you want to use your own styles, or require a more granular approach we recommend using [decorators](../writing-stories/decorators.md) instead.

--- a/docs/snippets/common/storybook-component-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-component-layout-param.js.mdx
@@ -1,0 +1,14 @@
+```js
+// Button.stories.js | Button.stories.ts
+
+import Button from './Button';
+
+export default {
+  title: 'Button',
+  component: Button,
+   // Sets the layout parameter component wide. 
+   parameters:{
+    layout:'centered',
+  },
+};
+```

--- a/docs/snippets/common/storybook-story-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-story-layout-param.js.mdx
@@ -1,0 +1,8 @@
+```js
+// Button.stories.js | Button.stories.ts
+
+export const WithLayout = Template.bind({});
+WithLayout.parameters = {
+  layout: 'centered',
+};
+```


### PR DESCRIPTION
With this pull request the configure/story layout documentation is adjusted to mention the layout parameter is not exclusive to  a global approach within `.storybook/preview.js` but it can also be applied on a story basis.

What was done:
- Adjusted `configure/story-layout/`
- Included a couple of examples to demonstrate how to use within a story.

@shilman let me know if this is ok with you.