### PR TITLE
Documentation: Change isToolshown type from String to Boolean

### DIFF
--- a/docs/configure/features-and-behavior.md
+++ b/docs/configure/features-and-behavior.md
@@ -23,7 +23,7 @@ The following table details how to use the API values:
 | **showPanel**         | Boolean       |Display panel that shows addon configurations                  |`true`                                          |
 | **panelPosition**     | String/Object |Where to show the addon panel                                  |`bottom` or `right`                             |
 | **enableShortcuts**   | Boolean       |Enable/disable shortcuts                                       |`true`                                          |
-| **isToolshown**       | String        |Show/hide tool bar                                             |`true`                                          |
+| **isToolshown**       | Boolean       |Show/hide tool bar                                             |`true`                                          |
 | **theme**             | Object        |Storybook Theme, see next section                              |`undefined`                                     |
 | **selectedPanel**     | String        |Id to select an addon panel                                    |`storybook/actions/panel`                       |
 | **initialActive**     | String        |Select the default active tab on Mobile                        |`sidebar` or `canvas` or `addons`               |


### PR DESCRIPTION
Issue: While going through the documentation, I noticed that the `isToolshown` api value is categorized as `String`, but I think that it should be `boolean`.

## What I did
I changed the type of `isToolshown` from `String` to `Boolean`.
## How to test
You can view the file preview.

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
