### PR TITLE
Core: Fix symlinks in static dir when building static Storybook

### DIFF
--- a/lib/core-server/src/utils/copy-all-static-files.ts
+++ b/lib/core-server/src/utils/copy-all-static-files.ts
@@ -15,7 +15,11 @@ export async function copyAllStaticFiles(staticDirs: any[] | undefined, outputDi
 
           // Storybook's own files should not be overwritten, so we skip such files if we find them
           const skipPaths = ['index.html', 'iframe.html'].map((f) => path.join(targetPath, f));
-          await fs.copy(staticPath, targetPath, { filter: (_, dest) => !skipPaths.includes(dest) });
+          await fs.copy(staticPath, targetPath, {
+            dereference: true,
+            preserveTimestamps: true,
+            filter: (_, dest) => !skipPaths.includes(dest),
+          });
         } catch (e) {
           logger.error(e.message);
           process.exit(-1);


### PR DESCRIPTION
Issue: -

## What I did

- Fixed symlink expansion in static dir when building Storybook
- Keep original file timestamps when copying static dir

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
