### PR TITLE
docs: update code snippets for writing an addon

### DIFF
--- a/docs/addons/writing-addons.md
+++ b/docs/addons/writing-addons.md
@@ -49,8 +49,8 @@ Once you've gone through the prompts your `package.json` should look like:
 We'll need to add the necessary dependencies and make some adjustments. Run the following commands:
 
 ```shell
-# Installs React
-yarn add react react-dom
+# Installs React and Babel CLI
+yarn add react react-dom @babel/cli
 
 # Adds Storybook:
 npx -p @storybook/cli sb init

--- a/docs/snippets/common/my-addon-preset-implementation.js.mdx
+++ b/docs/snippets/common/my-addon-preset-implementation.js.mdx
@@ -1,7 +1,9 @@
 ```js
 // /my-addon/src/preset.js
 
-export function managerEntries(entry = []) {
+function managerEntries(entry = []) {
   return [...entry, require.resolve("./register")]; //👈 addon implementation
 }
+
+module.exports = { managerEntries }
 ```


### PR DESCRIPTION
Issue: The current docs for writing an addon provide `preset.js` code that will error locally (node v15.12.0). Also, without using `@babel/cli`, addon authors won't be able to build their addon.

## What I did
Updated the relevant code snippets for the docs as seen below.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation? 👍  This is a docs change.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
