### PR TITLE
Addon-docs: Fix MDX compiler export to match new location

### DIFF
--- a/addons/docs/mdx-compiler-plugin.js
+++ b/addons/docs/mdx-compiler-plugin.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/mdx/mdx-compiler-plugin').createCompiler;
+module.exports = require('@storybook/csf-tools/mdx').createCompiler;


### PR DESCRIPTION
Issue: #15265 

## What I did

I moved the MDX compiler to a separate package to improve the Vite builder #15205, but screwed up the manual configuration for addon-docs in the process. This PR fixes it.

## How to test

Manually edit node_modules in an existing manually-configured project

Self-merging @yannbf 