### PR TITLE
Lit: Add typings for @storybook/lit

### DIFF
--- a/app/lit/src/client/index.ts
+++ b/app/lit/src/client/index.ts
@@ -11,7 +11,7 @@ export {
   raw,
 } from './preview';
 
-export * from './preview/types';
+export * from './preview/types-6-0';
 
 // TODO: disable HMR and do full page loads because of customElements.define
 if (module && module.hot && module.hot.decline) {

--- a/app/lit/src/client/preview/types-6-0.ts
+++ b/app/lit/src/client/preview/types-6-0.ts
@@ -1,0 +1,19 @@
+import { Args as DefaultArgs, Annotations, BaseMeta, BaseStory } from '@storybook/addons';
+import { StoryFnLitReturnType } from './types';
+
+export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/addons';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export type Meta<Args = DefaultArgs> = BaseMeta<string> & Annotations<Args, StoryFnLitReturnType>;
+
+/**
+ * Story function that represents a component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<Args = DefaultArgs> = BaseStory<Args, StoryFnLitReturnType> &
+  Annotations<Args, StoryFnLitReturnType>;

--- a/examples/lit-kitchen-sink/src/components/SbButton.stories.ts
+++ b/examples/lit-kitchen-sink/src/components/SbButton.stories.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import './SbButton';
+import { Story, Meta } from '@storybook/lit';
 
 export default {
   title: 'Examples / Button',
@@ -9,9 +9,9 @@ export default {
       handles: ['click', 'sb-button:click'],
     },
   },
-};
+} as Meta;
 
-const Template = ({ primary, backgroundColor, size, label, sbButtonClickHandler }: any) =>
+const Template: Story = ({ primary, backgroundColor, size, label, sbButtonClickHandler }) =>
   html`<sb-button
     ?primary="${primary}"
     .size="${size}"

--- a/examples/lit-kitchen-sink/src/stories/addons/actions/addon-actions.stories.ts
+++ b/examples/lit-kitchen-sink/src/stories/addons/actions/addon-actions.stories.ts
@@ -1,10 +1,11 @@
 import { html } from 'lit';
+import { Story, Meta } from '@storybook/lit';
 
 export default {
   title: 'Addons / Actions',
-};
+} as Meta;
 
-const Template = () => html`<button>Click Me!</button>`;
+const Template: Story = () => html`<button>Click Me!</button>`;
 
 export const Story1 = Template.bind({});
 Story1.storyName = 'Simple `click` handler';

--- a/examples/lit-kitchen-sink/src/stories/addons/background/addon-background.stories.ts
+++ b/examples/lit-kitchen-sink/src/stories/addons/background/addon-background.stories.ts
@@ -1,4 +1,5 @@
 import { html } from 'lit';
+import { Story, Meta } from '@storybook/lit';
 
 export default {
   title: 'Addons / Backgrounds',
@@ -11,9 +12,9 @@ export default {
       ],
     },
   },
-};
+} as Meta;
 
-const Template = () => html`<button>Click Me!</button>`;
+const Template: Story = () => html`<button>Click Me!</button>`;
 
 export const Default = Template.bind({});
 

--- a/examples/lit-kitchen-sink/src/stories/addons/controls/addon-controls.stories.ts
+++ b/examples/lit-kitchen-sink/src/stories/addons/controls/addon-controls.stories.ts
@@ -1,5 +1,7 @@
 import { html } from 'lit';
+import { Story, Meta } from '@storybook/lit';
 import '../../../components/SbButton';
+import { MetaProperty } from 'typescript';
 
 export default {
   title: 'Addons / Controls',
@@ -12,9 +14,9 @@ export default {
       },
     },
   },
-};
+} as Meta;
 
-const Template = ({ primary, backgroundColor, size, label, sbButtonClickHandler }: any) =>
+const Template: Story = ({ primary, backgroundColor, size, label, sbButtonClickHandler }) =>
   html`<sb-button
     ?primary="${primary}"
     .size="${size}"

--- a/examples/lit-kitchen-sink/src/stories/addons/controls/addon-controls.stories.ts
+++ b/examples/lit-kitchen-sink/src/stories/addons/controls/addon-controls.stories.ts
@@ -1,7 +1,6 @@
 import { html } from 'lit';
 import { Story, Meta } from '@storybook/lit';
 import '../../../components/SbButton';
-import { MetaProperty } from 'typescript';
 
 export default {
   title: 'Addons / Controls',

--- a/examples/lit-kitchen-sink/src/stories/addons/docs/addon-docs.stories.ts
+++ b/examples/lit-kitchen-sink/src/stories/addons/docs/addon-docs.stories.ts
@@ -1,30 +1,32 @@
 import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
+import { Story, Meta } from '@storybook/lit';
 import mdxNotes from './notes/notes.mdx';
 
 export default {
   title: `Addons / Docs / Stories`,
-};
+} as Meta;
 
-export const Basic = () => html`<div>Click docs tab to see basic docs</div>`;
+export const Basic: Story = () => html`<div>Click docs tab to see basic docs</div>`;
 
-export const NoDocs = () => html`<div>Click docs tab to see no docs error</div>`;
+export const NoDocs: Story = () => html`<div>Click docs tab to see no docs error</div>`;
 NoDocs.parameters = { docs: { page: null } };
 
-export const LargerThanPreview = () =>
+export const LargerThanPreview: Story = () =>
   html`<div style=${styleMap({ width: '1000px', background: 'pink' })}>HUGE</div>`;
 
-export const MdxOverride = () => html`<div>Click docs tab to see MDX-overridden docs</div>`;
+export const MdxOverride: Story = () => html`<div>Click docs tab to see MDX-overridden docs</div>`;
 MdxOverride.parameters = {
   docs: { page: mdxNotes },
 };
 
-export const InlineOverride = () => html`<div>Click docs tab to see JSX-overridden docs</div>`;
+export const InlineOverride: Story = () =>
+  html`<div>Click docs tab to see JSX-overridden docs</div>`;
 InlineOverride.parameters = {
   docs: { page: () => html`<div>Hello docs</div>` },
 };
 
-export const DocsDisable = () => html`<div>This story shouldn't show up in DocsPage</div>`;
+export const DocsDisable: Story = () => html`<div>This story shouldn't show up in DocsPage</div>`;
 DocsDisable.parameters = {
   docs: { disable: true },
 };

--- a/examples/lit-kitchen-sink/src/stories/addons/toolbars/addon-toolbars.stories.ts
+++ b/examples/lit-kitchen-sink/src/stories/addons/toolbars/addon-toolbars.stories.ts
@@ -1,8 +1,9 @@
 import { html } from 'lit';
+import { Story, Meta } from '@storybook/lit';
 
 export default {
   title: 'Addons / Toolbars',
-};
+} as Meta;
 
 const getCaptionForLocale = (locale: string) => {
   switch (locale) {
@@ -20,6 +21,6 @@ const getCaptionForLocale = (locale: string) => {
   }
 };
 
-export const Locale = (args: unknown, { globals: { locale } }: { globals: { locale: string } }) => {
+export const Locale: Story = (args, { globals: { locale } }) => {
   return html` <div>Your locale is '${locale}', so I say: ${getCaptionForLocale(locale)}</div> `;
 };

--- a/examples/lit-kitchen-sink/src/stories/addons/viewport/addon-viewport.stories.ts
+++ b/examples/lit-kitchen-sink/src/stories/addons/viewport/addon-viewport.stories.ts
@@ -1,4 +1,5 @@
 import { html } from 'lit';
+import { Story, Meta } from '@storybook/lit';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 export default {
@@ -8,9 +9,9 @@ export default {
       viewports: INITIAL_VIEWPORTS,
     },
   },
-};
+} as Meta;
 
-const Template = (args: { title: string }) => html`<h2>${args.title}</h2>`;
+const Template: Story<{ title: string }> = (args) => html`<h2>${args.title}</h2>`;
 
 export const Default = Template.bind({});
 Default.args = {


### PR DESCRIPTION
Issue: Could be part of #14930 or I can create a new one

## What I did
1 - Add typings for `Story` and `Meta`
2 - Stop exposing internal types that are used for ClientApi

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? yes, it's updated!
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

## Current limitation

It would be amazing if we could just automatically extract the properties of a given component, like we do with Angular components. I'm unsure whether this is already possible but I've [filed an issue](https://github.com/lit/lit/issues/1902) and hopefully we can get some perspective on this!

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
