### PR TITLE
fix(standalone-react): fix require statement of server options

### DIFF
--- a/app/react/standalone.js
+++ b/app/react/standalone.js
@@ -1,5 +1,5 @@
 const build = require('@storybook/core/standalone');
-const frameworkOptions = require('./dist/server/options').default;
+const frameworkOptions = require('./dist/cjs/server/options').default;
 
 async function buildStandalone(options) {
   return build(options, frameworkOptions);


### PR DESCRIPTION
require statement should specify which compilation distributed in `dist/` should be used to import `server options`

Issue: https://github.com/storybookjs/storybook/issues/13988

## What I did
Fix path in standalone for react to properly resolve server options imported from `dist/` folder

## Pending
If this is the right approach, we will need to apply this solution to the rest of apps: `vue`, `preact` , etc.

## How to test
```javascript
const storybook = require('@storybook/react/standalone');

storybook({
	mode: 'static',
	outputDir: ''
})
```

- Is this testable with Jest or Chromatic screenshots? Once validated the solution I will try to come up with a proposal to test this.
- Does this need a new example in the kitchen sink apps? I don't think so
- Does this need an update to the documentation? I don't think so

If your answer is yes to any of these, please make sure to include it in your PR.
