### PR TITLE
Modified Swatches keys to avoid duplicates

### DIFF
--- a/lib/components/src/blocks/ColorPalette.tsx
+++ b/lib/components/src/blocks/ColorPalette.tsx
@@ -121,10 +121,10 @@ interface ColorProps {
   colors: Colors;
 }
 
-function renderSwatch(color: string) {
+function renderSwatch(color: string, index: number) {
   return (
     <Swatch
-      key={color}
+      key={`${color}-${index}`}
       title={color}
       style={{
         background: color,
@@ -133,9 +133,9 @@ function renderSwatch(color: string) {
   );
 }
 
-function renderSwatchLabel(color: string, colorDescription?: string) {
+function renderSwatchLabel(color: string, index: number, colorDescription?: string) {
   return (
-    <SwatchLabel key={color} title={color}>
+    <SwatchLabel key={`${color}-${index}`} title={color}>
       <div>
         {color}
         {colorDescription && <span>{colorDescription}</span>}
@@ -148,16 +148,18 @@ function renderSwatchSpecimen(colors: Colors) {
   if (Array.isArray(colors)) {
     return (
       <SwatchSpecimen>
-        <SwatchColors>{colors.map((color) => renderSwatch(color))}</SwatchColors>
-        <SwatchLabels>{colors.map((color) => renderSwatchLabel(color))}</SwatchLabels>
+        <SwatchColors>{colors.map((color, index) => renderSwatch(color, index))}</SwatchColors>
+        <SwatchLabels>{colors.map((color, index) => renderSwatchLabel(color, index))}</SwatchLabels>
       </SwatchSpecimen>
     );
   }
   return (
     <SwatchSpecimen>
-      <SwatchColors>{Object.values(colors).map((color) => renderSwatch(color))}</SwatchColors>
+      <SwatchColors>
+        {Object.values(colors).map((color, index) => renderSwatch(color, index))}
+      </SwatchColors>
       <SwatchLabels>
-        {Object.keys(colors).map((color) => renderSwatchLabel(color, colors[color]))}
+        {Object.keys(colors).map((color, index) => renderSwatchLabel(color, index, colors[color]))}
       </SwatchLabels>
     </SwatchSpecimen>
   );


### PR DESCRIPTION
Issue: #14580

## What I did

Both `renderSwatch` and `renderSwatchLabel` were using the color value as the key by whether mapping the `colors` array or the `colors` object values and keys. Using the same color twice would then result in duplicate keys, which should be avoided for obvious reasons. I concatenated each color value with their respective index from the `Array.prototype.map` function to ensure there is no duplicate keys.

## How to test

There are two ways of feeding the `colors` prop, I have tested both ways with duplicates values:

**Array**
```jsx
  <ColorItem
    title="theme.color.primary"
    subtitle="Coral"
    colors={['#FF4785', '#FF4785']}
  />
```

**Object**
```jsx
  <ColorItem
    title="theme.color.positive"
    subtitle="Green"
    colors={{
      Apple: 'rgba(102,191,60,1)',
      Apple80: 'rgba(102,191,60,.8)',
      Apple80: 'rgba(102,191,60,.8)',
      Apple80: 'rgba(102,191,60,.7)',
      Apple60: 'rgba(102,191,60,.6)',
      Apple50: 'rgba(102,191,60,.6)',
      Apple30: 'rgba(102,191,60,.3)',
    }}
  />
```

Please note how I deliberately used the same `Apple80` key several times. It was done on purpose to check the resulting behaviour: in this case, only the last value will be considered, which is how it is supposed to be.

Before the fix, the duplicate value between `Apple60` and `Apple50` would raise a duplicate key error. This should work fine now!

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

## Note

I think I could have only relied on the index for the key instead of concatenating both value and index, but it felt safer to me. Feel free to provide some feedback if I'm doing the wrong way!
