### PR TITLE
Remove unused import from snippet

### DIFF
--- a/docs/snippets/common/storybook-main-using-existing-config.js.mdx
+++ b/docs/snippets/common/storybook-main-using-existing-config.js.mdx
@@ -1,8 +1,6 @@
 ```js
 // .storybook/main.js
 
-const path = require('path');
-
 // your app's webpack.config.js
 const custom = require('../webpack.config.js');
 


### PR DESCRIPTION
Issue:

## What I did

Removed unused `require('path')` from `storybook-main-using-existing-config.js.mdx`.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
