### PR TITLE
Svelte: Fix argType.type.name extraction

### DIFF
--- a/addons/docs/src/frameworks/svelte/extractArgTypes.test.ts
+++ b/addons/docs/src/frameworks/svelte/extractArgTypes.test.ts
@@ -102,8 +102,8 @@ describe('Extracting Arguments', () => {
             },
           },
           "type": Object {
-            "required": false,
             "name": "boolean",
+            "required": false,
           },
         },
         "slot_default": Object {
@@ -134,8 +134,8 @@ describe('Extracting Arguments', () => {
             },
           },
           "type": Object {
-            "required": false,
             "name": "string",
+            "required": false,
           },
         },
       }

--- a/addons/docs/src/frameworks/svelte/extractArgTypes.test.ts
+++ b/addons/docs/src/frameworks/svelte/extractArgTypes.test.ts
@@ -103,7 +103,7 @@ describe('Extracting Arguments', () => {
           },
           "type": Object {
             "required": false,
-            "summary": "boolean",
+            "name": "boolean",
           },
         },
         "slot_default": Object {
@@ -135,7 +135,7 @@ describe('Extracting Arguments', () => {
           },
           "type": Object {
             "required": false,
-            "summary": "string",
+            "name": "string",
           },
         },
       }

--- a/addons/docs/src/frameworks/svelte/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/svelte/extractArgTypes.ts
@@ -39,7 +39,7 @@ export const createArgTypes = (docgen: SvelteComponentDoc) => {
       description: item.description,
       type: {
         required: hasKeyword('required', item.keywords),
-        summary: item.type?.text,
+        name: item.type?.text,
       },
       table: {
         type: {


### PR DESCRIPTION
Issue: #15278

## What I did

ArgTypes for Svelte were incorrectly setting `type.summary` which should be `type.name`, as `summary` only exists in the context of `table`.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
