### PR TITLE
Upgrade `dotenv-webpack` to v6

### DIFF
--- a/lib/builder-webpack4/package.json
+++ b/lib/builder-webpack4/package.json
@@ -80,7 +80,7 @@
     "case-sensitive-paths-webpack-plugin": "^2.3.0",
     "core-js": "^3.8.2",
     "css-loader": "^3.6.0",
-    "dotenv-webpack": "^1.8.0",
+    "dotenv-webpack": "^6.0.0",
     "file-loader": "^6.2.0",
     "find-up": "^5.0.0",
     "fork-ts-checker-webpack-plugin": "^4.1.6",

--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -65,7 +65,7 @@
     "cpy": "^8.1.1",
     "css-loader": "^3.6.0",
     "detect-port": "^1.3.0",
-    "dotenv-webpack": "^1.8.0",
+    "dotenv-webpack": "^6.0.0",
     "express": "^4.17.1",
     "file-loader": "^6.2.0",
     "file-system-cache": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13283,13 +13283,6 @@ dot@^1.1.3:
   resolved "https://registry.yarnpkg.com/dot/-/dot-1.1.3.tgz#351360e00a748bce9a1f8f27c00c394a7e4e1e9f"
   integrity sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg==
 
-dotenv-defaults@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-1.1.1.tgz#032c024f4b5906d9990eb06d722dc74cc60ec1bd"
-  integrity sha512-6fPRo9o/3MxKvmRZBD3oNFdxODdhJtIy1zcJeUSCs6HCy4tarUpd+G67UTU9tF6OWXeSPqsm4fPAB+2eY9Rt9Q==
-  dependencies:
-    dotenv "^6.2.0"
-
 dotenv-defaults@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz#ea6f9632b3b5cc55e48b736760def5561f1cb7c0"
@@ -13302,13 +13295,6 @@ dotenv-expand@5.1.0, dotenv-expand@^5.1.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
-dotenv-webpack@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-1.8.0.tgz#7ca79cef2497dd4079d43e81e0796bc9d0f68a5e"
-  integrity sha512-o8pq6NLBehtrqA8Jv8jFQNtG9nhRtVqmoD4yWbgUyoU3+9WBlPe+c2EAiaJok9RB28QvrWvdWLZGeTT5aATDMg==
-  dependencies:
-    dotenv-defaults "^1.0.2"
-
 dotenv-webpack@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-6.0.0.tgz#cd42454ee754fe8b7adb4fb70196f6e45f41876c"
@@ -13316,7 +13302,7 @@ dotenv-webpack@^6.0.0:
   dependencies:
     dotenv-defaults "^2.0.1"
 
-dotenv@6.2.0, dotenv@^6.2.0:
+dotenv@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==


### PR DESCRIPTION
Issue: #14403

## What I did

This PR bumps `dotenv-webpack` to v6 in places that were still using v1.8, resolving #14403.

## How to test

All tests pass.

I also reviewed `dotenv-webpack`'s changelog to ensure there weren't side effects of this upgrade. Some parts of Storybook are already using v6 and there do not appear to be any breaking changes from this upgrade, so I feel pretty confident it will work fine.