### PR TITLE
React: Fix fast refresh socket connection error

### DIFF
--- a/app/react/src/server/framework-preset-react.ts
+++ b/app/react/src/server/framework-preset-react.ts
@@ -85,6 +85,14 @@ export async function webpackFinal(config: Configuration, options: Options) {
 
   return {
     ...config,
-    plugins: [...config.plugins, new ReactRefreshWebpackPlugin()],
+    plugins: [
+      ...config.plugins,
+      // Storybook uses webpack-hot-middleware https://github.com/storybookjs/storybook/issues/14114
+      new ReactRefreshWebpackPlugin({
+        overlay: {
+          sockIntegration: 'whm',
+        },
+      }),
+    ],
   };
 }


### PR DESCRIPTION
Issue: #14114 

## What I did

Updated the ReactFastRefreshPlugin config per experiments with @ndelangen @mrmckeb 

self-merging @tooppaaa 

## How to test

Untested. What we did by hand:	

- Install CRA (4.0+)
- Install SB
- See `'ws://localhost:3085/_content/ws' failed: Error during WebSocket handshake: Unexpected response code: 404`
- Patch this fix by hand
- See error fixed
