### PR TITLE
Controls: Reset ArgsTable state when switching stories

### DIFF
--- a/addons/controls/src/ControlsPanel.tsx
+++ b/addons/controls/src/ControlsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { ArgTypes, useArgs, useArgTypes, useParameter } from '@storybook/api';
+import { ArgTypes, useArgs, useArgTypes, useParameter, useStorybookState } from '@storybook/api';
 import { ArgsTable, NoControlsWarning, PresetColor, SortType } from '@storybook/components';
 
 import { PARAM_KEY } from './constants';
@@ -21,6 +21,7 @@ export const ControlsPanel: FC = () => {
     presetColors,
     hideNoControlsWarning = false,
   } = useParameter<ControlsParameters>(PARAM_KEY, {});
+  const { path } = useStorybookState();
 
   const hasControls = Object.values(rows).some((arg) => arg?.control);
   const showWarning = !(hasControls && isArgsStory) && !hideNoControlsWarning;
@@ -36,6 +37,7 @@ export const ControlsPanel: FC = () => {
       {showWarning && <NoControlsWarning />}
       <ArgsTable
         {...{
+          key: path, // resets state when switching stories
           compact: !expanded && hasControls,
           rows: withPresetColors,
           args,

--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -218,14 +218,17 @@ const useColorInput = (initialValue: string, onChange: (value: string) => string
     colorSpace,
   ]);
 
-  const updateValue = useCallback((update: string) => {
-    const parsed = parseValue(update);
-    setValue(parsed?.value || update || '');
-    if (!parsed) return;
-    setColor(parsed);
-    setColorSpace(parsed.colorSpace);
-    onChange(parsed.value);
-  }, []);
+  const updateValue = useCallback(
+    (update: string) => {
+      const parsed = parseValue(update);
+      setValue(parsed?.value || update || '');
+      if (!parsed) return;
+      setColor(parsed);
+      setColorSpace(parsed.colorSpace);
+      onChange(parsed.value);
+    },
+    [onChange]
+  );
 
   const cycleColorSpace = useCallback(() => {
     let next = COLOR_SPACES.indexOf(colorSpace) + 1;
@@ -234,7 +237,7 @@ const useColorInput = (initialValue: string, onChange: (value: string) => string
     const update = color?.[COLOR_SPACES[next]] || '';
     setValue(update);
     onChange(update);
-  }, [color, colorSpace]);
+  }, [color, colorSpace, onChange]);
 
   return { value, realValue, updateValue, color, colorSpace, cycleColorSpace };
 };


### PR DESCRIPTION
Issue: #14474

## What I did

Added the `key` prop to force React to create a fresh component rather than reuse a previous instance.
Added a missing dependency to `useCallback` in two places which could lead to the wrong onChange handler getting called.

This also fixes a similar issue with the JSON raw editor using stale data when switching stories.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
