### PR TITLE
Webpack5: Replace fullhash with contenthash

### DIFF
--- a/lib/builder-webpack5/src/preview/base-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/base-webpack.config.ts
@@ -53,7 +53,7 @@ export async function createDefaultWebpackConfig(
           test: /\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
           loader: require.resolve('file-loader'),
           options: {
-            name: 'static/media/[name].[fullhash:8].[ext]',
+            name: 'static/media/[name].[contenthash:8].[ext]',
           },
         },
         {
@@ -61,7 +61,7 @@ export async function createDefaultWebpackConfig(
           loader: require.resolve('url-loader'),
           options: {
             limit: 10000,
-            name: 'static/media/[name].[fullhash:8].[ext]',
+            name: 'static/media/[name].[contenthash:8].[ext]',
           },
         },
       ],


### PR DESCRIPTION
According to https://webpack.js.org/configuration/output/#template-strings `fullhash` is hash of compilation (and `hash` was too). So it doesn't make sense to use it if we want some unique names for assets.

https://github.com/storybookjs/storybook/issues/14253#issuecomment-801056885
https://github.com/storybookjs/storybook/pull/14255


BTW we shouldn't use `contenthash` id dev mode https://webpack.js.org/guides/build-performance/#avoid-production-specific-tooling, but I believe it's another issue