### PR TITLE
docs: correct typo and formatting

### DIFF
--- a/docs/snippets/common/badge-story-custom-argtypes.js.mdx
+++ b/docs/snippets/common/badge-story-custom-argtypes.js.mdx
@@ -15,7 +15,6 @@ export default {
           'negative',
           'warning',
           'error',
-          'error',
           'neutral'
         ],
       },

--- a/docs/snippets/common/badge-story-custom-argtypes.mdx.mdx
+++ b/docs/snippets/common/badge-story-custom-argtypes.mdx.mdx
@@ -18,7 +18,6 @@ import { Badge } from './Badge';
           'negative',
           'warning',
           'error',
-          'error',
           'neutral'
         ],
       },

--- a/docs/snippets/common/component-story-csf-argstable-customization.js.mdx
+++ b/docs/snippets/common/component-story-csf-argstable-customization.js.mdx
@@ -9,8 +9,8 @@ export default {
       description: 'overwritten description',
       table: {
         type: { 
-            summary: 'something short', 
-            detail: 'something really really long' 
+          summary: 'something short', 
+          detail: 'something really really long' 
         },
       },
       control: {

--- a/docs/snippets/common/component-story-mdx-argtypes.mdx.mdx
+++ b/docs/snippets/common/component-story-mdx-argtypes.mdx.mdx
@@ -6,19 +6,19 @@
   component={MyComponent}
   argTypes={{
     label: { 
-        name: 'label',
-       <!--- other argtypes required --->
+      name: 'label',
+      <!--- other argtypes required --->
     },
   }}
 />
 
 <Story name="some story" argTypes={{
   label: { 
-      name: 'different label', 
-        <!--- other required data --->
-    }
+    name: 'different label', 
+      <!--- other required data --->
+  }
 }}>
-   <!--- story contents --->
+  <!--- story contents --->
 </Story>
 
 ```

--- a/docs/snippets/common/component-story-mdx-argtypes.mdx.mdx
+++ b/docs/snippets/common/component-story-mdx-argtypes.mdx.mdx
@@ -15,7 +15,7 @@
 <Story name="some story" argTypes={{
   label: { 
     name: 'different label', 
-      <!--- other required data --->
+    <!--- other required data --->
   }
 }}>
   <!--- story contents --->

--- a/docs/snippets/common/storybook-customize-argtypes.js.mdx
+++ b/docs/snippets/common/storybook-customize-argtypes.js.mdx
@@ -9,8 +9,8 @@ export default {
       description: 'overwritten description',
       table: {
         type: { 
-            summary: 'something short', 
-            detail: 'something really really long' 
+          summary: 'something short', 
+          detail: 'something really really long' 
         },
       },
       control: {

--- a/docs/snippets/common/storybook-merged-argtypes.js.mdx
+++ b/docs/snippets/common/storybook-merged-argtypes.js.mdx
@@ -7,8 +7,8 @@ const argTypes = {
     description: 'overwritten description',
     table: {
       type: { 
-          summary: 'something short', 
-          detail: 'something really really long' 
+        summary: 'something short', 
+        detail: 'something really really long' 
       },
       defaultValue: { summary: 'Hello' },
     },

--- a/docs/snippets/react/component-story-custom-args-complex.mdx.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.mdx.mdx
@@ -15,7 +15,7 @@ export const someFunction = (valuePropertyA, valuePropertyB) => {
 export const Template = ({propertyA,propertyB,...rest})=>{
   <!---👇 Assigns the function result to a variable -->
   const someFunctionResult = someFunction(propertyA, propertyB);
-  return <YourComponent somePoperty={someFunctionResult} {...rest} />;
+  return <YourComponent someProperty={someFunctionResult} {...rest} />;
 }
 
 <Canvas>

--- a/docs/snippets/react/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.ts.mdx
@@ -31,6 +31,6 @@ const Template: Story<YourComponentProps> = ({ propertyA, propertyB, ...rest }) 
   //👇 Assigns the result from the function to a variable
   const someFunctionResult = someFunction(propertyA, propertyB);
 
-  return <YourComponent somePoperty={someFunctionResult} {...rest} />;
+  return <YourComponent someProperty={someFunctionResult} {...rest} />;
 };
 ```

--- a/docs/writing-stories/args.md
+++ b/docs/writing-stories/args.md
@@ -132,7 +132,7 @@ In order to protect against [XSS](https://owasp.org/www-community/attacks/xss/) 
 
 The `args` param is always a set of `key:value` pairs delimited with a semicolon `;`. Values will be coerced (cast) to their respective `argTypes` (which may have been automatically inferred). Objects and arrays are supported. Special values `null` and `undefined` can be set by prefixing with a bang `!`. For example, `args=obj.key:val;arr[0]:one;arr[1]:two;nil:!null` will be interpreted as:
 
-```
+```js
 {
   obj: { key: 'val' },
   arr: ['one', 'two'],
@@ -148,7 +148,7 @@ Args specified through the URL will extend and override any default values of ar
 
 Complex values such as JSX elements cannot be serialized to the manager (e.g. the Controls addon) or synced with the URL. To work around this limitation, arg values can be "mapped" from a simple string to a complex type using the `mapping` property in `argTypes`. This works on any type of arg, but makes most sense when used with the `select` control type.
 
-```
+```js
 argTypes: {
   label: {
     options: ['Normal', 'Bold', 'Italic'],


### PR DESCRIPTION
Issue: Some code snippets on the Storybook frontpage have small formatting issues.

## What I did

- Removed a duplication in the code of Badge story
- Corrected the indentation in some places
- Corrected a minor typo

## How to test

I did not test the changes locally.

I set up and got the [frontpage](https://github.com/storybookjs/frontpage) repo running on my machine, but I could not manage to get the changes reflected.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
