### PR TITLE
Bump telejson to 5.3.2 to use the ESM version

### DIFF
--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -55,7 +55,7 @@
     "qs": "^6.10.0",
     "regenerator-runtime": "^0.13.7",
     "store2": "^2.12.0",
-    "telejson": "^5.2.0",
+    "telejson": "^5.3.2",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"
   },

--- a/lib/channel-postmessage/package.json
+++ b/lib/channel-postmessage/package.json
@@ -46,7 +46,7 @@
     "core-js": "^3.8.2",
     "global": "^4.4.0",
     "qs": "^6.10.0",
-    "telejson": "^5.2.0"
+    "telejson": "^5.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/channel-websocket/package.json
+++ b/lib/channel-websocket/package.json
@@ -43,7 +43,7 @@
     "@storybook/channels": "6.3.0-alpha.33",
     "core-js": "^3.8.2",
     "global": "^4.4.0",
-    "telejson": "^5.2.0"
+    "telejson": "^5.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -90,7 +90,7 @@
     "resolve-from": "^5.0.0",
     "serve-favicon": "^2.5.0",
     "style-loader": "^1.3.0",
-    "telejson": "^5.2.0",
+    "telejson": "^5.3.2",
     "terser-webpack-plugin": "^4.2.3",
     "ts-dedent": "^2.0.0",
     "url-loader": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6194,7 +6194,7 @@ __metadata:
     qs: ^6.10.0
     regenerator-runtime: ^0.13.7
     store2: ^2.12.0
-    telejson: ^5.2.0
+    telejson: ^5.3.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
   peerDependencies:
@@ -6379,7 +6379,7 @@ __metadata:
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
-    telejson: ^5.2.0
+    telejson: ^5.3.2
   languageName: unknown
   linkType: soft
 
@@ -6390,7 +6390,7 @@ __metadata:
     "@storybook/channels": 6.3.0-alpha.33
     core-js: ^3.8.2
     global: ^4.4.0
-    telejson: ^5.2.0
+    telejson: ^5.3.2
   languageName: unknown
   linkType: soft
 
@@ -6707,7 +6707,7 @@ __metadata:
     resolve-from: ^5.0.0
     serve-favicon: ^2.5.0
     style-loader: ^1.3.0
-    telejson: ^5.2.0
+    telejson: ^5.3.2
     terser-webpack-plugin: ^4.2.3
     ts-dedent: ^2.0.0
     url-loader: ^4.1.1
@@ -39967,9 +39967,9 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"telejson@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "telejson@npm:5.2.0"
+"telejson@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "telejson@npm:5.3.2"
   dependencies:
     "@types/is-function": ^1.0.0
     global: ^4.4.0
@@ -39979,7 +39979,7 @@ resolve@1.19.0:
     isobject: ^4.0.0
     lodash: ^4.17.21
     memoizerific: ^1.11.3
-  checksum: 78f27dc71c3d787902e1f77c2023244739e622fdc03be8d9fb27f7667c8072f206532b001cc476d62291668c6e04ee08c047394284286fece6f3448b1a176240
+  checksum: 2c423700f1f696fe32a6b00020760b92b70cd76fb66d2057c4dc1231e740f59b97e71013a2657a76de5dce1baeef34a59875f38818370e23d0e883b7c4da0ca2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Should fix this: https://github.com/storybookjs/storybook/issues/14910

(Maybe it also solves https://github.com/storybookjs/storybook/issues/14938 - or maybe introduces a regression in the Webpack 5 builder? 😬 )

I suppose the automated test suite for Storybook should be able to give some answers.
