### PR TITLE
["bug", "documentation"] fix bug in example storybook-preview-body-font-size.html.mdx

### DIFF
--- a/docs/snippets/common/storybook-preview-body-font-size.html.mdx
+++ b/docs/snippets/common/storybook-preview-body-font-size.html.mdx
@@ -2,7 +2,7 @@
 <!-- .storybook/preview-body.html -->
 
 <style>
-  body {
+  html {
     font-size: 15px;
   }
 </style>


### PR DESCRIPTION
Rem values are relative to the root html element, not the body. see https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#rems

Issue:

## What I did
fix css selector for correct work.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need an update to the documentation?

Yes, in current example rem will not use font-size value from body tag, but in updated example from html tag - does.
