### PR TITLE
Feature: Added toggle prop to toolbar addon for a button without menu to cycle through values

### DIFF
--- a/addons/toolbars/src/components/ToolbarManager.tsx
+++ b/addons/toolbars/src/components/ToolbarManager.tsx
@@ -22,9 +22,9 @@ export const ToolbarManager: FC = () => {
       <Separator />
       {globalIds.map((id) => {
         const normalizedArgType = normalizeArgType(id, globalTypes[id] as ToolbarArgType);
-        const isCycle = normalizedArgType.toolbar.toggle === true;
+        const isToggle = normalizedArgType.toolbar.toggle === true;
 
-        return isCycle ? (
+        return isToggle ? (
           <ToolbarMenuToggle key={id} id={id} {...normalizedArgType} />
         ) : (
           <ToolbarMenuList key={id} id={id} {...normalizedArgType} />

--- a/addons/toolbars/src/components/ToolbarManager.tsx
+++ b/addons/toolbars/src/components/ToolbarManager.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { useGlobalTypes } from '@storybook/api';
 import { Separator } from '@storybook/components';
+import { ToolbarMenuToggle } from './ToolbarMenuToggle';
 import { ToolbarMenuList } from './ToolbarMenuList';
 import { normalizeArgType } from '../utils/normalize-toolbar-arg-type';
 import { ToolbarArgType } from '../types';
@@ -21,8 +22,13 @@ export const ToolbarManager: FC = () => {
       <Separator />
       {globalIds.map((id) => {
         const normalizedArgType = normalizeArgType(id, globalTypes[id] as ToolbarArgType);
+        const isCycle = normalizedArgType.toolbar.toggle === true;
 
-        return <ToolbarMenuList key={id} id={id} {...normalizedArgType} />;
+        return isCycle ? (
+          <ToolbarMenuToggle key={id} id={id} {...normalizedArgType} />
+        ) : (
+          <ToolbarMenuList key={id} id={id} {...normalizedArgType} />
+        );
       })}
     </>
   );

--- a/addons/toolbars/src/components/ToolbarMenuToggle.tsx
+++ b/addons/toolbars/src/components/ToolbarMenuToggle.tsx
@@ -1,0 +1,45 @@
+import React, { useCallback, FC } from 'react';
+import { useGlobals } from '@storybook/api';
+import { ToolbarMenuButton } from './ToolbarMenuButton';
+import { withKeyboardCycle, WithKeyboardCycleProps } from '../hoc/withKeyboardCycle';
+import { getSelectedIcon } from '../utils/get-selected-icon';
+import { ToolbarMenuProps } from '../types';
+
+type ToolbarMenuToggleProps = ToolbarMenuProps & WithKeyboardCycleProps;
+
+export const ToolbarMenuToggle: FC<ToolbarMenuToggleProps> = withKeyboardCycle(
+  ({ id, name, description, cycleValues = [], toolbar: { title: _title, items, showName } }) => {
+    const [globals, updateGlobals] = useGlobals();
+
+    const currentValue = globals[id];
+    const hasGlobalValue = !!currentValue;
+    const icon = getSelectedIcon({ currentValue, items });
+
+    let title = _title;
+
+    // Deprecation support for old "name of global arg used as title"
+    if (showName && !title) {
+      title = name;
+    }
+
+    const setNext = useCallback(() => {
+      const currentIndex = cycleValues.indexOf(currentValue);
+      const currentIsLast = currentIndex === cycleValues.length - 1;
+
+      const newCurrentIndex = currentIsLast ? 0 : currentIndex + 1;
+      const newCurrent = cycleValues[newCurrentIndex];
+
+      updateGlobals({ [id]: newCurrent });
+    }, [currentValue, updateGlobals]);
+
+    return (
+      <ToolbarMenuButton
+        active={hasGlobalValue}
+        description={description}
+        onClick={setNext}
+        icon={icon}
+        title={title}
+      />
+    );
+  }
+);

--- a/addons/toolbars/src/types.ts
+++ b/addons/toolbars/src/types.ts
@@ -31,6 +31,7 @@ export interface NormalizedToolbarConfig {
   preventDynamicIcon?: boolean;
   items: ToolbarItem[];
   shortcuts?: ToolbarShortcuts;
+  toggle?: boolean;
   /** @deprecated "name" no longer dual purposes as title - use "title" if a title is wanted */
   showName?: boolean;
 }


### PR DESCRIPTION
## What I did
Added a new parameter to the toolbar addon config named "toggle"

This will invoke a button that can cycle (since it will accept any number of items and not just two to toggle between) between the item values.

## How to test
You can just go to the `examples/official-storybook` and spin it up - then edit `preview.js` and change the localization config object to include a `toggle: true` and it should just cycle between all the locale values and keybinds should still work.

If a default value is not chosen from start you will have to add an icon value for the button to show initially



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200539748475788/1200567474272563) by [Unito](https://www.unito.io)
