### PR TITLE
Update theming.md

### DIFF
--- a/docs/configure/theming.md
+++ b/docs/configure/theming.md
@@ -113,6 +113,8 @@ Now your custom theme will replace Storybook's default theme and you'll see a si
 
 ![Storybook starter theme](./storybook-starter-custom-theme.png)
 
+**Note:** Once you're finished configuring the theme, remove the flag `--no-manager-cache` from the `storybook` script, otherwise loading times can be severely impacted.
+
 Let's take a look at more complex example. Copy the code below and paste it in `.storybook/YourTheme.js`.
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
Add a note to remove the CLI flag `--no-manager-cache` when finished developing the custom theme

Issue:
The theming documentation didn't explain the impacts of using the flag `--no-manager-cache`

## What I did
Updated the documentation to be clearer on the impacts of using the CLI flag

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
