### PR TITLE
Update sveltedoc-parser to 4.1.0

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -138,7 +138,7 @@
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
     "svelte": "^3.31.2",
-    "sveltedoc-parser": "^3.0.4",
+    "sveltedoc-parser": "^4.1.0",
     "vue": "^2.6.10 || ^3.0.0",
     "webpack": "*"
   },

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -50,7 +50,7 @@
     "react-dom": "16.14.0",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
-    "sveltedoc-parser": "^3.0.5",
+    "sveltedoc-parser": "^4.1.0",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -31556,10 +31556,10 @@ svelte@^3.31.2:
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.32.3.tgz#db0c50c65573ecffe4e2f4924e4862d8f9feda74"
   integrity sha512-5etu/wDwtewhnYO/631KKTjSmFrKohFLWNm1sWErVHXqGZ8eJLqrW0qivDSyYTcN8GbUqsR4LkIhftNFsjNehg==
 
-sveltedoc-parser@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/sveltedoc-parser/-/sveltedoc-parser-3.0.5.tgz#f3d9fe73f3dc9bc07c3dae75318e11cce814c063"
-  integrity sha512-oGBtSvmOGYSfFHYMWOvubjygcXdTxDDToxURYXLJwUcjPMMIgxApi4hwi7DOKz/l68Gl52VaYjSdCNAnRKWaWg==
+sveltedoc-parser@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sveltedoc-parser/-/sveltedoc-parser-4.1.0.tgz#4fddfcd917ae11e2f05bcabbc38c8de63124461e"
+  integrity sha512-m+NUJaKvVIySRnI19ujYEptxIOHwVvTU2GLKZBVqVQ+zZCrOv/H2F4VtRcjhNKQ/Vd+r7WakxfuUTGxNNdMU3A==
   dependencies:
     eslint "7.6.0"
     espree "7.2.0"


### PR DESCRIPTION
Issue: #14162

## What I did

Update sveltedoc-parser to 4.1.0
This version exports now types, I updated the code to use thoses types instead of internals types.


## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
