### PR TITLE
Controls: Fix edge case in datetime control

### DIFF
--- a/addons/knobs/src/components/types/Date.tsx
+++ b/addons/knobs/src/components/types/Date.tsx
@@ -86,9 +86,7 @@ export default class DateType extends Component<DateTypeProps, DateTypeState> {
     const [year, month, day] = e.target.value.split('-');
     const result = new Date(knob.value);
     if (result.getTime()) {
-      result.setFullYear(parseInt(year, 10));
-      result.setMonth(parseInt(month, 10) - 1);
-      result.setDate(parseInt(day, 10));
+      result.setFullYear(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
       if (result.getTime()) {
         valid = true;
         onChange(result.getTime());

--- a/lib/components/src/controls/Date.tsx
+++ b/lib/components/src/controls/Date.tsx
@@ -7,9 +7,7 @@ import { ControlProps, DateValue, DateConfig } from './types';
 const parseDate = (value: string) => {
   const [year, month, day] = value.split('-');
   const result = new Date();
-  result.setFullYear(parseInt(year, 10));
-  result.setMonth(parseInt(month, 10) - 1);
-  result.setDate(parseInt(day, 10));
+  result.setFullYear(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
   return result;
 };
 
@@ -75,9 +73,7 @@ export const DateControl: FC<DateProps> = ({ name, value, onChange, onFocus, onB
   const onDateChange = (e: ChangeEvent<HTMLInputElement>) => {
     const parsed = parseDate(e.target.value);
     const result = new Date(value);
-    result.setFullYear(parsed.getFullYear());
-    result.setMonth(parsed.getMonth());
-    result.setDate(parsed.getDate());
+    result.setFullYear(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
     const time = result.getTime();
     if (time) onChange(time);
     setValid(!!time);


### PR DESCRIPTION
Issue: #13771

## What I did

Mutating a Date object with `setMonth` and `setDate` will validate and potentially adjust it by rolling into the next month if the resulting month has fewer days than the resulting day.

I've modified the date change callback in each date-time component to apply changes in one step with `setFullYear` instead of separate steps for year/month/day.

## How to test

- Serve storybooks and navigate to `official-storybooks > Controls > Date > Basic`
- Change date to 31/01/2021
- Change date to 28/02/2021
- It shouldn't change to 28/03/2021

------

- Is this testable with Jest or Chromatic screenshots? ❌
- Does this need a new example in the kitchen sink apps? ❌
- Does this need an update to the documentation? ❌

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
