### PR TITLE
Codemod: Fix dist/node_modules ignore heuristic

### DIFF
--- a/lib/codemod/src/index.js
+++ b/lib/codemod/src/index.js
@@ -42,7 +42,7 @@ export async function runCodemod(codemod, { glob, logger, dryRun, rename, parser
     }
   }
 
-  const files = await globby([glob, '!node_modules', '!dist']);
+  const files = await globby([glob, '!**/node_modules', '!**/dist']);
   logger.log(`=> Applying ${codemod}: ${files.length} files`);
   if (!dryRun) {
     const parserArgs = parser ? ['--parser', parser] : [];


### PR DESCRIPTION
Issue: N/A

## What I did

Fix the ignore heuristics for codemod, which was searching through node_modules/dist folders! 🙈 

self-merging @yannbf (high five!)

## How to test

```
yarn sb migrate -g "examples/react-ts/**/*.stories.*" storiesof-to-csf
```

