### PR TITLE
docs: fix a minor typo

### DIFF
--- a/docs/addons/addon-types.md
+++ b/docs/addons/addon-types.md
@@ -47,7 +47,7 @@ Use this boilerplate code to add a new `button` to Storybook's Toolbar:
 
 <div class="aside">
 
-The <code>icon</code> element used in the example loads the icons from the <code>@storybook/components</code> package. See [here](../workflows/faq.md#what-icons-are-available-for-my-toolbar-or-my-addon) the list of available icons that you can use.
+The <code>icon</code> element used in the example loads the icons from the <code>@storybook/components</code> package. See [here](../workflows/faq.md#what-icons-are-available-for-my-toolbar-or-my-addon) for the list of available icons that you can use.
 
 </div>
 

--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -68,7 +68,7 @@ In your [`.storybook/preview.js`](../configure/overview.md#configure-story-rende
 
 <div class="aside">
 
-The <code>icon</code> element used in the examples loads the icons from the <code>@storybook/components</code> package. See [here](../workflows/faq.md#what-icons-are-available-for-my-toolbar-or-my-addon) the list of available icons that you can use.
+The <code>icon</code> element used in the examples loads the icons from the <code>@storybook/components</code> package. See [here](../workflows/faq.md#what-icons-are-available-for-my-toolbar-or-my-addon) for the list of available icons that you can use.
 
 </div>
 


### PR DESCRIPTION
## What I did

Fixed a small typo on https://storybook.js.org/docs/react/essentials/toolbars-and-globals#advanced-usage.

<img width="827" alt="Screen Shot 2021-06-25 at 17 17 47" src="https://user-images.githubusercontent.com/25715018/123410424-86231e00-d5d9-11eb-96d6-148f97e58661.png">

The second sentence should read:
> See here for the list of available icons that you can use.
