### PR TITLE
Chore: (Docs) Adjusts the styled-component get theme snippet

### DIFF
--- a/docs/snippets/common/storybook-preview-use-global-type.js.mdx
+++ b/docs/snippets/common/storybook-preview-use-global-type.js.mdx
@@ -5,8 +5,8 @@ import { ThemeProvider } from 'styled-components';
 
 import { MyThemes } from '../my-theme-folder/my-theme-file'
 
-// Function to obtain the intented theme
-const getTheme= (themeName)=>{
+// Function to obtain the intended theme
+const getTheme = (themeName) => {
   return MyThemes[themeName]
 }
 

--- a/docs/snippets/common/storybook-preview-use-global-type.js.mdx
+++ b/docs/snippets/common/storybook-preview-use-global-type.js.mdx
@@ -2,7 +2,13 @@
 // .storybook/preview.js
 
 import { ThemeProvider } from 'styled-components';
-import { StoryContext, StoryGetter, StoryWrapper } from '@storybook/addons';
+
+import { MyThemes } from '../my-theme-folder/my-theme-file'
+
+// Function to obtain the intented theme
+const getTheme= (themeName)=>{
+  return MyThemes[themeName]
+}
 
 const withThemeProvider=(Story,context)=>{
   const theme = getTheme(context.globals.theme);


### PR DESCRIPTION
With this small pull request, the essentials/toolbars and addons documentation is updated to fix some missing information in its snippets.

What was done:
- The Styled components snippet was updated to contain a missing function implementation (`getTheme`). 
- Removed imports from the snippet that were not being used at all.

Reported [here](https://discord.com/channels/486522875931656193/490822681307119618/830085323701878784)


Feel free to provide feedback