### PR TITLE
Core: Use named import for @storybook/addons, fixes vite builder

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -863,7 +863,7 @@ npx sb@next migrate upgrade-hierarchy-separators --glob="*/**/*.stories.@(tsx|js
 We also now default to showing "roots", which are non-expandable groupings in the sidebar for the top-level groups. If you'd like to disable this, set the `showRoots` option in `.storybook/manager.js`:
 
 ```js
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 
 addons.setConfig({
   showRoots: false,
@@ -1150,7 +1150,7 @@ You should use `addon.setConfig` to set them:
 
 ```js
 // in .storybook/manager.js
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 
 addons.setConfig({
   showRoots: false,

--- a/addons/a11y/src/a11yHighlight.ts
+++ b/addons/a11y/src/a11yHighlight.ts
@@ -1,5 +1,5 @@
 import global from 'global';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { STORY_CHANGED } from '@storybook/core-events';
 import { EVENTS, HIGHLIGHT_STYLE_ID } from './constants';
 

--- a/addons/a11y/src/a11yRunner.test.ts
+++ b/addons/a11y/src/a11yRunner.test.ts
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { EVENTS } from './constants';
 
 jest.mock('@storybook/addons');

--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -1,6 +1,6 @@
 import global from 'global';
 import axe from 'axe-core';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { EVENTS } from './constants';
 import { A11yParameters } from './params';
 

--- a/addons/actions/src/preview/__tests__/action.test.js
+++ b/addons/actions/src/preview/__tests__/action.test.js
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { action, configureActions } from '../..';
 
 jest.mock('@storybook/addons');

--- a/addons/actions/src/preview/__tests__/actions.test.js
+++ b/addons/actions/src/preview/__tests__/actions.test.js
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { actions } from '../..';
 
 jest.mock('@storybook/addons');

--- a/addons/controls/src/register.tsx
+++ b/addons/controls/src/register.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import addons, { types } from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 import { AddonPanel } from '@storybook/components';
 import { API, useArgTypes } from '@storybook/api';
 import { ControlsPanel } from './ControlsPanel';

--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -1,5 +1,5 @@
 import React, { FC, SyntheticEvent } from 'react';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { NAVIGATE_URL } from '@storybook/core-events';
 import { Source, Code, components } from '@storybook/components';
 import global from 'global';

--- a/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 import React from 'react';
 import PropTypes from 'prop-types';
-import addons, { StoryContext } from '@storybook/addons';
+import { addons, StoryContext } from '@storybook/addons';
 import { renderJsx, jsxDecorator } from './jsxDecorator';
 import { SNIPPET_RENDERED } from '../../shared';
 

--- a/addons/docs/src/register.ts
+++ b/addons/docs/src/register.ts
@@ -1,4 +1,4 @@
-import addons, { types } from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 import { ADDON_ID, PANEL_ID } from './shared';
 
 addons.register(ADDON_ID, () => {

--- a/addons/jest/src/index.ts
+++ b/addons/jest/src/index.ts
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { normalize, sep } from 'upath';
 import { ADD_TESTS, defineJestParameter } from './shared';
 

--- a/addons/jest/src/register.tsx
+++ b/addons/jest/src/register.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { ADDON_ID, PANEL_ID, PARAM_KEY } from './shared';
 
 import Panel from './components/Panel';

--- a/addons/links/src/preview.test.ts
+++ b/addons/links/src/preview.test.ts
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { SELECT_STORY } from '@storybook/core-events';
 
 import globalPkg from 'global';

--- a/addons/links/src/preview.ts
+++ b/addons/links/src/preview.ts
@@ -1,6 +1,6 @@
 import global from 'global';
 import qs from 'qs';
-import addons, { makeDecorator } from '@storybook/addons';
+import { addons, makeDecorator } from '@storybook/addons';
 import { STORY_CHANGED, SELECT_STORY } from '@storybook/core-events';
 import { toId } from '@storybook/csf';
 import { logger } from '@storybook/client-logger';

--- a/addons/links/src/react/components/link.test.tsx
+++ b/addons/links/src/react/components/link.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SELECT_STORY } from '@storybook/core-events';

--- a/addons/links/src/register.ts
+++ b/addons/links/src/register.ts
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 
 import EVENTS, { ADDON_ID } from './constants';
 

--- a/addons/storyshots/storyshots-core/src/api/index.ts
+++ b/addons/storyshots/storyshots-core/src/api/index.ts
@@ -1,5 +1,5 @@
 import global from 'global';
-import addons, { mockChannel } from '@storybook/addons';
+import { addons, mockChannel } from '@storybook/addons';
 import ensureOptionsDefaults from './ensureOptionsDefaults';
 import snapshotsTests from './snapshotsTestsTemplate';
 import integrityTest from './integrityTestTemplate';

--- a/addons/storysource/src/register.tsx
+++ b/addons/storysource/src/register.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 
 import { StoryPanel } from './StoryPanel';
 import { ADDON_ID, PANEL_ID } from '.';

--- a/addons/toolbars/src/register.tsx
+++ b/addons/toolbars/src/register.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import addons, { types } from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 import { ToolbarManager } from './components/ToolbarManager';
 import { ADDON_ID } from './constants';
 

--- a/addons/viewport/src/register.tsx
+++ b/addons/viewport/src/register.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import addons, { types } from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 
 import { ADDON_ID } from './constants';
 

--- a/app/angular/src/client/preview/angular-beta/DocsRenderer.ts
+++ b/app/angular/src/client/preview/angular-beta/DocsRenderer.ts
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import Events from '@storybook/core-events';
 import { AbstractRenderer } from './AbstractRenderer';
 import { StoryFnAngularReturnType } from '../types';

--- a/app/angular/src/client/preview/decorators.test.ts
+++ b/app/angular/src/client/preview/decorators.test.ts
@@ -1,4 +1,4 @@
-import addons, { mockChannel, StoryContext } from '@storybook/addons';
+import { addons, mockChannel, StoryContext } from '@storybook/addons';
 
 import { Component } from '@angular/core';
 import { moduleMetadata } from './decorators';

--- a/docs/snippets/common/storybook-addon-tab-example.js.mdx
+++ b/docs/snippets/common/storybook-addon-tab-example.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import addons, { types } from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 
 addons.register('my/tab', () => {
   addons.add('my-panel-addon/tab', {

--- a/docs/snippets/common/storybook-addon-toolbar-example.js.mdx
+++ b/docs/snippets/common/storybook-addon-toolbar-example.js.mdx
@@ -3,7 +3,7 @@
 
 import React from "react";
 
-import addons, { types } from "@storybook/addons";
+import { addons, types } from '@storybook/addons';
 
 import { Icons, IconButton } from '@storybook/components';
 

--- a/docs/workflows/faq.md
+++ b/docs/workflows/faq.md
@@ -66,7 +66,7 @@ A common error is that an addon tries to access the "channel", but the channel i
 
 1.  You're trying to access addon channel (e.g., by calling `setOptions`) in a non-browser environment like Jest. You may need to add a channel mock:
     ```js
-    import addons, { mockChannel } from '@storybook/addons';
+    import { addons, mockChannel } from '@storybook/addons';
 
     addons.setChannel(mockChannel());
     ```

--- a/examples/cra-ts-kitchen-sink/.storybook/localAddon/register.tsx
+++ b/examples/cra-ts-kitchen-sink/.storybook/localAddon/register.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import addons, { types } from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 
 const ID = 'local-addon';
 

--- a/examples/official-storybook/stories/core/events.stories.js
+++ b/examples/official-storybook/stories/core/events.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import Events from '@storybook/core-events';
 import { Button } from '@storybook/components';
 

--- a/lib/channels/README.md
+++ b/lib/channels/README.md
@@ -32,7 +32,7 @@ class Transport {
 Currently, channels are baked into storybook implementations and therefore this module is not designed to be used directly by addon developers. When developing addons, use the `getChannel` method exported by `@storybook/addons` module. For this to work, Storybook implementations should use the `setChannel` method before loading addons.
 
 ```js
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 
 const channel = addons.getChannel();
 ```

--- a/lib/client-api/src/client_api.test.ts
+++ b/lib/client-api/src/client_api.test.ts
@@ -1,5 +1,5 @@
 import { logger } from '@storybook/client-logger';
-import addons, { mockChannel } from '@storybook/addons';
+import { addons, mockChannel } from '@storybook/addons';
 import Events from '@storybook/core-events';
 import ClientApi from './client_api';
 import ConfigApi from './config_api';

--- a/lib/client-api/src/hooks.test.js
+++ b/lib/client-api/src/hooks.test.js
@@ -5,7 +5,7 @@ import {
   RESET_STORY_ARGS,
   UPDATE_GLOBALS,
 } from '@storybook/core-events';
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 import { defaultDecorateStory } from './decorators';
 import {
   applyHooks,

--- a/lib/client-api/src/story_store.test.ts
+++ b/lib/client-api/src/story_store.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import createChannel from '@storybook/channel-postmessage';
 import { toId } from '@storybook/csf';
-import addons, { mockChannel } from '@storybook/addons';
+import { addons, mockChannel } from '@storybook/addons';
 import Events from '@storybook/core-events';
 
 import StoryStore from './story_store';

--- a/lib/core-client/src/manager/provider.ts
+++ b/lib/core-client/src/manager/provider.ts
@@ -1,5 +1,5 @@
 import { Provider } from '@storybook/ui';
-import addons, { AddonStore, Channel, Config, Types } from '@storybook/addons';
+import { addons, AddonStore, Channel, Config, Types } from '@storybook/addons';
 import createChannel from '@storybook/channel-postmessage';
 import Events from '@storybook/core-events';
 

--- a/lib/core-client/src/preview/StoryRenderer.test.ts
+++ b/lib/core-client/src/preview/StoryRenderer.test.ts
@@ -13,7 +13,8 @@ import {
   STORY_RENDERED,
 } from '@storybook/core-events';
 import { toId } from '@storybook/csf';
-import addons, {
+import {
+  addons,
   StoryFn,
   StoryKind,
   StoryName,

--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -1,6 +1,6 @@
 import global from 'global';
 
-import addons, { DecorateStoryFunction, Channel } from '@storybook/addons';
+import { addons, DecorateStoryFunction, Channel } from '@storybook/addons';
 import createChannel from '@storybook/channel-postmessage';
 import { ClientApi, ConfigApi, StoryStore } from '@storybook/client-api';
 import Events from '@storybook/core-events';

--- a/lib/ui/src/components/preview/preview.tsx
+++ b/lib/ui/src/components/preview/preview.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet-async';
 
 import { API, Consumer, Combo, merge } from '@storybook/api';
 import { SET_CURRENT_STORY } from '@storybook/core-events';
-import addons, { types, Addon } from '@storybook/addons';
+import { addons, types, Addon } from '@storybook/addons';
 
 import { Loader } from '@storybook/components';
 import { Location } from '@storybook/router';

--- a/lib/ui/src/components/preview/toolbar.tsx
+++ b/lib/ui/src/components/preview/toolbar.tsx
@@ -5,7 +5,7 @@ import { styled } from '@storybook/theming';
 import { FlexBar, IconButton, Icons, Separator, TabButton, TabBar } from '@storybook/components';
 import { Consumer, Combo, API, Story, Group, State, merge } from '@storybook/api';
 import { shortcutToHumanString } from '@storybook/api/shortcut';
-import addons, { Addon, types } from '@storybook/addons';
+import { addons, Addon, types } from '@storybook/addons';
 
 import { Location, RenderData } from '@storybook/router';
 import { zoomTool } from './tools/zoom';


### PR DESCRIPTION
Issue:

The module `@storybook/addons` exposes both a default and named import for `addons`.  However, mixing named and default can cause problems in rollup, and it was causing the experimental vite builder to [explode](https://github.com/eirslett/storybook-builder-vite/issues/19).  

## What I did

I've switched over imports of `addons` from @storybook/addons to use the named export, as is [recommended](https://github.com/storybookjs/storybook/blob/0981b635eed95b48998b9a5fd6d67216802324fb/lib/addons/src/public_api.ts#L3) by `@storybook/addons` itself.

## How to test

- Is this testable with Jest or Chromatic screenshots? - no
- Does this need a new example in the kitchen sink apps? - no
- Does this need an update to the documentation? - yes

If your answer is yes to any of these, please make sure to include it in your PR.

I've updated all the docs and examples I could find.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
