### PR TITLE
Angular: Fix Ivy rendering to use at most one render promise at a time

### DIFF
--- a/addons/docs/src/frameworks/angular/prepareForInline.ts
+++ b/addons/docs/src/frameworks/angular/prepareForInline.ts
@@ -17,7 +17,8 @@ export const prepareForInline = (storyFn: StoryFn<IStory>, { id, parameters }: S
         return null;
       }
 
-      return limit(() => rendererFactory.getRendererInstance(id, node)).then(async (renderer) => {
+      return limit(async () => {
+        const renderer = await rendererFactory.getRendererInstance(id, node);
         await renderer.render({
           forced: false,
           parameters,


### PR DESCRIPTION
Issue:

## What I did

ensures that only one `render ` promise is made at a time

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
