### PR TITLE
Core: Fix autoRefs check in manager-webpack

### DIFF
--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-dev
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-dev
@@ -12,7 +12,6 @@ Object {
     "ROOT/addons/toolbars/dist/esm/register.js",
     "NODE_MODULES/@storybook/addon-measure/dist/esm/preset/manager.js",
     "NODE_MODULES/storybook-addon-outline/dist/esm/preset/register.js",
-    "ROOT/examples/cra-ts-essentials/.storybook/generated-refs.js",
   ],
   "keys": Array [
     "name",

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod
@@ -12,7 +12,6 @@ Object {
     "ROOT/addons/toolbars/dist/esm/register.js",
     "NODE_MODULES/@storybook/addon-measure/dist/esm/preset/manager.js",
     "NODE_MODULES/storybook-addon-outline/dist/esm/preset/register.js",
-    "ROOT/examples/cra-ts-essentials/.storybook/generated-refs.js",
   ],
   "keys": Array [
     "name",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-dev
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-dev
@@ -14,7 +14,6 @@ Object {
     "ROOT/addons/links/dist/esm/register.js",
     "ROOT/addons/storysource/dist/esm/register.js",
     "ROOT/addons/viewport/dist/esm/register.js",
-    "ROOT/examples/html-kitchen-sink/.storybook/generated-refs.js",
   ],
   "keys": Array [
     "name",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-prod
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-prod
@@ -14,7 +14,6 @@ Object {
     "ROOT/addons/links/dist/esm/register.js",
     "ROOT/addons/storysource/dist/esm/register.js",
     "ROOT/addons/viewport/dist/esm/register.js",
-    "ROOT/examples/html-kitchen-sink/.storybook/generated-refs.js",
   ],
   "keys": Array [
     "name",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_manager-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_manager-dev
@@ -14,7 +14,6 @@ Object {
     "ROOT/addons/toolbars/dist/esm/register.js",
     "NODE_MODULES/@storybook/addon-measure/dist/esm/preset/manager.js",
     "NODE_MODULES/storybook-addon-outline/dist/esm/preset/register.js",
-    "ROOT/examples/vue-3-cli/.storybook/generated-refs.js",
   ],
   "keys": Array [
     "name",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_manager-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_manager-prod
@@ -14,7 +14,6 @@ Object {
     "ROOT/addons/toolbars/dist/esm/register.js",
     "NODE_MODULES/@storybook/addon-measure/dist/esm/preset/manager.js",
     "NODE_MODULES/storybook-addon-outline/dist/esm/preset/register.js",
-    "ROOT/examples/vue-3-cli/.storybook/generated-refs.js",
   ],
   "keys": Array [
     "name",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-dev
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-dev
@@ -14,7 +14,6 @@ Object {
     "ROOT/addons/storysource/dist/esm/register.js",
     "ROOT/addons/viewport/dist/esm/register.js",
     "ROOT/addons/toolbars/dist/esm/register.js",
-    "ROOT/examples/web-components-kitchen-sink/.storybook/generated-refs.js",
   ],
   "keys": Array [
     "name",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-prod
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-prod
@@ -14,7 +14,6 @@ Object {
     "ROOT/addons/storysource/dist/esm/register.js",
     "ROOT/addons/viewport/dist/esm/register.js",
     "ROOT/addons/toolbars/dist/esm/register.js",
-    "ROOT/examples/web-components-kitchen-sink/.storybook/generated-refs.js",
   ],
   "keys": Array [
     "name",

--- a/lib/manager-webpack4/src/manager-config.ts
+++ b/lib/manager-webpack4/src/manager-config.ts
@@ -132,7 +132,7 @@ export async function getManagerWebpackConfig(options: Options): Promise<Configu
     });
   }
 
-  if (autoRefs || definedRefs) {
+  if ((autoRefs && autoRefs.length) || definedRefs) {
     entries.push(path.resolve(path.join(options.configDir, `generated-refs.js`)));
 
     // verify the refs are publicly reachable, if they are not we'll require stories.json at runtime, otherwise the ref won't work

--- a/lib/manager-webpack5/src/manager-config.ts
+++ b/lib/manager-webpack5/src/manager-config.ts
@@ -132,7 +132,7 @@ export async function getManagerWebpackConfig(options: Options): Promise<Configu
     });
   }
 
-  if (autoRefs || definedRefs) {
+  if ((autoRefs && autoRefs.length) || definedRefs) {
     entries.push(path.resolve(path.join(options.configDir, `generated-refs.js`)));
 
     // verify the refs are publicly reachable, if they are not we'll require stories.json at runtime, otherwise the ref won't work


### PR DESCRIPTION
Issue:

I came across this while running storybook through the [design-systems-cli](https://github.com/intuit/design-systems-cli) in the non-parent directly because of a babel warning, and saw the file was being generated but only had `refs: {}` as the content. Both `autoRefs` and `definedRefs` were empty in my case, but the file was being pushed into the entries still.

## What I did

Leveraged the same check for the [`autoRefs` from above](https://github.com/storybookjs/storybook/blob/7c6ce2f5980b4e00cfce7d419f127cc272b244fa/lib/manager-webpack4/src/manager-config.ts#L108) since it could be empty.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
