### PR TITLE
(Documentation) add unsupported addon Icon format

### DIFF
--- a/docs/addons/addon-catalog.md
+++ b/docs/addons/addon-catalog.md
@@ -31,12 +31,12 @@ We rely on metadata to organize your addon in the catalog. You must add the <cod
 
 Customize your addon's appearance by adding the `storybook` property with the following fields.
 
-| Property                | Description                       | Example                               |
-| ----------------------- | --------------------------------- | ------------------------------------- |
-| `displayName`           | Display name                      | Outline                               |
-| `icon`                  | Link to custom icon for the addon | https://yoursite.com/outline-icon.png |
-| `unsupportedFrameworks` | List of unsupported frameworks    | `["vue"]`                             |
-| `supportedFrameworks`   | List of supported frameworks      | `["react", "angular"]`                |
+| Property                | Description                                               | Example                               |
+| ----------------------- | --------------------------------------------------------- | ------------------------------------- |
+| `displayName`           | Display name                                              | Outline                               |
+| `icon`                  | Link to custom icon for the addon (SVG are not supported) | https://yoursite.com/outline-icon.png |
+| `unsupportedFrameworks` | List of unsupported frameworks                            | `["vue"]`                             |
+| `supportedFrameworks`   | List of supported frameworks                              | `["react", "angular"]`                |
 
 
 Use the table below as a reference when filling in the values for both the `supportedFrameworks` and `unsupportedFrameworks` metadata properties.


### PR DESCRIPTION
## What I did

SVG are not supported for SB addon Icon, add a quick note about it.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
