### PR TITLE
Angular: Fix some Ivy rendering glitches

### DIFF
--- a/app/angular/src/client/preview/angular-beta/AbstractRenderer.ts
+++ b/app/angular/src/client/preview/angular-beta/AbstractRenderer.ts
@@ -29,7 +29,6 @@ export abstract class AbstractRenderer {
     return new Promise<void>((resolve) => {
       if (platformRef && !platformRef.destroyed) {
         platformRef.onDestroy(async () => {
-          await AbstractRenderer.resetCompiledComponents();
           resolve();
         });
         // Destroys the current Angular platform and all Angular applications on the page.
@@ -82,6 +81,8 @@ export abstract class AbstractRenderer {
   }
 
   protected abstract beforeFullRender(): Promise<void>;
+
+  protected abstract afterFullRender(): Promise<void>;
 
   /**
    * Bootstrap main angular module with main component or send only new `props` with storyProps$
@@ -136,6 +137,7 @@ export abstract class AbstractRenderer {
       createStorybookModule(moduleMetadata),
       parameters.bootstrapModuleOptions ?? undefined
     );
+    await this.afterFullRender();
   }
 
   protected initAngularRootElement(targetDOMNode: HTMLElement, targetSelector: string) {

--- a/app/angular/src/client/preview/angular-beta/CanvasRenderer.ts
+++ b/app/angular/src/client/preview/angular-beta/CanvasRenderer.ts
@@ -15,4 +15,8 @@ export class CanvasRenderer extends AbstractRenderer {
   async beforeFullRender(): Promise<void> {
     await CanvasRenderer.resetPlatformBrowserDynamic();
   }
+
+  async afterFullRender(): Promise<void> {
+    await AbstractRenderer.resetCompiledComponents();
+  }
 }

--- a/app/angular/src/client/preview/angular-beta/DocsRenderer.ts
+++ b/app/angular/src/client/preview/angular-beta/DocsRenderer.ts
@@ -27,9 +27,11 @@ export class DocsRenderer extends AbstractRenderer {
     });
 
     await super.render({ ...options, forced: false });
-
-    await AbstractRenderer.resetCompiledComponents();
   }
 
   async beforeFullRender(): Promise<void> {}
+
+  async afterFullRender(): Promise<void> {
+    await AbstractRenderer.resetCompiledComponents();
+  }
 }

--- a/app/angular/src/client/preview/angular-beta/DocsRenderer.ts
+++ b/app/angular/src/client/preview/angular-beta/DocsRenderer.ts
@@ -26,6 +26,15 @@ export class DocsRenderer extends AbstractRenderer {
       await DocsRenderer.resetPlatformBrowserDynamic();
     });
 
+    /**
+     * Destroy and recreate the PlatformBrowserDynamic of angular
+     * when doc re render. Allows to call ngOnDestroy of angular
+     * for previous component
+     */
+    channel.once(Events.DOCS_RENDERED, async () => {
+      await DocsRenderer.resetPlatformBrowserDynamic();
+    });
+
     await super.render({ ...options, forced: false });
   }
 


### PR DESCRIPTION
Issue: @yngvebn https://discord.com/channels/486522875931656193/490770949910691862/854687468321767444

## What I did
- fix(angular): call AbstractRenderer.resetCompiledComponents after full render
to avoid having `ngIf/ngFor` ivy errors

- fix(angular): destroy component when doc re render
to correctly destroy the components after an HMR

## How to test

- Is this testable with Jest or Chromatic screenshots? 🤷‍♂️
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

