### PR TITLE
Angular: Improve story rendering mode

### DIFF
--- a/examples/angular-cli/.storybook/preview.ts
+++ b/examples/angular-cli/.storybook/preview.ts
@@ -39,4 +39,18 @@ export const globalTypes = {
       ],
     },
   },
+  locale: {
+    name: 'Locale',
+    description: 'Internationalization locale',
+    defaultValue: 'en',
+    toolbar: {
+      icon: 'globe',
+      items: [
+        { value: 'en', right: '🇺🇸', title: 'English' },
+        { value: 'es', right: '🇪🇸', title: 'Español' },
+        { value: 'zh', right: '🇨🇳', title: '中文' },
+        { value: 'kr', right: '🇰🇷', title: '한국어' },
+      ],
+    },
+  },
 };

--- a/examples/angular-cli/src/stories/addons/toolbars/locales/__snapshots__/locales.stories.storyshot
+++ b/examples/angular-cli/src/stories/addons/toolbars/locales/__snapshots__/locales.stories.storyshot
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Addons / Toolbars / Locales With Angular Service 1`] = `
+<storybook-wrapper>
+   Your locale is en<br /> I say: Hello 
+</storybook-wrapper>
+`;

--- a/examples/angular-cli/src/stories/addons/toolbars/locales/locales.stories.ts
+++ b/examples/angular-cli/src/stories/addons/toolbars/locales/locales.stories.ts
@@ -1,0 +1,48 @@
+import { DecoratorFunction } from '@storybook/addons';
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { Story } from '@storybook/angular/types-6-0';
+
+import { TranslatePipe } from './translate.pipe';
+import { DEFAULT_LOCALE } from './translate.service';
+
+const withLocaleProvider: DecoratorFunction<unknown> = (storyFunc, context) => {
+  const { locale } = context.globals;
+
+  // uses `moduleMetadata` decorator to cleanly add locale provider into module metadata
+
+  // It is also possible to do it directly in story with
+  // ```
+  // const sotry = storyFunc();
+  // sotry.moduleMetadata = {
+  //   ...sotry.moduleMetadata,
+  //   providers: [
+  //     ...(sotry.moduleMetadata?.providers ?? []),
+  //     { provide: DEFAULT_LOCALE, useValue: locale },
+  //   ],
+  // };
+  // return sotry;
+  // ```
+  // but more verbose
+
+  return moduleMetadata({ providers: [{ provide: DEFAULT_LOCALE, useValue: locale }] })(
+    storyFunc,
+    context
+  );
+};
+
+export default {
+  title: 'Addons / Toolbars / Locales',
+  decorators: [withLocaleProvider, moduleMetadata({ declarations: [TranslatePipe] })],
+} as Meta;
+
+export const WithAngularService: Story = (_args, { globals: { locale } }) => {
+  return {
+    template: `
+      Your locale is {{ locale }}<br>
+      I say: {{ 'hello' | translate }}
+    `,
+    props: {
+      locale,
+    },
+  };
+};

--- a/examples/angular-cli/src/stories/addons/toolbars/locales/translate.pipe.ts
+++ b/examples/angular-cli/src/stories/addons/toolbars/locales/translate.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TranslateService } from './translate.service';
+
+@Pipe({
+  name: 'translate',
+})
+export class TranslatePipe implements PipeTransform {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(private readonly translateService: TranslateService) {}
+
+  transform(value: string): string {
+    return `${this.translateService.getTranslation(value)}`;
+  }
+}

--- a/examples/angular-cli/src/stories/addons/toolbars/locales/translate.service.ts
+++ b/examples/angular-cli/src/stories/addons/toolbars/locales/translate.service.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+
+export const DEFAULT_LOCALE = new InjectionToken<string>('test');
+
+@Injectable({ providedIn: 'root' })
+export class TranslateService {
+  private locale = 'en';
+
+  private translation = {
+    en: { hello: 'Hello' },
+    es: { hello: 'Hola!' },
+    fr: { hello: 'Bonjour!' },
+    kr: { hello: '안녕하세요!' },
+    zh: { hello: '你好!' },
+  };
+
+  constructor(@Inject(DEFAULT_LOCALE) defaultLocale: string | null) {
+    if (defaultLocale) {
+      this.setLocale(defaultLocale);
+    }
+  }
+
+  setLocale(locale) {
+    this.locale = locale;
+  }
+
+  getTranslation(key: string) {
+    return this.translation[this.locale][key] ?? key;
+  }
+}

--- a/examples/angular-cli/src/stories/addons/toolbars/locales/translate.service.ts
+++ b/examples/angular-cli/src/stories/addons/toolbars/locales/translate.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import { Inject, Injectable, InjectionToken } from '@angular/core';
 
 export const DEFAULT_LOCALE = new InjectionToken<string>('test');
 

--- a/examples/angular-cli/src/stories/core/parameters/__snapshots__/all-parameters.stories.storyshot
+++ b/examples/angular-cli/src/stories/core/parameters/__snapshots__/all-parameters.stories.storyshot
@@ -43,6 +43,36 @@ exports[`Storyshots Core / Parameters / All parameters All parameters passed to 
             }
           ]
         }
+      },
+      "locale": {
+        "name": "Locale",
+        "description": "Internationalization locale",
+        "defaultValue": "en",
+        "toolbar": {
+          "icon": "globe",
+          "items": [
+            {
+              "value": "en",
+              "right": "🇺🇸",
+              "title": "English"
+            },
+            {
+              "value": "es",
+              "right": "🇪🇸",
+              "title": "Español"
+            },
+            {
+              "value": "zh",
+              "right": "🇨🇳",
+              "title": "中文"
+            },
+            {
+              "value": "kr",
+              "right": "🇰🇷",
+              "title": "한국어"
+            }
+          ]
+        }
       }
     },
     "globalParameter": "globalParameter",

--- a/examples/angular-cli/src/stories/others/ngx-translate/README.stories.mdx
+++ b/examples/angular-cli/src/stories/others/ngx-translate/README.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # [ngx-translate](https://github.com/ngx-translate/core)
 
-> No real example here to avoid adding more dependency to sotrybook mono repository
+> No real example here to avoid adding more dependency to storybook mono repository
 
 There are several ways to configure ngx-translate in storybook which will depend on your context.
 

--- a/examples/angular-cli/src/stories/others/ngx-translate/README.stories.mdx
+++ b/examples/angular-cli/src/stories/others/ngx-translate/README.stories.mdx
@@ -1,0 +1,58 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Others / ngx-translate / Readme" />
+
+# [ngx-translate](https://github.com/ngx-translate/core)
+
+> No real example here to avoid adding more dependency to sotrybook mono repository
+
+There are several ways to configure ngx-translate in storybook which will depend on your context.
+
+Here is a simple example with a storybook decorator that you can place in the `preview.ts` or locally on the stories.
+[See the doc on decorators](https://storybook.js.org/docs/angular/writing-stories/decorators)
+
+```ts
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { moduleMetadata } from '@storybook/angular';
+
+function createTranslateLoader(http: HttpClient) {
+  return new TranslateHttpLoader(http, '/assets/i18n/', '.json');
+}
+
+const TranslateModuleDecorator = (storyFunc, context) => {
+  const { locale } = context.globals;
+
+  return moduleMetadata({
+    imports: [
+      HttpClientModule,
+      TranslateModule.forRoot({
+        defaultLanguage: locale,
+        loader: {
+          provide: TranslateLoader,
+          useFactory: createTranslateLoader,
+          deps: [HttpClient],
+        },
+      }),
+    ],
+  })(storyFunc, context);
+};
+
+// for `preview.ts`
+export const decorators = [TranslateModuleDecorator];
+```
+
+If the `TranslateModule.forRoot` is made by another module you can try to set this provider `DEFAULT_LANGUAGE`
+
+```ts
+import { DEFAULT_LANGUAGE } from '@ngx-translate/core';
+
+const TranslateModuleDecorator = (storyFunc, context) => {
+  const { locale } = context.globals;
+
+  return moduleMetadata({
+    providers: [{ provide: DEFAULT_LANGUAGE, useValue: locale }],
+  })(storyFunc, context);
+};
+```


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13791 https://github.com/storybookjs/storybook/issues/6541

## What I did

Currently angular renderer executes completely the first time and then considers that all the next changes of the story only concern the components  (or template) properties  of the story.
But in some cases it also affects the module metadata. And in other cases you have to disable this optimization because it is not possible

This PR adds a verification of the change of the structure of the module metadata

## How to test

- Is this testable with Jest or Chromatic screenshots? ✅

- Does this need a new example in the kitchen sink apps? ✅

- Does this need an update to the documentation? 🤷‍♂️
Not sure. May be on [Consuming globals from within a story
](https://storybook.js.org/docs/angular/essentials/toolbars-and-globals#consuming-globals-from-within-a-story)
my-component-story-use-globaltype-backwards-compat
my-component-story-use-globaltype
