### PR TITLE
Chore: (Docs): Updates Angular snippets for 6.2

### DIFF
--- a/docs/snippets/angular/app-story-with-mock.ts.mdx
+++ b/docs/snippets/angular/app-story-with-mock.ts.mdx
@@ -10,7 +10,6 @@ export default {
 } as Meta;
 
 const Template: Story<AppComponent> = (args) => ({
-  component: AppComponent,
   props: args,
 });
 

--- a/docs/snippets/angular/button-group-story.ts.mdx
+++ b/docs/snippets/angular/button-group-story.ts.mdx
@@ -8,6 +8,8 @@ import { CommonModule } from '@angular/common';
 
 import ButtonGroup from './ButtonGroup.component';
 import Button from './button.component';
+
+//👇 Imports the Button stories
 import * as ButtonStories from './Button.stories';
 
 export default {
@@ -22,7 +24,6 @@ export default {
 } as Meta;
 
 const Template: Story<ButtonGroup> = (args) => ({
-  component: ButtonGroup,
   props: args,
 });
 

--- a/docs/snippets/angular/button-story-default-docs-code.ts.mdx
+++ b/docs/snippets/angular/button-story-default-docs-code.ts.mdx
@@ -8,22 +8,24 @@ import Button from './button.component';
 export default {
   title: 'Button',
   component: Button,
+  //👇 Creates specific argTypes
   argTypes: {
     backgroundColor: { control: 'color' }
   }
 } as Meta;
 
-// some function to demonstrate the behavior
+//👇 Some function to demonstrate the behavior
 const someFunction = (someValue: string) => {
   return `i am a ${someValue}`;
 };
 
 export const ExampleStory: Story<Button> = (args) => {
+  //👇 Destructure the label from the args object
   const { label } = args;
-  // assigns the function result to a variable and pass it as a prop into the component
+  
+  //👇 Assigns the function result to a variable and pass it as a prop into the component
   const functionResult = someFunction(label);
   return {
-    component: Button,
     props: {
       ...args,
       label: functionResult,

--- a/docs/snippets/angular/button-story-using-args.ts.mdx
+++ b/docs/snippets/angular/button-story-using-args.ts.mdx
@@ -3,12 +3,12 @@
 
 import { Story } from '@storybook/angular/types-6-0';
 
-// We create a “template” of how args map to rendering
+//👇 We create a “template” of how args map to rendering
 const Template: Story<Button> = (args) => ({
-  component: Button,
   props: args,
 });
 
+//👇 Each story then reuses that template
 export const Primary = Template.bind({});
 Primary.args = { background: '#ff0', label: 'Button' };
 

--- a/docs/snippets/angular/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/angular/button-story-with-addon-example.ts.mdx
@@ -8,6 +8,7 @@ import Button from './button.component';
 export default {
   title: 'Button',
   component: Button,
+  //👇 Creates specific parameters for the story
   parameters: {
     myAddon: {
       data: 'this data is passed to the addon',

--- a/docs/snippets/angular/button-story-with-args.ts.mdx
+++ b/docs/snippets/angular/button-story-with-args.ts.mdx
@@ -3,11 +3,12 @@
 
 import { Story } from '@storybook/angular/types-6-0';
 
+//👇 We create a “template” of how args map to rendering
 const Template: Story<Button> = (args) => ({
-  component: Button,
   props: args,
 });
 
+//👇 Each story then reuses that template
 export const Primary = Template.bind({});
 
 Primary.args = {

--- a/docs/snippets/angular/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/angular/button-story-with-blue-args.ts.mdx
@@ -7,7 +7,7 @@ import Button from './button.component';
 
 export default {
   title: 'Button',
-  component: Button,
+  //👇 Creates specific parameters for the story
   parameters: {
     backgrounds: {
       values: [

--- a/docs/snippets/angular/button-test.ts.mdx
+++ b/docs/snippets/angular/button-test.ts.mdx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/angular';
 
 import ButtonComponent from './button.component';
 
+//👇 Imports a specific story for the test
 import { Primary } from './Button.stories';
 
 test('renders the button in the primary state ', async () => {

--- a/docs/snippets/angular/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/angular/list-story-reuse-data.ts.mdx
@@ -1,6 +1,7 @@
 ```ts
 // List.stories.ts
 
+//👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
 
 export const ManyItems: Story<List> = (args) => ({

--- a/docs/snippets/angular/list-story-template.ts.mdx
+++ b/docs/snippets/angular/list-story-template.ts.mdx
@@ -6,10 +6,10 @@ import { Story } from '@storybook/angular/types-6-0';
 import ListComponent from './List.component';
 import ListItemComponent from './ListItem.component';
 
+//👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
 const ListTemplate: Story<ListComponent> = (args) => ({
-  component: ListComponent,
   moduleMetadata: {
     declarations: [ListComponent, ListItemComponent],
   },

--- a/docs/snippets/angular/list-story-unchecked.ts.mdx
+++ b/docs/snippets/angular/list-story-unchecked.ts.mdx
@@ -6,10 +6,10 @@ import { Story } from '@storybook/angular/types-6-0';
 import ListComponent from './List.component';
 import ListItemComponent from './ListItem.component';
 
+//👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
 export const OneItem: Story<ListComponent> = (args) => ({
-  component: ListComponent,
   moduleMetadata: {
     declarations: [ListComponent, ListItemComponent],
   },

--- a/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
@@ -8,7 +8,7 @@ import { ListComponent } from './list.component';
 export default {
   title: 'List',
   component: ListComponent,
-  subcomponents: { ListItemComponent },
+  subcomponents: { ListItemComponent }, //👈 Adds the ListItem component as a subcomponent
 } as Meta;
 
 const Template: Story<ListComponent> = (args) => ({

--- a/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
@@ -10,18 +10,18 @@ export default {
   title: 'Stories',
   component: MyComponent, 
   parameters: {
-    // the viewports object from the Essentials addon
+    //👇 The viewports object from the Essentials addon
     viewport: {
-      // the viewports you want to use
+      /👇 The viewports you want to use
       viewports: INITIAL_VIEWPORTS,
-      // your own default viewport
+
+      //👇 Your own default viewport
       defaultViewport: 'iphone6',
     }
   },
 } as Meta;
 
 export const myStory: Story<MyComponent> = () => ({
-  component: MyComponent,
   template: '<div></div>'
 });
 myStory.parameters = {

--- a/docs/snippets/angular/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/angular/my-component-with-env-variables.ts.mdx
@@ -11,7 +11,6 @@ export default {
 } as Meta;
 
 const Template: Story<MyComponent> = (args) => ({
-  component: MyComponent,
   props: args
 });
 

--- a/docs/snippets/angular/page-story-with-args-composition.ts.mdx
+++ b/docs/snippets/angular/page-story-with-args-composition.ts.mdx
@@ -11,7 +11,7 @@ import DocumentList from './DocumentList.component';
 import DocumentHeader from './DocumentHeader.component';
 import PageLayout from './PageLayout.component';
 
-
+//👇 Imports the required stories
 import * as PageLayoutStories from './PageLayout.stories';
 import * as DocumentHeaderStories from './DocumentHeader.stories';
 import * as DocumentListStories from './DocumentList.stories';
@@ -29,7 +29,6 @@ export default {
 } as Meta;
 
 const Template: Story<DocumentScreen> = (args) => ({
-  component: DocumentScreen,
   props: args,
 });
 

--- a/docs/snippets/angular/page-story.ts.mdx
+++ b/docs/snippets/angular/page-story.ts.mdx
@@ -24,7 +24,6 @@ export default {
 } as Meta;
 
 const Template: Story<Page> = (args) => ({
-  component: Page,
   props: args,
 });
 

--- a/docs/snippets/angular/table-story-fully-customize-controls.ts.mdx
+++ b/docs/snippets/angular/table-story-fully-customize-controls.ts.mdx
@@ -2,7 +2,6 @@
 // Table.stories.ts
 
 const TableStory: Story<TableComponent> = (args) => ({
-  component: TableComponent,
   props: args,
   template: `
     <table>
@@ -19,12 +18,12 @@ const TableStory: Story<TableComponent> = (args) => ({
 
 export const Numeric = TableStory.bind({});
 Numeric.args = {
-  // This arg is for the story component
+  //👇 This arg is for the story component
   data: [
     [1, 2, 3],
     [4, 5, 6],
   ],
-  // The remaining args get passed to the `Table` component
+  //👇 The remaining args get passed to the `Table` component
   size: 'large',
 };
 ```

--- a/docs/snippets/angular/your-component.ts.mdx
+++ b/docs/snippets/angular/your-component.ts.mdx
@@ -5,19 +5,19 @@ import { Meta, Story } from '@storybook/angular';
 
 import { YourComponent } from './your.component';
 
-// This default export determines where your story goes in the story list
+//👇 This default export determines where your story goes in the story list
 export default {
   title: 'YourComponent',
   component: YourComponent,
 } as Meta;
 
+//👇 We create a “template” of how args map to rendering
 const Template: Story<YourComponent> = (args) => ({
-  component: YourComponent,
   props: args,
 });
 
 export const YourStory = Template.bind({});
 YourStory.args = {
-  /* the args you need here will depend on your component */
+  /* 👇 The args you need here will depend on your component */
 };
 ```


### PR DESCRIPTION
With this pull request, the Angular snippets were updated for 6.2 as mentioned in #13749. @shilman based on the feedback you left [here](https://github.com/storybookjs/storybook/pull/13749#issuecomment-769517335) I'm just leaving the documentation label and leave out the patch. Also, I've left out the snippets that were either removed or updated in #14169.


