### PR TITLE
Docs: Add spaces for snippet

### DIFF
--- a/docs/snippets/react/button-story-rename-story.ts.mdx
+++ b/docs/snippets/react/button-story-rename-story.ts.mdx
@@ -7,5 +7,5 @@ import { Button, ButtonProps } from './Button';
 
 export const Primary: React.VFC<{}> = () => <Button primary>Button</Button>;
 
-Primary.storyName='I am the primary';
+Primary.storyName = 'I am the primary';
 ```


### PR DESCRIPTION
Issue:

There are no spaces in [this snippet ](https://github.com/storybookjs/storybook/blob/da189cafe0ffce291d909311e3a70731644116fe/docs/snippets/react/button-story-rename-story.ts.mdx)

![image](https://user-images.githubusercontent.com/2706062/111374555-4ed5d480-86ae-11eb-9b6f-59ce7027c0b7.png)

## What I did

Fixed it :)
