### PR TITLE
refactor(source-loader): replace `lodash/mapKeys` with native built-ins

### DIFF
--- a/lib/source-loader/src/abstract-syntax-tree/generate-helpers.js
+++ b/lib/source-loader/src/abstract-syntax-tree/generate-helpers.js
@@ -1,5 +1,4 @@
 import { storyNameFromExport, sanitize } from '@storybook/csf';
-import mapKeys from 'lodash/mapKeys';
 import { patchNode } from './parse-helpers';
 import getParser from './parsers';
 import {
@@ -145,9 +144,10 @@ export function generateStorySource({ source, ...options }) {
 
 function transformLocationMapToIds(parameters) {
   if (!parameters?.locationsMap) return parameters;
-  const locationsMap = mapKeys(parameters.locationsMap, (_value, key) => {
-    return sanitize(storyNameFromExport(key));
-  });
+  const locationsMap = Object.entries(parameters.locationsMap).reduce((acc, [key, value]) => {
+    acc[sanitize(storyNameFromExport(key))] = value;
+    return acc;
+  }, {});
   return { ...parameters, locationsMap };
 }
 


### PR DESCRIPTION
## What I did
I replaced `lodash/mapKeys` module with `Object.entries` and `Array.reduce` to reduce `lodash` usage to minimum.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes, existing tests should catch anything
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
