### PR TITLE
Yarn: Disable unnecessary builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,5 +323,41 @@
         "Other"
       ]
     ]
+  },
+  "dependenciesMeta": {
+    "@compodoc/compodoc": {
+      "built": false
+    },
+    "core-js": {
+      "built": false
+    },
+    "core-js-pure": {
+      "built": false
+    },
+    "ejs": {
+      "built": false
+    },
+    "level": {
+      "built": false
+    },
+    "node-uuid": {
+      "built": false,
+      "unplugged": false
+    },
+    "nodemon": {
+      "built": false
+    },
+    "parcel": {
+      "built": false
+    },
+    "preact": {
+      "built": false
+    },
+    "styled-components": {
+      "built": false
+    },
+    "yorkie": {
+      "built": false
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7383,18 +7383,41 @@ __metadata:
     webpack-dev-middleware: ^3.7.3
     window-size: ^1.1.1
   dependenciesMeta:
+    "@compodoc/compodoc":
+      built: false
     "@cypress/webpack-preprocessor":
       optional: true
+    core-js:
+      built: false
+    core-js-pure:
+      built: false
     cypress:
       optional: true
+    ejs:
+      built: false
+    level:
+      built: false
+    node-uuid:
+      built: false
+      unplugged: false
+    nodemon:
+      built: false
+    parcel:
+      built: false
+    preact:
+      built: false
     puppeteer:
       optional: true
+    styled-components:
+      built: false
     ts-loader:
       optional: true
     verdaccio:
       optional: true
     verdaccio-auth-memory:
       optional: true
+    yorkie:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What I did

Yarn spends unnecessary resources running postinstalls that don't do anything useful, i.e. print messages that Yarn wont show either way.

## How to test

Run `yarn rebuild` (or a fresh install) and see the amount of builds Yarn has to run is reduced, if using PnP in this repo observe that the `.yarn/unplugged` folder contains less items

```diff
  $ du -sh --inodes .yarn/unplugged/ && du -sh .yarn/unplugged/
- 12K     .yarn/unplugged/
- 61M     .yarn/unplugged/
+ 3.4K    .yarn/unplugged/
+ 37M     .yarn/unplugged/
```
