### PR TITLE
Chore: (Docs) Minor polish to the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report 🐞
-about: Something is broken and you have a reliable reproduction? Let us know here. For questions, please use "Question" below.
+about: Something is broken, and you have a reliable reproduction? Let us know here. For questions, please use "Question" below.
 labels: needs triage, bug
 ---
 
@@ -8,8 +8,8 @@ labels: needs triage, bug
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Please create a reproduction repo by running `npx sb@next repro` and following the instructions.
-When you're done, please link the repo here. We prioritize issues with reproductions over those without.
+Please create a reproduction by running `npx sb@next repro` and following the instructions. Read our [documentation](https://storybook.js.org/docs/react/contribute/how-to-reproduce) to learn more about creating reproductions.
+Paste your repository and deployed reproduction here. We prioritize issues with reproductions over those without.
 
 **System**
 Please paste the results of `npx sb@next info` here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report 🐞
-about: Something is broken, and you have a reliable reproduction? Let us know here. For questions, please use "Question" below.
+about: Something is broken and you have a reliable reproduction? Let us know here. For questions, please use "Question" below.
 labels: needs triage, bug
 ---
 


### PR DESCRIPTION
With this pull request, the bug report issue template was polished and now features the documentation on how to create a reproduction.

Feel free to provide feedback.

@shilman I left the maintenance label as a safeguard. If that's not the proper label, can you update it?



