### PR TITLE
Chore: (Docs) fixes broken link in GH for new framework docs

### DIFF
--- a/docs/api/new-frameworks.md
+++ b/docs/api/new-frameworks.md
@@ -24,7 +24,7 @@ Supporting a new framework in Storybook typically consists of two main aspects:
 
 ## Configuring the server
 
-Storybook has the concept of [presets](../addons/writing-presets#presets-api), which are typically babel/webpack configurations for file loading. If your framework has its own file format, e.g. “.vue,” you might need to transform these files into JS files at load time. If you expect every user of your framework to need this, you should add it to the framework. So far every framework added to Storybook has done this, because Storybook’s core configuration is very minimal.
+Storybook has the concept of [presets](../addons/writing-presets.md#presets-api), which are typically babel/webpack configurations for file loading. If your framework has its own file format, e.g. “.vue,” you might need to transform these files into JS files at load time. If you expect every user of your framework to need this, you should add it to the framework. So far every framework added to Storybook has done this, because Storybook’s core configuration is very minimal.
 
 ### Package structure
 


### PR DESCRIPTION
This pull request follows up #14351. 

What was done:
- Included the `.md` extension in the link to avoid GitHub 404 when clicking that link.


Going to self merge this once the checks clear