### PR TITLE
Addon-docs: Allow doc blocks to CJS imported

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -24,9 +24,9 @@
     "url": "https://opencollective.com/storybook"
   },
   "license": "MIT",
-  "main": "dist/cjs/public_api.js",
-  "module": "dist/esm/public_api.js",
-  "types": "dist/ts3.9/public_api.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/ts3.9/index.d.ts",
   "typesVersions": {
     "<3.8": {
       "*": [

--- a/addons/docs/src/index.ts
+++ b/addons/docs/src/index.ts
@@ -1,0 +1,1 @@
+export * from './blocks';

--- a/addons/docs/src/mdx/__testfixtures__/component-args.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/component-args.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin component-args.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/component-id.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/component-id.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin component-id.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/csf-imports.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/csf-imports.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin csf-imports.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Story, Meta, Canvas } from '@storybook/addon-docs/blocks';
 import { Welcome, Button } from '@storybook/angular/demo';

--- a/addons/docs/src/mdx/__testfixtures__/decorators.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/decorators.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin decorators.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/docs-only.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/docs-only.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin docs-only.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Meta } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/loaders.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/loaders.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin loaders.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/meta-quotes-in-title.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/meta-quotes-in-title.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin meta-quotes-in-title.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Meta } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/non-story-exports.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/non-story-exports.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin non-story-exports.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/parameters.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/parameters.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin parameters.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/previews.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/previews.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin previews.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Canvas, Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/story-args.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-args.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-args.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/story-current.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-current.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-current.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Story } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/story-def-text-only.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-def-text-only.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-def-text-only.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Story, Meta } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/story-definitions.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-definitions.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-definitions.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 import { Story, Meta } from '@storybook/addon-docs/blocks';

--- a/addons/docs/src/mdx/__testfixtures__/story-function-var.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-function-var.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-function-var.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 export const basicFn = () => <Button mdxType=\\"Button\\" />;

--- a/addons/docs/src/mdx/__testfixtures__/story-function.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-function.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-function.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 const makeShortcode = (name) =>
   function MDXDefaultShortcode(props) {

--- a/addons/docs/src/mdx/__testfixtures__/story-multiple-children.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-multiple-children.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-multiple-children.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Story, Meta } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/story-object.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-object.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-object.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Story, Meta } from '@storybook/addon-docs/blocks';
 import { Welcome, Button } from '@storybook/angular/demo';

--- a/addons/docs/src/mdx/__testfixtures__/story-references.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/story-references.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin story-references.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Story } from '@storybook/addon-docs/blocks';
 

--- a/addons/docs/src/mdx/__testfixtures__/title-template-string.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/title-template-string.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin title-template-string.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 import { titleFunction } from '../title-generators';

--- a/addons/docs/src/mdx/__testfixtures__/vanilla.output.snapshot
+++ b/addons/docs/src/mdx/__testfixtures__/vanilla.output.snapshot
@@ -3,7 +3,7 @@
 exports[`docs-mdx-compiler-plugin vanilla.mdx 1`] = `
 "/* @jsxRuntime classic */
 /* @jsx mdx */
-import { assertIsFn, AddContext } from '@storybook/addon-docs/blocks';
+import { assertIsFn, AddContext } from '@storybook/addon-docs';
 
 import { Button } from '@storybook/react/demo';
 

--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -459,7 +459,7 @@ function extractExports(root, options) {
 
   const defaultJsx = mdxToJsx.toJSX(root, {}, { ...options, skipExport: true });
   const fullJsx = [
-    'import { assertIsFn, AddContext } from "@storybook/addon-docs/blocks";',
+    'import { assertIsFn, AddContext } from "@storybook/addon-docs";',
     defaultJsx,
     ...storyExports,
     `const componentMeta = ${stringifyMeta(metaExport)};`,

--- a/addons/docs/src/public_api.ts
+++ b/addons/docs/src/public_api.ts
@@ -1,2 +1,0 @@
-// make it work with --isolatedModules
-export default {};


### PR DESCRIPTION
Issue: #14602 

## What I did

Instead of importing from `@storybook/addon-docs/blocks`, import from `@storybook/addon-docs` which exposes a CJS `main` field in `package.json`

## How to test

self-merging so @saranrapjs can test