### PR TITLE
Chore: (Docs): Community frameworks location updated

### DIFF
--- a/docs/get-started/installation-problems/marko.mdx
+++ b/docs/get-started/installation-problems/marko.mdx
@@ -1,2 +1,2 @@
 - You can also setup Storybook manually through the Storybook CLI. Add the `--type marko` flag when you initialize Storybook in your project.
-- If there's an installation problem, check the [README for the Marko framework](../../app/marko/README.md).
+- If there's an installation problem, check the [README for the Marko framework](https://github.com/storybookjs/marko).

--- a/docs/get-started/installation-problems/mithril.mdx
+++ b/docs/get-started/installation-problems/mithril.mdx
@@ -1,2 +1,2 @@
 - You can also setup Storybook manually through the Storybook CLI. Add the `--type mithril` flag when you initialize Storybook in your project.
-- If there's an installation problem, check the [README for the Mithril framework](../../app/mithril/README.md).
+- If there's an installation problem, check the [README for the Mithril framework](https://github.com/storybookjs/mithril).

--- a/docs/get-started/installation-problems/rax.mdx
+++ b/docs/get-started/installation-problems/rax.mdx
@@ -1,2 +1,2 @@
 - You can also setup Storybook manually through the Storybook CLI. Add the `--type rax` flag when you initialize Storybook in your project.
-- If there's an installation problem, check the [README for the Rax framework](../../app/rax/README.md).
+- If there's an installation problem, check the [README for the Rax framework](https://github.com/storybookjs/rax).

--- a/docs/get-started/installation-problems/riot.mdx
+++ b/docs/get-started/installation-problems/riot.mdx
@@ -1,2 +1,2 @@
 - You can also setup Storybook manually through the Storybook CLI. Add the `--type riot` flag when you initialize Storybook in your project.
-- If there's an installation problem, check the [README for the Riot framework](../../app/riot/README.md).
+- If there's an installation problem, check the [README for the Riot framework](https://github.com/storybookjs/riot/).

--- a/docs/snippets/common/storybook-babel-configuration-example.ts.mdx
+++ b/docs/snippets/common/storybook-babel-configuration-example.ts.mdx
@@ -1,12 +1,14 @@
 ```ts
-// mithril/src/server/framework-preset-mithril.ts
+// app/mithril/src/server/framework-preset-mithril.ts
+
+import { TransformOptions } from '@babel/core';
 
 export function babelDefault(config: TransformOptions) {
   return {
     ...config,
     plugins: [
-      ...config.plugins, 
-      require.resolve('@babel/plugin-transform-react-jsx')
+      ...config.plugins,
+      [require.resolve('@babel/plugin-transform-react-jsx'), {}, 'preset'],
     ],
   };
 }


### PR DESCRIPTION
With this pull request, the links for the community frameworks such as Rax are updated to their new "home". 

Follows up #14796.

Feel free to provide feedback.

