### PR TITLE
UI: Element em should not make text content bold

### DIFF
--- a/lib/components/src/typography/DocumentFormattingSample.md
+++ b/lib/components/src/typography/DocumentFormattingSample.md
@@ -32,6 +32,8 @@ _This is italic text_
 
 _This is italic text_
 
+_**This is bold italic text**_
+
 ~~Strikethrough~~
 
 ## Blockquotes

--- a/lib/components/src/typography/DocumentWrapper.stories.tsx
+++ b/lib/components/src/typography/DocumentWrapper.stories.tsx
@@ -43,6 +43,11 @@ export const withDOM = () => (
       <em>This is italic text</em>
     </p>
     <p>
+      <em>
+        <strong>This is bold italic text</strong>
+      </em>
+    </p>
+    <p>
       <s>Strikethrough</s>
     </p>
     <h2>Blockquotes</h2>

--- a/lib/theming/src/global.ts
+++ b/lib/theming/src/global.ts
@@ -46,8 +46,7 @@ export const createReset = memoize(1)(
       fontSize: '0.8em',
       top: '-0.2em',
     },
-
-    'b, em': {
+    'b, strong': {
       fontWeight: typography.weight.bold,
     },
 


### PR DESCRIPTION


Issue: #14155 

## What I did
* Do not make `em` bold in `lib/theming/src/global.ts`
* Set `strong` as bold
* Added scenario bold and emphasized text to `DocumentFormattingSample` and  `DocumentWrapper` 

## How to test

### Before change
![Screen Shot 2021-03-21 at 1 41 01 pm](https://user-images.githubusercontent.com/1872246/111892662-8ac3bd80-8a51-11eb-996b-d4806ae4b017.png)

### After change
![Screen Shot 2021-03-21 at 1 14 15 pm](https://user-images.githubusercontent.com/1872246/111892677-a4fd9b80-8a51-11eb-98fa-400801e82a2e.png)



