### PR TITLE
Addon-actions: Display DOM Event/CustomEvent data

### DIFF
--- a/examples/lit-kitchen-sink/yarn.lock
+++ b/examples/lit-kitchen-sink/yarn.lock
@@ -1763,14 +1763,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-a11y@portal:../../addons/a11y::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/channels": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/channels": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
+    "@storybook/theming": 6.3.0-alpha.22
     axe-core: ^4.2.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -1794,12 +1794,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-actions@portal:../../addons/actions::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
+    "@storybook/theming": 6.3.0-alpha.22
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -1826,12 +1826,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-backgrounds@portal:../../addons/backgrounds::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
+    "@storybook/theming": 6.3.0-alpha.22
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -1853,12 +1853,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-controls@portal:../../addons/controls::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/node-logger": 6.3.0-alpha.21
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/node-logger": 6.3.0-alpha.22
+    "@storybook/theming": 6.3.0-alpha.22
     core-js: ^3.8.2
     ts-dedent: ^2.0.0
   peerDependencies:
@@ -1885,19 +1885,19 @@ __metadata:
     "@mdx-js/loader": ^1.6.22
     "@mdx-js/mdx": ^1.6.22
     "@mdx-js/react": ^1.6.22
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/builder-webpack4": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/core": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/builder-webpack4": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/core": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
     "@storybook/csf": 0.0.1
-    "@storybook/node-logger": 6.3.0-alpha.21
-    "@storybook/postinstall": 6.3.0-alpha.21
-    "@storybook/source-loader": 6.3.0-alpha.21
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/node-logger": 6.3.0-alpha.22
+    "@storybook/postinstall": 6.3.0-alpha.22
+    "@storybook/source-loader": 6.3.0-alpha.22
+    "@storybook/theming": 6.3.0-alpha.22
     acorn: ^7.4.1
     acorn-jsx: ^5.3.1
     acorn-walk: ^7.2.0
@@ -1919,11 +1919,11 @@ __metadata:
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
   peerDependencies:
-    "@storybook/angular": 6.3.0-alpha.21
-    "@storybook/lit": 6.3.0-alpha.21
-    "@storybook/vue": 6.3.0-alpha.21
-    "@storybook/vue3": 6.3.0-alpha.21
-    "@storybook/web-components": 6.3.0-alpha.21
+    "@storybook/angular": 6.3.0-alpha.22
+    "@storybook/lit": 6.3.0-alpha.22
+    "@storybook/vue": 6.3.0-alpha.22
+    "@storybook/vue3": 6.3.0-alpha.22
+    "@storybook/web-components": 6.3.0-alpha.22
     lit: ^2.0.0-rc.1
     lit-html: ^1.0.0
     react: ^16.8.0 || ^17.0.0
@@ -1966,11 +1966,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-links@portal:../../addons/links::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
     "@storybook/csf": 0.0.1
-    "@storybook/router": 6.3.0-alpha.21
+    "@storybook/router": 6.3.0-alpha.22
     "@types/qs": ^6.9.5
     core-js: ^3.8.2
     global: ^4.4.0
@@ -1993,13 +1993,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-storysource@portal:../../addons/storysource::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/router": 6.3.0-alpha.21
-    "@storybook/source-loader": 6.3.0-alpha.21
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/router": 6.3.0-alpha.22
+    "@storybook/source-loader": 6.3.0-alpha.22
+    "@storybook/theming": 6.3.0-alpha.22
     core-js: ^3.8.2
     estraverse: ^5.2.0
     loader-utils: ^2.0.0
@@ -2022,10 +2022,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-toolbars@portal:../../addons/toolbars::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
     core-js: ^3.8.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -2042,12 +2042,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-viewport@portal:../../addons/viewport::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
+    "@storybook/theming": 6.3.0-alpha.22
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -2068,12 +2068,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addons@portal:../../lib/addons::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/channels": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
-    "@storybook/router": 6.3.0-alpha.21
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/channels": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
+    "@storybook/router": 6.3.0-alpha.22
+    "@storybook/theming": 6.3.0-alpha.22
     core-js: ^3.8.2
     global: ^4.4.0
     regenerator-runtime: ^0.13.7
@@ -2088,13 +2088,13 @@ __metadata:
   resolution: "@storybook/api@portal:../../lib/api::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
     "@reach/router": ^1.3.4
-    "@storybook/channels": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
+    "@storybook/channels": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
     "@storybook/csf": 0.0.1
-    "@storybook/router": 6.3.0-alpha.21
+    "@storybook/router": 6.3.0-alpha.22
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/theming": 6.3.0-alpha.22
     "@types/reach__router": ^1.3.7
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -2104,7 +2104,7 @@ __metadata:
     qs: ^6.10.0
     regenerator-runtime: ^0.13.7
     store2: ^2.12.0
-    telejson: ^5.1.0
+    telejson: ^5.2.0
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
   peerDependencies:
@@ -2138,20 +2138,20 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/channel-postmessage": 6.3.0-alpha.21
-    "@storybook/channels": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/core-common": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
-    "@storybook/node-logger": 6.3.0-alpha.21
-    "@storybook/router": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/channel-postmessage": 6.3.0-alpha.22
+    "@storybook/channels": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/core-common": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
+    "@storybook/node-logger": 6.3.0-alpha.22
+    "@storybook/router": 6.3.0-alpha.22
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.0-alpha.21
-    "@storybook/ui": 6.3.0-alpha.21
+    "@storybook/theming": 6.3.0-alpha.22
+    "@storybook/ui": 6.3.0-alpha.22
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     autoprefixer: ^9.8.6
@@ -2220,19 +2220,19 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/channel-postmessage": 6.3.0-alpha.21
-    "@storybook/channels": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/core-common": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
-    "@storybook/node-logger": 6.3.0-alpha.21
-    "@storybook/router": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/channel-postmessage": 6.3.0-alpha.22
+    "@storybook/channels": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/core-common": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
+    "@storybook/node-logger": 6.3.0-alpha.22
+    "@storybook/router": 6.3.0-alpha.22
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/theming": 6.3.0-alpha.22
     "@types/node": ^14.0.10
     babel-loader: ^8.2.2
     babel-plugin-macros: ^3.0.1
@@ -2273,13 +2273,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/channel-postmessage@portal:../../lib/channel-postmessage::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/channels": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
+    "@storybook/channels": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
-    telejson: ^5.1.0
+    telejson: ^5.2.0
   languageName: node
   linkType: soft
 
@@ -2297,11 +2297,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/client-api@portal:../../lib/client-api::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/channel-postmessage": 6.3.0-alpha.21
-    "@storybook/channels": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/channel-postmessage": 6.3.0-alpha.22
+    "@storybook/channels": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
     "@storybook/csf": 0.0.1
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
@@ -2335,9 +2335,9 @@ __metadata:
   resolution: "@storybook/components@portal:../../lib/components::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
     "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.3.0-alpha.21
+    "@storybook/client-logger": 6.3.0-alpha.22
     "@storybook/csf": 0.0.1
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/theming": 6.3.0-alpha.22
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -2368,13 +2368,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/core-client@portal:../../lib/core-client::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/channel-postmessage": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/channel-postmessage": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
     "@storybook/csf": 0.0.1
-    "@storybook/ui": 6.3.0-alpha.21
+    "@storybook/ui": 6.3.0-alpha.22
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2419,7 +2419,7 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.3.0-alpha.21
+    "@storybook/node-logger": 6.3.0-alpha.22
     "@storybook/semver": ^7.3.2
     "@types/glob-base": ^0.3.0
     "@types/micromatch": ^4.0.1
@@ -2470,14 +2470,14 @@ __metadata:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/builder-webpack4": 6.3.0-alpha.21
-    "@storybook/core-client": 6.3.0-alpha.21
-    "@storybook/core-common": 6.3.0-alpha.21
-    "@storybook/node-logger": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/builder-webpack4": 6.3.0-alpha.22
+    "@storybook/core-client": 6.3.0-alpha.22
+    "@storybook/core-common": 6.3.0-alpha.22
+    "@storybook/node-logger": 6.3.0-alpha.22
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.0-alpha.21
-    "@storybook/ui": 6.3.0-alpha.21
+    "@storybook/theming": 6.3.0-alpha.22
+    "@storybook/ui": 6.3.0-alpha.22
     "@types/node": ^14.0.10
     "@types/node-fetch": ^2.5.7
     "@types/pretty-hrtime": ^1.0.0
@@ -2513,7 +2513,7 @@ __metadata:
     resolve-from: ^5.0.0
     serve-favicon: ^2.5.0
     style-loader: ^1.3.0
-    telejson: ^5.1.0
+    telejson: ^5.2.0
     terser-webpack-plugin: ^4.2.3
     ts-dedent: ^2.0.0
     url-loader: ^4.1.1
@@ -2522,7 +2522,7 @@ __metadata:
     webpack-dev-middleware: ^3.7.3
     webpack-virtual-modules: ^0.2.2
   peerDependencies:
-    "@storybook/builder-webpack5": 6.3.0-alpha.21
+    "@storybook/builder-webpack5": 6.3.0-alpha.22
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -2537,10 +2537,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/core@portal:../../lib/core::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/core-client": 6.3.0-alpha.21
-    "@storybook/core-server": 6.3.0-alpha.21
+    "@storybook/core-client": 6.3.0-alpha.22
+    "@storybook/core-server": 6.3.0-alpha.22
   peerDependencies:
-    "@storybook/builder-webpack5": 6.3.0-alpha.21
+    "@storybook/builder-webpack5": 6.3.0-alpha.22
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -2564,10 +2564,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/lit@portal:../../app/lit::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/client-api": 6.3.0-alpha.21
-    "@storybook/core": 6.3.0-alpha.21
-    "@storybook/core-common": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/client-api": 6.3.0-alpha.22
+    "@storybook/core": 6.3.0-alpha.22
+    "@storybook/core-common": 6.3.0-alpha.22
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2609,7 +2609,7 @@ __metadata:
   resolution: "@storybook/router@portal:../../lib/router::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
     "@reach/router": ^1.3.4
-    "@storybook/client-logger": 6.3.0-alpha.21
+    "@storybook/client-logger": 6.3.0-alpha.22
     "@types/reach__router": ^1.3.7
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -2640,8 +2640,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@portal:../../lib/source-loader::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
     "@storybook/csf": 0.0.1
     core-js: ^3.8.2
     estraverse: ^5.2.0
@@ -2663,7 +2663,7 @@ __metadata:
     "@emotion/core": ^10.1.1
     "@emotion/is-prop-valid": ^0.8.6
     "@emotion/styled": ^10.0.27
-    "@storybook/client-logger": 6.3.0-alpha.21
+    "@storybook/client-logger": 6.3.0-alpha.22
     core-js: ^3.8.2
     deep-object-diff: ^1.1.0
     emotion-theming: ^10.0.27
@@ -2683,15 +2683,15 @@ __metadata:
   resolution: "@storybook/ui@portal:../../lib/ui::locator=lit-kitchen-sink%40workspace%3A."
   dependencies:
     "@emotion/core": ^10.1.1
-    "@storybook/addons": 6.3.0-alpha.21
-    "@storybook/api": 6.3.0-alpha.21
-    "@storybook/channels": 6.3.0-alpha.21
-    "@storybook/client-logger": 6.3.0-alpha.21
-    "@storybook/components": 6.3.0-alpha.21
-    "@storybook/core-events": 6.3.0-alpha.21
-    "@storybook/router": 6.3.0-alpha.21
+    "@storybook/addons": 6.3.0-alpha.22
+    "@storybook/api": 6.3.0-alpha.22
+    "@storybook/channels": 6.3.0-alpha.22
+    "@storybook/client-logger": 6.3.0-alpha.22
+    "@storybook/components": 6.3.0-alpha.22
+    "@storybook/core-events": 6.3.0-alpha.22
+    "@storybook/router": 6.3.0-alpha.22
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.3.0-alpha.21
+    "@storybook/theming": 6.3.0-alpha.22
     "@types/markdown-to-jsx": ^6.11.3
     copy-to-clipboard: ^3.3.1
     core-js: ^3.8.2
@@ -11862,9 +11862,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"telejson@npm:^5.1.0":
-  version: 5.1.1
-  resolution: "telejson@npm:5.1.1"
+"telejson@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "telejson@npm:5.2.0"
   dependencies:
     "@types/is-function": ^1.0.0
     global: ^4.4.0
@@ -11874,7 +11874,7 @@ fsevents@^1.2.7:
     isobject: ^4.0.0
     lodash: ^4.17.21
     memoizerific: ^1.11.3
-  checksum: d76ec66f8821f00bbece5ce41967328908a98a5cddd06a505da55167d05937da02a61e7ccd1fc61e2e46bda7f06037802dbe49205779b287ef81b80caab83776
+  checksum: 78f27dc71c3d787902e1f77c2023244739e622fdc03be8d9fb27f7667c8072f206532b001cc476d62291668c6e04ee08c047394284286fece6f3448b1a176240
   languageName: node
   linkType: hard
 

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -55,7 +55,7 @@
     "qs": "^6.10.0",
     "regenerator-runtime": "^0.13.7",
     "store2": "^2.12.0",
-    "telejson": "^5.1.0",
+    "telejson": "^5.2.0",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"
   },

--- a/lib/channel-postmessage/package.json
+++ b/lib/channel-postmessage/package.json
@@ -46,7 +46,7 @@
     "core-js": "^3.8.2",
     "global": "^4.4.0",
     "qs": "^6.10.0",
-    "telejson": "^5.1.0"
+    "telejson": "^5.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/channel-websocket/package.json
+++ b/lib/channel-websocket/package.json
@@ -43,7 +43,7 @@
     "@storybook/channels": "6.3.0-alpha.22",
     "core-js": "^3.8.2",
     "global": "^4.4.0",
-    "telejson": "^5.1.0"
+    "telejson": "^5.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -88,7 +88,7 @@
     "resolve-from": "^5.0.0",
     "serve-favicon": "^2.5.0",
     "style-loader": "^1.3.0",
-    "telejson": "^5.1.0",
+    "telejson": "^5.2.0",
     "terser-webpack-plugin": "^4.2.3",
     "ts-dedent": "^2.0.0",
     "url-loader": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6117,7 +6117,7 @@ __metadata:
     qs: ^6.10.0
     regenerator-runtime: ^0.13.7
     store2: ^2.12.0
-    telejson: ^5.1.0
+    telejson: ^5.2.0
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
   peerDependencies:
@@ -6306,7 +6306,7 @@ __metadata:
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
-    telejson: ^5.1.0
+    telejson: ^5.2.0
   languageName: unknown
   linkType: soft
 
@@ -6317,7 +6317,7 @@ __metadata:
     "@storybook/channels": 6.3.0-alpha.22
     core-js: ^3.8.2
     global: ^4.4.0
-    telejson: ^5.1.0
+    telejson: ^5.2.0
   languageName: unknown
   linkType: soft
 
@@ -6631,7 +6631,7 @@ __metadata:
     resolve-from: ^5.0.0
     serve-favicon: ^2.5.0
     style-loader: ^1.3.0
-    telejson: ^5.1.0
+    telejson: ^5.2.0
     terser-webpack-plugin: ^4.2.3
     ts-dedent: ^2.0.0
     url-loader: ^4.1.1
@@ -22691,6 +22691,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"has-symbols@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-symbols@npm:1.0.2"
+  checksum: bfac913244c77e6cb4e3cb6d617a70419f5fa4e1959e828a789b958933ceb997706eafb9615f27089e8fa57449094a3c81695ed3ec0c3b2fa8be8d506640b0f7
+  languageName: node
+  linkType: hard
+
 "has-unicode@npm:^2.0.0, has-unicode@npm:^2.0.1":
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
@@ -24857,6 +24864,16 @@ fsevents@^1.2.7:
     call-bind: ^1.0.2
     has-symbols: ^1.0.1
   checksum: 51bed6de11c869a507576285b20747ca9da4f4e28829b8d8d9c9f0367b5494de56e4d50278dcaf9e6a264b6ebe8c5f81e267726b3911933ddcf5c65a3ca8ca4b
+  languageName: node
+  linkType: hard
+
+"is-regex@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "is-regex@npm:1.1.3"
+  dependencies:
+    call-bind: ^1.0.2
+    has-symbols: ^1.0.2
+  checksum: 91abb3a54dfec0e12901860df4d7282da97578c85ea4c8e95674d146e7cfddc02084e5fc6eaee6142d161bf0d0fed22034e4176ef1378058e20f22271a2cb73e
   languageName: node
   linkType: hard
 
@@ -28496,7 +28513,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.x, lodash@npm:>=3.5 <5, lodash@npm:^4.0.0, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.13, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.3, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.2.1, lodash@npm:^4.5.1, lodash@npm:~4.17.10":
+"lodash@npm:4.x, lodash@npm:>=3.5 <5, lodash@npm:^4.0.0, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.13, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.3, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.2.1, lodash@npm:^4.5.1, lodash@npm:~4.17.10":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -39859,19 +39876,19 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"telejson@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "telejson@npm:5.1.0"
+"telejson@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "telejson@npm:5.2.0"
   dependencies:
     "@types/is-function": ^1.0.0
     global: ^4.4.0
     is-function: ^1.0.2
-    is-regex: ^1.1.1
+    is-regex: ^1.1.2
     is-symbol: ^1.0.3
     isobject: ^4.0.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     memoizerific: ^1.11.3
-  checksum: d1707c912a5694b95745378f9e4ed948c5a7ccc9a888542b01d585d5784e475f34be9004b68b93f1e48131389bd96acffd6a7a5b10382bc9946968ef17b5cba0
+  checksum: 78f27dc71c3d787902e1f77c2023244739e622fdc03be8d9fb27f7667c8072f206532b001cc476d62291668c6e04ee08c047394284286fece6f3448b1a176240
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #8544

## What I did

A workaround has been found in `telejson` to keep interesting data when serializing DOM Event/CustomEvent. For details, see https://github.com/storybookjs/telejson/pull/63. 

So I just bumped `telejson` everywhere in the monorepo to include the "fix".

## How to test

- Run `lit` or `web_components` kitchen sink, go to Actions stories and check that actions displayed in `Action` panel contain more than just `isTrusted` attribute.

**Before**
![image](https://user-images.githubusercontent.com/4112568/117695498-95344500-b1c0-11eb-8806-008913c9f7d9.png)

**After**
![image](https://user-images.githubusercontent.com/4112568/117695116-3373db00-b1c0-11eb-92f7-b7fe67799598.png)

