### PR TITLE
Possibly wrong API specified in docs

### DIFF
--- a/docs/snippets/react/component-story-custom-args-complex.js.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.js.mdx
@@ -16,8 +16,10 @@ export default {
   //👇 Creates specific argTypes with options
   argTypes: {
     propertyA: {
-      options: ['Item One', 'Item Two', 'Item Three'],
-      control: { type: 'select' } // automatically inferred when 'options' is defined
+      control: { 
+        type: 'select' 
+        options: ['Item One', 'Item Two', 'Item Three'],
+      }
     },
     propertyB: {
       options: ['Another Item One', 'Another Item Two', 'Another Item Three'],


### PR DESCRIPTION
Issue:

options property is supposed to be part of the control property and not on the same level. (as demoed on the same page above: https://storybook.js.org/docs/react/essentials/controls

also type does not seem to be "automatically inferred when 'options' is defined" but defaults to a text input. Tested with a string array

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

