### PR TITLE
Added if on viewMode to avoid incorrect Settings Router load

### DIFF
--- a/lib/ui/src/app.tsx
+++ b/lib/ui/src/app.tsx
@@ -47,11 +47,16 @@ const App = React.memo<AppProps>(
           {
             key: 'settings',
             render: () => <SettingsPages />,
-            route: (({ children }) => (
-              <Route path="/settings" startsWith>
-                {children}
-              </Route>
-            )) as FunctionComponent,
+            route: (({ children }) => {
+              if (viewMode === 'settings') {
+                return (
+                  <Route path="/settings" startsWith>
+                    {children}
+                  </Route>
+                );
+              }
+              return null;
+            }) as FunctionComponent,
           },
         ],
       }),


### PR DESCRIPTION
Issue: #14718

## What I did

Added an if statement that checks the viewMode before loading the Settings Route. This fixes the bug mentioned in issue #14718.