### PR TITLE
Addon-docs/Angular: Fix inline rendering setup

### DIFF
--- a/addons/docs/angular/inline.js
+++ b/addons/docs/angular/inline.js
@@ -1,1 +1,0 @@
-module.exports = require('../dist/esm/frameworks/angular/prepareForInline');

--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -1,9 +1,13 @@
 import { SourceType } from '../../shared';
 import { extractArgTypes, extractComponentDescription } from './compodoc';
 import { sourceDecorator } from './sourceDecorator';
+import { prepareForInline } from './prepareForInline';
 
 export const parameters = {
   docs: {
+    // probably set this to true by default once it's battle-tested
+    inlineStories: false,
+    prepareForInline,
     extractArgTypes,
     extractComponentDescription,
     source: {

--- a/examples/angular-cli/.storybook/preview.ts
+++ b/examples/angular-cli/.storybook/preview.ts
@@ -1,6 +1,4 @@
-import { addParameters } from '@storybook/angular';
 import { setCompodocJson } from '@storybook/addon-docs/angular';
-import { prepareForInline } from '@storybook/addon-docs/angular/inline';
 import addCssWarning from '../src/cssWarning';
 
 // @ts-ignore
@@ -17,17 +15,16 @@ setCompodocJson(filtered);
 
 addCssWarning();
 
-addParameters({
+export const parameters = {
   docs: {
     inlineStories: true,
-    prepareForInline,
   },
   options: {
     storySort: {
       order: ['Welcome', 'Core ', 'Addons ', 'Basics '],
     },
   },
-});
+};
 
 export const globalTypes = {
   theme: {


### PR DESCRIPTION
Issue: #8153

## What I did

Set up Angular `prepareForInline` inside the preset. Users can enable it on by simply setting `docs.inlineStories: true` and we don't need to create another entry point or import in the user's code.

**NOTE** that this is a breaking change for prerelease users, since this PR removes the unnecessary entry point.

## How to test

```
cd examples/angular-cli && yarn storybook
```

