### PR TITLE
Accessibility: Adds title to close button on settings page

### DIFF
--- a/lib/ui/src/settings/index.tsx
+++ b/lib/ui/src/settings/index.tsx
@@ -82,6 +82,7 @@ const Pages: FunctionComponent<{
             e.preventDefault();
             return onClose();
           }}
+          title="Close settings page"
         >
           <Icons icon="close" />
         </IconButton>


### PR DESCRIPTION
Issue: N/A

## What I did

I've added a `title` attribute to the Close button on the Settings page.

This is needed to provide a helpful title when using a screen reader, otherwise the screen reader only sees a button element without telling the user what the button does. This also provides a helpful selector since previously there wasn't a good way to identify the generic button in something like a Cypress test.

## How to test

1. Start any Storybook app locally
2. Navigate to the `?path=/settings/about` page
3. In the top-right, hover over the X button with your mouse and verify that you see the title text "Close settings page"

## Screenshots

<img width="543" alt="Screen Shot 2021-05-04 at 3 06 48 PM" src="https://user-images.githubusercontent.com/13806458/117071448-6152ae80-acec-11eb-950f-836595765439.png">
<img width="144" alt="Screen Shot 2021-05-04 at 3 07 12 PM" src="https://user-images.githubusercontent.com/13806458/117071453-61eb4500-acec-11eb-9c1a-24eca470b8ab.png">
<img width="1260" alt="Screen Shot 2021-05-04 at 3 07 45 PM" src="https://user-images.githubusercontent.com/13806458/117071455-6283db80-acec-11eb-9d18-40795b37f146.png">


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
