### PR TITLE
Update markdown-to-jsx version to fix url links in comments

### DIFF
--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -52,7 +52,7 @@
     "fast-deep-equal": "^3.1.3",
     "global": "^4.4.0",
     "lodash": "^4.17.20",
-    "markdown-to-jsx": "^7.1.0",
+    "markdown-to-jsx": "^7.1.3",
     "memoizerific": "^1.11.3",
     "overlayscrollbars": "^1.13.1",
     "polished": "^4.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6548,7 +6548,7 @@ __metadata:
     global: ^4.4.0
     jest: ^26.6.3
     lodash: ^4.17.20
-    markdown-to-jsx: ^7.1.0
+    markdown-to-jsx: ^7.1.3
     memoizerific: ^1.11.3
     overlayscrollbars: ^1.13.1
     polished: ^4.0.5
@@ -29208,12 +29208,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"markdown-to-jsx@npm:^7.1.0":
-  version: 7.1.1
-  resolution: "markdown-to-jsx@npm:7.1.1"
+"markdown-to-jsx@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "markdown-to-jsx@npm:7.1.3"
   peerDependencies:
     react: ">= 0.14.0"
-  checksum: 0850194a149008054b4a2edaea18d34acf5777454d1c83fb1c5d4a74e494d4dc363fa9697fbb31c675b08408941d53712949b5add5e2ac23b88750e05f06274e
+  checksum: 296fc76230b772748ceb4ce26c1c8ca9d279885548378007c201e101c3cd9f131ed4a905f6c0ba606ffbf81851f2c6fbdca568208995a76919c83ab2234b7c19
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/14176

## What I did

There was an issue with `markdown-to-jsx`, in that it was generating a link twice, when `compodocs` already generated an anchor tag for a given URL string. So when `markdown-to-jsx` would see this:

```html
<a href="https://example.com">
  https://example.com
</a>
```

It would then generate the following:

```html
<a href="https://example.com">
  <a href="https://example.com">
    https://example.com
  </a>
</a>
```

As it adds an anchor tag automatically when it sees a URL link in text.

I issued a PR to `markdown-to-jsx` fixing the duplicated nested link issue (https://github.com/probablyup/markdown-to-jsx/pull/381), it was merged a few days ago. This PR updates the version of the library to apply the fix on this side.

## How to test

1. Add a JSDoc comment with links to the ChipsGroup component on the angular-cli example: https://github.com/storybookjs/storybook/blob/abc74c3f93d48734a7b759e2bec10d234fa81b7e/examples/angular-cli/src/stories/basics/ng-module/angular-src/chips-group.component.ts#L41

It could be something like:
```
  /**
   * This is a test
   * https://example.com
   */
```

2. Run the `angular-cli` example using `yarn storybook`, and go to the ChipsGroup docs page: http://localhost:9008/?path=/docs/basics-ngmodule-module-with-multiple-component--chips-group
3. Validate that the link is generated, and that upon inspecting the DOM elements, there's a single `a` element present.


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
