### PR TITLE
Update code snippets to use `argTypes[key].options` instead of `control.options`

### DIFF
--- a/docs/snippets/angular/component-story-custom-args-icons.ts.mdx
+++ b/docs/snippets/angular/component-story-custom-args-icons.ts.mdx
@@ -15,10 +15,7 @@ export default {
   component: Icon,
   argTypes: {
     icon: {
-      control: {
-        type: 'select',
-        options: Object.keys(iconMap),
-      },
+      options: Object.keys(iconMap),
     },
   },
 } as Meta;

--- a/docs/snippets/common/badge-story-custom-argtypes.js.mdx
+++ b/docs/snippets/common/badge-story-custom-argtypes.js.mdx
@@ -8,16 +8,13 @@ export default {
     status: {
       name: 'Badge Status',
       description: 'Available options available to the Badge',
-      control: {
-        type: 'select',
-        options: [
-          'positive',
-          'negative',
-          'warning',
-          'error',
-          'neutral'
-        ],
-      },
+      options: [
+        'positive',
+        'negative',
+        'warning',
+        'error',
+        'neutral'
+      ],
       table: {
         defaultValue: {
           summary: 'positive'

--- a/docs/snippets/common/badge-story-custom-argtypes.mdx.mdx
+++ b/docs/snippets/common/badge-story-custom-argtypes.mdx.mdx
@@ -11,16 +11,13 @@ import { Badge } from './Badge';
     status: {
       name: 'Badge Status',
       description: 'Available options available to the Badge',
-      control: {
-        type: 'select',
-        options: [
-          'positive',
-          'negative',
-          'warning',
-          'error',
-          'neutral'
-        ],
-      },
+      options: [
+        'positive',
+        'negative',
+        'warning',
+        'error',
+        'neutral'
+      ],
       table: {
         defaultValue: {
           summary: 'positive'

--- a/docs/snippets/common/button-story-controls-radio-group.js.mdx
+++ b/docs/snippets/common/button-story-controls-radio-group.js.mdx
@@ -6,10 +6,8 @@ export default {
   component: Button,
   argTypes: {
     variant: {
-      control: {
-        type: 'radio',
-        options: ['primary', 'secondary']
-      }
+      options: ['primary', 'secondary'],
+      control: { type: 'radio' }
     }
   }
 };

--- a/docs/snippets/common/button-story-controls-radio-group.mdx.mdx
+++ b/docs/snippets/common/button-story-controls-radio-group.mdx.mdx
@@ -6,10 +6,8 @@
   component={Button}
   argTypes={{
     variant: {
-      control: {
-        type: 'radio',
-        options: ['primary', 'secondary']
-      }
+      options: ['primary', 'secondary'],
+      control: { type: 'radio' }
     }
   }}
 />

--- a/docs/snippets/svelte/table-story-fully-customize-controls.native-format.mdx
+++ b/docs/snippets/svelte/table-story-fully-customize-controls.native-format.mdx
@@ -12,9 +12,7 @@
   component={Table}
   argTypes={{
     size: {
-      control: { 
-        type: 'select', 
-        options: ['small', 'medium', 'large'] },
+      options: ['small', 'medium', 'large'],
     },
   }}
 />

--- a/docs/snippets/vue/component-story-custom-args-icons.2.js.mdx
+++ b/docs/snippets/vue/component-story-custom-args-icons.2.js.mdx
@@ -14,10 +14,7 @@ export default {
   //👇 Creates specific argTypes with options
   argTypes: {
     icon: {
-      control: {
-        type: 'select',
-        options: Object.keys(iconMap),
-      },
+      options: Object.keys(iconMap),
     },
   },
 };

--- a/docs/snippets/vue/component-story-custom-args-icons.3.js.mdx
+++ b/docs/snippets/vue/component-story-custom-args-icons.3.js.mdx
@@ -14,10 +14,7 @@ export default {
   //👇 Creates specific argTypes with options
   argTypes: {
     icon: {
-      control: {
-        type: 'select',
-        options: Object.keys(iconMap),
-      },
+      options: Object.keys(iconMap),
     },
   },
 };


### PR DESCRIPTION
Issue: -

## What I did

Checked all code snippets for references to `control.options` and hoisted them all. Also removed instances of `controls: { type: 'select' }` since that is the default when `options` is specified.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
