### PR TITLE
Chore: (Docs) Adjusts links to the addons gallery

### DIFF
--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -9,7 +9,7 @@ title: 'DocsPage'
 </div>
 
 
-When you install [Storybook Docs](https://github.com/storybookjs/storybook/blob/master/addons/docs/README.md), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
+When you install [Storybook Docs](https://storybook.js.org/addons/@storybook/addon-docs), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your stories, text descriptions, docgen comments, args tables, and code examples into a single page for each component.
 
 The best practice for docs is for each component to have its own set of documentation and stories.
 

--- a/docs/writing-docs/introduction.md
+++ b/docs/writing-docs/introduction.md
@@ -27,4 +27,4 @@ You can also create free-form pages for each component using [MDX](./mdx.md), a 
 
 In both cases, you’ll use [Doc Blocks](./doc-blocks.md) as the building blocks to create full featured documentation.
 
-Docs is autoconfigured to work out of the box in most use cases. In some cases you may need or want to tweak the configuration. Read more about it in the [readme](../../addons/docs/README.md).
+Docs is autoconfigured to work out of the box in most use cases. In some cases you may need or want to tweak the configuration. Read more about it [here](https://storybook.js.org/addons/@storybook/addon-docs).


### PR DESCRIPTION
With this pull request, the documentation is updated to point readers to the addons gallery instead of the addon location in the monorepo and with that prevent 404 and issues with branches, such as mentioned in #13347 for instance.

@shilman one thing caught my eye when adjusting the links. It seems that for instance, the Docs addon in the gallery is pulling in Storybook readme as opposed to its own readme file. 
Also one other thing. It seems that searching for `storyshots` in the gallery is only pulling in the puppeteer version of it. Not the `@storybook/addon-storyshots` (searched for that specific and some permutations and didn't pan out).


Feel free to provide feedback

 