### PR TITLE
Svelte: Improve default webpack config

### DIFF
--- a/app/svelte/src/server/framework-preset-svelte.ts
+++ b/app/svelte/src/server/framework-preset-svelte.ts
@@ -9,6 +9,8 @@ export async function webpack(config: Configuration, options: Options): Promise<
     options
   );
 
+  const mainFields = (config.resolve.mainFields as string[]) || ['browser', 'module', 'main'];
+
   return {
     ...config,
     module: {
@@ -26,6 +28,7 @@ export async function webpack(config: Configuration, options: Options): Promise<
       ...config.resolve,
       extensions: [...config.resolve.extensions, '.svelte'],
       alias: config.resolve.alias,
+      mainFields: ['svelte', ...mainFields],
     },
   };
 }


### PR DESCRIPTION
Issue: #14221

## What I did

Added 'svelte' in the webpack mainFields, in the first position.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
