### PR TITLE
Add `funding` to manifests

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -20,6 +20,10 @@
     "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "addons/a11y"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/actions"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -19,6 +19,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/backgrounds"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "author": "jbaxleyiii",
   "main": "dist/cjs/index.js",

--- a/addons/controls/package.json
+++ b/addons/controls/package.json
@@ -20,6 +20,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/controls"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/register.js",
   "module": "dist/esm/register.js",

--- a/addons/cssresources/package.json
+++ b/addons/cssresources/package.json
@@ -18,6 +18,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/cssresources"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "author": "nm123github",
   "main": "dist/cjs/index.js",

--- a/addons/design-assets/package.json
+++ b/addons/design-assets/package.json
@@ -20,6 +20,10 @@
     "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "addons/design-assets"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -19,6 +19,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/docs"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/public_api.js",
   "module": "dist/esm/public_api.js",

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/essentials"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/events/package.json
+++ b/addons/events/package.json
@@ -18,6 +18,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/events"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/google-analytics/package.json
+++ b/addons/google-analytics/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/google-analytics"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/register.js",
   "module": "dist/esm/register.js",

--- a/addons/graphql/package.json
+++ b/addons/graphql/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/graphql"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/jest/package.json
+++ b/addons/jest/package.json
@@ -21,6 +21,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/jest"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "author": "Renaud Tertrais <renaud.tertrais@gmail.com> (https://github.com/renaudtertrais)",
   "main": "dist/cjs/index.js",

--- a/addons/knobs/package.json
+++ b/addons/knobs/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/knobs"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/links"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/queryparams/package.json
+++ b/addons/queryparams/package.json
@@ -17,6 +17,10 @@
     "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "addons/addon-queryparams"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/storyshots/storyshots-core"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/ts3.9/index.js",
   "module": "dist/ts3.9/index.js",

--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -15,6 +15,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/storyshots/storyshots-puppeteer"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/ts3.9/index.js",
   "module": "dist/ts3.9/index.js",

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/storysource"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/addons/toolbars/package.json
+++ b/addons/toolbars/package.json
@@ -20,6 +20,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/toolbars"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/register.js",
   "module": "dist/esm/register.js",

--- a/addons/viewport/package.json
+++ b/addons/viewport/package.json
@@ -17,6 +17,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/viewport"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/preview.js",
   "module": "dist/esm/preview.js",

--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/angular"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/ts3.9/client/index.js",
   "module": "dist/ts3.9/client/index.js",

--- a/app/aurelia/package.json
+++ b/app/aurelia/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/aurelia"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/ember/package.json
+++ b/app/ember/package.json
@@ -11,6 +11,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/ember"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/html/package.json
+++ b/app/html/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/html"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/marionette/package.json
+++ b/app/marionette/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/marionette"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/marko/package.json
+++ b/app/marko/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/marko"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/mithril/package.json
+++ b/app/mithril/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/mithril"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/preact"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/rax/package.json
+++ b/app/rax/package.json
@@ -15,6 +15,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/rax"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/react"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/riot/package.json
+++ b/app/riot/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/riot"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/server"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/svelte"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/vue"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/vue3/package.json
+++ b/app/vue3/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/vue3"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "app/web-components"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/client/index.js",
   "module": "dist/esm/client/index.js",

--- a/dev-kits/addon-decorator/package.json
+++ b/dev-kits/addon-decorator/package.json
@@ -17,6 +17,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "addons/actions"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/dev-kits/addon-parameter/package.json
+++ b/dev-kits/addon-parameter/package.json
@@ -17,6 +17,10 @@
     "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "dev-kit/addon-parameter"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/dev-kits/addon-preview-wrapper/package.json
+++ b/dev-kits/addon-preview-wrapper/package.json
@@ -17,6 +17,10 @@
     "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "dev-kit/addon-preview-wrappe"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/dev-kits/addon-roundtrip/package.json
+++ b/dev-kits/addon-roundtrip/package.json
@@ -17,6 +17,10 @@
     "url": "git+https://github.com/storybooks/storybook.git",
     "directory": "dev-kit/addon-roundtrip"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/addons"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/public_api.js",

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -13,6 +13,10 @@
     "type": "git",
     "url": "https://github.com/storybookjs/storybook.git"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/lib/builder-webpack4/package.json
+++ b/lib/builder-webpack4/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/core"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/lib/builder-webpack5/package.json
+++ b/lib/builder-webpack5/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/core"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/lib/channel-postmessage/package.json
+++ b/lib/channel-postmessage/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/channel-postmessage"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/channel-websocket/package.json
+++ b/lib/channel-websocket/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/channel-websocket"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/channels/package.json
+++ b/lib/channels/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/channels"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/cli-sb/package.json
+++ b/lib/cli-sb/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/cli"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "bin": "./index.js",
   "scripts": {

--- a/lib/cli-storybook/package.json
+++ b/lib/cli-storybook/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/cli"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "bin": {
     "sb": "./index.js",

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/cli"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "author": "Storybook Team",
   "typesVersions": {

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/client-api"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/client-logger/package.json
+++ b/lib/client-logger/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/client-logger"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/codemod"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/components"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/core-client/package.json
+++ b/lib/core-client/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/core"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/lib/core-common/package.json
+++ b/lib/core-common/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/core"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/lib/core-events/package.json
+++ b/lib/core-events/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/core-events"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/core"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/core"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/lib/node-logger/package.json
+++ b/lib/node-logger/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/node-logger"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/postinstall/package.json
+++ b/lib/postinstall/package.json
@@ -15,6 +15,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/postinstall"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/router/package.json
+++ b/lib/router/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/router"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -15,6 +15,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/source-loader"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/theming/package.json
+++ b/lib/theming/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/theming"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/storybookjs/storybook.git",
     "directory": "lib/ui"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "type": "git",
     "url": "https://github.com/storybookjs/storybook.git"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
   "workspaces": {
     "packages": [
       "addons/*",


### PR DESCRIPTION
Issue: #14514

## What I did

I added a `funding` property to all `package.json` files other than the example projects.

I was intimidated by the number of projects, so I used the following script:

```bash
#!/bin/bash

# Find all `package.json` files other than examples
manifests=`git ls-files | grep 'package.json' | grep -v '^examples'`

function add_funding {
  file=$1

  # Insert `funding` block after `repository` block
  sed -i .bak -e '/^  "repository"/i\
  "funding": {\
    "type": "opencollective",\
    "url": "https://opencollective.com/storybook"\
  },' $file
 }

for manifest in $manifests
do
  add_funding $manifest
done

# Remove `sed` backup files (and this script, as a side effect)
git clean -f
```

## How to test

Run `npm fund` from the monorepo root. The top entry should be all the subprojects listed under Storybook's Open Collective URL.