### PR TITLE
Fix link to babel.ts source

### DIFF
--- a/docs/configure/babel.md
+++ b/docs/configure/babel.md
@@ -14,7 +14,7 @@ We have added ES2016 support with Babel for transpiling your JS code.
 
 In addition to that, we've added a few additional features, like object spreading and async await.
 
-Check out our [source](https://github.com/storybookjs/storybook/blob/master/lib/core/src/server/common/babel.ts) to learn more about these plugins.
+Check out our [source](https://github.com/storybookjs/storybook/blob/next/lib/core-common/src/utils/babel.ts) to learn more about these plugins.
 
 ### Custom config file
 


### PR DESCRIPTION
Issue: Broken link to Babel.ts source file in docs page

## What I did

Fixed linked to babel.ts source in documentation

## How to test

Visit https://storybook.js.org/docs/react/configure/babel page and click link to `babel.ts` in https://storybook.js.org/docs/react/configure/babel#default-configuration section