### PR TITLE
Addon-docs: Fix per-story `docs.source` parameter

### DIFF
--- a/addons/docs/src/blocks/Canvas.tsx
+++ b/addons/docs/src/blocks/Canvas.tsx
@@ -8,13 +8,9 @@ import {
 } from '@storybook/components';
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { SourceContext, SourceContextProps } from './SourceContainer';
-import { getSourceProps } from './Source';
+import { getSourceProps, SourceState } from './Source';
 
-export enum SourceState {
-  OPEN = 'open',
-  CLOSED = 'closed',
-  NONE = 'none',
-}
+export { SourceState };
 
 type CanvasProps = PurePreviewProps & {
   withSource?: SourceState;
@@ -26,8 +22,8 @@ const getPreviewProps = (
   docsContext: DocsContextProps,
   sourceContext: SourceContextProps
 ): PurePreviewProps => {
-  const { mdxComponentMeta, mdxStoryNameToKey, parameters } = docsContext;
-  const sourceState = withSource || parameters?.docs?.source?.state || SourceState.CLOSED;
+  const { mdxComponentMeta, mdxStoryNameToKey } = docsContext;
+  let sourceState = withSource;
   if (sourceState === SourceState.NONE) {
     return props;
   }
@@ -50,6 +46,8 @@ const getPreviewProps = (
       )
   );
   const sourceProps = getSourceProps({ ids: targetIds }, docsContext, sourceContext);
+  if (!sourceState) sourceState = sourceProps.state;
+
   return {
     ...props, // pass through columns etc.
     withSource: sourceProps,

--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -66,6 +66,7 @@ const getSourceState = (storyIds: string[], docsContext: DocsContextProps) => {
     .filter(Boolean);
 
   if (states.length === 0) return SourceState.CLOSED;
+  // FIXME: handling multiple stories is a pain
   return states[0];
 };
 

--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -15,6 +15,12 @@ import { SourceType } from '../shared';
 
 import { enhanceSource } from './enhanceSource';
 
+export enum SourceState {
+  OPEN = 'open',
+  CLOSED = 'closed',
+  NONE = 'none',
+}
+
 interface CommonProps {
   language?: string;
   dark?: boolean;
@@ -48,6 +54,19 @@ const getStoryContext = (storyId: StoryId, docsContext: DocsContextProps): Story
   }
 
   return storyContext;
+};
+
+const getSourceState = (storyIds: string[], docsContext: DocsContextProps) => {
+  const states = storyIds
+    .map((storyId) => {
+      const storyContext = getStoryContext(storyId, docsContext);
+      if (!storyContext) return null;
+      return storyContext.parameters.docs?.source?.state;
+    })
+    .filter(Boolean);
+
+  if (states.length === 0) return SourceState.CLOSED;
+  return states[0];
 };
 
 const getStorySource = (storyId: StoryId, sourceContext: SourceContextProps): string => {
@@ -88,11 +107,13 @@ const getSnippet = (snippet: string, storyContext?: StoryContext): string => {
   return enhanced?.docs?.source?.code || '';
 };
 
+type SourceStateProps = { state: SourceState };
+
 export const getSourceProps = (
   props: SourceProps,
   docsContext: DocsContextProps,
   sourceContext: SourceContextProps
-): PureSourceProps => {
+): PureSourceProps & SourceStateProps => {
   const { id: currentId, parameters = {} } = docsContext;
 
   const codeProps = props as CodeProps;
@@ -100,10 +121,12 @@ export const getSourceProps = (
   const multiProps = props as MultiSourceProps;
 
   let source = codeProps.code; // prefer user-specified code
+
+  const targetId =
+    singleProps.id === CURRENT_SELECTION || !singleProps.id ? currentId : singleProps.id;
+  const targetIds = multiProps.ids || [targetId];
+
   if (!source) {
-    const targetId =
-      singleProps.id === CURRENT_SELECTION || !singleProps.id ? currentId : singleProps.id;
-    const targetIds = multiProps.ids || [targetId];
     source = targetIds
       .map((storyId) => {
         const storySource = getStorySource(storyId, sourceContext);
@@ -113,13 +136,20 @@ export const getSourceProps = (
       .join('\n\n');
   }
 
+  const state = getSourceState(targetIds, docsContext);
+
   const { docs: docsParameters = {} } = parameters;
   const { source: sourceParameters = {} } = docsParameters;
   const { language: docsLanguage = null } = sourceParameters;
 
   return source
-    ? { code: source, language: props.language || docsLanguage || 'jsx', dark: props.dark || false }
-    : { error: SourceError.SOURCE_UNAVAILABLE };
+    ? {
+        code: source,
+        state,
+        language: props.language || docsLanguage || 'jsx',
+        dark: props.dark || false,
+      }
+    : { error: SourceError.SOURCE_UNAVAILABLE, state };
 };
 
 /**

--- a/examples/official-storybook/preview.js
+++ b/examples/official-storybook/preview.js
@@ -10,7 +10,6 @@ import {
   styled,
   useTheme,
 } from '@storybook/theming';
-import { DocsPage } from '@storybook/addon-docs';
 import { Symbols } from '@storybook/components';
 
 import addHeadWarning from './head-warning';
@@ -159,7 +158,6 @@ export const parameters = {
   },
   docs: {
     theme: themes.light,
-    page: () => <DocsPage subtitleSlot={({ kind }) => `Subtitle: ${kind}`} />,
   },
   controls: {
     presetColors: [

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -31,11 +31,6 @@ export default {
   },
   parameters: {
     chromatic: { disable: true },
-    docs: {
-      source: {
-        state: 'open',
-      },
-    },
   },
 };
 
@@ -53,7 +48,10 @@ Basic.args = {
   children: 'basic',
   json: DEFAULT_NESTED_OBJECT,
 };
-Basic.parameters = { chromatic: { disable: false } };
+Basic.parameters = {
+  chromatic: { disable: false },
+  docs: { source: { state: 'open' } },
+};
 
 export const Action = Template.bind({});
 Action.args = {
@@ -104,6 +102,7 @@ CustomControlMatchers.parameters = {
       date: /whateverIwant/,
     },
   },
+  docs: { source: { state: 'open' } },
 };
 CustomControlMatchers.args = {
   whateverIwant: '10/10/2020',


### PR DESCRIPTION
Issue: #14850 

## What I did

The source block was getting the parameters for the currently selected story only, but the Docs page can show all stories on the page.

- [x] Get per-story parameters
- [x] Add demo stories in `official-storybook`
- [x] Fix an outdated API in `official-storybook` preview config

## How to test

See attached stories:
- [ ] Before: all stories' source is open
- [ ] After: only the stories with `docs.source.state` set is open