### PR TITLE
Addon-docs: Fix table dark mode

### DIFF
--- a/examples/official-storybook/stories/addon-docs/markdown.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/markdown.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
+import { Icons } from '@storybook/components';
 
 <Meta title="Addons/Docs/markdown-docs" />
 
@@ -126,6 +127,15 @@ Right aligned columns
 |   data | path to data files to supply the data that will be passed into templates. |
 | engine |    engine to be used for processing templates. Handlebars is the default. |
 |    ext |                                      extension to be used for dest files. |
+
+Table with icons
+
+| SVG                     | Name     |
+| ----------------------- | -------- |
+| <Icons icon="mobile" /> | `mobile` |
+| <Icons icon="grid" />   | `grid`   |
+| <Icons icon="alert" />  | `alert`  |
+| <Icons icon="check" />  | `check`  |
 
 ## Links
 

--- a/examples/official-storybook/stories/addon-docs/mdx.stories.js
+++ b/examples/official-storybook/stories/addon-docs/mdx.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DocsContainer } from '@storybook/addon-docs/blocks';
+import { themes } from '@storybook/theming';
 import markdown from './markdown.stories.mdx';
 
 export default {
@@ -15,3 +16,16 @@ export const Typography = () => {
   const Docs = markdown.parameters.docs.page;
   return <Docs />;
 };
+
+export const DarkModeDocs = () => {
+  const Docs = markdown.parameters.docs.page;
+  return <Docs />;
+};
+
+DarkModeDocs.decorators = [
+  (storyFn) => (
+    <DocsContainer context={{ parameters: { docs: { theme: themes.dark } } }}>
+      {storyFn()}
+    </DocsContainer>
+  ),
+];

--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -166,21 +166,23 @@ export const Table = styled.table<{}>(withReset, withMargin, ({ theme }) => ({
   borderCollapse: 'collapse',
   '& tr': {
     borderTop: `1px solid ${theme.appBorderColor}`,
-    backgroundColor: 'white',
+    backgroundColor: theme.appContentBg,
     margin: 0,
     padding: 0,
   },
   '& tr:nth-of-type(2n)': {
-    backgroundColor: `${theme.color.lighter}`,
+    backgroundColor: theme.base === 'dark' ? theme.color.darker : theme.color.lighter,
   },
   '& tr th': {
     fontWeight: 'bold',
+    color: theme.color.defaultText,
     border: `1px solid ${theme.appBorderColor}`,
     margin: 0,
     padding: '6px 13px',
   },
   '& tr td': {
     border: `1px solid ${theme.appBorderColor}`,
+    color: theme.color.defaultText,
     margin: 0,
     padding: '6px 13px',
   },

--- a/lib/theming/src/themes/dark.ts
+++ b/lib/theming/src/themes/dark.ts
@@ -10,7 +10,7 @@ const theme: ThemeVars = {
 
   // UI
   appBg: '#2f2f2f',
-  appContentBg: '#333',
+  appContentBg: color.darkest,
   appBorderColor: 'rgba(255,255,255,.1)',
   appBorderRadius: 4,
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/14029

## What I did

* Change the styles for the [Table](https://github.com/storybookjs/storybook/blob/df27d3adf36bf484e1c37b2525893e54dd3b3f22/lib/components/src/typography/DocumentFormatting.tsx#L162) component used in Docs pages. The main issue was the table background, which was using styles from the `light` theme before.
* Uses `color.darkest` as the value for `appContentBg` in the dark theme, as it was using the same value.
* Adds an example of a table with icons.

This is how the tables look now in Dark mode:
![image](https://user-images.githubusercontent.com/11748696/111409588-db779700-869c-11eb-9bfe-51cb1178e145.png)

And in Light mode there were no visual changes:
![image](https://user-images.githubusercontent.com/11748696/111409640-f3e7b180-869c-11eb-8726-c33b49080688.png)

## How to test

### Manual Test

1. Change the official-storybook example theme from `theme.light` to `theme.dark`: https://github.com/storybookjs/storybook/blob/df27d3adf36bf484e1c37b2525893e54dd3b3f22/examples/official-storybook/preview.js#L161
2. Run the official-storybook example `cd examples/official-storybook` and `yarn storybook`. (Also run `yarn build core components addon-docs theming` in the root folder to update the build with the theme changes).
3. Go to Docs > markdown-page document: http://localhost:9011/?path=/docs/addons-docs-markdown-docs--page
4. Assert that the table looks like the image attached above of the dark theme table.

## Questions

For setting the alternative rows background color (pair rows in this case), I did the following:

```
'& tr:nth-of-type(2n)': {
    backgroundColor: theme.base === 'dark' ? theme.color.darker : theme.color.lighter,
},
```

I'm not sure if this was the way to go, I also thought of adding a new theme variable, something like `theme.appAlternativeContentBg`, but not sure if this would be used that often.