### PR TITLE
Toolbars: Add missing `regenerator-runtime` dependency

### DIFF
--- a/addons/toolbars/package.json
+++ b/addons/toolbars/package.json
@@ -50,7 +50,8 @@
     "@storybook/client-api": "6.3.0-rc.11",
     "@storybook/components": "6.3.0-rc.11",
     "@storybook/theming": "6.3.0-rc.11",
-    "core-js": "^3.8.2"
+    "core-js": "^3.8.2",
+    "regenerator-runtime": "^0.13.7"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6052,6 +6052,7 @@ __metadata:
     "@storybook/components": 6.3.0-rc.11
     "@storybook/theming": 6.3.0-rc.11
     core-js: ^3.8.2
+    regenerator-runtime: ^0.13.7
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13830#issuecomment-864242992

## What I did

I just added `regenerator-runtime` as dependency in `@storybook/addon-toolbars`
