### PR TITLE
Addon-docs/Angular: Keep inlineStories to false by default

### DIFF
--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -6,7 +6,7 @@ import { prepareForInline } from './prepareForInline';
 export const parameters = {
   docs: {
     // probably set this to true by default once it's battle-tested
-    inlineStories: true,
+    inlineStories: false,
     prepareForInline,
     extractArgTypes,
     extractComponentDescription,


### PR DESCRIPTION
Issue: 

🙈  multiple reverts and bounces of this subject have lost a small essential change

## What I did

keep a inlineStories = false as expected ... 

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

![image](https://user-images.githubusercontent.com/4974420/113399034-d5bdc900-939f-11eb-9180-014e25c6a2ed.png)
