### PR TITLE
Angular: Add compodoc to ng builder

### DIFF
--- a/app/angular/src/builders/build-storybook/index.spec.ts
+++ b/app/angular/src/builders/build-storybook/index.spec.ts
@@ -1,12 +1,19 @@
-import { Architect } from '@angular-devkit/architect';
+import { Architect, createBuilder } from '@angular-devkit/architect';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { schema } from '@angular-devkit/core';
 import * as path from 'path';
 
 const buildStandaloneMock = jest.fn().mockImplementation((_options: unknown) => Promise.resolve());
-
 jest.doMock('@storybook/angular/standalone', () => buildStandaloneMock);
 
+const cpSpawnMock = {
+  spawn: jest.fn().mockImplementation(() => ({
+    stdout: { on: () => {} },
+    stderr: { on: () => {} },
+    on: (_event: string, cb: any) => cb(0),
+  })),
+};
+jest.doMock('child_process', () => cpSpawnMock);
 describe('Build Storybook Builder', () => {
   let architect: Architect;
   let architectHost: TestingArchitectHost;
@@ -18,14 +25,40 @@ describe('Build Storybook Builder', () => {
     architectHost = new TestingArchitectHost();
     architect = new Architect(architectHost, registry);
 
+    architectHost.addBuilder(
+      '@angular-devkit/build-angular:browser',
+      createBuilder(() => {
+        return { success: true };
+      })
+    );
+    architectHost.addTarget(
+      { project: 'angular-cli', target: 'build-2' },
+      '@angular-devkit/build-angular:browser',
+      {
+        outputPath: 'dist/angular-cli',
+        index: 'src/index.html',
+        main: 'src/main.ts',
+        polyfills: 'src/polyfills.ts',
+        tsConfig: 'src/tsconfig.app.json',
+        assets: ['src/favicon.ico', 'src/assets'],
+        styles: ['src/styles.css'],
+        scripts: [],
+      }
+    );
+
     // This will either take a Node package name, or a path to the directory
     // for the package.json file.
     await architectHost.addBuilderFromPackage(path.join(__dirname, '../../..'));
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should work', async () => {
     const run = await architect.scheduleBuilder('@storybook/angular:build-storybook', {
       browserTarget: 'angular-cli:build-2',
+      compodoc: false,
     });
 
     const output = await run.result;
@@ -33,6 +66,7 @@ describe('Build Storybook Builder', () => {
     await run.stop();
 
     expect(output.success).toBeTruthy();
+    expect(cpSpawnMock.spawn).not.toHaveBeenCalledWith();
     expect(buildStandaloneMock).toHaveBeenCalledWith({
       angularBrowserTarget: 'angular-cli:build-2',
       browserTarget: 'angular-cli:build-2',
@@ -43,6 +77,41 @@ describe('Build Storybook Builder', () => {
       outputDir: 'storybook-static',
       staticDir: [],
       mode: 'static',
+      compodoc: false,
+      compodocArgs: ['-e', 'json'],
+    });
+  });
+
+  it('should run compodoc', async () => {
+    const run = await architect.scheduleBuilder('@storybook/angular:build-storybook', {
+      browserTarget: 'angular-cli:build-2',
+    });
+
+    const output = await run.result;
+
+    await run.stop();
+
+    expect(output.success).toBeTruthy();
+    expect(cpSpawnMock.spawn).toHaveBeenCalledWith('compodoc', [
+      '-p',
+      'src/tsconfig.app.json',
+      '-d',
+      '',
+      '-e',
+      'json',
+    ]);
+    expect(buildStandaloneMock).toHaveBeenCalledWith({
+      angularBrowserTarget: 'angular-cli:build-2',
+      browserTarget: 'angular-cli:build-2',
+      configDir: '.storybook',
+      docs: false,
+      loglevel: undefined,
+      quiet: false,
+      outputDir: 'storybook-static',
+      staticDir: [],
+      mode: 'static',
+      compodoc: true,
+      compodocArgs: ['-e', 'json'],
     });
   });
 });

--- a/app/angular/src/builders/build-storybook/schema.json
+++ b/app/angular/src/builders/build-storybook/schema.json
@@ -40,6 +40,19 @@
       "type": "boolean",
       "description": "Starts Storybook in documentation mode. Learn more about it : https://storybook.js.org/docs/react/writing-docs/build-documentation#preview-storybooks-documentation.",
       "default": false
+    },
+    "compodoc": {
+      "type": "boolean",
+      "description": "Execute compodoc before.",
+      "default": true
+    },
+    "compodocArgs": {
+      "type": "array",
+      "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
+      "default": ["-e", "json"],
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,

--- a/app/angular/src/builders/start-storybook/index.spec.ts
+++ b/app/angular/src/builders/start-storybook/index.spec.ts
@@ -1,11 +1,19 @@
-import { Architect } from '@angular-devkit/architect';
+import { Architect, createBuilder } from '@angular-devkit/architect';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { schema } from '@angular-devkit/core';
 import * as path from 'path';
 
 const buildStandaloneMock = jest.fn().mockImplementation((_options: unknown) => Promise.resolve());
-
 jest.doMock('@storybook/angular/standalone', () => buildStandaloneMock);
+
+const cpSpawnMock = {
+  spawn: jest.fn().mockImplementation(() => ({
+    stdout: { on: () => {} },
+    stderr: { on: () => {} },
+    on: (_event: string, cb: any) => cb(0),
+  })),
+};
+jest.doMock('child_process', () => cpSpawnMock);
 
 describe('Start Storybook Builder', () => {
   let architect: Architect;
@@ -18,15 +26,40 @@ describe('Start Storybook Builder', () => {
     architectHost = new TestingArchitectHost();
     architect = new Architect(architectHost, registry);
 
+    architectHost.addBuilder(
+      '@angular-devkit/build-angular:browser',
+      createBuilder(() => {
+        return { success: true };
+      })
+    );
+    architectHost.addTarget(
+      { project: 'angular-cli', target: 'build-2' },
+      '@angular-devkit/build-angular:browser',
+      {
+        outputPath: 'dist/angular-cli',
+        index: 'src/index.html',
+        main: 'src/main.ts',
+        polyfills: 'src/polyfills.ts',
+        tsConfig: 'src/tsconfig.app.json',
+        assets: ['src/favicon.ico', 'src/assets'],
+        styles: ['src/styles.css'],
+        scripts: [],
+      }
+    );
     // This will either take a Node package name, or a path to the directory
     // for the package.json file.
     await architectHost.addBuilderFromPackage(path.join(__dirname, '../../..'));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should work', async () => {
     const run = await architect.scheduleBuilder('@storybook/angular:start-storybook', {
       browserTarget: 'angular-cli:build-2',
       port: 4400,
+      compodoc: false,
     });
 
     const output = await run.result;
@@ -34,6 +67,7 @@ describe('Start Storybook Builder', () => {
     await run.stop();
 
     expect(output.success).toBeTruthy();
+    expect(cpSpawnMock.spawn).not.toHaveBeenCalledWith();
     expect(buildStandaloneMock).toHaveBeenCalledWith({
       angularBrowserTarget: 'angular-cli:build-2',
       browserTarget: 'angular-cli:build-2',
@@ -49,6 +83,46 @@ describe('Start Storybook Builder', () => {
       sslCert: undefined,
       sslKey: undefined,
       staticDir: [],
+      compodoc: false,
+      compodocArgs: ['-e', 'json'],
+    });
+  });
+
+  it('should run compodoc', async () => {
+    const run = await architect.scheduleBuilder('@storybook/angular:start-storybook', {
+      browserTarget: 'angular-cli:build-2',
+    });
+
+    const output = await run.result;
+
+    await run.stop();
+
+    expect(output.success).toBeTruthy();
+    expect(cpSpawnMock.spawn).toHaveBeenCalledWith('compodoc', [
+      '-p',
+      'src/tsconfig.app.json',
+      '-d',
+      '',
+      '-e',
+      'json',
+    ]);
+    expect(buildStandaloneMock).toHaveBeenCalledWith({
+      angularBrowserTarget: 'angular-cli:build-2',
+      browserTarget: 'angular-cli:build-2',
+      ci: false,
+      configDir: '.storybook',
+      docs: false,
+      host: 'localhost',
+      https: false,
+      port: 9009,
+      quiet: false,
+      smokeTest: false,
+      sslCa: undefined,
+      sslCert: undefined,
+      sslKey: undefined,
+      staticDir: [],
+      compodoc: true,
+      compodocArgs: ['-e', 'json'],
     });
   });
 });

--- a/app/angular/src/builders/start-storybook/index.ts
+++ b/app/angular/src/builders/start-storybook/index.ts
@@ -1,14 +1,23 @@
-import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder,
+  targetFromTargetString,
+} from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
+import { BrowserBuilderOptions } from '@angular-devkit/build-angular';
 import { from, Observable, of } from 'rxjs';
 import { CLIOptions } from '@storybook/core-common';
 import { map, switchMap } from 'rxjs/operators';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import buildStandalone, { StandaloneOptions } from '@storybook/angular/standalone';
+import { runCompodoc } from '../utils/run-compodoc';
 
 export type StorybookBuilderOptions = JsonObject & {
   browserTarget: string;
+  compodoc: boolean;
+  compodocArgs: string[];
 } & Pick<
     // makes sure the option exists
     CLIOptions,
@@ -32,9 +41,17 @@ export default createBuilder(commandBuilder);
 
 function commandBuilder(
   options: StorybookBuilderOptions,
-  _context: BuilderContext
+  context: BuilderContext
 ): Observable<StorybookBuilderOutput> {
-  return of({}).pipe(
+  return from(setup(options, context)).pipe(
+    switchMap(({ browserOptions }) =>
+      options.compodoc
+        ? runCompodoc(
+            { compodocArgs: options.compodocArgs, tsconfig: browserOptions.tsConfig },
+            context
+          )
+        : of({})
+    ),
     map(() => ({
       ...options,
       angularBrowserTarget: options.browserTarget,
@@ -44,6 +61,19 @@ function commandBuilder(
       return { success: true };
     })
   );
+}
+
+async function setup(options: StorybookBuilderOptions, context: BuilderContext) {
+  const browserTarget = targetFromTargetString(options.browserTarget);
+  const browserOptions = await context.validateOptions<JsonObject & BrowserBuilderOptions>(
+    await context.getTargetOptions(browserTarget),
+    await context.getBuilderNameForTarget(browserTarget)
+  );
+
+  return {
+    browserOptions,
+    browserTarget,
+  };
 }
 
 function runInstance(options: StandaloneOptions) {

--- a/app/angular/src/builders/start-storybook/schema.json
+++ b/app/angular/src/builders/start-storybook/schema.json
@@ -67,6 +67,19 @@
       "type": "boolean",
       "description": "Starts Storybook in documentation mode. Learn more about it : https://storybook.js.org/docs/react/writing-docs/build-documentation#preview-storybooks-documentation.",
       "default": false
+    },
+    "compodoc": {
+      "type": "boolean",
+      "description": "Execute compodoc before.",
+      "default": true
+    },
+    "compodocArgs": {
+      "type": "array",
+      "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
+      "default": ["-e", "json"],
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,

--- a/app/angular/src/builders/utils/run-compodoc.ts
+++ b/app/angular/src/builders/utils/run-compodoc.ts
@@ -1,0 +1,41 @@
+import { BuilderContext } from '@angular-devkit/architect';
+import { spawn } from 'child_process';
+import { Observable } from 'rxjs';
+
+export const runCompodoc = (
+  { compodocArgs, tsconfig }: { compodocArgs: string[]; tsconfig: string },
+  context: BuilderContext
+): Observable<void> => {
+  return new Observable<void>((observer) => {
+    const finalCompodocArgs = [
+      // Default options
+      '-p',
+      tsconfig,
+      '-d',
+      `${context.workspaceRoot}`,
+      ...compodocArgs,
+    ];
+
+    try {
+      const child = spawn('compodoc', finalCompodocArgs);
+
+      child.stdout.on('data', (data) => {
+        context.logger.info(data.toString());
+      });
+      child.stderr.on('data', (data) => {
+        context.logger.error(data.toString());
+      });
+
+      child.on('close', (code) => {
+        if (code === 0) {
+          observer.next();
+          observer.complete();
+        } else {
+          observer.error();
+        }
+      });
+    } catch (error) {
+      observer.error(error);
+    }
+  });
+};


### PR DESCRIPTION
Issue: 👾  next of https://github.com/storybookjs/storybook/pull/15061

Add the same features available natively in the storybook init for angular


## What I did

Executer compodoc dans les builders angular avant le démarrage de storybook 

It also allows to remove the specific script for compodoc in the package.json
the minimal package.json-> script configuration becomes : 
```json
"scripts": {
    "build-storybook": "ng run angular-cli:build-storybook",
    "storybook": "ng run angular-cli:storybook",
    ...
}
```
And in angular.json : 
```json
  "projects": {
    ...
    "angular-cli": {
      "architect": {
        ...
        "build": {
          "builder": "@angular-devkit/build-angular:browser",
          "options": {...},
        ...
        "storybook": {
          "builder": "@storybook/angular:start-storybook",
          "options": {
            "browserTarget": "angular-cli:build",
            "port": 4400,
            "staticDir": ["src/assets"]
            // "compodoc": false // if you do not use compodoc
          }
        },
        "build-storybook": {
          "builder": "@storybook/angular:build-storybook",
          "options": {
            "browserTarget": "angular-cli:build",
            "staticDir": ["src/assets"]
            // "compodoc": false // if you do not use compodoc
          }
        }
      }
...
```



✏️  A negative point the compodoc logs are not in color 😞 

## How to test

- Is this testable with Jest or Chromatic screenshots? YES
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?
