### PR TITLE
Build: Create webpack stats target directory if needed and accept boolean flag

### DIFF
--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -142,7 +142,7 @@ export interface CLIOptions {
   docsDll?: boolean;
   uiDll?: boolean;
   debugWebpack?: boolean;
-  webpackStatsJson?: string;
+  webpackStatsJson?: string | boolean;
   outputDir?: string;
 }
 

--- a/lib/core-server/src/build-dev.ts
+++ b/lib/core-server/src/build-dev.ts
@@ -86,7 +86,8 @@ export async function buildDevStandalone(options: CLIOptions & LoadOptions & Bui
   const managerStats = managerResult && managerResult.stats;
 
   if (options.webpackStatsJson) {
-    await outputStats(options.webpackStatsJson, previewStats, managerStats);
+    const target = options.webpackStatsJson === true ? options.outputDir : options.webpackStatsJson;
+    await outputStats(target, previewStats, managerStats);
   }
 
   if (options.smokeTest) {

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -93,7 +93,8 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
   const [managerStats, previewStats] = await Promise.all([manager, preview]);
 
   if (options.webpackStatsJson) {
-    await outputStats(options.webpackStatsJson, previewStats, managerStats);
+    const target = options.webpackStatsJson === true ? options.outputDir : options.webpackStatsJson;
+    await outputStats(target, previewStats, managerStats);
   }
 
   logger.info(`=> Output directory: ${options.outputDir}`);

--- a/lib/core-server/src/cli/dev.ts
+++ b/lib/core-server/src/cli/dev.ts
@@ -12,10 +12,10 @@ export async function getDevCli(packageJson: {
 
   program
     .version(packageJson.version)
-    .option('-p, --port [number]', 'Port to run Storybook', (str) => parseInt(str, 10))
-    .option('-h, --host [string]', 'Host to run Storybook')
+    .option('-p, --port <number>', 'Port to run Storybook', (str) => parseInt(str, 10))
+    .option('-h, --host <string>', 'Host to run Storybook')
     .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
-    .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
+    .option('-c, --config-dir <dir-name>', 'Directory where to load Storybook configurations from')
     .option(
       '--https',
       'Serve Storybook over HTTPS. Note: You must provide your own certificate information.'
@@ -29,7 +29,7 @@ export async function getDevCli(packageJson: {
     .option('--ssl-key <key>', 'Provide an SSL key. (Required with --https)')
     .option('--smoke-test', 'Exit after successful start')
     .option('--ci', "CI mode (skip interactive prompts, don't open browser)")
-    .option('--loglevel [level]', 'Control level of logging during build')
+    .option('--loglevel <level>', 'Control level of logging during build')
     .option('--quiet', 'Suppress verbose build output')
     .option('--no-version-updates', 'Suppress update check', true)
     .option(
@@ -44,7 +44,7 @@ export async function getDevCli(packageJson: {
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option('--webpack-stats-json [directory]', 'Write Webpack Stats JSON to disk')
     .option(
-      '--preview-url [string]',
+      '--preview-url <string>',
       'Disables the default storybook preview and lets your use your own'
     )
     .option('--docs', 'Build a documentation-only site using addon-docs')

--- a/lib/core-server/src/cli/prod.ts
+++ b/lib/core-server/src/cli/prod.ts
@@ -27,18 +27,18 @@ export function getProdCli(packageJson: {
   program
     .version(packageJson.version)
     .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
-    .option('-o, --output-dir [dir-name]', 'Directory where to store built files')
-    .option('-c, --config-dir [dir-name]', 'Directory where to load Storybook configurations from')
+    .option('-o, --output-dir <dir-name>', 'Directory where to store built files')
+    .option('-c, --config-dir <dir-name>', 'Directory where to load Storybook configurations from')
     .option('-w, --watch', 'Enable watch mode')
     .option('--quiet', 'Suppress verbose build output')
-    .option('--loglevel [level]', 'Control level of logging during build')
+    .option('--loglevel <level>', 'Control level of logging during build')
     .option('--no-dll', 'Do not use dll reference (no-op)')
     .option('--docs-dll', 'Use Docs dll reference (legacy)')
     .option('--ui-dll', 'Use UI dll reference (legacy)')
     .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
     .option('--webpack-stats-json [directory]', 'Write Webpack Stats JSON to disk')
     .option(
-      '--preview-url [string]',
+      '--preview-url <string>',
       'Disables the default storybook preview and lets your use your own'
     )
     .option('--docs', 'Build a documentation-only site using addon-docs')

--- a/lib/core-server/src/utils/output-stats.ts
+++ b/lib/core-server/src/utils/output-stats.ts
@@ -18,6 +18,6 @@ export async function outputStats(directory: string, previewStats?: any, manager
 
 export const writeStats = async (directory: string, name: string, stats: Stats) => {
   const filePath = path.join(directory, `${name}-stats.json`);
-  await fs.writeFile(filePath, JSON.stringify(stats.toJson(), null, 2), 'utf8');
+  await fs.outputFile(filePath, JSON.stringify(stats.toJson(), null, 2), 'utf8');
   return filePath;
 };


### PR DESCRIPTION
Issue: -

## What I did

Instead of `writeFile` this uses `outputFile` so that it will create directories if needed.
With this change, `--webpack-stats-json` won't require a value anymore. If the flag is present with no value (`true`), it will use the outputDir as its value.
Also I updated the args definitions to correctly use `<>` (required) and `[]` (optional)

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
