### PR TITLE
Angular: Allow usage of all component valid selectors

### DIFF
--- a/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.test.ts
+++ b/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.test.ts
@@ -29,6 +29,102 @@ describe('angular source decorator', () => {
     });
   });
 
+  describe('with component with attribute selector', () => {
+    @Component({
+      selector: 'doc-button[foo]',
+      template: '<button></button>',
+    })
+    class WithAttributeComponent {}
+
+    it('should add attribute to template', async () => {
+      const component = WithAttributeComponent;
+      const props = {};
+      const argTypes: ArgTypes = {};
+      const source = computesTemplateSourceFromComponent(component, props, argTypes);
+      expect(source).toEqual(`<doc-button foo></doc-button>`);
+    });
+  });
+
+  describe('with component with attribute and value selector', () => {
+    @Component({
+      selector: 'doc-button[foo=bar]',
+      template: '<button></button>',
+    })
+    class WithAttributeValueComponent {}
+
+    it('should add attribute to template', async () => {
+      const component = WithAttributeValueComponent;
+      const props = {};
+      const argTypes: ArgTypes = {};
+      const source = computesTemplateSourceFromComponent(component, props, argTypes);
+      expect(source).toEqual(`<doc-button foo="bar"></doc-button>`);
+    });
+  });
+
+  describe('with component with attribute only selector', () => {
+    @Component({
+      selector: '[foo]',
+      template: '<button></button>',
+    })
+    class WithAttributeOnlyComponent {}
+
+    it('should create a div and add attribute to template', async () => {
+      const component = WithAttributeOnlyComponent;
+      const props = {};
+      const argTypes: ArgTypes = {};
+      const source = computesTemplateSourceFromComponent(component, props, argTypes);
+      expect(source).toEqual(`<div foo></div>`);
+    });
+  });
+
+  describe('with component with class selector', () => {
+    @Component({
+      selector: 'doc-button.foo',
+      template: '<button></button>',
+    })
+    class WithClassComponent {}
+
+    it('should add class to template', async () => {
+      const component = WithClassComponent;
+      const props = {};
+      const argTypes: ArgTypes = {};
+      const source = computesTemplateSourceFromComponent(component, props, argTypes);
+      expect(source).toEqual(`<doc-button class="foo"></doc-button>`);
+    });
+  });
+
+  describe('with component with class only selector', () => {
+    @Component({
+      selector: '.foo',
+      template: '<button></button>',
+    })
+    class WithClassComponent {}
+
+    it('should create a div and add attribute to template', async () => {
+      const component = WithClassComponent;
+      const props = {};
+      const argTypes: ArgTypes = {};
+      const source = computesTemplateSourceFromComponent(component, props, argTypes);
+      expect(source).toEqual(`<div class="foo"></div>`);
+    });
+  });
+
+  describe('with component with multiple selectors', () => {
+    @Component({
+      selector: 'doc-button, doc-button2',
+      template: '<button></button>',
+    })
+    class WithMultipleSelectorsComponent {}
+
+    it('should use the first selector', async () => {
+      const component = WithMultipleSelectorsComponent;
+      const props = {};
+      const argTypes: ArgTypes = {};
+      const source = computesTemplateSourceFromComponent(component, props, argTypes);
+      expect(source).toEqual(`<doc-button></doc-button>`);
+    });
+  });
+
   describe('no argTypes', () => {
     it('should generate tag-only template with no props', () => {
       const component = InputComponent;

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/__snapshots__/multiple-selector.component.stories.storyshot
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/__snapshots__/multiple-selector.component.stories.storyshot
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Basics / Component / With Complex Selectors attribute selectors 1`] = `
+<storybook-wrapper>
+  <storybook-attribute-selector
+    foo=""
+  >
+    <p>
+      Attribute selector
+    </p>
+  </storybook-attribute-selector>
+</storybook-wrapper>
+`;
+
+exports[`Storyshots Basics / Component / With Complex Selectors attribute value selectors 1`] = `
+<storybook-wrapper>
+  <storybook-attribute-value-selector
+    foo="bar"
+  >
+    <p>
+      Attribute with value
+    </p>
+  </storybook-attribute-value-selector>
+</storybook-wrapper>
+`;
+
+exports[`Storyshots Basics / Component / With Complex Selectors multiple selectors 1`] = `
+<storybook-wrapper>
+  <storybook-multiple-selector>
+    <p>
+      Multiple selector
+    </p>
+  </storybook-multiple-selector>
+</storybook-wrapper>
+`;

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/__snapshots__/multiple-selector.component.stories.storyshot
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/__snapshots__/multiple-selector.component.stories.storyshot
@@ -1,25 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Basics / Component / With Complex Selectors Input Selectors 1`] = `
+<storybook-wrapper>
+  <foo>
+    foo
+  </foo>
+</storybook-wrapper>
+`;
+
 exports[`Storyshots Basics / Component / With Complex Selectors attribute selectors 1`] = `
 <storybook-wrapper>
   <storybook-attribute-selector
-    foo=""
+    foo="bar"
   >
-    <p>
+    <h3>
       Attribute selector
-    </p>
+    </h3>
+     Selector: "storybook-attribute-selector[foo=bar]" 
+    <br />
+     Generated template: "&lt;storybook-attribute-selector foo="bar"&gt;&lt;/storybook-attribute-selector&gt;" 
   </storybook-attribute-selector>
 </storybook-wrapper>
 `;
 
-exports[`Storyshots Basics / Component / With Complex Selectors attribute value selectors 1`] = `
+exports[`Storyshots Basics / Component / With Complex Selectors class selectors 1`] = `
 <storybook-wrapper>
   <storybook-attribute-value-selector
-    foo="bar"
+    class="foo"
   >
-    <p>
-      Attribute with value
-    </p>
+    <h3>
+      Class selector
+    </h3>
+     Selector: "storybook-class-selector.foo" 
+    <br />
+     Generated template: "&lt;storybook-class-selector class="bar"&gt;&lt;/storybook-class-selector&gt;" 
   </storybook-attribute-value-selector>
 </storybook-wrapper>
 `;
@@ -27,9 +41,12 @@ exports[`Storyshots Basics / Component / With Complex Selectors attribute value 
 exports[`Storyshots Basics / Component / With Complex Selectors multiple selectors 1`] = `
 <storybook-wrapper>
   <storybook-multiple-selector>
-    <p>
+    <h3>
       Multiple selector
-    </p>
+    </h3>
+     Selector: "storybook-multiple-selector, storybook-multiple-selector2" 
+    <br />
+     Generated template: "&lt;storybook-multiple-selector&gt;&lt;/storybook-multiple-selector&gt;" 
   </storybook-multiple-selector>
 </storybook-wrapper>
 `;

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/attribute-selector.component.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/attribute-selector.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'storybook-attribute-selector[foo]',
-  template: '<p>Attribute selector</p>',
+  selector: 'storybook-attribute-selector[foo=bar]',
+  template: `<h3>Attribute selector</h3>
+    Selector: "storybook-attribute-selector[foo=bar]" <br />
+    Generated template: "&lt;storybook-attribute-selector
+    foo="bar">&lt;/storybook-attribute-selector>" `,
 })
 export class AttributeSelectorComponent {}

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/attribute-selector.component.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/attribute-selector.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'storybook-attribute-selector[foo]',
+  template: '<p>Attribute selector</p>',
+})
+export class AttributeSelectorComponent {}

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/attributewithvalue-selector.component.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/attributewithvalue-selector.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'storybook-attribute-value-selector[foo=bar]',
+  template: '<p>Attribute with value</p>',
+})
+export class AttributeWithValueSelectorComponent {}

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/attributewithvalue-selector.component.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/attributewithvalue-selector.component.ts
@@ -1,7 +1,0 @@
-import { Component } from '@angular/core';
-
-@Component({
-  selector: 'storybook-attribute-value-selector[foo=bar]',
-  template: '<p>Attribute with value</p>',
-})
-export class AttributeWithValueSelectorComponent {}

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/class-selector.component.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/class-selector.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'storybook-attribute-value-selector.foo',
+  template: `<h3>Class selector</h3>
+    Selector: "storybook-class-selector.foo" <br />
+    Generated template: "&lt;storybook-class-selector class="bar">&lt;/storybook-class-selector>" `,
+})
+export class ClassSelectorComponent {}

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/multiple-selector.component.stories.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/multiple-selector.component.stories.ts
@@ -1,6 +1,6 @@
 import { MultipleSelectorComponent } from './multiple-selector.component';
 import { AttributeSelectorComponent } from './attribute-selector.component';
-import { AttributeWithValueSelectorComponent } from './attributewithvalue-selector.component';
+import { ClassSelectorComponent } from './class-selector.component';
 
 export default {
   title: 'Basics / Component / With Complex Selectors',
@@ -20,9 +20,9 @@ AttributeSelectors.parameters = {
   component: AttributeSelectorComponent,
 };
 
-export const AttributeValueSelectors = () => ({});
+export const ClassSelectors = () => ({});
 
-AttributeValueSelectors.storyName = 'attribute value selectors';
-AttributeValueSelectors.parameters = {
-  component: AttributeWithValueSelectorComponent,
+ClassSelectors.storyName = 'class selectors';
+ClassSelectors.parameters = {
+  component: ClassSelectorComponent,
 };

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/multiple-selector.component.stories.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/multiple-selector.component.stories.ts
@@ -1,0 +1,28 @@
+import { MultipleSelectorComponent } from './multiple-selector.component';
+import { AttributeSelectorComponent } from './attribute-selector.component';
+import { AttributeWithValueSelectorComponent } from './attributewithvalue-selector.component';
+
+export default {
+  title: 'Basics / Component / With Complex Selectors',
+};
+
+export const MultipleSelectors = () => ({});
+
+MultipleSelectors.storyName = 'multiple selectors';
+MultipleSelectors.parameters = {
+  component: MultipleSelectorComponent,
+};
+
+export const AttributeSelectors = () => ({});
+
+AttributeSelectors.storyName = 'attribute selectors';
+AttributeSelectors.parameters = {
+  component: AttributeSelectorComponent,
+};
+
+export const AttributeValueSelectors = () => ({});
+
+AttributeValueSelectors.storyName = 'attribute value selectors';
+AttributeValueSelectors.parameters = {
+  component: AttributeWithValueSelectorComponent,
+};

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/multiple-selector.component.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/multiple-selector.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'storybook-multiple-selector, storybook-multiple-selector2',
+  template: '<p>Multiple selector</p>',
+})
+export class MultipleSelectorComponent {}

--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/multiple-selector.component.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/multiple-selector.component.ts
@@ -2,6 +2,8 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'storybook-multiple-selector, storybook-multiple-selector2',
-  template: '<p>Multiple selector</p>',
+  template: `<h3>Multiple selector</h3>
+    Selector: "storybook-multiple-selector, storybook-multiple-selector2" <br />
+    Generated template: "&lt;storybook-multiple-selector>&lt;/storybook-multiple-selector>" `,
 })
 export class MultipleSelectorComponent {}


### PR DESCRIPTION
Issue: #14079

## What I did

Added checks for all valid angular directive/component selectors to allow templates to be generated correctly.  

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
Tests added

- Does this need a new example in the kitchen sink apps?
Possibly. Examples added but they don't show much. Could be removed?

- Does this need an update to the documentation?
No
