### PR TITLE
Svelte: Fix Cannot read property '__docgen' of undefined

### DIFF
--- a/addons/docs/src/frameworks/svelte/sourceDecorator.test.ts
+++ b/addons/docs/src/frameworks/svelte/sourceDecorator.test.ts
@@ -41,4 +41,7 @@ describe('generateSvelteSource', () => {
       </Component>
     `);
   });
+  test('component is not set', () => {
+    expect(generateSvelteSource(null, null, null, null)).toBeNull();
+  });
 });

--- a/addons/docs/src/frameworks/svelte/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/svelte/sourceDecorator.ts
@@ -58,6 +58,10 @@ function toSvelteProperty(key: string, value: any, argTypes: ArgTypes): string {
  * @param component Component
  */
 function getComponentName(component: any): string {
+  if (component == null) {
+    return null;
+  }
+
   const { __docgen = {} } = component;
   let { name } = __docgen;
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/addon-svelte-csf/issues/15

When a svelte stories doesn't set the component in the default export (or with <Meta/> in addon-svelte-csf), then the stories doesn't show with "Cannot read property '__docgen' of undefined"

## What I did

The svelte source decorators was using the component without checking if it's set or not. I have added a null check here.

## How to test

- Is this testable with Jest or Chromatic screenshots? Done
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
