### PR TITLE
CSF: Add undeclared dependency `regenerator-runtime`

### DIFF
--- a/lib/csf-tools/package.json
+++ b/lib/csf-tools/package.json
@@ -46,7 +46,8 @@
     "@babel/types": "^7.12.11",
     "@storybook/csf": "^0.0.1",
     "core-js": "^3.8.2",
-    "fs-extra": "^9.0.1"
+    "fs-extra": "^9.0.1",
+    "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6758,6 +6758,7 @@ __metadata:
     core-js: ^3.8.2
     fs-extra: ^9.0.1
     globby: ^11.0.2
+    regenerator-runtime: ^0.13.7
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Issue:

The PnP e2e test started failing in https://github.com/storybookjs/storybook/pull/14945 (cc @shilman)

Fixes https://github.com/yarnpkg/berry/runs/2606936463?check_suite_focus=true#step:5:267

## What I did

Add undeclared dependency `regenerator-runtime` to `@storybook/csf-tools`

## How to test

CI should be green