### PR TITLE
Storyshots: Make `vue-jest` and `svelte` optional peer dependencies

### DIFF
--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -132,7 +132,13 @@
     "rxjs": {
       "optional": true
     },
+    "svelte": {
+      "optional": true
+    },
     "vue": {
+      "optional": true
+    },
+    "vue-jest": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6283,7 +6283,11 @@ __metadata:
       optional: true
     rxjs:
       optional: true
+    svelte:
+      optional: true
     vue:
+      optional: true
+    vue-jest:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Issue: #14758 

## What I did

Made `vue-jest` and `svelte` optional peer dependencies

## How to test

Run an install and see that there is no complaint about missing peer dependencies for a framework you're not using