### PR TITLE
Upgrade react-colorful to latest (fixing webpack 5 issue)

### DIFF
--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.20",
     "prop-types": "^15.7.2",
     "qs": "^6.10.0",
-    "react-colorful": "^5.0.1",
+    "react-colorful": "^5.1.2",
     "react-lifecycles-compat": "^3.0.4",
     "react-select": "^3.2.0",
     "regenerator-runtime": "^0.13.7"

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -53,7 +53,7 @@
     "overlayscrollbars": "^1.13.1",
     "polished": "^4.0.5",
     "prop-types": "^15.7.2",
-    "react-colorful": "^5.0.1",
+    "react-colorful": "^5.1.2",
     "react-popper-tooltip": "^3.1.1",
     "react-syntax-highlighter": "^13.5.3",
     "react-textarea-autosize": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6197,7 +6197,7 @@ __metadata:
     lodash: ^4.17.20
     prop-types: ^15.7.2
     qs: ^6.10.0
-    react-colorful: ^5.0.1
+    react-colorful: ^5.1.2
     react-lifecycles-compat: ^3.0.4
     react-select: ^3.2.0
     regenerator-runtime: ^0.13.7
@@ -7002,7 +7002,7 @@ __metadata:
     overlayscrollbars: ^1.13.1
     polished: ^4.0.5
     prop-types: ^15.7.2
-    react-colorful: ^5.0.1
+    react-colorful: ^5.1.2
     react-popper-tooltip: ^3.1.1
     react-syntax-highlighter: ^13.5.3
     react-textarea-autosize: ^8.3.0
@@ -38199,13 +38199,13 @@ fsevents@2.1.2:
   languageName: node
   linkType: hard
 
-"react-colorful@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "react-colorful@npm:5.0.1"
+"react-colorful@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "react-colorful@npm:5.1.2"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 966c7a2cb81e9b63194f9547ddb73b0fb366578f8ac6de9a2ef4323211b2b8a856dd22d23339d99a4fb7a7558367e75769deb97011104e388a0836ed11ec9d57
+  checksum: 922296ea50580503b5e10f7e19409334143abdb6bf3028f2697a323d284c652f2887e93d7f380d5ce8c340bcc9b58a0e728916433d20e74bd510295134df2c64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Helping with a webpack 5 bug that got discovered while using `resolve.conditionNames`

Issue:

## What I did

Upgraded react-colorful to latest version, author of the library made this change: https://github.com/omgovich/react-colorful/commit/217ba26b69c628d65d7ecdcc5b336eb57df634b3, https://github.com/omgovich/react-colorful/pull/124 which added fallback when using `resolve.conditionNames`. For example with this webpack setup: 

```
module.exports = {
  addons: [
    '@storybook/addon-links',
    '@storybook/addon-essentials',
    '@storybook/addon-a11y',
  ],
  core: {
    builder: 'webpack5',
  },
  webpackFinal: async (config, { configType }) => {
    if (configType === 'DEVELOPMENT') {
      // this what seems to be breaking storybook dev
      config.resolve.conditionNames = ['development'];
    }

    // without this you won't be able to build the storybook (ignore this)
    config.resolve.fallback = { crypto: false };

    return config;
  },
};
```

You'll end up with the following error:

```
ModuleNotFoundError: Module not found: Error: Package path . is not exported from package /Users/redacted/Projects/DesignSystems/mono/node_modules/react-colorful (see exports field in /Users/redacted/Projects/DesignSystems/mono/node_modules/react-colorful/package.json)
    at /Users/redacted/Projects/DesignSystems/mono/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/Compilation.js:1668:28
```

## How to test

No new tests are required but see webpack config example in this PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
