### PR TITLE
Core: Enable community builders

### DIFF
--- a/lib/core-server/src/utils/get-preview-builder.ts
+++ b/lib/core-server/src/utils/get-preview-builder.ts
@@ -8,7 +8,10 @@ export async function getPreviewBuilder(configDir: Options['configDir']) {
   const mainFile = getInterpretedFile(main);
   const { core } = mainFile ? serverRequire(mainFile) : { core: null };
   const builder = core?.builder || DEFAULT_WEBPACK;
+  const builderPackage = ['webpack4', 'webpack5'].includes(builder)
+    ? `@storybook/builder-${builder}`
+    : builder;
 
-  const previewBuilder = await import(`@storybook/builder-${builder}`);
+  const previewBuilder = await import(builderPackage);
   return previewBuilder;
 }


### PR DESCRIPTION
Issue: N/A

## What I did

Open up the builder setting to enable community experimentation. Note: this is experimental and may change before 6.3 is released.

self-merging @ndelangen 

## How to test

N/A
