### PR TITLE
docs: fix css-loader options for v3 api schema

### DIFF
--- a/docs/snippets/common/storybook-preset-configuration.js.mdx
+++ b/docs/snippets/common/storybook-preset-configuration.js.mdx
@@ -7,10 +7,9 @@ module.exports = {
       name: '@storybook/preset-scss',
       options: {
         cssLoaderOptions: {
-           modules: true,
-           localIdentName: '[name]__[local]--[hash:base64:5]',
-        }
-      }
+          modules: { localIdentName: '[name]__[local]--[hash:base64:5]' },
+        },
+      },
     },
   ],
 };


### PR DESCRIPTION
Issue:
localIdentName option was removed in favor modules.localIdentName option
https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#300-2019-06-11

## What I did
fix snippet