### PR TITLE
Publish Storybook Docs: Raise warning about overwriting

### DIFF
--- a/docs/workflows/publish-storybook.md
+++ b/docs/workflows/publish-storybook.md
@@ -8,6 +8,10 @@ Storybook is more than a UI component development tool. Teams also publish Story
 
 First, we’ll need to build Storybook as a static web application using `build-storybook`, a command that’s installed by default. If you're using Yarn run the following command:
 
+<div class="aside">
+💡 <strong>Note</strong>: Be careful when running the <code>build-storybook</code> command with the <code>-o</code> flag as you might unknowingly overwrite essential files and folders. For instance <strong>avoid</strong> running <code>build-storybook -o ./</code> as this will replace the root project contents with the output of the command. 
+</div>
+
 ```shell
 yarn build-storybook -o ./path/to/build
 ```
@@ -17,10 +21,6 @@ If you're using npm run the following command:
 ```shell
 npm run build-storybook -- -o ./path/to/build
 ```
-
-<div class="aside">
-💡 <strong>Note</strong>: Be careful when running the <code>build-storybook</code> command with the <code>-o</code> flag as you might unknowingly overwrite essential files and folders. For instance <strong>avoid</strong> running <code>build-storybook -o ./</code> as this will replace the root project contents with the output of the command. 
-</div>
 
 Storybook will create a static web application at the path you specify. This can be served by any web server. Try it out locally by running:
 


### PR DESCRIPTION
## What I did

Move the the warning above the example command so excited developers don't — for example — quickly copy and paste and run something like `yarn build-storybook -o ~/Desktop`

Old:

<img width="840" alt="Screen Shot 2021-03-22 at 3 51 40 PM" src="https://user-images.githubusercontent.com/3692/112070273-92a36080-8b2a-11eb-8b61-b83fbf36733b.png">

New:

<img width="826" alt="Screen Shot 2021-03-22 at 3 51 29 PM" src="https://user-images.githubusercontent.com/3692/112070284-9931d800-8b2a-11eb-8469-b37b940030c7.png">

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
