### PR TITLE
CSF: Optionally pass Args generic type from BaseAnnotations to ArgTypes

### DIFF
--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -43,9 +43,9 @@ export interface ArgType {
   [key: string]: any;
 }
 
-export interface ArgTypes {
-  [key: string]: ArgType;
-}
+export type ArgTypes<Args = Record<string, any>> = {
+  [key in keyof Partial<Args>]: ArgType;
+};
 
 export interface StoryIdentifier {
   id: StoryId;
@@ -174,7 +174,7 @@ export interface BaseAnnotations<Args, StoryFnReturnType> {
    * ArgTypes encode basic metadata for args, such as `name`, `description`, `defaultValue` for an arg. These get automatically filled in by Storybook Docs.
    * @see [Control annotations](https://github.com/storybookjs/storybook/blob/91e9dee33faa8eff0b342a366845de7100415367/addons/controls/README.md#control-annotations)
    */
-  argTypes?: ArgTypes;
+  argTypes?: ArgTypes<Args>;
 
   /**
    * Custom metadata for a story.


### PR DESCRIPTION
Issue: #14301 

## What I did
Added the possibility got type Meta's generic Args to be passed to the ArgTypes property for the BaseAnnotation interface.

## How to test
I didn't see any _ts-expect_ or similar libraries so automatically test for types. Manually it can be tested.

## Notes
The Args generic could be propagated to ArgTypes in more situations, other than just the BaseAnnotations type. 
For example in StoryContext:
```
export declare type StoryContext = StoryIdentifier & {
    ...
    args: Args;
    argTypes: ArgTypes;
    ...
};
```
These kind of changes however may have required many more changes on related types. And I am not sure how used it would be. Meta seems to be the type most directly used by a user. 
The default generic for ArgTypes is therefore set to `Record<string, any>`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
