### PR TITLE
fix(core-server): build config inconsistency

### DIFF
--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -107,7 +107,7 @@ export async function buildStatic({ packageJson, ...loadOptions }: LoadOptions) 
       ...cliOptions,
       ...loadOptions,
       packageJson,
-      configDir: cliOptions.configDir || './.storybook',
+      configDir: loadOptions.configDir || cliOptions.configDir || './.storybook',
       outputDir: loadOptions.outputDir || cliOptions.outputDir || './storybook-static',
       ignorePreview: !!loadOptions.ignorePreview || !!cliOptions.previewUrl,
       docsMode: !!cliOptions.docs,


### PR DESCRIPTION
Issue: #14561 (more info there), [nuxt-community/storybook#259](https://github.com/nuxt-community/storybook/issues/259)

`buildDev()` and `buildStatic()` don't resolve the `configDir` option the same way:
- `buildDev()` configuration resolver: https://github.com/storybookjs/storybook/blob/next/lib/core-server/src/build-dev.ts#L122
- `buildStatic()` configuration resolver: https://github.com/storybookjs/storybook/blob/next/lib/core-server/src/build-static.ts#L110

## What I did

Made `configDir` resolve strategy the same as in: https://github.com/storybookjs/storybook/blob/next/lib/core-server/src/build-static.ts#L110

## How to test

- Is this testable with Jest or Chromatic screenshots? n/a
- Does this need a new example in the kitchen sink apps? n/a
- Does this need an update to the documentation? n/a

## Additional context

Was unable to run tests on Windows because they seem to rely on POSIX paths where my machine uses win32 ones. However I checked before/after and consistently have the same amount of test "failing" because of that.

cc @ndelangen
