### PR TITLE
Tighten up `StoryFn` types

### DIFF
--- a/addons/backgrounds/src/decorators/withBackground.ts
+++ b/addons/backgrounds/src/decorators/withBackground.ts
@@ -1,4 +1,9 @@
-import { StoryFn as StoryFunction, StoryContext, useMemo, useEffect } from '@storybook/addons';
+import {
+  PartialStoryFn as StoryFunction,
+  StoryContext,
+  useMemo,
+  useEffect,
+} from '@storybook/addons';
 
 import { PARAM_KEY as BACKGROUNDS_PARAM_KEY } from '../constants';
 import { clearStyles, addBackgroundStyle, getBackgroundColorByName } from '../helpers';

--- a/addons/backgrounds/src/decorators/withGrid.ts
+++ b/addons/backgrounds/src/decorators/withGrid.ts
@@ -1,6 +1,11 @@
 import dedent from 'ts-dedent';
 import deprecate from 'util-deprecate';
-import { StoryFn as StoryFunction, StoryContext, useMemo, useEffect } from '@storybook/addons';
+import {
+  PartialStoryFn as StoryFunction,
+  StoryContext,
+  useMemo,
+  useEffect,
+} from '@storybook/addons';
 
 import { clearStyles, addGridStyle } from '../helpers';
 import { PARAM_KEY as BACKGROUNDS_PARAM_KEY } from '../constants';

--- a/addons/docs/src/frameworks/angular/prepareForInline.ts
+++ b/addons/docs/src/frameworks/angular/prepareForInline.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IStory, StoryContext } from '@storybook/angular';
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 import { logger } from '@storybook/client-logger';
 
 const customElementsVersions: Record<string, number> = {};
@@ -9,7 +9,10 @@ const customElementsVersions: Record<string, number> = {};
  * Uses angular element to generate on-the-fly web components and reference it with `customElements`
  * then it is added into react
  */
-export const prepareForInline = (storyFn: StoryFn<IStory>, { id, parameters }: StoryContext) => {
+export const prepareForInline = (
+  storyFn: PartialStoryFn<IStory>,
+  { id, parameters }: StoryContext
+) => {
   // Upgrade story version in order that the next defined component has a unique key
   customElementsVersions[id] =
     customElementsVersions[id] !== undefined ? customElementsVersions[id] + 1 : 0;

--- a/addons/docs/src/frameworks/angular/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/angular/sourceDecorator.ts
@@ -1,4 +1,4 @@
-import { addons, StoryContext, StoryFn } from '@storybook/addons';
+import { addons, StoryContext, PartialStoryFn } from '@storybook/addons';
 import { IStory } from '@storybook/angular';
 import { computesTemplateSourceFromComponent } from '@storybook/angular/renderer';
 import prettierHtml from 'prettier/parser-html';
@@ -30,7 +30,7 @@ const prettyUp = (source: string) => {
  * @param storyFn Fn
  * @param context  StoryContext
  */
-export const sourceDecorator = (storyFn: StoryFn<IStory>, context: StoryContext) => {
+export const sourceDecorator = (storyFn: PartialStoryFn<IStory>, context: StoryContext) => {
   const story = storyFn();
   if (skipSourceRender(context)) {
     return story;

--- a/addons/docs/src/frameworks/html/config.tsx
+++ b/addons/docs/src/frameworks/html/config.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 
 export const parameters = {
   docs: {
     inlineStories: true,
-    prepareForInline: (storyFn: StoryFn<string>) => {
+    prepareForInline: (storyFn: PartialStoryFn<string>) => {
       const html = storyFn();
       if (typeof html === 'string') {
         // eslint-disable-next-line react/no-danger

--- a/addons/docs/src/frameworks/react/config.ts
+++ b/addons/docs/src/frameworks/react/config.ts
@@ -1,4 +1,4 @@
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 import { extractArgTypes } from './extractArgTypes';
 import { extractComponentDescription } from '../../lib/docgen';
 import { jsxDecorator } from './jsxDecorator';
@@ -7,7 +7,7 @@ export const parameters = {
   docs: {
     inlineStories: true,
     // NOTE: that the result is a react element. Hooks support is provided by the outer code.
-    prepareForInline: (storyFn: StoryFn) => storyFn(),
+    prepareForInline: (storyFn: PartialStoryFn) => storyFn(),
     extractArgTypes,
     extractComponentDescription,
   },

--- a/addons/docs/src/frameworks/svelte/prepareForInline.ts
+++ b/addons/docs/src/frameworks/svelte/prepareForInline.ts
@@ -1,11 +1,11 @@
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 
 import React from 'react';
 
 // @ts-ignore
 import HOC from './HOC.svelte';
 
-export const prepareForInline = (storyFn: StoryFn) => {
+export const prepareForInline = (storyFn: PartialStoryFn) => {
   const el = React.useRef(null);
   React.useEffect(() => {
     const root = new HOC({

--- a/addons/docs/src/frameworks/vue/prepareForInline.ts
+++ b/addons/docs/src/frameworks/vue/prepareForInline.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import Vue from 'vue';
-import { StoryFn, StoryContext } from '@storybook/addons';
+import { PartialStoryFn, StoryContext } from '@storybook/addons';
 
 // Inspired by https://github.com/egoist/vue-to-react,
 // modified to store args as props in the root store
@@ -9,7 +9,7 @@ import { StoryFn, StoryContext } from '@storybook/addons';
 const COMPONENT = 'STORYBOOK_COMPONENT';
 const VALUES = 'STORYBOOK_VALUES';
 
-export const prepareForInline = (storyFn: StoryFn, { args }: StoryContext) => {
+export const prepareForInline = (storyFn: PartialStoryFn, { args }: StoryContext) => {
   const component = storyFn();
   const el = React.useRef(null);
 

--- a/addons/docs/src/frameworks/vue3/prepareForInline.ts
+++ b/addons/docs/src/frameworks/vue3/prepareForInline.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 import * as Vue from 'vue';
-import { StoryFn, StoryContext } from '@storybook/addons';
+import { PartialStoryFn, StoryContext } from '@storybook/addons';
 import { app } from '@storybook/vue3';
 
 // This is cast as `any` to workaround type errors caused by Vue 2 types
 const { render, h } = Vue as any;
 
-export const prepareForInline = (storyFn: StoryFn, { args }: StoryContext) => {
+export const prepareForInline = (storyFn: PartialStoryFn, { args }: StoryContext) => {
   const component = storyFn();
 
   const vnode = h(component, args);

--- a/app/angular/src/client/preview/angular/helpers.ts
+++ b/app/angular/src/client/preview/angular/helpers.ts
@@ -5,7 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { BrowserModule } from '@angular/platform-browser';
 import { Observable, ReplaySubject, Subscriber } from 'rxjs';
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 import { AppComponent } from './components/app.component';
 import { STORY } from './app.token';
 import { NgModuleMetadata, StoryFnAngularReturnType } from '../types';
@@ -130,7 +130,7 @@ const getExistenceOfComponentInModules = (
   });
 };
 
-const initModule = (storyFn: StoryFn<StoryFnAngularReturnType>) => {
+const initModule = (storyFn: PartialStoryFn<StoryFnAngularReturnType>) => {
   const storyObj = storyFn();
   const { component, template, props, styles, moduleMetadata = {} } = storyObj;
 
@@ -198,7 +198,7 @@ const draw = (newModule: DynamicComponentType): void => {
   }
 };
 
-export const renderNgApp = (storyFn: StoryFn<StoryFnAngularReturnType>, forced: boolean) => {
+export const renderNgApp = (storyFn: PartialStoryFn<StoryFnAngularReturnType>, forced: boolean) => {
   if (!forced) {
     draw(initModule(storyFn));
   } else {

--- a/app/angular/src/client/preview/decorateStory.ts
+++ b/app/angular/src/client/preview/decorateStory.ts
@@ -1,4 +1,4 @@
-import { DecoratorFunction, StoryContext, StoryFn } from '@storybook/addons';
+import { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/addons';
 import { computesTemplateFromComponent } from './angular-beta/ComputesTemplateFromComponent';
 
 import { StoryFnAngularReturnType } from './types';
@@ -14,11 +14,11 @@ const defaultContext: StoryContext = {
 };
 
 export default function decorateStory(
-  mainStoryFn: StoryFn<StoryFnAngularReturnType>,
+  mainStoryFn: LegacyStoryFn<StoryFnAngularReturnType>,
   decorators: DecoratorFunction<StoryFnAngularReturnType>[]
-): StoryFn<StoryFnAngularReturnType> {
+): LegacyStoryFn<StoryFnAngularReturnType> {
   const returnDecorators = decorators.reduce(
-    (previousStoryFn: StoryFn<StoryFnAngularReturnType>, decorator) => (
+    (previousStoryFn: LegacyStoryFn<StoryFnAngularReturnType>, decorator) => (
       context: StoryContext = defaultContext
     ) => {
       const decoratedStory = decorator(

--- a/app/angular/src/client/preview/render.ts
+++ b/app/angular/src/client/preview/render.ts
@@ -1,4 +1,4 @@
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 import { RendererService } from './angular-beta/RendererService';
 
 import { renderNgApp } from './angular/helpers';
@@ -12,7 +12,7 @@ export default function render({
   forceRender,
   parameters,
 }: {
-  storyFn: StoryFn<StoryFnAngularReturnType>;
+  storyFn: PartialStoryFn<StoryFnAngularReturnType>;
   showMain: () => void;
   forceRender: boolean;
   parameters: Parameters;

--- a/app/angular/src/client/preview/types.ts
+++ b/app/angular/src/client/preview/types.ts
@@ -11,7 +11,7 @@ export interface ICollection {
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/aurelia/src/client/preview/decorators.ts
+++ b/app/aurelia/src/client/preview/decorators.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 import { IRegistry, IContainer } from 'aurelia';
 import { StoryFnAureliaReturnType } from './types';
 
 export const addRegistries = (...items: IRegistry[]) => (
-  storyFn: StoryFn<StoryFnAureliaReturnType>
+  storyFn: PartialStoryFn<StoryFnAureliaReturnType>
 ) => {
   const story = storyFn();
   story.items = story.items || [];
@@ -21,7 +21,7 @@ export interface Component {
 }
 
 export const addComponents = (...components: Component[] | unknown[]) => (
-  storyFn: StoryFn<StoryFnAureliaReturnType>
+  storyFn: PartialStoryFn<StoryFnAureliaReturnType>
 ) => {
   const story = storyFn();
   story.components = story.components || [];
@@ -34,7 +34,7 @@ export const addComponents = (...components: Component[] | unknown[]) => (
 };
 
 export const addContainer = (container: IContainer) => (
-  storyFn: StoryFn<StoryFnAureliaReturnType>
+  storyFn: PartialStoryFn<StoryFnAureliaReturnType>
 ) => {
   const story = storyFn();
 

--- a/app/aurelia/src/client/preview/types.ts
+++ b/app/aurelia/src/client/preview/types.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 import { IRegistry, IContainer, Constructable } from 'aurelia';
 import { Component } from './decorators';
 
 export interface RenderMainArgs {
-  storyFn: StoryFn<Partial<StoryFnAureliaReturnType>>;
+  storyFn: PartialStoryFn<Partial<StoryFnAureliaReturnType>>;
   selectedKind: string;
   selectedStory: string;
   showMain: () => void;
@@ -26,7 +26,7 @@ export interface ShowErrorArgs {
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/html/src/client/preview/types.ts
+++ b/app/html/src/client/preview/types.ts
@@ -4,7 +4,7 @@ export type StoryFnHtmlReturnType = string | Node;
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/mithril/src/client/preview/types.ts
+++ b/app/mithril/src/client/preview/types.ts
@@ -4,7 +4,7 @@ export type { RenderContext } from '@storybook/core';
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/preact/src/client/preview/types.ts
+++ b/app/preact/src/client/preview/types.ts
@@ -11,7 +11,7 @@ export interface ShowErrorArgs {
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/react/src/client/preview/types.ts
+++ b/app/react/src/client/preview/types.ts
@@ -13,7 +13,7 @@ export type StoryFnReactReturnType = ReactElement<unknown>;
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/server/src/client/preview/types.ts
+++ b/app/server/src/client/preview/types.ts
@@ -13,7 +13,7 @@ export type FetchStoryHtmlType = (
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/svelte/src/client/preview/decorators.ts
+++ b/app/svelte/src/client/preview/decorators.ts
@@ -1,4 +1,4 @@
-import { StoryFn, DecoratorFunction, StoryContext } from '@storybook/addons';
+import { LegacyStoryFn, DecoratorFunction, StoryContext } from '@storybook/addons';
 import SlotDecorator from './SlotDecorator.svelte';
 
 const defaultContext: StoryContext = {
@@ -73,7 +73,7 @@ function prepareStory(context: StoryContext, story: any, originalStory?: any) {
 
 export function decorateStory(storyFn: any, decorators: any[]) {
   return decorators.reduce(
-    (previousStoryFn: StoryFn, decorator: DecoratorFunction) => (
+    (previousStoryFn: LegacyStoryFn, decorator: DecoratorFunction) => (
       context: StoryContext = defaultContext
     ) => {
       let story;

--- a/app/vue/src/client/preview/index.ts
+++ b/app/vue/src/client/preview/index.ts
@@ -3,10 +3,10 @@ import Vue, { VueConstructor, ComponentOptions } from 'vue';
 import { start } from '@storybook/core/client';
 import {
   ClientStoryApi,
-  StoryFn,
   DecoratorFunction,
   StoryContext,
   Loadable,
+  LegacyStoryFn,
 } from '@storybook/addons';
 
 import './globals';
@@ -74,11 +74,13 @@ const defaultContext: StoryContext = {
 };
 
 function decorateStory(
-  storyFn: StoryFn<StoryFnVueReturnType>,
+  storyFn: LegacyStoryFn<StoryFnVueReturnType>,
   decorators: DecoratorFunction<VueConstructor>[]
-): StoryFn<VueConstructor> {
+): LegacyStoryFn<VueConstructor> {
   return decorators.reduce(
-    (decorated: StoryFn<VueConstructor>, decorator) => (context: StoryContext = defaultContext) => {
+    (decorated: LegacyStoryFn<VueConstructor>, decorator) => (
+      context: StoryContext = defaultContext
+    ) => {
       let story;
 
       const decoratedStory = decorator(

--- a/app/vue/src/client/preview/types.ts
+++ b/app/vue/src/client/preview/types.ts
@@ -12,7 +12,7 @@ export type StoryFnVueReturnType = string | Component;
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/vue3/src/client/preview/index.ts
+++ b/app/vue3/src/client/preview/index.ts
@@ -3,7 +3,7 @@ import { h } from 'vue';
 import { start } from '@storybook/core/client';
 import {
   ClientStoryApi,
-  StoryFn,
+  LegacyStoryFn,
   DecoratorFunction,
   StoryContext,
   Loadable,
@@ -55,11 +55,11 @@ const defaultContext: StoryContext = {
 };
 
 function decorateStory(
-  storyFn: StoryFn<StoryFnVueReturnType>,
+  storyFn: LegacyStoryFn<StoryFnVueReturnType>,
   decorators: DecoratorFunction<ConcreteComponent>[]
-): StoryFn<Component> {
+): LegacyStoryFn<Component> {
   return decorators.reduce(
-    (decorated: StoryFn<ConcreteComponent>, decorator) => (
+    (decorated: LegacyStoryFn<ConcreteComponent>, decorator) => (
       context: StoryContext = defaultContext
     ) => {
       let story;
@@ -82,7 +82,7 @@ function decorateStory(
 
       return prepare(decoratedStory, story);
     },
-    (context) => prepare(storyFn(context))
+    (context: StoryContext) => prepare(storyFn(context))
   );
 }
 const framework = 'vue3';

--- a/app/vue3/src/client/preview/types.ts
+++ b/app/vue3/src/client/preview/types.ts
@@ -11,7 +11,7 @@ export type StoryFnVueReturnType = ConcreteComponent<any>;
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/app/web-components/src/client/preview/types.ts
+++ b/app/web-components/src/client/preview/types.ts
@@ -7,7 +7,7 @@ export type StoryFnHtmlReturnType = string | Node | TemplateResult | SVGTemplate
 
 export interface IStorybookStory {
   name: string;
-  render: () => any;
+  render: ((context: any) => any) | ((args: any, context: any) => any);
 }
 
 export interface IStorybookSection {

--- a/examples/aurelia-kitchen-sink/src/stories/custom-element.stories.ts
+++ b/examples/aurelia-kitchen-sink/src/stories/custom-element.stories.ts
@@ -1,4 +1,4 @@
-import { StoryFn } from '@storybook/addons';
+import { PartialStoryFn } from '@storybook/addons';
 import { withActions, action } from '@storybook/addon-actions';
 import { withKnobs, text } from '@storybook/addon-knobs';
 
@@ -6,7 +6,7 @@ import { StoryFnAureliaReturnType, addComponents } from '@storybook/aurelia';
 import { CoolButton } from '../cool-button/cool-button';
 import 'bootstrap/scss/bootstrap.scss';
 
-type StoryType = StoryFn<Partial<StoryFnAureliaReturnType>> & {
+type StoryType = PartialStoryFn<Partial<StoryFnAureliaReturnType>> & {
   storyName: string;
 };
 

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -97,9 +97,9 @@ export type StoryGetter = (context: StoryContext) => any;
 // This is the type of story function passed to a decorator -- does not rely on being passed any context
 export type PartialStoryFn<ReturnType = unknown> = (p?: StoryContextUpdate) => ReturnType;
 // This is a passArgsFirst: false user story function
-export type LegacyStoryFn<ReturnType = unknown> = (p?: StoryContext) => ReturnType;
+export type LegacyStoryFn<ReturnType = unknown> = (p: StoryContext) => ReturnType;
 // This is a passArgsFirst: true user story function
-export type ArgsStoryFn<ReturnType = unknown> = (a?: Args, p?: StoryContext) => ReturnType;
+export type ArgsStoryFn<ReturnType = unknown> = (a: Args, p: StoryContext) => ReturnType;
 // This is either type of user story function
 export type StoryFn<ReturnType = unknown> = LegacyStoryFn<ReturnType> | ArgsStoryFn<ReturnType>;
 

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -14,6 +14,7 @@ import {
   Comparator,
   Parameters,
   Args,
+  PartialStoryFn,
   LegacyStoryFn,
   ArgsStoryFn,
   StoryContext,
@@ -434,7 +435,7 @@ export default class StoryStore {
 
     const storyParametersWithArgTypes = { ...storyParameters, argTypes, __isArgsStory };
 
-    const storyFn: LegacyStoryFn = (runtimeContext: StoryContext) => {
+    const storyFn: PartialStoryFn = (runtimeContext: StoryContext) => {
       storyFnWarning();
       return getDecorated()({
         ...identification,

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -5,6 +5,7 @@ import {
   StoryKind,
   ViewMode,
   StoryIdentifier,
+  LegacyStoryFn,
   StoryFn,
   Parameters,
   Args,
@@ -14,6 +15,7 @@ import {
   LoaderFunction,
   DecorateStoryFunction,
   StoryContext,
+  PartialStoryFn,
 } from '@storybook/addons';
 import StoryStore from './story_store';
 import { HooksContext } from './hooks';
@@ -53,11 +55,11 @@ export type AddStoryArgs = StoryIdentifier & {
 
 export type StoreItem = StoryIdentifier & {
   parameters: Parameters;
-  getDecorated: () => StoryFn<any>;
+  getDecorated: () => LegacyStoryFn<any>;
   getOriginal: () => StoryFn<any>;
   applyLoaders: () => Promise<StoryContext>;
-  storyFn: StoryFn<any>;
-  unboundStoryFn: StoryFn<any>;
+  storyFn: PartialStoryFn<any>;
+  unboundStoryFn: LegacyStoryFn<any>;
   hooks: HooksContext;
   args: Args;
   initialArgs: Args;

--- a/lib/core-client/src/preview/StoryRenderer.tsx
+++ b/lib/core-client/src/preview/StoryRenderer.tsx
@@ -4,7 +4,7 @@ import { document } from 'global';
 import AnsiToHtml from 'ansi-to-html';
 import dedent from 'ts-dedent';
 
-import { StoryId, StoryKind, StoryFn, ViewMode, Channel } from '@storybook/addons';
+import { StoryId, StoryKind, LegacyStoryFn, ViewMode, Channel } from '@storybook/addons';
 import Events from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 import { StoryStore } from '@storybook/client-api';
@@ -17,7 +17,7 @@ interface RenderMetadata {
   id: StoryId;
   kind: StoryKind;
   viewMode: ViewMode;
-  getDecorated: () => StoryFn<any>;
+  getDecorated: () => LegacyStoryFn<any>;
 }
 
 const layoutClassMap = {


### PR DESCRIPTION
In https://github.com/storybookjs/storybook/pull/14692 I added a `PartialStoryFn` type, which is the thing that a decorator accepts as an argument:

```
export type PartialStoryFn<ReturnType = unknown> = (p?: StoryContextUpdate) => ReturnType;
```

A decorator doesn't *have* to pass the context into the story it is passed, it's automatically bound.

This fact led to our other story types (`LegacyStoryFn`, `ArgsStoryFn` and the union `StoryFn`) having optional arguments, which was actually really wrong, you would expect them to break if passed no context.

This PR attempts to tighten that up. It's kind of a big change, not sure if it needs to be a major version change.