### PR TITLE
Addon docs

### DIFF
--- a/docs/addons/writing-addons.md
+++ b/docs/addons/writing-addons.md
@@ -12,6 +12,10 @@ For this example, we're going to build a bare-bones addon which:
 - Retrieves a custom parameter from the stories.
 - Displays the parameter data in the panel.
 
+### Addon kit
+
+This guide shows you how to setup an addon from scratch. Alternatively, you can jumpstart your addon development with the [`addon-kit`](https://github.com/storybookjs/addon-kit).
+
 ### Addon directory structure
 
 We recommend a common addon file and directory structure for consistency.

--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -10,6 +10,8 @@ A major strength of Storybook are [addons](/addons/) that extend Storybook’s U
 - [Viewport](./viewport.md)
 - [Backgrounds](./backgrounds.md)
 - [Toolbars & globals](./toolbars-and-globals.md)
+- [Measure](/addons/@storybook/addon-measure)
+- [Outline](/addons/storybook-addon-outline)
 
 ### Installation
 If you're running `sb init` to add Storybook to your project, the essentials package (`@storybook/addon-essentials`) is already installed and configured for you . You can skip the rest of this section.
@@ -21,7 +23,7 @@ npm install --save-dev @storybook/addon-essentials
 ```
 
 <div class="aside">
-💡 <strong>Note</strong>: If you're using <a href="https://yarnpkg.com/">yarn</a> as a package manager, you'll need to adjust the command accordingly. 
+💡 <strong>Note</strong>: If you're using <a href="https://yarnpkg.com/">yarn</a> as a package manager, you'll need to adjust the command accordingly.
 </div>
 
 Update your Storybook configuration (in `.storybook/main.js`) to include the essentials addon.


### PR DESCRIPTION
Issue:

## What I did
* Added measure and outline to list of essentials in docs
* Added a note about the addon-kit to the top of write an addon docs page 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
