### PR TITLE
Addon-docs: Fix source block error on dynamically-generated stories

### DIFF
--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -20,6 +20,9 @@ const extract = (targetId: string, { source, locationsMap }: StorySource) => {
 
   const sanitizedStoryName = storyIdToSanitizedStoryName(targetId);
   const location = locationsMap[sanitizedStoryName];
+  if (!location) {
+    return source;
+  }
   const lines = source.split('\n');
 
   return extractSource(location, lines);


### PR DESCRIPTION
Issue:
Docs page throw an error `Cannot read property 'startBody' of undefined` when using generated stories because it cannot get its source code from locationsMap.

```
TypeError
Cannot read property 'startBody' of undefined
Call Stack
 extractSource  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:87896:24
 extract  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:64109:43
 enhanceSource  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:64126:15
 getSnippet  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:63520:51
 undefined  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:63537:14
 getSourceProps  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:63534:24
 getPreviewProps  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:62648:48
 Canvas  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:62661:22
 renderWithHooks  vendors~main.3cb0f4d0aaa9b1174e6e.bundle.js:250003:18
```

## What I did
The fix is using the same simple fallback to the whole story file code same as when locationsMap is not passed from caller few lines above.

## How to test
To simulate the situation it requires quite specific situation where we generate stories based on api response. (Note everything works well for us this way except the docs throw mentioned error).

story:
```ts
export default {
   title: "Some Title"
}

export const Default = () => <Component />

generateStories("Some Title", Default)
```
```ts
async function generateStories(title, BaseStory) {
   const data = await (await fetch("...")).json()
   storyStore?.startConfiguring()
   const stories = storiesOf(title, module)
   for(const item of data) {
       stories.add(title, BaseStory, {
           providedData: item 
       })
   }
   storyStore?.finishConfiguring()
}
```

- Is this testable with Jest or Chromatic screenshots? (nope)
- Does this need a new example in the kitchen sink apps? (nope)
- Does this need an update to the documentation? (nope)

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
