### PR TITLE
Core: Only use dotenv-webpack when a user has a dotenv file

### DIFF
--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -18,6 +18,7 @@ import {
   nodeModulesPaths,
   interpolate,
   Options,
+  hasDotenv,
 } from '@storybook/core-common';
 import { createBabelLoader } from './babel-loader-preview';
 
@@ -175,7 +176,7 @@ export default async ({
       isProd ? null : new HotModuleReplacementPlugin(),
       new CaseSensitivePathsPlugin(),
       quiet ? null : new ProgressPlugin({}),
-      new Dotenv({ silent: true }),
+      hasDotenv() ? new Dotenv({ silent: true }) : null,
       shouldCheckTs ? new ForkTsCheckerWebpackPlugin(tsCheckOptions) : null,
     ].filter(Boolean),
     module: {

--- a/lib/core-common/src/index.ts
+++ b/lib/core-common/src/index.ts
@@ -21,5 +21,6 @@ export * from './utils/template';
 export * from './utils/interpolate';
 export * from './utils/validate-configuration-files';
 export * from './utils/to-require-context';
+export * from './utils/has-dotenv';
 
 export * from './types';

--- a/lib/core-common/src/utils/has-dotenv.ts
+++ b/lib/core-common/src/utils/has-dotenv.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+// https://github.com/mrsteele/dotenv-webpack/blob/master/src/index.js#L34
+const DOTENV_FILE = path.join('.', '.env');
+
+/**
+ * Is there a .env file in the current directory?
+ * This is the default behavior of `dotenv-webpack-plugin`
+ */
+export const hasDotenv = () => fs.existsSync(DOTENV_FILE);

--- a/lib/core-common/src/utils/has-dotenv.ts
+++ b/lib/core-common/src/utils/has-dotenv.ts
@@ -1,11 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 
-// https://github.com/mrsteele/dotenv-webpack/blob/master/src/index.js#L34
-const DOTENV_FILE = path.join('.', '.env');
-
 /**
  * Is there a .env file in the current directory?
+ *
  * This is the default behavior of `dotenv-webpack-plugin`
+ * https://github.com/mrsteele/dotenv-webpack/blob/master/src/index.js#L34
  */
-export const hasDotenv = () => fs.existsSync(DOTENV_FILE);
+export const hasDotenv = () => fs.existsSync(path.join('.', '.env'));

--- a/lib/manager-webpack5/src/manager-webpack.config.ts
+++ b/lib/manager-webpack5/src/manager-webpack.config.ts
@@ -19,6 +19,7 @@ import {
   getManagerMainTemplate,
   Options,
   ManagerWebpackOptions,
+  hasDotenv,
 } from '@storybook/core-common';
 
 import { babelLoader } from './babel-loader-manager';
@@ -103,7 +104,7 @@ export default async ({
         template,
       }) as any) as WebpackPluginInstance,
       (new CaseSensitivePathsPlugin() as any) as WebpackPluginInstance,
-      new Dotenv({ silent: true }),
+      hasDotenv() ? new Dotenv({ silent: true }) : null,
       // graphql sources check process variable
       new DefinePlugin({
         'process.env': stringifyEnvs(envs),


### PR DESCRIPTION
Issue: #14257 

## What I did

Get rid of webpack5 warning when `dotenv-webpack`'s `process.env` definition conflicts with our own `DefinePlugin` usage by simply not using the plugin unless the user has a `.env` file in the current directory.

This was not a problem in Webpack4, but has gotten more strict in Webpack5.

This PR does not solve the problem where users DO have a `.env` file, but it should remove spurious warnings for users that DON'T.

## How to test

Not easy to test in the current monorepo setup because we cannot run webpack5