### PR TITLE
Core: Resolve builders relatively to config file

### DIFF
--- a/lib/core-server/src/utils/get-preview-builder.ts
+++ b/lib/core-server/src/utils/get-preview-builder.ts
@@ -1,16 +1,17 @@
 import path from 'path';
 import { getInterpretedFile, serverRequire, Options } from '@storybook/core-common';
 
-const DEFAULT_WEBPACK = 'webpack4';
-
 export async function getPreviewBuilder(configDir: Options['configDir']) {
   const main = path.resolve(configDir, 'main');
   const mainFile = getInterpretedFile(main);
   const { core } = mainFile ? serverRequire(mainFile) : { core: null };
-  const builder = core?.builder || DEFAULT_WEBPACK;
-  const builderPackage = ['webpack4', 'webpack5'].includes(builder)
-    ? `@storybook/builder-${builder}`
-    : builder;
+  const builder = core?.builder;
+  const builderPackage = builder
+    ? require.resolve(
+        ['webpack4', 'webpack5'].includes(builder) ? `@storybook/builder-${builder}` : builder,
+        { paths: [main] }
+      )
+    : require.resolve('@storybook/builder-webpack4');
 
   const previewBuilder = await import(builderPackage);
   return previewBuilder;


### PR DESCRIPTION
Issue:

When a user specifies a builder without using the absolute path it's resolved relative to `@storybook/core-server` which makes it rely on hoisting to locate it

## What I did

Update `@storybook/core-server` to resolve the builder relative to the config file

## How to test

Try using the Webpack 5 builder without resolving it up front in the config file with PnP