### PR TITLE
Core: Fix prebuilt manager usage on first run

### DIFF
--- a/lib/manager-webpack4/src/utils/prebuilt-manager.ts
+++ b/lib/manager-webpack4/src/utils/prebuilt-manager.ts
@@ -1,4 +1,3 @@
-import { logger } from '@storybook/node-logger';
 import { pathExists } from 'fs-extra';
 import path from 'path';
 import {
@@ -44,6 +43,5 @@ export const getPrebuiltDir = async (options: Options): Promise<string | false> 
   const autoRefs = await getAutoRefs(options);
   if (autoRefs.length > 0) return false;
 
-  logger.info('=> Using prebuilt manager');
   return prebuiltDir;
 };

--- a/lib/manager-webpack5/src/index.ts
+++ b/lib/manager-webpack5/src/index.ts
@@ -20,6 +20,8 @@ let reject: (reason?: any) => void;
 
 type WebpackBuilder = Builder<Configuration, Stats>;
 
+export const WEBPACK_VERSION = '5';
+
 export const getConfig: WebpackBuilder['getConfig'] = getManagerWebpackConfig;
 
 export const makeStatsFromError = (err: string) =>
@@ -31,39 +33,41 @@ export const makeStatsFromError = (err: string) =>
 
 export const executor = {
   get: async (options: Options) => {
-    const version = ((await options.presets.apply('webpackVersion')) || '5') as string;
+    const version = ((await options.presets.apply('webpackVersion')) || WEBPACK_VERSION) as string;
     const webpackInstance =
       (await options.presets.apply<{ default: typeof webpack }>('webpackInstance'))?.default ||
       webpack;
-    checkWebpackVersion({ version }, '5', 'manager-webpack5');
+    checkWebpackVersion({ version }, WEBPACK_VERSION, `manager-webpack${WEBPACK_VERSION}`);
     return webpackInstance;
   },
 };
 
 export const start: WebpackBuilder['start'] = async ({ startTime, options, router }) => {
-  const webpackInstance = await executor.get(options);
-
   const prebuiltDir = await getPrebuiltDir(options);
-  const config = await getConfig(options);
+  if (prebuiltDir && options.managerCache && !options.smokeTest) {
+    logger.info('=> Using prebuilt manager');
+    router.use('/', express.static(prebuiltDir));
+    return;
+  }
 
+  const config = await getConfig(options);
   if (options.cache) {
-    // Retrieve the Storybook version number to bust cache up upgrades.
+    // Retrieve the Storybook version number to bust cache on upgrades.
     const packageFile = await findUp('package.json', { cwd: __dirname });
     const { version: storybookVersion } = await fs.readJSON(packageFile);
-    const cacheKey = `managerConfig@${storybookVersion}`;
+    const cacheKey = `managerConfig-webpack${WEBPACK_VERSION}@${storybookVersion}`;
 
     if (options.managerCache) {
       const [useCache, hasOutput] = await Promise.all([
-        // must run even if outputDir doesn't exist, otherwise the 2nd run won't use cache
+        // useManagerCache sets the cache, so it must run even if outputDir doesn't exist yet,
+        // otherwise the 2nd run won't be able to use the manager built on the 1st run.
         useManagerCache(cacheKey, options, config),
         fs.pathExists(options.outputDir),
       ]);
       if (useCache && hasOutput && !options.smokeTest) {
         logger.line(1); // force starting new line
         logger.info('=> Using cached manager');
-        // Manager static files
-        router.use('/', express.static(prebuiltDir || options.outputDir));
-
+        router.use('/', express.static(options.outputDir));
         return;
       }
     } else if (!options.smokeTest && (await clearManagerCache(cacheKey, options))) {
@@ -72,6 +76,7 @@ export const start: WebpackBuilder['start'] = async ({ startTime, options, route
     }
   }
 
+  const webpackInstance = await executor.get(options);
   const compiler = (webpackInstance as any)(config);
 
   if (!compiler) {

--- a/lib/manager-webpack5/src/utils/prebuilt-manager.ts
+++ b/lib/manager-webpack5/src/utils/prebuilt-manager.ts
@@ -1,4 +1,3 @@
-import { logger } from '@storybook/node-logger';
 import { pathExists } from 'fs-extra';
 import path from 'path';
 import {
@@ -44,6 +43,5 @@ export const getPrebuiltDir = async (options: Options): Promise<string | false> 
   const autoRefs = await getAutoRefs(options);
   if (autoRefs.length > 0) return false;
 
-  logger.info('=> Using prebuilt manager');
   return prebuiltDir;
 };


### PR DESCRIPTION
Issue: #15115

## What I did

When the prebuilt manager can be used, ensure that we actually do so and not continue compiling the manager anyway.
I've also made the webpack version part of the cache key for manager caching, so you won't end up using a cached webpack4 manager when switching to webpack5.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? We should have one that uses the prebuilt manager
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
