### PR TITLE
chore: disable chromatic for angular story

### DIFF
--- a/examples/angular-cli/src/stories/basics/component-with-ng-on-destroy/component-with-on-destroy.stories.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-ng-on-destroy/component-with-on-destroy.stories.ts
@@ -32,6 +32,7 @@ export default {
   component: OnDestroyComponent,
   parameters: {
     storyshots: { disable: true }, // disabled due to new Date()
+    chromatic: { disable: true }, // disabled due to new Date()
   },
 } as Meta;
 


### PR DESCRIPTION
Issue: N/A

## What I did

Same reason as storyshots was disabled.  The story uses new Date() which causes inconsistency in the snapshots in every PR
 
## How to test

- Is this testable with Jest or Chromatic screenshots? yes