### PR TITLE
Fix link to Shopify Polaris's Storybook

### DIFF
--- a/docs/get-started/examples.md
+++ b/docs/get-started/examples.md
@@ -37,7 +37,7 @@ Learn how leading teams build design systems.
 - [Workday Canvas](https://workday.github.io/canvas-kit/?path=/story/welcome-getting-started--page)
 - [Salesforce Lightning](http://design-system-react-components.herokuapp.com/?path=/story/sldsaccordion--base)
 - [IBM Carbon](https://react.carbondesignsystem.com/?path=/story/accordion--accordion)
-- [Shopify Polaris](https://master--5d559397bae39100201eedc1.chromatic.com/)
+- [Shopify Polaris](https://main--5d559397bae39100201eedc1.chromatic.com)
 - [Airbnb Dates](http://airbnb.io/react-dates/?path=/story/daterangepicker-drp--default)
 - [Lonely Planet](http://lonelyplanet.github.io/backpack-ui/?path=/story/styles--design-tokens)
 - [Wix Style](https://www.wix.com/pages/wix-style-react/?path=/story/*)


### PR DESCRIPTION
We renamed the `master` branch to `main`, and I think this should point to our Storybook rather than Chromatic.