### PR TITLE
Addon-storyshots: Make @storybook/react dependency optional

### DIFF
--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -108,6 +108,9 @@
     "@storybook/angular": {
       "optional": true
     },
+    "@storybook/react": {
+      "optional": true
+    },
     "@storybook/vue": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5895,6 +5895,8 @@ __metadata:
       optional: true
     "@storybook/angular":
       optional: true
+    "@storybook/react":
+      optional: true
     "@storybook/vue":
       optional: true
     "@storybook/vue3":


### PR DESCRIPTION
It isn't needed if I use other framework