### PR TITLE
Build: Fix selectors used in Cypress tests and E2E exit code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           command: yarn wait-on http://localhost:6000
       - run:
           name: Run E2E tests
-          command: yarn test:e2e-framework --clean --skip angular11 --skip angular --skip vue3 --skip web_components_typescript --skip cra
+          command: yarn test:e2e-framework --clean --all --skip angular11 --skip angular --skip vue3 --skip web_components_typescript --skip cra
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,7 @@ jobs:
       - run:
           name: Run E2E tests
           command: yarn test:e2e-framework --clean --all --skip angular11 --skip angular --skip vue3 --skip web_components_typescript --skip cra
+          no_output_timeout: 5m
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress
@@ -220,6 +221,7 @@ jobs:
           name: Run E2E tests
           # Do not test CRA here because it's done in PnP part
           command: yarn test:e2e-framework vue3 angular angular11 web_components_typescript
+          no_output_timeout: 5m
       - store_artifacts:
           path: /tmp/storybook/cypress
           destination: cypress

--- a/cypress/generated/addon-controls.spec.ts
+++ b/cypress/generated/addon-controls.spec.ts
@@ -8,7 +8,7 @@ describe('addon-controls', () => {
 
     // Text input: Label
     cy.getStoryElement().find('button').should('contain.text', 'Button');
-    cy.get('#label').clear().type('Hello world');
+    cy.get('textarea[name=label]').clear().type('Hello world');
     cy.getStoryElement().find('button').should('contain.text', 'Hello world');
 
     // Args in URL
@@ -16,11 +16,11 @@ describe('addon-controls', () => {
 
     // Boolean toggle: Primary/secondary
     cy.getStoryElement().find('button').should('have.css', 'background-color', 'rgb(30, 167, 253)');
-    cy.get('#primary').click();
+    cy.get('input[name=primary]').click();
     cy.getStoryElement().find('button').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
 
     // Color picker: Background color
-    cy.get('input[placeholder="Choose color"]').type('red');
+    cy.get('input[placeholder="Choose color..."]').type('red');
     cy.getStoryElement().find('button').should('have.css', 'background-color', 'rgb(255, 0, 0)');
 
     // TODO: enable this once the controls for size are aligned in all CLI templates.

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -211,24 +211,17 @@ const {
 let { pnp, useLocalSbCli, clean: startWithCleanSlate }: ProgramOptions = program;
 
 const typedConfigs: { [key: string]: Parameters } = configs;
-let e2eConfigs: { [key: string]: Parameters } = {};
 
 let openCypressInUIMode = !process.env.CI;
 
-const getConfig = async () => {
-  if (shouldRunAllFrameworks) {
-    logger.info(`📑 Running test for ALL frameworks`);
-    Object.values(typedConfigs).forEach((config) => {
-      e2eConfigs[`${config.name}-${config.version}`] = config;
-    });
-  }
+const getConfig = async (): Promise<Parameters[]> => {
+  let e2eConfigsToRun = Object.values(typedConfigs);
 
-  // Compute the list of frameworks we will run E2E for
-  if (frameworkArgs.length > 0) {
-    frameworkArgs.forEach((framework) => {
-      e2eConfigs[framework] = Object.values(typedConfigs).find((c) => c.name === framework);
-    });
-  } else {
+  if (shouldRunAllFrameworks) {
+    // Nothing to do here
+  } else if (frameworkArgs.length > 0) {
+    e2eConfigsToRun = e2eConfigsToRun.filter((config) => frameworkArgs.includes(config.name));
+  } else if (!process.env.CI) {
     const selectedValues = await prompts([
       {
         type: 'toggle',
@@ -272,18 +265,17 @@ const getConfig = async () => {
 
     useLocalSbCli = selectedValues.useLocalSbCli;
     openCypressInUIMode = selectedValues.openCypressInUIMode;
-    e2eConfigs = selectedValues.frameworks;
+    e2eConfigsToRun = selectedValues.frameworks;
   }
 
   // Remove frameworks listed with `--skip` arg
-  frameworksToSkip.forEach((framework) => {
-    delete e2eConfigs[framework];
-  });
+  e2eConfigsToRun = e2eConfigsToRun.filter((config) => !frameworksToSkip.includes(config.name));
+
+  return e2eConfigsToRun;
 };
 
 const perform = async (): Promise<Record<string, boolean>> => {
-  await getConfig();
-  const narrowedConfigs = Object.values(e2eConfigs);
+  const narrowedConfigs: Parameters[] = await getConfig();
 
   const list = filterDataForCurrentCircleCINode(narrowedConfigs) as Parameters[];
 

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -119,6 +119,7 @@ const runTests = async ({ name, ...rest }: Parameters) => {
     logger.info(`🎉 Storybook is working great with ${name}!`);
   } catch (e) {
     logger.info(`🥺 Storybook has some issues with ${name}!`);
+    throw e;
   } finally {
     server.close();
   }

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -55,6 +55,10 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
+  '@storybook/react-docgen-typescript-plugin':
+    access: $all
+    publish: $all
+    proxy: npmjs
 
   # storybook packages are NOT proxied to global registry
   # allowing us to republish any version during tests


### PR DESCRIPTION
## What I did

 - Selectors used in Cypress tests were not pointing to existing element so I replaced them with working ones
 - After a refactoring, E2E tests didn't use the result code of Cypress tests anymore so even if Cypress tests were failing the e2e step was ok
 - In some cases (covered by the e2e extended test suite) a prompt was displayed, causing the CI to fails after a 10min timeout.
 - Reduce CircleCI `no_output_timeout` to 5m for E2E steps
 - Add `@storybook/react-docgen-typescript-plugin` to the list of `@storybook/*` that aren't available in the monorepo (and so in verdaccio when running the e2e)
 
## How to test

- Check on CI 