### PR TITLE
CLI: Add `SKIP_PREFLIGHT_CHECK` in CRA repro

### DIFF
--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -39,6 +39,7 @@ export const cra: Parameters = {
     'npx create-react-app@{{version}} {{appName}} --use-npm',
     'cd {{appName}}',
     'echo "FAST_REFRESH=true" > .env',
+    'echo "SKIP_PREFLIGHT_CHECK=true" > .env',
   ].join(' && '),
 };
 


### PR DESCRIPTION
Issue: WIP

#15085 

## What I did

CRA complains unnecessarily about babel versions. This disables it from the repro, to eliminate one source of confusion.

self-merging @jonniebigodes @gaetanmaisse @tooppaaa 

## How to test

```
yarn sb repro -t cra cra-test
cd cra-test
yarn storybook
```