### PR TITLE
Components: Handle `null` when parsing input in color picker

### DIFF
--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -55,7 +55,9 @@ const expandShorthand = (value: string) => {
   return `#${r}${r}${g}${g}${b}${b}`;
 };
 
-const parseValue = (input: string | { color: string; title?: string }): ParsedColor => {
+const parseValue = (input: string | { color: string; title?: string } | null): ParsedColor => {
+  if (!input) return undefined;
+
   const { color, title } = typeof input === 'object' ? input : { color: input, title: undefined };
   if (!color) return undefined;
 


### PR DESCRIPTION
Issue: The E2E are failing for the vast majority of setups (framework + config).

## What I did

It looks like the input can be null 🤷 it's the case for most of our E2E tests based on CLI `sb init`


## How to test

- CI should be back to 🟢 
- Locally, for instance : `yarn test:e2e-framework --clean --use-local-sb-cli sfcVue` then `yarn storybook` and try to navigate to `Button > Primary` story
