### PR TITLE
Build: Disable yarn immutable install by default during E2E tests

### DIFF
--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -107,6 +107,8 @@ const configureYarn2 = async ({ cwd }: Options) => {
     // Disable fallback mode to make sure everything is required correctly
     `yarn config set pnpFallbackMode none`,
     `yarn config set enableGlobalCache true`,
+    // We need to be able to update lockfile when bootstrapping the examples
+    `yarn config set enableImmutableInstalls false`,
     // Add package extensions
     // https://github.com/facebook/create-react-app/pull/9872
     `yarn config set "packageExtensions.react-scripts@*.peerDependencies.react" "*"`,


### PR DESCRIPTION
## What I did

When running the E2E tests we are doing a fresh install of Yarn using the latest version; as of Yarn 3.0.0 rc1 a behaviour on dep install has been updated:
 > The enableImmutableInstalls will now default to true on CI (we still recommend to explicitly use --immutable on the CLI).
You can re-allow mutations by adding YARN_ENABLE_IMMUTABLE_INSTALLS=false in your environment variables.

So I updated the Yarn config used in the E2E to be able to properly bootstrap the different projects.

For details, see https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#300-rc1

## How to test

- CI should be back to 🟢 