### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,9 +118,8 @@ A good way to do that is using the example `cra-kitchen-sink` app embedded in th
 # Download and build this repository:
 git clone https://github.com/storybookjs/storybook.git
 cd storybook
+yarn
 yarn bootstrap --core
-
-# NOTE: on windows you may need to run `yarn` before `yarn bootstrap`!
 
 # make changes to try and reproduce the problem, such as adding components + stories
 cd examples/cra-kitchen-sink


### PR DESCRIPTION
I had to run `yarn` before I could run `yarn bootstrap --core` on macOS Big Sur. Perhaps this is now required for everyone, not just Windows users.

Issue:

## What I did

Tried to boostrap a fresh copy of Storybook for development.

## How to test

Try bootstrapping a fresh Storybook and see if you too need to run `yarn` like I did.