### PR TITLE
Webpack5: Always set `resolve.fallback.crypto` to `false`

### DIFF
--- a/addons/a11y/preset.js
+++ b/addons/a11y/preset.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 function managerEntries(entry = []) {
   return [...entry, require.resolve('./dist/esm/register')];
 }
@@ -11,17 +10,4 @@ function config(entry = []) {
   ];
 }
 
-async function webpack(webpackConfig, options) {
-  const core = await options.presets.apply('core');
-  if ((core && core.builder) !== 'webpack5') {
-    return webpackConfig;
-  }
-  if (!webpackConfig.resolve.fallback) {
-    webpackConfig.resolve.fallback = {};
-  }
-  webpackConfig.resolve.fallback.crypto = false;
-
-  return webpackConfig;
-}
-
-module.exports = { managerEntries, config, webpack };
+module.exports = { managerEntries, config };

--- a/lib/builder-webpack5/src/preview/base-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/base-webpack.config.ts
@@ -76,5 +76,12 @@ export async function createDefaultWebpackConfig(
         },
       ],
     },
+    resolve: {
+      ...storybookBaseConfig.resolve,
+      fallback: {
+        ...storybookBaseConfig.resolve?.fallback,
+        crypto: false,
+      },
+    },
   };
 }


### PR DESCRIPTION
Issue: #14538

Related: #14909

## What I did

Pull the workaround from `addon-a11y` into `builder-webpack5` where it belongs

## How to test

TBD?