### PR TITLE
documentation fixes for addons/controls 

### DIFF
--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -84,23 +84,39 @@ export const Reflow = () => {
   const label = text('Label', 'reflow');
   return (
     <>
-      {Array.from({ length: count }, (_, i) => (
-        <Button label={`button ${i}`} />
+      {[...Array(count)].map((_, i) => (
+        <Button key={i} label={`button ${i}`} />
       ))}
     </>
   );
 };
-```
+``` 
 
 And again, as above, this can be rewritten using [fully custom args](https://storybook.js.org/docs/react/essentials/controls#fully-custom-args):
 
 ```jsx
 export const Reflow = ({ count, label, ...args }) => (
+  <>
+    {[...Array(count)].map((_, i) => (
+        <Button key={i} label={`${label} ${i}`} {...args} />
+    ))}
+  </>
   <>{Array.from({ length: count }, (_, i) => <Button label={`${label} ${i}` {...args}} />)}</>
 );
-Reflow.args = { count: 3, label: 'reflow' };
+
+Reflow.args = { 
+  count: 3, 
+  label: 'reflow' 
+};
+
 Reflow.argTypes = {
-  count: { control: { type: 'range', min: 0, max: 20 } }
+  count: { 
+    control: { 
+      type: 'range', 
+      min: 0, 
+      max: 20 
+    } 
+  }
 };
 ```
 
@@ -125,6 +141,7 @@ export default {
 };
 
 export const Basic = (args) => <Button {...args} />;
+
 Basic.args = {
   label: 'hello',
   borderWidth: 1,

--- a/addons/controls/README.md
+++ b/addons/controls/README.md
@@ -101,7 +101,6 @@ export const Reflow = ({ count, label, ...args }) => (
         <Button key={i} label={`${label} ${i}`} {...args} />
     ))}
   </>
-  <>{Array.from({ length: count }, (_, i) => <Button label={`${label} ${i}` {...args}} />)}</>
 );
 
 Reflow.args = { 


### PR DESCRIPTION
Replaced verbose, uncommonly used, `Array.from` in favor of the commonly-used method (shortest & cleanest method) for generating JSX while also including the very important `key` prop. 

Also fixed a minor mistake in the example code:

```JSX
<Button label={`${label} ${i}` {...args}} />
```

Should have the `args` outside of the `label` prop:

```JSX
<Button key={i} label={`${label} ${i}`} {...args} />
```

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
