### PR TITLE
Build: Put E2E tests back on track

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           command: yarn wait-on http://localhost:6000
       - run:
           name: Run E2E tests
-          command: yarn test:e2e-framework --clean --skip angular --skip vue3 --skip web_components_typescript --skip cra
+          command: yarn test:e2e-framework --clean --skip angular11 --skip angular --skip vue3 --skip web_components_typescript --skip cra
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress
@@ -218,8 +218,8 @@ jobs:
           command: yarn wait-on http://localhost:6000
       - run:
           name: Run E2E tests
-          # Do not test CRA here because it's done in PnP part
-          command: yarn test:e2e-framework vue3 angular web_components_typescript
+          # Do not test CRA here because it's done in PnP part and add `angular` as soon as SB will support Angular 12
+          command: yarn test:e2e-framework vue3 angular11 web_components_typescript
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,8 +218,8 @@ jobs:
           command: yarn wait-on http://localhost:6000
       - run:
           name: Run E2E tests
-          # Do not test CRA nor Web Components here because it's done in PnP part
-          command: yarn test:e2e-framework vue3 angular
+          # Do not test CRA here because it's done in PnP part
+          command: yarn test:e2e-framework vue3 angular web_components_typescript
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress
@@ -266,7 +266,7 @@ jobs:
           command: yarn wait-on http://localhost:6000
       - run:
           name: run e2e tests
-          command: yarn test:e2e-framework --pnp sfcVue cra web_components_typescript
+          command: yarn test:e2e-framework --pnp sfcVue cra
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress

--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -103,6 +103,12 @@ export const angular10: Parameters = {
   version: 'v10-lts',
 };
 
+export const angular11: Parameters = {
+  ...baseAngular,
+  name: 'angular11',
+  version: 'v11-lts',
+};
+
 export const angular: Parameters = baseAngular;
 // #endregion
 


### PR DESCRIPTION
## What I did

 - Web components: Run `web_components_typescript` e2e test with node_modules linker instead of PnP. It looks like there is an issue with PnP, it sometimes fails to parse TypeScript stories, I didn't understand why yet 🤷🏻  
 - Angular: Add a config for Angular 11 and use it in the e2e until Angular 12 is supported.

