### PR TITLE
Addon-docs: Fix ArgsTable sorting when using of={Component}

### DIFF
--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -195,10 +195,10 @@ export const StoryTable: FC<
 
 export const ComponentsTable: FC<ComponentsProps> = (props) => {
   const context = useContext(DocsContext);
-  const { components, include, exclude } = props;
+  const { components, include, exclude, sort } = props;
 
   const tabs = addComponentTabs({}, components, context, include, exclude);
-  return <TabbedArgsTable tabs={tabs} />;
+  return <TabbedArgsTable tabs={tabs} sort={sort} />;
 };
 
 export const ArgsTable: FC<ArgsTableProps> = (props) => {
@@ -222,7 +222,8 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     } catch (err) {
       mainProps = { error: err.message };
     }
-    return <PureArgsTable {...mainProps} />;
+
+    return <PureArgsTable {...mainProps} sort={sort} />;
   }
 
   if (components) {

--- a/examples/cra-ts-kitchen-sink/src/stories/PropsSort.js
+++ b/examples/cra-ts-kitchen-sink/src/stories/PropsSort.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 export const PropsSort = () => <div>PropsSort!</div>;
 PropsSort.propTypes = {
-  foo: PropTypes.string,
+  foo: PropTypes.string.isRequired,
   middleWithDefaultValue: PropTypes.string,
   bar: PropTypes.string,
   endWithDefaultValue: PropTypes.string,

--- a/examples/cra-ts-kitchen-sink/src/stories/props-sort.stories.mdx
+++ b/examples/cra-ts-kitchen-sink/src/stories/props-sort.stories.mdx
@@ -1,7 +1,12 @@
 import { PropsSort } from './PropsSort';
 import { ArgsTable, Meta } from '@storybook/addon-docs/blocks';
+import { SortType } from "@storybook/components";
 
-<Meta title="PropsSort" />
+<Meta 
+    title="PropsSort"
+/>
 
 <ArgsTable of={PropsSort} />
 <ArgsTable of={PropsSort} exclude={['foo']} />
+<ArgsTable of={PropsSort} sort="alpha" />
+<ArgsTable of={PropsSort} sort="requiredFirst" />


### PR DESCRIPTION
The following PR https://github.com/storybookjs/storybook/pull/13125/files added sorting to ArgsTable however the following was not working.

```
<ArgsTable of={PropsSort} sort="alpha" />
```

## What I did

Added code to [docs/blocks/ArgsTable](https://github.com/storybookjs/storybook/blob/next/addons/docs/src/blocks/ArgsTable.tsx) to forward the `sort` prop to the underlying ArgsTable component when using ComponentsTable.

For `alpha` sorting...

Before: 

![image](https://user-images.githubusercontent.com/794579/115440356-a56a8d00-a1dd-11eb-85b9-54fcaf422d3e.png)

After:

![image](https://user-images.githubusercontent.com/794579/115440415-b3201280-a1dd-11eb-94bc-14487a219d6f.png)

## How to test

I added 2 ArgsTable (alpha, requiredFirst) to cra-ts-kitchen-sink at `?path=/story/propssort--page`

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
