### PR TITLE
WebComponents: Fix types and improve CLI detection

### DIFF
--- a/app/web-components/src/client/preview/types.ts
+++ b/app/web-components/src/client/preview/types.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { TemplateResult, SVGTemplateResult } from 'lit-element';
+import { TemplateResult, SVGTemplateResult } from 'lit-html';
 
 export type { RenderContext } from '@storybook/core';
 export { Args, ArgTypes, Parameters, StoryContext } from '@storybook/addons';

--- a/lib/cli/src/detect.test.ts
+++ b/lib/cli/src/detect.test.ts
@@ -160,6 +160,16 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
+    name: ProjectType.WEB_COMPONENTS,
+    files: {
+      'package.json': {
+        dependencies: {
+          'lit-html': '1.0.0',
+        },
+      },
+    },
+  },
+  {
     name: ProjectType.MITHRIL,
     files: {
       'package.json': {

--- a/lib/cli/src/project_types.ts
+++ b/lib/cli/src/project_types.ts
@@ -206,9 +206,9 @@ export const supportedTemplates: TemplateConfiguration[] = [
   },
   {
     preset: ProjectType.WEB_COMPONENTS,
-    dependencies: ['lit-element'],
+    dependencies: ['lit-element', 'lit-html'],
     matcherFunction: ({ dependencies }) => {
-      return dependencies.every(Boolean);
+      return dependencies.some(Boolean);
     },
   },
   {

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -164,7 +164,7 @@ export const vue3: Parameters = {
 export const web_components: Parameters = {
   name: 'web_components',
   version: 'latest',
-  generator: fromDeps('lit-html', 'lit-element'),
+  generator: fromDeps('lit-element'),
 };
 
 export const web_components_typescript: Parameters = {

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -51,6 +51,10 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
+  '@storybook/addon-svelte-csf':
+    access: $all
+    publish: $all
+    proxy: npmjs
 
   # storybook packages are NOT proxied to global registry
   # allowing us to republish any version during tests


### PR DESCRIPTION
Related to https://github.com/storybookjs/storybook/pull/12395#issuecomment-800632234

## What I did

 - use types from `lit-html` instead of `lit-element` to avoid dependency issues for `lit-html`-only users
 - remove unneeded `lit-html` dep and keep only `lit-element` in config used to run WC E2E test
 - add detection of bare `lit-html` projects (and not only `lit-element` ones) in SB CLI

## How to test

- CI should be 🟢 
- Using this branch locally with yarn link should allow you to make SB runs in a bare `lit-html` project, and `sb init` should properly detect a WC setup.
