### PR TITLE
CLI: Fix color regex in CLI template

### DIFF
--- a/lib/cli/src/generators/configure.ts
+++ b/lib/cli/src/generators/configure.ts
@@ -49,7 +49,7 @@ export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
     matchers: {
-      color: /(background|color)$/i,
+      color: /color$/i,
       date: /Date$/,
     },
   },


### PR DESCRIPTION
Issue: #14902 

## What I did

Made the controls color matcher more conservative. The "costs" are too high when this hits a false positive.

## How to test

See repro linked in issue
