### PR TITLE
API: Add addon keyboard shortcuts & create shortcuts for addon-viewport

### DIFF
--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -146,12 +146,15 @@ export const ViewportTool: FunctionComponent = memo(
     }
 
     useEffect(() => {
+      registerShortcuts(api, setState);
+    }, []);
+
+    useEffect(() => {
       setState({
         selected:
           defaultViewport || (viewports[state.selected] ? state.selected : responsiveViewport.id),
         isRotated: state.isRotated,
       });
-      registerShortcuts(api, setState);
     }, [defaultViewport]);
 
     const { selected, isRotated } = state;

--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -6,7 +6,8 @@ import { styled, Global, Theme, withTheme } from '@storybook/theming';
 
 import { Icons, IconButton, WithTooltip, TooltipLinkList } from '@storybook/components';
 
-import { useParameter, useAddonState } from '@storybook/api';
+import { useStorybookApi, useParameter, useAddonState } from '@storybook/api';
+import { registerShortcuts } from './shortcuts';
 import { PARAM_KEY, ADDON_ID } from './constants';
 import { MINIMAL_VIEWPORTS } from './defaults';
 import { ViewportAddonParameter, ViewportMap, ViewportStyles, Styles } from './models';
@@ -135,8 +136,10 @@ export const ViewportTool: FunctionComponent = memo(
     });
 
     const list = toList(viewports);
+    const api = useStorybookApi();
 
     if (!list.find((i) => i.id === defaultViewport)) {
+      // eslint-disable-next-line no-console
       console.warn(
         `Cannot find "defaultViewport" of "${defaultViewport}" in addon-viewport configs, please check the "viewports" setting in the configuration.`
       );
@@ -148,6 +151,7 @@ export const ViewportTool: FunctionComponent = memo(
           defaultViewport || (viewports[state.selected] ? state.selected : responsiveViewport.id),
         isRotated: state.isRotated,
       });
+      registerShortcuts(api, setState);
     }, [defaultViewport]);
 
     const { selected, isRotated } = state;

--- a/addons/viewport/src/Tool.tsx
+++ b/addons/viewport/src/Tool.tsx
@@ -146,8 +146,8 @@ export const ViewportTool: FunctionComponent = memo(
     }
 
     useEffect(() => {
-      registerShortcuts(api, setState);
-    }, []);
+      registerShortcuts(api, setState, Object.keys(viewports));
+    }, [viewports]);
 
     useEffect(() => {
       setState({

--- a/addons/viewport/src/shortcuts.ts
+++ b/addons/viewport/src/shortcuts.ts
@@ -1,0 +1,59 @@
+import { API } from '@storybook/api';
+import { ADDON_ID } from './constants';
+import { MINIMAL_VIEWPORTS } from './defaults';
+
+const viewportsKeys = Object.keys(MINIMAL_VIEWPORTS);
+const getCurrentViewportIndex = (current: string): number => viewportsKeys.indexOf(current);
+const getNextViewport = (current: string): string => {
+  const currentViewportIndex = getCurrentViewportIndex(current);
+  return currentViewportIndex === viewportsKeys.length - 1
+    ? viewportsKeys[0]
+    : viewportsKeys[currentViewportIndex + 1];
+};
+const getPreviousViewport = (current: string): string => {
+  const currentViewportIndex = getCurrentViewportIndex(current);
+  return currentViewportIndex < 1
+    ? viewportsKeys[viewportsKeys.length - 1]
+    : viewportsKeys[currentViewportIndex - 1];
+};
+
+export const registerShortcuts = async (api: API, setState: any) => {
+  await api.setAddonShortcut(ADDON_ID, {
+    label: 'Previous viewport',
+    defaultShortcut: ['shift', 'V'],
+    actionName: 'previous',
+    action: () => {
+      const { selected, isRotated } = api.getAddonState(ADDON_ID);
+      setState({
+        selected: getPreviousViewport(selected),
+        isRotated,
+      });
+    },
+  });
+
+  await api.setAddonShortcut(ADDON_ID, {
+    label: 'Next viewport',
+    defaultShortcut: ['V'],
+    actionName: 'next',
+    action: () => {
+      const { selected, isRotated } = api.getAddonState(ADDON_ID);
+      setState({
+        selected: getNextViewport(selected),
+        isRotated,
+      });
+    },
+  });
+
+  await api.setAddonShortcut(ADDON_ID, {
+    label: 'Reset viewport',
+    defaultShortcut: ['control', 'V'],
+    actionName: 'reset',
+    action: () => {
+      const { isRotated } = api.getAddonState(ADDON_ID);
+      setState({
+        selected: 'reset',
+        isRotated,
+      });
+    },
+  });
+};

--- a/addons/viewport/src/shortcuts.ts
+++ b/addons/viewport/src/shortcuts.ts
@@ -47,7 +47,7 @@ export const registerShortcuts = async (api: API, setState: any, viewportsKeys: 
 
   await api.setAddonShortcut(ADDON_ID, {
     label: 'Reset viewport',
-    defaultShortcut: ['control', 'V'],
+    defaultShortcut: ['alt', 'V'],
     actionName: 'reset',
     action: () => {
       const { isRotated } = api.getAddonState(ADDON_ID);

--- a/addons/viewport/src/shortcuts.ts
+++ b/addons/viewport/src/shortcuts.ts
@@ -1,23 +1,24 @@
 import { API } from '@storybook/api';
 import { ADDON_ID } from './constants';
-import { MINIMAL_VIEWPORTS } from './defaults';
 
-const viewportsKeys = Object.keys(MINIMAL_VIEWPORTS);
-const getCurrentViewportIndex = (current: string): number => viewportsKeys.indexOf(current);
-const getNextViewport = (current: string): string => {
-  const currentViewportIndex = getCurrentViewportIndex(current);
+const getCurrentViewportIndex = (viewportsKeys: string[], current: string): number =>
+  viewportsKeys.indexOf(current);
+
+const getNextViewport = (viewportsKeys: string[], current: string): string => {
+  const currentViewportIndex = getCurrentViewportIndex(viewportsKeys, current);
   return currentViewportIndex === viewportsKeys.length - 1
     ? viewportsKeys[0]
     : viewportsKeys[currentViewportIndex + 1];
 };
-const getPreviousViewport = (current: string): string => {
-  const currentViewportIndex = getCurrentViewportIndex(current);
+
+const getPreviousViewport = (viewportsKeys: string[], current: string): string => {
+  const currentViewportIndex = getCurrentViewportIndex(viewportsKeys, current);
   return currentViewportIndex < 1
     ? viewportsKeys[viewportsKeys.length - 1]
     : viewportsKeys[currentViewportIndex - 1];
 };
 
-export const registerShortcuts = async (api: API, setState: any) => {
+export const registerShortcuts = async (api: API, setState: any, viewportsKeys: string[]) => {
   await api.setAddonShortcut(ADDON_ID, {
     label: 'Previous viewport',
     defaultShortcut: ['shift', 'V'],
@@ -25,7 +26,7 @@ export const registerShortcuts = async (api: API, setState: any) => {
     action: () => {
       const { selected, isRotated } = api.getAddonState(ADDON_ID);
       setState({
-        selected: getPreviousViewport(selected),
+        selected: getPreviousViewport(viewportsKeys, selected),
         isRotated,
       });
     },
@@ -38,7 +39,7 @@ export const registerShortcuts = async (api: API, setState: any) => {
     action: () => {
       const { selected, isRotated } = api.getAddonState(ADDON_ID);
       setState({
-        selected: getNextViewport(selected),
+        selected: getNextViewport(viewportsKeys, selected),
         isRotated,
       });
     },

--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -128,3 +128,11 @@ You can change your story through [parameters](../writing-stories/parameters.md)
 />
 
 <!-- prettier-ignore-end -->
+
+### Keyboard shortcuts
+
+* Previous viewport: `shift + v`
+* Next viewport: `v`
+* Reset viewport: `control + v`
+
+These shortcuts can be edited in Storybook's Keyboard shortcuts page.

--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -131,8 +131,9 @@ You can change your story through [parameters](../writing-stories/parameters.md)
 
 ### Keyboard shortcuts
 
-* Previous viewport: `shift + v`
-* Next viewport: `v`
-* Reset viewport: `control + v`
+* Previous viewport: <kbd>shift</kbd> + <kbd>v</kbd>
+* Next viewport: <kbd>v</kbd>
+* Reset viewport: <kbd>control</kbd> + <kbd>v</kbd>
+
 
 These shortcuts can be edited in Storybook's Keyboard shortcuts page.

--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -133,7 +133,7 @@ You can change your story through [parameters](../writing-stories/parameters.md)
 
 * Previous viewport: <kbd>shift</kbd> + <kbd>v</kbd>
 * Next viewport: <kbd>v</kbd>
-* Reset viewport: <kbd>control</kbd> + <kbd>v</kbd>
+* Reset viewport: <kbd>alt</kbd> + <kbd>v</kbd>
 
 
 These shortcuts can be edited in Storybook's Keyboard shortcuts page.

--- a/lib/api/src/tests/shortcuts.test.js
+++ b/lib/api/src/tests/shortcuts.test.js
@@ -10,7 +10,134 @@ function createMockStore() {
   };
 }
 
+const mockAddonShortcut = {
+  addon: 'my-addon',
+  shortcut: {
+    label: 'Do something',
+    defaultShortcut: ['O'],
+    actionName: 'doSomething',
+    action: () => {
+      //
+    },
+  },
+};
+
+const mockAddonSecondShortcut = {
+  addon: 'my-addon',
+  shortcut: {
+    label: 'Do something else',
+    defaultShortcut: ['P'],
+    actionName: 'doSomethingElse',
+    action: () => {
+      //
+    },
+  },
+};
+
+const mockSecondAddonShortcut = {
+  addon: 'my-other-addon',
+  shortcut: {
+    label: 'Create issue',
+    defaultShortcut: ['N'],
+    actionName: 'createIssue',
+    action: () => {
+      //
+    },
+  },
+};
+
 describe('shortcuts api', () => {
+  it('gets defaults', () => {
+    const store = createMockStore();
+
+    const { api, state } = initShortcuts({ store });
+    store.setState(state);
+
+    expect(api.getDefaultShortcuts()).toHaveProperty('fullScreen', ['F']);
+  });
+
+  it('gets defaults including addon ones', async () => {
+    const store = createMockStore();
+
+    const { api, state } = initShortcuts({ store });
+    store.setState(state);
+
+    await api.setAddonShortcut(mockAddonShortcut.addon, mockAddonShortcut.shortcut);
+    await api.setAddonShortcut(mockAddonSecondShortcut.addon, mockAddonSecondShortcut.shortcut);
+    await api.setAddonShortcut(mockSecondAddonShortcut.addon, mockSecondAddonShortcut.shortcut);
+
+    expect(api.getDefaultShortcuts()).toHaveProperty('fullScreen', ['F']);
+    expect(api.getDefaultShortcuts()).toHaveProperty(
+      `${mockAddonShortcut.addon}-${mockAddonShortcut.shortcut.actionName}`,
+      mockAddonShortcut.shortcut.defaultShortcut
+    );
+    expect(api.getDefaultShortcuts()).toHaveProperty(
+      `${mockAddonSecondShortcut.addon}-${mockAddonSecondShortcut.shortcut.actionName}`,
+      mockAddonSecondShortcut.shortcut.defaultShortcut
+    );
+    expect(api.getDefaultShortcuts()).toHaveProperty(
+      `${mockSecondAddonShortcut.addon}-${mockSecondAddonShortcut.shortcut.actionName}`,
+      mockSecondAddonShortcut.shortcut.defaultShortcut
+    );
+  });
+
+  it('gets addons shortcuts', async () => {
+    const store = createMockStore();
+
+    const { api, state } = initShortcuts({ store });
+    store.setState(state);
+
+    await api.setAddonShortcut(mockAddonShortcut.addon, mockAddonShortcut.shortcut);
+    await api.setAddonShortcut(mockAddonSecondShortcut.addon, mockAddonSecondShortcut.shortcut);
+    await api.setAddonShortcut(mockSecondAddonShortcut.addon, mockSecondAddonShortcut.shortcut);
+
+    expect(api.getAddonsShortcuts()).toStrictEqual({
+      [`${mockAddonShortcut.addon}-${mockAddonShortcut.shortcut.actionName}`]: mockAddonShortcut.shortcut,
+      [`${mockAddonSecondShortcut.addon}-${mockAddonSecondShortcut.shortcut.actionName}`]: mockAddonSecondShortcut.shortcut,
+      [`${mockSecondAddonShortcut.addon}-${mockSecondAddonShortcut.shortcut.actionName}`]: mockSecondAddonShortcut.shortcut,
+    });
+  });
+
+  it('gets addons shortcut labels', async () => {
+    const store = createMockStore();
+
+    const { api, state } = initShortcuts({ store });
+    store.setState(state);
+
+    await api.setAddonShortcut(mockAddonShortcut.addon, mockAddonShortcut.shortcut);
+    await api.setAddonShortcut(mockAddonSecondShortcut.addon, mockAddonSecondShortcut.shortcut);
+    await api.setAddonShortcut(mockSecondAddonShortcut.addon, mockSecondAddonShortcut.shortcut);
+
+    expect(api.getAddonsShortcutLabels()).toStrictEqual({
+      [`${mockAddonShortcut.addon}-${mockAddonShortcut.shortcut.actionName}`]: mockAddonShortcut
+        .shortcut.label,
+      [`${mockAddonSecondShortcut.addon}-${mockAddonSecondShortcut.shortcut.actionName}`]: mockAddonSecondShortcut
+        .shortcut.label,
+      [`${mockSecondAddonShortcut.addon}-${mockSecondAddonShortcut.shortcut.actionName}`]: mockSecondAddonShortcut
+        .shortcut.label,
+    });
+  });
+
+  it('gets addons shortcut defaults', async () => {
+    const store = createMockStore();
+
+    const { api, state } = initShortcuts({ store });
+    store.setState(state);
+
+    await api.setAddonShortcut(mockAddonShortcut.addon, mockAddonShortcut.shortcut);
+    await api.setAddonShortcut(mockAddonSecondShortcut.addon, mockAddonSecondShortcut.shortcut);
+    await api.setAddonShortcut(mockSecondAddonShortcut.addon, mockSecondAddonShortcut.shortcut);
+
+    expect(api.getAddonsShortcutDefaults()).toStrictEqual({
+      [`${mockAddonShortcut.addon}-${mockAddonShortcut.shortcut.actionName}`]: mockAddonShortcut
+        .shortcut.defaultShortcut,
+      [`${mockAddonSecondShortcut.addon}-${mockAddonSecondShortcut.shortcut.actionName}`]: mockAddonSecondShortcut
+        .shortcut.defaultShortcut,
+      [`${mockSecondAddonShortcut.addon}-${mockSecondAddonShortcut.shortcut.actionName}`]: mockSecondAddonShortcut
+        .shortcut.defaultShortcut,
+    });
+  });
+
   it('sets defaults', () => {
     const store = createMockStore();
 
@@ -18,6 +145,31 @@ describe('shortcuts api', () => {
     store.setState(state);
 
     expect(api.getShortcutKeys().fullScreen).toEqual(['F']);
+  });
+
+  it('sets addon shortcut with default value', async () => {
+    const store = createMockStore();
+
+    const { api, state } = initShortcuts({ store });
+    store.setState(state);
+
+    await api.setAddonShortcut(mockAddonShortcut.addon, mockAddonShortcut.shortcut);
+    await api.setAddonShortcut(mockAddonSecondShortcut.addon, mockAddonSecondShortcut.shortcut);
+    await api.setAddonShortcut(mockSecondAddonShortcut.addon, mockSecondAddonShortcut.shortcut);
+
+    expect(api.getDefaultShortcuts()).toHaveProperty('fullScreen', ['F']);
+    expect(api.getDefaultShortcuts()).toHaveProperty(
+      `${mockAddonShortcut.addon}-${mockAddonShortcut.shortcut.actionName}`,
+      mockAddonShortcut.shortcut.defaultShortcut
+    );
+    expect(api.getDefaultShortcuts()).toHaveProperty(
+      `${mockAddonSecondShortcut.addon}-${mockAddonSecondShortcut.shortcut.actionName}`,
+      mockAddonSecondShortcut.shortcut.defaultShortcut
+    );
+    expect(api.getDefaultShortcuts()).toHaveProperty(
+      `${mockSecondAddonShortcut.addon}-${mockSecondAddonShortcut.shortcut.actionName}`,
+      mockSecondAddonShortcut.shortcut.defaultShortcut
+    );
   });
 
   it('sets defaults, augmenting anything that was persisted', () => {
@@ -51,17 +203,38 @@ describe('shortcuts api', () => {
     expect(api.getShortcutKeys().fullScreen).toEqual(['X']);
   });
 
+  it('sets new values for addon shortcuts', async () => {
+    const store = createMockStore();
+
+    const { api, state } = initShortcuts({ store });
+    store.setState(state);
+
+    const { addon, shortcut } = mockAddonShortcut;
+    await api.setAddonShortcut(addon, shortcut);
+
+    await api.setShortcut(`${addon}-${shortcut.actionName}`, ['I']);
+    expect(api.getShortcutKeys()[`${addon}-${shortcut.actionName}`]).toEqual(['I']);
+  });
+
   it('restores all defaults', async () => {
     const store = createMockStore();
 
     const { api, state } = initShortcuts({ store });
     store.setState(state);
 
+    const { addon, shortcut } = mockAddonShortcut;
+    await api.setAddonShortcut(addon, shortcut);
+
     await api.setShortcut('fullScreen', ['X']);
     await api.setShortcut('togglePanel', ['B']);
+    await api.setShortcut(`${addon}-${shortcut.actionName}`, ['I']);
+
     await api.restoreAllDefaultShortcuts();
     expect(api.getShortcutKeys().fullScreen).toEqual(['F']);
     expect(api.getShortcutKeys().togglePanel).toEqual(['A']);
+    expect(api.getShortcutKeys()[`${addon}-${shortcut.actionName}`]).toEqual(
+      shortcut.defaultShortcut
+    );
   });
 
   it('restores single default', async () => {
@@ -70,10 +243,42 @@ describe('shortcuts api', () => {
     const { api, state } = initShortcuts({ store });
     store.setState(state);
 
+    await api.setAddonShortcut(mockAddonShortcut.addon, mockAddonShortcut.shortcut);
+    await api.setAddonShortcut(mockAddonSecondShortcut.addon, mockAddonSecondShortcut.shortcut);
+    await api.setAddonShortcut(mockSecondAddonShortcut.addon, mockSecondAddonShortcut.shortcut);
+
     await api.setShortcut('fullScreen', ['X']);
     await api.setShortcut('togglePanel', ['B']);
+    await api.setShortcut(`${mockAddonShortcut.addon}-${mockAddonShortcut.shortcut.actionName}`, [
+      'I',
+    ]);
+    await api.setShortcut(
+      `${mockAddonSecondShortcut.addon}-${mockAddonSecondShortcut.shortcut.actionName}`,
+      ['H']
+    );
+    await api.setShortcut(
+      `${mockSecondAddonShortcut.addon}-${mockSecondAddonShortcut.shortcut.actionName}`,
+      ['G']
+    );
     await api.restoreDefaultShortcut('fullScreen');
+    await api.restoreDefaultShortcut(
+      `${mockAddonShortcut.addon}-${mockAddonShortcut.shortcut.actionName}`
+    );
+
     expect(api.getShortcutKeys().fullScreen).toEqual(['F']);
     expect(api.getShortcutKeys().togglePanel).toEqual(['B']);
+    expect(
+      api.getShortcutKeys()[`${mockAddonShortcut.addon}-${mockAddonShortcut.shortcut.actionName}`]
+    ).toEqual(mockAddonShortcut.shortcut.defaultShortcut);
+    expect(
+      api.getShortcutKeys()[
+        `${mockAddonSecondShortcut.addon}-${mockAddonSecondShortcut.shortcut.actionName}`
+      ]
+    ).toEqual(['H']);
+    expect(
+      api.getShortcutKeys()[
+        `${mockSecondAddonShortcut.addon}-${mockSecondAddonShortcut.shortcut.actionName}`
+      ]
+    ).toEqual(['G']);
   });
 });

--- a/lib/ui/src/components/sidebar/Menu.stories.tsx
+++ b/lib/ui/src/components/sidebar/Menu.stories.tsx
@@ -58,6 +58,7 @@ export const Expanded = () => {
     {
       // @ts-ignore
       getShortcutKeys: () => ({}),
+      getAddonsShortcuts: () => ({}),
       versionUpdateAvailable: () => false,
       releaseNotesVersion: () => '6.0.0',
     },
@@ -74,6 +75,7 @@ export const ExpandedWithoutReleaseNotes = () => {
     {
       // @ts-ignore
       getShortcutKeys: () => ({}),
+      getAddonsShortcuts: () => ({}),
       versionUpdateAvailable: () => false,
       releaseNotesVersion: () => undefined,
     },

--- a/lib/ui/src/containers/menu.tsx
+++ b/lib/ui/src/containers/menu.tsx
@@ -205,6 +205,20 @@ export const useMenu = (
     [api, enableShortcuts, shortcutKeys]
   );
 
+  const getAddonsShortcuts = (): any[] => {
+    const addonsShortcuts = api.getAddonsShortcuts();
+    const keys = shortcutKeys as any;
+    return Object.entries(addonsShortcuts)
+      .filter(([actionName, { showInMenu }]) => showInMenu)
+      .map(([actionName, { label, action }]) => ({
+        id: actionName,
+        title: label,
+        onClick: () => action(),
+        right: enableShortcuts ? <Shortcut keys={keys[actionName]} /> : null,
+        left: <MenuItemIcon />,
+      }));
+  };
+
   return useMemo(
     () => [
       about,
@@ -221,6 +235,7 @@ export const useMenu = (
       prev,
       next,
       collapse,
+      ...getAddonsShortcuts(),
     ],
     [
       about,

--- a/lib/ui/src/settings/shortcuts.tsx
+++ b/lib/ui/src/settings/shortcuts.tsx
@@ -143,10 +143,12 @@ export interface ShortcutsScreenState {
   activeFeature: Feature;
   successField: Feature;
   shortcutKeys: Record<Feature, any>;
+  addonsShortcutLabels?: Record<string, string>;
 }
 
 export interface ShortcutsScreenProps {
   shortcutKeys: Record<Feature, any>;
+  addonsShortcutLabels?: Record<string, string>;
   setShortcut: Function;
   restoreDefaultShortcut: Function;
   restoreAllDefaultShortcuts: Function;
@@ -162,6 +164,7 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
       // As the user interacts with the page, the state stores the temporary, unsaved shortcuts
       // This object also includes the error attached to each shortcut
       shortcutKeys: toShortcutState(props.shortcutKeys),
+      addonsShortcutLabels: props.addonsShortcutLabels,
     };
   }
 
@@ -261,10 +264,10 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
   };
 
   renderKeyInput = () => {
-    const { shortcutKeys } = this.state;
+    const { shortcutKeys, addonsShortcutLabels } = this.state;
     const arr = Object.entries(shortcutKeys).map(([feature, { shortcut }]: [Feature, any]) => (
       <Row key={feature}>
-        <Description>{shortcutLabels[feature]}</Description>
+        <Description>{shortcutLabels[feature] || addonsShortcutLabels[feature]}</Description>
 
         <TextInput
           spellCheck="false"
@@ -272,6 +275,7 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
           className="modalInput"
           onBlur={this.onBlur}
           onFocus={this.onFocus(feature)}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           onKeyDown={this.onKeyDown}
           value={shortcut ? shortcutToHumanString(shortcut) : ''}

--- a/lib/ui/src/settings/shortcuts_page.tsx
+++ b/lib/ui/src/settings/shortcuts_page.tsx
@@ -7,10 +7,17 @@ import { ShortcutsScreen } from './shortcuts';
 const ShortcutsPage: FunctionComponent<{}> = () => (
   <Consumer>
     {({
-      api: { getShortcutKeys, setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts },
+      api: {
+        getShortcutKeys,
+        getAddonsShortcutLabels,
+        setShortcut,
+        restoreDefaultShortcut,
+        restoreAllDefaultShortcuts,
+      },
     }) => (
       <ShortcutsScreen
         shortcutKeys={getShortcutKeys()}
+        addonsShortcutLabels={getAddonsShortcutLabels()}
         {...{ setShortcut, restoreDefaultShortcut, restoreAllDefaultShortcuts }}
       />
     )}


### PR DESCRIPTION
Issue: #14401 

# What I did

This is my very first time going deeper into Storybook's source code and architecture. I'm therefore not confident about all this but I really wanted to give it a try to learn and improve. My french fellow @kaelig* wanted a way to cycle through viewports using keyboard shortcuts, which is a great idea to save some time and efforts while visually testing components.

Defining this kind of addon-specific shortcuts should be the addon's responsibility: we obviously don't want to make them available if the relevant addon is not actually used and specified into Storybook's `main.js` configuration file.  Unfortunately, I could not find any way to create addon-specific shortcuts. At the moment, it looks like Storybook does not offer addon developers such a feature, which could be really interesting way beyond `addon-viewport`.

This is why I've tried to go a bit further than the original issue's feature request by extending the shortcut API so that addon developers can provide their own shortcuts.

## Extending the shortcut API

Storybook provides a shortcut API which exposes methods to get, set and reset shortcuts. This API is pretty narrow/restricted since it relies on some hard-coded and core-related values (e.g. go fullscreen, show/hide addons, etc.)

### `setAddonShortcut(addon, shortcut)`
First, I've added a `setAddonShortcut` method which can be used to set addon-specific shortcuts. When called, it creates (or overwrites) a shortcut key whose name is a simple concatenation of the actual addon id and an `actionName` to avoid potential duplicates across different addons. It also feeds a global `addonsShortcuts` object which will be consumed later on to actually execute the relevant action and get the shortcut's description and default value.

This method requires two arguments :
1. `addon`: a string which should correspond to the relevant addon's id (often set as a `ADDON_ID` constant).
2. `shortcut`: an object of type `AddonShortcut` which describes the actual shortcut.

This `shortcut` argument is explicitely typed (see the `AddonShortcut` interface):
* `label`: Label of the shortcut which will be displayed in Storybook's keyboard shortcuts setting page/the menu.
* `defaultShortcut`: the `KeyCollection` value which defines the expected keyboard shortcut key to apply the relevant action.
* `actionName`: the action name which should be unique within a single addon.
* `showInMenu`: a boolean which determines whether the shortcut should be displayed inside Storybook's menu. (optional and defaults to `false`).
* `action`: the actual action that should be triggered when pressing the shortcut key.

### Display and customize the addon shortcuts

At this point, the addon shortcuts should be working correctly if correctly set from any addon. However, Storybook:
1. Lets the user customize all the shortcuts from the Keyboard shortcuts page.
2. Displays some of the shortcuts into the menu (accessible from the meatballs button (···))

#### Customize addon shortcuts

The Keyboard shortcuts page browses `shortcutKeys` to build a list of all customizable shortcuts. This `shortcutKeys` now includes our addon-specific shortcuts, which is pretty useful for the users to customize both core and addon-specific shortcuts . However, until now, every single shortcut had its label hard-coded through a `shortcutLabels` const passed as a prop to the `ShortcutsScreen` component.

I therefore needed a way to fetch the addon-specific shortcuts' labels/titles: this is why I've added both `getAddonsShortcuts` and `getAddonsShortcutLabels` methods to the shortcut API. They are used to pass addon-specific shortcuts' labels through an `addonsShortcutLabels` prop to the `ShortcutScreen` component. This component will now try to display a shortcut's hard-coded label and if it does not exist, will try to display an addon-specific shortcut label.

Customization and persistence are automatically handled by the existing shortcut API.

#### Reset shortcuts to their default values.

Similarly, core shortcuts' default values are hard-coded. I had to add  `getAddonsShortcutDefaults`  to get default values for addon shortcuts, and a `getDefaultShortcuts` which returns a merged object of both core and addon-specific shortcuts' default values to make `restoreAllDefaultShortcuts` and `restoreDefaultShortcut`  work properly in both cases.

#### Display shortcuts into Storybook's menu

I also made it possible to display addon-specific shortcuts into the Storybook's menu. When adding an addon-specific shortcut, you just have to set the `showInMenu` property to `true`. It will also make use of the  `getAddonsShortcuts` and `getAddonsShortcutLabels` methods from the updated shortcut API to display the right label.

## Adding `addon-viewport` shortcuts

I've used the updated shortcut API to add three different shortcuts to the viewport addon:
* `shift + v` to set to the previous viewport.
* `v` to set to the next viewport.
* `ctrl + v` to reset the viewport (not referenced in the original issue).

These shortcuts are registered one at a time from an async function (`registerShortcuts`). To be honest, I did not really know the best way to call this function: I just assumed it had to be called within the Functional Component since calling `useStorybookApi` anywhere else would raise an error. I eventually called it inside a `useEffect` hook without an empty dep array to avoid useless calls. Unfortunately, it still gets called twice instead of just once and I'm not sure why.

## Pitfalls and notes
* I still have no clear idea on how to handle shortcut conflicts.
* If this eventually gets accepted and merged: we should maybe update the [Create an addon tutorial](https://storybook.js.org/tutorials/create-an-addon/)
* I have updated the `addon-viewport` to list the different shortcuts (previous viewport, next viewport, clear viewport).
* I have updated the shortcut api's unit tests but I've never been that much comfortable with unit testing so this might be irrelevant). I used three different mocks : two different shortcuts from the same fake addon, and another one from another fake addon, just in case we want to make sure everything works fine with multiple addons and multiple shortcuts on a single addon.

# How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? yes

_(*) I'm still waiting for that design tokens roundtable transcript kaelig, ne m'oublie pas please ! 😛_

Edit 24/04/2021 : I remove the WIP status: I need some feedback which is not likely to happen from a draft state.  Please do not hesitate pointing out anythig I could have done wrong and help me improve, <3