### PR TITLE
Refactor: Replace `lodash/range` with `Array.from`

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -77,7 +77,6 @@ Basic.args = { label: 'hello' };
 Similarly, we can also consider a story that uses knob inputs to change its behavior:
 
 ```jsx
-import range from 'lodash/range';
 import { number, text } from '@storybook/addon-knobs';
 
 export const Reflow = () => {
@@ -85,7 +84,7 @@ export const Reflow = () => {
   const label = text('Label', 'reflow');
   return (
     <>
-      {range(count).map((i) => (
+      {Array.from({ length: count }, (_, i) => (
         <Button label={`button ${i}`} />
       ))}
     </>
@@ -97,7 +96,7 @@ And again, as above, this can be rewritten using [fully custom args](https://sto
 
 ```jsx
 export const Reflow = ({ count, label, ...args }) => (
-  <>{range(count).map((i) => <Button label={`${label} ${i}` {...args}} />)}</>
+  <>{Array.from({ length: count }, (_, i) => <Button label={`${label} ${i}` {...args}} />)}</>
 );
 Reflow.args = { count: 3, label: 'reflow' };
 Reflow.argTypes = {

--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 import React from 'react';
-import range from 'lodash/range';
 import PropTypes from 'prop-types';
 import addons, { StoryContext } from '@storybook/addons';
 import { renderJsx, jsxDecorator } from './jsxDecorator';
@@ -46,10 +45,10 @@ describe('renderJsx', () => {
     `);
   });
   it('large objects', () => {
-    const obj: Record<string, string> = {};
-    range(20).forEach((i) => {
-      obj[`key_${i}`] = `val_${i}`;
-    });
+    const obj = Array.from({ length: 20 }).reduce((acc, _, i) => {
+      acc[`key_${i}`] = `val_${i}`;
+      return acc;
+    }, {});
     expect(renderJsx(<div data-val={obj} />, {})).toMatchInlineSnapshot(`
       <div
         data-val={{
@@ -79,7 +78,7 @@ describe('renderJsx', () => {
   });
 
   it('long arrays', () => {
-    const arr = range(20).map((i) => `item ${i}`);
+    const arr = Array.from({ length: 20 }, (_, i) => `item ${i}`);
     expect(renderJsx(<div data-val={arr} />, {})).toMatchInlineSnapshot(`
       <div
         data-val={[

--- a/examples/official-storybook/stories/addon-docs/props.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/props.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
-import range from 'lodash/range';
 import { DocgenButton } from '../../components/DocgenButton';
 import { ButtonGroup, SubGroup } from '../../components/ButtonGroup';
 import { ForwardRefButton } from '../../components/ForwardRefButton';
@@ -143,7 +142,7 @@ export const Template = (args) => (
     {({ background, label, count }) => {
       return (
         <ButtonGroup background={background}>
-          {range(count).map((i) => (
+          {Array.from({ length: count }, (_, i) => (
             <DocgenButton key={i} label={`${label} ${i}`} />
           ))}
         </ButtonGroup>


### PR DESCRIPTION
## What I did
I replaced [`lodash/range`](https://lodash.com/docs/4.17.15#range) with native [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) to create an array of N-elements.

```js
console.log(Array.from({ length: 3 })); // [undefined, undefined, undefined]
```

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
