### PR TITLE
Angular: Improve docs inline rendering setup

### DIFF
--- a/addons/docs/angular/README.md
+++ b/addons/docs/angular/README.md
@@ -220,12 +220,10 @@ Then update `.storybook/preview.js`:
 
 ```js
 import { addParameters } from '@storybook/angular';
-import { prepareForInline } from '@storybook/addon-docs/angular/inline';
 
 addParameters({
   docs: {
     inlineStories: true,
-    prepareForInline,
   },
 });
 ```

--- a/addons/docs/angular/inline.js
+++ b/addons/docs/angular/inline.js
@@ -1,1 +1,0 @@
-module.exports = require('../dist/esm/frameworks/angular/prepareForInline');

--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -1,9 +1,13 @@
 import { SourceType } from '../../shared';
 import { extractArgTypes, extractComponentDescription } from './compodoc';
 import { sourceDecorator } from './sourceDecorator';
+import { prepareForInline } from './prepareForInline';
 
 export const parameters = {
   docs: {
+    // probably set this to true by default once it's battle-tested
+    inlineStories: true,
+    prepareForInline,
     extractArgTypes,
     extractComponentDescription,
     source: {

--- a/addons/docs/src/frameworks/angular/prepareForInline.ts
+++ b/addons/docs/src/frameworks/angular/prepareForInline.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IStory, StoryContext } from '@storybook/angular';
-import { ElementRendererService } from '@storybook/angular/element-renderer';
 import { StoryFn } from '@storybook/addons';
+import { logger } from '@storybook/client-logger';
 
 const customElementsVersions: Record<string, number> = {};
 
@@ -27,6 +27,15 @@ export const prepareForInline = (storyFn: StoryFn<IStory>, { id, parameters }: S
     }
 
     async componentDidMount() {
+      const { ElementRendererService } = await import('@storybook/angular/element-renderer').catch(
+        (error) => {
+          logger.error(
+            'Check the documentation to activate `inlineStories`. The `@angular/elements` & `@webcomponents/custom-elements` dependencies are required.'
+          );
+          throw error;
+        }
+      );
+
       // eslint-disable-next-line no-undef
       customElements.define(
         customElementsName,

--- a/addons/docs/src/frameworks/angular/preset.ts
+++ b/addons/docs/src/frameworks/angular/preset.ts
@@ -1,0 +1,29 @@
+import { Configuration, IgnorePlugin, Plugin } from 'webpack';
+
+export function webpackFinal(webpackConfig: Configuration = {}): Configuration {
+  return {
+    ...webpackConfig,
+    plugins: [...webpackConfig.plugins, ...makeAngularElementRendererOptional()],
+  };
+}
+/**
+ * Ignore `@storybook/angular/element-renderer` import if `@angular/elements` is not available
+ */
+function makeAngularElementRendererOptional(): Plugin[] {
+  if (
+    moduleIsAvailable('@angular/elements') &&
+    moduleIsAvailable('@webcomponents/custom-elements')
+  ) {
+    return [];
+  }
+  return [new IgnorePlugin(/@storybook(\\|\/)angular(\\|\/)element-renderer/)];
+}
+
+function moduleIsAvailable(moduleName: string): boolean {
+  try {
+    require.resolve(moduleName);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/examples/angular-cli/.storybook/preview.ts
+++ b/examples/angular-cli/.storybook/preview.ts
@@ -1,6 +1,4 @@
-import { addParameters } from '@storybook/angular';
 import { setCompodocJson } from '@storybook/addon-docs/angular';
-import { prepareForInline } from '@storybook/addon-docs/angular/inline';
 import addCssWarning from '../src/cssWarning';
 
 // @ts-ignore
@@ -17,17 +15,16 @@ setCompodocJson(filtered);
 
 addCssWarning();
 
-addParameters({
+export const parameters = {
   docs: {
     inlineStories: true,
-    prepareForInline,
   },
   options: {
     storySort: {
       order: ['Welcome', 'Core ', 'Addons ', 'Basics '],
     },
   },
-});
+};
 
 export const globalTypes = {
   theme: {


### PR DESCRIPTION
Issue:

## What I did


Re adds the changes made in this [PR](https://github.com/storybookjs/storybook/pull/14270
) and revert in this [one](https://github.com/storybookjs/storybook/pull/14310) 

But this time adds a Webpack configuration to make `@storybook/angular/element-renderer` import optional if the sb client does not have the right dependencies

> Set up Angular prepareForInline inside the preset. Users can enable it on by simply setting docs.inlineStories: true and we don't need to create another entry point or import in the user's code.
> NOTE that this is a breaking change for prerelease users, since this PR removes the unnecessary entry point.


## How to test

- Is this testable with Jest or Chromatic screenshots? 
> yes it is tested by e2e 
- Does this need a new example in the kitchen sink apps? 
> N/A
- Does this need an update to the documentation? 
> Done

