### PR TITLE
CLI: Add option to force-build iframe despite custom preview URL

### DIFF
--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -123,6 +123,7 @@ export interface CLIOptions {
   port?: number;
   ignorePreview?: boolean;
   previewUrl?: string;
+  forceBuildPreview?: boolean;
   host?: string;
   staticDir?: string[];
   configDir?: string;

--- a/lib/core-server/src/build-dev.ts
+++ b/lib/core-server/src/build-dev.ts
@@ -125,7 +125,7 @@ export async function buildDev(loadOptions: LoadOptions) {
       ...loadOptions,
       configDir: loadOptions.configDir || cliOptions.configDir || './.storybook',
       configType: 'DEVELOPMENT',
-      ignorePreview: !!cliOptions.previewUrl,
+      ignorePreview: !!cliOptions.previewUrl && !cliOptions.forceBuildPreview,
       docsMode: !!cliOptions.docs,
       cache,
     });

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -124,7 +124,8 @@ export async function buildStatic({ packageJson, ...loadOptions }: LoadOptions) 
       packageJson,
       configDir: loadOptions.configDir || cliOptions.configDir || './.storybook',
       outputDir: loadOptions.outputDir || cliOptions.outputDir || './storybook-static',
-      ignorePreview: !!loadOptions.ignorePreview || !!cliOptions.previewUrl,
+      ignorePreview:
+        (!!loadOptions.ignorePreview || !!cliOptions.previewUrl) && !cliOptions.forceBuildPreview,
       docsMode: !!cliOptions.docs,
       configType: 'PRODUCTION',
       cache,

--- a/lib/core-server/src/cli/dev.ts
+++ b/lib/core-server/src/cli/dev.ts
@@ -47,6 +47,7 @@ export async function getDevCli(packageJson: {
       '--preview-url <string>',
       'Disables the default storybook preview and lets your use your own'
     )
+    .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
     .option('--docs', 'Build a documentation-only site using addon-docs')
     .option('--modern', 'Use modern browser modules')
     .parse(process.argv);

--- a/lib/core-server/src/cli/prod.ts
+++ b/lib/core-server/src/cli/prod.ts
@@ -15,6 +15,7 @@ export interface ProdCliOptions {
   uiDll?: boolean;
   debugWebpack?: boolean;
   previewUrl?: string;
+  forceBuildPreview?: boolean;
   docs?: boolean;
   modern?: boolean;
 }
@@ -42,6 +43,7 @@ export function getProdCli(packageJson: {
       '--preview-url <string>',
       'Disables the default storybook preview and lets your use your own'
     )
+    .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
     .option('--docs', 'Build a documentation-only site using addon-docs')
     .option('--modern', 'Use modern browser modules')
     .parse(process.argv);


### PR DESCRIPTION
Issue: #14591

## What I did

Added a new CLI option, `--force-build-preview` that forces `start/build-storybook` to build the preview iframe even when `--preview-url` is specified.

Some background:

**5.2(?)** SB adds `--preview-url` so users can specify an externally-provided preview iframe. It contained a bug where it also built the preview iframe even though it shouldn't be needed.

**5.x** Users discover they can use `--preview-url` to work around a bug in how Storybook handles static files, relying on the bug https://github.com/storybookjs/storybook/issues/3699#issuecomment-750539941

**6.2** While refactoring the build process to support pluggable builders, we fix the bug introduced in 5.2, breaking the workaround. #14591

**6.3** Not wanting to risk a breaking change in the webpack setup, we introduce a new feature to force the building of the preview URL. This is hopefully temporary and can be replaced with a solution to #3699 in 7.0.

cc @sarahbethfederman @manuelpuyol @karlbao

## How to test

```
yarn build-storybook --preview-url=http://localhost:5000 --force-build-preview
# Observe iframe.html has been generated
```