### PR TITLE
globalTypes with toolbar requires addon-toolbars

### DIFF
--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -72,6 +72,10 @@ The <code>icon</code> element used in the examples loads the icons from the <cod
 
 </div>
 
+<div class="aside">
+  The <code>@storybook/addon-toolbars</code> addon is required to use toolbars. The toolbars addon is included by default in <code>@storybook/addon-essentials</code>.
+</div>
+
 By adding the configuration element `right`, the text will be displayed on the right side in the toolbar menu, once you connect it to a decorator.
 
 Here's a list of the configuration options available.


### PR DESCRIPTION
Adding a note that @storybook/addon-toolbars is required to use globalTypes to define toolbars.

Had a really tough time finding why the documentation wasn't working properly. It was because I updated from a old version that didn't have @storybook/addon-essentials.

Issue:
After updating the the latest storybook version I was underable to add custom toolbars. This was due to not having the toolbar plugin. It's unclear this is a requirement in the existing documentation.


## What I did
Updated the documentation on preview.js to denote that the toolbars addon is needed in order for the toolbars to be shown.

## How to test
Verify documentation is updated

- Is this testable with Jest or Chromatic screenshots? Nope
- Does this need a new example in the kitchen sink apps? Nope
- Does this need an update to the documentation? This is a documentation update
