### PR TITLE
Pass proper stack of an error

### DIFF
--- a/lib/core-client/src/preview/loadCsf.ts
+++ b/lib/core-client/src/preview/loadCsf.ts
@@ -57,7 +57,8 @@ const loadStories = (
             typeof req.resolve === 'function' ? req.resolve(filename) : filename
           );
         } catch (error) {
-          logger.warn(`Unexpected error while loading ${filename}: ${error}`);
+          const errorString = error.message && error.stack ? `${error.message}\n ${error.stack}` : error.toString();
+          logger.warn(`Unexpected error while loading ${filename}: ${errorString}`);
         }
       });
     });


### PR DESCRIPTION
Issue: Stack of an error is not the error's, but the storybook's.

## What I did
Pass stack explicitly (toString does not include it).

## How to test

- Is this testable with Jest or Chromatic screenshots? - Passively?
- Does this need a new example in the kitchen sink apps? - No
- Does this need an update to the documentation? - No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
