### PR TITLE
Core: Fix `features`, `core`, `logLevel` in main.js config types

### DIFF
--- a/examples/official-storybook/main.ts
+++ b/examples/official-storybook/main.ts
@@ -2,7 +2,7 @@
 
 import type { StorybookConfig } from '@storybook/react/types';
 
-module.exports = {
+const config: StorybookConfig = {
   stories: [
     // FIXME: Breaks e2e tests './intro.stories.mdx',
     '../../lib/ui/src/**/*.stories.@(js|tsx|mdx)',
@@ -35,4 +35,6 @@ module.exports = {
     builder: 'webpack4',
   },
   logLevel: 'debug',
-} as StorybookConfig;
+};
+
+module.exports = config;

--- a/examples/react-ts-webpack4/main.ts
+++ b/examples/react-ts-webpack4/main.ts
@@ -1,6 +1,6 @@
 import type { StorybookConfig } from '@storybook/react/types';
 
-module.exports = {
+const config: StorybookConfig = {
   stories: ['./src/*.stories.*'],
   logLevel: 'debug',
   addons: [
@@ -27,4 +27,6 @@ module.exports = {
       propFilter: (prop) => ['label', 'disabled'].includes(prop.name),
     },
   },
-} as StorybookConfig;
+};
+
+module.exports = config;

--- a/examples/react-ts/main.ts
+++ b/examples/react-ts/main.ts
@@ -1,6 +1,6 @@
 import type { StorybookConfig } from '@storybook/react/types';
 
-module.exports = {
+const config: StorybookConfig = {
   stories: ['./src/*.stories.*'],
   logLevel: 'debug',
   addons: [
@@ -31,4 +31,6 @@ module.exports = {
   features: {
     postcss: false,
   },
-} as StorybookConfig;
+};
+
+module.exports = config;

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -229,12 +229,14 @@ export interface StorybookConfig {
         options?: any;
       }
   >;
+  core?: CoreConfig;
+  logLevel?: string;
   /**
    * Allows to disable deprecated implicit PostCSS loader.
    */
   features?: {
-    postcss?: boolean
-  }
+    postcss?: boolean;
+  };
   /**
    * Tells Storybook where to find stories.
    *

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -230,6 +230,12 @@ export interface StorybookConfig {
       }
   >;
   /**
+   * Allows to disable deprecated implicit PostCSS loader.
+   */
+  features?: {
+    postcss?: boolean
+  }
+  /**
    * Tells Storybook where to find stories.
    *
    * @example `['./src/*.stories.@(j|t)sx?']`


### PR DESCRIPTION
Issue: `features` setting [was added recently](https://github.com/storybookjs/storybook/pull/14478) to the `main.js` config. It's not reflected in the `StorybookConfig` type.

## What I did

Added `features`, `core` and `loglevel` to the `StorybookConfig` type.

## How to test

Updated usage of `StorybookConfig` in examples should throw an error if the config type doesn't have some field.