### PR TITLE
Angular: set the @ViewChild with a non-empty value in StorybookWrapperComponent

### DIFF
--- a/app/angular/src/client/preview/angular-beta/StorybookWrapperComponent.ts
+++ b/app/angular/src/client/preview/angular-beta/StorybookWrapperComponent.ts
@@ -38,10 +38,14 @@ const getNonInputsOutputsProps = (
  */
 export const createStorybookWrapperComponent = (
   template: string,
-  storyComponent: Type<unknown>,
+  storyComponent: Type<unknown> | undefined,
   styles: string[],
   initialProps?: ICollection
 ): Type<any> => {
+  // In ivy, a '' selector is not allowed, therefore we need to just set it to anything if
+  // storyComponent was not provided.
+  const viewChildSelector = storyComponent ?? '__storybook-noop';
+
   @Component({
     selector: RendererService.SELECTOR_STORYBOOK_WRAPPER,
     template,
@@ -52,9 +56,9 @@ export const createStorybookWrapperComponent = (
 
     private storyWrapperPropsSubscription: Subscription;
 
-    @ViewChild(storyComponent ?? '', { static: true }) storyComponentElementRef: ElementRef;
+    @ViewChild(viewChildSelector, { static: true }) storyComponentElementRef: ElementRef;
 
-    @ViewChild(storyComponent ?? '', { read: ViewContainerRef, static: true })
+    @ViewChild(viewChildSelector, { read: ViewContainerRef, static: true })
     storyComponentViewContainerRef: ViewContainerRef;
 
     // Used in case of a component without selector


### PR DESCRIPTION

Issue: https://github.com/storybookjs/storybook/issues/14575. maybe other ??? 🤔 

## What I did

Fix the error :
> Unhandled Promise rejection: Can't construct a query for the property "storyComponentElementRef" of "StorybookWrapperComponent" since the query selector wasn't defined. ; Zone: <root> ; Task: Promise.then ; Value: Error: Can't construct a query for the property "storyComponentElementRef" of "StorybookWrapperComponent" since the query selector wasn't defined.
which appears on angular v11 once the ngcc command is executed


## How to test

- Is this testable with Jest or Chromatic screenshots? 
> hardly :/ I don't know how to do it 
- Does this need a new example in the kitchen sink apps? 
> nope
- Does this need an update to the documentation? 
> nope 

If your answer is yes to any of these, please make sure to include it in your PR.
