### PR TITLE
Core: Import `isPlainObject` directly from lodash

### DIFF
--- a/lib/client-api/src/args.ts
+++ b/lib/client-api/src/args.ts
@@ -1,6 +1,6 @@
 import { Args, ArgTypes } from '@storybook/addons';
 import { once } from '@storybook/client-logger';
-import { isPlainObject } from 'lodash';
+import isPlainObject from 'lodash/isPlainObject';
 import dedent from 'ts-dedent';
 
 type ValueType = { name: string; value?: ObjectValueType | ValueType };


### PR DESCRIPTION
## What I did
I changed how `isPlainObject` is imported from `lodash`, so that it directly imports the module instead of importing it from main module with many other exported modules.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
