### PR TITLE
Build: Remove MDX to make chromatic/IE pass in CI

### DIFF
--- a/examples/cra-ts-essentials/src/stories/Test.stories.mdx
+++ b/examples/cra-ts-essentials/src/stories/Test.stories.mdx
@@ -1,7 +1,0 @@
-import { Meta } from '@storybook/addon-docs';
-
-<Meta title="DocsOnlyMdx" parameters={{ chromatic: { disable: true } }} />
-
-# CRA TS Essentials
-
-Welcome to `cra-ts-essentials` some basic typescript stories in CRA.


### PR DESCRIPTION
Issue: N/A

## What I did

Delete docs-only MDX story which was causing IE to break in one of our Chromatic CI tests

Self-merging @ndelangen 

## How to test

- [ ] Does CI pass?