### PR TITLE
controls: allow for identically named slots/properties/etc

### DIFF
--- a/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/custom-elements.snapshot
+++ b/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/custom-elements.snapshot
@@ -11,18 +11,6 @@ Object {
           "name": "back-side",
           "type": "boolean",
         },
-        Object {
-          "default": "\\"Your Message\\"",
-          "description": "Header message",
-          "name": "header",
-          "type": "string",
-        },
-        Object {
-          "default": "[]",
-          "description": "Data rows",
-          "name": "rows",
-          "type": "object",
-        },
       ],
       "cssParts": Array [
         Object {
@@ -66,14 +54,12 @@ Object {
           "type": "boolean",
         },
         Object {
-          "attribute": "header",
           "default": "\\"Your Message\\"",
           "description": "Header message",
           "name": "header",
           "type": "string",
         },
         Object {
-          "attribute": "rows",
           "default": "[]",
           "description": "Data rows",
           "name": "rows",

--- a/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/input.js
+++ b/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/input.js
@@ -116,8 +116,8 @@ export class DemoWcCard extends LitElement {
         reflect: true,
         attribute: 'back-side',
       },
-      header: { type: String },
-      rows: { type: Object },
+      header: { type: String, attribute: false },
+      rows: { type: Object, attribute: false },
     };
   }
 

--- a/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/properties.snapshot
+++ b/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/properties.snapshot
@@ -2,92 +2,7 @@
 
 exports[`web-components component properties lit-element-demo-card 1`] = `
 Object {
-  "": Object {
-    "description": "This is an unnamed slot (the default slot)",
-    "name": "",
-    "required": false,
-    "table": Object {
-      "category": "slots",
-      "defaultValue": Object {
-        "summary": undefined,
-      },
-      "type": Object {
-        "summary": undefined,
-      },
-    },
-    "type": Object {
-      "name": "void",
-    },
-  },
-  "--demo-wc-card-back-color": Object {
-    "description": "Font color for back",
-    "name": "--demo-wc-card-back-color",
-    "required": false,
-    "table": Object {
-      "category": "css custom properties",
-      "defaultValue": Object {
-        "summary": undefined,
-      },
-      "type": Object {
-        "summary": undefined,
-      },
-    },
-    "type": Object {
-      "name": "void",
-    },
-  },
-  "--demo-wc-card-front-color": Object {
-    "description": "Font color for front",
-    "name": "--demo-wc-card-front-color",
-    "required": false,
-    "table": Object {
-      "category": "css custom properties",
-      "defaultValue": Object {
-        "summary": undefined,
-      },
-      "type": Object {
-        "summary": undefined,
-      },
-    },
-    "type": Object {
-      "name": "void",
-    },
-  },
-  "--demo-wc-card-header-font-size": Object {
-    "description": "Header font size",
-    "name": "--demo-wc-card-header-font-size",
-    "required": false,
-    "table": Object {
-      "category": "css custom properties",
-      "defaultValue": Object {
-        "summary": undefined,
-      },
-      "type": Object {
-        "summary": undefined,
-      },
-    },
-    "type": Object {
-      "name": "void",
-    },
-  },
-  "back": Object {
-    "description": "Back of the card",
-    "name": "back",
-    "required": false,
-    "table": Object {
-      "category": "css shadow parts",
-      "defaultValue": Object {
-        "summary": undefined,
-      },
-      "type": Object {
-        "summary": undefined,
-      },
-    },
-    "type": Object {
-      "name": "void",
-    },
-  },
-  "back-side": Object {
+  "attributes:back-side": Object {
     "description": "Indicates that the back of the card is shown",
     "name": "back-side",
     "required": false,
@@ -104,24 +19,109 @@ Object {
       "name": "void",
     },
   },
-  "backSide": Object {
-    "description": "Indicates that the back of the card is shown",
-    "name": "backSide",
+  "attributes:header": Object {
+    "description": "Header message",
+    "name": "header",
     "required": false,
     "table": Object {
-      "category": "properties",
+      "category": "attributes",
       "defaultValue": Object {
-        "summary": "false",
+        "summary": "\\"Your Message\\"",
       },
       "type": Object {
-        "summary": "boolean",
+        "summary": "string",
       },
     },
     "type": Object {
-      "name": "boolean",
+      "name": "void",
     },
   },
-  "front": Object {
+  "attributes:rows": Object {
+    "description": "Data rows",
+    "name": "rows",
+    "required": false,
+    "table": Object {
+      "category": "attributes",
+      "defaultValue": Object {
+        "summary": "[]",
+      },
+      "type": Object {
+        "summary": "object",
+      },
+    },
+    "type": Object {
+      "name": "void",
+    },
+  },
+  "css custom properties:--demo-wc-card-back-color": Object {
+    "description": "Font color for back",
+    "name": "--demo-wc-card-back-color",
+    "required": false,
+    "table": Object {
+      "category": "css custom properties",
+      "defaultValue": Object {
+        "summary": undefined,
+      },
+      "type": Object {
+        "summary": undefined,
+      },
+    },
+    "type": Object {
+      "name": "void",
+    },
+  },
+  "css custom properties:--demo-wc-card-front-color": Object {
+    "description": "Font color for front",
+    "name": "--demo-wc-card-front-color",
+    "required": false,
+    "table": Object {
+      "category": "css custom properties",
+      "defaultValue": Object {
+        "summary": undefined,
+      },
+      "type": Object {
+        "summary": undefined,
+      },
+    },
+    "type": Object {
+      "name": "void",
+    },
+  },
+  "css custom properties:--demo-wc-card-header-font-size": Object {
+    "description": "Header font size",
+    "name": "--demo-wc-card-header-font-size",
+    "required": false,
+    "table": Object {
+      "category": "css custom properties",
+      "defaultValue": Object {
+        "summary": undefined,
+      },
+      "type": Object {
+        "summary": undefined,
+      },
+    },
+    "type": Object {
+      "name": "void",
+    },
+  },
+  "css shadow parts:back": Object {
+    "description": "Back of the card",
+    "name": "back",
+    "required": false,
+    "table": Object {
+      "category": "css shadow parts",
+      "defaultValue": Object {
+        "summary": undefined,
+      },
+      "type": Object {
+        "summary": undefined,
+      },
+    },
+    "type": Object {
+      "name": "void",
+    },
+  },
+  "css shadow parts:front": Object {
     "description": "Front of the card",
     "name": "front",
     "required": false,
@@ -138,7 +138,41 @@ Object {
       "name": "void",
     },
   },
-  "header": Object {
+  "events:side-changed": Object {
+    "description": "Fires whenever it switches between front/back",
+    "name": "side-changed",
+    "required": false,
+    "table": Object {
+      "category": "events",
+      "defaultValue": Object {
+        "summary": undefined,
+      },
+      "type": Object {
+        "summary": undefined,
+      },
+    },
+    "type": Object {
+      "name": "void",
+    },
+  },
+  "properties:backSide": Object {
+    "description": "Indicates that the back of the card is shown",
+    "name": "backSide",
+    "required": false,
+    "table": Object {
+      "category": "properties",
+      "defaultValue": Object {
+        "summary": "false",
+      },
+      "type": Object {
+        "summary": "boolean",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+    },
+  },
+  "properties:header": Object {
     "description": "Header message",
     "name": "header",
     "required": false,
@@ -155,7 +189,7 @@ Object {
       "name": "string",
     },
   },
-  "rows": Object {
+  "properties:rows": Object {
     "description": "Data rows",
     "name": "rows",
     "required": false,
@@ -172,12 +206,12 @@ Object {
       "name": "object",
     },
   },
-  "side-changed": Object {
-    "description": "Fires whenever it switches between front/back",
-    "name": "side-changed",
+  "slots:": Object {
+    "description": "This is an unnamed slot (the default slot)",
+    "name": "unnamed (default slot)",
     "required": false,
     "table": Object {
-      "category": "events",
+      "category": "slots",
       "defaultValue": Object {
         "summary": undefined,
       },

--- a/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/properties.snapshot
+++ b/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/properties.snapshot
@@ -19,40 +19,6 @@ Object {
       "name": "void",
     },
   },
-  "attributes:header": Object {
-    "description": "Header message",
-    "name": "header",
-    "required": false,
-    "table": Object {
-      "category": "attributes",
-      "defaultValue": Object {
-        "summary": "\\"Your Message\\"",
-      },
-      "type": Object {
-        "summary": "string",
-      },
-    },
-    "type": Object {
-      "name": "void",
-    },
-  },
-  "attributes:rows": Object {
-    "description": "Data rows",
-    "name": "rows",
-    "required": false,
-    "table": Object {
-      "category": "attributes",
-      "defaultValue": Object {
-        "summary": "[]",
-      },
-      "type": Object {
-        "summary": "object",
-      },
-    },
-    "type": Object {
-      "name": "void",
-    },
-  },
   "css custom properties:--demo-wc-card-back-color": Object {
     "description": "Font color for back",
     "name": "--demo-wc-card-back-color",

--- a/addons/docs/src/frameworks/web-components/custom-elements.ts
+++ b/addons/docs/src/frameworks/web-components/custom-elements.ts
@@ -41,8 +41,12 @@ function mapData(data: TagItem[], category: string) {
     data &&
     data.reduce((acc, item) => {
       const type = category === 'properties' ? { name: item.type } : { name: 'void' };
-      acc[item.name] = {
-        name: item.name,
+      let { name } = item;
+      if (category === 'slots' && name === '') {
+        name = 'unnamed (default slot)';
+      }
+      acc[`${category}:${item.name}`] = {
+        name,
         required: false,
         description: item.description,
         type,


### PR DESCRIPTION
Fixes #13410.

Maybe this is a suitable fix?

I fixed two things here:

1. Default slots never appeared as their name was empty, so somewhere down the stack they get lost and show up as a blank row
2. Two identically named args from different categories overwrite each other (e.g. properties vs slots, slots vs. events, etc)

To fix them:

1. I gave the default slot a default name (but left its identifier blank still to avoid making something like `default` an impossible slot)
2. I simply templated the ID of the arg to be `${category}:${name}` since the ID/key doesn't seem to be used for anything other than an identifier internally (isn't rendered)

Let me know if this seems like a sensible fix, otherwise im happy to rework it however.

p.s. the tests will likely fail right now, i haven't yet figured out how they work but will update once i do