### PR TITLE
Chore: (Docs) Tweaks to the README and MAINTAINERS

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,53 +1,77 @@
-This document will document some of the processes that members of the documentation team should adhere to.
+This document outlines some of the processes that the maintainers should adhere to.
 
 # PR Process
 
 1. Triage with the correct [label](#labels)
-2. If there is a change related to it ensure it has been published and tested before closing
+2. If there is a change related to it, ensure it has been published and tested before closing
 
 # Labels
 
-| label name  | purpose |
-|:--------------:|:------------|
-| accessibility | |
-| addon:(name) | |
-| app:(name) | |
-| api:(name) | |
-| cleanup | Minor cleanup style change that won't show up in release changelog |
-| bug | |
-| cli | |
-| good first review | |
-| compatibility with other tools | |
-| patch | Bugfix & documentation PR that need to be picked to release branch |
-| picked | Patch PRs cherry-picked to master |
-| compatibility with other tools | |
-| components | |
-| core | |
-| decorators | |
-| dependencies | |
-| discussion | |
-| do not merge | |
-| documentation | |
-| feature request | |
-| good first issue | |
-| has workaround | |
-| help wanted | |
-| high priority | |
-| in progress | |
-| inactive | |
-| maintenance | |
-| merged | |
-| needs example | |
-| needs more info | |
-| needs rebase | |
-| needs reproduction | |
-| needs review | |
-| performance issue | |
-| presets | |
-| question / support | |
-| ready | |
-| security | |
-| todo | |
-| typescript | |
-| ui | |
-| won't fix | |
+| label name                     | purpose                                                                                                                                             |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| accessibility                  | Issue, bug, or pull request related to accessibility                                                                                                |
+| addon:(name)                   | Issue, bug, or pull request related to Storybook addons (e.g., [Controls](/docs/essentials/controls.md))                                            |
+| app:(name)                     | Issue, bug, or pull request related to Storybook's supported frameworks (e.g., React)                                                               |
+| api:(name)                     | Issue, bug, or pull request related to Storybook's API (e.g.,[makeDecorator](/docs/addons/addons-api.md#makeDecorator-API))                         |
+| args                           | Issue, bug, or pull request related to Storybook's [args](/docs/writing-stories/args.md)                                                            |
+| babel/webpack                  | Issue, bug, or pull request related to Storybook's build system (e.g., Webpack or Babel), for Webpack 5 issues see below                            |
+| block:(name)                   | Issue or bug within a certain surface are of Storybook (e.g., [argsTable](/docs/writing-docs/doc-blocks.md#argstable))                              |
+| BREAKING CHANGE                | Issue or pull request that introduces a breaking change within Storybook's ecosystem.                                                               |
+| BREAKING PRERELASE             | Breaking, but only for prerelease users (not relative to the stable release)                                                                        |
+| build-storybook                | Issue, bug, or pull request related to Storybook's production build                                                                                 |
+| cleanup                        | Minor cleanup style change that won't show up in release changelog                                                                                  |
+| bug                            | A bug within Storybook                                                                                                                              |
+| cli                            | Issue, bug, or pull request that affects the Storybook's CLI                                                                                        |
+| compatibility with other tools | Issue, bug, or pull request between Storybook and other tools (e.g., [Nuxt](https://nuxtjs.org/))                                                   |
+| components                     | Issue, bug, or pull request related to Storybook's internal components                                                                              |
+| composition                    | Issue, bug, or pull request related to Storybook [Composition](/docs/workflows/storybook-composition.md)                                            |
+| configuration                  | Issue, bug, or pull request related to Storybook [configuration](/docs/configure/overview.md)                                                       |
+| core                           | Issue, bug, or pull request related to Storybook's Core                                                                                             |
+| cra                            | Issue, bug, or pull request that affects Storybook's compatibility with Create React APP ([CRA](https://create-react-app.dev/docs/getting-started/))|
+| CSF                            | Issue, bug, or pull request related to Storybook's [Component Story Format (CSF)](/docs/api/csf.md)                                                 |
+| decorators                     | Issue, bug, or pull related to Storybook's [Decorators](/docs/writing-stories/decorators.md)                                                        |
+| dependencies                   | Issue, bug, or pull request that related to upstream dependencies                                                                                   |
+| discussion                     | Issue currently being discussed between the maintainers and community                                                                               |
+| do not merge                   | Pull request that will introduce regressions and will not be merged                                                                                 |
+| documentation                  | Issue, bug, or pull request that affects Storybook's documentation                                                                                  |
+| duplicate                      | Question or issue already asked in the repo's issues                                                                                                |
+| feature request                | Request for a new feature to be included in Storybook                                                                                               |
+| flow                           | Issue, bug, or pull request related to Storybook and Flow                                                                                           |
+| Funded on Issuehunt            | Storybook issue funded on [IssueHunt](https://issuehunt.io/)                                                                                        |
+| gatsby                         | Issue, bug, or pull request that affects Storybook and [Gatsby](https://www.gatsbyjs.com/)                                                          |
+| good first issue               | Low impact Storybook issues that help new members get involved and start contributing                                                               |
+| has workaround                 | Issue or bug that has an alternative way to be solved with Storybook                                                                                |
+| help wanted                    | Issue, or bug that requires additional help from the community                                                                                      |
+| ie11                           | Issue, bug, or pull request related to Storybook and IE11                                                                                           |
+| in progress                    | Issue or pull request that is currently being reviewed or worked on with the author                                                                 |
+| inactive                       | Issue, or pull request that has gone stale and no active development has been done                                                                  |
+| maintenance                    | Issue, or pull request related to Storybook's internal maintenance                                                                                  |
+| mdx                            | Issue, bug, or pull request related to MDX and Storybook                                                                                            |
+| medium                         | Issue or pull request that involves a significant amount of work within Storybook                                                                   |
+| monorepos                      | Issue, bug, or pull request related to Storybook and monorepos (e.g., [lerna](https://lerna.js.org/) )                                              |
+| mui                            | Issue, bug, or pull request that affects Storybook and [Material-UI](https://material-ui.com/)                                                      |
+| multiframework                 | Issue, bug, or pull request that affects multiple supported frameworks (e.g., React, Vue)                                                           |
+| needs more info                | Issue, or bug that requires additional context from the author                                                                                      |
+| needs reproduction             | Issue, or bug that requires a reproduction to be looked at                                                                                          |
+| needs triage                   | Issue, bug, or pull request that requires further investigation from the maintainers                                                                |
+| nextjs                         | Issue, bug, or pull request related to Storybook's integration with [Next.js](https://nextjs.org/)                                                  |
+| nx                             | Issue, bug, or pull request related to Storybook's integration with [NX](https://nx.dev/)                                                           |
+| other                          | Storybook's miscellaneous issue or pull request                                                                                                     |
+| P(n)                           | Bug or issue priority. Ranges from `0` (most urgent) to `N` (least urgent)                                                                          |
+| patch                          | Bug fix and documentation pull request that will be picked to the master branch                                                                     |
+| performance issue              | Issue, bug or pull request that affects Storybook's performance                                                                                     |
+| picked                         | Patch PRs cherry-picked to the master branch                                                                                                        |
+| presets                        | Issue, bug, or pull requests that affect Storybook's presets                                                                                        |
+| question / support             | General question about Storybook                                                                                                                    |
+| run e2e extended test suite    | Pull request that affects Storybook's testing suite                                                                                                 |
+| search                         | Issue, bug or pull request related to Storybook's search functionality                                                                              |
+| security                       | Issue, bug, or pull request that addresses security with Storybook                                                                                  |
+| small                          | Issue or pull request that requires a small amount of work to be done                                                                               |
+| source-loader                  | Issue, bug, or pull request related to code display within Storybook's stories                                                                      |
+| theming                        | Issue, bug, or pull request related to Storybook customization (e.g., [theming](/docs/configure/theming.md))                                        |
+| todo                           | Issue or pull request currently being worked on                                                                                                     |
+| typescript                     | Issue, bug, or pull request related to TypeScript                                                                                                   |
+| ui                             | Issue, bug, or pull request related to Storybook's UI                                                                                               |
+| webpack5                       | Issue, bug, or pull request related to Webpack 5                                                                                                    |
+| won't fix                      | Issue or pull request that won't be addressed by the maintainers (e.g., introduces a regression)                                                    |
+| yarn/npm                       | Issue or pull request related to node package managers                                                                                              |

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ See [Addon / Framework Support Table](https://storybook.js.org/docs/react/api/fr
 | ---------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | [info](https://github.com/storybookjs/deprecated-addons/tree/master/addons/info)   | Annotate stories with extra component usage information  |
 | [notes](https://github.com/storybookjs/deprecated-addons/tree/master/addons/notes) | Annotate Storybook stories with notes                    |
-| [contexts](https://github.com/storybookjs/storybook/tree/master/addons/contexts)   | Addon for driving your components under dynamic contexts |
-| [options](https://github.com/storybookjs/storybook/tree/master/addons/options/)    | Customize the Storybook UI in code                       |
+| [contexts](https://storybook.js.org/addons/@storybook/addon-contexts/)             | Addon for driving your components under dynamic contexts |
+| [options](https://www.npmjs.com/package/@storybook/addon-options)                  | Customize the Storybook UI in code                       |
 
 In order to continue improving your experience, we have to eventually deprecate certain addons in favor of new, better tools.
 


### PR DESCRIPTION
With this pull request the following issue and discussion are addressed:
- #14490
- #12961

What was done:
- Ran through the broken links mentioned in #12961 to check what might be the issue:
     - Status code [404:NotFound] - Link: https://now-examples-slackin-rrirkqohko.now.sh/ (not present anymore)
     - Status code [404:NotFound] - Link: https://github.com/storybookjs/storybook/blob/next/app/react-native  (already updated)
    - Status code [404:NotFound] - Link: https://github.com/storybookjs/storybook/tree/master/addons/contexts (updated the link to the addons page)
    - Status code [404:NotFound] - Link: https://github.com/storybookjs/storybook/tree/master/addons/options/ (updated to npm page)
    - Status code [404:NotFound] - Link: https://opencollective.com/storybook/sponsor/27/website (it's working properly)
    - Status code [404:NotFound] - Link: https://opencollective.com/storybook/sponsor/28/website (it's working properly)
    - Status code [404:NotFound] - Link: https://opencollective.com/storybook/sponsor/29/website (it's working properly)

- Updated the label's list to what's currently in play. Some of the ones documented are currently not used.

Feel free to provide feedback