### PR TITLE
Addon-controls: Fix duplicate color swatch id's in Color control

### DIFF
--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -303,9 +303,10 @@ export const ColorControl: FC<ColorProps> = ({
             />
             {presets.length > 0 && (
               <Swatches>
-                {presets.map((preset) => (
+                {presets.map((preset, index: number) => (
                   <WithTooltip
-                    key={preset.value}
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={`${preset.value}-${index}`}
                     hasChrome={false}
                     tooltip={<Note note={preset.keyword || preset.value} />}
                   >


### PR DESCRIPTION
Issue: #14793

## What I did

* Changed key to `{preset.value}-${index}`  for looped `Swatches` to avoid duplicate keys

## How to test

### Before change

https://user-images.githubusercontent.com/1872246/118210109-4f6fc900-b4ad-11eb-854e-a8f688c64901.mp4

### After change


https://user-images.githubusercontent.com/1872246/118210289-ad041580-b4ad-11eb-8ce9-258158974aaa.mp4


