### PR TITLE
Addon-docs: Fix un-prefixed path links

### DIFF
--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -95,6 +95,8 @@ export const AnchorMdx: FC<AnchorMdxProps> = (props) => {
           href={href}
           onClick={(event: SyntheticEvent) => {
             event.preventDefault();
+            // use the A element's href, which has been modified for
+            // local paths without a `?path=` query param prefix
             navigate(event.currentTarget.getAttribute('href'));
           }}
           target={target}

--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -95,7 +95,7 @@ export const AnchorMdx: FC<AnchorMdxProps> = (props) => {
           href={href}
           onClick={(event: SyntheticEvent) => {
             event.preventDefault();
-            navigate(href);
+            navigate(event.currentTarget.getAttribute('href'));
           }}
           target={target}
           {...rest}

--- a/examples/official-storybook/stories/addon-docs/markdown.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/markdown.stories.mdx
@@ -145,6 +145,8 @@ Table with icons
 
 [link to in page anchor](#h1-heading)
 
+[link to another story (docs, without prefix)](/docs/addons-docs-docs-only--page)
+
 [link to another story (docs)](?path=/docs/addons-docs-docs-only--page)
 
 [link to another story (canvas)](?path=/story/addons-docs-buttongroup--basic)

--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -73,7 +73,6 @@ export const Pre = styled.pre<{}>(withReset, withMargin, ({ theme }) => ({
 const Link: FunctionComponent<any> = ({ href: input, children, ...props }) => {
   const isStorybookPath = /^\//.test(input);
   const isAnchorUrl = /^#.*/.test(input);
-
   const href = isStorybookPath ? `?path=${input}` : input;
   const target = isAnchorUrl ? '_self' : '_top';
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13630

## What I did

- The href attribute (prop) was being modified (prefixed) by the Link component, but the click-handler didn't read this modification.

It seems the logical place to change/prefix the href would be in the`addons/docs/src/blocks/mdx.tsx` code itself, but this is a fine solution that backwards compatible for now.