### PR TITLE
CLI: Fix prerelease upgrade

### DIFF
--- a/lib/cli/src/upgrade.ts
+++ b/lib/cli/src/upgrade.ts
@@ -99,7 +99,8 @@ export const upgrade = async ({ prerelease, skipCheck, useNpm, dryRun }: Options
 
   const flags = [];
   if (!dryRun) flags.push('--upgrade');
-  if (prerelease) flags.push('--newest');
+  flags.push('--target');
+  flags.push(prerelease ? 'greatest' : 'latest');
   const check = spawnSync('npx', ['npm-check-updates', '/storybook/', ...flags], {
     stdio: 'pipe',
   }).output.toString();


### PR DESCRIPTION
Issue: -

Currently `sb upgrade --prerelease` can upgrades to the _newest_ release, which is nearly always the latest prerelease. However, when I release a patch release and don't immediately release a prerelease afterwards, it will upgrade to the patch release instead, which is incorrect behavior.

## What I did

Now `npm-check-updates` supports a `--target greatest` flag. The "greatest" release will nearly always be the prerelease, and in the cases that it's not, it's still the intended behavior.

self-merging @tooppaaa 

## How to test

Run the CLI on an old project
