### PR TITLE
Revert "Addon-docs/Angular: Fix inline rendering setup"

### DIFF
--- a/addons/docs/angular/inline.js
+++ b/addons/docs/angular/inline.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/esm/frameworks/angular/prepareForInline');

--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -1,13 +1,9 @@
 import { SourceType } from '../../shared';
 import { extractArgTypes, extractComponentDescription } from './compodoc';
 import { sourceDecorator } from './sourceDecorator';
-import { prepareForInline } from './prepareForInline';
 
 export const parameters = {
   docs: {
-    // probably set this to true by default once it's battle-tested
-    inlineStories: false,
-    prepareForInline,
     extractArgTypes,
     extractComponentDescription,
     source: {

--- a/examples/angular-cli/.storybook/preview.ts
+++ b/examples/angular-cli/.storybook/preview.ts
@@ -1,4 +1,6 @@
+import { addParameters } from '@storybook/angular';
 import { setCompodocJson } from '@storybook/addon-docs/angular';
+import { prepareForInline } from '@storybook/addon-docs/angular/inline';
 import addCssWarning from '../src/cssWarning';
 
 // @ts-ignore
@@ -15,16 +17,17 @@ setCompodocJson(filtered);
 
 addCssWarning();
 
-export const parameters = {
+addParameters({
   docs: {
     inlineStories: true,
+    prepareForInline,
   },
   options: {
     storySort: {
       order: ['Welcome', 'Core ', 'Addons ', 'Basics '],
     },
   },
-};
+});
 
 export const globalTypes = {
   theme: {


### PR DESCRIPTION
Reverts storybookjs/storybook#14270

This PR made inline rendering for Angular easier to configure for users, and consistent with other frameworks. However, it introduces breaking dependency changes and is breaking our CI. Reverting the change for 6.2 and will update probably in 7.0.

self-merging @yngvebn @ThibaudAV @gaetanmaisse 