### PR TITLE
docs: update framework support

### DIFF
--- a/docs/frameworks.js
+++ b/docs/frameworks.js
@@ -111,12 +111,12 @@ module.exports = {
         },
         {
           name: 'Dynamic source',
-          supported: ['react'],
+          supported: ['react', 'vue', 'angular', 'svelte'],
           path: 'writing-docs/doc-blocks#source',
         },
         {
           name: 'Args Table',
-          supported: ['react', 'vue', 'angular', 'html', 'ember', 'web-components'],
+          supported: ['react', 'vue', 'angular', 'html', 'ember', 'web-components', 'svelte'],
           path: 'writing-docs/doc-blocks#argstable',
         },
         {
@@ -126,7 +126,7 @@ module.exports = {
         },
         {
           name: 'Inline stories',
-          supported: ['react', 'vue', 'web-components', 'html', 'svelte'],
+          supported: ['react', 'vue', 'web-components', 'html', 'svelte', 'angular'],
           path: 'writing-docs/doc-blocks#inline-rendering',
         },
       ],


### PR DESCRIPTION
Angular and Svelte have been revamped in 6.2 and now support new features, we should update the support table in our docs.

## What I did

- Add angular to Inline rendering table
- Add svelte to args table
- Add vue, angular and svelte to dynamic source
