### PR TITLE
CLI: Keep Webpack 4 builder for Angular lower than 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,8 +218,8 @@ jobs:
           command: yarn wait-on http://localhost:6000
       - run:
           name: Run E2E tests
-          # Do not test CRA here because it's done in PnP part and add `angular` as soon as SB will support Angular 12
-          command: yarn test:e2e-framework vue3 angular11 web_components_typescript
+          # Do not test CRA here because it's done in PnP part
+          command: yarn test:e2e-framework vue3 angular angular11 web_components_typescript
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress

--- a/lib/cli/src/generators/ANGULAR/index.ts
+++ b/lib/cli/src/generators/ANGULAR/index.ts
@@ -33,7 +33,9 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
       'Could not find a default project in your Angular workspace.\nSet a defaultProject in your angular.json and re-run the installation.'
     );
   }
-  const angularVersion = semver.coerce(await packageManager.getVersion('@angular/core'))?.version;
+  const angularVersion = semver.coerce(
+    packageManager.retrievePackageJson().dependencies['@angular/core']
+  )?.version;
   const isWebpack5 = semver.gte(angularVersion, '12.0.0');
   const updatedOptions = isWebpack5 ? { ...options, builder: CoreBuilder.Webpack5 } : options;
 

--- a/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -55,6 +55,10 @@ export abstract class JsPackageManager {
     done();
   }
 
+  /**
+   * Read the `package.json` file available in the directory the command was call from
+   * If there is no `package.json` it will create one.
+   */
   public retrievePackageJson(): PackageJsonWithDepsAndDevDeps {
     let packageJson = readPackageJson();
     if (!packageJson) {
@@ -151,6 +155,15 @@ export abstract class JsPackageManager {
     return Promise.all(packageNames.map((packageName) => this.getVersion(packageName)));
   }
 
+  /**
+   * Return the latest version of the input package available on npmjs registry.
+   * If constraint are provided it return the latest version matching the constraints.
+   *
+   * For `@storybook/*` packages the latest version is retrieved from `cli/src/versions.json` file directly
+   *
+   * @param packageName The name of the package
+   * @param constraint A valid semver constraint, example: '1.x || >=2.5.0 || 5.0.0 - 7.2.3'
+   */
   public async getVersion(packageName: string, constraint?: string): Promise<string> {
     let current: string;
 


### PR DESCRIPTION
## What I did

 - I fixed the computation of Angular version used in the users' projects
 - I enabled Angular 12 e2e tests as part of our CI checks. Angular 11 is kept for now as the release is out only for a few days and SB + Angular 12 use Webpack4 builder and SB + Angular 11 is using Webpack 5 builder

## How to test

- CI should be 🟢 