### PR TITLE
Essentials: Add measure and outline addons

### DIFF
--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -50,7 +50,7 @@
     "@storybook/node-logger": "6.3.0-beta.8",
     "core-js": "^3.8.2",
     "regenerator-runtime": "^0.13.7",
-    "storybook-addon-outline": "^1.2.0",
+    "storybook-addon-outline": "^1.3.0",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -50,7 +50,7 @@
     "@storybook/node-logger": "6.3.0-beta.8",
     "core-js": "^3.8.2",
     "regenerator-runtime": "^0.13.7",
-    "storybook-addon-outline": "^1.3.0",
+    "storybook-addon-outline": "^1.3.1",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -43,6 +43,7 @@
     "@storybook/addon-backgrounds": "6.3.0-beta.8",
     "@storybook/addon-controls": "6.3.0-beta.8",
     "@storybook/addon-docs": "6.3.0-beta.8",
+    "@storybook/addon-measure": "^1.1.0",
     "@storybook/addon-toolbars": "6.3.0-beta.8",
     "@storybook/addon-viewport": "6.3.0-beta.8",
     "@storybook/addons": "6.3.0-beta.8",
@@ -50,7 +51,7 @@
     "@storybook/node-logger": "6.3.0-beta.8",
     "core-js": "^3.8.2",
     "regenerator-runtime": "^0.13.7",
-    "storybook-addon-outline": "^1.3.1",
+    "storybook-addon-outline": "^1.3.2",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -50,6 +50,7 @@
     "@storybook/node-logger": "6.3.0-beta.8",
     "core-js": "^3.8.2",
     "regenerator-runtime": "^0.13.7",
+    "storybook-addon-outline": "^1.2.0",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {

--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -37,9 +37,9 @@ export function addons(options: PresetOptions = {}) {
 
   const main = requireMain(options.configDir);
   return (
-    ['docs', 'controls', 'actions', 'backgrounds', 'viewport', 'toolbars']
+    ['docs', 'controls', 'actions', 'backgrounds', 'viewport', 'toolbars', 'measure', 'outline']
       .filter((key) => (options as any)[key] !== false)
-      .map((key) => `@storybook/addon-${key}`)
+      .map((key) => (key === 'outline' ? `storybook-addon-${key}` : `@storybook/addon-${key}`))
       .filter((addon) => !checkInstalled(addon, main))
       // Use `require.resolve` to ensure Yarn PnP compatibility
       // Files of various addons should be resolved in the context of `addon-essentials` as they are listed as deps here

--- a/lib/components/src/Zoom/Zoom.stories.tsx
+++ b/lib/components/src/Zoom/Zoom.stories.tsx
@@ -85,6 +85,12 @@ iFrameActualSize.args = {
   active: true,
 };
 
+// The iFrame stories are disabled because useGlobals works in practice
+// but, for some reason breaks in the stories for Zoom.iFrame
+iFrameActualSize.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
 export const iFrameZoomedIn = TemplateIFrame.bind({});
 
 iFrameZoomedIn.args = {
@@ -92,9 +98,17 @@ iFrameZoomedIn.args = {
   active: true,
 };
 
+iFrameZoomedIn.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
 export const iFrameZoomedOut = TemplateIFrame.bind({});
 
 iFrameZoomedOut.args = {
   scale: 3,
   active: true,
+};
+
+iFrameZoomedOut.parameters = {
+  chromatic: { disableSnapshot: true },
 };

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-dev
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-dev
@@ -10,6 +10,8 @@ Object {
     "ROOT/addons/actions/dist/esm/register.js",
     "ROOT/addons/backgrounds/dist/esm/register.js",
     "ROOT/addons/toolbars/dist/esm/register.js",
+    "NODE_MODULES/@storybook/addon-measure/dist/preset/manager.js",
+    "NODE_MODULES/storybook-addon-outline/dist/preset/register.js",
     "ROOT/examples/cra-ts-essentials/.storybook/generated-refs.js",
   ],
   "keys": Array [

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod
@@ -10,6 +10,8 @@ Object {
     "ROOT/addons/actions/dist/esm/register.js",
     "ROOT/addons/backgrounds/dist/esm/register.js",
     "ROOT/addons/toolbars/dist/esm/register.js",
+    "NODE_MODULES/@storybook/addon-measure/dist/preset/manager.js",
+    "NODE_MODULES/storybook-addon-outline/dist/preset/register.js",
     "ROOT/examples/cra-ts-essentials/.storybook/generated-refs.js",
   ],
   "keys": Array [

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-dev
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-dev
@@ -12,6 +12,8 @@ Object {
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "NODE_MODULES/@storybook/addon-measure/dist/preset/preview.js-generated-other-entry.js",
+    "NODE_MODULES/storybook-addon-outline/dist/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/examples/cra-ts-essentials/.storybook/preview.js-generated-config-entry.js",
     "ROOT/examples/cra-ts-essentials/.storybook/generated-stories-entry.js",
     "NODE_MODULES/webpack-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined",

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod
@@ -12,6 +12,8 @@ Object {
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "NODE_MODULES/@storybook/addon-measure/dist/preset/preview.js-generated-other-entry.js",
+    "NODE_MODULES/storybook-addon-outline/dist/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/examples/cra-ts-essentials/.storybook/preview.js-generated-config-entry.js",
     "ROOT/examples/cra-ts-essentials/.storybook/generated-stories-entry.js",
   ],

--- a/lib/core-server/src/__snapshots__/vue-3-cli_manager-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_manager-dev
@@ -12,6 +12,8 @@ Object {
     "ROOT/addons/backgrounds/dist/esm/register.js",
     "ROOT/addons/viewport/dist/esm/register.js",
     "ROOT/addons/toolbars/dist/esm/register.js",
+    "NODE_MODULES/@storybook/addon-measure/dist/preset/manager.js",
+    "NODE_MODULES/storybook-addon-outline/dist/preset/register.js",
     "ROOT/examples/vue-3-cli/.storybook/generated-refs.js",
   ],
   "keys": Array [

--- a/lib/core-server/src/__snapshots__/vue-3-cli_manager-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_manager-prod
@@ -12,6 +12,8 @@ Object {
     "ROOT/addons/backgrounds/dist/esm/register.js",
     "ROOT/addons/viewport/dist/esm/register.js",
     "ROOT/addons/toolbars/dist/esm/register.js",
+    "NODE_MODULES/@storybook/addon-measure/dist/preset/manager.js",
+    "NODE_MODULES/storybook-addon-outline/dist/preset/register.js",
     "ROOT/examples/vue-3-cli/.storybook/generated-refs.js",
   ],
   "keys": Array [

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
@@ -13,6 +13,8 @@ Object {
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "NODE_MODULES/@storybook/addon-measure/dist/preset/preview.js-generated-other-entry.js",
+    "NODE_MODULES/storybook-addon-outline/dist/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/examples/vue-3-cli/.storybook/preview.ts-generated-config-entry.js",
     "ROOT/examples/vue-3-cli/.storybook/generated-stories-entry.js",
     "NODE_MODULES/webpack-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
@@ -13,6 +13,8 @@ Object {
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addParameter.js-generated-other-entry.js",
+    "NODE_MODULES/@storybook/addon-measure/dist/preset/preview.js-generated-other-entry.js",
+    "NODE_MODULES/storybook-addon-outline/dist/preset/addDecorator.js-generated-other-entry.js",
     "ROOT/examples/vue-3-cli/.storybook/preview.ts-generated-config-entry.js",
     "ROOT/examples/vue-3-cli/.storybook/generated-stories-entry.js",
   ],

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -59,6 +59,10 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
+  '@storybook/addon-measure':
+    access: $all
+    publish: $all
+    proxy: npmjs
 
   # storybook packages are NOT proxied to global registry
   # allowing us to republish any version during tests

--- a/yarn.lock
+++ b/yarn.lock
@@ -5818,7 +5818,7 @@ __metadata:
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
-    storybook-addon-outline: ^1.3.1
+    storybook-addon-outline: ^1.3.2
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
@@ -6118,7 +6118,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addons@6.3.0-beta.8, @storybook/addons@workspace:*, @storybook/addons@workspace:lib/addons":
+"@storybook/addons@6.3.0-beta.8, @storybook/addons@^6.3.0-beta.6, @storybook/addons@workspace:*, @storybook/addons@workspace:lib/addons":
   version: 0.0.0-use.local
   resolution: "@storybook/addons@workspace:lib/addons"
   dependencies:
@@ -6215,7 +6215,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/api@6.3.0-beta.8, @storybook/api@workspace:*, @storybook/api@workspace:lib/api":
+"@storybook/api@6.3.0-beta.8, @storybook/api@^6.3.0-beta.6, @storybook/api@workspace:*, @storybook/api@workspace:lib/api":
   version: 0.0.0-use.local
   resolution: "@storybook/api@workspace:lib/api"
   dependencies:
@@ -6552,7 +6552,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/components@6.3.0-beta.8, @storybook/components@workspace:*, @storybook/components@workspace:lib/components":
+"@storybook/components@6.3.0-beta.8, @storybook/components@^6.3.0-beta.6, @storybook/components@workspace:*, @storybook/components@workspace:lib/components":
   version: 0.0.0-use.local
   resolution: "@storybook/components@workspace:lib/components"
   dependencies:
@@ -6684,7 +6684,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-events@6.3.0-beta.8, @storybook/core-events@workspace:*, @storybook/core-events@workspace:lib/core-events":
+"@storybook/core-events@6.3.0-beta.8, @storybook/core-events@^6.3.0-beta.6, @storybook/core-events@workspace:*, @storybook/core-events@workspace:lib/core-events":
   version: 0.0.0-use.local
   resolution: "@storybook/core-events@workspace:lib/core-events"
   dependencies:
@@ -39059,9 +39059,9 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"storybook-addon-outline@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "storybook-addon-outline@npm:1.3.1"
+"storybook-addon-outline@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "storybook-addon-outline@npm:1.3.2"
   dependencies:
     "@storybook/addons": ^6.3.0-beta.6
     "@storybook/api": ^6.3.0-beta.6
@@ -39071,7 +39071,7 @@ resolve@1.19.0:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 4af1f3cbc334195204fa7220624e00abf5a5a31100fc659a770780ffa47c83e14f9c021cfac21608634793efb6ad243cdc54ca6f58bc48da7e8a2d796791c62b
+  checksum: 75586ff5093ab904ad1d5d98b0934d009192ebb02db4ae986f40f50e4b72e0ce131afa46932d68dca6e9849a13e7355cb7745b19dc60e5b9624a696eb8b611aa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5817,6 +5817,7 @@ __metadata:
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
+    storybook-addon-outline: ^1.2.0
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
@@ -5896,6 +5897,26 @@ __metadata:
       optional: true
   languageName: unknown
   linkType: soft
+
+"@storybook/addon-measure@npm:latest":
+  version: 1.1.0
+  resolution: "@storybook/addon-measure@npm:1.1.0"
+  peerDependencies:
+    "@storybook/addons": ^6.3.0-beta.1
+    "@storybook/api": ^6.3.0-beta.1
+    "@storybook/components": ^6.3.0-beta.1
+    "@storybook/core-events": ^6.3.0-beta.1
+    "@storybook/theming": ^6.3.0-beta.1
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 33441086c7870b58fe718e3084b7fd7ff194938c243ac156a132eb7ee6e66b0e03d3556ab061b47fcc28ffdc134428502f9aeb67c615075f0869f34ae773a366
+  languageName: node
+  linkType: hard
 
 "@storybook/addon-postcss@npm:^2.0.0":
   version: 2.0.0
@@ -7437,6 +7458,27 @@ __metadata:
     react-dom: ^16.8.0 || ^17.0.0
   languageName: unknown
   linkType: soft
+
+"@storybook/router@npm:6.2.9":
+  version: 6.2.9
+  resolution: "@storybook/router@npm:6.2.9"
+  dependencies:
+    "@reach/router": ^1.3.4
+    "@storybook/client-logger": 6.2.9
+    "@types/reach__router": ^1.3.7
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.20
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: eb1bb075ff68bb07b5a1bceda8581c35e90f0d726ba5d107804face72e31e1c629e2e26f57c71413fe162f9ef630cd44b1183b8615e67797a26b29437e028fe3
+  languageName: node
+  linkType: hard
 
 "@storybook/semver@npm:^7.3.2":
   version: 7.3.2
@@ -39037,6 +39079,18 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
+"storybook-addon-outline@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "storybook-addon-outline@npm:1.2.0"
+  dependencies:
+    "@storybook/addons": ^6.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 9a6d5cb027b43ed9cbe9884b813eada1c02eede778254d328ca09c80e858a5b2e17f3e220aec6e5cb724fc28737a1ea7986b947a75fac09084a71eba039398aa
+  languageName: node
+  linkType: hard
+
 "storybook@workspace:lib/cli-storybook":
   version: 0.0.0-use.local
   resolution: "storybook@workspace:lib/cli-storybook"
@@ -40098,6 +40152,22 @@ resolve@1.19.0:
     stream-events: ^1.0.5
     uuid: ^3.3.2
   checksum: 315856efe6aec9b8d7812b5f2a0894aa4637c08055dbe9af43c491debec79fe8709b5965d1a9da2de7eee359ec93076900593044a08399a620c4a57ded49ddf0
+  languageName: node
+  linkType: hard
+
+"telejson@npm:^5.1.0":
+  version: 5.3.3
+  resolution: "telejson@npm:5.3.3"
+  dependencies:
+    "@types/is-function": ^1.0.0
+    global: ^4.4.0
+    is-function: ^1.0.2
+    is-regex: ^1.1.2
+    is-symbol: ^1.0.3
+    isobject: ^4.0.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+  checksum: 14be7bf39634c253181eceabe10c6fe1768ba2baf7a1aad8b0289b9ca7fff976d4ecd9445628ef1e9faf382e2c46e3a7db7da2e3b0bd8a540917d20ff18cd182
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5807,6 +5807,7 @@ __metadata:
     "@storybook/addon-backgrounds": 6.3.0-beta.8
     "@storybook/addon-controls": 6.3.0-beta.8
     "@storybook/addon-docs": 6.3.0-beta.8
+    "@storybook/addon-measure": ^1.1.0
     "@storybook/addon-toolbars": 6.3.0-beta.8
     "@storybook/addon-viewport": 6.3.0-beta.8
     "@storybook/addons": 6.3.0-beta.8
@@ -5817,7 +5818,7 @@ __metadata:
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
-    storybook-addon-outline: ^1.2.0
+    storybook-addon-outline: ^1.3.0
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
@@ -5898,7 +5899,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-measure@npm:latest":
+"@storybook/addon-measure@npm:^1.1.0":
   version: 1.1.0
   resolution: "@storybook/addon-measure@npm:1.1.0"
   peerDependencies:
@@ -7458,27 +7459,6 @@ __metadata:
     react-dom: ^16.8.0 || ^17.0.0
   languageName: unknown
   linkType: soft
-
-"@storybook/router@npm:6.2.9":
-  version: 6.2.9
-  resolution: "@storybook/router@npm:6.2.9"
-  dependencies:
-    "@reach/router": ^1.3.4
-    "@storybook/client-logger": 6.2.9
-    "@types/reach__router": ^1.3.7
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.20
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-    ts-dedent: ^2.0.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: eb1bb075ff68bb07b5a1bceda8581c35e90f0d726ba5d107804face72e31e1c629e2e26f57c71413fe162f9ef630cd44b1183b8615e67797a26b29437e028fe3
-  languageName: node
-  linkType: hard
 
 "@storybook/semver@npm:^7.3.2":
   version: 7.3.2
@@ -39079,15 +39059,18 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"storybook-addon-outline@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "storybook-addon-outline@npm:1.2.0"
+"storybook-addon-outline@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "storybook-addon-outline@npm:1.3.0"
   dependencies:
-    "@storybook/addons": ^6.0.0
+    "@storybook/addons": ^6.3.0-beta.6
+    "@storybook/api": ^6.3.0-beta.6
+    "@storybook/components": ^6.3.0-beta.6
+    "@storybook/core-events": ^6.3.0-beta.6
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 9a6d5cb027b43ed9cbe9884b813eada1c02eede778254d328ca09c80e858a5b2e17f3e220aec6e5cb724fc28737a1ea7986b947a75fac09084a71eba039398aa
+  checksum: bd973699508e9a553a101563663122cc9648d5a389567b07b6f09ee4db1587c9dd11ebe75b66b74336c927d9b18f254d59f1d398c6e335d672af212db9430442
   languageName: node
   linkType: hard
 
@@ -40152,22 +40135,6 @@ resolve@1.19.0:
     stream-events: ^1.0.5
     uuid: ^3.3.2
   checksum: 315856efe6aec9b8d7812b5f2a0894aa4637c08055dbe9af43c491debec79fe8709b5965d1a9da2de7eee359ec93076900593044a08399a620c4a57ded49ddf0
-  languageName: node
-  linkType: hard
-
-"telejson@npm:^5.1.0":
-  version: 5.3.3
-  resolution: "telejson@npm:5.3.3"
-  dependencies:
-    "@types/is-function": ^1.0.0
-    global: ^4.4.0
-    is-function: ^1.0.2
-    is-regex: ^1.1.2
-    is-symbol: ^1.0.3
-    isobject: ^4.0.0
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-  checksum: 14be7bf39634c253181eceabe10c6fe1768ba2baf7a1aad8b0289b9ca7fff976d4ecd9445628ef1e9faf382e2c46e3a7db7da2e3b0bd8a540917d20ff18cd182
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5818,7 +5818,7 @@ __metadata:
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
-    storybook-addon-outline: ^1.3.0
+    storybook-addon-outline: ^1.3.1
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
@@ -39059,18 +39059,19 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"storybook-addon-outline@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "storybook-addon-outline@npm:1.3.0"
+"storybook-addon-outline@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "storybook-addon-outline@npm:1.3.1"
   dependencies:
     "@storybook/addons": ^6.3.0-beta.6
     "@storybook/api": ^6.3.0-beta.6
     "@storybook/components": ^6.3.0-beta.6
     "@storybook/core-events": ^6.3.0-beta.6
+    ts-dedent: ^2.1.1
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: bd973699508e9a553a101563663122cc9648d5a389567b07b6f09ee4db1587c9dd11ebe75b66b74336c927d9b18f254d59f1d398c6e335d672af212db9430442
+  checksum: 4af1f3cbc334195204fa7220624e00abf5a5a31100fc659a770780ffa47c83e14f9c021cfac21608634793efb6ad243cdc54ca6f58bc48da7e8a2d796791c62b
   languageName: node
   linkType: hard
 
@@ -41011,6 +41012,13 @@ resolve@1.19.0:
   version: 2.0.0
   resolution: "ts-dedent@npm:2.0.0"
   checksum: dc22c2a7184ce80cb19b5619199dc33128750c7ffe366eecdb50fcc39a19347921d950c90af8418ef4d15271528bc75340efa23acce271aeb618c9a54fd0383c
+  languageName: node
+  linkType: hard
+
+"ts-dedent@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "ts-dedent@npm:2.1.1"
+  checksum: 7ac68dbc2e864db6e3f0500a8b6af5bf775020bfe09816cf647469e06acdcb76d2a24b1b0211614c3c44e0978aa081a51a3dde6b8f211a68f945cbc177f7f9c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue:

## What I did
Added the Measure and Outline addons to `@storybook/addon-essentials`

## How to test
Build `@storybook/addon-essentials` and load up any of the example Storybooks

- Is this testable with Jest or Chromatic screenshots?
No

- Does this need a new example in the kitchen sink apps?
No

- Does this need an update to the documentation?
Yes, should add Measure and Outline to the list of essential addons

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
