### PR TITLE
Addon-a11y: Reorder color blindness types by most common

### DIFF
--- a/addons/a11y/src/components/VisionDeficiency.tsx
+++ b/addons/a11y/src/components/VisionDeficiency.tsx
@@ -8,14 +8,14 @@ const iframeId = 'storybook-preview-iframe';
 
 const baseList = [
   'blurred vision',
-  'protanopia',
-  'protanomaly',
-  'deuteranopia',
   'deuteranomaly',
-  'tritanopia',
+  'protanomaly',
+  'protanopia',
+  'deuteranopia',
   'tritanomaly',
-  'achromatopsia',
+  'tritanopia',
   'achromatomaly',
+  'achromatopsia',
   'mono',
 ] as const;
 

--- a/addons/a11y/src/components/VisionDeficiency.tsx
+++ b/addons/a11y/src/components/VisionDeficiency.tsx
@@ -9,9 +9,9 @@ const iframeId = 'storybook-preview-iframe';
 const baseList = [
   'blurred vision',
   'deuteranomaly',
+  'deuteranopia',
   'protanomaly',
   'protanopia',
-  'deuteranopia',
   'tritanomaly',
   'tritanopia',
   'achromatomaly',

--- a/addons/a11y/src/components/VisionDeficiency.tsx
+++ b/addons/a11y/src/components/VisionDeficiency.tsx
@@ -16,7 +16,7 @@ const baseList = [
   'tritanopia',
   'achromatomaly',
   'achromatopsia',
-  'mono',
+  'grayscale',
 ] as const;
 
 type Filter = typeof baseList[number] | null;
@@ -28,7 +28,7 @@ const getFilter = (filter: Filter) => {
   if (filter === 'blurred vision') {
     return 'blur(2px)';
   }
-  if (filter === 'mono') {
+  if (filter === 'grayscale') {
     return 'grayscale(100%)';
   }
   return `url('#${filter}')`;

--- a/addons/a11y/src/components/VisionSimulator.tsx
+++ b/addons/a11y/src/components/VisionSimulator.tsx
@@ -91,7 +91,7 @@ const getColorList = (active: Filter, set: (i: Filter) => void): Link[] => [
   })),
 ];
 
-export const VisionDeficiency: FunctionComponent = () => {
+export const VisionSimulator: FunctionComponent = () => {
   const [filter, setFilter] = useState<Filter>(null);
 
   return (
@@ -118,7 +118,7 @@ export const VisionDeficiency: FunctionComponent = () => {
         closeOnClick
         onDoubleClick={() => setFilter(null)}
       >
-        <IconButton key="filter" active={!!filter} title="Vision Deficiency Emulation">
+        <IconButton key="filter" active={!!filter} title="Vision simulator">
           <Icons icon="accessibility" />
         </IconButton>
       </WithTooltip>

--- a/addons/a11y/src/register.tsx
+++ b/addons/a11y/src/register.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addons, types } from '@storybook/addons';
 import { ADDON_ID, PANEL_ID, PARAM_KEY } from './constants';
-import { VisionDeficiency } from './components/VisionDeficiency';
+import { VisionSimulator } from './components/VisionSimulator';
 import { A11YPanel } from './components/A11YPanel';
 import { A11yContextProvider } from './components/A11yContext';
 
@@ -10,7 +10,7 @@ addons.register(ADDON_ID, () => {
     title: '',
     type: types.TOOL,
     match: ({ viewMode }) => viewMode === 'story',
-    render: () => <VisionDeficiency />,
+    render: () => <VisionSimulator />,
   });
 
   addons.add(PANEL_ID, {


### PR DESCRIPTION
Issue: #14767 

## What I did

- Reordered the list of color blindness types from most common to least common and grouped by type. [See some statistics here](https://www.color-blindness.com/types-of-color-blindness/).
- Changed label of mono to grayscale to more accurately reflect the filter and reduce the ambiguity that the current label suggests
- Change the name of the component and language to be more inclusive

See further discussion in the [web a11y Slack](https://web-a11y.slack.com/archives/C042TSFGN/p1619749258466500?thread_ts=1619746108.462600&cid=C042TSFGN)


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
