### PR TITLE
Essentials: Update addon measure and outline

### DIFF
--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -43,7 +43,7 @@
     "@storybook/addon-backgrounds": "6.4.0-alpha.0",
     "@storybook/addon-controls": "6.4.0-alpha.0",
     "@storybook/addon-docs": "6.4.0-alpha.0",
-    "@storybook/addon-measure": "^1.2.3",
+    "@storybook/addon-measure": "^1.3.1",
     "@storybook/addon-toolbars": "6.4.0-alpha.0",
     "@storybook/addon-viewport": "6.4.0-alpha.0",
     "@storybook/addons": "6.4.0-alpha.0",
@@ -51,7 +51,7 @@
     "@storybook/node-logger": "6.4.0-alpha.0",
     "core-js": "^3.8.2",
     "regenerator-runtime": "^0.13.7",
-    "storybook-addon-outline": "^1.3.3",
+    "storybook-addon-outline": "^1.4.0",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5776,7 +5776,7 @@ __metadata:
     "@storybook/addon-backgrounds": 6.4.0-alpha.0
     "@storybook/addon-controls": 6.4.0-alpha.0
     "@storybook/addon-docs": 6.4.0-alpha.0
-    "@storybook/addon-measure": ^1.2.3
+    "@storybook/addon-measure": ^1.3.1
     "@storybook/addon-toolbars": 6.4.0-alpha.0
     "@storybook/addon-viewport": 6.4.0-alpha.0
     "@storybook/addons": 6.4.0-alpha.0
@@ -5787,7 +5787,7 @@ __metadata:
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
-    storybook-addon-outline: ^1.3.3
+    storybook-addon-outline: ^1.4.0
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
@@ -5868,15 +5868,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-measure@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "@storybook/addon-measure@npm:1.2.3"
+"@storybook/addon-measure@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@storybook/addon-measure@npm:1.3.1"
   peerDependencies:
-    "@storybook/addons": ^6.3.0-beta.1
-    "@storybook/api": ^6.3.0-beta.1
-    "@storybook/components": ^6.3.0-beta.1
-    "@storybook/core-events": ^6.3.0-beta.1
-    "@storybook/theming": ^6.3.0-beta.1
+    "@storybook/addons": ^6.3.0
+    "@storybook/api": ^6.3.0
+    "@storybook/components": ^6.3.0
+    "@storybook/core-events": ^6.3.0
+    "@storybook/theming": ^6.3.0
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -5884,7 +5884,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 8c46d5b5a067ef0a4d333f9cfd1c7fe408810b487113523ed411b29d7b4f02b33f777b0aeafbec679893d783850c9f3cbaf922dba9d365e4282bbd2ee8ab3182
+  checksum: fa7f86f24dc9ad534c35042bc026955ffffcd4cf8636d021239e502410c557a98a651b672e8d0a7f0cdb74d32679f805d88f0df1002b573ee61c9a67cc254df0
   languageName: node
   linkType: hard
 
@@ -6109,7 +6109,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addons@npm:^6.3.0-beta.6":
+"@storybook/addons@npm:^6.3.0":
   version: 6.3.0
   resolution: "@storybook/addons@npm:6.3.0"
   dependencies:
@@ -6242,7 +6242,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/api@npm:6.3.0, @storybook/api@npm:^6.3.0-beta.6":
+"@storybook/api@npm:6.3.0, @storybook/api@npm:^6.3.0":
   version: 6.3.0
   resolution: "@storybook/api@npm:6.3.0"
   dependencies:
@@ -6635,7 +6635,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/components@npm:^6.3.0-beta.6":
+"@storybook/components@npm:^6.3.0":
   version: 6.3.0
   resolution: "@storybook/components@npm:6.3.0"
   dependencies:
@@ -6774,7 +6774,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-events@npm:6.3.0, @storybook/core-events@npm:^6.3.0-beta.6":
+"@storybook/core-events@npm:6.3.0, @storybook/core-events@npm:^6.3.0":
   version: 6.3.0
   resolution: "@storybook/core-events@npm:6.3.0"
   dependencies:
@@ -39740,19 +39740,19 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"storybook-addon-outline@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "storybook-addon-outline@npm:1.3.3"
+"storybook-addon-outline@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "storybook-addon-outline@npm:1.4.0"
   dependencies:
-    "@storybook/addons": ^6.3.0-beta.6
-    "@storybook/api": ^6.3.0-beta.6
-    "@storybook/components": ^6.3.0-beta.6
-    "@storybook/core-events": ^6.3.0-beta.6
+    "@storybook/addons": ^6.3.0
+    "@storybook/api": ^6.3.0
+    "@storybook/components": ^6.3.0
+    "@storybook/core-events": ^6.3.0
     ts-dedent: ^2.1.1
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: db9f175f086ef1a5fd8e6fff6a912e5b5383afab1cb267a2b896ff4e213a0e3d2dad98766cc28ef5420d28da656cc569a644ca5c48c99993472f8ac0e0e5b8b5
+  checksum: d1d94b9b75b96afa43715dac48f892a42906148f26a30ad27db26fb7fd106a860c97a4748a33a2ec041762fca865336de2529860ec441c33ee3f5a2a4cd0ef42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue:

## What I did
Updated the measure and outline addons. This fixes the dependency warnings. 

