### PR TITLE
UI: Skip duplicate storyId breaking sidebar

### DIFF
--- a/lib/ui/src/components/sidebar/utils.ts
+++ b/lib/ui/src/components/sidebar/utils.ts
@@ -36,7 +36,7 @@ export const getDescendantIds = memoize(1000)(
   (data: StoriesHash, id: string, skipLeafs: boolean): string[] => {
     const { children = [] } = data[id] || {};
     return children.reduce((acc, childId) => {
-      if (skipLeafs && data[childId].isLeaf) return acc;
+      if (!data[childId] || (skipLeafs && data[childId].isLeaf)) return acc;
       acc.push(childId, ...getDescendantIds(data, childId, skipLeafs));
       return acc;
     }, []);


### PR DESCRIPTION
Issue: #13687

## What I did

Ensure we have data for a storyId before attempting to use it in the sidebar. This can happen when the same child ID exists in two places (duplicate story paths).

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
