### PR TITLE
Build: Increase CI `build` step to XL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
 jobs:
   build:
     executor:
-      class: large
+      class: xlarge
       name: sb_node_12_classic
     steps:
       - git-shallow-clone/checkout_advanced:


### PR DESCRIPTION
Issue: Build is failing on next/etc.

## What I did

Increase the resources due to "out of memory" error

self-merging @ndelangen @gaetanmaisse 

## How to test

CI passes
