### PR TITLE
Docs: Add code snippets for Web Component

### DIFF
--- a/docs/configure/environment-variables.md
+++ b/docs/configure/environment-variables.md
@@ -49,6 +49,7 @@ Then you can access this environment variable anywhere, even within your stories
     'vue/my-component-with-env-variables.2.js.mdx',
     'vue/my-component-with-env-variables.3.js.mdx',
     'angular/my-component-with-env-variables.ts.mdx',
+    'web-components/my-component-with-env-variables.js.mdx',
   ]}
 />
 

--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -123,6 +123,7 @@ You can change your story through [parameters](../writing-stories/parameters.md)
     'react/my-component-story-configure-viewports.mdx.mdx',
     'vue/my-component-story-configure-viewports.js.mdx',
     'angular/my-component-story-configure-viewports.ts.mdx',
+    'web-components/my-component-story-configure-viewports.js.mdx',
   ]}
 />
 

--- a/docs/snippets/web-components/button-group-story.js.mdx
+++ b/docs/snippets/web-components/button-group-story.js.mdx
@@ -1,0 +1,26 @@
+```js
+// demo-button-group.stories.js
+
+import { html } from 'lit-html';
+
+import './demo-button-group';
+
+//👇 Imports the Button stories
+import * as ButtonStories from './demo-button.stories';
+
+export default {
+  title: 'ButtonGroup',
+};
+
+const Template = ({ buttons, orientation }) => {
+  return html`
+    <demo-button-group .buttons=${buttons} .orientation=${orientation}></demo-button-group>
+  `;
+};
+
+export const Pair = Template.bind({});
+Pair.args = {
+  buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
+  orientation: 'horizontal',
+};
+```

--- a/docs/snippets/web-components/list-story-expanded.js.mdx
+++ b/docs/snippets/web-components/list-story-expanded.js.mdx
@@ -1,0 +1,32 @@
+```js
+// demo-list.stories.js
+
+import { html } from 'lit-html';
+
+import './demo-list';
+import './demo-list-item';
+
+export default {
+  title: 'List',
+};
+
+export const Empty = (args) => html`<demo-list></demo-list>`;
+
+export const OneItem = (args) => {
+  return html`
+    <demo-list>
+      <demo-list-item></demo-list-item>
+    </demo-list>
+  `;
+};
+
+export const ManyItems = (args) => {
+  return html`
+    <demo-list>
+      <demo-list-item></demo-list-item>
+      <demo-list-item></demo-list-item>
+      <demo-list-item></demo-list-item>
+    </demo-list>
+  `;
+};
+```

--- a/docs/snippets/web-components/list-story-reuse-data.js.mdx
+++ b/docs/snippets/web-components/list-story-reuse-data.js.mdx
@@ -1,0 +1,25 @@
+```js
+// demo-list.stories.js
+
+import { html } from 'lit-html';
+
+import './demo-list';
+import './demo-list-item';
+
+export default {
+  title: 'List',
+};
+
+//👇 We're importing the necessary stories from ListItem
+import { Selected, Unselected } from './demo-list-item.stories';
+
+export const ManyItems = (args) => {
+  return html`
+    <demo-list>
+      ${Selected({ ...args, ...Selected.args })}
+      ${Unselected({ ...args, ...Unselected.args })}
+      ${Unselected({ ...args, ...Unselected.args })}
+    </demo-list>
+  `;
+};
+```

--- a/docs/snippets/web-components/list-story-starter.js.mdx
+++ b/docs/snippets/web-components/list-story-starter.js.mdx
@@ -1,0 +1,14 @@
+```js
+// demo-list.stories.js
+
+import { html } from 'lit-html';
+
+import './demo-list';
+
+export default {
+  title: 'List',
+};
+
+// Always an empty list, not super interesting
+const Template = (args) => html`<demo-list></demo-list>`
+```

--- a/docs/snippets/web-components/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/web-components/my-component-story-configure-viewports.js.mdx
@@ -1,0 +1,29 @@
+```js
+// my-component.stories.js
+
+import { html } from 'lit-html';
+
+import './my-component';
+
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+
+export default {
+  title: 'Stories',
+  parameters: {
+    //👇 The viewports object from the Essentials addon
+    viewport: {
+      //👇 The viewports you want to use
+      viewports: INITIAL_VIEWPORTS,
+      //👇 Your own default viewport
+      defaultViewport: 'iphone6'
+    },
+  };
+};
+
+export const MyStory = () => html`<my-component></my-component>`;
+MyStory.parameters = {
+  viewport: {
+    defaultViewport: 'iphonex'
+  },
+};
+```

--- a/docs/snippets/web-components/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/web-components/my-component-with-env-variables.js.mdx
@@ -1,0 +1,19 @@
+```js
+// my-component.stories.js
+
+import { html } from 'lit-html';
+
+import './my-component';
+
+export default {
+  title: 'A story using environment variables inside a .env file',
+};
+
+const Template = ({ propertyA }) => html`<my-component .propertyA=${propertyA}></my-component>`;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  propertyA: process.env.STORYBOOK_DATA_KEY,
+};
+```

--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -142,6 +142,7 @@ What’s more, you can import args to reuse when writing stories for other compo
     'vue/button-group-story.2.js.mdx',
     'vue/button-group-story.3.js.mdx',
     'svelte/button-group-story.js.mdx',
+    'web-components/button-group-story.js.mdx',
   ]}
 />
 
@@ -228,6 +229,7 @@ When building design systems or component libraries, you may have two or more co
     'angular/list-story-starter.ts.mdx',
     'vue/list-story-starter.2.js.mdx',
     'vue/list-story-starter.3.js.mdx',
+    'web-components/list-story-starter.js.mdx',
   ]}
 />
 
@@ -244,6 +246,7 @@ In such cases, it makes sense to render a different function for each story:
     'angular/list-story-expanded.ts.mdx',
     'vue/list-story-expanded.2.js.mdx',
     'vue/list-story-expanded.3.js.mdx',
+    'web-components/list-story-expanded.js.mdx',
   ]}
 />
 
@@ -260,6 +263,7 @@ You can also reuse stories from the child `ListItem` in your `List` component. T
     'angular/list-story-reuse-data.ts.mdx',
     'vue/list-story-reuse-data.2.js.mdx',
     'vue/list-story-reuse-data.3.js.mdx',
+    'web-components/list-story-reuse-data.js.mdx',
   ]}
 />
 


### PR DESCRIPTION
Follows https://github.com/storybookjs/storybook/pull/14163

## What I did

I added missing Web Components code snippets for https://storybook.js.org/docs/web-components/writing-stories/introduction. I also added one in https://storybook.js.org/docs/web-components/configure/environment-variables.

I will work on the remaining ones, but I think it will need some improvement in the code to be feature-align with other frameworks. @jonniebigodes feels free to ping me on Discord if you want to discuss that :)



## How to test
 - Read the files to check I didn't make any typo or obvious mistakes and trust me for the story formats :-p
