### PR TITLE
Addon-a11y: Fix broken highlight result styles

### DIFF
--- a/addons/a11y/src/highlight.ts
+++ b/addons/a11y/src/highlight.ts
@@ -2,11 +2,10 @@ export const highlightStyle = (color: string) => `
   outline: 2px dashed ${color};
   outline-offset: 2px;
   box-shadow: 0 0 0 6px rgba(255,255,255,0.6);
-}
 `;
 
 export const highlightObject = (color: string) => ({
   outline: `2px dashed ${color}`,
   outlineOffset: 2,
-  boxShadow: '0 0 0 6px rgba(255,255,255,0.6),',
+  boxShadow: '0 0 0 6px rgba(255,255,255,0.6)',
 });


### PR DESCRIPTION
## What I did

I fixed broken styles that are added by A11Y addon when result highlighting is enabled. The issue was caused by the duplicated closing bracket. I also removed the unnecessary comma at the end of the object format which caused the `box-shadow` to be missing in the addon's highlight story.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

<img width="433" alt="Screen Shot 2021-04-09 at 00 24 59" src="https://user-images.githubusercontent.com/920747/114103802-0636c300-98ca-11eb-89ae-d829bba96460.png">
