### PR TITLE
Add info about Lit in migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -168,16 +168,20 @@ Storybook 6.2 introduced **experimental** webpack5 support for building user com
 
 If you're upgrading from 6.2 and already using the experimental webpack5 feature, this might be a breaking change (hence the 'experimental' label) and you should try adding the manager builder:
 
-```
+```shell
 yarn add @storybook/manager-webpack5 --dev
+# Or
+npm install @storybook/manager-webpack5 --save-dev
 ```
 
 ### Angular 12 upgrade
 
 Storybook 6.3 supports Angular 12 out of the box when you install it fresh. However, if you're upgrading your project from a previous version, you'll need to do the following steps to force Storybook to use webpack 5 for building your project:
 
-```js
-npm install @storybook/builder-webpack5 --save-dev # or yarn
+```shell
+yarn add @storybook/builder-webpack5 --dev
+# Or
+npm install @storybook/builder-webpack5 --save-dev
 ```
 
 Then edit your `.storybook/main.js` config:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 - [From version 6.2.x to 6.3.0](#from-version-62x-to-630)
   - [Webpack 5 manager build](#webpack-5-manager-build)
   - [Angular 12 upgrade](#angular-12-upgrade)
+  - [Lit support](#lit-support)
   - [6.3 deprecations](#63-deprecations)
     - [Deprecated scoped blocks imports](#deprecated-scoped-blocks-imports)
     - [Deprecated `argType.defaultValue`](#deprecated-argtypedefaultvalue)
@@ -188,6 +189,14 @@ module.exports = {
   },
 };
 ```
+
+### Lit support
+
+Storybook 6.3 introduces Lit 2 support in a non-breaking way to ease migration from `lit-html`/`lit-element` to `lit`.
+
+To do so, it relies on helpers added in the latest minor versions of `lit-html`/`lit-element`. So when upgrading to Storybook 6.3, please ensure your project is using `lit-html` 1.4.x or `lit-element` 2.5.x.
+
+According to the package manager you are using, it can be handled automatically when updating Storybook or can require to manually update the versions and regenerate the lockfile.
 
 ### 6.3 deprecations
 


### PR DESCRIPTION
## What I did

Related to https://github.com/storybookjs/storybook/issues/13489

I added a small section about Lit support in Storybook 6.3 as some users may face issues with wrong `lit-html`/`lit-element` versions. SB 6.3 require `lit-html` 1.4.x or `lit-element` 2.5.x and according to the package manager used in their projects users may need to bump this dep manually (in the vast majority of cases it should/will be handled automatically)