### PR TITLE
Core: Fix config.js-based configuration

### DIFF
--- a/lib/core-server/src/utils/get-preview-builder.ts
+++ b/lib/core-server/src/utils/get-preview-builder.ts
@@ -1,10 +1,13 @@
 import path from 'path';
 import { getInterpretedFile, serverRequire, Options } from '@storybook/core-common';
 
+const DEFAULT_WEBPACK = 'webpack4';
+
 export async function getPreviewBuilder(configDir: Options['configDir']) {
   const main = path.resolve(configDir, 'main');
-  const { core } = serverRequire(getInterpretedFile(main));
-  const builder = core?.builder || 'webpack4';
+  const mainFile = getInterpretedFile(main);
+  const { core } = mainFile ? serverRequire(mainFile) : { core: null };
+  const builder = core?.builder || DEFAULT_WEBPACK;
 
   const previewBuilder = await import(`@storybook/builder-${builder}`);
   return previewBuilder;


### PR DESCRIPTION
Issue: #14458 

## What I did

Don't try to require `main.js` when the file doesn't exist

self-merging @ndelangen 

## How to test

```
cd examples/react-ts
# replace main.js with config.js
yarn storybook 
```

```js
// config.js
import { configure } from '@storybook/react';
configure(require.context('./src', true, /\.stories\..*/), module);
```

