### PR TITLE
Core: Don't include args param in docs mode URL

### DIFF
--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -151,11 +151,13 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
   const initModule = () => {
     // Sets `args` parameter in URL, omitting any args that have their initial value or cannot be unserialized safely.
     const updateArgsParam = (args?: Story['args']) => {
+      const { path, viewMode } = fullAPI.getUrlState();
+      if (viewMode !== 'story') return;
       const currentStory = fullAPI.getCurrentStoryData();
       const initialArgs = (isStory(currentStory) && currentStory.initialArgs) || {};
       const argsString = buildArgsParam(initialArgs, args);
       const argsParam = argsString.length ? `&args=${argsString}` : '';
-      queryNavigate(`${fullAPI.getUrlState().path}${argsParam}`, { replace: true });
+      queryNavigate(`${path}${argsParam}`, { replace: true });
       api.setQueryParams({ args: argsString });
     };
 

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -8,7 +8,6 @@ import { window } from 'global';
 import { ModuleArgs, ModuleFn } from '../index';
 import { PanelPositions } from './layout';
 import { isStory } from '../lib/stories';
-import type { Story } from '../lib/stories';
 
 interface Additions {
   isFullscreen?: boolean;
@@ -150,11 +149,14 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
 
   const initModule = () => {
     // Sets `args` parameter in URL, omitting any args that have their initial value or cannot be unserialized safely.
-    const updateArgsParam = (args?: Story['args']) => {
+    const updateArgsParam = () => {
       const { path, viewMode } = fullAPI.getUrlState();
       if (viewMode !== 'story') return;
+
       const currentStory = fullAPI.getCurrentStoryData();
-      const initialArgs = (isStory(currentStory) && currentStory.initialArgs) || {};
+      if (!isStory(currentStory)) return;
+
+      const { args, initialArgs } = currentStory;
       const argsString = buildArgsParam(initialArgs, args);
       const argsParam = argsString.length ? `&args=${argsString}` : '';
       queryNavigate(`${path}${argsParam}`, { replace: true });
@@ -164,13 +166,13 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
     fullAPI.on(SET_CURRENT_STORY, () => updateArgsParam());
 
     let handleOrId: any;
-    fullAPI.on(STORY_ARGS_UPDATED, ({ args }) => {
+    fullAPI.on(STORY_ARGS_UPDATED, () => {
       if ('requestIdleCallback' in window) {
         if (handleOrId) window.cancelIdleCallback(handleOrId);
-        handleOrId = window.requestIdleCallback(() => updateArgsParam(args), { timeout: 1000 });
+        handleOrId = window.requestIdleCallback(updateArgsParam, { timeout: 1000 });
       } else {
         if (handleOrId) clearTimeout(handleOrId);
-        setTimeout(updateArgsParam, 100, args);
+        setTimeout(updateArgsParam, 100);
       }
     });
 


### PR DESCRIPTION
Issue: -

## What I did

- Omit args param on the docs tab, to eliminate some weird behavior when changing args on the docs page while the 2nd or later story is selected.
- Restore the args param when switching between stories, or navigating from docs to canvas. This means any arg changes made on the docs page *will* be reflected in the URL when switching back to the canvas.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
