### PR TITLE
Addon-docs/Vue: Fix string docgen 

### DIFF
--- a/addons/docs/src/lib/docgen/createPropDef.ts
+++ b/addons/docs/src/lib/docgen/createPropDef.ts
@@ -23,12 +23,18 @@ function createDefaultValue(
   type: DocgenType
 ): PropDefaultValue {
   if (defaultValue != null) {
-    const { value, computed } = defaultValue;
+    const { value, computed, func } = defaultValue;
+
+    console.log(defaultValue);
 
     if (!isDefaultValueBlacklisted(value)) {
       // Work around a bug in `react-docgen-typescript-loader`, which returns 'string' for a string
       // default, instead of "'string'" -- which is incorrect (PR to RDT to follow)
-      if (typeof computed === 'undefined' && type.name === 'string') {
+      if (
+        typeof computed === 'undefined' &&
+        typeof func === 'undefined' &&
+        type.name === 'string'
+      ) {
         return createSummaryValue(JSON.stringify(value));
       }
 

--- a/addons/docs/src/lib/docgen/createPropDef.ts
+++ b/addons/docs/src/lib/docgen/createPropDef.ts
@@ -25,7 +25,6 @@ function createDefaultValue(
   if (defaultValue != null) {
     const { value, computed, func } = defaultValue;
 
-    console.log(defaultValue);
 
     if (!isDefaultValueBlacklisted(value)) {
       // Work around a bug in `react-docgen-typescript-loader`, which returns 'string' for a string

--- a/addons/docs/src/lib/docgen/extractDocgenProps.test.ts
+++ b/addons/docs/src/lib/docgen/extractDocgenProps.test.ts
@@ -93,6 +93,25 @@ TypeSystems.forEach((x) => {
         expect(propDef.required).toBe(false);
         expect(propDef.defaultValue.summary).toBe('"Default"');
       });
+
+      it('should map defaults docgen info properly, vue', () => {
+        const component = createComponent({
+          ...createStringType(x),
+          description: 'Hey! Hey!',
+          defaultValue: {
+            value: "'Default'",
+            func: false,
+          },
+        });
+
+        const { propDef } = extractComponentProps(component, DOCGEN_SECTION)[0];
+
+        expect(propDef.name).toBe(PROP_NAME);
+        expect(propDef.type.summary).toBe('string');
+        expect(propDef.description).toBe('Hey! Hey!');
+        expect(propDef.required).toBe(false);
+        expect(propDef.defaultValue.summary).toBe("'Default'");
+      });
     }
 
     it('should remove JSDoc tags from the description', () => {

--- a/addons/docs/src/lib/docgen/types.ts
+++ b/addons/docs/src/lib/docgen/types.ts
@@ -33,6 +33,7 @@ export interface DocgenTypeScriptType extends DocgenType {}
 export interface DocgenPropDefaultValue {
   value: string;
   computed?: boolean;
+  func?: boolean;
 }
 
 export interface DocgenInfo {

--- a/examples/vue-3-cli/src/stories/Button.vue
+++ b/examples/vue-3-cli/src/stories/Button.vue
@@ -1,5 +1,7 @@
 <template>
-  <button type="button" :class="classes" @click="onClick" :style="style">{{ label }}</button>
+  <button type="button" :class="classes" @click="onClick" :style="style">
+    {{ label }} - {{ sublabel }}
+  </button>
 </template>
 
 <script lang="typescript">
@@ -13,6 +15,10 @@ export default {
     label: {
       type: String,
       required: true,
+    },
+    sublabel: {
+      type: String,
+      default: 'sublabel',
     },
     primary: {
       type: Boolean,


### PR DESCRIPTION
Issue: #14056

## What I did

Ensure we don't accidentally try and fix `react-docgen-typescript` when we are in *vue*

## How to test

1. There is a test for what the input looks like in vue3
2. There is also a story in vue3, although it should be noted we don't current ever look at these stories :/