### PR TITLE
Add documentation on usage with Vue CLI

### DIFF
--- a/docs/configure/webpack.md
+++ b/docs/configure/webpack.md
@@ -91,6 +91,8 @@ If you're using a non-standard Storybook config directory, you should put `main.
 
 If you have an existing webpack config for your project and want to reuse this app's configuration, you can import your main webpack config into Storybook's [`.storybook/main.js`](./overview.md#configure-story-rendering) and merge both:
 
+NB! If you are using Vue CLI you need to use the resolved webpack config file, which is found at `<projectRoot>/node_modules/@vue/cli-service/webpack.config.js`.
+
 The following code snippet shows how you can replace the loaders from Storybook with the ones from your app's `webpack.config.js`:
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
Ref: https://cli.vuejs.org/guide/webpack.html#inspecting-the-project-s-webpack-config

If project is generated with Vue CLI, `vue-svg-loader` will require the use of the `chainWebpack` function which means `vue.config.js` wont be a fully resolved webpack config.  In that case the resolved webpack config can be found at `https://cli.vuejs.org/guide/webpack.html#inspecting-the-project-s-webpack-config` according to the above linked documentation.

Issue:

## What I did

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
