### PR TITLE
Storyshots: Add server to supported frameworks

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/SupportedFramework.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/SupportedFramework.ts
@@ -5,6 +5,7 @@ export type SupportedFramework =
   | 'react'
   | 'riot'
   | 'react-native'
+  | 'server'
   | 'svelte'
   | 'vue'
   | 'vue3'

--- a/addons/storyshots/storyshots-core/src/frameworks/server/loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/server/loader.ts
@@ -1,0 +1,32 @@
+import global from 'global';
+import configure from '../configure';
+import { Loader } from '../Loader';
+import { StoryshotsOptions } from '../../api/StoryshotsOptions';
+
+function test(options: StoryshotsOptions): boolean {
+  return options.framework === 'server';
+}
+
+function load(options: StoryshotsOptions) {
+  global.STORYBOOK_ENV = 'server';
+
+  const storybook = jest.requireActual('@storybook/server');
+
+  configure({ ...options, storybook });
+
+  return {
+    framework: 'server' as const,
+    renderTree: jest.requireActual('./renderTree').default,
+    renderShallowTree: () => {
+      throw new Error('Shallow renderer is not supported for server');
+    },
+    storybook,
+  };
+}
+
+const serverLoader: Loader = {
+  load,
+  test,
+};
+
+export default serverLoader;

--- a/addons/storyshots/storyshots-core/src/frameworks/server/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/server/renderTree.ts
@@ -1,0 +1,20 @@
+import { document, Node } from 'global';
+
+function getRenderedTree(story: { render: () => any }) {
+  const component = story.render();
+
+  if (component instanceof Node) {
+    return component;
+  }
+
+  const section: HTMLElement = document.createElement('section');
+  section.innerHTML = component;
+
+  if (section.childElementCount > 1) {
+    return section;
+  }
+
+  return section.firstChild;
+}
+
+export default getRenderedTree;


### PR DESCRIPTION
Issue: storyshots does not allow the usage of the server framework

## What I did

- Added server as supported framework

## How to test

```
// storybook.test.js
import initStoryshots from '@storybook/addon-storyshots';

initStoryshots({
    ...
    framework: 'server',
    ...
});
```
