### PR TITLE
Angular: Clear root / docs-root when navigating from one tab to the other

### DIFF
--- a/app/angular/src/client/preview/angular-beta/RendererFactory.test.ts
+++ b/app/angular/src/client/preview/angular-beta/RendererFactory.test.ts
@@ -212,6 +212,32 @@ describe('RendererFactory', () => {
   });
 
   describe('DocsRenderer', () => {
+    describe('when canvas render is done before', () => {
+      beforeEach(async () => {
+        // Init first Canvas render
+        const render = await rendererFactory.getRendererInstance('my-story', rootTargetDOMNode);
+        await render.render({
+          storyFnAngular: {
+            template: 'Canvas 🖼',
+          },
+          forced: true,
+          parameters: {} as any,
+          targetDOMNode: rootTargetDOMNode,
+        });
+      });
+
+      it('should reset root HTML', async () => {
+        global.document.getElementById('root').appendChild(global.document.createElement('👾'));
+
+        expect(global.document.getElementById('root').innerHTML).toContain('Canvas 🖼');
+        const render = await rendererFactory.getRendererInstance(
+          'my-story-in-docs',
+          rootDocstargetDOMNode
+        );
+        expect(global.document.getElementById('root').innerHTML).toBe('');
+      });
+    });
+
     it('should get DocsRenderer instance', async () => {
       const render = await rendererFactory.getRendererInstance(
         'my-story-in-docs',

--- a/app/angular/src/client/preview/angular-beta/RendererFactory.ts
+++ b/app/angular/src/client/preview/angular-beta/RendererFactory.ts
@@ -12,8 +12,9 @@ export class RendererFactory {
     const renderType = getRenderType(targetDOMNode);
     // keep only instances of the same type
     if (this.lastRenderType && this.lastRenderType !== renderType) {
-      this.rendererMap.clear();
       await AbstractRenderer.resetPlatformBrowserDynamic();
+      clearRootHTMLElement(renderType);
+      this.rendererMap.clear();
     }
 
     if (!this.rendererMap.has(storyId)) {
@@ -35,3 +36,17 @@ export class RendererFactory {
 export const getRenderType = (targetDOMNode: HTMLElement): RenderType => {
   return targetDOMNode.id === 'root' ? 'canvas' : 'docs';
 };
+
+export function clearRootHTMLElement(renderType: RenderType) {
+  switch (renderType) {
+    case 'canvas':
+      global.document.getElementById('docs-root').innerHTML = '';
+      break;
+
+    case 'docs':
+      global.document.getElementById('root').innerHTML = '';
+      break;
+    default:
+      break;
+  }
+}


### PR DESCRIPTION
Issue:

when I switch from canvas to docs the canvas story is not displayed
exactly the same problem :
https://discord.com/channels/486522875931656193/490770949910691862/850254520281595914
And the problem is that it continues to update the component / story in the root and not root-docs html element

## What I did

clear root / docs-root when navigating from one to the other 
otherwise angular will select the 1st component that matches the ng selector (which is the story id) and will not work for the 2nd

Usually angular's destroy PlatformBrowserDynamic does the cleaning. but in some applications it doesn't. this solution makes sure it's done in all cases 

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

