### PR TITLE
CI: Use Large executor to fix stuck Angular e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
           destination: cypress
   e2e-tests-core:
     executor:
-      class: medium
+      class: large
       name: sb_cypress_6_node_12
     parallelism: 2
     steps:


### PR DESCRIPTION
## What I did

Use Large executor to fix stuck Angular e2e test 🤷🏻 

## How to test

- `e2e-tests-core` CI job should be 🟢 