### PR TITLE
CLI: Update project template for web-components

### DIFF
--- a/lib/cli/src/generators/WEB-COMPONENTS/index.ts
+++ b/lib/cli/src/generators/WEB-COMPONENTS/index.ts
@@ -1,9 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
-import { copyTemplate } from '../../helpers';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  await baseGenerator(packageManager, npmOptions, options, 'web-components');
-  copyTemplate(__dirname, options.storyFormat);
+  return baseGenerator(packageManager, npmOptions, options, 'web-components');
 };
 
 export default generator;

--- a/lib/cli/src/generators/WEB-COMPONENTS/template-csf/.storybook/preview.js
+++ b/lib/cli/src/generators/WEB-COMPONENTS/template-csf/.storybook/preview.js
@@ -1,3 +1,0 @@
-// import { setCustomElements } from '@storybook/web-components';
-// import customElements from '../custom-elements.json';
-// setCustomElements(customElements);

--- a/lib/cli/src/generators/WEB-COMPONENTS/template-csf/.storybook/preview.js
+++ b/lib/cli/src/generators/WEB-COMPONENTS/template-csf/.storybook/preview.js
@@ -1,30 +1,3 @@
-/* global window */
-
-import {
-  configure,
-  addParameters,
-  // setCustomElements,
-} from '@storybook/web-components';
-
+// import { setCustomElements } from '@storybook/web-components';
 // import customElements from '../custom-elements.json';
-
 // setCustomElements(customElements);
-
-addParameters({
-  docs: {
-    iframeHeight: '200px',
-  },
-});
-
-// configure(require.context('../stories', true, /\.stories\.(js|mdx)$/), module);
-
-// force full reload to not reregister web components
-const req = require.context('../stories', true, /\.stories\.(js|mdx)$/);
-configure(req, module);
-if (module.hot) {
-  module.hot.accept(req.id, () => {
-    const currentLocationHref = window.location.href;
-    window.history.pushState(null, null, currentLocationHref);
-    window.location.reload();
-  });
-}


### PR DESCRIPTION
Issue: #9793

## What I did

Fix the `web-components` project template:
- [x] remove docs iframe height because sb/w-c is inline by default now
- [x] remove the configure and HMR because it's built into sb/wc

## How to test

In a new w-c project:

```
/path/to/lib/cli/bin/index.js init
yarn storybook
```