### PR TITLE
Core: Add `shortcuts` URL param to disable keyboard shortcuts

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,7 @@
     - [Deprecated addon-knobs](#deprecated-addon-knobs)
     - [Deprecated scoped blocks imports](#deprecated-scoped-blocks-imports)
     - [Deprecated `argType.defaultValue`](#deprecated-argtypedefaultvalue)
+    - [Deprecated layout URL params](#deprecated-layout-url-params)
 - [From version 6.1.x to 6.2.0](#from-version-61x-to-620)
   - [MDX pattern tweaked](#mdx-pattern-tweaked)
   - [6.2 Angular overhaul](#62-angular-overhaul)
@@ -240,6 +241,14 @@ export default {
   },
 };
 ```
+
+#### Deprecated layout URL params
+
+Several URL params to control the manager layout have been deprecated and will be removed in 7.0:
+
+- `addons=0`: use `panel=false` instead
+- `panelRight=1`: use `panel=right` instead
+- `stories=0`: use `nav=false` instead
 
 ## From version 6.1.x to 6.2.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -250,6 +250,8 @@ Several URL params to control the manager layout have been deprecated and will b
 - `panelRight=1`: use `panel=right` instead
 - `stories=0`: use `nav=false` instead
 
+Additionally, support for legacy URLs using `selectedKind` and `selectedStory` will be removed in 7.0. Use `path` instead.
+
 ## From version 6.1.x to 6.2.0
 
 ### MDX pattern tweaked

--- a/docs/configure/features-and-behavior.md
+++ b/docs/configure/features-and-behavior.md
@@ -2,7 +2,7 @@
 title: 'Features and behavior'
 ---
 
-To control the layout of Storybook’s UI you can use the `setConfig` addons API in your [`.storybook/manager.js`](./overview.md#configure-story-rendering):
+To control the layout of Storybook’s UI you can use `addons.setConfig` in your [`.storybook/manager.js`](./overview.md#configure-story-rendering):
 
 <!-- prettier-ignore-start -->
 
@@ -25,7 +25,7 @@ The following table details how to use the API values:
 | **enableShortcuts**   | Boolean       |Enable/disable shortcuts                                       |`true`                                          |
 | **isToolshown**       | String        |Show/hide tool bar                                             |`true`                                          |
 | **theme**             | Object        |Storybook Theme, see next section                              |`undefined`                                     |
-| **selectedPanel**     | String        |Id to select an addon panel                                    |`my-panel`                                      |
+| **selectedPanel**     | String        |Id to select an addon panel                                    |`storybook/actions/panel`                       |
 | **initialActive**     | String        |Select the default active tab on Mobile                        |`sidebar` or `canvas` or `addons`               |
 | **sidebar**           | Object        |Sidebar options, see below                                     |`{ showRoots: false }`                          |
 | **toolbar**           | Object        |Modify the tools in the toolbar using the addon id             |`{ fullscreen: { hidden: false } } }`           |
@@ -43,3 +43,15 @@ The following options are configurable under the `toolbar` namespace:
 | Name                  | Type          | Description                                                   | Example Value                                  |
 | ----------------------|:-------------:|:-------------------------------------------------------------:|:----------------------------------------------:|
 | **id**                | String        |Toggle visibility for toolbar item                             |`{ hidden: false }`                            |
+
+## Configuring through URL parameters
+
+Some features can be controlled through URL parameters:
+
+| Config option         | Query param   | Supported values           |
+| ----------------------|:-------------:|:--------------------------:|
+| **enableShortcuts**   | `shortcuts`   | `false`                    |
+| **isFullscreen**      | `full`        | `true`                     |
+| **showNav**           | `nav`         | `false`                    |
+| **showPanel**         | `panel`       | `false`, `right`, `bottom` |
+| **selectedPanel**     | `addonPanel`  | Any panel ID               |

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -11,19 +11,10 @@ import deepEqual from 'fast-deep-equal';
 import global from 'global';
 
 import { ModuleArgs, ModuleFn } from '../index';
-import { PanelPositions } from './layout';
+import { Layout, UI } from './layout';
 import { isStory } from '../lib/stories';
 
 const { window: globalWindow } = global;
-
-interface Additions {
-  isFullscreen?: boolean;
-  showPanel?: boolean;
-  panelPosition?: PanelPositions;
-  showNav?: boolean;
-  selectedPanel?: string;
-  viewMode?: string;
-}
 
 export interface SubState {
   customQueryParams: QueryParams;
@@ -42,7 +33,8 @@ let prevParams: ReturnType<typeof queryFromLocation>;
 const initialUrlSupport = ({
   state: { location, path, viewMode, storyId: storyIdFromUrl },
 }: ModuleArgs) => {
-  const addition: Additions = {};
+  const layout: Partial<Layout> = {};
+  const ui: Partial<UI> = {};
   const query = queryFromLocation(location);
   let selectedPanel;
 
@@ -50,6 +42,7 @@ const initialUrlSupport = ({
     full,
     panel,
     nav,
+    shortcuts,
     addons,
     panelRight,
     stories,
@@ -61,28 +54,31 @@ const initialUrlSupport = ({
   } = query;
 
   if (full === '1') {
-    addition.isFullscreen = true;
+    layout.isFullscreen = true;
   }
   if (panel) {
     if (['right', 'bottom'].includes(panel)) {
-      addition.panelPosition = panel;
+      layout.panelPosition = panel;
     } else if (panel === '0') {
-      addition.showPanel = false;
+      layout.showPanel = false;
     }
   }
   if (nav === '0') {
-    addition.showNav = false;
+    layout.showNav = false;
+  }
+  if (shortcuts === '0') {
+    ui.enableShortcuts = false;
   }
 
   // Legacy URLs
   if (addons === '0') {
-    addition.showPanel = false;
+    layout.showPanel = false;
   }
   if (panelRight === '1') {
-    addition.panelPosition = 'right';
+    layout.panelPosition = 'right';
   }
   if (stories === '0') {
-    addition.showNav = false;
+    layout.showNav = false;
   }
 
   if (addonPanel) {
@@ -104,7 +100,7 @@ const initialUrlSupport = ({
   const customQueryParams = deepEqual(prevParams, otherParams) ? prevParams : otherParams;
   prevParams = customQueryParams;
 
-  return { viewMode, layout: addition, selectedPanel, location, path, customQueryParams, storyId };
+  return { viewMode, layout, ui, selectedPanel, location, path, customQueryParams, storyId };
 };
 
 export interface QueryParams {

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -78,24 +78,27 @@ const initialUrlSupport = ({
   // @deprecated Superceded by `panel=false`, to be removed in 7.0
   if (addons === '0') {
     once.warn(dedent`
-      The 'addons' query param is deprecated and will be removed in Storybook 7.0.
-      Use 'panel=false' instead.
+      The 'addons' query param is deprecated and will be removed in Storybook 7.0. Use 'panel=false' instead.
+
+      More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-layout-url-params
     `);
     layout.showPanel = false;
   }
   // @deprecated Superceded by `panel=right`, to be removed in 7.0
   if (panelRight === '1') {
     once.warn(dedent`
-      The 'panelRight' query param is deprecated and will be removed in Storybook 7.0.
-      Use 'panel=right' instead.
+      The 'panelRight' query param is deprecated and will be removed in Storybook 7.0. Use 'panel=right' instead.
+
+      More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-layout-url-params
     `);
     layout.panelPosition = 'right';
   }
   // @deprecated Superceded by `nav=false`, to be removed in 7.0
   if (stories === '0') {
     once.warn(dedent`
-      The 'stories' query param is deprecated and will be removed in Storybook 7.0.
-      Use 'nav=false' instead.
+      The 'stories' query param is deprecated and will be removed in Storybook 7.0. Use 'nav=false' instead.
+
+      More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-layout-url-params
     `);
     layout.showNav = false;
   }

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -49,10 +49,10 @@ const initialUrlSupport = ({
     addons, // deprecated
     panelRight, // deprecated
     stories, // deprecated
-    selectedKind,
-    selectedStory,
+    selectedKind, // deprecated
+    selectedStory, // deprecated
     path: queryPath,
-    ...otherParams
+    ...otherParams // the rest gets passed to the iframe
   } = query;
 
   if (full === 'true' || full === '1') {
@@ -103,15 +103,17 @@ const initialUrlSupport = ({
     layout.showNav = false;
   }
 
+  // @deprecated To be removed in 7.0
   // If the user hasn't set the storyId on the URL, we support legacy URLs (selectedKind/selectedStory)
   // NOTE: this "storyId" can just be a prefix of a storyId, really it is a storyIdSpecifier.
   let storyId = storyIdFromUrl;
-  if (!storyId) {
-    if (selectedKind && selectedStory) {
-      storyId = toId(selectedKind, selectedStory);
-    } else if (selectedKind) {
-      storyId = sanitize(selectedKind);
-    }
+  if (!storyId && selectedKind) {
+    once.warn(dedent`
+      The 'selectedKind' and 'selectedStory' query params are deprecated and will be removed in Storybook 7.0. Use 'path' instead.
+
+      More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-layout-url-params
+    `);
+    storyId = selectedStory ? toId(selectedKind, selectedStory) : sanitize(selectedKind);
   }
 
   // Avoid returning a new object each time if no params actually changed.

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -1,4 +1,5 @@
 import { navigate as navigateRouter, NavigateOptions } from '@reach/router';
+import { once } from '@storybook/client-logger';
 import {
   NAVIGATE_URL,
   STORY_ARGS_UPDATED,
@@ -9,6 +10,7 @@ import { queryFromLocation, navigate as queryNavigate, buildArgsParam } from '@s
 import { toId, sanitize } from '@storybook/csf';
 import deepEqual from 'fast-deep-equal';
 import global from 'global';
+import dedent from 'ts-dedent';
 
 import { ModuleArgs, ModuleFn } from '../index';
 import { Layout, UI } from './layout';
@@ -75,14 +77,26 @@ const initialUrlSupport = ({
 
   // @deprecated Superceded by `panel=false`, to be removed in 7.0
   if (addons === '0') {
+    once.warn(dedent`
+      The 'addons' query param is deprecated and will be removed in Storybook 7.0.
+      Use 'panel=false' instead.
+    `);
     layout.showPanel = false;
   }
   // @deprecated Superceded by `panel=right`, to be removed in 7.0
   if (panelRight === '1') {
+    once.warn(dedent`
+      The 'panelRight' query param is deprecated and will be removed in Storybook 7.0.
+      Use 'panel=right' instead.
+    `);
     layout.panelPosition = 'right';
   }
   // @deprecated Superceded by `nav=false`, to be removed in 7.0
   if (stories === '0') {
+    once.warn(dedent`
+      The 'stories' query param is deprecated and will be removed in Storybook 7.0.
+      Use 'nav=false' instead.
+    `);
     layout.showNav = false;
   }
 

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -43,46 +43,47 @@ const initialUrlSupport = ({
     panel,
     nav,
     shortcuts,
-    addons,
-    panelRight,
-    stories,
     addonPanel,
+    addons, // deprecated
+    panelRight, // deprecated
+    stories, // deprecated
     selectedKind,
     selectedStory,
     path: queryPath,
     ...otherParams
   } = query;
 
-  if (full === '1') {
+  if (full === 'true' || full === '1') {
     layout.isFullscreen = true;
   }
   if (panel) {
     if (['right', 'bottom'].includes(panel)) {
       layout.panelPosition = panel;
-    } else if (panel === '0') {
+    } else if (panel === 'false' || panel === '0') {
       layout.showPanel = false;
     }
   }
-  if (nav === '0') {
+  if (nav === 'false' || nav === '0') {
     layout.showNav = false;
   }
-  if (shortcuts === '0') {
+  if (shortcuts === 'false' || shortcuts === '0') {
     ui.enableShortcuts = false;
   }
+  if (addonPanel) {
+    selectedPanel = addonPanel;
+  }
 
-  // Legacy URLs
+  // @deprecated Superceded by `panel=false`, to be removed in 7.0
   if (addons === '0') {
     layout.showPanel = false;
   }
+  // @deprecated Superceded by `panel=right`, to be removed in 7.0
   if (panelRight === '1') {
     layout.panelPosition = 'right';
   }
+  // @deprecated Superceded by `nav=false`, to be removed in 7.0
   if (stories === '0') {
     layout.showNav = false;
-  }
-
-  if (addonPanel) {
-    selectedPanel = addonPanel;
   }
 
   // If the user hasn't set the storyId on the URL, we support legacy URLs (selectedKind/selectedStory)

--- a/lib/api/src/tests/url.test.js
+++ b/lib/api/src/tests/url.test.js
@@ -30,6 +30,17 @@ describe('initial state', () => {
       expect(layout).toEqual({ showNav: false });
     });
 
+    it('handles shortcuts parameter', () => {
+      const navigate = jest.fn();
+      const location = { search: qs.stringify({ shortcuts: '0' }) };
+
+      const {
+        state: { ui },
+      } = initURL({ navigate, state: { location } });
+
+      expect(ui).toEqual({ enableShortcuts: false });
+    });
+
     it('handles panel parameter, bottom', () => {
       const navigate = jest.fn();
       const location = { search: qs.stringify({ panel: 'bottom' }) };

--- a/lib/api/src/tests/url.test.js
+++ b/lib/api/src/tests/url.test.js
@@ -2,6 +2,7 @@ import qs from 'qs';
 
 import { init as initURL } from '../modules/url';
 
+jest.mock('@storybook/client-logger');
 jest.useFakeTimers();
 
 describe('initial state', () => {


### PR DESCRIPTION
Issue: #15172

## What I did

This adds a new `shortcuts` query param for the manager. When set to `false` it will set `ui.enableShortcuts: false`, so that keyboard shortcuts will be disabled. This is particularly useful when embedding stories on a page, where keyboard shortcuts might conflict.

Additionally, I've taken the opportunity to support `true` and `false` as alternative to `0` or `1`, add a table of supported params to the docs, and properly deprecate some legacy params.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? yes, added

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
