### PR TITLE
UI: Fix padded layout in Firefox after resetting scale

### DIFF
--- a/examples/angular-cli/.storybook/main.js
+++ b/examples/angular-cli/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     '@storybook/addon-controls',
     '@storybook/addon-storysource',
     '@storybook/addon-actions',
+    '@storybook/addon-viewport',
     '@storybook/addon-links',
     '@storybook/addon-jest',
     '@storybook/addon-backgrounds',

--- a/lib/core-common/src/templates/base-preview-head.html
+++ b/lib/core-common/src/templates/base-preview-head.html
@@ -40,6 +40,7 @@
     margin: 0;
     padding: 1rem;
     display: block;
+    box-sizing: border-box;
   }
 
   .sb-wrapper {


### PR DESCRIPTION
Issue: #15041 

## What I did
I've started the angular project (example/angular-cli), noticed the bug in firefox (not in chrome). Applied the suggested fix (add box-sizing property). 

## How to test
- Assuming no need to add a specific test.
- reproduce steps are in the issue.

* i've added the viewport addon to the storybook instance. im not sure if it's desirable to keep that in there. let me know if we need to remove it.

Regards

