### PR TITLE
Core: Preserve other query params when changing args/globals

### DIFF
--- a/lib/api/src/tests/url.test.js
+++ b/lib/api/src/tests/url.test.js
@@ -1,8 +1,12 @@
 import qs from 'qs';
 
+import { SET_CURRENT_STORY, GLOBALS_UPDATED } from '@storybook/core-events';
+import { navigate as reachNavigate } from '@reach/router';
+
 import { init as initURL } from '../modules/url';
 
 jest.mock('@storybook/client-logger');
+jest.mock('@reach/router');
 jest.useFakeTimers();
 
 describe('initial state', () => {
@@ -150,5 +154,106 @@ describe('queryParams', () => {
     api.setQueryParams({ foo: 'bar' });
 
     expect(api.getQueryParam('foo')).toEqual('bar');
+  });
+});
+
+describe('initModule', () => {
+  const store = {
+    state: {},
+    getState() {
+      return this.state;
+    },
+    setState(value) {
+      this.state = { ...this.state, ...value };
+    },
+  };
+  const storyState = (storyId) => ({
+    path: `/story/${storyId}`,
+    storyId,
+    viewMode: 'story',
+  });
+
+  const fullAPI = {
+    callbacks: {},
+    on(event, fn) {
+      this.callbacks[event] = this.callbacks[event] || [];
+      this.callbacks[event].push(fn);
+    },
+    emit(event, ...args) {
+      this.callbacks[event]?.forEach((cb) => cb(...args));
+    },
+    showReleaseNotesOnLaunch: jest.fn(),
+  };
+
+  beforeEach(() => {
+    store.state = {};
+    fullAPI.callbacks = {};
+  });
+
+  it('updates args param on SET_CURRENT_STORY', async () => {
+    store.setState(storyState('test--story'));
+
+    const { api, init } = initURL({ store, state: { location: {} }, fullAPI });
+    Object.assign(fullAPI, api, {
+      getCurrentStoryData: () => ({
+        args: { a: 1, b: 2 },
+        initialArgs: { a: 1, b: 1 },
+        isLeaf: true,
+      }),
+    });
+    init();
+
+    fullAPI.emit(SET_CURRENT_STORY);
+    expect(reachNavigate).toHaveBeenCalledWith(
+      '/?path=/story/test--story&args=b:2',
+      expect.objectContaining({ replace: true })
+    );
+    expect(store.getState().customQueryParams).toEqual({ args: 'b:2' });
+  });
+
+  it('updates globals param on GLOBALS_UPDATED', async () => {
+    store.setState(storyState('test--story'));
+
+    const { api, init } = initURL({ store, state: { location: {} }, fullAPI });
+    Object.assign(fullAPI, api);
+    init();
+
+    fullAPI.emit(GLOBALS_UPDATED, { globals: { a: 2 }, initialGlobals: { a: 1, b: 1 } });
+    expect(reachNavigate).toHaveBeenCalledWith(
+      '/?path=/story/test--story&globals=a:2;b:!undefined',
+      expect.objectContaining({ replace: true })
+    );
+    expect(store.getState().customQueryParams).toEqual({ globals: 'a:2;b:!undefined' });
+  });
+
+  it('adds url params alphabetically', async () => {
+    store.setState({ ...storyState('test--story'), customQueryParams: { full: 1 } });
+
+    const { api, init } = initURL({ store, state: { location: {} }, fullAPI });
+    Object.assign(fullAPI, api, {
+      getCurrentStoryData: () => ({ args: { a: 1 }, isLeaf: true }),
+    });
+    init();
+
+    fullAPI.emit(GLOBALS_UPDATED, { globals: { g: 2 } });
+    expect(reachNavigate).toHaveBeenCalledWith(
+      '/?path=/story/test--story&full=1&globals=g:2',
+      expect.objectContaining({ replace: true })
+    );
+
+    fullAPI.emit(SET_CURRENT_STORY);
+    expect(reachNavigate).toHaveBeenCalledWith(
+      '/?path=/story/test--story&args=a:1&full=1&globals=g:2',
+      expect.objectContaining({ replace: true })
+    );
+  });
+
+  it('navigates to release notes when needed', () => {
+    fullAPI.showReleaseNotesOnLaunch.mockReturnValueOnce(true);
+
+    const navigate = jest.fn();
+    initURL({ store, state: { location: {} }, navigate, fullAPI }).init();
+
+    expect(navigate).toHaveBeenCalledWith('/settings/release-notes');
   });
 });


### PR DESCRIPTION
Issue: #15193

## What I did

When changing the `args` or `globals` query params, make sure we also keep other existing query params unchanged.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
