### PR TITLE
Addon-docs: Add parameter to show code by default

### DIFF
--- a/addons/docs/docs/docspage.md
+++ b/addons/docs/docs/docspage.md
@@ -13,6 +13,7 @@ When you install [Storybook Docs](../README.md), `DocsPage` is the zero-config d
   - [Remixing DocsPage using doc blocks](#remixing-docspage-using-doc-blocks)
 - [Story file names](#story-file-names)
 - [Inline stories vs. Iframe stories](#inline-stories-vs-iframe-stories)
+- [Show/Hide code](#showhide-code)
 - [More resources](#more-resources)
 
 ## Motivation
@@ -185,23 +186,21 @@ With that function, anyone using the docs addon for `@storybook/vue` can make th
 
 ## Show/Hide code
 
-By default, the code block under the Preview is collapsed.
+By default, the code block under the Preview is collapsed and you have to click on "Show code" to reveal it.
 
-You have to click on "Show code" to reveal it.
-
-You can override this default behavior:
+You can override this default behavior in `.storybook/preview.js` (or in any of your components/stories):
 
 ```js
-import { addParameters } from '@storybook/react';
-
-addParameters({
+export const parameters = {
   docs: {
-    isCodeExpanded: true,
+    source: {
+      state: 'open',
+    },
   },
-});
+};
 ```
 
-With that flag, now the docs addon will show all code blocks by default.
+With that flag, now the docs addon will show all code blocks open by default.
 
 ## More resources
 

--- a/addons/docs/docs/docspage.md
+++ b/addons/docs/docs/docspage.md
@@ -183,7 +183,7 @@ addParameters({
 
 With that function, anyone using the docs addon for `@storybook/vue` can make their stories render inline, either globally with the `inlineStories` docs parameter, or on a per-story-basis using the `inline` prop on the `<Story>` doc block. If you come up with an elegant and flexible implementation for the `prepareForInline` function for your own framework, let us know! We'd love to make it the default configuration, to make inline stories more accessible for a larger variety of frameworks!
 
-## Showing code by default
+## Show/Hide code
 
 By default, the code block under the Preview is collapsed.
 

--- a/addons/docs/docs/docspage.md
+++ b/addons/docs/docs/docspage.md
@@ -183,6 +183,26 @@ addParameters({
 
 With that function, anyone using the docs addon for `@storybook/vue` can make their stories render inline, either globally with the `inlineStories` docs parameter, or on a per-story-basis using the `inline` prop on the `<Story>` doc block. If you come up with an elegant and flexible implementation for the `prepareForInline` function for your own framework, let us know! We'd love to make it the default configuration, to make inline stories more accessible for a larger variety of frameworks!
 
+## Showing code by default
+
+By default, the code block under the Preview is collapsed.
+
+You have to click on "Show code" to reveal it.
+
+You can override this default behavior:
+
+```js
+import { addParameters } from '@storybook/react';
+
+addParameters({
+  docs: {
+    isCodeExpanded: true,
+  },
+});
+```
+
+With that flag, now the docs addon will show all code blocks by default.
+
 ## More resources
 
 - References: [README](../README.md) / [DocsPage](docspage.md) / [MDX](mdx.md) / [FAQ](faq.md) / [Recipes](recipes.md) / [Theming](theming.md) / [Props](props-tables.md)

--- a/addons/docs/src/blocks/Canvas.tsx
+++ b/addons/docs/src/blocks/Canvas.tsx
@@ -59,7 +59,7 @@ const getPreviewProps = (
     withSource: sourceProps,
     isExpanded: withSource
       ? withSource === SourceState.OPEN
-      : docsContext?.parameters?.docs?.isExpanded,
+      : docsContext?.parameters?.docs?.isCodeExpanded,
   };
 };
 

--- a/addons/docs/src/blocks/Canvas.tsx
+++ b/addons/docs/src/blocks/Canvas.tsx
@@ -44,7 +44,7 @@ const getPreviewProps = (
   const stories = childArray.filter(
     (c: ReactElement) => c.props && (c.props.id || c.props.name)
   ) as ReactElement[];
-  const { mdxComponentMeta, mdxStoryNameToKey } = docsContext;
+  const { mdxComponentMeta, mdxStoryNameToKey, parameters } = docsContext;
   const targetIds = stories.map(
     (s) =>
       s.props.id ||
@@ -59,7 +59,7 @@ const getPreviewProps = (
     withSource: sourceProps,
     isExpanded: withSource
       ? withSource === SourceState.OPEN
-      : docsContext?.parameters?.docs?.isCodeExpanded,
+      : parameters?.docs?.isCodeExpanded,
   };
 };
 

--- a/addons/docs/src/blocks/Canvas.tsx
+++ b/addons/docs/src/blocks/Canvas.tsx
@@ -57,7 +57,9 @@ const getPreviewProps = (
   return {
     ...props, // pass through columns etc.
     withSource: sourceProps,
-    isExpanded: withSource === SourceState.OPEN,
+    isExpanded: withSource
+      ? withSource === SourceState.OPEN
+      : docsContext?.parameters?.docs?.isExpanded,
   };
 };
 

--- a/addons/docs/src/blocks/Canvas.tsx
+++ b/addons/docs/src/blocks/Canvas.tsx
@@ -57,9 +57,7 @@ const getPreviewProps = (
   return {
     ...props, // pass through columns etc.
     withSource: sourceProps,
-    isExpanded: withSource
-      ? withSource === SourceState.OPEN
-      : parameters?.docs?.isCodeExpanded,
+    isExpanded: withSource === SourceState.OPEN || parameters?.docs?.isCodeExpanded,
   };
 };
 

--- a/addons/docs/src/blocks/Canvas.tsx
+++ b/addons/docs/src/blocks/Canvas.tsx
@@ -22,16 +22,13 @@ type CanvasProps = PurePreviewProps & {
 };
 
 const getPreviewProps = (
-  {
-    withSource = SourceState.CLOSED,
-    mdxSource,
-    children,
-    ...props
-  }: CanvasProps & { children?: ReactNode },
+  { withSource, mdxSource, children, ...props }: CanvasProps & { children?: ReactNode },
   docsContext: DocsContextProps,
   sourceContext: SourceContextProps
 ): PurePreviewProps => {
-  if (withSource === SourceState.NONE) {
+  const { mdxComponentMeta, mdxStoryNameToKey, parameters } = docsContext;
+  const sourceState = withSource || parameters?.docs?.source?.state || SourceState.CLOSED;
+  if (sourceState === SourceState.NONE) {
     return props;
   }
   if (mdxSource) {
@@ -44,7 +41,6 @@ const getPreviewProps = (
   const stories = childArray.filter(
     (c: ReactElement) => c.props && (c.props.id || c.props.name)
   ) as ReactElement[];
-  const { mdxComponentMeta, mdxStoryNameToKey, parameters } = docsContext;
   const targetIds = stories.map(
     (s) =>
       s.props.id ||
@@ -57,7 +53,7 @@ const getPreviewProps = (
   return {
     ...props, // pass through columns etc.
     withSource: sourceProps,
-    isExpanded: withSource === SourceState.OPEN || parameters?.docs?.isCodeExpanded,
+    isExpanded: sourceState === SourceState.OPEN,
   };
 };
 

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -30,10 +30,10 @@ export default {
     },
   },
   parameters: {
-    docs: {
-      isExpanded: false,
-    },
     chromatic: { disable: true },
+    docs: {
+      isCodeExpanded: true,
+    },
   },
 };
 

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -29,7 +29,12 @@ export default {
       },
     },
   },
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      isExpanded: false,
+    },
+    chromatic: { disable: true },
+  },
 };
 
 const DEFAULT_NESTED_OBJECT = { a: 4, b: { c: 'hello', d: [1, 2, 3] } };

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -32,7 +32,9 @@ export default {
   parameters: {
     chromatic: { disable: true },
     docs: {
-      isCodeExpanded: true,
+      source: {
+        state: 'open',
+      },
     },
   },
 };


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/10430

## What I did

The property `isExpanded` was already available on `<Canvas>` block

Now you can set `docs.source.state` on your Addon Docs configuration! 

```javascript
export const parameters = {
  docs: {
    source: {
      state: 'open',
     },
  },
};
```

## How to test

Visit https://5a375b97f4b14f0020b0cda3-wplcskzipa.chromatic.com/?path=/docs/addons-controls--basic
Where Code bocks are shown by default now.

- Is this testable with Jest or Chromatic screenshots? ✅ 
- Does this need a new example in the kitchen sink apps? ❎ 
- Does this need an update to the documentation? ✅ 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
