### PR TITLE
Controls: Fix defaultValue without PropType

### DIFF
--- a/addons/docs/src/frameworks/react/__testfixtures__/js-class-component/docgen.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/js-class-component/docgen.snapshot
@@ -50,7 +50,9 @@ PropsWriter.defaultProps = {
   localReference: local,
   importedReference: imported,
   globalReference: Date,
-  stringGlobalName: 'top'
+  stringGlobalName: 'top',
+  // eslint-disable-next-line react/default-props-match-prop-types
+  stringNoPropType: 'stringNoPropType'
 };
 export const component = PropsWriter;
 PropsWriter.__docgenInfo = {
@@ -183,6 +185,13 @@ PropsWriter.__docgenInfo = {
       },
       \\"required\\": false,
       \\"description\\": \\"\\"
+    },
+    \\"stringNoPropType\\": {
+      \\"defaultValue\\": {
+        \\"value\\": \\"'stringNoPropType'\\",
+        \\"computed\\": false
+      },
+      \\"required\\": false
     },
     \\"numberRequired\\": {
       \\"type\\": {

--- a/addons/docs/src/frameworks/react/__testfixtures__/js-class-component/input.js
+++ b/addons/docs/src/frameworks/react/__testfixtures__/js-class-component/input.js
@@ -48,6 +48,8 @@ PropsWriter.defaultProps = {
   importedReference: imported,
   globalReference: Date,
   stringGlobalName: 'top',
+  // eslint-disable-next-line react/default-props-match-prop-types
+  stringNoPropType: 'stringNoPropType',
 };
 
 export const component = PropsWriter;


### PR DESCRIPTION
Issue: #14377

## What I did

Handle the case where `type` is `null`

## How to test

- Is this testable with Jest or Chromatic screenshots?
Chromatic - yes
Jest - couldn't get the `extractDocgenProps.test` to easily recreate this situation (you need the first prop to have a type and the second to not, which isn't possible in the current test harness).
