### PR TITLE
Storyshots: Make preact-render-to-string optional peer dependency

### DIFF
--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -126,6 +126,9 @@
     "preact": {
       "optional": true
     },
+    "preact-render-to-string": {
+      "optional": true
+    },
     "react": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5929,6 +5929,8 @@ __metadata:
       optional: true
     preact:
       optional: true
+    preact-render-to-string:
+      optional: true
     react:
       optional: true
     react-dom:


### PR DESCRIPTION
Issue: #14758

Continuation of #14835

## What I did

Made `preact-render-to-string` optional peer dependency

## How to test

Run an install and see that there is no complaint about missing peer dependencies for a framework you're not using