### PR TITLE
docs: remove unnecessary character

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -263,7 +263,7 @@ Several URL params to control the manager layout have been deprecated and will b
 - `panelRight=1`: use `panel=right` instead
 - `stories=0`: use `nav=false` instead
 
-Additionally, support for legacy URLs using `selectedKind` and `selectedStory` will be removed in 7.0. Use `path` instead.
+Additionally, support for legacy URLs using `selectedKind` and `selectedStory` will be removed in 7.0. Use `path` instead.
 
 ## From version 6.1.x to 6.2.0
 


### PR DESCRIPTION
Issue: There is an unnecessary character in MIGRATION.md.

![スクリーンショット 2021-06-28 13 30 18](https://user-images.githubusercontent.com/9845816/123580683-49dc0180-d815-11eb-9fe6-10bcdb143f45.png)


## What I did

I removed the unnecessary character.

<!-- 
## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

-->

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
