### PR TITLE
CLI: properly detect vuetify3

### DIFF
--- a/lib/cli/src/project_types.ts
+++ b/lib/cli/src/project_types.ts
@@ -126,7 +126,10 @@ export const supportedTemplates: TemplateConfiguration[] = [
   },
   {
     preset: ProjectType.SFC_VUE,
-    dependencies: ['vue-loader', 'vuetify'],
+    dependencies: {
+      'vue-loader': (versionRange) => ltMajor(versionRange, 16),
+      vuetify: (versionRange) => ltMajor(versionRange, 3),
+    },
     matcherFunction: ({ dependencies }) => {
       return dependencies.some(Boolean);
     },


### PR DESCRIPTION
Issue: [Vuetify 3 alpha for Vue 3 was released 2021-03-03](https://github.com/vuetifyjs/vuetify/releases/tag/v3.0.0-alpha.0). `npx sb init` no longer detects the correct type for projects using Vuetify v3.

## What I did

Updated `ProjectType.SFC_VUE` in `./lib/cli/src/project_types.ts` to match ONLY for `vue-loader < v16` and `vuetify < v3`.

## How to test

1. Make sure to rebuild `storybook` from local clone
2. Use `@vue/cli` to create a new Vue 3 app: `vue create myApp`
3. `cd` into the app directory: `cd myApp`
4. Use the Vue CLI to add Vuetify 3: `vue add vuetify`, select v3 alpha from the options
5. Run `/path/to/storybook/lib/cli/bin/index.js init`
6. Confirm that sb runs: `npm run storybook`

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
