### PR TITLE
Core: Add `core.disableWebpackDefaults` preset

### DIFF
--- a/lib/builder-webpack4/src/presets/custom-webpack-preset.ts
+++ b/lib/builder-webpack4/src/presets/custom-webpack-preset.ts
@@ -1,11 +1,20 @@
 import * as webpackReal from 'webpack';
 import { logger } from '@storybook/node-logger';
-import { loadCustomWebpackConfig } from '@storybook/core-common';
+import { CoreConfig, loadCustomWebpackConfig, Options } from '@storybook/core-common';
+import type { Configuration } from 'webpack';
 import { createDefaultWebpackConfig } from '../preview/base-webpack.config';
 
-export async function webpack(config: any, options: any) {
+export async function webpack(config: Configuration, options: Options) {
+  // @ts-ignore
   const { configDir, configType, presets, webpackConfig } = options;
-  const defaultConfig = await createDefaultWebpackConfig(config, options);
+
+  const coreOptions = await options.presets.apply<CoreConfig>('core');
+
+  let defaultConfig = config;
+  if (!coreOptions.disableWebpackDefaults) {
+    defaultConfig = await createDefaultWebpackConfig(config, options);
+  }
+
   const finalDefaultConfig = await presets.apply('webpackFinal', defaultConfig, options);
 
   // through standalone webpackConfig option

--- a/lib/builder-webpack4/src/presets/custom-webpack-preset.ts
+++ b/lib/builder-webpack4/src/presets/custom-webpack-preset.ts
@@ -8,10 +8,10 @@ export async function webpack(config: Configuration, options: Options) {
   // @ts-ignore
   const { configDir, configType, presets, webpackConfig } = options;
 
-  const coreOptions = await options.presets.apply<CoreConfig>('core');
+  const coreOptions = await presets.apply<CoreConfig>('core');
 
   let defaultConfig = config;
-  if (!coreOptions.disableWebpackDefaults) {
+  if (!coreOptions?.disableWebpackDefaults) {
     defaultConfig = await createDefaultWebpackConfig(config, options);
   }
 

--- a/lib/builder-webpack5/src/presets/custom-webpack-preset.ts
+++ b/lib/builder-webpack5/src/presets/custom-webpack-preset.ts
@@ -1,6 +1,6 @@
 import * as webpackReal from 'webpack';
 import { logger } from '@storybook/node-logger';
-import { loadCustomWebpackConfig, Options } from '@storybook/core-common';
+import { loadCustomWebpackConfig, Options, CoreConfig } from '@storybook/core-common';
 import type { Configuration } from 'webpack';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
@@ -9,7 +9,14 @@ import { createDefaultWebpackConfig } from '../preview/base-webpack.config';
 export async function webpack(config: Configuration, options: Options) {
   // @ts-ignore
   const { configDir, configType, presets, webpackConfig } = options;
-  const defaultConfig = await createDefaultWebpackConfig(config, options);
+
+  const coreOptions = await options.presets.apply<CoreConfig>('core');
+
+  let defaultConfig = config;
+  if (!coreOptions.disableWebpackDefaults) {
+    defaultConfig = await createDefaultWebpackConfig(config, options);
+  }
+
   const finalDefaultConfig = await presets.apply('webpackFinal', defaultConfig, options);
 
   // through standalone webpackConfig option

--- a/lib/builder-webpack5/src/presets/custom-webpack-preset.ts
+++ b/lib/builder-webpack5/src/presets/custom-webpack-preset.ts
@@ -10,10 +10,10 @@ export async function webpack(config: Configuration, options: Options) {
   // @ts-ignore
   const { configDir, configType, presets, webpackConfig } = options;
 
-  const coreOptions = await options.presets.apply<CoreConfig>('core');
+  const coreOptions = await presets.apply<CoreConfig>('core');
 
   let defaultConfig = config;
-  if (!coreOptions.disableWebpackDefaults) {
+  if (!coreOptions?.disableWebpackDefaults) {
     defaultConfig = await createDefaultWebpackConfig(config, options);
   }
 

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -20,8 +20,9 @@ export interface TypescriptConfig {
   };
 }
 
-interface CoreConfig {
+export interface CoreConfig {
   builder: 'webpack4' | 'webpack5';
+  disableWebpackDefaults?: boolean;
 }
 
 export interface Presets {
@@ -156,6 +157,7 @@ export interface BuilderOptions {
   docsMode: boolean;
   versionCheck?: VersionCheck;
   releaseNotesData?: ReleaseNotesData;
+  disableWebpackDefaults?: boolean;
 }
 
 export interface StorybookConfigOptions {


### PR DESCRIPTION
Issue:

## What I did

Add a `ignoreWebpackDefaults` which allows builders to opt-out from having Storybook add default webpack configs that are hard to remove unless someone manually removes them in the `webpackFinal` callback in the `main.js`.

This already happens for the CRA by testing whether the preset is present in the add-on list.

https://github.com/storybookjs/storybook/blob/a1371660575b8bf4a529920e28d55505908dcee6/lib/builder-webpack5/src/preview/base-webpack.config.ts#L9-L17

In [Nx](https://nx.dev) we have a similar Storybook builder (executor) that starts Storybook builds and similar to CRA we have a custom Webpack setup which we want to use for Storybook as well. Having this flag, allows to opt-out from the defaults not just for the CRA.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
