### PR TITLE
@storybook/web-components: Replace lit-html with lit@2.0.0

### DIFF
--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -65,12 +65,12 @@
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
-    "lit-html": "^1.3.0"
+    "lit": "^2.0.0-rc.1"
   },
   "peerDependencies": {
     "@babel/core": "*",
     "babel-loader": "^7.0.0 || ^8.0.0",
-    "lit-html": "^1.0.0"
+    "lit": "^2.0.0"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/app/web-components/src/client/preview/render.ts
+++ b/app/web-components/src/client/preview/render.ts
@@ -1,6 +1,6 @@
 import { document, Node } from 'global';
 import dedent from 'ts-dedent';
-import { render, TemplateResult } from 'lit-html';
+import { render, TemplateResult } from 'lit';
 import { simulatePageLoad, simulateDOMContentLoaded } from '@storybook/client-api';
 import { RenderContext } from './types';
 
@@ -17,7 +17,7 @@ export default function renderMain({
   const element = storyFn();
 
   showMain();
-  if (element instanceof TemplateResult) {
+  if (isTemplateResult(element)) {
     // `render` stores the TemplateInstance in the Node and tries to update based on that.
     // Since we reuse `rootElement` for all stories, remove the stored instance first.
     // But forceRender means that it's the same story, so we want too keep the state in that case.
@@ -49,4 +49,9 @@ export default function renderMain({
       `,
     });
   }
+}
+
+function isTemplateResult(x: TemplateResult): x is TemplateResult {
+  const { _$litType$, strings, values } = x;
+  return _$litType$ !== undefined && Array.isArray(strings) && Array.isArray(values);
 }

--- a/examples/web-components-kitchen-sink/package.json
+++ b/examples/web-components-kitchen-sink/package.json
@@ -34,7 +34,7 @@
     "eventemitter3": "^4.0.7",
     "format-json": "^1.0.3",
     "global": "^4.4.0",
-    "lit-element": "^2.4.0"
+    "lit": "^2.0.0-rc.1"
   },
   "storybook": {
     "chromatic": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4839,6 +4839,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lit/reactive-element@npm:^1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@lit/reactive-element@npm:1.0.0-rc.1"
+  checksum: 14652c3c43a469f1699a9b986a5c5f3e0d5a9d67c1ce3f7dc8f1d31c9c1887df1c7f0ea9b03bfa445d1de02b7a0042585cb731e236a5988ccc3189fe2a755031
+  languageName: node
+  linkType: hard
+
 "@marko/babel-types@npm:^5.1.1":
   version: 5.1.1
   resolution: "@marko/babel-types@npm:5.1.1"
@@ -8330,7 +8337,7 @@ __metadata:
     babel-plugin-bundled-import-meta: ^0.3.1
     core-js: ^3.8.2
     global: ^4.4.0
-    lit-html: ^1.3.0
+    lit: ^2.0.0-rc.1
     react: 16.14.0
     react-dom: 16.14.0
     read-pkg-up: ^7.0.1
@@ -8339,7 +8346,7 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
     babel-loader: ^7.0.0 || ^8.0.0
-    lit-html: ^1.0.0
+    lit: ^2.0.0
   bin:
     build-storybook: ./bin/build.js
     start-storybook: ./bin/index.js
@@ -9948,6 +9955,13 @@ __metadata:
   version: 0.2.0
   resolution: "@types/tmp@npm:0.2.0"
   checksum: e639b7ed4a219da18407f5c0ec5297e4759d8d3b5b9d54b8a54a7b948ee1477c63dccf71931b742cf5e1a4377456f44b7e8167e1551aa058dda05bc770e1602c
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:^1.0.1":
+  version: 1.0.6
+  resolution: "@types/trusted-types@npm:1.0.6"
+  checksum: 4bc61ac65b8e42d17c77a23f29cdf94e498acd2e23f4c00cf15c8281de94263ac313d46cbcd7cd1d03c066d497f9396845e3210ff0074f5f90f212cb3e8aac28
   languageName: node
   linkType: hard
 
@@ -30811,10 +30825,40 @@ fsevents@2.1.2:
   languageName: node
   linkType: hard
 
+"lit-element@npm:^3.0.0-rc.1":
+  version: 3.0.0-rc.1
+  resolution: "lit-element@npm:3.0.0-rc.1"
+  dependencies:
+    "@lit/reactive-element": ^1.0.0-rc.1
+    lit-html: ^2.0.0-rc.1
+  checksum: b801b17df7c164d67ff0fef518944b4702f3b64bc25b5e39b5b91d5ca350ff03b78720896673f01b955458595295c855f022f9508c03892440b1697c8238288d
+  languageName: node
+  linkType: hard
+
 "lit-html@npm:^1.1.1, lit-html@npm:^1.3.0":
   version: 1.3.0
   resolution: "lit-html@npm:1.3.0"
   checksum: 2b9fe3140d8f48a013f2b1a6e8cb2504b56bbad1b849bc61687b47c6dc158e69381e9f289030a9712f33b8c8ed49b0126a8cc801087c61464e132cce4b0e7fa4
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^2.0.0-rc.1":
+  version: 2.0.0-rc.2
+  resolution: "lit-html@npm:2.0.0-rc.2"
+  dependencies:
+    "@types/trusted-types": ^1.0.1
+  checksum: 2ccf663cd7c6557db86d840f3b80c65644a935a2a857fe34714eb201989ce8eccd45f936e5596fa810bafc5bf5851973e2e296b8cfb691cdea23108d15e40c87
+  languageName: node
+  linkType: hard
+
+"lit@npm:^2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "lit@npm:2.0.0-rc.1"
+  dependencies:
+    "@lit/reactive-element": ^1.0.0-rc.1
+    lit-element: ^3.0.0-rc.1
+    lit-html: ^2.0.0-rc.1
+  checksum: d13466a257650bb11d234a5c808300696c742b51cc51518ebf7f048d18f3c3140d4e5212e08cd23640f286a364135f444a441e3e94892f6a643d509f1bf146c7
   languageName: node
   linkType: hard
 
@@ -47353,7 +47397,7 @@ typescript@4.1.3:
     eventemitter3: ^4.0.7
     format-json: ^1.0.3
     global: ^4.4.0
-    lit-element: ^2.4.0
+    lit: ^2.0.0-rc.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Issue: `@storybook/web-components` is incompatible with the latest RC of `lit`, formerly known as `lit-element` and `lit-html`. Reason: The `TemplateResult` type changed and cannot be detected using the `instanceof` operator anymore.

## What I did

1. Change `lit-html` dependency for `@storybook/web-components` to `lit@2.0.0-rc.1`
2. Implemented an updated detection for the `TemplateResult` type in `app/web-components/src/client/preview/render.ts`
3. Updated the WebComponents kitchen sink accordingly

## How to test

The WebComponents kitchen sink is updated accordingly.

## Release Candidate Dependency

`lit` is currently available as release candidate only. I don't know if you want to upgrade the dependency already. If you want to wait, I will update the pull request accordingly, once lit releases officially its new major.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
