### PR TITLE
CLI: Update types in React typescript templates

### DIFF
--- a/lib/cli/src/frameworks/react/ts/Button.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Button.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Story, Meta } from '@storybook/react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import { Button, ButtonProps } from './Button';
+import { Button } from './Button';
 
 export default {
   title: 'Example/Button',
@@ -9,9 +9,9 @@ export default {
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-} as Meta;
+} as ComponentMeta<typeof Button>;
 
-const Template: Story<ButtonProps> = (args) => <Button {...args} />;
+const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
 Primary.args = {

--- a/lib/cli/src/frameworks/react/ts/Button.tsx
+++ b/lib/cli/src/frameworks/react/ts/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import './button.css';
 
-export interface ButtonProps {
+interface ButtonProps {
   /**
    * Is this the principal call to action on the page?
    */
@@ -27,13 +27,13 @@ export interface ButtonProps {
 /**
  * Primary UI component for user interaction
  */
-export const Button: React.FC<ButtonProps> = ({
+export const Button = ({
   primary = false,
   size = 'medium',
   backgroundColor,
   label,
   ...props
-}) => {
+}: ButtonProps) => {
   const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
   return (
     <button

--- a/lib/cli/src/frameworks/react/ts/Header.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Header.stories.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Story, Meta } from '@storybook/react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import { Header, HeaderProps } from './Header';
+import { Header } from './Header';
 
 export default {
   title: 'Example/Header',
   component: Header,
-} as Meta;
+} as ComponentMeta<typeof Header>;
 
-const Template: Story<HeaderProps> = (args) => <Header {...args} />;
+const Template: ComponentStory<typeof Header> = (args) => <Header {...args} />;
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {

--- a/lib/cli/src/frameworks/react/ts/Header.tsx
+++ b/lib/cli/src/frameworks/react/ts/Header.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { Button } from './Button';
 import './header.css';
 
-export interface HeaderProps {
+interface HeaderProps {
   user?: {};
   onLogin: () => void;
   onLogout: () => void;
   onCreateAccount: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ user, onLogin, onLogout, onCreateAccount }) => (
+export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
   <header>
     <div className="wrapper">
       <div>

--- a/lib/cli/src/frameworks/react/ts/Page.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Page.stories.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { Story, Meta } from '@storybook/react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import { Page, PageProps } from './Page';
+import { Page } from './Page';
 import * as HeaderStories from './Header.stories';
 
 export default {
   title: 'Example/Page',
   component: Page,
-} as Meta;
+} as ComponentMeta<typeof Page>;
 
-const Template: Story<PageProps> = (args) => <Page {...args} />;
+const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {

--- a/lib/cli/src/frameworks/react/ts/Page.tsx
+++ b/lib/cli/src/frameworks/react/ts/Page.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { Header } from './Header';
 import './page.css';
 
-export interface PageProps {
+interface PageProps {
   user?: {};
   onLogin: () => void;
   onLogout: () => void;
   onCreateAccount: () => void;
 }
 
-export const Page: React.FC<PageProps> = ({ user, onLogin, onLogout, onCreateAccount }) => (
+export const Page = ({ user, onLogin, onLogout, onCreateAccount }: PageProps) => (
   <article>
     <Header user={user} onLogin={onLogin} onLogout={onLogout} onCreateAccount={onCreateAccount} />
 

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -243,6 +243,7 @@ const getConfig = async (): Promise<Parameters[]> => {
         type: 'autocompleteMultiselect',
         message: 'Select the frameworks to run',
         name: 'frameworks',
+        min: 1,
         hint:
           'You can also run directly with package name like `test:e2e-framework react`, or `yarn test:e2e-framework --all` for all packages!',
         choices: Object.keys(configs).map((key) => {


### PR DESCRIPTION
Issue: N/A

## What I did

1 - Update types to use `ComponentStory` and `ComponentMeta`

2 - Remove `React.FC` as the components don't receive children so they shouldn't be FC

3 - Fix a small thing in the CLI for e2e where users were able to press enter without selecting a framework, and the script would do nothing

## How to test

- Does this need an update to the documentation? Not this, but it's good to think about updating the React typescript docs if we want more people to use this type.