### PR TITLE
Controls: Add button control

### DIFF
--- a/addons/controls/preset.js
+++ b/addons/controls/preset.js
@@ -5,4 +5,8 @@ function managerEntries(entry = [], options) {
   return [...entry, require.resolve('./dist/esm/register')];
 }
 
-module.exports = { managerEntries };
+function config(entry = []) {
+  return [...entry, require.resolve('./preview')];
+}
+
+module.exports = { config, managerEntries };

--- a/addons/controls/preview.ts
+++ b/addons/controls/preview.ts
@@ -1,0 +1,3 @@
+import { withButtonActions } from './dist/cjs/decorators';
+
+export const decorators = [withButtonActions];

--- a/addons/controls/src/ControlsPanel.tsx
+++ b/addons/controls/src/ControlsPanel.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
-import { ArgTypes, useArgs, useArgTypes, useParameter } from '@storybook/api';
+import { Args, ArgTypes, useArgs, useChannel, useArgTypes, useParameter } from '@storybook/api';
 import { ArgsTable, NoControlsWarning, PresetColor, SortType } from '@storybook/components';
 
-import { PARAM_KEY } from './constants';
+import { CONTROL_BUTTON_CLICK, PARAM_KEY } from './constants';
 
 interface ControlsParameters {
   sort?: SortType;
@@ -12,6 +12,7 @@ interface ControlsParameters {
 }
 
 export const ControlsPanel: FC = () => {
+  const emit = useChannel({});
   const [args, updateArgs, resetArgs] = useArgs();
   const rows = useArgTypes();
   const isArgsStory = useParameter<boolean>('__isArgsStory', false);
@@ -22,6 +23,13 @@ export const ControlsPanel: FC = () => {
     hideNoControlsWarning = false,
   } = useParameter<ControlsParameters>(PARAM_KEY, {});
 
+  const buttonArgs = Object.entries(rows).reduce(
+    (acc, [key, { control }]) => ({
+      ...acc,
+      [key]: control?.type === 'button' ? () => emit(CONTROL_BUTTON_CLICK, key) : args[key],
+    }),
+    {} as Args
+  );
   const hasControls = Object.values(rows).some((arg) => arg?.control);
   const showWarning = !(hasControls && isArgsStory) && !hideNoControlsWarning;
 
@@ -38,7 +46,7 @@ export const ControlsPanel: FC = () => {
         {...{
           compact: !expanded && hasControls,
           rows: withPresetColors,
-          args,
+          args: buttonArgs,
           updateArgs,
           resetArgs,
           inAddonPanel: true,

--- a/addons/controls/src/constants.ts
+++ b/addons/controls/src/constants.ts
@@ -1,2 +1,3 @@
 export const ADDON_ID = 'addon-controls' as const;
 export const PARAM_KEY = 'controls' as const;
+export const CONTROL_BUTTON_CLICK = 'control-button-click' as const;

--- a/addons/controls/src/decorators.ts
+++ b/addons/controls/src/decorators.ts
@@ -1,14 +1,16 @@
 import { useChannel, useArgs } from '@storybook/client-api';
-import type { StoryFn } from '@storybook/addons';
+import { StoryFn, useStoryContext } from '@storybook/addons';
 import { CONTROL_BUTTON_CLICK } from './constants';
 
 export const withButtonActions = (storyFn: StoryFn) => {
-  const [args] = useArgs();
+  const [args, updateArgs] = useArgs();
+  const context = useStoryContext();
+
   useChannel({
     [CONTROL_BUTTON_CLICK]: (name: string) => {
       // FIXME: I don't have a way to enforce those values, as i don't have the arg types :(
-      args[name]();
+      updateArgs(args[name](args));
     },
   });
-  return storyFn();
+  return storyFn({ ...context, args });
 };

--- a/addons/controls/src/decorators.ts
+++ b/addons/controls/src/decorators.ts
@@ -1,0 +1,14 @@
+import { useChannel, useArgs } from '@storybook/client-api';
+import type { StoryFn } from '@storybook/addons';
+import { CONTROL_BUTTON_CLICK } from './constants';
+
+export const withButtonActions = (storyFn: StoryFn) => {
+  const [args] = useArgs();
+  useChannel({
+    [CONTROL_BUTTON_CLICK]: (name: string) => {
+      // FIXME: I don't have a way to enforce those values, as i don't have the arg types :(
+      args[name]();
+    },
+  });
+  return storyFn();
+};

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -48,7 +48,10 @@ export const Basic = Template.bind({});
 Basic.args = {
   children: 'basic',
   json: DEFAULT_NESTED_OBJECT,
-  buttonAction: () => console.warn('ey! stop this!'),
+  buttonAction: () => {
+    console.log({ DEFAULT_NESTED_OBJECT });
+    console.log('ey! stop this!');
+  },
 };
 Basic.parameters = { chromatic: { disable: false } };
 

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -55,6 +55,29 @@ Basic.args = {
 };
 Basic.parameters = { chromatic: { disable: false } };
 
+export const Counter = ({ count }) => (
+  <>
+    <p>You clicked {count} times</p>
+  </>
+);
+Counter.argTypes = {
+  plusClick: {
+    control: { type: 'button', label: 'Add one' },
+  },
+  minusClick: {
+    control: { type: 'button', label: 'Remove one' },
+  },
+};
+Counter.args = {
+  count: 0,
+  plusClick: ({ count, ...args }) => {
+    return { count: count + 1, ...args };
+  },
+  minusClick: ({ count, ...args }) => {
+    return { count: count - 1, ...args };
+  },
+};
+
 export const Action = Template.bind({});
 Action.args = {
   children: 'hmmm',

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -15,6 +15,9 @@ export default {
       control: { type: 'select', labels: { Bold: 'BOLD' } },
       mapping: { Bold: <b>Bold</b> },
     },
+    buttonAction: {
+      control: { type: 'button', label: 'Click me!' },
+    },
     background: {
       name: 'Background color',
       control: {
@@ -45,6 +48,7 @@ export const Basic = Template.bind({});
 Basic.args = {
   children: 'basic',
   json: DEFAULT_NESTED_OBJECT,
+  buttonAction: () => console.warn('ey! stop this!'),
 };
 Basic.parameters = { chromatic: { disable: false } };
 

--- a/lib/components/src/blocks/ArgsTable/ArgControl.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgControl.tsx
@@ -2,6 +2,7 @@ import React, { FC, useCallback, useState, useEffect } from 'react';
 import { Args, ArgType } from './types';
 import {
   BooleanControl,
+  ButtonControl,
   ColorControl,
   DateControl,
   FilesControl,
@@ -54,6 +55,8 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs }) => {
       return <ObjectControl {...props} {...control} />;
     case 'boolean':
       return <BooleanControl {...props} {...control} />;
+    case 'button':
+      return <ButtonControl {...props} {...control} />;
     case 'color':
       return <ColorControl {...props} {...control} />;
     case 'date':

--- a/lib/components/src/controls/Button.tsx
+++ b/lib/components/src/controls/Button.tsx
@@ -1,0 +1,53 @@
+import React, { FC } from 'react';
+
+import { styled } from '@storybook/theming';
+import { ControlProps, ButtonValue, ButtonConfig } from './types';
+
+const Label = styled.label(({ theme }) => ({
+  // FIXME: blatantly stolen from knobs, design review?
+  button: {
+    border: 0,
+    cursor: 'pointer',
+    overflow: 'hidden',
+    position: 'relative',
+    textAlign: 'center',
+    textDecoration: 'none',
+    transition: 'all 150ms ease-out',
+    transform: 'translate3d(0,0,0)',
+    verticalAlign: 'top',
+    whiteSpace: 'nowrap',
+    userSelect: 'none',
+    opacity: 1,
+    margin: 0,
+    fontSize: '12px',
+    fontWeight: 700,
+    lineHeight: 1,
+    background: '#fafafa',
+    color: '#333333',
+    boxShadow: 'rgba(0,0,0,.1) 0 0 0 1px inset',
+    borderRadius: '4px',
+    padding: '10px 16px',
+    display: 'inline',
+    '&:focus': {
+      outline: 'none',
+      boxShadow: `${theme.color.secondary} 0 0 0 1px inset !important`,
+    },
+  },
+}));
+
+export type ButtonProps = ControlProps<ButtonValue> & ButtonConfig;
+export const ButtonControl: FC<ButtonProps> = ({
+  name,
+  label = name, // FIXME: Use name if label is missing?
+  defaultValue,
+  value = defaultValue,
+  onChange, // FIXME: how to use this?
+  onBlur,
+  onFocus,
+}) => (
+  <Label htmlFor={name} title={label}>
+    <button type="button" onClick={value} name={name} onBlur={onBlur} onFocus={onFocus}>
+      {label}
+    </button>
+  </Label>
+);

--- a/lib/components/src/controls/Button.tsx
+++ b/lib/components/src/controls/Button.tsx
@@ -41,7 +41,6 @@ export const ButtonControl: FC<ButtonProps> = ({
   label = name, // FIXME: Use name if label is missing?
   defaultValue,
   value = defaultValue,
-  onChange, // FIXME: how to use this?
   onBlur,
   onFocus,
 }) => (

--- a/lib/components/src/controls/index.tsx
+++ b/lib/components/src/controls/index.tsx
@@ -4,6 +4,7 @@ export * from './types';
 
 export * from './Array';
 export * from './Boolean';
+export * from './Button';
 export type { ColorProps } from './Color';
 
 const LazyColorControl = React.lazy(() => import('./Color'));

--- a/lib/components/src/controls/types.ts
+++ b/lib/components/src/controls/types.ts
@@ -19,6 +19,11 @@ export interface ArrayConfig {
 export type BooleanValue = boolean;
 export interface BooleanConfig {}
 
+export type ButtonValue = (...args: any[]) => any;
+export interface ButtonConfig {
+  label?: string;
+}
+
 export type ColorValue = string;
 export type PresetColor = ColorValue | { color: ColorValue; title?: string };
 export interface ColorConfig {
@@ -71,6 +76,7 @@ export interface TextConfig {}
 export type ControlType =
   | 'array'
   | 'boolean'
+  | 'button'
   | 'color'
   | 'date'
   | 'number'
@@ -82,6 +88,7 @@ export type ControlType =
 export type Control =
   | ArrayConfig
   | BooleanConfig
+  | ButtonConfig
   | ColorConfig
   | DateConfig
   | NumberConfig


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/11971

Adds button control to addon-control

## What I did

I added a new button control on the controls add-on

## How to test

- Is this testable with Jest or Chromatic screenshots? Don't know, will follow reviewers advice
- Does this need a new example in the kitchen sink apps? Yes, Will need to update some examples
- Does this need an update to the documentation? Yes, will add after getting the draft accepted

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
