### PR TITLE
Chore: (Docs) Adds missing comma in Get started section

### DIFF
--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -15,8 +15,8 @@ Pick a simple component from your project, like a Button, and write a `.stories.
     'angular/your-component.ts.mdx',
     'vue/your-component.2.js.mdx',
     'vue/your-component.3.js.mdx',
-    'svelte/your-component.js.mdx'
-    'web-components/your-component.js.mdx'
+    'svelte/your-component.js.mdx',
+    'web-components/your-component.js.mdx',
   ]}
 />
 


### PR DESCRIPTION
With this pull request a missing comma is added to prevent build failures when using snippets. It follows up #14163.

