### PR TITLE
UI: Fix React unique key warning when using renderLabel

### DIFF
--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -20,7 +20,7 @@ export interface Root {
   isComponent: false;
   isRoot: true;
   isLeaf: false;
-  label?: React.ReactNode;
+  renderLabel?: (item: Root) => React.ReactNode;
   startCollapsed?: boolean;
 }
 
@@ -34,7 +34,7 @@ export interface Group {
   isComponent: boolean;
   isRoot: false;
   isLeaf: false;
-  label?: React.ReactNode;
+  renderLabel?: (item: Group) => React.ReactNode;
   // MDX docs-only stories are "Group" type
   parameters?: {
     docsOnly?: boolean;
@@ -53,7 +53,7 @@ export interface Story {
   isComponent: boolean;
   isRoot: false;
   isLeaf: true;
-  label?: React.ReactNode;
+  renderLabel?: (item: Story) => React.ReactNode;
   parameters?: {
     fileName: string;
     options: {
@@ -186,7 +186,7 @@ export const transformStoriesRawToStoriesHash = (
       }
 
       if (root.length && index === 0) {
-        const rootElement: Root = {
+        list.push({
           id,
           name,
           depth: index,
@@ -194,11 +194,11 @@ export const transformStoriesRawToStoriesHash = (
           isComponent: false,
           isLeaf: false,
           isRoot: true,
+          renderLabel,
           startCollapsed: collapsedRoots.includes(id),
-        };
-        list.push({ ...rootElement, label: renderLabel?.(rootElement) });
+        });
       } else {
-        const groupElement: Group = {
+        list.push({
           id,
           name,
           parent,
@@ -207,14 +207,11 @@ export const transformStoriesRawToStoriesHash = (
           isComponent: false,
           isLeaf: false,
           isRoot: false,
+          renderLabel,
           parameters: {
             docsOnly: parameters?.docsOnly,
             viewMode: parameters?.viewMode,
           },
-        };
-        list.push({
-          ...groupElement,
-          label: renderLabel?.(groupElement),
         });
       }
 
@@ -233,15 +230,15 @@ export const transformStoriesRawToStoriesHash = (
       });
     });
 
-    const story: Story = {
+    acc[item.id] = {
       ...item,
       depth: rootAndGroups.length,
       parent: rootAndGroups[rootAndGroups.length - 1].id,
       isLeaf: true,
       isComponent: false,
       isRoot: false,
+      renderLabel,
     };
-    acc[item.id] = { ...story, label: renderLabel?.(story) };
 
     return acc;
   }, {} as StoriesHash);

--- a/lib/ui/src/components/sidebar/Tree.tsx
+++ b/lib/ui/src/components/sidebar/Tree.tsx
@@ -137,7 +137,7 @@ const Node = React.memo<NodeProps>(
             onSelectStoryId(item.id);
           }}
         >
-          {item.label || item.name}
+          {item.renderLabel?.(item) || item.name}
         </LeafNode>
       );
     }
@@ -162,7 +162,7 @@ const Node = React.memo<NodeProps>(
             }}
           >
             <CollapseIcon isExpanded={isExpanded} />
-            {item.label || item.name}
+            {item.renderLabel?.(item) || item.name}
           </CollapseButton>
           {isExpanded && (
             <Action
@@ -205,7 +205,7 @@ const Node = React.memo<NodeProps>(
           if (item.isComponent && !isExpanded) onSelectStoryId(item.id);
         }}
       >
-        {item.label || item.name}
+        {item.renderLabel?.(item) || item.name}
       </BranchNode>
     );
   }


### PR DESCRIPTION
Issue: #14102

## What I did

Somehow React thinks the result of invoking `renderLabel` is an array and logs a 'key prop' warning. I suspect this happened because we were calling the `renderLabel` function outside of a React tree context, passing the result along in the story data before injecting it elsewhere in a React tree. Needless to say the only way I was able to fix it without affecting the user-facing API was by passing the function itself along in the story data and invoking it where we're rendering it. It might actually be more memory efficient because we're passing the same function reference for each story.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
