### PR TITLE
Addon-a11y: Highlight all elements correctly

### DIFF
--- a/addons/a11y/src/a11yHighlight.ts
+++ b/addons/a11y/src/a11yHighlight.ts
@@ -21,9 +21,12 @@ const highlight = (infos: HighlightInfo) => {
   const id = HIGHLIGHT_STYLE_ID;
   resetHighlight();
 
+  // Make sure there are no duplicated selectors
+  const elements = Array.from(new Set(infos.elements));
+
   const sheet = document.createElement('style');
   sheet.setAttribute('id', id);
-  sheet.innerHTML = infos.elements
+  sheet.innerHTML = elements
     .map(
       (target) =>
         `${target}{ 

--- a/addons/a11y/src/highlight.ts
+++ b/addons/a11y/src/highlight.ts
@@ -2,7 +2,6 @@ export const highlightStyle = (color: string) => `
   outline: 2px dashed ${color};
   outline-offset: 2px;
   box-shadow: 0 0 0 6px rgba(255,255,255,0.6);
-}
 `;
 
 export const highlightObject = (color: string) => ({


### PR DESCRIPTION
Issue: Couldn't find an open issue for this

## What I did

There was an extra curly bracket in the css for highlighting elements in the a11y addon, that resulted in a broken stylesheet.

Before:
![image](https://user-images.githubusercontent.com/1671563/118283724-f5ccc600-b4cf-11eb-9e2d-d85c345d80a4.png)

After:
![image](https://user-images.githubusercontent.com/1671563/118283732-f9f8e380-b4cf-11eb-827f-6cdb9edb027c.png)


## How to test

Build the addon and run any storybook, then toggle all elements to see the difference

```
yarn build addon-a11y
yarn start
```

Or check the chromatic build and test it there as well!

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
