### PR TITLE
Vue 3: rename slot args if prop args with same name already exist

### DIFF
--- a/addons/docs/src/frameworks/vue3/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue3/extractArgTypes.ts
@@ -1,3 +1,4 @@
+import upperFirst from 'lodash/upperFirst';
 import { ArgTypes } from '@storybook/api';
 import { ArgTypesExtractor, hasDocgen, extractComponentProps } from '../../lib/docgen';
 import { convert } from '../../lib/convert';
@@ -21,8 +22,10 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
         // eslint-disable-next-line no-empty
       } catch {}
 
-      results[name] = {
-        name,
+      const argName = name in results && section === 'slots' ? `slot${upperFirst(name)}` : name;
+
+      results[argName] = {
+        name: argName,
         description,
         type: { required, ...sbType },
         defaultValue,


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12850

## What I did

If a slot argument is generated and a prop argument with the same name already exists, the slot argument will have a `slot` prefix (e.g. `default` -> `slotDefault`).

## How to test

- **Is this testable with Jest or Chromatic screenshots?** Probably, but I wasn't able to find an existing test suite for Vue 3, and I'm not experienced enough to build one up from the ground.
- **Does this need a new example in the kitchen sink apps?** I think it would make sense. I created a small working example in this branch: https://github.com/TimonLukas/storybook/tree/vue3-prop-slot-args-example I'm not sure what the best practice for merging it is - should it be integrated into an already existing story?
- **Does this need an update to the documentation?** It should be documented, but I wasn't able to find Vue 3-specific documentation beyond the blog posts.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
