### PR TITLE
Maintenance: Build ESM in watch mode, not modern for now

### DIFF
--- a/scripts/utils/compile-babel.js
+++ b/scripts/utils/compile-babel.js
@@ -90,7 +90,7 @@ async function babelify(options = {}) {
   const runners = watch
     ? [
         run({ watch, dir: './dist/cjs', silent, errorCallback }),
-        run({ watch, dir: './dist/modern', silent, errorCallback }),
+        run({ watch, dir: './dist/esm', silent, errorCallback }),
       ]
     : [
         run({ dir: './dist/cjs', silent, errorCallback }),


### PR DESCRIPTION
Issue: In progress

#15013 

## What I did

Revert watch changes temporarily until we can fix the bug

self-merging @ndelangen 

## How to test

Terminal 1:
```
cd examples/official-storybook
yarn storybook
```

Terminal 2:
```
yarn build components --watch
# 1. edit a component with a visible change
# 2. observe update in official-storybook
```