### PR TITLE
Core: Fix double rebuilds by removing aggregateTimeout

### DIFF
--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -130,7 +130,6 @@ export default async ({
       publicPath: '',
     },
     watchOptions: {
-      aggregateTimeout: 10,
       ignored: /node_modules/,
     },
     plugins: [

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -128,7 +128,6 @@ export default async ({
       logging: 'error',
     },
     watchOptions: {
-      aggregateTimeout: 10,
       ignored: /node_modules/,
     },
     ignoreWarnings: [

--- a/lib/manager-webpack4/src/manager-webpack.config.ts
+++ b/lib/manager-webpack4/src/manager-webpack.config.ts
@@ -68,7 +68,6 @@ export default async ({
       publicPath: '',
     },
     watchOptions: {
-      aggregateTimeout: 2000,
       ignored: /node_modules/,
     },
     plugins: [

--- a/lib/manager-webpack5/src/manager-webpack.config.ts
+++ b/lib/manager-webpack5/src/manager-webpack.config.ts
@@ -68,7 +68,6 @@ export default async ({
       publicPath: '',
     },
     watchOptions: {
-      aggregateTimeout: 2000,
       ignored: /node_modules/,
     },
     plugins: [


### PR DESCRIPTION
Issue:

Rebuild on MacOS happened twice because of low `aggregateTimeout`.

## What I did

I added small webpack plugin to get some info about rebuilds:

```js
(compiler) => {
      compiler.hooks.invalid.tap('MyWatchPlugin', (filename, changeTime) => {
        console.log('invalid ', filename, ' ', changeTime);
      });
}
```

And after a change in VS Code in `animation.stories.mdx` I got 2 invalidation messages with a 137ms diffrence.
```
invalid  
/client/src/components/animation/animation.stories.mdx   1624650320319ms
webpack building...
99% done plugins webpack-hot-middlewarewebpack built preview 96b915b14387a27ea005 in 3524ms
108 assets
5283 modules
preview (webpack 5.39.1) compiled successfully in 3524 ms

invalid  
/client/src/components/animation/animation.stories.mdx   1624650320456ms
webpack building...
99% done plugins webpack-hot-middlewarewebpack built preview 96b915b14387a27ea005 in 2059ms
108 assets
5283 modules
preview (webpack 5.39.1) compiled successfully in 2059 ms
```

first I started to think that it's somehow related to file saving in VS Code and decided to try `touch /client/src/components/animation/animation.stories.mdx` and got only 1 rebuild as expected. But then I tried to edit a file in TextEdit (default MacOS editor) and again got 2 rebuilds. So I think it could be related to how MacOS FS implements saving. Maybe it updates file content file and metadata separately.

Webpack default [sets default aggregateTimeout to 200ms](ttps://webpack.js.org/configuration/watch/#watchoptionsaggregatetimeout) so I removed override from storybook's configs. 


## How to test

Run storybook in dev mode, change one file and you should see only 1 rebuild.
