### PR TITLE
Build: Remove outdated `@types/cpy` dependency

### DIFF
--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -101,7 +101,6 @@
     "@storybook/builder-webpack5": "6.3.0-alpha.22",
     "@types/case-sensitive-paths-webpack-plugin": "^2.1.4",
     "@types/compression": "^1.7.0",
-    "@types/cpy": "^7.1.3",
     "@types/dotenv-webpack": "^3.0.0",
     "@types/ip": "^1.1.0",
     "@types/serve-favicon": "^2.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6588,7 +6588,6 @@ __metadata:
     "@storybook/ui": 6.3.0-alpha.22
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/compression": ^1.7.0
-    "@types/cpy": ^7.1.3
     "@types/dotenv-webpack": ^3.0.0
     "@types/ip": ^1.1.0
     "@types/node": ^14.0.10
@@ -8013,15 +8012,6 @@ __metadata:
   version: 2.5.4
   resolution: "@types/core-js@npm:2.5.4"
   checksum: 7203722dc0a231cfc34bfbe150cde62b5392b9d7c84bc4d48b743b71b67484280523f83cbbdb3b3d39085f13e2dcfbd2d76e6b7bad17e00943770583786995e3
-  languageName: node
-  linkType: hard
-
-"@types/cpy@npm:^7.1.3":
-  version: 7.1.3
-  resolution: "@types/cpy@npm:7.1.3"
-  dependencies:
-    cpy: "*"
-  checksum: 597e33d41d3e5fef6d234885e4f2403941d92e98b29d4a3728ba5a308f3d5cdc9cadba23cd3ede4899738872ad42d70aa1063bb74ae74eb7dd7a624a69ee8409
   languageName: node
   linkType: hard
 
@@ -15935,7 +15925,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cpy@npm:*, cpy@npm:^8.1.1":
+"cpy@npm:^8.1.1":
   version: 8.1.1
   resolution: "cpy@npm:8.1.1"
   dependencies:


### PR DESCRIPTION
## What I did

Remove outdated @types/cpy dependency

> ➤ YN0061: │ @types/cpy@npm:7.1.3 is deprecated: This is a stub types definition for cpy. cpy provides its own type definitions, so you don't need @types/cpy installed!


## How to test

- Build step in CI should be 🟢  