### PR TITLE
fix: mdx compiler switch to new path

### DIFF
--- a/addons/docs/src/mdx/mdx-compiler-plugin.js
+++ b/addons/docs/src/mdx/mdx-compiler-plugin.js
@@ -459,7 +459,7 @@ function extractExports(root, options) {
 
   const defaultJsx = mdxToJsx.toJSX(root, {}, { ...options, skipExport: true });
   const fullJsx = [
-    'import { assertIsFn, AddContext } from "@storybook/addon-docs/blocks";',
+    'import { assertIsFn, AddContext } from "@storybook/addon-docs";',
     defaultJsx,
     ...storyExports,
     `const componentMeta = ${stringifyMeta(metaExport)};`,


### PR DESCRIPTION
This is a proposed patch to an existing draft branch on the main storybook repo here: https://github.com/storybookjs/storybook/pull/14769