### PR TITLE
Controls/Knobs: Set input to empty string when value is null

### DIFF
--- a/addons/knobs/src/components/types/Number.tsx
+++ b/addons/knobs/src/components/types/Number.tsx
@@ -5,7 +5,7 @@ import { styled } from '@storybook/theming';
 import { Form } from '@storybook/components';
 import { KnobControlConfig, KnobControlProps } from './types';
 
-type NumberTypeKnobValue = number;
+type NumberTypeKnobValue = number | null;
 
 export interface NumberTypeKnobOptions {
   range?: boolean;
@@ -95,12 +95,13 @@ export default class NumberType extends Component<NumberTypeProps> {
 
   render() {
     const { knob } = this.props;
+    const inputValue = knob.value === null ? '' : knob.value;
 
     return knob.range ? (
       <RangeWrapper>
         <RangeLabel>{knob.min}</RangeLabel>
         <RangeInput
-          value={knob.value}
+          value={inputValue}
           type="range"
           name={knob.name}
           min={knob.min}
@@ -112,7 +113,7 @@ export default class NumberType extends Component<NumberTypeProps> {
       </RangeWrapper>
     ) : (
       <Form.Input
-        value={knob.value}
+        value={inputValue}
         type="number"
         name={knob.name}
         min={knob.min}

--- a/addons/knobs/src/index.ts
+++ b/addons/knobs/src/index.ts
@@ -34,7 +34,7 @@ export function boolean(name: string, value: boolean, groupId?: string) {
 
 export function number(
   name: string,
-  value: number,
+  value: number | null,
   options: NumberTypeKnobOptions = {},
   groupId?: string
 ) {

--- a/lib/components/src/controls/Number.tsx
+++ b/lib/components/src/controls/Number.tsx
@@ -30,6 +30,7 @@ export const NumberControl: FC<NumberProps> = ({
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange(parse(event.target.value));
   };
+  const inputValue = value === null ? '' : value;
 
   return (
     <Wrapper>
@@ -38,7 +39,7 @@ export const NumberControl: FC<NumberProps> = ({
         onChange={handleChange}
         size="flex"
         placeholder="Adjust number dynamically"
-        value={value === null ? undefined : value}
+        value={inputValue}
         {...{ name, min, max, step, onFocus, onBlur }}
       />
     </Wrapper>

--- a/lib/components/src/controls/Range.tsx
+++ b/lib/components/src/controls/Range.tsx
@@ -135,7 +135,7 @@ const RangeInput = styled.input(({ theme }) => ({
   },
   '&:focus::-ms-fill-lower': { background: '#dddddd' },
   '&:focus::-ms-fill-upper': { background: '#e0e0e0' },
-  '@supports (-ms-ime-align:auto)': { 'input[type=range]': { margin: '0' } },
+  '@supports (msImeAlign:auto)': { 'input[type=range]': { margin: '0' } },
 }));
 
 const RangeLabel = styled.span({
@@ -164,13 +164,16 @@ export const RangeControl: FC<RangeProps> = ({
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange(parse(event.target.value));
   };
+  const inputValue = value === null ? '' : value;
+
   return (
     <RangeWrapper>
       <RangeLabel>{min}</RangeLabel>
       <RangeInput
         type="range"
         onChange={handleChange}
-        {...{ name, value, min, max, step, onFocus, onBlur }}
+        value={inputValue}
+        {...{ name, min, max, step, onFocus, onBlur }}
       />
       <RangeLabel>{`${value} / ${max}`}</RangeLabel>
     </RangeWrapper>


### PR DESCRIPTION
Issue: #13826

## What I did

React is adding errors to the console: `value prop on 'input' should not be null` and `A component is changing a controlled input of type number to be uncontrolled` whenever the contents of a number control or knob are deleted.

In this PR, I set the input value to an empty string when the value of the knob or control is null. This prevents React from throwing errors about input values being null and inputs changing from controlled to uncontrolled.

## How to test

In the current official storybook and kitchen sink examples if you delete the text inside a number knob or control there will be errors in the console.  Examples of this issue can be found in the stories for examples/official-storybook in `controls/number` and `addons/knobs/withKnobs/tweaks static values`. 

In this branch there are no longer any errors in the console when you delete the text in a number control or number knob.

- Is this testable with Jest or Chromatic screenshots?
No

- Does this need a new example in the kitchen sink apps?
No

- Does this need an update to the documentation?
No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
