### PR TITLE
Use Storybook's built-in accessibility icon for VisionDeficiency tab.

### DIFF
--- a/addons/a11y/src/components/VisionDeficiency.tsx
+++ b/addons/a11y/src/components/VisionDeficiency.tsx
@@ -119,7 +119,7 @@ export const VisionDeficiency: FunctionComponent = () => {
         onDoubleClick={() => setFilter(null)}
       >
         <IconButton key="filter" active={!!filter} title="Vision Deficiency Emulation">
-          <Icons icon="mirror" />
+          <Icons icon="accessibility" />
         </IconButton>
       </WithTooltip>
       <Hidden>


### PR DESCRIPTION
Issue: The mirror icon does not accurately reflect the Vision Deficiency tool's purpose in the toolbar.

## What I did
Changed the icon for this a11y feature to Storybook's built-in "accessibility" icon.

Old: 
<img width="31" alt="Screen Shot 2021-04-21 at 11 48 29 AM" src="https://user-images.githubusercontent.com/4335783/115585048-4c602f00-a299-11eb-9452-a14aa2a83097.png"> 

New: 
<img width="28" alt="Screen Shot 2021-04-21 at 12 00 19 PM" src="https://user-images.githubusercontent.com/4335783/115584977-36eb0500-a299-11eb-8144-17386157090d.png">

## How to test

- Is this testable with Jest or Chromatic screenshots?  No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
