### PR TITLE
Core: Fix file-loader options for ESM compat

### DIFF
--- a/lib/builder-webpack4/src/preview/base-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/base-webpack.config.ts
@@ -110,6 +110,7 @@ export async function createDefaultWebpackConfig(
           test: /\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
           loader: require.resolve('file-loader'),
           options: {
+            esModule: false,
             name: isProd
               ? 'static/media/[name].[contenthash:8].[ext]'
               : 'static/media/[path][name].[ext]',

--- a/lib/builder-webpack5/src/preview/base-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/base-webpack.config.ts
@@ -55,6 +55,7 @@ export async function createDefaultWebpackConfig(
           test: /\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
           loader: require.resolve('file-loader'),
           options: {
+            esModule: false,
             name: isProd
               ? 'static/media/[name].[contenthash:8].[ext]'
               : 'static/media/[path][name].[ext]',

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
@@ -435,6 +435,7 @@ Object {
       Object {
         "loader": "NODE_MODULES/file-loader/dist/cjs.js",
         "options": Object {
+          "esModule": false,
           "name": "static/media/[path][name].[ext]",
         },
         "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
@@ -434,6 +434,7 @@ Object {
       Object {
         "loader": "NODE_MODULES/file-loader/dist/cjs.js",
         "options": Object {
+          "esModule": false,
           "name": "static/media/[name].[contenthash:8].[ext]",
         },
         "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
@@ -433,6 +433,7 @@ Object {
       Object {
         "loader": "NODE_MODULES/file-loader/dist/cjs.js",
         "options": Object {
+          "esModule": false,
           "name": "static/media/[path][name].[ext]",
         },
         "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
@@ -432,6 +432,7 @@ Object {
       Object {
         "loader": "NODE_MODULES/file-loader/dist/cjs.js",
         "options": Object {
+          "esModule": false,
           "name": "static/media/[name].[contenthash:8].[ext]",
         },
         "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
@@ -464,6 +464,7 @@ Object {
       Object {
         "loader": "NODE_MODULES/file-loader/dist/cjs.js",
         "options": Object {
+          "esModule": false,
           "name": "static/media/[path][name].[ext]",
         },
         "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
@@ -463,6 +463,7 @@ Object {
       Object {
         "loader": "NODE_MODULES/file-loader/dist/cjs.js",
         "options": Object {
+          "esModule": false,
           "name": "static/media/[name].[contenthash:8].[ext]",
         },
         "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",


### PR DESCRIPTION
Issue: #3339

## What I did
File-loader settings broke in 6.2. This fixes it.

## How to test
See the "welcome" story in `examples/vue-kitchen-sink`. Somehow this got through! :see_no_evil: 

![](https://user-images.githubusercontent.com/488689/113582639-3167ab00-965b-11eb-8bc3-37ccaf7830c0.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1199622255231368/1200152433742398) by [Unito](https://www.unito.io)
