### PR TITLE
Addon-docs/Vue,Vue3: Fix preset options for vue-docgen-api

### DIFF
--- a/addons/docs/src/frameworks/vue/preset.ts
+++ b/addons/docs/src/frameworks/vue/preset.ts
@@ -1,4 +1,16 @@
 export function webpackFinal(webpackConfig: any = {}, options: any = {}) {
+  let vueDocgenOptions = {};
+
+  options.presetsList.forEach((preset: any) => {
+    if (preset.name.includes('addon-docs') && preset.options.vueDocgenOptions) {
+      const appendableOptions = preset.options.vueDocgenOptions;
+      vueDocgenOptions = {
+        ...vueDocgenOptions,
+        ...appendableOptions,
+      };
+    }
+  });
+
   webpackConfig.module.rules.push({
     test: /\.vue$/,
     loader: require.resolve('vue-docgen-loader', { paths: [require.resolve('@storybook/vue')] }),
@@ -6,7 +18,7 @@ export function webpackFinal(webpackConfig: any = {}, options: any = {}) {
     options: {
       docgenOptions: {
         alias: webpackConfig.resolve.alias,
-        ...options.vueDocgenOptions,
+        ...vueDocgenOptions,
       },
     },
   });

--- a/addons/docs/src/frameworks/vue/preset.ts
+++ b/addons/docs/src/frameworks/vue/preset.ts
@@ -1,19 +1,9 @@
-interface Preset {
-  readonly name: string;
-  readonly options: any;
-}
+import type { Options } from '@storybook/core-common';
 
-interface PresetOptions {
-  readonly presetsList: Preset[];
-}
-
-export function webpackFinal(
-  webpackConfig: any = {},
-  options: PresetOptions = { presetsList: [] }
-) {
+export function webpackFinal(webpackConfig: any = {}, options: Options) {
   let vueDocgenOptions = {};
 
-  options.presetsList.forEach((preset) => {
+  options.presetsList?.forEach((preset) => {
     if (preset.name.includes('addon-docs') && preset.options.vueDocgenOptions) {
       const appendableOptions = preset.options.vueDocgenOptions;
       vueDocgenOptions = {

--- a/addons/docs/src/frameworks/vue/preset.ts
+++ b/addons/docs/src/frameworks/vue/preset.ts
@@ -1,7 +1,19 @@
-export function webpackFinal(webpackConfig: any = {}, options: any = {}) {
+interface Preset {
+  readonly name: string;
+  readonly options: any;
+}
+
+interface PresetOptions {
+  readonly presetsList: Preset[];
+}
+
+export function webpackFinal(
+  webpackConfig: any = {},
+  options: PresetOptions = { presetsList: [] }
+) {
   let vueDocgenOptions = {};
 
-  options.presetsList.forEach((preset: any) => {
+  options.presetsList.forEach((preset) => {
     if (preset.name.includes('addon-docs') && preset.options.vueDocgenOptions) {
       const appendableOptions = preset.options.vueDocgenOptions;
       vueDocgenOptions = {

--- a/addons/docs/src/frameworks/vue3/preset.ts
+++ b/addons/docs/src/frameworks/vue3/preset.ts
@@ -1,4 +1,18 @@
-export function webpackFinal(webpackConfig: any = {}, options: any = {}) {
+import type { Options } from '@storybook/core-common';
+
+export function webpackFinal(webpackConfig: any = {}, options: Options) {
+  let vueDocgenOptions = {};
+
+  options.presetsList?.forEach((preset) => {
+    if (preset.name.includes('addon-docs') && preset.options.vueDocgenOptions) {
+      const appendableOptions = preset.options.vueDocgenOptions;
+      vueDocgenOptions = {
+        ...vueDocgenOptions,
+        ...appendableOptions,
+      };
+    }
+  });
+
   webpackConfig.module.rules.push({
     test: /\.vue$/,
     loader: require.resolve('vue-docgen-loader', { paths: [require.resolve('@storybook/vue3')] }),
@@ -6,7 +20,7 @@ export function webpackFinal(webpackConfig: any = {}, options: any = {}) {
     options: {
       docgenOptions: {
         alias: webpackConfig.resolve.alias,
-        ...options.vueDocgenOptions,
+        ...vueDocgenOptions,
       },
     },
   });


### PR DESCRIPTION
Issue: #9695

As of pull request #9699,  it is possible to provide `addon-docs` a `vueDocGenOptions` parameter, which is supposed to fix issue #9695. Unfortunately, as stated in the issue, this is not working properly. @pocka started debugging and noticed that `options.vueDocgenOptions` returns `undefined`. I went a little bit further by browsing the whole `options` object to find any occurrence of my custom configuration defined in Storybook's `main.js` file.

I found it within the `options.presetsList` array. Please note there are actually two presets related to `addon-blocks`:

````js
[
  ...otherPresets,
  {
    name: 'project\node_modules\@storybook\addon-docs\dist\frameworks\common\preset.js',
    options: {
      vueDocgenOptions: {
        /** My custom vue-docgen-api configuration is found here. */
      }
    },
    preset: {},
  },
  {
    name: 'project\node_modules\@storybook\addon-docs\dist\frameworks\vue\preset.js',
    options: {},
    preset: {},
  },
],
````

## What I did

I basically defined an option object for vue-docgen-api and merged all preset options matching `adddon-docs` and containing a `vueDocgenOptions` key into this object. The option object is then passed to `vue-docgen-loader`'s `options.docgenOptions`.

There is likely a better and cleaner way to fix it, but this is all I came up with given my relatively poor knowledge regarding storybook addons configuration.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no