### PR TITLE
Fixed regression introduced in #14563.

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/src/axeTest.ts
+++ b/addons/storyshots/storyshots-puppeteer/src/axeTest.ts
@@ -15,7 +15,7 @@ export const axeTest = (customConfig: Partial<AxeConfig> = {}) => {
   const config = { ...defaultAxeConfig, ...customConfig };
   const { beforeAxeTest } = config;
 
-  puppeteerTest({
+  return puppeteerTest({
     ...config,
     async testBody(page, options) {
       const parameters = options.context.parameters.a11y;


### PR DESCRIPTION
The regression prevented Axe tests from being run and instead the default snapshots were being used. This was due to a missing `return` statement that I overlooked in the original source because of the implicit return.

Additional context can be found here: https://github.com/storybookjs/storybook/pull/14563/files#r637109923