### PR TITLE
Updated refs function signature to include StorybookOptions object

### DIFF
--- a/docs/snippets/common/storybook-main-ref-per-environment.js.mdx
+++ b/docs/snippets/common/storybook-main-ref-per-environment.js.mdx
@@ -3,10 +3,8 @@
 
 module.exports = {
   // Your existing Storybook configuration
-  refs: (config) => {
-    //👇 Retrieves the current environment from the config object
-    const { configType } = config; 
-
+  // 👇 Retrieve the current environment from the configType argument
+  refs: (config, { configType }) => {
     if (configType === 'DEVELOPMENT') {
       return {
         react: {


### PR DESCRIPTION
Discussed here:
https://discord.com/channels/486522875931656193/735329186880946247/821352835995795459

Issue:

## What I did

- Updated Compose Storybooks per environment code snippet
- Refs function signature now includes a deconstructed StorybookOptions object


## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
