### PR TITLE
Core: Restore webpack4 watchOptions

### DIFF
--- a/examples/angular-cli/src/stories/basics/component-with-complex-selectors/__snapshots__/multiple-selector.component.stories.storyshot
+++ b/examples/angular-cli/src/stories/basics/component-with-complex-selectors/__snapshots__/multiple-selector.component.stories.storyshot
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Basics / Component / With Complex Selectors Input Selectors 1`] = `
-<storybook-wrapper>
-  <foo>
-    foo
-  </foo>
-</storybook-wrapper>
-`;
-
 exports[`Storyshots Basics / Component / With Complex Selectors attribute selectors 1`] = `
 <storybook-wrapper>
   <storybook-attribute-selector

--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -127,10 +127,10 @@ export default async ({
       filename: isProd ? '[name].[contenthash:8].iframe.bundle.js' : '[name].iframe.bundle.js',
       publicPath: '',
     },
-    // watchOptions: {
-    //   aggregateTimeout: 10,
-    //   ignored: /node_modules/,
-    // },
+    watchOptions: {
+      aggregateTimeout: 10,
+      ignored: /node_modules/,
+    },
     plugins: [
       new FilterWarningsPlugin({
         exclude: /export '\S+' was not found in 'global'/,

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-dev
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-dev
@@ -23,6 +23,7 @@ Object {
     "devtool",
     "entry",
     "output",
+    "watchOptions",
     "plugins",
     "module",
     "resolve",

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod
@@ -22,6 +22,7 @@ Object {
     "devtool",
     "entry",
     "output",
+    "watchOptions",
     "plugins",
     "module",
     "resolve",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
@@ -27,6 +27,7 @@ Object {
     "devtool",
     "entry",
     "output",
+    "watchOptions",
     "plugins",
     "module",
     "resolve",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
@@ -26,6 +26,7 @@ Object {
     "devtool",
     "entry",
     "output",
+    "watchOptions",
     "plugins",
     "module",
     "resolve",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
@@ -24,6 +24,7 @@ Object {
     "devtool",
     "entry",
     "output",
+    "watchOptions",
     "plugins",
     "module",
     "resolve",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
@@ -23,6 +23,7 @@ Object {
     "devtool",
     "entry",
     "output",
+    "watchOptions",
     "plugins",
     "module",
     "resolve",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
@@ -26,6 +26,7 @@ Object {
     "devtool",
     "entry",
     "output",
+    "watchOptions",
     "plugins",
     "module",
     "resolve",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
@@ -25,6 +25,7 @@ Object {
     "devtool",
     "entry",
     "output",
+    "watchOptions",
     "plugins",
     "module",
     "resolve",


### PR DESCRIPTION
Issue: N/A

## What I did

`watchOptions` were accidentally (??) commented out for webpack4 during the webpack5 refactor. Restoring them since that's probably a bug.

self-merging @ndelangen 

## How to test

CI passes
