### PR TITLE
UI: Fix tab display when there is only one tab

### DIFF
--- a/lib/ui/src/components/preview/preview.stories.tsx
+++ b/lib/ui/src/components/preview/preview.stories.tsx
@@ -39,6 +39,20 @@ export default {
 export const noTabs = () => (
   <Consumer>
     {({ api }: Combo) => {
+      return (
+        <Preview
+          {...previewProps}
+          api={{ ...api, getElements: () => ({}) }}
+          story={{ parameters: { previewTabs: { canvas: { hidden: true } } } }}
+        />
+      );
+    }}
+  </Consumer>
+);
+
+export const withCanvasTab = () => (
+  <Consumer>
+    {({ api }: Combo) => {
       return <Preview {...previewProps} api={{ ...api, getElements: () => ({}) }} />;
     }}
   </Consumer>

--- a/lib/ui/src/components/preview/preview.tsx
+++ b/lib/ui/src/components/preview/preview.tsx
@@ -146,8 +146,7 @@ const Preview = React.memo<PreviewProps>((props) => {
   const tabs = useTabs(previewId, baseUrl, withLoader, getElements, story);
 
   const shouldScale = viewMode === 'story';
-  const isToolshown =
-    !(viewMode === 'docs' && tabs.filter((t) => !t.hidden).length < 2) && options.isToolshown;
+  const { isToolshown } = options;
 
   const initialRender = useRef(true);
   useEffect(() => {

--- a/lib/ui/src/components/preview/toolbar.tsx
+++ b/lib/ui/src/components/preview/toolbar.tsx
@@ -181,8 +181,7 @@ export function filterTools(
     path: State['path'];
   }
 ) {
-  const tabsTool = createTabsTool(tabs);
-  const toolsLeft = [tabs.filter((p) => !p.hidden).length > 1 ? tabsTool : null, ...tools];
+  const toolsLeft = [tabs.filter((p) => !p.hidden).length >= 1 && createTabsTool(tabs), ...tools];
   const toolsRight = [...toolsExtra];
 
   const filter = (item: Partial<Addon>) =>


### PR DESCRIPTION
Issue: #14598 

## What I did

* Only use option `isToolshown` to set `isToolshown` 
*  Render tabs if there only is one tab

## How to test

### Scenarios

#### Canvas disabled, docs panels enbaled
<img width="1053" alt="Screen Shot 2021-05-04 at 6 20 39 pm" src="https://user-images.githubusercontent.com/1872246/116978347-efd42980-ad06-11eb-90dd-6de834769456.png">

#### Canvas enbaled, docs panels disabled
<img width="746" alt="Screen Shot 2021-05-04 at 6 20 11 pm" src="https://user-images.githubusercontent.com/1872246/116978378-f95d9180-ad06-11eb-9125-af94d04bb7e2.png">

#### Canvas enbaled, docs panels enbaled
<img width="1287" alt="Screen Shot 2021-05-04 at 6 04 09 pm" src="https://user-images.githubusercontent.com/1872246/116978413-08444400-ad07-11eb-9bda-3bdfb55ef534.png">

#### Canvas disabled, docs panels disabled
<img width="946" alt="Screen Shot 2021-05-04 at 6 18 48 pm" src="https://user-images.githubusercontent.com/1872246/116978598-480b2b80-ad07-11eb-83fc-1c7dea816bdf.png">



