### PR TITLE
Angular: Pass bootstrapOptions to angular

### DIFF
--- a/app/angular/src/client/preview/angular-beta/ElementRendererService.ts
+++ b/app/angular/src/client/preview/angular-beta/ElementRendererService.ts
@@ -38,7 +38,10 @@ export class ElementRendererService {
 
     return this.rendererService
       .newPlatformBrowserDynamic()
-      .bootstrapModule(createElementsModule(ngModule))
+      .bootstrapModule(
+        createElementsModule(ngModule),
+        parameters.bootstrapModuleOptions ?? undefined
+      )
       .then((m) => m.instance.ngEl);
   }
 }

--- a/app/angular/src/client/preview/angular-beta/RendererService.test.ts
+++ b/app/angular/src/client/preview/angular-beta/RendererService.test.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
+import { Parameters } from '../types-6-0';
 import { RendererService } from './RendererService';
 
 jest.mock('@angular/platform-browser-dynamic');
@@ -181,6 +181,35 @@ describe('RendererService', () => {
       });
 
       expect(countDestroy).toEqual(1);
+    });
+
+    describe('bootstrap module options', () => {
+      async function setupComponentWithWhitespace(bootstrapModuleOptions: unknown) {
+        await rendererService.render({
+          storyFnAngular: {
+            template: '<div>   </div>',
+            props: {},
+          },
+          forced: false,
+          parameters: {
+            bootstrapModuleOptions,
+          } as Parameters,
+        });
+      }
+
+      it('should preserve whitespaces', async () => {
+        await setupComponentWithWhitespace({ preserveWhitespaces: true });
+        expect(document.body.getElementsByTagName('storybook-wrapper')[0].innerHTML).toBe(
+          '<div>   </div>'
+        );
+      });
+
+      it('should remove whitespaces', async () => {
+        await setupComponentWithWhitespace({ preserveWhitespaces: false });
+        expect(document.body.getElementsByTagName('storybook-wrapper')[0].innerHTML).toBe(
+          '<div></div>'
+        );
+      });
     });
   });
 });

--- a/app/angular/src/client/preview/angular-beta/RendererService.ts
+++ b/app/angular/src/client/preview/angular-beta/RendererService.ts
@@ -105,7 +105,10 @@ export class RendererService {
     }
     this.storyProps$ = storyProps$;
 
-    await this.newPlatformBrowserDynamic().bootstrapModule(createStorybookModule(moduleMetadata));
+    await this.newPlatformBrowserDynamic().bootstrapModule(
+      createStorybookModule(moduleMetadata),
+      parameters.bootstrapModuleOptions ?? undefined
+    );
   }
 
   public newPlatformBrowserDynamic() {

--- a/app/angular/src/client/preview/types-6-0.ts
+++ b/app/angular/src/client/preview/types-6-0.ts
@@ -33,6 +33,7 @@ export type Parameters = DefaultParameters & {
   /** Uses legacy angular rendering engine that use dynamic component */
   angularLegacyRendering?: boolean;
   component: unknown;
+  bootstrapModuleOptions?: unknown;
 };
 
 export type StoryContext = DefaultStoryContext & { parameters: Parameters };

--- a/examples/angular-cli/src/stories/core/parameters/__snapshots__/bootstrap-options.stories.storyshot
+++ b/examples/angular-cli/src/stories/core/parameters/__snapshots__/bootstrap-options.stories.storyshot
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Core / Parameters / With Bootstrap Options With Preserve Whitespaces 1`] = `
+<storybook-wrapper>
+  <component-with-whitespace>
+    <div>
+      <p>
+        Some content
+      </p>
+    </div>
+  </component-with-whitespace>
+</storybook-wrapper>
+`;

--- a/examples/angular-cli/src/stories/core/parameters/bootstrap-options.stories.ts
+++ b/examples/angular-cli/src/stories/core/parameters/bootstrap-options.stories.ts
@@ -1,0 +1,24 @@
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'component-with-whitespace',
+  template: ` <div>
+    <p>Some content</p>
+  </div>`,
+})
+class ComponentWithWhitespace {}
+
+export default {
+  title: 'Core / Parameters / With Bootstrap Options',
+  parameters: {
+    bootstrapOptions: {
+      preserveWhitespaces: true,
+    },
+  },
+  component: ComponentWithWhitespace,
+} as Meta;
+
+export const WithPreserveWhitespaces: Story = (_args) => ({});
+
+WithPreserveWhitespaces.storyName = 'With Preserve Whitespaces';


### PR DESCRIPTION
Issue: #3193

## What I did
Pass `bootstrapOptions` from parameters to angular `bootstrapModule` call.

## How to test

- Is this testable with Jest or Chromatic screenshots?
I added new tests
- Does this need a new example in the kitchen sink apps?
I added a new example
- Does this need an update to the documentation?
I am not sure were this could be added to the documentation.
