### PR TITLE
Components: Deprecate html components entry point

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,6 +11,7 @@
     - [Deprecated default PostCSS plugins](#deprecated-default-postcss-plugins)
     - [Deprecated showRoots config option](#deprecated-showroots-config-option)
     - [Deprecated control.options](#deprecated-controloptions)
+    - [Deprecated storybook components html entry point](#deprecated-storybook-components-html-entry-point)
 - [From version 6.0.x to 6.1.0](#from-version-60x-to-610)
   - [Addon-backgrounds preset](#addon-backgrounds-preset)
   - [Single story hoisting](#single-story-hoisting)
@@ -273,6 +274,18 @@ argTypes: {
 Keys in `control.labels` as well as in `mapping` should match the values in `options`. Neither object has to be exhaustive, in case of a missing property, the option value will be used directly.
 
 If you are currently using an object as value for `control.options`, be aware that the key and value are reversed in `control.labels`.
+
+#### Deprecated storybook components html entry point
+
+Storybook HTML components are now exported directly from '@storybook/components' for better ESM and Typescript compatibility. The old entry point will be removed in SB 7.0.
+
+```js
+// before
+import { components } from '@storybook/components/html';
+
+// after
+import { components } from '@storybook/components';
+```
 
 ## From version 6.0.x to 6.1.0
 

--- a/lib/components/html.d.ts
+++ b/lib/components/html.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/ts3.9/html.d';

--- a/lib/components/html.js
+++ b/lib/components/html.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/cjs/html');

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -58,7 +58,8 @@
     "react-syntax-highlighter": "^13.5.3",
     "react-textarea-autosize": "^8.3.0",
     "regenerator-runtime": "^0.13.7",
-    "ts-dedent": "^2.0.0"
+    "ts-dedent": "^2.0.0",
+    "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "css": "^3.0.0",

--- a/lib/components/src/html.tsx
+++ b/lib/components/src/html.tsx
@@ -1,0 +1,15 @@
+import dedent from 'ts-dedent';
+import deprecate from 'util-deprecate';
+
+const deprecatedHtmlEndpoint = deprecate(
+  () => {},
+  dedent`
+    The entry point '@storybook/components/html' is deprecated. Please use '@storybook/components' directly instead.
+
+    See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-storybook-components-html-entry-point
+  `
+);
+deprecatedHtmlEndpoint();
+
+export * from './typography/DocumentFormatting';
+export { components, resetComponents } from './index';


### PR DESCRIPTION
Issue: #14320 

## What I did

Deprecated the endpoint instead of removing it

self-merging @tmeasday 

## How to test

Import from '@storybook/components/html' in a project?
