### PR TITLE
Webpack5: Remove deprecated webpack-filter-warnings-plugin

### DIFF
--- a/lib/builder-webpack5/package.json
+++ b/lib/builder-webpack5/package.json
@@ -94,7 +94,6 @@
     "util-deprecate": "^1.0.2",
     "webpack": "^5.9.0",
     "webpack-dev-middleware": "^4.1.0",
-    "webpack-filter-warnings-plugin": "^1.2.1",
     "webpack-hot-middleware": "^2.25.0",
     "webpack-virtual-modules": "^0.4.1"
   },

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -9,8 +9,6 @@ import TerserWebpackPlugin from 'terser-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
-// @ts-ignore
-import FilterWarningsPlugin from 'webpack-filter-warnings-plugin';
 
 import themingPaths from '@storybook/theming/paths';
 
@@ -132,13 +130,15 @@ export default async ({
       aggregateTimeout: 10,
       ignored: /node_modules/,
     },
+    ignoreWarnings: [
+      {
+        message: /export '\S+' was not found in 'global'/,
+      },
+    ],
     plugins: [
-      new FilterWarningsPlugin({
-        exclude: /export '\S+' was not found in 'global'/,
-      }),
       Object.keys(virtualModuleMapping).length > 0
         ? new VirtualModulePlugin(virtualModuleMapping)
-        : null,
+        : (null as any),
       new HtmlWebpackPlugin({
         filename: `iframe.html`,
         // FIXME: `none` isn't a known option


### PR DESCRIPTION
Issue: #13990 

## What I did

Replace deprecated plugin with built-in `ignoreWarnings` feature:

https://webpack.js.org/configuration/other-options/#ignorewarnings

self-merging @ndelangen 

## How to test

CI passes