### PR TITLE
Core: Remove updateGlobals warning message

### DIFF
--- a/lib/api/src/modules/globals.ts
+++ b/lib/api/src/modules/globals.ts
@@ -37,8 +37,6 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
     const currentGlobals = store.getState()?.globals;
     if (!deepEqual(globals, currentGlobals)) {
       store.setState({ globals });
-    } else {
-      logger.info('Tried to update globals but the old and new values are equal.');
     }
   };
 


### PR DESCRIPTION
## What I did

Remove the log when updating globals with same values. I thought the log would be helpful, but it just ends up adding clutter. It could happen that globals are updated based on different scenarios, like HMR etc, and a fresh installed Storybook is logging that already, so I think we should not log it.

The fact that a fresh install already logs that might tell us that there's some code running multiple times where it shouldn't, though 🤔

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
