### PR TITLE
Addon-Links: Fix react.d.ts paths

### DIFF
--- a/addons/links/react.d.ts
+++ b/addons/links/react.d.ts
@@ -1,2 +1,2 @@
-export * from './dist/react';
-export { default as LinkTo } from './dist/react';
+export * from './dist/ts3.9/react';
+export { default as LinkTo } from './dist/ts3.9/react';


### PR DESCRIPTION
Issue:
../../node_modules/@storybook/addon-links/react.d.ts(1,15): error TS7016: Could not find a declaration file for module './dist/
esm/react'. 'C:/dev/design-system/node_modules/@storybook/addon-links/dist/esm/react/index.js' implicitly has an 'any' type.

## What I did
Fix TS Path

