### PR TITLE
Controls: Color picker QA fixes

### DIFF
--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -23,6 +23,7 @@ const PickerTooltip = styled(WithTooltip)({
 });
 
 const TooltipContent = styled.div({
+  width: 200,
   margin: 5,
 
   '.react-colorful__saturation': {
@@ -35,6 +36,10 @@ const TooltipContent = styled.div({
     borderRadius: '0 0 4px 4px',
   },
 });
+
+const Note = styled(TooltipNote)(({ theme }) => ({
+  fontFamily: theme.typography.fonts.base,
+}));
 
 const Swatches = styled.div({
   display: 'grid',
@@ -62,11 +67,13 @@ const Swatch = ({ value, active, onClick, style, ...props }: SwatchProps) => {
   return <SwatchColor {...props} {...{ active, onClick }} style={{ ...style, backgroundImage }} />;
 };
 
-const Input = styled(Form.Input)({
+const Input = styled(Form.Input)(({ theme }) => ({
   width: '100%',
   paddingLeft: 30,
   paddingRight: 30,
-});
+  boxSizing: 'border-box',
+  fontFamily: theme.typography.fonts.base,
+}));
 
 const ToggleIcon = styled(Icons)(({ theme }) => ({
   position: 'absolute',
@@ -76,6 +83,7 @@ const ToggleIcon = styled(Icons)(({ theme }) => ({
   width: 20,
   height: 20,
   padding: 4,
+  boxSizing: 'border-box',
   cursor: 'pointer',
   color: theme.input.color,
 }));
@@ -278,7 +286,7 @@ export const ColorControl: FC<ColorProps> = ({
                   <WithTooltip
                     key={preset.value}
                     hasChrome={false}
-                    tooltip={<TooltipNote note={preset.keyword || preset.value} />}
+                    tooltip={<Note note={preset.keyword || preset.value} />}
                   >
                     <Swatch
                       value={preset[colorSpace]}

--- a/lib/components/src/tooltip/TooltipNote.tsx
+++ b/lib/components/src/tooltip/TooltipNote.tsx
@@ -20,6 +20,6 @@ export interface TooltipNoteProps {
   note: string;
 }
 
-export const TooltipNote: FunctionComponent<TooltipNoteProps> = ({ note }) => {
-  return <Note>{note}</Note>;
+export const TooltipNote: FunctionComponent<TooltipNoteProps> = ({ note, ...props }) => {
+  return <Note {...props}>{note}</Note>;
 };


### PR DESCRIPTION
Issue: #14374

## What I did

- Added `box-sizing: border-box` and other default styles where needed. The official-storybook has these, but the other examples don't.
- Fixed invalid presets from getting added by tracking a `valid` prop.

The tooltip position is also a bit jittery in docs mode. I haven't been able to figure that out yet.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
