### PR TITLE
Vue2: Check types when `typescript.check` is true

### DIFF
--- a/app/vue/src/server/framework-preset-vue.ts
+++ b/app/vue/src/server/framework-preset-vue.ts
@@ -2,7 +2,11 @@
 import VueLoaderPlugin from 'vue-loader/lib/plugin';
 import type { Configuration } from 'webpack';
 
-export function webpack(config: Configuration) {
+import type { Options, TypescriptConfig } from '@storybook/core-common';
+
+export async function webpack(config: Configuration, { presets }: Options) {
+  const typescriptOptions = await presets.apply<TypescriptConfig>('typescript', {} as any);
+
   config.plugins.push(new VueLoaderPlugin());
   config.module.rules.push({
     test: /\.vue$/,
@@ -15,7 +19,7 @@ export function webpack(config: Configuration) {
       {
         loader: require.resolve('ts-loader'),
         options: {
-          transpileOnly: true,
+          transpileOnly: !typescriptOptions.check,
           appendTsSuffixTo: [/\.vue$/],
         },
       },


### PR DESCRIPTION
Issue: #14987 

## What I did

Enables type checking when `typescript.check` is `true` on Storybook for Vue.js (vue2).

I noticed `@storybook/vue3` also has an issue with type checking. As it is not listed in [the exclusion list](https://github.com/storybookjs/storybook/blob/abc74c3f93d48734a7b759e2bec10d234fa81b7e/lib/builder-webpack4/src/preview/useBaseTsSupport.ts#L8), `fork-ts-checker-webpack-plugin` runs when a user sets `typescript.check: true`. However, [the plugin does not check SFCs by default](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#vuejs). I could apply the same patch for `@storybook/vue3` but it may be a breaking change for users configuring `fork-ts-checker-webpack-plugin` already, so did not include it here. Please tell me if I should include a patch for vue3 too.

## How to test

- Is this testable with Jest or Chromatic screenshots? ... No
- Does this need a new example in the kitchen sink apps? ... No (without breaking builds)
- Does this need an update to the documentation? ... No

If your answer is yes to any of these, please make sure to include it in your PR.

---

How to manually test on `vue-kitchen-sink`:

1. Create a simple `tsconfig.json`
    ```js
    {
      "compilerOptions": {
        "allowJs": true,
        "strict": true,
        "module": "ES2020",
        "moduleResolution": "Node",
        "target": "ES2015"
      },
      "include": ["./src/**/*.ts", "./src/**/*.vue"]
    }
    ```
2. Enable type checking in `vue-kitchen-sink/.storybook/main.js`
3. Create a `.ts` file so tsc won't complain
    ```ts
    // vue-kitchen-sink/src/foo.ts
    export default 0
    ```
4. Add `const foo: string = 0` to `vue-kitchen-sink/src/stories/components/ButtonTs.vue`
5. Run `yarn storybook` and See an error

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
