### PR TITLE
Do not try to named import from global

### DIFF
--- a/addons/a11y/src/a11yHighlight.ts
+++ b/addons/a11y/src/a11yHighlight.ts
@@ -1,9 +1,11 @@
-import { document } from 'global';
+import global from 'global';
 import addons from '@storybook/addons';
 import { STORY_CHANGED } from '@storybook/core-events';
 import { EVENTS, HIGHLIGHT_STYLE_ID } from './constants';
 
 import { highlightStyle } from './highlight';
+
+const { document } = global;
 
 if (module && module.hot && module.hot.decline) {
   module.hot.decline();
@@ -29,7 +31,7 @@ const highlight = (infos: HighlightInfo) => {
   sheet.innerHTML = elements
     .map(
       (target) =>
-        `${target}{ 
+        `${target}{
           ${highlightStyle(infos.color)}
          }`
     )

--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -1,8 +1,10 @@
-import { document, window as globalWindow } from 'global';
+import global from 'global';
 import axe from 'axe-core';
 import addons from '@storybook/addons';
 import { EVENTS } from './constants';
 import { A11yParameters } from './params';
+
+const { document, window: globalWindow } = global;
 
 if (module && module.hot && module.hot.decline) {
   module.hot.decline();

--- a/addons/actions/src/preview/withActions.ts
+++ b/addons/actions/src/preview/withActions.ts
@@ -1,5 +1,5 @@
 // Based on http://backbonejs.org/docs/backbone.html#section-164
-import { document, Element } from 'global';
+import global from 'global';
 import { useEffect } from '@storybook/client-api';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
@@ -8,6 +8,8 @@ import { makeDecorator } from '@storybook/addons';
 import { actions } from './actions';
 
 import { PARAM_KEY } from '../constants';
+
+const { document, Element } = global;
 
 const delegateEventSplitter = /^(\S+)\s*(.*)$/;
 

--- a/addons/backgrounds/src/helpers/index.ts
+++ b/addons/backgrounds/src/helpers/index.ts
@@ -1,9 +1,11 @@
-import { document } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
 
 import { logger } from '@storybook/client-logger';
 
 import { Background } from '../types';
+
+const { document } = global;
 
 export const getBackgroundColorByName = (
   currentSelectedValue: string,

--- a/addons/docs/src/blocks/DocsContainer.tsx
+++ b/addons/docs/src/blocks/DocsContainer.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useEffect } from 'react';
-import { document, window as globalWindow } from 'global';
+import global from 'global';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 import { MDXProvider } from '@mdx-js/react';
@@ -11,6 +11,8 @@ import { storyBlockIdFromId } from './Story';
 import { SourceContainer } from './SourceContainer';
 import { CodeOrSourceMdx, AnchorMdx, HeadersMdx } from './mdx';
 import { scrollToElement } from './utils';
+
+const { document, window: globalWindow } = global;
 
 export interface DocsContainerProps {
   context: DocsContextProps;
@@ -27,7 +29,7 @@ const warnOptionsTheme = deprecate(
   () => {},
   dedent`
     Deprecated parameter: options.theme => docs.theme
-    
+
     https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/theming.md#storybook-theming
 `
 );

--- a/addons/docs/src/blocks/Meta.tsx
+++ b/addons/docs/src/blocks/Meta.tsx
@@ -1,10 +1,12 @@
 import React, { FC, useContext } from 'react';
-import { document } from 'global';
+import global from 'global';
 import { Args, BaseAnnotations, BaseMeta } from '@storybook/addons';
 import { Anchor } from './Anchor';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { getDocsStories } from './utils';
 import { Component } from './types';
+
+const { document } = global;
 
 type MetaProps = BaseMeta<Component> & BaseAnnotations<Args, any>;
 

--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -2,9 +2,11 @@ import React, { FC, SyntheticEvent } from 'react';
 import addons from '@storybook/addons';
 import { NAVIGATE_URL } from '@storybook/core-events';
 import { Source, Code, components } from '@storybook/components';
-import { document } from 'global';
+import global from 'global';
 import { styled } from '@storybook/theming';
 import { DocsContext, DocsContextProps } from './DocsContext';
+
+const { document } = global;
 
 // Hacky utility for asserting identifiers in MDX Story elements
 export const assertIsFn = (val: any) => {

--- a/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/input.js
+++ b/addons/docs/src/frameworks/web-components/__testfixtures__/lit-element-demo-card/input.js
@@ -1,5 +1,7 @@
-import { CustomEvent } from 'global';
+import global from 'global';
 import { LitElement, html, css } from 'lit-element';
+
+const { CustomEvent } = global;
 
 const demoWcCardStyle = css`
   :host {

--- a/addons/links/src/preview.test.ts
+++ b/addons/links/src/preview.test.ts
@@ -1,8 +1,10 @@
 import addons from '@storybook/addons';
 import { SELECT_STORY } from '@storybook/core-events';
 
-import { __STORYBOOK_STORY_STORE__ } from 'global';
+import globalPkg from 'global';
 import { linkTo, hrefTo } from './preview';
+
+const { __STORYBOOK_STORY_STORE__ } = globalPkg;
 
 jest.mock('@storybook/addons');
 jest.mock('global', () => ({

--- a/addons/links/src/preview.ts
+++ b/addons/links/src/preview.ts
@@ -1,15 +1,17 @@
-import {
-  document,
-  HTMLElement,
-  __STORYBOOK_STORY_STORE__ as storyStore,
-  __STORYBOOK_CLIENT_API__ as clientApi,
-} from 'global';
+import global from 'global';
 import qs from 'qs';
 import addons, { makeDecorator } from '@storybook/addons';
 import { STORY_CHANGED, SELECT_STORY } from '@storybook/core-events';
 import { toId } from '@storybook/csf';
 import { logger } from '@storybook/client-logger';
 import { PARAM_KEY } from './constants';
+
+const {
+  document,
+  HTMLElement,
+  __STORYBOOK_STORY_STORE__: storyStore,
+  __STORYBOOK_CLIENT_API__: clientApi,
+} = global;
 
 interface ParamsId {
   storyId: string;

--- a/addons/storyshots/storyshots-core/src/api/index.ts
+++ b/addons/storyshots/storyshots-core/src/api/index.ts
@@ -1,4 +1,4 @@
-import global, { describe } from 'global';
+import global from 'global';
 import addons, { mockChannel } from '@storybook/addons';
 import ensureOptionsDefaults from './ensureOptionsDefaults';
 import snapshotsTests from './snapshotsTestsTemplate';
@@ -6,6 +6,7 @@ import integrityTest from './integrityTestTemplate';
 import loadFramework from '../frameworks/frameworkLoader';
 import { StoryshotsOptions } from './StoryshotsOptions';
 
+const { describe } = global;
 global.STORYBOOK_REACT_CLASSES = global.STORYBOOK_REACT_CLASSES || {};
 
 type TestMethod = 'beforeAll' | 'beforeEach' | 'afterEach' | 'afterAll';

--- a/addons/storyshots/storyshots-core/src/api/integrityTestTemplate.ts
+++ b/addons/storyshots/storyshots-core/src/api/integrityTestTemplate.ts
@@ -1,8 +1,10 @@
 /* eslint-disable jest/no-export */
 import fs from 'fs';
 import glob from 'glob';
-import { describe, it } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
+
+const { describe, it } = global;
 
 expect.extend({
   notToBeAbandoned(storyshots, stories2snapsConverter) {

--- a/addons/storyshots/storyshots-core/src/api/snapshotsTestsTemplate.ts
+++ b/addons/storyshots/storyshots-core/src/api/snapshotsTestsTemplate.ts
@@ -1,8 +1,10 @@
 /* eslint-disable jest/valid-title */
 /* eslint-disable jest/no-export */
 /* eslint-disable jest/expect-expect */
-import { describe, it } from 'global';
+import global from 'global';
 import { addSerializer } from 'jest-specific-snapshot';
+
+const { describe, it } = global;
 
 function snapshotTest({ item, asyncJest, framework, testMethod, testMethodParams }: any) {
   const { name } = item;

--- a/addons/storyshots/storyshots-core/src/frameworks/html/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/html/renderTree.ts
@@ -1,4 +1,6 @@
-import { document, Node } from 'global';
+import global from 'global';
+
+const { document, Node } = global;
 
 function getRenderedTree(story: { render: () => any }) {
   const component = story.render();

--- a/addons/storyshots/storyshots-core/src/frameworks/riot/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/riot/renderTree.ts
@@ -1,4 +1,6 @@
-import { document } from 'global';
+import global from 'global';
+
+const { document } = global;
 
 const riotForStorybook = jest.requireActual('@storybook/riot');
 

--- a/addons/storyshots/storyshots-core/src/frameworks/svelte/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/svelte/renderTree.ts
@@ -1,5 +1,7 @@
-import { document } from 'global';
+import global from 'global';
 import { set_current_component } from 'svelte/internal';
+
+const { document } = global;
 
 /**
  * Provides functionality to convert your raw story to the resulting markup.

--- a/addons/storyshots/storyshots-core/src/frameworks/vue3/renderTree.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/vue3/renderTree.ts
@@ -1,6 +1,8 @@
 import * as Vue from 'vue';
-import { document } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
+
+const { document } = global;
 
 // This is cast as `any` to workaround type errors caused by Vue 2 types
 const { render, h } = Vue as any;

--- a/app/angular/src/client/preview/angular/helpers.ts
+++ b/app/angular/src/client/preview/angular/helpers.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { document } from 'global';
+import global from 'global';
 import { enableProdMode, NgModule, Component, NgModuleRef, Type, NgZone } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
@@ -9,6 +9,8 @@ import { StoryFn } from '@storybook/addons';
 import { AppComponent } from './components/app.component';
 import { STORY } from './app.token';
 import { NgModuleMetadata, StoryFnAngularReturnType } from '../types';
+
+const { document } = global;
 
 declare global {
   interface Window {

--- a/app/angular/src/client/preview/globals.ts
+++ b/app/angular/src/client/preview/globals.ts
@@ -1,5 +1,7 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
 
 import './angular-polyfills';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_ENV = 'angular';

--- a/app/ember/src/client/preview/globals.ts
+++ b/app/ember/src/client/preview/globals.ts
@@ -1,4 +1,6 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_NAME = process.env.STORYBOOK_NAME;
 globalWindow.STORYBOOK_ENV = 'ember';

--- a/app/ember/src/client/preview/render.ts
+++ b/app/ember/src/client/preview/render.ts
@@ -1,6 +1,8 @@
-import { window as globalWindow, document } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
 import { RenderContext, ElementArgs, OptionsArgs } from './types';
+
+const { window: globalWindow, document } = global;
 
 declare let Ember: any;
 

--- a/app/html/src/client/preview/globals.ts
+++ b/app/html/src/client/preview/globals.ts
@@ -1,3 +1,5 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_ENV = 'HTML';

--- a/app/html/src/client/preview/render.ts
+++ b/app/html/src/client/preview/render.ts
@@ -1,8 +1,9 @@
-import { document, Node } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
 import { simulatePageLoad, simulateDOMContentLoaded } from '@storybook/client-api';
 import { RenderContext } from './types';
 
+const { document, Node } = global;
 const rootElement = document.getElementById('root');
 
 export default function renderMain({

--- a/app/lit/src/client/index.ts
+++ b/app/lit/src/client/index.ts
@@ -1,4 +1,6 @@
-import { EventSource, window } from 'global';
+import global from 'global';
+
+const { EventSource, window } = global;
 
 export {
   storiesOf,

--- a/app/lit/src/client/preview/globals.ts
+++ b/app/lit/src/client/preview/globals.ts
@@ -1,3 +1,4 @@
-import { window } from 'global';
+import global from 'global';
 
+const { window } = global;
 window.STORYBOOK_ENV = 'lit';

--- a/app/lit/src/client/preview/render.ts
+++ b/app/lit/src/client/preview/render.ts
@@ -1,9 +1,10 @@
-import { document } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
 import { render } from 'lit';
 import { isTemplateResult } from 'lit/directive-helpers.js';
 import { RenderContext } from './types';
 
+const { document } = global;
 const rootElement = document.getElementById('root');
 
 export default function renderMain({ storyFn, kind, name, showMain, showError }: RenderContext) {

--- a/app/preact/src/client/preview/globals.ts
+++ b/app/preact/src/client/preview/globals.ts
@@ -1,4 +1,6 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 if (globalWindow) {
   globalWindow.STORYBOOK_ENV = 'preact';

--- a/app/preact/src/client/preview/render.tsx
+++ b/app/preact/src/client/preview/render.tsx
@@ -1,8 +1,9 @@
 import * as preact from 'preact';
-import { document } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
 import { RenderContext, StoryFnPreactReturnType } from './types';
 
+const { document } = global;
 const rootElement = document ? document.getElementById('root') : null;
 
 let renderedStory: Element;

--- a/app/react/src/client/preview/globals.ts
+++ b/app/react/src/client/preview/globals.ts
@@ -1,4 +1,6 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 if (globalWindow) {
   globalWindow.STORYBOOK_ENV = 'react';

--- a/app/react/src/client/preview/render.tsx
+++ b/app/react/src/client/preview/render.tsx
@@ -1,8 +1,10 @@
-import { document, FRAMEWORK_OPTIONS } from 'global';
+import global from 'global';
 import React, { Component, FunctionComponent, ReactElement, StrictMode, Fragment } from 'react';
 import ReactDOM from 'react-dom';
 
 import { StoryContext, RenderContext } from './types';
+
+const { document, FRAMEWORK_OPTIONS } = global;
 
 const rootEl = document ? document.getElementById('root') : null;
 

--- a/app/server/src/client/preview/globals.ts
+++ b/app/server/src/client/preview/globals.ts
@@ -1,3 +1,5 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_ENV = 'SERVER';

--- a/app/server/src/client/preview/render.ts
+++ b/app/server/src/client/preview/render.ts
@@ -1,9 +1,10 @@
-import { document, fetch, Node } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
 import { Args, ArgTypes } from '@storybook/api';
 import { simulatePageLoad, simulateDOMContentLoaded } from '@storybook/client-api';
 import { RenderContext, FetchStoryHtmlType } from './types';
 
+const { document, fetch, Node } = global;
 const rootElement = document.getElementById('root');
 
 const defaultFetchStoryHtml: FetchStoryHtmlType = async (url, path, params, storyContext) => {

--- a/app/svelte/src/client/preview/globals.ts
+++ b/app/svelte/src/client/preview/globals.ts
@@ -1,3 +1,5 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_ENV = 'svelte';

--- a/app/svelte/src/client/preview/render.ts
+++ b/app/svelte/src/client/preview/render.ts
@@ -1,6 +1,8 @@
-import { document } from 'global';
+import global from 'global';
 import { RenderContext } from './types';
 import PreviewRender from './PreviewRender.svelte';
+
+const { document } = global;
 
 type Component = any;
 

--- a/app/vue/src/client/preview/globals.ts
+++ b/app/vue/src/client/preview/globals.ts
@@ -1,4 +1,6 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_REACT_CLASSES = {};
 globalWindow.STORYBOOK_ENV = 'vue';

--- a/app/vue3/src/client/preview/globals.ts
+++ b/app/vue3/src/client/preview/globals.ts
@@ -1,4 +1,6 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_REACT_CLASSES = {};
 globalWindow.STORYBOOK_ENV = 'vue3';

--- a/app/web-components/src/client/index.ts
+++ b/app/web-components/src/client/index.ts
@@ -1,4 +1,6 @@
-import { window, EventSource } from 'global';
+import global from 'global';
+
+const { window, EventSource } = global;
 
 export {
   storiesOf,

--- a/app/web-components/src/client/preview/globals.ts
+++ b/app/web-components/src/client/preview/globals.ts
@@ -1,3 +1,5 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_ENV = 'web-components';

--- a/app/web-components/src/client/preview/render.ts
+++ b/app/web-components/src/client/preview/render.ts
@@ -1,4 +1,4 @@
-import { document, Node } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
 import { render } from 'lit-html';
 // Keep `.js` extension to avoid issue with Webpack (related to export map?)
@@ -7,6 +7,7 @@ import { isTemplateResult } from 'lit-html/directive-helpers.js';
 import { simulatePageLoad, simulateDOMContentLoaded } from '@storybook/client-api';
 import { RenderContext } from './types';
 
+const { document, Node } = global;
 const rootElement = document.getElementById('root');
 
 export default function renderMain({

--- a/docs/snippets/common/storybook-client-globals-example-file.ts.mdx
+++ b/docs/snippets/common/storybook-client-globals-example-file.ts.mdx
@@ -1,6 +1,7 @@
 ```ts
 // vue/src/client/preview/globals.ts
 
-import { window as globalWindow } from 'global';
+import global from 'global';
+const { window: globalWindow } = global;
 globalWindow.STORYBOOK_ENV = 'vue';
 ```

--- a/examples/angular-cli/src/cssWarning.ts
+++ b/examples/angular-cli/src/cssWarning.ts
@@ -1,4 +1,6 @@
-import { document } from 'global';
+import global from 'global';
+
+const { document } = global;
 
 export default function addCssWarning() {
   const warning = document.createElement('h1');

--- a/examples/cra-kitchen-sink/src/index.js
+++ b/examples/cra-kitchen-sink/src/index.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { document } from 'global';
+import global from 'global';
 
 import App from './App';
 import './index.css';
+
+const { document } = global;
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/examples/cra-react15/src/App.test.js
+++ b/examples/cra-react15/src/App.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { document } from 'global';
+import global from 'global';
 import App from './App';
+
+const { document } = global;
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/examples/cra-react15/src/index.js
+++ b/examples/cra-react15/src/index.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-import { document } from 'global';
+import global from 'global';
 import App from './App';
+
+const { document } = global;
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/examples/html-kitchen-sink/stories/addon-a11y.stories.js
+++ b/examples/html-kitchen-sink/stories/addon-a11y.stories.js
@@ -1,5 +1,6 @@
-import { document, setTimeout } from 'global';
+import global from 'global';
 
+const { document, setTimeout } = global;
 const text = 'Testing the a11y addon';
 
 export default {

--- a/examples/html-kitchen-sink/stories/button.stories.js
+++ b/examples/html-kitchen-sink/stories/button.stories.js
@@ -1,6 +1,8 @@
-import { document } from 'global';
+import global from 'global';
 import { action } from '@storybook/addon-actions';
 import { useEffect } from '@storybook/client-api';
+
+const { document } = global;
 
 export default {
   title: 'Demo',

--- a/examples/html-kitchen-sink/stories/from-essentials/Button.ts
+++ b/examples/html-kitchen-sink/stories/from-essentials/Button.ts
@@ -1,6 +1,8 @@
-import { document } from 'global';
+import global from 'global';
 
 import './button.css';
+
+const { document } = global;
 
 export interface ButtonProps {
   /**

--- a/examples/html-kitchen-sink/stories/from-essentials/Header.ts
+++ b/examples/html-kitchen-sink/stories/from-essentials/Header.ts
@@ -1,7 +1,9 @@
-import { document } from 'global';
+import global from 'global';
 
 import './header.css';
 import { createButton } from './Button';
+
+const { document } = global;
 
 export interface HeaderProps {
   user?: {};

--- a/examples/html-kitchen-sink/stories/from-essentials/Page.ts
+++ b/examples/html-kitchen-sink/stories/from-essentials/Page.ts
@@ -1,7 +1,9 @@
-import { document } from 'global';
+import global from 'global';
 
 import './page.css';
 import { createHeader } from './Header';
+
+const { document } = global;
 
 export interface PageProps {
   user?: {};

--- a/examples/official-storybook/head-warning.js
+++ b/examples/official-storybook/head-warning.js
@@ -1,4 +1,6 @@
-import { document } from 'global';
+import global from 'global';
+
+const { document } = global;
 
 // HMR will cause this code to be invoked multiple times, so each warning should have a unique ID
 export default function addHeadWarning(id, text) {

--- a/examples/official-storybook/preview.js
+++ b/examples/official-storybook/preview.js
@@ -1,4 +1,4 @@
-import { document } from 'global';
+import global from 'global';
 import React, { Fragment, useEffect } from 'react';
 import isChromatic from 'chromatic/isChromatic';
 import {
@@ -14,6 +14,8 @@ import { DocsPage } from '@storybook/addon-docs';
 import { Symbols } from '@storybook/components';
 
 import addHeadWarning from './head-warning';
+
+const { document } = global;
 
 if (process.env.NODE_ENV === 'development') {
   if (!process.env.DOTENV_DEVELOPMENT_DISPLAY_WARNING) {

--- a/examples/official-storybook/stories/addon-actions.stories.js
+++ b/examples/official-storybook/stories/addon-actions.stories.js
@@ -1,9 +1,10 @@
 /* eslint-disable react/prop-types */
-import { window as globalWindow, File } from 'global';
+import global from 'global';
 import React, { Fragment } from 'react';
 import { action, actions, configureActions } from '@storybook/addon-actions';
 import { Form } from '@storybook/components';
 
+const { window: globalWindow, File } = global;
 const { Button } = Form;
 
 export default {

--- a/examples/official-storybook/stories/addon-queryparams.stories.js
+++ b/examples/official-storybook/stories/addon-queryparams.stories.js
@@ -1,5 +1,7 @@
-import { document } from 'global';
+import global from 'global';
 import React from 'react';
+
+const { document } = global;
 
 export default {
   title: 'Addons/QueryParams',

--- a/examples/svelte-kitchen-sink/src/components/Button.test.js
+++ b/examples/svelte-kitchen-sink/src/components/Button.test.js
@@ -1,5 +1,7 @@
-import { document } from 'global';
+import global from 'global';
 import Button from './Button.svelte';
+
+const { document } = global;
 
 let target;
 let component;

--- a/examples/web-components-kitchen-sink/src/DemoWcCard.js
+++ b/examples/web-components-kitchen-sink/src/DemoWcCard.js
@@ -1,7 +1,9 @@
 /* eslint-disable import/extensions */
-import { CustomEvent } from 'global';
+import global from 'global';
 import { LitElement, html } from 'lit-element';
 import { demoWcCardStyle } from './demoWcCardStyle.css.js';
+
+const { CustomEvent } = global;
 
 /**
  * This is a container looking like a card with a back and front side you can switch

--- a/examples/web-components-kitchen-sink/stories/addon-a11y.stories.js
+++ b/examples/web-components-kitchen-sink/stories/addon-a11y.stories.js
@@ -1,6 +1,7 @@
-import { document, setTimeout } from 'global';
+import global from 'global';
 import { html } from 'lit-html';
 
+const { document, setTimeout } = global;
 const text = 'Testing the a11y addon';
 
 export default {

--- a/lib/addons/src/hooks.ts
+++ b/lib/addons/src/hooks.ts
@@ -1,4 +1,4 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
 import { logger } from '@storybook/client-logger';
 import {
   FORCE_RE_RENDER,
@@ -10,6 +10,8 @@ import {
 } from '@storybook/core-events';
 import { addons } from './index';
 import { StoryGetter, StoryContext, Args } from './types';
+
+const { window: globalWindow } = global;
 
 interface Hook {
   name: string;

--- a/lib/api/src/lib/shortcut.ts
+++ b/lib/api/src/lib/shortcut.ts
@@ -1,7 +1,9 @@
-import { navigator } from 'global';
+import global from 'global';
 
 // The shortcut is our JSON-ifiable representation of a shortcut combination
 import { KeyCollection, Event } from '../modules/shortcuts';
+
+const { navigator } = global;
 
 export const isMacLike = () =>
   navigator && navigator.platform ? !!navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) : false;

--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -1,10 +1,12 @@
-import { DOCS_MODE, document } from 'global';
+import global from 'global';
 import pick from 'lodash/pick';
 import deepEqual from 'fast-deep-equal';
 import { themes, ThemeVars } from '@storybook/theming';
 
 import merge from '../lib/merge';
 import { State, ModuleFn } from '../index';
+
+const { DOCS_MODE, document } = global;
 
 export type PanelPositions = 'bottom' | 'right';
 export type ActiveTabsType = 'sidebar' | 'canvas' | 'addons';

--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -1,4 +1,4 @@
-import { location, fetch } from 'global';
+import global from 'global';
 import dedent from 'ts-dedent';
 import {
   transformStoriesRawToStoriesHash,
@@ -8,6 +8,8 @@ import {
 } from '../lib/stories';
 
 import { ModuleFn } from '../index';
+
+const { location, fetch } = global;
 
 export interface SubState {
   refs: Refs;
@@ -166,12 +168,12 @@ export const init: ModuleFn = ({ store, provider, fullAPI }, { runCheck = true }
           message: dedent`
             Error: Loading of ref failed
               at fetch (lib/api/src/modules/refs.ts)
-            
+
             URL: ${url}
-            
+
             We weren't able to load the above URL,
             it's possible a CORS error happened.
-            
+
             Please check your dev-tools network tab.
           `,
         } as Error;

--- a/lib/api/src/modules/release-notes.ts
+++ b/lib/api/src/modules/release-notes.ts
@@ -1,7 +1,9 @@
-import { RELEASE_NOTES_DATA } from 'global';
+import global from 'global';
 import memoize from 'memoizerific';
 
 import { ModuleFn } from '../index';
+
+const { RELEASE_NOTES_DATA } = global;
 
 export interface ReleaseNotes {
   success?: boolean;

--- a/lib/api/src/modules/shortcuts.ts
+++ b/lib/api/src/modules/shortcuts.ts
@@ -1,10 +1,12 @@
-import { navigator, document } from 'global';
+import global from 'global';
 import { PREVIEW_KEYDOWN } from '@storybook/core-events';
 
 import { ModuleFn } from '../index';
 
 import { shortcutMatchesShortcut, eventToShortcut } from '../lib/shortcut';
 import { focusableUIElements } from './layout';
+
+const { navigator, document } = global;
 
 export const isMacLike = () =>
   navigator && navigator.platform ? !!navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) : false;

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -1,4 +1,4 @@
-import { DOCS_MODE } from 'global';
+import global from 'global';
 import { toId, sanitize } from '@storybook/csf';
 import {
   UPDATE_STORY_ARGS,
@@ -30,6 +30,8 @@ import type {
 
 import { Args, ModuleFn } from '../index';
 import { ComposedRef } from './refs';
+
+const { DOCS_MODE } = global;
 
 type Direction = -1 | 1;
 type ParameterName = string;

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -3,11 +3,13 @@ import { NAVIGATE_URL, STORY_ARGS_UPDATED, SET_CURRENT_STORY } from '@storybook/
 import { queryFromLocation, navigate as queryNavigate, buildArgsParam } from '@storybook/router';
 import { toId, sanitize } from '@storybook/csf';
 import deepEqual from 'fast-deep-equal';
-import { window as globalWindow } from 'global';
+import global from 'global';
 
 import { ModuleArgs, ModuleFn } from '../index';
 import { PanelPositions } from './layout';
 import { isStory } from '../lib/stories';
+
+const { window: globalWindow } = global;
 
 interface Additions {
   isFullscreen?: boolean;

--- a/lib/api/src/modules/versions.ts
+++ b/lib/api/src/modules/versions.ts
@@ -1,10 +1,12 @@
-import { VERSIONCHECK } from 'global';
+import global from 'global';
 import semver from '@storybook/semver';
 import memoize from 'memoizerific';
 
 import { version as currentVersion } from '../version';
 
 import { ModuleFn } from '../index';
+
+const { VERSIONCHECK } = global;
 
 export interface Version {
   version: string;

--- a/lib/api/src/tests/refs.test.js
+++ b/lib/api/src/tests/refs.test.js
@@ -1,5 +1,7 @@
-import { fetch } from 'global';
+import global from 'global';
 import { getSourceType, init as initRefs } from '../modules/refs';
+
+const { fetch } = global;
 
 jest.mock('global', () => {
   const globalMock = {

--- a/lib/api/src/tests/shortcut.test.js
+++ b/lib/api/src/tests/shortcut.test.js
@@ -1,6 +1,7 @@
-import { KeyboardEvent } from 'global';
+import global from 'global';
 import { eventToShortcut, keyToSymbol } from '../lib/shortcut';
 
+const { KeyboardEvent } = global;
 const ev = (attr) => new KeyboardEvent('keydown', { ...attr });
 
 describe('eventToShortcut', () => {

--- a/lib/channel-postmessage/src/index.ts
+++ b/lib/channel-postmessage/src/index.ts
@@ -1,9 +1,11 @@
-import { window as globalWindow, document, location } from 'global';
+import global from 'global';
 import * as EVENTS from '@storybook/core-events';
 import Channel, { ChannelEvent, ChannelHandler } from '@storybook/channels';
 import { logger, pretty } from '@storybook/client-logger';
 import { isJSON, parse, stringify } from 'telejson';
 import qs from 'qs';
+
+const { window: globalWindow, document, location } = global;
 
 interface Config {
   page: 'manager' | 'preview';

--- a/lib/channel-websocket/src/index.ts
+++ b/lib/channel-websocket/src/index.ts
@@ -1,6 +1,8 @@
-import { WebSocket } from 'global';
+import global from 'global';
 import { Channel, ChannelHandler } from '@storybook/channels';
 import { isJSON, parse, stringify } from 'telejson';
+
+const { WebSocket } = global;
 
 type OnError = (message: Event) => void;
 

--- a/lib/client-api/src/queryparams.ts
+++ b/lib/client-api/src/queryparams.ts
@@ -1,5 +1,7 @@
-import { document } from 'global';
+import global from 'global';
 import { parse } from 'qs';
+
+const { document } = global;
 
 export const getQueryParams = () => {
   // document.location is not defined in react-native

--- a/lib/client-api/src/simulate-pageload.ts
+++ b/lib/client-api/src/simulate-pageload.ts
@@ -1,4 +1,6 @@
-import { document } from 'global';
+import global from 'global';
+
+const { document } = global;
 
 // https://html.spec.whatwg.org/multipage/scripting.html
 const runScriptTypes = [

--- a/lib/client-logger/src/index.ts
+++ b/lib/client-logger/src/index.ts
@@ -1,4 +1,6 @@
-import { LOGLEVEL, console } from 'global';
+import global from 'global';
+
+const { LOGLEVEL, console } = global;
 
 type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
 

--- a/lib/codemod/src/transforms/__testfixtures__/csf-to-mdx/story-function.input.js
+++ b/lib/codemod/src/transforms/__testfixtures__/csf-to-mdx/story-function.input.js
@@ -1,4 +1,6 @@
-import { document } from 'global';
+import global from 'global';
+
+const { document } = global;
 
 export default {
   title: 'Function',

--- a/lib/codemod/src/transforms/__testfixtures__/csf-to-mdx/story-function.output.snapshot
+++ b/lib/codemod/src/transforms/__testfixtures__/csf-to-mdx/story-function.output.snapshot
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`csf-to-mdx transforms correctly using "story-function.input.js" data 1`] = `
-"import { document } from 'global';
+"import global from 'global';
 import { Meta, Story } from '@storybook/addon-docs';
 
+const {
+  document,
+} = global;
 <Meta title='Function' />
 
 <Story name='function' height='100px'>{() => {

--- a/lib/components/src/Loader/Loader.tsx
+++ b/lib/components/src/Loader/Loader.tsx
@@ -1,9 +1,11 @@
-import { EventSource, CONFIG_TYPE } from 'global';
+import global from 'global';
 import { transparentize } from 'polished';
 import React, { ComponentProps, FunctionComponent, useEffect, useState } from 'react';
 import { styled, keyframes } from '@storybook/theming';
 import { Icons } from '../icon/icon';
 import { rotate360 } from '../shared/animation';
+
+const { EventSource, CONFIG_TYPE } = global;
 
 const LoaderWrapper = styled.div<{ size?: number }>(({ size = 32 }) => ({
   borderRadius: '50%',

--- a/lib/components/src/Zoom/Zoom.tsx
+++ b/lib/components/src/Zoom/Zoom.tsx
@@ -1,6 +1,8 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
 import { ZoomElement as Element } from './ZoomElement';
 import { ZoomIFrame as IFrame } from './ZoomIFrame';
+
+const { window: globalWindow } = global;
 
 export const browserSupportsCssZoom = (): boolean => {
   try {

--- a/lib/components/src/Zoom/browserSupportsCssZoom.ts
+++ b/lib/components/src/Zoom/browserSupportsCssZoom.ts
@@ -1,4 +1,6 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 export function browserSupportsCssZoom(): boolean {
   try {

--- a/lib/components/src/blocks/IFrame.tsx
+++ b/lib/components/src/blocks/IFrame.tsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 interface IFrameProps {
   id: string;

--- a/lib/components/src/blocks/Preview.stories.tsx
+++ b/lib/components/src/blocks/Preview.stories.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { styled } from '@storybook/theming';
-import { window as globalWindow } from 'global';
+import global from 'global';
 
 import { Spaced } from '../spaced/Spaced';
 import { Preview } from './Preview';
 import { Story } from './Story';
 import { Button } from '../Button/Button';
 import * as Source from './Source.stories';
+
+const { window: globalWindow } = global;
 
 export default {
   title: 'Docs/Preview',

--- a/lib/components/src/controls/Object.tsx
+++ b/lib/components/src/controls/Object.tsx
@@ -1,4 +1,4 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
 import cloneDeep from 'lodash/cloneDeep';
 import React, {
   ComponentProps,
@@ -18,6 +18,8 @@ import type { ControlProps, ObjectValue, ObjectConfig } from './types';
 import { Form } from '../form';
 import { Icons, IconsProps } from '../icon/icon';
 import { IconButton } from '../bar/button';
+
+const { window: globalWindow } = global;
 
 type JsonTreeProps = ComponentProps<typeof JsonTree>;
 

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps, FunctionComponent, MouseEvent, useState } from 'react';
 import { logger } from '@storybook/client-logger';
 import { styled } from '@storybook/theming';
-import { navigator, document, window as globalWindow } from 'global';
+import global from 'global';
 import memoize from 'memoizerific';
 
 // @ts-ignore
@@ -35,6 +35,8 @@ import { ScrollArea } from '../ScrollArea/ScrollArea';
 
 import { formatter } from './formatter';
 import type { SyntaxHighlighterProps } from './syntaxhighlighter-types';
+
+const { navigator, document, window: globalWindow } = global;
 
 ReactSyntaxHighlighter.registerLanguage('jsextra', jsExtras);
 ReactSyntaxHighlighter.registerLanguage('jsx', jsx);

--- a/lib/components/src/tooltip/WithTooltip.tsx
+++ b/lib/components/src/tooltip/WithTooltip.tsx
@@ -1,10 +1,12 @@
 import React, { FunctionComponent, ReactNode, useCallback, useState, useEffect } from 'react';
 import { styled } from '@storybook/theming';
-import { document } from 'global';
+import global from 'global';
 
 import TooltipTrigger from 'react-popper-tooltip';
 import { Modifier, Placement } from '@popperjs/core';
 import { Tooltip } from './Tooltip';
+
+const { document } = global;
 
 // A target that doesn't speak popper
 const TargetContainer = styled.div<{ mode: string }>`

--- a/lib/core-client/src/globals/globals.ts
+++ b/lib/core-client/src/globals/globals.ts
@@ -1,3 +1,5 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_REACT_CLASSES = {};

--- a/lib/core-client/src/manager/conditional-polyfills.ts
+++ b/lib/core-client/src/manager/conditional-polyfills.ts
@@ -1,4 +1,6 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
+
+const { window: globalWindow } = global;
 
 export const importPolyfills = () => {
   const polyfills = [];

--- a/lib/core-client/src/manager/index.ts
+++ b/lib/core-client/src/manager/index.ts
@@ -1,7 +1,9 @@
-import { document } from 'global';
+import global from 'global';
 import renderStorybookUI from '@storybook/ui';
 import Provider from './provider';
 import { importPolyfills } from './conditional-polyfills';
+
+const { document } = global;
 
 importPolyfills().then(() => {
   const rootEl = document.getElementById('root');

--- a/lib/core-client/src/preview/StoryRenderer.tsx
+++ b/lib/core-client/src/preview/StoryRenderer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { document } from 'global';
+import global from 'global';
 import AnsiToHtml from 'ansi-to-html';
 import dedent from 'ts-dedent';
 
@@ -11,6 +11,8 @@ import { StoryStore } from '@storybook/client-api';
 
 import { NoDocs } from './NoDocs';
 import { RenderStoryFunction, RenderContextWithoutStoryContext } from './types';
+
+const { document } = global;
 
 // We have "changed" story if this changes
 interface RenderMetadata {

--- a/lib/core-client/src/preview/start.test.ts
+++ b/lib/core-client/src/preview/start.test.ts
@@ -1,6 +1,8 @@
-import { document, window as globalWindow } from 'global';
+import global from 'global';
 
 import start from './start';
+
+const { document, window: globalWindow } = global;
 
 jest.mock('@storybook/client-logger');
 jest.mock('global', () => ({

--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -1,4 +1,4 @@
-import { navigator, window as globalWindow } from 'global';
+import global from 'global';
 
 import addons, { DecorateStoryFunction, Channel } from '@storybook/addons';
 import createChannel from '@storybook/channel-postmessage';
@@ -10,6 +10,7 @@ import { RenderStoryFunction } from './types';
 import { loadCsf } from './loadCsf';
 import { StoryRenderer } from './StoryRenderer';
 
+const { navigator, window: globalWindow } = global;
 const isBrowser =
   navigator &&
   navigator.userAgent &&

--- a/lib/core-client/src/preview/url.test.ts
+++ b/lib/core-client/src/preview/url.test.ts
@@ -1,6 +1,8 @@
-import { history, document } from 'global';
+import global from 'global';
 
 import { pathToId, setPath, parseQueryParameters, getSelectionSpecifierFromPath } from './url';
+
+const { history, document } = global;
 
 jest.mock('global', () => ({
   history: { replaceState: jest.fn() },

--- a/lib/core-client/src/preview/url.ts
+++ b/lib/core-client/src/preview/url.ts
@@ -1,10 +1,12 @@
-import { history, document } from 'global';
+import global from 'global';
 import qs from 'qs';
 import deprecate from 'util-deprecate';
 import { StoreSelectionSpecifier, StoreSelection } from '@storybook/client-api';
 import { StoryId, ViewMode } from '@storybook/addons';
 
 import { parseArgsParam } from './parseArgsParam';
+
+const { history, document } = global;
 
 export function pathToId(path: string) {
   const match = (path || '').match(/^\/story\/(.+)/);
@@ -58,8 +60,8 @@ const getFirstString = (v: ValueOf<qs.ParsedQs>): string | void => {
 
 const deprecatedLegacyQuery = deprecate(
   () => 0,
-  `URL formats with \`selectedKind\` and \`selectedName\` query parameters are deprecated. 
-Use \`id=$storyId\` instead. 
+  `URL formats with \`selectedKind\` and \`selectedName\` query parameters are deprecated.
+Use \`id=$storyId\` instead.
 See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#new-url-structure`
 );
 

--- a/lib/router/src/router.tsx
+++ b/lib/router/src/router.tsx
@@ -1,4 +1,4 @@
-import { document } from 'global';
+import global from 'global';
 import React, { ReactNode } from 'react';
 
 import {
@@ -14,6 +14,8 @@ import {
 } from '@reach/router';
 import { ToggleVisibility } from './visibility';
 import { queryFromString, parsePath, getMatch, StoryData } from './utils';
+
+const { document } = global;
 
 interface Other extends StoryData {
   path: string;

--- a/lib/theming/src/tests/util.test.js
+++ b/lib/theming/src/tests/util.test.js
@@ -1,5 +1,7 @@
-import { window as globalWindow } from 'global';
+import global from 'global';
 import { lightenColor as lighten, darkenColor as darken, getPreferredColorScheme } from '../utils';
+
+const { window: globalWindow } = global;
 
 describe('utils', () => {
   it('should apply polished when valid arguments are passed', () => {

--- a/lib/theming/src/utils.ts
+++ b/lib/theming/src/utils.ts
@@ -1,7 +1,9 @@
 import { rgba, lighten, darken } from 'polished';
-import { window as globalWindow } from 'global';
+import global from 'global';
 
 import { logger } from '@storybook/client-logger';
+
+const { window: globalWindow } = global;
 
 export const mkColor = (color: string) => ({ color });
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -53,9 +53,11 @@ export default class MyProvider extends Provider {
 Then you need to initialize the UI like this:
 
 ```js
-import { document } from 'global';
+import global from 'global';
 import renderStorybookUI from '@storybook/ui';
 import Provider from './provider';
+
+const { document } = global;
 
 const roolEl = document.getElementById('root');
 renderStorybookUI(roolEl, new Provider());

--- a/lib/ui/src/components/layout/app.mockdata.tsx
+++ b/lib/ui/src/components/layout/app.mockdata.tsx
@@ -1,4 +1,4 @@
-import { setInterval } from 'global';
+import global from 'global';
 import React, { Component, FunctionComponent } from 'react';
 import { styled } from '@storybook/theming';
 import { Collection } from '@storybook/addons';
@@ -10,6 +10,8 @@ import { Preview } from '../preview/preview';
 import { previewProps } from '../preview/preview.mockdata';
 import { mockDataset } from '../sidebar/mockdata';
 import { DesktopProps } from './desktop';
+
+const { setInterval } = global;
 
 export const shortcuts: State['shortcuts'] = {
   fullScreen: ['F'],

--- a/lib/ui/src/components/preview/tools/copy.tsx
+++ b/lib/ui/src/components/preview/tools/copy.tsx
@@ -1,10 +1,12 @@
-import { PREVIEW_URL } from 'global';
+import global from 'global';
 import React from 'react';
 import copy from 'copy-to-clipboard';
 import { IconButton, Icons } from '@storybook/components';
 import { Consumer, Combo } from '@storybook/api';
 import { Addon } from '@storybook/addons';
 import { stringifyQueryParams } from '../utils/stringifyQueryParams';
+
+const { PREVIEW_URL } = global;
 
 const copyMapper = ({ state }: Combo) => {
   const { storyId, refId, refs } = state;

--- a/lib/ui/src/components/preview/tools/eject.tsx
+++ b/lib/ui/src/components/preview/tools/eject.tsx
@@ -1,9 +1,11 @@
-import { PREVIEW_URL } from 'global';
+import global from 'global';
 import React from 'react';
 import { IconButton, Icons } from '@storybook/components';
 import { Consumer, Combo } from '@storybook/api';
 import { Addon } from '@storybook/addons';
 import { stringifyQueryParams } from '../utils/stringifyQueryParams';
+
+const { PREVIEW_URL } = global;
 
 const ejectMapper = ({ state }: Combo) => {
   const { storyId, refId, refs } = state;

--- a/lib/ui/src/components/sidebar/RefBlocks.tsx
+++ b/lib/ui/src/components/sidebar/RefBlocks.tsx
@@ -1,4 +1,4 @@
-import { window as globalWindow, document } from 'global';
+import global from 'global';
 import React, { FunctionComponent, useState, useCallback, Fragment } from 'react';
 
 import { Icons, WithTooltip, Spaced, Button, Link } from '@storybook/components';
@@ -6,6 +6,8 @@ import { logger } from '@storybook/client-logger';
 import { styled } from '@storybook/theming';
 
 import { Loader, Contained } from './Loader';
+
+const { window: globalWindow, document } = global;
 
 const TextStyle = styled.div(({ theme }) => ({
   fontSize: theme.typography.size.s2 - 1,

--- a/lib/ui/src/components/sidebar/RefIndicator.tsx
+++ b/lib/ui/src/components/sidebar/RefIndicator.tsx
@@ -1,4 +1,4 @@
-import { document, window as globalWindow } from 'global';
+import global from 'global';
 import React, { FunctionComponent, useMemo, ComponentProps, useCallback, forwardRef } from 'react';
 
 import { Icons, WithTooltip, Spaced, TooltipLinkList } from '@storybook/components';
@@ -9,6 +9,8 @@ import { useStorybookApi } from '@storybook/api';
 import { MenuItemIcon } from './Menu';
 import { RefType } from './types';
 import { getStateType } from './utils';
+
+const { document, window: globalWindow } = global;
 
 export type ClickHandler = ComponentProps<typeof TooltipLinkList>['links'][number]['onClick'];
 export interface IndicatorIconProps {

--- a/lib/ui/src/components/sidebar/Search.tsx
+++ b/lib/ui/src/components/sidebar/Search.tsx
@@ -3,7 +3,7 @@ import { styled } from '@storybook/theming';
 import { Icons } from '@storybook/components';
 import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
 import Fuse, { FuseOptions } from 'fuse.js';
-import { document } from 'global';
+import global from 'global';
 import { transparentize } from 'polished';
 import React, { useMemo, useRef, useState, useCallback } from 'react';
 
@@ -21,6 +21,8 @@ import {
   isCloseType,
 } from './types';
 import { searchItem } from './utils';
+
+const { document } = global;
 
 const DEFAULT_MAX_SEARCH_RESULTS = 50;
 

--- a/lib/ui/src/components/sidebar/SearchResults.tsx
+++ b/lib/ui/src/components/sidebar/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@storybook/theming';
 import { Icons } from '@storybook/components';
-import { document, DOCS_MODE } from 'global';
+import global from 'global';
 import React, {
   FunctionComponent,
   MouseEventHandler,
@@ -22,6 +22,8 @@ import {
 } from './types';
 import { getLink } from './utils';
 import { matchesKeyCode, matchesModifiers } from '../../keybinding';
+
+const { document, DOCS_MODE } = global;
 
 const ResultsList = styled.ol({
   listStyle: 'none',

--- a/lib/ui/src/components/sidebar/Sidebar.tsx
+++ b/lib/ui/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { DOCS_MODE } from 'global';
+import global from 'global';
 import React, { FunctionComponent, useMemo } from 'react';
 
 import { styled } from '@storybook/theming';
@@ -13,6 +13,8 @@ import { Search } from './Search';
 import { SearchResults } from './SearchResults';
 import { Refs, CombinedDataset, Selection } from './types';
 import { useLastViewed } from './useLastViewed';
+
+const { DOCS_MODE } = global;
 
 const Container = styled.nav({
   position: 'absolute',

--- a/lib/ui/src/components/sidebar/TreeNode.tsx
+++ b/lib/ui/src/components/sidebar/TreeNode.tsx
@@ -1,8 +1,10 @@
 import { styled, Color, Theme } from '@storybook/theming';
 import { Icons } from '@storybook/components';
-import { DOCS_MODE } from 'global';
+import global from 'global';
 import { transparentize } from 'polished';
 import React, { FunctionComponent, ComponentProps } from 'react';
+
+const { DOCS_MODE } = global;
 
 export const CollapseIcon = styled.span<{ isExpanded: boolean }>(({ theme, isExpanded }) => ({
   display: 'inline-block',

--- a/lib/ui/src/components/sidebar/useExpanded.ts
+++ b/lib/ui/src/components/sidebar/useExpanded.ts
@@ -1,13 +1,15 @@
 import type { StoriesHash } from '@storybook/api';
 import { useStorybookApi } from '@storybook/api';
 import { STORIES_COLLAPSE_ALL, STORIES_EXPAND_ALL } from '@storybook/core-events';
-import { document } from 'global';
+import global from 'global';
 import throttle from 'lodash/throttle';
 import React, { Dispatch, MutableRefObject, useCallback, useEffect, useReducer } from 'react';
 import { matchesKeyCode, matchesModifiers } from '../../keybinding';
 import { Highlight } from './types';
 
 import { isAncestor, getAncestorIds, getDescendantIds, scrollIntoView } from './utils';
+
+const { document } = global;
 
 export type ExpandedState = Record<string, boolean>;
 

--- a/lib/ui/src/components/sidebar/useHighlighted.ts
+++ b/lib/ui/src/components/sidebar/useHighlighted.ts
@@ -1,4 +1,4 @@
-import { document, window as globalWindow } from 'global';
+import global from 'global';
 import {
   Dispatch,
   MutableRefObject,
@@ -12,6 +12,8 @@ import { matchesKeyCode, matchesModifiers } from '../../keybinding';
 
 import { CombinedDataset, Highlight, Selection } from './types';
 import { cycle, isAncestor, scrollIntoView } from './utils';
+
+const { document, window: globalWindow } = global;
 
 export interface HighlightedProps {
   containerRef: MutableRefObject<HTMLElement>;

--- a/lib/ui/src/components/sidebar/utils.ts
+++ b/lib/ui/src/components/sidebar/utils.ts
@@ -1,11 +1,13 @@
 import memoize from 'memoizerific';
-import { document, window as globalWindow, DOCS_MODE } from 'global';
+import global from 'global';
 import { SyntheticEvent } from 'react';
 import type { StoriesHash } from '@storybook/api';
 import { isRoot } from '@storybook/api';
 
 import { DEFAULT_REF_ID } from './data';
 import { Item, RefType, Dataset, SearchItem } from './types';
+
+const { document, window: globalWindow, DOCS_MODE } = global;
 
 export const createId = (itemId: string, refId?: string) =>
   !refId || refId === DEFAULT_REF_ID ? itemId : `${refId}_${itemId}`;

--- a/lib/ui/src/containers/preview.tsx
+++ b/lib/ui/src/containers/preview.tsx
@@ -1,10 +1,12 @@
-import { PREVIEW_URL } from 'global';
+import global from 'global';
 import React from 'react';
 
 import type { Combo, StoriesHash } from '@storybook/api';
 import { Consumer, isRoot, isGroup, isStory } from '@storybook/api';
 
 import { Preview } from '../components/preview/preview';
+
+const { PREVIEW_URL } = global;
 
 export type Item = StoriesHash[keyof StoriesHash];
 

--- a/lib/ui/src/index.tsx
+++ b/lib/ui/src/index.tsx
@@ -1,4 +1,4 @@
-import { DOCS_MODE } from 'global';
+import global from 'global';
 import React, { FunctionComponent } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -10,6 +10,8 @@ import { HelmetProvider } from 'react-helmet-async';
 import App from './app';
 
 import Provider from './provider';
+
+const { DOCS_MODE } = global;
 
 // @ts-ignore
 ThemeProvider.displayName = 'ThemeProvider';

--- a/lib/ui/src/settings/index.tsx
+++ b/lib/ui/src/settings/index.tsx
@@ -2,13 +2,15 @@ import { useStorybookApi, useStorybookState } from '@storybook/api';
 import { IconButton, Icons, FlexBar, TabBar, TabButton, ScrollArea } from '@storybook/components';
 import { Location, Route } from '@storybook/router';
 import { styled } from '@storybook/theming';
-import { document } from 'global';
+import global from 'global';
 import React, { FunctionComponent, SyntheticEvent, Fragment } from 'react';
 
 import { AboutPage } from './about_page';
 import { ReleaseNotesPage } from './release_notes_page';
 import { ShortcutsPage } from './shortcuts_page';
 import { matchesModifiers, matchesKeyCode } from '../keybinding';
+
+const { document } = global;
 
 const TabBarButton = React.memo<{
   changeTab: (tab: string) => void;


### PR DESCRIPTION
Issue: #14913 

## What I did

Instead of trying to import named exports from the `global` package which don't exist, this imports a default `global` from the package, and then destructures off the pieces that are desired.  This prevents the error experienced in the referenced issue.

I got agreement from @ndelangen for this approach in [discord](https://discord.com/channels/486522875931656193/501692020226654208/846779578332872704) prior to tackling this one.

## How to test

I had a hard time linking my changes into my reproduction.  It seems that snowpack does not play well with the yarn symlinks that are created via `npx sb@next link --local`.  I did, however, copy the built `dist` folder from `client-logger` out of my changed repo and into my reproduction, and the error changed from one usage to another (there are many, and it's hard to copy them all over).  So I'm pretty certain this change does fix the issue.

- Is this testable with Jest or Chromatic screenshots? I don't think so
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
