### PR TITLE
Pass watchOptions from webpack config to webpackDevMiddleware (v3 only)

### DIFF
--- a/lib/builder-webpack4/src/index.ts
+++ b/lib/builder-webpack4/src/index.ts
@@ -71,6 +71,7 @@ export const start: WebpackBuilder['start'] = async ({ startTime, options, route
     publicPath: config.output?.publicPath as string,
     writeToDisk: true,
     logLevel: 'error',
+    watchOptions: config.watchOptions || {},
   };
 
   compilation = webpackDevMiddleware(compiler, middlewareOptions);

--- a/lib/core-server/src/manager/builder.ts
+++ b/lib/core-server/src/manager/builder.ts
@@ -73,6 +73,7 @@ export const start: WebpackBuilder['start'] = async ({ startTime, options, route
   const middlewareOptions: Parameters<typeof webpackDevMiddleware>[1] = {
     publicPath: config.output?.publicPath as string,
     writeToDisk: true,
+    watchOptions: config.watchOptions || {},
   };
 
   compilation = webpackDevMiddleware(compiler, middlewareOptions);


### PR DESCRIPTION
Issue: When a user specifies [`watchOptions`](https://v4.webpack.js.org/configuration/watch/) in `webpackFinal` or `managerWebpack`, it should be carried to webpackDevMiddleware.

This allows users to specify directories they'd like the watcher to ignore (useful on large codebases).

## What I did

Passed `config.watchOptions` (when defined) to `webpackDevMiddleware` where `webpack-dev-middleware@3` is loaded.

Note that this should only applies to `webpack-dev-middleware@3`, as `v4` takes this setting directly from the compiler's webpack config.

**Important:** this code must be removed when `webpack-dev-middleware` is updated to v4.

## How to test

I'd appreciate guidance on how to write tests.