### PR TITLE
CLI: Fix link to `sb init` docs

### DIFF
--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -245,7 +245,7 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
       default:
         paddedLog(`We couldn't detect your project type. (code: ${projectType})`);
         paddedLog(
-          'You can specify a project type explicitly via `sb init --type <type>` or follow some of the slow start guides: https://storybook.js.org/basics/slow-start-guide/'
+          'You can specify a project type explicitly via `sb init --type <type>`, see our docs on how to configure Storybook for your framework: https://storybook.js.org/docs/react/get-started/install'
         );
 
         // Add a new line for the clear visibility.


### PR DESCRIPTION
With this pull request the Storybook CLI is updated to provide the proper URL and message when the user attempts to install Storybook into an empty project. The URL currently provided is pointing to https://storybook.js.org/basics/slow-start-guide/, which is resolved into https://storybook.js.org/docs/react/configure/overview, which should not be the case.

I ran into this small issue while watching [this](https://youtu.be/qWAoHIPEWQs?t=558).

@shilman I left the `cli` label attached to this pull request, let me know I need any additional ones.

Feel free to provide feedback