### PR TITLE
Build: Change nx cloud access token to read-only token

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -22,7 +22,7 @@
           "package",
           "prepare"
         ],
-        "accessToken": "NzM2ODA4OTYtZGYyMi00MmVlLTgxNmEtODU1NGMwNjk0M2EzfHJlYWQtd3JpdGU=",
+        "accessToken": "NGVmYTkxMmItYzY3OS00MjkxLTk1ZDktZDFmYTFmNmVlNGY4fHJlYWQ=",
         "canTrackAnalytics": false,
         "showUsageWarnings": true
       }


### PR DESCRIPTION
Issue:

## What I did

The token checked into the repo is a `read-write` token which is not a huge deal but should be a `read-only` token.

## How to test

You should still be able to get cache hits locally and CI should populate the cache.

If you pull down this branch, the following should be instant after installing dependencies:

`yarn prepare` > Core & Examples (core)

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
