### PR TITLE
refactor: replace `lodash/mapValues` with native built-ins

### DIFF
--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 import React, { FC, useContext, useEffect, useState, useCallback } from 'react';
-import mapValues from 'lodash/mapValues';
 import {
   ArgsTable as PureArgsTable,
   ArgsTableProps as PureArgsTableProps,
@@ -117,10 +116,13 @@ const addComponentTabs = (
   sort?: SortType
 ) => ({
   ...tabs,
-  ...mapValues(components, (comp) => ({
-    rows: extractComponentArgTypes(comp, context, include, exclude),
-    sort,
-  })),
+  ...Object.entries(components).reduce<typeof tabs>((acc, [key, comp]) => {
+    acc[key] = {
+      rows: extractComponentArgTypes(comp, context, include, exclude),
+      sort,
+    };
+    return acc;
+  }, {}),
 });
 
 export const StoryTable: FC<

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.ts
@@ -1,5 +1,5 @@
-import mapValues from 'lodash/mapValues';
 import { ArgTypesEnhancer, combineParameters } from '@storybook/client-api';
+import { ArgTypes } from '@storybook/api';
 import { normalizeArgTypes } from './normalizeArgTypes';
 
 export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
@@ -7,7 +7,10 @@ export const enhanceArgTypes: ArgTypesEnhancer = (context) => {
   const { extractArgTypes } = docs;
 
   const normalizedArgTypes = normalizeArgTypes(userArgTypes);
-  const namedArgTypes = mapValues(normalizedArgTypes, (val, key) => ({ name: key, ...val }));
+  const namedArgTypes = Object.entries(normalizedArgTypes).reduce<ArgTypes>((acc, [key, val]) => {
+    acc[key] = { name: key, ...val };
+    return acc;
+  }, {});
   const extractedArgTypes = extractArgTypes && component ? extractArgTypes(component) : {};
   const withExtractedTypes = extractedArgTypes
     ? combineParameters(extractedArgTypes, namedArgTypes)

--- a/addons/docs/src/frameworks/common/normalizeArgTypes.ts
+++ b/addons/docs/src/frameworks/common/normalizeArgTypes.ts
@@ -1,4 +1,3 @@
-import mapValues from 'lodash/mapValues';
 import { ArgTypes } from '@storybook/api';
 import { SBType } from '@storybook/client-api';
 
@@ -8,11 +7,13 @@ const normalizeControl = (control?: any) =>
   typeof control === 'string' ? { type: control } : control;
 
 export const normalizeArgTypes = (argTypes: ArgTypes) =>
-  mapValues(argTypes, (argType) => {
-    if (!argType) return argType;
-    const normalized = { ...argType };
-    const { type, control } = argType;
-    if (type) normalized.type = normalizeType(type);
-    if (control) normalized.control = normalizeControl(control);
-    return normalized;
-  });
+  Object.entries(argTypes).reduce<ArgTypes>((acc, [key, argType]) => {
+    const value = { ...argType };
+    if (argType) {
+      const { type, control } = argType;
+      if (type) value.type = normalizeType(type);
+      if (control) value.control = normalizeControl(control);
+    }
+    acc[key] = value;
+    return acc;
+  }, {});

--- a/addons/docs/src/frameworks/react/react-argtypes.stories.tsx
+++ b/addons/docs/src/frameworks/react/react-argtypes.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import mapValues from 'lodash/mapValues';
 import { storiesOf, StoryContext } from '@storybook/react';
 import { ArgsTable } from '@storybook/components';
 import { Args } from '@storybook/api';
@@ -35,7 +34,10 @@ function FormatArg({ arg }) {
 
 const ArgsStory = ({ component }: any) => {
   const { rows } = argsTableProps(component);
-  const initialArgs = mapValues(rows, (argType) => argType.defaultValue) as Args;
+  const initialArgs = Object.entries(rows).reduce<Args>((acc, [key, argType]) => {
+    acc[key] = argType.defaultValue;
+    return acc;
+  }, {});
 
   const [args, setArgs] = useState(initialArgs);
   return (

--- a/addons/docs/src/lib/convert/convert.test.ts
+++ b/addons/docs/src/lib/convert/convert.test.ts
@@ -1,11 +1,11 @@
 import 'jest-specific-snapshot';
-import mapValues from 'lodash/mapValues';
 import { transformSync } from '@babel/core';
 import requireFromString from 'require-from-string';
 import fs from 'fs';
 
 import { convert } from './index';
 import { normalizeNewlines } from '../utils';
+import { DocgenInfo } from '../docgen/types';
 
 expect.addSnapshotSerializer({
   print: (val: any) => JSON.stringify(val, null, 2),
@@ -797,7 +797,10 @@ const convertCommon = (code: string, fileExt: string) => {
   const { Component } = requireFromString(transformToModule(docgenPretty));
   // eslint-disable-next-line no-underscore-dangle
   const { props = {} } = Component.__docgenInfo || {};
-  const types = mapValues(props, (prop) => convert(prop));
+  const types = Object.entries(props).reduce((acc, [key, prop]) => {
+    acc[key] = convert(prop as DocgenInfo);
+    return acc;
+  }, {});
   return types;
 };
 

--- a/addons/docs/src/lib/convert/proptypes/convert.ts
+++ b/addons/docs/src/lib/convert/proptypes/convert.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-case-declarations */
-import mapValues from 'lodash/mapValues';
 import { SBType } from '@storybook/client-api';
 import { PTType } from './types';
 import { trimQuotes } from '../utils';
@@ -34,7 +33,10 @@ export const convert = (type: PTType): SBType | any => {
       return { ...base, name, value: convert(value as PTType) };
     case 'shape':
     case 'exact':
-      const values = mapValues(value, (field) => convert(field));
+      const values = Object.entries<any>(value).reduce<any>((acc, [key, field]) => {
+        acc[key] = convert(field);
+        return acc;
+      }, {});
       return { ...base, name: 'object', value: values };
     case 'union':
       return { ...base, name: 'union', value: value.map((v: PTType) => convert(v)) };

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -2,7 +2,6 @@ import React from 'react';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 import { sanitize } from '@storybook/csf';
-import mapValues from 'lodash/mapValues';
 
 import { StoryId, StoryKind, Args, Parameters, combineParameters } from '../index';
 import merge from './merge';
@@ -137,14 +136,17 @@ export const denormalizeStoryParameters = ({
   kindParameters,
   stories,
 }: SetStoriesPayload): StoriesRaw => {
-  return mapValues(stories, (storyData) => ({
-    ...storyData,
-    parameters: combineParameters(
-      globalParameters,
-      kindParameters[storyData.kind],
-      (storyData.parameters as unknown) as Parameters
-    ),
-  }));
+  return Object.entries(stories).reduce<StoriesRaw>((acc, [key, storyData]) => {
+    acc[key] = {
+      ...storyData,
+      parameters: combineParameters(
+        globalParameters,
+        kindParameters[storyData.kind],
+        (storyData.parameters as unknown) as Parameters
+      ),
+    };
+    return acc;
+  }, {});
 };
 
 export const transformStoriesRawToStoriesHash = (

--- a/lib/client-api/src/ensureArgTypes.ts
+++ b/lib/client-api/src/ensureArgTypes.ts
@@ -1,10 +1,13 @@
-import mapValues from 'lodash/mapValues';
+import { ArgTypes } from '@storybook/addons';
 import { ArgTypesEnhancer } from './types';
 import { combineParameters } from './parameters';
 
 export const ensureArgTypes: ArgTypesEnhancer = (context) => {
   const { argTypes: userArgTypes = {}, args = {} } = context.parameters;
   if (!args) return userArgTypes;
-  const argTypes = mapValues(args, (_arg, name) => ({ name }));
+  const argTypes = Object.keys(args).reduce<ArgTypes>((acc, name) => {
+    acc[name] = { name };
+    return acc;
+  }, {});
   return combineParameters(argTypes, userArgTypes);
 };

--- a/lib/client-api/src/inferControls.ts
+++ b/lib/client-api/src/inferControls.ts
@@ -1,5 +1,4 @@
-import mapValues from 'lodash/mapValues';
-import { ArgType } from '@storybook/addons';
+import { ArgType, ArgTypes } from '@storybook/addons';
 import { SBEnumType, ArgTypesEnhancer } from './types';
 import { combineParameters } from './parameters';
 import { filterArgTypes } from './filterArgTypes';
@@ -56,9 +55,10 @@ export const inferControls: ArgTypesEnhancer = (context) => {
   if (!__isArgsStory) return argTypes;
 
   const filteredArgTypes = filterArgTypes(argTypes, include, exclude);
-  const withControls = mapValues(filteredArgTypes, (argType, name) => {
-    return argType?.type && inferControl(argType, name, matchers);
-  });
+  const withControls = Object.entries(filteredArgTypes).reduce<ArgTypes>((acc, [name, argType]) => {
+    acc[name] = argType?.type && inferControl(argType, name, matchers);
+    return acc;
+  }, {});
 
   return combineParameters(withControls, filteredArgTypes);
 };


### PR DESCRIPTION
## What I did
I continued the work started in #14324 and #14323, this time I replaced `lodash/mapValues` with combination of `Object.entries`/`Object.keys` and `Array.reduce`. Most of the time I spent on getting TS types right, unfortunately in many places the types are missing and I had to use `any` as I could not figure out what else to put. If you feel like it is not worth it, feel free to close this PR, no hard feelings :)

## How to test

- Is this testable with Jest or Chromatic screenshots? yes
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no
