### PR TITLE
CLI: Use arg-parser defaults

### DIFF
--- a/lib/cli/src/generate.ts
+++ b/lib/cli/src/generate.ts
@@ -102,7 +102,3 @@ program.on('command:*', ([invalidCmd]) => {
 });
 
 program.usage('<command> [options]').version(pkg.version).parse(process.argv);
-
-if (program.rawArgs.length < 3) {
-  program.help();
-}


### PR DESCRIPTION
## What I did
This PR aims at removing extraneous code.

## Motivation
From [v5.0.0](https://github.com/tj/commander.js/releases/tag/v5.0.0), `Commander.js` displays help information for missing subcommand by default.

## How to test
Invoke the `sb` binary without any arguments; help information shows up as expected.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
