### PR TITLE
Avoid rebinding story during decoration

### DIFF
--- a/examples/official-storybook/stories/core/rendering.stories.js
+++ b/examples/official-storybook/stories/core/rendering.stories.js
@@ -1,20 +1,55 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { useArgs } from '@storybook/client-api';
 
 export default {
   title: 'Core/Rendering',
 };
 
 // NOTE: in our example apps each component is mounted twice as we render in strict mode
-let timesMounted = 0;
+let timesCounterMounted = 0;
 export const Counter = () => {
   const countRef = useRef();
 
-  if (!countRef.current) timesMounted += 1;
+  if (!countRef.current) timesCounterMounted += 1;
   countRef.current = (countRef.current || 0) + 1;
 
   return (
     <div>
-      Mounted: {timesMounted}, rendered (this mount): {countRef.current}
+      Mounted: {timesCounterMounted}, rendered (this mount): {countRef.current}
     </div>
   );
 };
+
+// An example to test what happens when the story is remounted due to argChanges
+let timesArgsChangeMounted = 0;
+export const ArgsChange = () => {
+  const countRef = useRef();
+
+  if (!countRef.current) timesArgsChangeMounted += 1;
+  countRef.current = true;
+
+  return (
+    <div>
+      Mounted: {timesArgsChangeMounted} (NOTE: we use strict mode so this number is 2x what you'd
+      expect -- it should be 2, not 4 though!)
+    </div>
+  );
+};
+
+ArgsChange.args = {
+  first: 0,
+};
+
+ArgsChange.decorators = [
+  (StoryFn) => {
+    const [args, updateArgs] = useArgs();
+
+    useEffect(() => {
+      if (args.first === 0) {
+        updateArgs({ first: 1 });
+      }
+    }, []);
+
+    return <StoryFn />;
+  },
+];

--- a/lib/addons/src/hooks.ts
+++ b/lib/addons/src/hooks.ts
@@ -162,9 +162,13 @@ const hookify = (fn: AbstractFunction) => (...args: any[]) => {
 let numberOfRenders = 0;
 const RENDER_LIMIT = 25;
 export const applyHooks = (
-  applyDecorators: (getStory: StoryGetter, decorators: Decorator[]) => StoryGetter
-) => (getStory: StoryGetter, decorators: Decorator[]) => {
-  const decorated = applyDecorators(hookify(getStory), decorators.map(hookify));
+  applyDecorators: (
+    getStory: StoryGetter,
+    decorators: Decorator[],
+    getStoryContext: () => StoryContext
+  ) => StoryGetter
+) => (getStory: StoryGetter, decorators: Decorator[], getStoryContext: () => StoryContext) => {
+  const decorated = applyDecorators(hookify(getStory), decorators.map(hookify), getStoryContext);
   return (context: StoryContext) => {
     const { hooks } = context;
     hooks.prevMountedDecorators = hooks.mountedDecorators;

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -144,7 +144,8 @@ export type LoaderFunction = (c: StoryContext) => Promise<Record<string, any>>;
 
 export type DecorateStoryFunction<StoryFnReturnType = unknown> = (
   storyFn: StoryFn<StoryFnReturnType>,
-  decorators: DecoratorFunction<StoryFnReturnType>[]
+  decorators: DecoratorFunction<StoryFnReturnType>[],
+  getStoryContext: () => StoryContext
 ) => StoryFn<StoryFnReturnType>;
 
 export interface ClientStoryApi<StoryFnReturnType = unknown> {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -581,7 +581,6 @@ export default class StoryStore {
   };
 
   getStoryContext(id: StoryId) {
-    console.log(this._storyContexts, id, this._storyContexts[id]);
     return this._storyContexts[id];
   }
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -458,7 +458,6 @@ export default class StoryStore {
 
     const unboundStoryFn: LegacyStoryFn = (context: StoryContext) => {
       const result = getDecorated()(context);
-      // delete this._storyContexts[id]; // <- FIXME when to delete this?
       return result;
     };
 


### PR DESCRIPTION
Issue: #12255

## What I did

Rather than using a closure and rebinding the story function with the `context` as it is decorated, instead use a `getStoryContext()` function on the store to find out the context of the rendering story.

## How to test

- Is this testable with Jest or Chromatic screenshots?

There is a Chromatic test. Not sure if we need a test for `getStoryContext`, it isn't really intended to be used externally.

- Does this need a new example in the kitchen sink apps?

See above.

- Does this need an update to the documentation?

No
