### PR TITLE
Fix: only show addons in mobile menu if docsOnly is false

### DIFF
--- a/lib/ui/src/app.tsx
+++ b/lib/ui/src/app.tsx
@@ -61,7 +61,7 @@ const App = React.memo<AppProps>(
     if (!width || !height) {
       content = <div />;
     } else if (width < 600) {
-      content = <Mobile {...props} viewMode={viewMode} options={layout} />;
+      content = <Mobile {...props} viewMode={viewMode} options={layout} docsOnly={docsOnly} />;
     } else {
       content = (
         <Desktop

--- a/lib/ui/src/components/layout/mobile.stories.tsx
+++ b/lib/ui/src/components/layout/mobile.stories.tsx
@@ -35,6 +35,9 @@ export const InitialCanvas = ({ props }: { props: MobileProps }) => (
 export const InitialAddons = ({ props }: { props: MobileProps }) => (
   <Mobile {...props} options={{ ...props.options, initialActive: ActiveTabs.ADDONS }} />
 );
+
+export const docsOnly = ({ props }: { props: MobileProps }) => <Mobile {...props} docsOnly />;
+
 export const Page = ({ props }: { props: MobileProps }) => (
   <Mobile
     {...props}

--- a/lib/ui/src/components/layout/mobile.tsx
+++ b/lib/ui/src/components/layout/mobile.tsx
@@ -137,10 +137,9 @@ export interface MobileProps {
   Preview: ComponentType<any>;
   Panel: ComponentType<any>;
   Notifications: ComponentType<any>;
-
   viewMode: State['viewMode'];
-
   pages: Page[];
+  docsOnly: boolean;
 }
 
 export interface MobileState {
@@ -158,9 +157,18 @@ class Mobile extends Component<MobileProps, MobileState> {
   }
 
   render() {
-    const { Sidebar, Preview, Panel, Notifications, pages, viewMode, options } = this.props;
-    const { active } = this.state;
+    const {
+      Sidebar,
+      Preview,
+      Panel,
+      Notifications,
+      pages,
+      viewMode,
+      options,
+      docsOnly,
+    } = this.props;
 
+    const { active } = this.state;
     return (
       <Root>
         <Notifications
@@ -196,7 +204,7 @@ class Mobile extends Component<MobileProps, MobileState> {
               <Route key={key}>{key}</Route>
             ))}
           </TabButton>
-          {viewMode ? (
+          {viewMode && !docsOnly ? (
             <TabButton onClick={() => this.setState({ active: ADDONS })} active={active === ADDONS}>
               Addons
             </TabButton>


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13547

## What I did
* Added prop `docsOnly` to  `Mobile` component
* Only render menu option `Addons` if `docsOnly` is `false`


## How to test
https://user-images.githubusercontent.com/1872246/117087024-a4b32880-ad91-11eb-9d90-3f71bee18597.mp4

