### PR TITLE
refactor(core-server): rename options prop from 'staticDir' to 'staticDirs'

### DIFF
--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -124,7 +124,7 @@ export interface CLIOptions {
   ignorePreview?: boolean;
   previewUrl?: string;
   host?: string;
-  staticDir?: string[];
+  staticDirs?: string[];
   configDir?: string;
   https?: boolean;
   sslCa?: string[];

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -30,7 +30,7 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
     throw new Error("Won't remove current directory. Check your outputDir!");
   }
 
-  if (options.staticDir?.includes('/')) {
+  if (options.staticDirs?.includes('/')) {
     throw new Error("Won't copy root directory. Check your staticDirs!");
   }
 
@@ -49,7 +49,7 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
   await fs.emptyDir(options.outputDir);
 
   await cpy(defaultFavIcon, options.outputDir);
-  await copyAllStaticFiles(options.staticDir, options.outputDir);
+  await copyAllStaticFiles(options.staticDirs, options.outputDir);
 
   const previewBuilder: Builder<unknown, unknown> = await getPreviewBuilder(options.configDir);
 

--- a/lib/core-server/src/utils/server-statics.ts
+++ b/lib/core-server/src/utils/server-statics.ts
@@ -9,12 +9,12 @@ import dedent from 'ts-dedent';
 
 const defaultFavIcon = require.resolve('../public/favicon.ico');
 
-export async function useStatics(router: any, options: { staticDir?: string[] }) {
+export async function useStatics(router: any, options: { staticDirs?: string[] }) {
   let hasCustomFavicon = false;
 
-  if (options.staticDir && options.staticDir.length > 0) {
+  if (options.staticDirs && options.staticDirs.length > 0) {
     await Promise.all(
-      options.staticDir.map(async (dir) => {
+      options.staticDirs.map(async (dir) => {
         try {
           const { staticDir, staticPath, targetEndpoint } = await parseStaticDir(dir);
           logger.info(


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Rename option property `staticDir` to `staticDirs`

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The variable is `string[]` type so it has sense to be in plural.

Context: https://github.com/storybookjs/storybook/pull/14068#pullrequestreview-615204622
@shilman 