### PR TITLE
Core: Only call setup function on story navigation

### DIFF
--- a/lib/core-client/src/preview/StoryRenderer.tsx
+++ b/lib/core-client/src/preview/StoryRenderer.tsx
@@ -278,11 +278,11 @@ export class StoryRenderer {
   }) {
     if (getDecorated) {
       try {
-        const { applyLoaders, runSetupFunction, unboundStoryFn } = context;
+        const { applyLoaders, runSetupFunction, unboundStoryFn, forceRender } = context;
         const storyContext = await applyLoaders();
         const storyFn = () => unboundStoryFn(storyContext);
         await this.render({ ...context, storyContext, storyFn });
-        if (isCsf3Enabled()) {
+        if (isCsf3Enabled() && !forceRender) {
           await runSetupFunction();
         }
         this.channel.emit(Events.STORY_RENDERED, id);


### PR DESCRIPTION
Issue: N/A

## What I did

CSF3 (experimental) introduces a `setup` function that gets called after every story render. The problem is that if you update the controls, it causes the `setup` function to re-render, and args changes can result in elements not being on screen when the `setup` function needs them.

The solution in this PR is to not run the setup function when (the confusingly named) `forceRender` is set. `forceRender` means that there was no story navigation and we want to force the story to re-render for some other reason.

## How to test

See the `AccountForm` "Verification Password Mismatch" demo in `examples/react-ts`. After the setup function finishes, toggle the `passwordVerification` boolean. This causes a crash prior to this PR, but simply adjusts the prop as expected after this PR.

self-merging @tmeasday 