### PR TITLE
Controls: Fix width of Select control

### DIFF
--- a/lib/components/src/controls/options/Select.tsx
+++ b/lib/components/src/controls/options/Select.tsx
@@ -20,6 +20,7 @@ const styleResets: CSSObject = {
 const OptionsSelect = styled.select(({ theme }) => ({
   ...styleResets,
 
+  boxSizing: 'border-box',
   position: 'relative',
   padding: '6px 10px',
   width: '100%',


### PR DESCRIPTION
Issue:
Select in ArgsTable/ArgsRow had extra width due to the padding, which caused the right border to be cut off.

<img width="1552" alt="Before" src="https://user-images.githubusercontent.com/10190995/110159494-a2d3e580-7d9f-11eb-871d-06ce9c183e16.png">

## What I did
Changed the styling to `box-sizing: border-box`.

## How to test
<img width="1552" alt="After" src="https://user-images.githubusercontent.com/10190995/110159659-dadb2880-7d9f-11eb-88ea-9f03d8019cbf.png">

