### PR TITLE
Migrate lit related web components (lit-element, lit-html) codebase to Lit 2

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -120,8 +120,7 @@
     "fs-extra": "^9.0.1",
     "jest": "^26.6.3",
     "jest-specific-snapshot": "^4.0.0",
-    "lit-element": "^2.4.0",
-    "lit-html": "^1.3.0",
+    "lit": "^2.0.0-rc.1",
     "require-from-string": "^2.0.2",
     "rxjs": "^6.6.3",
     "styled-components": "^5.2.1",
@@ -138,7 +137,7 @@
     "@storybook/vue": "6.3.0-alpha.16",
     "@storybook/vue3": "6.3.0-alpha.16",
     "@storybook/web-components": "6.3.0-alpha.16",
-    "lit-html": "^1.0.0",
+    "lit": "^2.0.0-rc.1",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
     "svelte": "^3.31.2",
@@ -159,7 +158,7 @@
     "@storybook/web-components": {
       "optional": true
     },
-    "lit-html": {
+    "lit": {
       "optional": true
     },
     "react": {

--- a/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/input.js
+++ b/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/input.js
@@ -1,5 +1,5 @@
 import { CustomEvent } from 'global';
-import { LitElement, html, css } from 'lit-element';
+import { LitElement, html, css } from 'lit';
 
 const demoWcCardStyle = css`
   :host {

--- a/addons/docs/src/frameworks/web-components/__testfixtures__/lit-html-welcome/input.js
+++ b/addons/docs/src/frameworks/web-components/__testfixtures__/lit-html-welcome/input.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 export const Welcome = () => html`
   <div class="main">

--- a/addons/docs/src/frameworks/web-components/config.js
+++ b/addons/docs/src/frameworks/web-components/config.js
@@ -1,6 +1,6 @@
 /* global window */
 import React from 'react';
-import { render } from 'lit-html';
+import { render } from 'lit';
 import { extractArgTypes, extractComponentDescription } from './custom-elements';
 
 export const parameters = {

--- a/addons/docs/src/frameworks/web-components/web-components-properties.test.ts
+++ b/addons/docs/src/frameworks/web-components/web-components-properties.test.ts
@@ -24,10 +24,6 @@ const runWebComponentsAnalyzer = (inputPath: string) => {
 };
 
 describe('web-components component properties', () => {
-  // we need to mock lit-html and dynamically require custom-elements
-  // because lit-html is distributed as ESM not CJS
-  // https://github.com/Polymer/lit-html/issues/516
-  jest.mock('lit-html', () => {});
   // eslint-disable-next-line global-require
   const { extractArgTypesFromElements } = require('./custom-elements');
 

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -63,7 +63,7 @@
     "@storybook/vue": "6.3.0-alpha.16",
     "@storybook/web-components": "6.3.0-alpha.16",
     "babel-loader": "^8.0.0",
-    "lit-html": "^1.0.0",
+    "lit": "^2.0.0-rc.1",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
     "webpack": "*"
@@ -75,7 +75,7 @@
     "@storybook/web-components": {
       "optional": true
     },
-    "lit-html": {
+    "lit": {
       "optional": true
     },
     "react": {

--- a/app/web-components/README.md
+++ b/app/web-components/README.md
@@ -55,8 +55,11 @@ By default the following folders are included
 
 - `src/*.js`
 - `packages/*/src/*.js`
+- `node_modules/lit/*.js`
 - `node_modules/lit-html/*.js`
 - `node_modules/lit-element/*.js`
+- `node_modules/@lit/*.js`
+- `node_modules/@lit-labs/*.js`
 - `node_modules/@open-wc/*.js`
 - `node_modules/@polymer/*.js`
 - `node_modules/@vaadin/*.js`

--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -3,7 +3,7 @@
   "version": "6.3.0-alpha.16",
   "description": "Storybook for web-components: View web components snippets in isolation with Hot Reloading.",
   "keywords": [
-    "lit-html",
+    "lit",
     "storybook",
     "web-components"
   ],
@@ -65,12 +65,12 @@
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
-    "lit-html": "^1.3.0"
+    "lit": "^2.0.0-rc.1"
   },
   "peerDependencies": {
     "@babel/core": "*",
     "babel-loader": "^7.0.0 || ^8.0.0",
-    "lit-html": "^1.0.0"
+    "lit": "^2.0.0-rc.1"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/app/web-components/src/client/preview/render.ts
+++ b/app/web-components/src/client/preview/render.ts
@@ -1,6 +1,8 @@
 import { document, Node } from 'global';
 import dedent from 'ts-dedent';
-import { render, TemplateResult } from 'lit-html';
+import { render } from 'lit';
+// eslint-disable-next-line import/extensions
+import { isTemplateResult } from 'lit/directive-helpers.js';
 import { simulatePageLoad, simulateDOMContentLoaded } from '@storybook/client-api';
 import { RenderContext } from './types';
 
@@ -17,7 +19,7 @@ export default function renderMain({
   const element = storyFn();
 
   showMain();
-  if (element instanceof TemplateResult) {
+  if (isTemplateResult(element)) {
     // `render` stores the TemplateInstance in the Node and tries to update based on that.
     // Since we reuse `rootElement` for all stories, remove the stored instance first.
     // But forceRender means that it's the same story, so we want too keep the state in that case.

--- a/app/web-components/src/client/preview/types.ts
+++ b/app/web-components/src/client/preview/types.ts
@@ -1,9 +1,9 @@
-import { TemplateResult, SVGTemplateResult } from 'lit-html';
+import { TemplateResult } from 'lit';
 
 export type { RenderContext } from '@storybook/core';
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/addons';
 
-export type StoryFnHtmlReturnType = string | Node | TemplateResult | SVGTemplateResult;
+export type StoryFnHtmlReturnType = string | Node | TemplateResult;
 
 export interface IStorybookStory {
   name: string;

--- a/app/web-components/src/server/framework-preset-web-components.ts
+++ b/app/web-components/src/server/framework-preset-web-components.ts
@@ -6,8 +6,11 @@ export function webpack(config: Configuration) {
     test: [
       new RegExp(`src(.*)\\.js$`),
       new RegExp(`packages(\\/|\\\\)*(\\/|\\\\)src(\\/|\\\\)(.*)\\.js$`),
+      new RegExp(`node_modules(\\/|\\\\)lit(.*)\\.js$`),
       new RegExp(`node_modules(\\/|\\\\)lit-html(.*)\\.js$`),
       new RegExp(`node_modules(\\/|\\\\)lit-element(.*)\\.js$`),
+      new RegExp(`node_modules(\\/|\\\\)@lit(.*)\\.js$`),
+      new RegExp(`node_modules(\\/|\\\\)@lit-labs(.*)\\.js$`),
       new RegExp(`node_modules(\\/|\\\\)@open-wc(.*)\\.js$`),
       new RegExp(`node_modules(\\/|\\\\)@polymer(.*)\\.js$`),
       new RegExp(`node_modules(\\/|\\\\)@vaadin(.*)\\.js$`),

--- a/docs/snippets/web-components/button-group-story.js.mdx
+++ b/docs/snippets/web-components/button-group-story.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-button-group.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button-group';
 

--- a/docs/snippets/web-components/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/web-components/button-story-component-args-primary.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-button.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button';
 

--- a/docs/snippets/web-components/button-story-component-decorator.js.mdx
+++ b/docs/snippets/web-components/button-story-component-decorator.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-button.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button';
 

--- a/docs/snippets/web-components/button-story-rename-story.js.mdx
+++ b/docs/snippets/web-components/button-story-rename-story.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-button.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button';
 

--- a/docs/snippets/web-components/button-story-using-args.js.mdx
+++ b/docs/snippets/web-components/button-story-using-args.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-button.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button';
 

--- a/docs/snippets/web-components/button-story-with-args.js.mdx
+++ b/docs/snippets/web-components/button-story-with-args.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-button.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button';
 

--- a/docs/snippets/web-components/button-story-with-blue-args.js.mdx
+++ b/docs/snippets/web-components/button-story-with-blue-args.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-button.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button';
 

--- a/docs/snippets/web-components/button-story-with-emojis.js.mdx
+++ b/docs/snippets/web-components/button-story-with-emojis.js.mdx
@@ -1,7 +1,7 @@
 ```ts
 // demo-button.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button';
 

--- a/docs/snippets/web-components/button-story.js.mdx
+++ b/docs/snippets/web-components/button-story.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-button.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-button';
 

--- a/docs/snippets/web-components/list-story-expanded.js.mdx
+++ b/docs/snippets/web-components/list-story-expanded.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-list.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-list';
 import './demo-list-item';

--- a/docs/snippets/web-components/list-story-reuse-data.js.mdx
+++ b/docs/snippets/web-components/list-story-reuse-data.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-list.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-list';
 import './demo-list-item';

--- a/docs/snippets/web-components/list-story-starter.js.mdx
+++ b/docs/snippets/web-components/list-story-starter.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // demo-list.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './demo-list';
 

--- a/docs/snippets/web-components/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/web-components/my-component-story-configure-viewports.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // my-component.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './my-component';
 

--- a/docs/snippets/web-components/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/web-components/my-component-with-env-variables.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // my-component.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './my-component';
 

--- a/docs/snippets/web-components/your-component-with-decorator.js.mdx
+++ b/docs/snippets/web-components/your-component-with-decorator.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // your-component.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './your-component';
 

--- a/docs/snippets/web-components/your-component.js.mdx
+++ b/docs/snippets/web-components/your-component.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // your-component.stories.js
 
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import './your-component';
 

--- a/examples/web-components-kitchen-sink/package.json
+++ b/examples/web-components-kitchen-sink/package.json
@@ -34,7 +34,7 @@
     "eventemitter3": "^4.0.7",
     "format-json": "^1.0.3",
     "global": "^4.4.0",
-    "lit-element": "^2.4.0"
+    "lit": "^2.0.0-rc.1"
   },
   "storybook": {
     "chromatic": {

--- a/examples/web-components-kitchen-sink/src/DemoWcCard.js
+++ b/examples/web-components-kitchen-sink/src/DemoWcCard.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/extensions */
 import { CustomEvent } from 'global';
-import { LitElement, html } from 'lit-element';
+import { LitElement, html } from 'lit';
 import { demoWcCardStyle } from './demoWcCardStyle.css.js';
 
 /**

--- a/examples/web-components-kitchen-sink/src/demoWcCardStyle.css.js
+++ b/examples/web-components-kitchen-sink/src/demoWcCardStyle.css.js
@@ -1,4 +1,4 @@
-import { css } from 'lit-element';
+import { css } from 'lit';
 
 export const demoWcCardStyle = css`
   :host {

--- a/examples/web-components-kitchen-sink/stories/addon-a11y.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-a11y.stories.js
@@ -1,5 +1,5 @@
 import { document, setTimeout } from 'global';
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 const text = 'Testing the a11y addon';
 

--- a/examples/web-components-kitchen-sink/stories/addon-actions.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-actions.stories.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 const buttonStory = () => () => html` <button type="button">Hello World</button> `;
 

--- a/examples/web-components-kitchen-sink/stories/addon-backgrounds.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-backgrounds.stories.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/extensions */
-import { html } from 'lit-html';
+import { html } from 'lit';
 import '../demo-wc-card.js';
 
 export default {

--- a/examples/web-components-kitchen-sink/stories/addon-controls.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-controls.stories.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/extensions */
-import { html } from 'lit-html';
+import { html } from 'lit';
 import '../demo-wc-card.js';
 
 export default {

--- a/examples/web-components-kitchen-sink/stories/addon-docs.stories.mdx
+++ b/examples/web-components-kitchen-sink/stories/addon-docs.stories.mdx
@@ -1,6 +1,6 @@
 import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import '../demo-wc-card.js';
 
 # Storybook Docs for Web Components

--- a/examples/web-components-kitchen-sink/stories/addon-knobs.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-knobs.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/extensions */
 import { action } from '@storybook/addon-actions';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import '../demo-wc-card.js';
 
 import {

--- a/examples/web-components-kitchen-sink/stories/card.stories.js
+++ b/examples/web-components-kitchen-sink/stories/card.stories.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/extensions */
-import { html } from 'lit-html';
+import { html } from 'lit';
 import '../demo-wc-card.js';
 
 export default {

--- a/examples/web-components-kitchen-sink/stories/issues/11831-unknown-component.stories.js
+++ b/examples/web-components-kitchen-sink/stories/issues/11831-unknown-component.stories.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/extensions */
-import { html } from 'lit-html';
+import { html } from 'lit';
 import '../../demo-wc-card.js';
 
 export default {

--- a/examples/web-components-kitchen-sink/stories/script.stories.js
+++ b/examples/web-components-kitchen-sink/stories/script.stories.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 export default {
   title: 'Script Tag',

--- a/examples/web-components-kitchen-sink/stories/welcome.stories.js
+++ b/examples/web-components-kitchen-sink/stories/welcome.stories.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { withLinks } from '@storybook/addon-links';
 
 export default {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+const esModules = ['lit', 'lit-element', 'lit-html', '@lit'].join('|');
+
 module.exports = {
   cacheDirectory: '.cache/jest',
   clearMocks: true,
@@ -49,6 +51,7 @@ module.exports = {
     '^.+\\.[jt]sx?$': '<rootDir>/scripts/utils/jest-transform-js.js',
     '^.+\\.mdx$': '@storybook/addon-docs/jest-transform-mdx',
   },
+  transformIgnorePatterns: [`<rootDir>/node_modules/(?!${esModules})`],
   testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
   testPathIgnorePatterns: [
     '/node_modules/',

--- a/lib/cli/src/detect.test.ts
+++ b/lib/cli/src/detect.test.ts
@@ -170,6 +170,16 @@ const MOCK_FRAMEWORK_FILES = [
     },
   },
   {
+    name: ProjectType.WEB_COMPONENTS,
+    files: {
+      'package.json': {
+        dependencies: {
+          lit: '2.0.0',
+        },
+      },
+    },
+  },
+  {
     name: ProjectType.MITHRIL,
     files: {
       'package.json': {

--- a/lib/cli/src/frameworks/web-components/js/Button.js
+++ b/lib/cli/src/frameworks/web-components/js/Button.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './button.css';
 
 /**

--- a/lib/cli/src/frameworks/web-components/js/Header.js
+++ b/lib/cli/src/frameworks/web-components/js/Header.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import { Button } from './Button';
 import './header.css';

--- a/lib/cli/src/frameworks/web-components/js/Page.js
+++ b/lib/cli/src/frameworks/web-components/js/Page.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { Header } from './Header';
 import './page.css';
 

--- a/lib/cli/src/frameworks/web-components/ts/Button.ts
+++ b/lib/cli/src/frameworks/web-components/ts/Button.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import './button.css';
 
 export interface ButtonProps {

--- a/lib/cli/src/frameworks/web-components/ts/Header.ts
+++ b/lib/cli/src/frameworks/web-components/ts/Header.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 
 import { Button } from './Button';
 import './header.css';

--- a/lib/cli/src/frameworks/web-components/ts/Page.ts
+++ b/lib/cli/src/frameworks/web-components/ts/Page.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { Header } from './Header';
 import './page.css';
 

--- a/lib/cli/src/generators/WEB-COMPONENTS/index.ts
+++ b/lib/cli/src/generators/WEB-COMPONENTS/index.ts
@@ -3,7 +3,7 @@ import { copyTemplate } from '../../helpers';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
   baseGenerator(packageManager, npmOptions, options, 'web-components', {
-    extraPackages: ['lit-html'],
+    extraPackages: ['lit'],
   });
   copyTemplate(__dirname, options.storyFormat);
 };

--- a/lib/cli/src/project_types.ts
+++ b/lib/cli/src/project_types.ts
@@ -211,7 +211,7 @@ export const supportedTemplates: TemplateConfiguration[] = [
   },
   {
     preset: ProjectType.WEB_COMPONENTS,
-    dependencies: ['lit-element', 'lit-html'],
+    dependencies: ['lit-element', 'lit-html', 'lit'],
     matcherFunction: ({ dependencies }) => {
       return dependencies.some(Boolean);
     },

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
@@ -193,8 +193,11 @@ Object {
         "test": Array [
           "/src(.*)\\\\.js$/",
           "/packages(\\\\/|\\\\\\\\)*(\\\\/|\\\\\\\\)src(\\\\/|\\\\\\\\)(.*)\\\\.js$/",
+          "NODE_MODULES(\\\\/|\\\\\\\\)lit(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)lit-html(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)lit-element(.*)\\\\.js$/",
+          "NODE_MODULES(\\\\/|\\\\\\\\)@lit(.*)\\\\.js$/",
+          "NODE_MODULES(\\\\/|\\\\\\\\)@lit-labs(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)@open-wc(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)@polymer(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)@vaadin(.*)\\\\.js$/",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
@@ -192,8 +192,11 @@ Object {
         "test": Array [
           "/src(.*)\\\\.js$/",
           "/packages(\\\\/|\\\\\\\\)*(\\\\/|\\\\\\\\)src(\\\\/|\\\\\\\\)(.*)\\\\.js$/",
+          "NODE_MODULES(\\\\/|\\\\\\\\)lit(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)lit-html(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)lit-element(.*)\\\\.js$/",
+          "NODE_MODULES(\\\\/|\\\\\\\\)@lit(.*)\\\\.js$/",
+          "NODE_MODULES(\\\\/|\\\\\\\\)@lit-labs(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)@open-wc(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)@polymer(.*)\\\\.js$/",
           "NODE_MODULES(\\\\/|\\\\\\\\)@vaadin(.*)\\\\.js$/",

--- a/scripts/run-e2e-config.ts
+++ b/scripts/run-e2e-config.ts
@@ -172,7 +172,7 @@ export const vue3: Parameters = {
 export const web_components: Parameters = {
   name: 'web_components',
   version: 'latest',
-  generator: fromDeps('lit-element'),
+  generator: fromDeps('lit'),
 };
 
 export const web_components_typescript: Parameters = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4859,6 +4859,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lit/reactive-element@npm:^1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@lit/reactive-element@npm:1.0.0-rc.1"
+  checksum: 14652c3c43a469f1699a9b986a5c5f3e0d5a9d67c1ce3f7dc8f1d31c9c1887df1c7f0ea9b03bfa445d1de02b7a0042585cb731e236a5988ccc3189fe2a755031
+  languageName: node
+  linkType: hard
+
 "@marko/babel-types@npm:^5.1.1":
   version: 5.1.1
   resolution: "@marko/babel-types@npm:5.1.1"
@@ -8350,7 +8357,7 @@ __metadata:
     babel-plugin-bundled-import-meta: ^0.3.1
     core-js: ^3.8.2
     global: ^4.4.0
-    lit-html: ^1.3.0
+    lit: ^2.0.0-rc.1
     react: 16.14.0
     react-dom: 16.14.0
     read-pkg-up: ^7.0.1
@@ -8359,7 +8366,7 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
     babel-loader: ^7.0.0 || ^8.0.0
-    lit-html: ^1.0.0
+    lit: ^2.0.0-rc.1
   bin:
     build-storybook: ./bin/build.js
     start-storybook: ./bin/index.js
@@ -9968,6 +9975,13 @@ __metadata:
   version: 0.2.0
   resolution: "@types/tmp@npm:0.2.0"
   checksum: e639b7ed4a219da18407f5c0ec5297e4759d8d3b5b9d54b8a54a7b948ee1477c63dccf71931b742cf5e1a4377456f44b7e8167e1551aa058dda05bc770e1602c
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:^1.0.1":
+  version: 1.0.6
+  resolution: "@types/trusted-types@npm:1.0.6"
+  checksum: 4bc61ac65b8e42d17c77a23f29cdf94e498acd2e23f4c00cf15c8281de94263ac313d46cbcd7cd1d03c066d497f9396845e3210ff0074f5f90f212cb3e8aac28
   languageName: node
   linkType: hard
 
@@ -30813,10 +30827,40 @@ fsevents@2.1.2:
   languageName: node
   linkType: hard
 
+"lit-element@npm:^3.0.0-rc.1":
+  version: 3.0.0-rc.1
+  resolution: "lit-element@npm:3.0.0-rc.1"
+  dependencies:
+    "@lit/reactive-element": ^1.0.0-rc.1
+    lit-html: ^2.0.0-rc.1
+  checksum: b801b17df7c164d67ff0fef518944b4702f3b64bc25b5e39b5b91d5ca350ff03b78720896673f01b955458595295c855f022f9508c03892440b1697c8238288d
+  languageName: node
+  linkType: hard
+
 "lit-html@npm:^1.1.1, lit-html@npm:^1.3.0":
   version: 1.3.0
   resolution: "lit-html@npm:1.3.0"
   checksum: 2b9fe3140d8f48a013f2b1a6e8cb2504b56bbad1b849bc61687b47c6dc158e69381e9f289030a9712f33b8c8ed49b0126a8cc801087c61464e132cce4b0e7fa4
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^2.0.0-rc.1":
+  version: 2.0.0-rc.2
+  resolution: "lit-html@npm:2.0.0-rc.2"
+  dependencies:
+    "@types/trusted-types": ^1.0.1
+  checksum: 2ccf663cd7c6557db86d840f3b80c65644a935a2a857fe34714eb201989ce8eccd45f936e5596fa810bafc5bf5851973e2e296b8cfb691cdea23108d15e40c87
+  languageName: node
+  linkType: hard
+
+"lit@npm:^2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "lit@npm:2.0.0-rc.1"
+  dependencies:
+    "@lit/reactive-element": ^1.0.0-rc.1
+    lit-element: ^3.0.0-rc.1
+    lit-html: ^2.0.0-rc.1
+  checksum: d13466a257650bb11d234a5c808300696c742b51cc51518ebf7f048d18f3c3140d4e5212e08cd23640f286a364135f444a441e3e94892f6a643d509f1bf146c7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6147,8 +6147,7 @@ __metadata:
     jest: ^26.6.3
     jest-specific-snapshot: ^4.0.0
     js-string-escape: ^1.0.1
-    lit-element: ^2.4.0
-    lit-html: ^1.3.0
+    lit: ^2.0.0-rc.1
     loader-utils: ^2.0.0
     lodash: ^4.17.20
     prettier: ~2.2.1
@@ -6174,7 +6173,7 @@ __metadata:
     "@storybook/vue": 6.3.0-alpha.16
     "@storybook/vue3": 6.3.0-alpha.16
     "@storybook/web-components": 6.3.0-alpha.16
-    lit-html: ^1.0.0
+    lit: ^2.0.0-rc.1
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
     svelte: ^3.31.2
@@ -6190,7 +6189,7 @@ __metadata:
       optional: true
     "@storybook/web-components":
       optional: true
-    lit-html:
+    lit:
       optional: true
     react:
       optional: true
@@ -30837,7 +30836,7 @@ fsevents@2.1.2:
   languageName: node
   linkType: hard
 
-"lit-html@npm:^1.1.1, lit-html@npm:^1.3.0":
+"lit-html@npm:^1.1.1":
   version: 1.3.0
   resolution: "lit-html@npm:1.3.0"
   checksum: 2b9fe3140d8f48a013f2b1a6e8cb2504b56bbad1b849bc61687b47c6dc158e69381e9f289030a9712f33b8c8ed49b0126a8cc801087c61464e132cce4b0e7fa4

--- a/yarn.lock
+++ b/yarn.lock
@@ -30817,15 +30817,6 @@ fsevents@2.1.2:
   languageName: node
   linkType: hard
 
-"lit-element@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "lit-element@npm:2.4.0"
-  dependencies:
-    lit-html: ^1.1.1
-  checksum: d1f9e28f7e5fc9f23c7d5973608310dfc905d52a0bed36d0dc2dbdf5d5cbee636f60fb8a280d1e92ba3c6e5a8ce2173923bfd5056fb528837e67ab7a3f485953
-  languageName: node
-  linkType: hard
-
 "lit-element@npm:^3.0.0-rc.1":
   version: 3.0.0-rc.1
   resolution: "lit-element@npm:3.0.0-rc.1"
@@ -30833,13 +30824,6 @@ fsevents@2.1.2:
     "@lit/reactive-element": ^1.0.0-rc.1
     lit-html: ^2.0.0-rc.1
   checksum: b801b17df7c164d67ff0fef518944b4702f3b64bc25b5e39b5b91d5ca350ff03b78720896673f01b955458595295c855f022f9508c03892440b1697c8238288d
-  languageName: node
-  linkType: hard
-
-"lit-html@npm:^1.1.1":
-  version: 1.3.0
-  resolution: "lit-html@npm:1.3.0"
-  checksum: 2b9fe3140d8f48a013f2b1a6e8cb2504b56bbad1b849bc61687b47c6dc158e69381e9f289030a9712f33b8c8ed49b0126a8cc801087c61464e132cce4b0e7fa4
   languageName: node
   linkType: hard
 
@@ -47398,7 +47382,7 @@ typescript@4.1.3:
     eventemitter3: ^4.0.7
     format-json: ^1.0.3
     global: ^4.4.0
-    lit-element: ^2.4.0
+    lit: ^2.0.0-rc.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6231,7 +6231,7 @@ __metadata:
     "@storybook/vue": 6.3.0-alpha.16
     "@storybook/web-components": 6.3.0-alpha.16
     babel-loader: ^8.0.0
-    lit-html: ^1.0.0
+    lit: ^2.0.0-rc.1
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
     webpack: "*"
@@ -6240,7 +6240,7 @@ __metadata:
       optional: true
     "@storybook/web-components":
       optional: true
-    lit-html:
+    lit:
       optional: true
     react:
       optional: true


### PR DESCRIPTION
Issue:

## What I did

Migrated codebase to Lit 2 (lit-element 3, lit-html 2) (RC)

As you may not be aware, but lit-element (now called lit) has had a fairly big new launch last week with Lit 2.
They have a new website [here](https://lit.dev)

Sadly this new version, in RC at the moment, isn't compatible with what we currently have in storybook so we need to tweak a few things. This is a breaking change and I am pretty sure, once this is merged, storybook will no longer support lit-element 2, or lit-html 1.

## How to test

- Is this testable with Jest or Chromatic screenshots? yes
- Does this need a new example in the kitchen sink apps? no, updated examples
- Does this need an update to the documentation? yes

Would require to update the documentation to mention it will only support Lit 2, I don't see an easy way where both version could end up being supported.

cc @justinfagnani do we have an estimated timeline on when we should expect a non RC version to drop? 
