### PR TITLE
Addon-docs: Exclude decorators in dynamic source snippets

### DIFF
--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -155,12 +155,13 @@ describe('renderJsx', () => {
 });
 
 // @ts-ignore
-const makeContext = (name: string, parameters: any, args: any): StoryContext => ({
+const makeContext = (name: string, parameters: any, args: any, extra?: object): StoryContext => ({
   id: `jsx-test--${name}`,
   kind: 'js-text',
   name,
   parameters,
   args,
+  ...extra,
 });
 
 describe('jsxDecorator', () => {
@@ -183,21 +184,29 @@ describe('jsxDecorator', () => {
     );
   });
 
-  it('should render dynamically when provided a component', () => {
-    const Component = ({ className }: { className: string }) => (
-      <div className={className}>component</div>
+  it('should not render decorators when provided excludeDecorators parameter', () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const decoratedStoryFn = (args: any) => (
+      <div style={{ padding: 25, border: '3px solid red' }}>{storyFn(args)}</div>
     );
-    const storyFn = (args: any) => <Component {...args} />;
     const context = makeContext(
       'args',
-      { __isArgsStory: true, component: Component },
-      { className: 'test' }
+      {
+        __isArgsStory: true,
+        docs: {
+          source: {
+            excludeDecorators: true,
+          },
+        },
+      },
+      {},
+      { originalStoryFn: storyFn }
     );
-    jsxDecorator(storyFn, context);
+    jsxDecorator(decoratedStoryFn, context);
     expect(mockChannel.emit).toHaveBeenCalledWith(
       SNIPPET_RENDERED,
       'jsx-test--args',
-      '<Component className="test" />'
+      '<div>\n  args story\n</div>'
     );
   });
 

--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -183,6 +183,24 @@ describe('jsxDecorator', () => {
     );
   });
 
+  it('should render dynamically when provided a component', () => {
+    const Component = ({ className }: { className: string }) => (
+      <div className={className}>component</div>
+    );
+    const storyFn = (args: any) => <Component {...args} />;
+    const context = makeContext(
+      'args',
+      { __isArgsStory: true, component: Component },
+      { className: 'test' }
+    );
+    jsxDecorator(storyFn, context);
+    expect(mockChannel.emit).toHaveBeenCalledWith(
+      SNIPPET_RENDERED,
+      'jsx-test--args',
+      '<Component className="test" />'
+    );
+  });
+
   it('should skip dynamic rendering for no-args stories', () => {
     const storyFn = () => <div>classic story</div>;
     const context = makeContext('classic', {}, {});

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -166,8 +166,14 @@ export const jsxDecorator = (storyFn: any, context: StoryContext) => {
     ...(context?.parameters.jsx || {}),
   } as Required<JSXOptions>;
 
+  let storyOrComponent = story;
+  const { parameters, args } = context;
+  if (parameters.component) {
+    storyOrComponent = React.createElement(parameters.component, { ...args });
+  }
+
   let jsx = '';
-  const rendered = renderJsx(story, options);
+  const rendered = renderJsx(storyOrComponent, options);
   if (rendered) {
     jsx = applyTransformSource(rendered, options, context);
   }

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -169,7 +169,7 @@ export const jsxDecorator = (storyFn: any, context: StoryContext) => {
   let storyOrComponent = story;
   const { parameters, args } = context;
   if (parameters.component) {
-    storyOrComponent = React.createElement(parameters.component, { ...args });
+    storyOrComponent = React.createElement(parameters.component, args);
   }
 
   let jsx = '';

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -167,9 +167,9 @@ export const jsxDecorator = (storyFn: any, context: StoryContext) => {
   } as Required<JSXOptions>;
 
   // Exclude decorators from source code snippet by default
-  const sourceJsx = context?.parameters.docs?.source?.includeDecorators
-    ? story
-    : context.originalStoryFn(context.args);
+  const sourceJsx = context?.parameters.docs?.source?.excludeDecorators
+    ? context.originalStoryFn(context.args) 
+    : story;
 
   let jsx = '';
   const rendered = renderJsx(sourceJsx, options);

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -166,14 +166,13 @@ export const jsxDecorator = (storyFn: any, context: StoryContext) => {
     ...(context?.parameters.jsx || {}),
   } as Required<JSXOptions>;
 
-  let storyOrComponent = story;
-  const { parameters, args } = context;
-  if (parameters.component) {
-    storyOrComponent = React.createElement(parameters.component, args);
-  }
+  // Exclude decorators from source code snippet by default
+  const sourceJsx = context?.parameters.docs?.source?.includeDecorators
+    ? story
+    : context.originalStoryFn(context.args);
 
   let jsx = '';
-  const rendered = renderJsx(storyOrComponent, options);
+  const rendered = renderJsx(sourceJsx, options);
   if (rendered) {
     jsx = applyTransformSource(rendered, options, context);
   }

--- a/examples/cra-kitchen-sink/.storybook/preview.js
+++ b/examples/cra-kitchen-sink/.storybook/preview.js
@@ -5,4 +5,9 @@ addParameters({
     storySort: (a, b) =>
       a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
   },
+  docs: {
+    source: {
+      excludeDecorators: true,
+    },
+  },
 });

--- a/examples/cra-kitchen-sink/src/stories/decorators.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/decorators.stories.js
@@ -34,10 +34,3 @@ export const Nested = (args) => (
   </Button>
 );
 Nested.args = { onClick: action('clicked', { depth: 1 }) };
-Nested.parameters = {
-  docs: {
-    source: {
-      includeDecorators: false,
-    },
-  },
-};

--- a/examples/cra-kitchen-sink/src/stories/decorators.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/decorators.stories.js
@@ -1,6 +1,15 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Button } from '@storybook/react/demo';
+import PropTypes from 'prop-types';
+
+const Bold = ({ children }) => {
+  return <b>{children}</b>;
+};
+
+Bold.propTypes = {
+  children: PropTypes.string.isRequired,
+};
 
 export default {
   title: 'Decorators',
@@ -18,3 +27,17 @@ export const WithArgs = (args) => <Button {...args} />;
 WithArgs.args = { onClick: action('clicked', { depth: 1 }), children: 'With args' };
 
 export const Basic = () => <Button onClick={action('clicked', { depth: 1 })}>Basic</Button>;
+
+export const Nested = (args) => (
+  <Button {...args}>
+    <Bold>Hello</Bold>
+  </Button>
+);
+Nested.args = { onClick: action('clicked', { depth: 1 }) };
+Nested.parameters = {
+  docs: {
+    source: {
+      includeDecorators: false,
+    },
+  },
+};

--- a/examples/cra-kitchen-sink/src/stories/decorators.stories.js
+++ b/examples/cra-kitchen-sink/src/stories/decorators.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { Button } from '@storybook/react/demo';
+
+export default {
+  title: 'Decorators',
+  component: Button,
+  decorators: [
+    (Story) => (
+      <div style={{ padding: 25, border: '3px solid red' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const WithArgs = (args) => <Button {...args} />;
+WithArgs.args = { onClick: action('clicked', { depth: 1 }), children: 'With args' };
+
+export const Basic = () => <Button onClick={action('clicked', { depth: 1 })}>Basic</Button>;

--- a/examples/official-storybook/stories/hooks.stories.js
+++ b/examples/official-storybook/stories/hooks.stories.js
@@ -1,8 +1,17 @@
-import React from 'react';
+import React, { useContext, createContext } from 'react';
 import { useEffect, useRef, useState } from '@storybook/client-api';
+
+const Consumer = () => {
+  // testing hooks in the component itself,
+  // rendering JSX for the component without decorators
+  // per https://github.com/storybookjs/storybook/pull/14652/
+  const value = useContext(DummyContext);
+  return <div>value: {value}</div>;
+};
 
 export default {
   title: 'Core/Hooks',
+  component: Consumer,
 };
 
 export const Checkbox = () => {
@@ -44,3 +53,19 @@ export const ReactHookCheckbox = () => {
     </label>
   );
 };
+
+const DummyContext = createContext({});
+
+export const Context = (args) => {
+  // testing hooks in the story
+  const storyContext = useContext(DummyContext);
+  return <Consumer />;
+};
+
+Context.decorators = [
+  (Story) => (
+    <DummyContext.Provider value="hello">
+      <Story />
+    </DummyContext.Provider>
+  ),
+];

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -62,6 +62,7 @@ export type StoryContext = StoryIdentifier & {
   globals: Args;
   hooks?: HooksContext;
   viewMode?: ViewMode;
+  originalStoryFn: ArgsStoryFn;
 };
 
 export interface WrapperSettings {

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -62,7 +62,7 @@ export type StoryContext = StoryIdentifier & {
   globals: Args;
   hooks?: HooksContext;
   viewMode?: ViewMode;
-  originalStoryFn: ArgsStoryFn;
+  originalStoryFn?: ArgsStoryFn;
 };
 
 export interface WrapperSettings {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -487,6 +487,7 @@ export default class StoryStore {
           args: {},
           argTypes: {},
           globals: {},
+          originalStoryFn: getOriginal(),
         }),
       }),
       { __isArgsStory, ...combinedParameters }
@@ -506,6 +507,7 @@ export default class StoryStore {
         argTypes,
         globals: this._globals,
         viewMode: this._selection?.viewMode,
+        originalStoryFn: getOriginal(),
       });
     };
 
@@ -521,6 +523,7 @@ export default class StoryStore {
         argTypes,
         globals: this._globals,
         viewMode: this._selection?.viewMode,
+        originalStoryFn: getOriginal(),
       };
       const loadResults = await Promise.all(loaders.map((loader) => loader(context)));
       const loaded = Object.assign({}, ...loadResults);
@@ -554,6 +557,7 @@ export default class StoryStore {
           args: initialArgsBeforeEnhancers,
           argTypes,
           globals: {},
+          originalStoryFn: getOriginal(),
         }),
       }),
       initialArgsBeforeEnhancers


### PR DESCRIPTION
Issues: #12022 #11542

## What I did

The dynamic code snippet is generated by a decorator called [`jsxDecorator`](https://github.com/storybookjs/storybook/blob/next/addons/docs/src/frameworks/react/jsxDecorator.tsx) which is included in `kindMetadata.decorators`.

This decorator runs after the story decorators provided by the developer, which normally include i18n providers, data fetching or visual styling that shouldn't be shown in the code snippet.

The order of the decorators can be seen here:
https://github.com/storybookjs/storybook/blob/next/lib/client-api/src/story_store.ts#L379

Re-ordering the decorators would be the easiest solution, but that seems like it would be breaking change to library due to some addons possibly expecting the output of story decorators.

So, to bypass the story decorators, the solution myself and @jamesb3ll came up with is to use the `component` from the story context. If the developer has provided a component we can construct the JSX element using `React.createElement` together with the `args` as the props. That component is then converted to readable code string using the `react-element-to-jsx-string` library.

We've updated the tests to reflect this, any feedback on this solution would be great.

