### PR TITLE
Examples: Move from placehold.it to place-hold.it for mock images

### DIFF
--- a/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
@@ -8,6 +8,6 @@ export default {
 } as Meta;
 
 export const withAnImage = () => ({
-  template: `<img src="https://placehold.it/350x150" alt="My CDN placeholder" />`
+  template: `<img src="https://place-hold.it/350x150" alt="My CDN placeholder" />`
 });
 ```

--- a/docs/snippets/common/storybook-theme-example-variables.ts.mdx
+++ b/docs/snippets/common/storybook-theme-example-variables.ts.mdx
@@ -7,6 +7,6 @@ export default create({
   base: 'light',
   brandTitle: 'My custom storybook',
   brandUrl: 'https://example.com',
-  brandImage: 'https://placehold.it/350x150',
+  brandImage: 'https://place-hold.it/350x150',
 });
 ```

--- a/docs/snippets/common/your-theme.js.mdx
+++ b/docs/snippets/common/your-theme.js.mdx
@@ -36,6 +36,6 @@ export default create({
 
   brandTitle: 'My custom storybook',
   brandUrl: 'https://example.com',
-  brandImage: 'https://placehold.it/350x150',
+  brandImage: 'https://place-hold.it/350x150',
 });
 ```

--- a/docs/snippets/react/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.js.mdx
@@ -8,6 +8,6 @@ export default {
 };
 
 export const withAnImage = () => (
-  <img src="https://placehold.it/350x150" alt="My CDN placeholder" />
+  <img src="https://place-hold.it/350x150" alt="My CDN placeholder" />
 );
 ```

--- a/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
@@ -5,6 +5,6 @@ export default {
   title: "img",
 };
 export const withAnImage = () => ({
-  template: '<img src="https://placehold.it/350x150" alt="My CDN placeholder"/>'
+  template: '<img src="https://place-hold.it/350x150" alt="My CDN placeholder"/>'
 });
 ```

--- a/examples/official-storybook/stories/addon-a11y/image.stories.js
+++ b/examples/official-storybook/stories/addon-a11y/image.stories.js
@@ -2,7 +2,7 @@
 import React from 'react';
 
 const text = 'Testing the a11y addon';
-const image = 'http://placehold.it/350x150';
+const image = 'http://place-hold.it/350x150';
 
 export default {
   title: 'Addons/A11y/Image',

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -57,7 +57,7 @@ Action.args = {
 
 export const ImageFileControl = (args) => <img src={args.imageUrls[0]} alt="Your Example Story" />;
 ImageFileControl.args = {
-  imageUrls: ['http://placehold.it/350x150'],
+  imageUrls: ['http://place-hold.it/350x150'],
 };
 
 export const CustomControls = Template.bind({});

--- a/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.input.js
+++ b/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.input.js
@@ -98,7 +98,7 @@ storiesOf('Button').addWithInfo(
       </a>
     </p>
     <p>
-      <img src="http://placehold.it/350x150" />
+      <img src="http://place-hold.it/350x150" />
     </p>
   </div>,
   () => (
@@ -128,7 +128,7 @@ storiesOf('Button').addWithInfo(
       </a>
     </p>
     <p>
-      <img src="http://placehold.it/350x150" />
+      <img src="http://place-hold.it/350x150" />
     </p>
   </div>,
   () => <Button label="The Button" onClick={action('onClick')} />,

--- a/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.output.snapshot
+++ b/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.output.snapshot
@@ -98,7 +98,7 @@ storiesOf('Button').add('simple usage (JSX description)', withInfo(<div>
     </a>
   </p>
   <p>
-    <img src=\\"http://placehold.it/350x150\\" />
+    <img src=\\"http://place-hold.it/350x150\\" />
   </p>
 </div>)(() => (
   <div>
@@ -125,7 +125,7 @@ storiesOf('Button').add('simple usage (inline JSX description)', withInfo({
       </a>
     </p>
     <p>
-      <img src=\\"http://placehold.it/350x150\\" />
+      <img src=\\"http://place-hold.it/350x150\\" />
     </p>
   </div>,
 

--- a/lib/components/src/blocks/Description.stories.tsx
+++ b/lib/components/src/blocks/Description.stories.tsx
@@ -13,7 +13,7 @@ const markdownCaption = `
 
 The group looked like tall, exotic grazing animals, swaying gracefully and unconsciously with the movement of the train, their high heels like polished hooves against the gray metal of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses.
 
-![An image](http://placehold.it/350x150)
+![An image](http://place-hold.it/350x150)
 
 He stared at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a skyscraper canyon.
 `;

--- a/lib/components/src/blocks/DocsPageExampleCaption.md
+++ b/lib/components/src/blocks/DocsPageExampleCaption.md
@@ -2,7 +2,7 @@
 
 The group looked like tall, exotic grazing animals, swaying gracefully and unconsciously with the movement of the train, their high heels like polished hooves against the gray metal of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses.
 
-![An image](http://placehold.it/350x150)
+![An image](http://place-hold.it/350x150)
 
 He stared at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a skyscraper canyon. Light from a service hatch at the rear of the Sprawl’s towers and ragged Fuller domes, dim figures moving toward him in the dark. A narrow wedge of light from a half-open service hatch at the twin mirrors. Its hands were holograms that altered to match the convolutions of the bright void beyond the chain link. Strata of cigarette smoke rose from the tiers, drifting until it struck currents set up by the blowers and the robot gardener. Still it was a steady pulse of pain midway down his spine. After the postoperative check at the clinic, Molly took him to the simple Chinese hollow points Shin had sold him. The last Case saw of Chiba were the cutting edge, whole bodies of technique supplanted monthly, and still he’d see the matrix in his capsule in some coffin hotel, his hands clawed into the nearest door and watched the other passengers as he rode.
 

--- a/lib/components/src/blocks/DocsPageExampleCaption.mdx
+++ b/lib/components/src/blocks/DocsPageExampleCaption.mdx
@@ -2,7 +2,7 @@
 
 The group looked like tall, exotic grazing animals, swaying gracefully and unconsciously with the movement of the train, their high heels like polished hooves against the gray metal of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses.
 
-![An image](http://placehold.it/350x150)
+![An image](http://place-hold.it/350x150)
 
 He stared at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a skyscraper canyon. Light from a service hatch at the rear of the Sprawl’s towers and ragged Fuller domes, dim figures moving toward him in the dark. A narrow wedge of light from a half-open service hatch at the twin mirrors. Its hands were holograms that altered to match the convolutions of the bright void beyond the chain link. Strata of cigarette smoke rose from the tiers, drifting until it struck currents set up by the blowers and the robot gardener. Still it was a steady pulse of pain midway down his spine. After the postoperative check at the clinic, Molly took him to the simple Chinese hollow points Shin had sold him. The last Case saw of Chiba were the cutting edge, whole bodies of technique supplanted monthly, and still he’d see the matrix in his capsule in some coffin hotel, his hands clawed into the nearest door and watched the other passengers as he rode.
 

--- a/lib/components/src/blocks/IconGallery.stories.tsx
+++ b/lib/components/src/blocks/IconGallery.stories.tsx
@@ -23,10 +23,10 @@ export const defaultStyle = () => (
       <ExampleIcon icon="facehappy" />
     </IconItem>
     <IconItem name="bar">
-      <img src="https://placehold.it/50x50" alt="example" />
+      <img src="https://place-hold.it/50x50" alt="example" />
     </IconItem>
     <IconItem name="bar">
-      <img src="https://placehold.it/50x50" alt="example" />
+      <img src="https://place-hold.it/50x50" alt="example" />
     </IconItem>
   </IconGallery>
 );

--- a/lib/theming/src/tests/create.test.js
+++ b/lib/theming/src/tests/create.test.js
@@ -66,13 +66,13 @@ describe('create brand', () => {
   it('should accept values', () => {
     const result = create({
       base: 'light',
-      brandImage: 'https://placehold.it/350x150',
+      brandImage: 'https://place-hold.it/350x150',
       brandTitle: 'my custom storybook',
       brandUrl: 'https://example.com',
     });
 
     expect(result).toMatchObject({
-      brandImage: 'https://placehold.it/350x150',
+      brandImage: 'https://place-hold.it/350x150',
       brandTitle: 'my custom storybook',
       brandUrl: 'https://example.com',
     });


### PR DESCRIPTION
Issue:

## What I did

It looks like a dash is missing in the `place-hold.it` urls.

Is for example `https://placehold.it/350x150` (does not generate any image placeholder):

![https://placehold.it/350x150](https://placehold.it/350x150)

Should be `https://place-hold.it/350x150` (which does generate the following image):

![https://place-hold.it/350x150](https://place-hold.it/350x150)

## How to test

I tested manually I have to say. I ran a search a replace to fix the typo.
