### PR TITLE
Addon-docs: Remove all defaultValue eval-ing

### DIFF
--- a/addons/docs/src/frameworks/react/__testfixtures__/10017-ts-union/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/10017-ts-union/argTypes.snapshot
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 10017-ts-union 1`] = `
+Object {
+  "icon": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "specify icon=\\"search\\" or icon={IconComponent}",
+    "name": "icon",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "union",
+      },
+    },
+    "type": Object {
+      "name": "union",
+      "raw": "React.ReactNode | string",
+      "required": true,
+      "value": Array [
+        Object {
+          "name": "other",
+          "raw": "React.ReactNode",
+          "value": "ReactReactNode",
+        },
+        Object {
+          "name": "string",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/10278-ts-multiple-components/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/10278-ts-multiple-components/argTypes.snapshot
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 10278-ts-multiple-components 1`] = `
+Object {
+  "aProperty": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "aProperty",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "any",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": true,
+      "value": "any",
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/8140-js-prop-types-oneof/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8140-js-prop-types-oneof/argTypes.snapshot
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 8140-js-prop-types-oneof 1`] = `
+Object {
+  "blank": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "No background or border if static alert",
+    "name": "blank",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "bool",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+  "icon": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "Allows icon override, accepts material icon name",
+    "name": "icon",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "message": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "message",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": true,
+    },
+  },
+  "mode": Object {
+    "control": Object {
+      "type": "radio",
+    },
+    "description": "",
+    "name": "mode",
+    "options": Array [
+      "static",
+      "timed",
+    ],
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'static'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "'static' | 'timed'",
+      },
+    },
+    "type": Object {
+      "name": "enum",
+      "required": false,
+      "value": Array [
+        "static",
+        "timed",
+      ],
+    },
+  },
+  "type": Object {
+    "control": Object {
+      "type": "radio",
+    },
+    "description": "",
+    "name": "type",
+    "options": Array [
+      "success",
+      "warning",
+      "error",
+      "primary",
+    ],
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'warning'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "'success' | 'warning' | 'error' | 'primary'",
+      },
+    },
+    "type": Object {
+      "name": "enum",
+      "required": false,
+      "value": Array [
+        "success",
+        "warning",
+        "error",
+        "primary",
+      ],
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/8143-ts-imported-types/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8143-ts-imported-types/argTypes.snapshot
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 8143-ts-imported-types 1`] = `
+Object {
+  "bar": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "bar",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Foo['bar']",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "raw": "Foo['bar']",
+      "required": true,
+      "value": "Foo['bar']",
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/8143-ts-react-fc-generics/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8143-ts-react-fc-generics/argTypes.snapshot
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 8143-ts-react-fc-generics 1`] = `
+Object {
+  "padding": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "padding",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'0'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/8279-js-styled-docgen/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8279-js-styled-docgen/argTypes.snapshot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 8279-js-styled-docgen 1`] = `Object {}`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/8428-js-static-prop-types/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8428-js-static-prop-types/argTypes.snapshot
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 8428-js-static-prop-types 1`] = `
+Object {
+  "test": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "Please work...",
+    "name": "test",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/8663-js-styled-components/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8663-js-styled-components/argTypes.snapshot
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 8663-js-styled-components 1`] = `
+Object {
+  "bg": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "bg",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/8740-ts-multi-props/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8740-ts-multi-props/argTypes.snapshot
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 8740-ts-multi-props 1`] = `
+Object {
+  "size": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "size",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'a'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/8894-9511-ts-forward-ref/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/8894-9511-ts-forward-ref/argTypes.snapshot
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 8894-9511-ts-forward-ref 1`] = `
+Object {
+  "disabled": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "disabled",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "variant": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "variant",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'small'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9023-js-hoc/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9023-js-hoc/argTypes.snapshot
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9023-js-hoc 1`] = `
+Object {
+  "classes": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "classes",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "object",
+      },
+    },
+    "type": Object {
+      "name": "object",
+      "required": true,
+    },
+  },
+  "dismissible": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "dismissible",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "bool",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+  "icon": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "icon",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "elementType",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "elementType",
+    },
+  },
+  "variant": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "variant",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'primary'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9399-js-proptypes-shape/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9399-js-proptypes-shape/argTypes.snapshot
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9399-js-proptypes-shape 1`] = `
+Object {
+  "areas": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "areas",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": "[object]",
+        "summary": "object[]",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "required": true,
+      "value": Object {
+        "name": "object",
+        "value": Object {
+          "names": Object {
+            "name": "array",
+            "value": Object {
+              "name": "string",
+            },
+          },
+          "position": Object {
+            "name": "string",
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9465-ts-type-props/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9465-ts-type-props/argTypes.snapshot
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9465-ts-type-props 1`] = `
+Object {
+  "disabled": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "disabled",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "boolean",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9493-ts-display-name/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9493-ts-display-name/argTypes.snapshot
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9493-ts-display-name 1`] = `
+Object {
+  "message": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "A message alerting about Empire activities.",
+    "name": "message",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": true,
+    },
+  },
+  "title": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "A title that brings attention to the alert.",
+    "name": "title",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'Code Yellow'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "union",
+      },
+    },
+    "type": Object {
+      "name": "union",
+      "raw": "'Code Red' | 'Code Yellow' | 'Code Green'",
+      "required": false,
+      "value": Array [
+        Object {
+          "name": "other",
+          "value": "literal",
+        },
+        Object {
+          "name": "other",
+          "value": "literal",
+        },
+        Object {
+          "name": "other",
+          "value": "literal",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9556-ts-react-default-exports/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9556-ts-react-default-exports/argTypes.snapshot
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9556-ts-react-default-exports 1`] = `
+Object {
+  "isDisabled": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "isDisabled",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "boolean",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9575-ts-camel-case/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9575-ts-camel-case/argTypes.snapshot
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9575-ts-camel-case 1`] = `
+Object {
+  "color": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "color",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'primary'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9586-js-react-memo/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9586-js-react-memo/argTypes.snapshot
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9586-js-react-memo 1`] = `
+Object {
+  "label": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "label",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": true,
+    },
+  },
+  "onClick": Object {
+    "description": "",
+    "name": "onClick",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "func",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "required": true,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9591-ts-import-types/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9591-ts-import-types/argTypes.snapshot
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9591-ts-import-types 1`] = `
+Object {
+  "other": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "other",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9592-ts-styled-props/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9592-ts-styled-props/argTypes.snapshot
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9592-ts-styled-props 1`] = `
+Object {
+  "title": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "title",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": true,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9626-js-default-values/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9626-js-default-values/argTypes.snapshot
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9626-js-default-values 1`] = `
+Object {
+  "title": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "title",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'Beta'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9668-js-proptypes-no-jsdoc/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9668-js-proptypes-no-jsdoc/argTypes.snapshot
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9668-js-proptypes-no-jsdoc 1`] = `
+Object {
+  "heads": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "heads",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "array",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "required": true,
+      "value": undefined,
+    },
+  },
+  "onAddClick": Object {
+    "description": "",
+    "name": "onAddClick",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "func",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9721-ts-deprecated-jsdoc/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9721-ts-deprecated-jsdoc/argTypes.snapshot
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9721-ts-deprecated-jsdoc 1`] = `
+Object {
+  "size": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "The size (replaces width)",
+    "name": "size",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "signature",
+      },
+    },
+    "type": Object {
+      "name": "object",
+      "raw": "{ width: number; height: number }",
+      "required": true,
+      "value": Object {
+        "height": Object {
+          "name": "number",
+        },
+        "width": Object {
+          "name": "number",
+        },
+      },
+    },
+  },
+  "width": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "width",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": true,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9764-ts-extend-props/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9764-ts-extend-props/argTypes.snapshot
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9764-ts-extend-props 1`] = `
+Object {
+  "checked": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "checked",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "boolean",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+  "defaultChecked": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "defaultChecked",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "boolean",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+  "value": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "The input content value",
+    "name": "value",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "union",
+      },
+    },
+    "type": Object {
+      "name": "union",
+      "raw": "string | number",
+      "required": false,
+      "value": Array [
+        Object {
+          "name": "string",
+        },
+        Object {
+          "name": "number",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9827-ts-default-values/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9827-ts-default-values/argTypes.snapshot
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9827-ts-default-values 1`] = `
+Object {
+  "bar": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "bar",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Array",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "raw": "string[]",
+      "required": false,
+      "value": Array [
+        Object {
+          "name": "string",
+        },
+      ],
+    },
+  },
+  "foo": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "foo",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "boolean",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": true,
+    },
+  },
+  "title": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "title",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'this is the default :)'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9832-ts-enum-export/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9832-ts-enum-export/argTypes.snapshot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9832-ts-enum-export 1`] = `Object {}`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/9922-ts-component-props/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/9922-ts-component-props/argTypes.snapshot
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties 9922-ts-component-props 1`] = `
+Object {
+  "spacing": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "spacing",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": true,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/js-class-component/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/js-class-component/argTypes.snapshot
@@ -1,0 +1,386 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties js-class-component 1`] = `
+Object {
+  "arrayOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "arrayOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "['array',    'optional']",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string[]",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "required": false,
+      "value": Object {
+        "name": "string",
+      },
+    },
+  },
+  "arrayRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "arrayRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string[]",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "required": true,
+      "value": Object {
+        "name": "string",
+      },
+    },
+  },
+  "booleanOptional": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "booleanOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "bool",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+  "booleanRequired": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "booleanRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "bool",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": true,
+    },
+  },
+  "dateOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "dateOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "new Date('20 Jan 1983')",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "instanceOf(Date)",
+    },
+  },
+  "dateRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "dateRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": true,
+      "value": "instanceOf(Date)",
+    },
+  },
+  "functionOptional": Object {
+    "description": "",
+    "name": "functionOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "() => 'foo'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "func",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "required": false,
+    },
+  },
+  "functionRequired": Object {
+    "description": "",
+    "name": "functionRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "func",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "required": true,
+    },
+  },
+  "globalReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "globalReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "any",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "any",
+    },
+  },
+  "importedReference": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "importedReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "imported",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "localReference": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "localReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'local-value'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "numberOptional": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "numberOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "1",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": false,
+    },
+  },
+  "numberRequired": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "numberRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": true,
+    },
+  },
+  "objectOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "objectOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "{ object: 'optional' }",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "{ }",
+      },
+    },
+    "type": Object {
+      "name": "object",
+      "required": false,
+      "value": Object {},
+    },
+  },
+  "objectRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "objectRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "{ }",
+      },
+    },
+    "type": Object {
+      "name": "object",
+      "required": true,
+      "value": Object {},
+    },
+  },
+  "stringGlobalName": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringGlobalName",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'top'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "stringOptional": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'stringOptional'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "stringRequired": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": true,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/js-function-component-inline-defaults-no-propTypes/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/js-function-component-inline-defaults-no-propTypes/argTypes.snapshot
@@ -1,0 +1,237 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties js-function-component-inline-defaults-no-propTypes 1`] = `
+Object {
+  "arrayOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "arrayOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "['array', 'optional']",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "booleanOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "booleanOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "dateOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "dateOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "new Date('20 Jan 1983')",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "functionOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "functionOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "() => 'foo'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "globalReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "globalReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "importedReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "importedReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "imported",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "localReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "localReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'local-value'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "numberOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "numberOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "1",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "objectOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "objectOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "{ object: 'optional' }",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "stringGlobalName": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "stringGlobalName",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'top'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "stringOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "stringOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'stringOptional'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/js-function-component-inline-defaults/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/js-function-component-inline-defaults/argTypes.snapshot
@@ -1,0 +1,386 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties js-function-component-inline-defaults 1`] = `
+Object {
+  "arrayOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "arrayOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "['array',    'optional']",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string[]",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "required": false,
+      "value": Object {
+        "name": "string",
+      },
+    },
+  },
+  "arrayRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "arrayRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string[]",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "required": true,
+      "value": Object {
+        "name": "string",
+      },
+    },
+  },
+  "booleanOptional": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "booleanOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "bool",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+  "booleanRequired": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "booleanRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "bool",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": true,
+    },
+  },
+  "dateOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "dateOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "new Date('20 Jan 1983')",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "instanceOf(Date)",
+    },
+  },
+  "dateRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "dateRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": true,
+      "value": "instanceOf(Date)",
+    },
+  },
+  "functionOptional": Object {
+    "description": "",
+    "name": "functionOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "() => 'foo'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "func",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "required": false,
+    },
+  },
+  "functionRequired": Object {
+    "description": "",
+    "name": "functionRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "func",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "required": true,
+    },
+  },
+  "globalReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "globalReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "any",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "any",
+    },
+  },
+  "importedReference": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "importedReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "imported",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "localReference": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "localReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'local-value'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "numberOptional": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "numberOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "1",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": false,
+    },
+  },
+  "numberRequired": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "numberRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": true,
+    },
+  },
+  "objectOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "objectOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "{ object: 'optional' }",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "{ }",
+      },
+    },
+    "type": Object {
+      "name": "object",
+      "required": false,
+      "value": Object {},
+    },
+  },
+  "objectRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "objectRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "{ }",
+      },
+    },
+    "type": Object {
+      "name": "object",
+      "required": true,
+      "value": Object {},
+    },
+  },
+  "stringGlobalName": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringGlobalName",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'top'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "stringOptional": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'stringOptional'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "stringRequired": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": true,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/js-function-component/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/js-function-component/argTypes.snapshot
@@ -1,0 +1,386 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties js-function-component 1`] = `
+Object {
+  "arrayOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "arrayOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "['array',    'optional']",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string[]",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "required": false,
+      "value": Object {
+        "name": "string",
+      },
+    },
+  },
+  "arrayRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "arrayRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string[]",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "required": true,
+      "value": Object {
+        "name": "string",
+      },
+    },
+  },
+  "booleanOptional": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "booleanOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "bool",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+  "booleanRequired": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "booleanRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "bool",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": true,
+    },
+  },
+  "dateOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "dateOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "new Date('20 Jan 1983')",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "instanceOf(Date)",
+    },
+  },
+  "dateRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "dateRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": true,
+      "value": "instanceOf(Date)",
+    },
+  },
+  "functionOptional": Object {
+    "description": "",
+    "name": "functionOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "() => 'foo'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "func",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "required": false,
+    },
+  },
+  "functionRequired": Object {
+    "description": "",
+    "name": "functionRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "func",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "required": true,
+    },
+  },
+  "globalReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "globalReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "any",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "any",
+    },
+  },
+  "importedReference": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "importedReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "imported",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "localReference": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "localReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'local-value'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "numberOptional": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "numberOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "1",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": false,
+    },
+  },
+  "numberRequired": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "numberRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": true,
+    },
+  },
+  "objectOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "objectOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "{ object: 'optional' }",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "{ }",
+      },
+    },
+    "type": Object {
+      "name": "object",
+      "required": false,
+      "value": Object {},
+    },
+  },
+  "objectRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "objectRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "{ }",
+      },
+    },
+    "type": Object {
+      "name": "object",
+      "required": true,
+      "value": Object {},
+    },
+  },
+  "stringGlobalName": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringGlobalName",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'top'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "stringOptional": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'stringOptional'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "stringRequired": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": true,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/ts-function-component-inline-defaults/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/ts-function-component-inline-defaults/argTypes.snapshot
@@ -1,0 +1,279 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties ts-function-component-inline-defaults 1`] = `
+Object {
+  "arrayOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "arrayOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "['array', 'optional']",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "booleanOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "booleanOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "dateOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "dateOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "new Date('20 Jan 1983')",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "enumGlobalName": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "enumGlobalName",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'top'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "functionOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "functionOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "() => 'foo'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "globalReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "globalReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "importedReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "importedReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "imported",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "localReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "localReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'local-value'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "numberOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "numberOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "1",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "objectOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "objectOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "{ object: 'optional' }",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "stringGlobalName": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "stringGlobalName",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'top'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "stringOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "stringOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'stringOptional'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+  "unionGlobalName": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": undefined,
+    "name": "unionGlobalName",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'top'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "unknown",
+      },
+    },
+    "type": Object {
+      "required": false,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/__testfixtures__/ts-function-component/argTypes.snapshot
+++ b/addons/docs/src/frameworks/react/__testfixtures__/ts-function-component/argTypes.snapshot
@@ -1,0 +1,396 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react component properties ts-function-component 1`] = `
+Object {
+  "arrayOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "arrayOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "['array',    'optional']",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Array",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "raw": "string[]",
+      "required": false,
+      "value": Array [
+        Object {
+          "name": "string",
+        },
+      ],
+    },
+  },
+  "arrayRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "arrayRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Array",
+      },
+    },
+    "type": Object {
+      "name": "array",
+      "raw": "string[]",
+      "required": true,
+      "value": Array [
+        Object {
+          "name": "string",
+        },
+      ],
+    },
+  },
+  "booleanOptional": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "booleanOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "false",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "boolean",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": false,
+    },
+  },
+  "booleanRequired": Object {
+    "control": Object {
+      "type": "boolean",
+    },
+    "description": "",
+    "name": "booleanRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "boolean",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+      "required": true,
+    },
+  },
+  "dateOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "dateOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "new Date('20 Jan 1983')",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "Date",
+    },
+  },
+  "dateRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "dateRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": true,
+      "value": "Date",
+    },
+  },
+  "functionOptional": Object {
+    "description": "",
+    "name": "functionOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "() => 'foo'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "signature",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "raw": "() => string",
+      "required": false,
+    },
+  },
+  "functionRequired": Object {
+    "description": "",
+    "name": "functionRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "signature",
+      },
+    },
+    "type": Object {
+      "name": "function",
+      "raw": "() => string",
+      "required": true,
+    },
+  },
+  "globalReference": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "globalReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "Date",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "any",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "required": false,
+      "value": "any",
+    },
+  },
+  "importedReference": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "importedReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "imported",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "localReference": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "localReference",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'local-value'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "numberOptional": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "",
+    "name": "numberOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "1",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": false,
+    },
+  },
+  "numberRequired": Object {
+    "control": Object {
+      "type": "number",
+    },
+    "description": "Description",
+    "name": "numberRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "number",
+      },
+    },
+    "type": Object {
+      "name": "number",
+      "required": true,
+    },
+  },
+  "objectOptional": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "objectOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "{ object: 'optional' }",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Record",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "raw": "Record<string, string>",
+      "required": false,
+      "value": "Record",
+    },
+  },
+  "objectRequired": Object {
+    "control": Object {
+      "type": "object",
+    },
+    "description": "",
+    "name": "objectRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "Record",
+      },
+    },
+    "type": Object {
+      "name": "other",
+      "raw": "Record<string, string>",
+      "required": true,
+      "value": "Record",
+    },
+  },
+  "stringGlobalName": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringGlobalName",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'top'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "stringOptional": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringOptional",
+    "table": Object {
+      "defaultValue": Object {
+        "detail": undefined,
+        "summary": "'stringOptional'",
+      },
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "stringRequired": Object {
+    "control": Object {
+      "type": "text",
+    },
+    "description": "",
+    "name": "stringRequired",
+    "table": Object {
+      "defaultValue": null,
+      "jsDocTags": undefined,
+      "type": Object {
+        "detail": undefined,
+        "summary": "string",
+      },
+    },
+    "type": Object {
+      "name": "string",
+      "required": true,
+    },
+  },
+}
+`;

--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -7,26 +7,18 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
     const { rows } = extractProps(component);
     if (rows) {
       return rows.reduce((acc: ArgTypes, row: PropDef) => {
-        const { name, type, sbType, defaultValue: defaultSummary, jsDocTags, required } = row;
+        const {
+          name,
+          type,
+          sbType,
+          defaultValue: defaultSummary,
+          jsDocTags,
+          required,
+          ...rest
+        } = row;
 
-        let defaultValue;
-        if (component.defaultProps) {
-          defaultValue = component.defaultProps[name];
-        } else {
-          const defaultValueString =
-            defaultSummary && (defaultSummary.detail || defaultSummary.summary);
-          try {
-            if (defaultValueString) {
-              // eslint-disable-next-line no-new-func
-              defaultValue = Function(`"use strict";return (${defaultValueString})`)();
-            }
-            // eslint-disable-next-line no-empty
-          } catch {}
-        }
-
-        acc[row.name] = {
-          ...row,
-          defaultValue,
+        acc[name] = {
+          ...rest,
           type: { required, ...sbType },
           table: {
             type,

--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -9,16 +9,17 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
       return rows.reduce((acc: ArgTypes, row: PropDef) => {
         const {
           name,
+          description,
           type,
           sbType,
           defaultValue: defaultSummary,
           jsDocTags,
           required,
-          ...rest
         } = row;
 
         acc[name] = {
-          ...rest,
+          name,
+          description,
           type: { required, ...sbType },
           table: {
             type,

--- a/addons/docs/src/frameworks/react/react-argtypes.stories.tsx
+++ b/addons/docs/src/frameworks/react/react-argtypes.stories.tsx
@@ -4,7 +4,6 @@ import { storiesOf, StoryContext } from '@storybook/react';
 import { ArgsTable } from '@storybook/components';
 import { Args } from '@storybook/api';
 import { inferControls } from '@storybook/client-api';
-import { useTheme, Theme } from '@storybook/theming';
 
 import { extractArgTypes } from './extractArgTypes';
 import { Component } from '../../blocks';
@@ -16,23 +15,6 @@ const argsTableProps = (component: Component) => {
   return { rows };
 };
 
-function FormatArg({ arg }) {
-  const theme = useTheme<Theme>();
-  const badgeStyle = {
-    background: theme.background.hoverable,
-    border: `1px solid ${theme.background.hoverable}`,
-    borderRadius: 2,
-  };
-  if (typeof arg !== 'undefined') {
-    try {
-      return <code>{JSON.stringify(arg, null, 2)}</code>;
-    } catch (err) {
-      return <code style={badgeStyle}>{arg.toString()}</code>;
-    }
-  }
-  return <code style={badgeStyle}>undefined</code>;
-}
-
 const ArgsStory = ({ component }: any) => {
   const { rows } = argsTableProps(component);
   const initialArgs = mapValues(rows, (argType) => argType.defaultValue) as Args;
@@ -40,11 +22,16 @@ const ArgsStory = ({ component }: any) => {
   const [args, setArgs] = useState(initialArgs);
   return (
     <>
+      <p>
+        <b>NOTE:</b> these stories are to help visualise the snapshot tests in{' '}
+        <code>./react-properties.test.js</code>.
+      </p>
+      <ArgsTable rows={rows} args={args} updateArgs={(val) => setArgs({ ...args, ...val })} />
       <table>
         <thead>
           <tr>
-            <th>key</th>
-            <th>val</th>
+            <th>arg name</th>
+            <th>argType</th>
           </tr>
         </thead>
         <tbody>
@@ -54,13 +41,12 @@ const ArgsStory = ({ component }: any) => {
                 <code>{key}</code>
               </td>
               <td>
-                <FormatArg arg={val} />
+                <pre>{JSON.stringify(rows[key])}</pre>
               </td>
             </tr>
           ))}
         </tbody>
       </table>
-      <ArgsTable rows={rows} args={args} updateArgs={(val) => setArgs({ ...args, ...val })} />
     </>
   );
 };
@@ -132,5 +118,7 @@ issuesFixtures.forEach((fixture) => {
   // eslint-disable-next-line import/no-dynamic-require, global-require
   const { component } = require(`./__testfixtures__/${fixture}/input`);
 
-  issuesStories.add(fixture, () => <ArgsStory component={component} />);
+  issuesStories.add(fixture, () => <ArgsStory component={component} />, {
+    chromatic: { disable: true },
+  });
 });

--- a/addons/docs/src/frameworks/react/react-properties.test.ts
+++ b/addons/docs/src/frameworks/react/react-properties.test.ts
@@ -3,9 +3,12 @@ import path from 'path';
 import fs from 'fs';
 
 import { transformFileSync, transformSync } from '@babel/core';
+import { inferControls } from '@storybook/client-api';
+import { StoryContext } from '@storybook/react';
 import requireFromString from 'require-from-string';
 
 import { extractProps } from './extractProps';
+import { extractArgTypes } from './extractArgTypes';
 import { normalizeNewlines } from '../../lib/utils';
 
 // jest.mock('../imported', () => () => ({ imported: 'imported-value' }), { virtual: true });
@@ -63,6 +66,11 @@ describe('react component properties', () => {
           const { component } = requireFromString(docgenModule, inputPath);
           const properties = extractProps(component);
           expect(properties).toMatchSpecificSnapshot(path.join(testDir, 'properties.snapshot'));
+
+          const argTypes = extractArgTypes(component);
+          const parameters = { __isArgsStory: true, argTypes };
+          const rows = inferControls(({ parameters } as unknown) as StoryContext);
+          expect(rows).toMatchSpecificSnapshot(path.join(testDir, 'argTypes.snapshot'));
         });
       }
     }

--- a/addons/docs/src/frameworks/react/react-properties.test.ts
+++ b/addons/docs/src/frameworks/react/react-properties.test.ts
@@ -67,6 +67,7 @@ describe('react component properties', () => {
           const properties = extractProps(component);
           expect(properties).toMatchSpecificSnapshot(path.join(testDir, 'properties.snapshot'));
 
+          // snapshot the output of `extractArgTypes`
           const argTypes = extractArgTypes(component);
           const parameters = { __isArgsStory: true, argTypes };
           const rows = inferControls(({ parameters } as unknown) as StoryContext);

--- a/addons/docs/src/frameworks/svelte/extractArgTypes.test.ts
+++ b/addons/docs/src/frameworks/svelte/extractArgTypes.test.ts
@@ -90,7 +90,6 @@ describe('Extracting Arguments', () => {
           "control": Object {
             "type": "boolean",
           },
-          "defaultValue": true,
           "description": null,
           "name": "rounded",
           "table": Object {
@@ -123,7 +122,6 @@ describe('Extracting Arguments', () => {
           "control": Object {
             "type": "text",
           },
-          "defaultValue": "",
           "description": null,
           "name": "text",
           "table": Object {

--- a/addons/docs/src/frameworks/svelte/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/svelte/extractArgTypes.ts
@@ -41,7 +41,6 @@ export const createArgTypes = (docgen: SvelteComponentDoc) => {
         required: hasKeyword('required', item.keywords),
         summary: item.type?.text,
       },
-      defaultValue: item.defaultValue,
       table: {
         type: {
           summary: item.type?.text,

--- a/addons/docs/src/frameworks/vue/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue/extractArgTypes.ts
@@ -17,18 +17,10 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
     props.forEach(({ propDef, docgenInfo, jsDocTags }) => {
       const { name, type, description, defaultValue: defaultSummary, required } = propDef;
       const sbType = section === 'props' ? convert(docgenInfo) : { name: 'void' };
-      let defaultValue = defaultSummary && (defaultSummary.detail || defaultSummary.summary);
-      try {
-        // eslint-disable-next-line no-eval
-        defaultValue = eval(defaultValue);
-        // eslint-disable-next-line no-empty
-      } catch {}
-
       results[name] = {
         name,
         description,
         type: { required, ...sbType },
-        defaultValue,
         table: {
           type,
           jsDocTags,

--- a/addons/docs/src/frameworks/vue/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue/extractArgTypes.ts
@@ -1,11 +1,8 @@
 import { ArgTypes } from '@storybook/api';
 import { ArgTypesExtractor, hasDocgen, extractComponentProps } from '../../lib/docgen';
 import { convert } from '../../lib/convert';
-import { trimQuotes } from '../../lib/convert/utils';
 
 const SECTIONS = ['props', 'events', 'slots'];
-
-const trim = (val: any) => (val && typeof val === 'string' ? trimQuotes(val) : val);
 
 export const extractArgTypes: ArgTypesExtractor = (component) => {
   if (!hasDocgen(component)) {

--- a/addons/docs/src/frameworks/vue3/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue3/extractArgTypes.ts
@@ -14,18 +14,11 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
     props.forEach(({ propDef, docgenInfo, jsDocTags }) => {
       const { name, type, description, defaultValue: defaultSummary, required } = propDef;
       const sbType = section === 'props' ? convert(docgenInfo) : { name: 'void' };
-      let defaultValue = defaultSummary && (defaultSummary.detail || defaultSummary.summary);
-      try {
-        // eslint-disable-next-line no-eval
-        defaultValue = eval(defaultValue);
-        // eslint-disable-next-line no-empty
-      } catch {}
 
       results[name] = {
         name,
         description,
         type: { required, ...sbType },
-        defaultValue,
         table: {
           type,
           jsDocTags,


### PR DESCRIPTION
Telescoping on https://github.com/storybookjs/storybook/pull/14899

Issue: #14579 

## What I did

 - Simply do not eval and set `argType.defaultValue` in any case.

## What I did *not* do

 - If `argType.defaultValue` is set, we continue to use it as the initial arg value (if the arg is otherwise unset).
    - This means we do not break backwards compatibility
    - Also it means we don't need to change the implementation of actions' argType enhancer

 - I think maybe we can clean up some test cases, @shilman we should probably walk through it together

## How to test

- Is this testable with Jest or Chromatic screenshots?

Yes, lots of stories will be affected.