### PR TITLE
Use semantic version constraint for prettier (^2.2.1 instead of ~2.2.1)

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -90,7 +90,7 @@
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.20",
     "p-limit": "^3.1.0",
-    "prettier": "~2.2.1",
+    "prettier": "^2.2.1",
     "prop-types": "^15.7.2",
     "react-element-to-jsx-string": "^14.3.2",
     "regenerator-runtime": "^0.13.7",

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -51,7 +51,7 @@
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "loader-utils": "^2.0.0",
-    "prettier": "~2.2.1",
+    "prettier": "^2.2.1",
     "prop-types": "^15.7.2",
     "react-syntax-highlighter": "^13.5.3",
     "regenerator-runtime": "^0.13.7"

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -51,7 +51,7 @@
     "globby": "^11.0.2",
     "jscodeshift": "^0.7.0",
     "lodash": "^4.17.20",
-    "prettier": "~2.2.1",
+    "prettier": "^2.2.1",
     "recast": "^0.19.0",
     "regenerator-runtime": "^0.13.7"
   },

--- a/lib/csf-tools/package.json
+++ b/lib/csf-tools/package.json
@@ -52,7 +52,7 @@
     "fs-extra": "^9.0.1",
     "js-string-escape": "^1.0.1",
     "lodash": "^4.17.20",
-    "prettier": "~2.2.1",
+    "prettier": "^2.2.1",
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -49,7 +49,7 @@
     "global": "^4.4.0",
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.20",
-    "prettier": "~2.2.1",
+    "prettier": "^2.2.1",
     "regenerator-runtime": "^0.13.7"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "npmlog": "^4.1.2",
     "p-limit": "^3.1.0",
     "postcss-loader": "^4.2.0",
-    "prettier": "~2.2.1",
+    "prettier": "^2.2.1",
     "prompts": "^2.4.0",
     "raf": "^3.4.1",
     "regenerator-runtime": "^0.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5708,7 +5708,7 @@ __metadata:
     loader-utils: ^2.0.0
     lodash: ^4.17.20
     p-limit: ^3.1.0
-    prettier: ~2.2.1
+    prettier: ^2.2.1
     prop-types: ^15.7.2
     react-element-to-jsx-string: ^14.3.2
     regenerator-runtime: ^0.13.7
@@ -6027,7 +6027,7 @@ __metadata:
     core-js: ^3.8.2
     estraverse: ^5.2.0
     loader-utils: ^2.0.0
-    prettier: ~2.2.1
+    prettier: ^2.2.1
     prop-types: ^15.7.2
     react-syntax-highlighter: ^13.5.3
     regenerator-runtime: ^0.13.7
@@ -6520,7 +6520,7 @@ __metadata:
     jest-specific-snapshot: ^4.0.0
     jscodeshift: ^0.7.0
     lodash: ^4.17.20
-    prettier: ~2.2.1
+    prettier: ^2.2.1
     recast: ^0.19.0
     regenerator-runtime: ^0.13.7
   languageName: unknown
@@ -6759,7 +6759,7 @@ __metadata:
     js-string-escape: ^1.0.1
     js-yaml: ^3.14.1
     lodash: ^4.17.20
-    prettier: ~2.2.1
+    prettier: ^2.2.1
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
   languageName: unknown
@@ -7355,7 +7355,7 @@ __metadata:
     npmlog: ^4.1.2
     p-limit: ^3.1.0
     postcss-loader: ^4.2.0
-    prettier: ~2.2.1
+    prettier: ^2.2.1
     prompts: ^2.4.0
     puppeteer: ^2.1.1
     raf: ^3.4.1
@@ -7471,7 +7471,7 @@ __metadata:
     global: ^4.4.0
     loader-utils: ^2.0.0
     lodash: ^4.17.20
-    prettier: ~2.2.1
+    prettier: ^2.2.1
     regenerator-runtime: ^0.13.7
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -34502,7 +34502,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prettier@npm:~2.2.1":
+"prettier@npm:^2.2.1":
   version: 2.2.1
   resolution: "prettier@npm:2.2.1"
   bin:


### PR DESCRIPTION
Issue: #14714

## What I did

Replaced prettier version constraints `~2.2.1` with `^2.2.1` in all places. I did not update prettier itselft (still resolves to 2.2.1, see the yarn.lock diff).

## How to test

- Is this testable with Jest or Chromatic screenshots? **No**
- Does this need a new example in the kitchen sink apps? **No**
- Does this need an update to the documentation? **No**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
