### PR TITLE
Core: Support `argType.type.summary` when mapping url args

### DIFF
--- a/lib/client-api/src/args.ts
+++ b/lib/client-api/src/args.ts
@@ -3,13 +3,13 @@ import { once } from '@storybook/client-logger';
 import isPlainObject from 'lodash/isPlainObject';
 import dedent from 'ts-dedent';
 
-type ValueType = { name: string; value?: ObjectValueType | ValueType };
+type ValueType = { name?: string; summary?: string; value?: ObjectValueType | ValueType };
 type ObjectValueType = Record<string, ValueType>;
 
 const INCOMPATIBLE = Symbol('incompatible');
 const map = (arg: unknown, type: ValueType): any => {
   if (arg === undefined || arg === null || !type) return arg;
-  switch (type.name) {
+  switch (type.name || type.summary) {
     case 'string':
       return String(arg);
     case 'enum':


### PR DESCRIPTION
Issue: #15278

## What I did

Sometimes we get a `type.summary` rather than a `type.name`, which causes the url args mapping to fail. This fixes that.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
