### PR TITLE
Chore: (Docs snippets) Updates for jsx and tsx support

### DIFF
--- a/docs/essentials/auto-generated-controls/react.mdx
+++ b/docs/essentials/auto-generated-controls/react.mdx
@@ -1,6 +1,8 @@
 To use auto-detected controls with React, you must fill in the `component` field in your story metadata:
 
 ```ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
+
 import { Button } from './Button';
 
 export default {

--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -29,6 +29,8 @@ npm install --save-dev @storybook/addon-essentials
 Update your Storybook configuration (in `.storybook/main.js`) to include the essentials addon.
 
 ```js
+// .storybook/main.js
+
 module.exports = {
   addons: ['@storybook/addon-essentials'],
 };

--- a/docs/snippets/common/badge-story-custom-argtypes.js.mdx
+++ b/docs/snippets/common/badge-story-custom-argtypes.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Badge.stories.js | Badge.stories.ts
+// Badge.stories.js | Badge.stories.jsx  | Badge.stories.ts | Badge.stories.tsx
 
 export default {
   component: Badge,

--- a/docs/snippets/common/button-group-story-subcomponents.js.mdx
+++ b/docs/snippets/common/button-group-story-subcomponents.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// ButtonGroup.stories.js
+// ButtonGroup.stories.js | ButtonGroup.stories.jsx
 
 import { Button, ButtonGroup } from '../ButtonGroup';
 

--- a/docs/snippets/common/button-group-story-subcomponents.ts.mdx
+++ b/docs/snippets/common/button-group-story-subcomponents.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// ButtonGroup.stories.ts
+// ButtonGroup.stories.ts | ButtonGroup.stories.tsx
 
 import { Meta } from '@storybook/react/types-6-0';
 

--- a/docs/snippets/common/button-story-action-event-handle.js.mdx
+++ b/docs/snippets/common/button-story-action-event-handle.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/button-story-argtypes-with-categories.js.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-categories.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/button-story-argtypes-with-subcategories.js.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-subcategories.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/button-story-controls-primary-variant.js.mdx
+++ b/docs/snippets/common/button-story-controls-primary-variant.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 const Primary = Template.bind({});
 Primary.args = {

--- a/docs/snippets/common/button-story-controls-radio-group.js.mdx
+++ b/docs/snippets/common/button-story-controls-radio-group.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/button-story-default-export.js.mdx
+++ b/docs/snippets/common/button-story-default-export.js.mdx
@@ -1,7 +1,7 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
-  title: 'Button'
-}
+  title: 'Button',
+};
 ```

--- a/docs/snippets/common/button-story-disable-addon.js.mdx
+++ b/docs/snippets/common/button-story-disable-addon.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js |  Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/button-story-disable-docspage-component.js.mdx
+++ b/docs/snippets/common/button-story-disable-docspage-component.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 import { Button } from './Button';
 

--- a/docs/snippets/common/button-story-docs-code-type.js.mdx
+++ b/docs/snippets/common/button-story-docs-code-type.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',
@@ -10,7 +10,7 @@ export default {
   parameters: {
     docs: {
       source: {
-        type: 'code'
+        type: 'code',
       }
     }
   }

--- a/docs/snippets/common/button-story-docspage-with-custom-component.js.mdx
+++ b/docs/snippets/common/button-story-docspage-with-custom-component.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 import { Button } from './Button';
 

--- a/docs/snippets/common/button-story-docspage-with-mdx.js.mdx
+++ b/docs/snippets/common/button-story-docspage-with-mdx.js.mdx
@@ -1,6 +1,5 @@
 ```js
-
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 import { Button } from './Button';
 

--- a/docs/snippets/common/button-story-grouped.js.mdx
+++ b/docs/snippets/common/button-story-grouped.js.mdx
@@ -1,7 +1,7 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
-  title: 'Design System/Atoms/Button'
-}
+  title: 'Design System/Atoms/Button',
+};
 ```

--- a/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx
+++ b/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const Large = Template.bind({});
 

--- a/docs/snippets/common/button-story-hoisted.js.mdx
+++ b/docs/snippets/common/button-story-hoisted.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 import { Button as ButtonComponent } from './Button';
 

--- a/docs/snippets/common/button-story-matching-argtypes.js.mdx
+++ b/docs/snippets/common/button-story-matching-argtypes.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/button-story-onclick-action-argtype.js.mdx
+++ b/docs/snippets/common/button-story-onclick-action-argtype.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/button-story-primary-composition.js.mdx
+++ b/docs/snippets/common/button-story-primary-composition.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 const Primary = ButtonStory.bind({});
 Primary.args = {

--- a/docs/snippets/common/button-story-primary-long-name.js.mdx
+++ b/docs/snippets/common/button-story-primary-long-name.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const PrimaryLongName = Template.bind({});
 

--- a/docs/snippets/common/button-story-remix-docspage.js.mdx
+++ b/docs/snippets/common/button-story-remix-docspage.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/common/button-story-remix-docspage.ts.mdx
+++ b/docs/snippets/common/button-story-remix-docspage.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/common/button-story-with-parameters.js.mdx
+++ b/docs/snippets/common/button-story-with-parameters.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const Primary = Template.bind({});
 Primary.args ={

--- a/docs/snippets/common/checkbox-story-csf.js.mdx
+++ b/docs/snippets/common/checkbox-story-csf.js.mdx
@@ -1,11 +1,11 @@
 ```js
-// Checkbox.stories.js
+// Checkbox.stories.js | Checkbox.stories.jsx 
 
 import { Checkbox } from './Checkbox';
 
 export default { 
-    title: 'MDX/Checkbox', 
-    component: Checkbox
+  title: 'MDX/Checkbox',
+  component: Checkbox,
 };
 
 const Template = (args) => <Checkbox {...args} />

--- a/docs/snippets/common/checkbox-story-grouped.js.mdx
+++ b/docs/snippets/common/checkbox-story-grouped.js.mdx
@@ -1,7 +1,7 @@
 ```js
-// Checkbox.stories.js | Checkbox.stories.ts
+// Checkbox.stories.js | Checkbox.stories.jsx | Checkbox.stories.ts | Checkbox.stories.tsx
 
 export default {
-  title: 'Design System/Atoms/Checkbox'
-}
+  title: 'Design System/Atoms/Checkbox',
+};
 ```

--- a/docs/snippets/common/component-story-csf-argstable-customization.js.mdx
+++ b/docs/snippets/common/component-story-csf-argstable-customization.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/component-story-csf-description.js.mdx
+++ b/docs/snippets/common/component-story-csf-description.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'CustomDescription',

--- a/docs/snippets/common/component-story-custom-args-mapping.js.mdx
+++ b/docs/snippets/common/component-story-custom-args-mapping.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 import { Button } from './button';
 import { ArrowUp, ArrowDown, ArrowLeft, ArrowRight } from './icons';

--- a/docs/snippets/common/component-story-custom-source.js.mdx
+++ b/docs/snippets/common/component-story-custom-source.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const CustomSource = () => Template.bind({});
 

--- a/docs/snippets/common/component-story-disable-controls-alt.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-alt.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourComponent.stories.js | YourComponent.stories.ts
+// YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
 import { YourComponent } from './your-component'
 

--- a/docs/snippets/common/component-story-disable-controls-regex.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-regex.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourComponent.stories.js | YourComponent.stories.ts
+// YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
 ArrayInclude = Template.bind({})
 ArrayInclude.parameters = { controls: { include: ['foo', 'bar'] } };

--- a/docs/snippets/common/component-story-disable-controls.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourComponent.stories.js | YourComponent.stories.ts
+// YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
 import { YourComponent } from './your-component'
 

--- a/docs/snippets/common/component-story-dynamic-title.js.mdx
+++ b/docs/snippets/common/component-story-dynamic-title.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.ts
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 import base from 'paths.macro';
 

--- a/docs/snippets/common/component-story-sort-controls.js.mdx
+++ b/docs/snippets/common/component-story-sort-controls.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourComponent.stories.js | YourComponent.stories.ts
+// YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
 import { YourComponent } from './your-component'
 

--- a/docs/snippets/common/custom-docs-page.ts-component.ts.mdx
+++ b/docs/snippets/common/custom-docs-page.ts-component.ts.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-export const CustomDocumentationComponent: React.FC<{}> = () => {
+export const CustomDocumentationComponent: React.VFC<{}> = () => {
   return (
     <div>
       <h1>Replacing DocsPage with a custom component</h1>

--- a/docs/snippets/common/foo-bar-baz-story.js.mdx
+++ b/docs/snippets/common/foo-bar-baz-story.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// FooBar.stories.js | FooBar.stories.ts
+// FooBar.stories.js | FooBar.stories.jsx | FooBar.stories.ts | FooBar.stories.tsx
 
 export default {
   title: 'Foo/Bar',

--- a/docs/snippets/common/gizmo-story-controls-customization.js.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Gizmo.stories.js | Gizmo.stories.ts
+// Gizmo.stories.js | Gizmo.stories.jsx | Gizmo.stories.ts | Gizmo.stories.tsx
 
 export default {
   title: 'Gizmo',

--- a/docs/snippets/common/my-component-story-import-json.js.mdx
+++ b/docs/snippets/common/my-component-story-import-json.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.ts
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 // This will automatically be parsed to the contents of `data.json`
 import data from './data.json';

--- a/docs/snippets/common/my-component-story-import-static-asset.js.mdx
+++ b/docs/snippets/common/my-component-story-import-static-asset.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.ts
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 // This will include './static/image.png' in the bundle. 
 // And return a path to be included in a src attribute

--- a/docs/snippets/common/my-component-story-mandatory-export.js.mdx
+++ b/docs/snippets/common/my-component-story-mandatory-export.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.story.js
+// MyComponent.story.js | MyComponent.story.jsx | MyComponent.story.ts | MyComponent.story.tsx
 
 import MyComponent from './MyComponent';
 

--- a/docs/snippets/common/my-component-story-use-globaltype-backwards-compat.js.mdx
+++ b/docs/snippets/common/my-component-story-use-globaltype-backwards-compat.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 export const StoryWithLocale = ({ globals: { locale } }) => {
   const caption = getCaptionForLocale(locale);

--- a/docs/snippets/common/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/common/my-component-story-use-globaltype.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 const getCaptionForLocale = (locale) => {
   switch(locale) {

--- a/docs/snippets/common/my-component-story-with-storyname.js.mdx
+++ b/docs/snippets/common/my-component-story-with-storyname.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.story.js | MyComponent.story.jsx | MyComponent.story.ts | MyComponent.story.tsx
 
 export const Simple = () => <MyComponent />;
 

--- a/docs/snippets/common/my-component-story.js.mdx
+++ b/docs/snippets/common/my-component-story.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.ts
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 import { MyComponent } from './MyComponent';
 

--- a/docs/snippets/common/other-foo-bar-story.js.mdx
+++ b/docs/snippets/common/other-foo-bar-story.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// FooBar.stories.js | FooBar.stories.ts
+// FooBar.stories.js | FooBar.stories.jsx | FooBar.stories.ts | FooBar.stories.tsx
 
 export default {
   title: 'OtherFoo/Bar',

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 // To apply a set of backgrounds to all stories of Button:
 export default {

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 // To apply a grid to all stories of Button:
 export default {

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const Large = Template.bind({});
 Large.parameters = {

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-grid.js.mdx
@@ -1,11 +1,11 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const Large = Template.bind({});
 Large.parameters = {
   backgrounds: {
     grid: {
-      disable: true
+      disable: true,
     }
   }
 };

--- a/docs/snippets/common/storybook-addon-backgrounds-override-background-color.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-override-background-color.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx |  Button.stories.ts | Button.stories.tsx
 
 export const Large = Template.bind({});
 Large.parameters = {

--- a/docs/snippets/common/storybook-component-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-component-layout-param.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 import Button from './Button';
 

--- a/docs/snippets/common/storybook-customize-argtypes.js.mdx
+++ b/docs/snippets/common/storybook-customize-argtypes.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
   title: 'Button',

--- a/docs/snippets/common/storybook-story-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-story-layout-param.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const WithLayout = Template.bind({});
 WithLayout.parameters = {

--- a/docs/snippets/react/app-story-with-mock.js.mdx
+++ b/docs/snippets/react/app-story-with-mock.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// App.stories.js
+// App.stories.js | App.stories.jsx | App.stories.ts | App.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-component-with-proptypes.js.mdx
+++ b/docs/snippets/react/button-component-with-proptypes.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.js
+// Button.js | Button.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-component-with-proptypes.ts.mdx
+++ b/docs/snippets/react/button-component-with-proptypes.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.tsx
+// Button.ts | Button.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-group-story.js.mdx
+++ b/docs/snippets/react/button-group-story.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// ButtonGroup.stories.js
+// ButtonGroup.stories.js | ButtonGroup.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-group-story.ts.mdx
+++ b/docs/snippets/react/button-group-story.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// ButtonGroup.stories.tsx
+// ButtonGroup.stories.ts | ButtonGroup.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-implementation.js.mdx
+++ b/docs/snippets/react/button-implementation.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.js
+// Button.js | Button.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-implementation.ts.mdx
+++ b/docs/snippets/react/button-implementation.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.ts
+// Button.ts | Button.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-click-handler-args.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-args.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const Text = ({ label, onClick }) => <Button label={label} onClick={onClick} />;
 Text.args = {

--- a/docs/snippets/react/button-story-click-handler-simple-docs.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simple-docs.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const Text = ({ label, onClick }) => <Button label={label} onClick={onClick} />;
 ```

--- a/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export const Text = (args) => <Button {...args} />;
 ```

--- a/docs/snippets/react/button-story-click-handler.js.mdx
+++ b/docs/snippets/react/button-story-click-handler.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-default-docs-code.js.mdx
+++ b/docs/snippets/react/button-story-default-docs-code.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-default-docs-code.ts.mdx
+++ b/docs/snippets/react/button-story-default-docs-code.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-default-export-with-component.js.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-rename-story.js.mdx
+++ b/docs/snippets/react/button-story-rename-story.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-rename-story.ts.mdx
+++ b/docs/snippets/react/button-story-rename-story.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-using-args.js.mdx
+++ b/docs/snippets/react/button-story-using-args.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 //👇 We create a “template” of how args map to rendering
 const Template = (args) => <Button {...args} />;

--- a/docs/snippets/react/button-story-using-args.ts.mdx
+++ b/docs/snippets/react/button-story-using-args.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 //👇 We create a “template” of how args map to rendering
 const Template: Story<ButtonProps> = (args) => <Button {...args} />;

--- a/docs/snippets/react/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/react/button-story-with-addon-example.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-with-blue-args.js.mdx
+++ b/docs/snippets/react/button-story-with-blue-args.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-blue-args.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-with-emojis.js.mdx
+++ b/docs/snippets/react/button-story-with-emojis.js.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 export const Primary = () => <Button background="#ff0" label="Button" />;
 export const Secondary = () => <Button background="#ff0" label="😄👍😍💯" />;

--- a/docs/snippets/react/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/react/button-story-with-emojis.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 export const Primary: React.VFC<{}> = () => <Button background="#ff0" label="Button" />;
 export const Secondary: React.VFC<{}> = () => <Button background="#ff0" label="😄👍😍💯" />;

--- a/docs/snippets/react/button-story-with-parameters.js.mdx
+++ b/docs/snippets/react/button-story-with-parameters.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-with-parameters.ts.mdx
+++ b/docs/snippets/react/button-story-with-parameters.ts.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.tsx
+// Button.stories.ts | Button.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story-with-sample.js.mdx
+++ b/docs/snippets/react/button-story-with-sample.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js
+// Button.stories.js | Button.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/button-story.with-hooks.js.mdx
+++ b/docs/snippets/react/button-story.with-hooks.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.ts | Button.stories.jsx | Button.stories.tsx
 
 import React, { useState } from 'react';
 

--- a/docs/snippets/react/checkbox-story-csf.js.mdx
+++ b/docs/snippets/react/checkbox-story-csf.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Checkbox.stories.js
+// Checkbox.stories.js | Checkbox.stories.jsx | // Checkbox.stories.ts | Checkbox.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/component-story-custom-args-complex.js.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourComponent.stories.js
+// YourComponent.stories.js | YourComponent.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// YourComponent.stories.js
+// YourComponent.stories.ts | YourComponent.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-with-import.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-without-import.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/component-story-with-query.js.mdx
+++ b/docs/snippets/react/component-story-with-query.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// my-component-with-query.stories.js
+// my-component-with-query.stories.js | my-component-with-query.stories.jsx
 
 import MyComponentThatHasAQuery, { MyQuery } from '../component-that-has-a-query';
 

--- a/docs/snippets/react/component-styled-variables-object-notation.js.mdx
+++ b/docs/snippets/react/component-styled-variables-object-notation.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.js
+// MyComponent.js | MyComponent.jsx
 
 const Component = styled.div(({ theme }) => ({
   background: theme.background.app,

--- a/docs/snippets/react/component-styled-variables-template-literals.js.mdx
+++ b/docs/snippets/react/component-styled-variables-template-literals.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.js
+// MyComponent.js | MyComponent.jsx
 
 const Component = styled.div`
   background: `${props => props.theme.background.app}`

--- a/docs/snippets/react/list-story-expanded.js.mdx
+++ b/docs/snippets/react/list-story-expanded.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// List.stories.js
+// List.stories.js | List.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-expanded.ts.mdx
+++ b/docs/snippets/react/list-story-expanded.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// List.stories.tsx
+// List.stories.ts | List.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-reuse-data.js.mdx
+++ b/docs/snippets/react/list-story-reuse-data.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// List.stories.js
+// List.stories.js | List.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/react/list-story-reuse-data.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// List.stories.tsx
+// List.stories.ts | List.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-starter.js.mdx
+++ b/docs/snippets/react/list-story-starter.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// List.stories.js
+// List.stories.js | List.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-starter.ts.mdx
+++ b/docs/snippets/react/list-story-starter.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// List.stories.tsx
+// List.stories.ts | List.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-template.js.mdx
+++ b/docs/snippets/react/list-story-template.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// List.stories.js
+// List.stories.js | List.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-template.ts.mdx
+++ b/docs/snippets/react/list-story-template.ts.mdx
@@ -1,5 +1,5 @@
 ```js
-// List.stories.tsx
+// List.stories.ts | List.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-unchecked.js.mdx
+++ b/docs/snippets/react/list-story-unchecked.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// List.stories.js
+// List.stories.js | List.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-unchecked.ts.mdx
+++ b/docs/snippets/react/list-story-unchecked.ts.mdx
@@ -1,7 +1,8 @@
 ```ts
-// List.stories.tsx
+// List.stories.ts | List.stories.tsx
 
 import React from 'react';
+
 import { List, ListProps } from './List';
 
 //👇 Instead of importing ListItem, we import the stories

--- a/docs/snippets/react/list-story-with-subcomponents.js.mdx
+++ b/docs/snippets/react/list-story-with-subcomponents.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// List.stories.js
+// List.stories.js | List.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/react/list-story-with-subcomponents.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// List.stories.tsx
+// List.stories.ts | List.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-with-unchecked-children.js.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// List.stories.js
+// List.stories.js | List.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -1,9 +1,11 @@
 ```ts
-// List.stories.tsx
+// List.stories.ts | List.stories.tsx
 
 import React from 'react';
 
 import { List, ListProps } from './List';
+
+//👇 Instead of importing ListItem, we import the stories
 import { Unchecked } from './ListItem.stories';
 
 const Template: Story<ListProps> = (args) => <List {...args} />;

--- a/docs/snippets/react/loader-story.js.mdx
+++ b/docs/snippets/react/loader-story.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// TodoItem.stories.js
+// TodoItem.stories.js | TodoItem.stories.jsx | TodoItem.stories.ts | TodoItem.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/mock-context-container-provider.js.mdx
+++ b/docs/snippets/react/mock-context-container-provider.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// pages/profile.js
+// pages/profile.js | pages/profile.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/mock-context-container.js.mdx
+++ b/docs/snippets/react/mock-context-container.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// ProfilePage.stories.js
+// ProfilePage.stories.js | ProfilePage.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/mock-context-create.js.mdx
+++ b/docs/snippets/react/mock-context-create.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// ProfilePageContext.js
+// ProfilePageContext.js | ProfilePageContext.jsx
 
 import { createContext } from 'react';
 

--- a/docs/snippets/react/mock-context-in-use.js.mdx
+++ b/docs/snippets/react/mock-context-in-use.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// ProfilePage.js
+// ProfilePage.js | ProfilePage.jsx
 
 import { useContext } from 'react';
 

--- a/docs/snippets/react/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/react/my-component-story-basic-and-props.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.story.js | MyComponent.story.jsx | MyComponent.story.ts | MyComponent.story.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.ts
+// MyComponent.stories.js | MyComponent.stories.ts | MyComponent.stories.jsx | MyComponent.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/react/my-component-story-with-nonstory.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.jsx | MyComponent.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js
+// MyComponent.stories.js | MyComponent.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// MyComponent.stories.tsx
+// MyComponent.stories.ts | MyComponent.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/page-story-slots.js.mdx
+++ b/docs/snippets/react/page-story-slots.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Page.stories.js
+// Page.stories.js | Page.stories.jsx
 
 import React from 'react';
 import Page from './Page';

--- a/docs/snippets/react/page-story-slots.ts.mdx
+++ b/docs/snippets/react/page-story-slots.ts.mdx
@@ -1,5 +1,5 @@
-```js
-// Page.stories.js
+```ts
+// Page.stories.ts | Page.stories.tsx
 
 import React from 'react';
 import { Story, Meta } from '@storybook/react';

--- a/docs/snippets/react/page-story-with-args-composition.js.mdx
+++ b/docs/snippets/react/page-story-with-args-composition.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourPage.stories.js
+// YourPage.stories.js | YourPage.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/page-story-with-args-composition.ts.mdx
+++ b/docs/snippets/react/page-story-with-args-composition.ts.mdx
@@ -1,5 +1,5 @@
-```js
-// YourPage.stories.js
+```ts
+// YourPage.stories.ts | YourPage.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/page-story.js.mdx
+++ b/docs/snippets/react/page-story.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Page.stories.js
+// Page.stories.js | Page.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/page-story.ts.mdx
+++ b/docs/snippets/react/page-story.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Page.stories.tsx
+// Page.stories.ts | Page.stories.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/simple-page-implementation.js.mdx
+++ b/docs/snippets/react/simple-page-implementation.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourPage.js
+// YourPage.js | YourPage.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/simple-page-implementation.ts.mdx
+++ b/docs/snippets/react/simple-page-implementation.ts.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourPage.tsx
+// YourPage.ts | YourPage.tsx
 
 import React from 'react';
 

--- a/docs/snippets/react/table-story-fully-customize-controls.js.mdx
+++ b/docs/snippets/react/table-story-fully-customize-controls.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Table.stories.js
+// Table.stories.js | Table.stories.jsx
 
 const TableStory = ({ data, ...args }) => (
   <Table {...args} >

--- a/docs/snippets/react/your-component.js.mdx
+++ b/docs/snippets/react/your-component.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// YourComponent.stories.js
+// YourComponent.stories.js | YourComponent.stories.jsx
 
 import React from 'react';
 

--- a/docs/snippets/react/your-component.ts.mdx
+++ b/docs/snippets/react/your-component.ts.mdx
@@ -1,9 +1,9 @@
 ```ts
-// YourComponent.stories.tsx
+// YourComponent.stories.ts | YourComponent.stories.tsx
 
 import React, { ComponentProps } from 'react';
 
-import { Story } from '@storybook/react';
+import { Story, Meta } from '@storybook/react';
 
 import { YourComponent } from './YourComponent';
 
@@ -11,7 +11,7 @@ import { YourComponent } from './YourComponent';
 export default {
   title: 'YourComponent',
   component: YourComponent,
-};
+} as Meta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: Story<ComponentProps<typeof YourComponent>> = (args) => <YourComponent {...args} />;

--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -11,8 +11,8 @@ Storybook uses the generic term arguments (args for short) when talking about Re
 A component’s stories are defined in a story file that lives alongside the component file. The story file is for development-only, it won't be included in your production bundle.
 
 ```
-Button.js | ts
-Button.stories.js | ts
+Button.js | ts | jsx | tsx
+Button.stories.js | ts | jsx | tsx
 ```
 
 ## Component Story Format

--- a/docs/writing-stories/parameters.md
+++ b/docs/writing-stories/parameters.md
@@ -11,7 +11,7 @@ For example, let’s customize the backgrounds addon via a parameter. We’ll us
 We can set a parameter for a single story with the `parameters` key on a CSF export:
 
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.ts | Button.stories.jsx | Button.stories.tsx 
 
 export const Primary = Template.bind({});
 Primary.args = {
@@ -33,7 +33,7 @@ Primary.parameters = {
 We can set the parameters for all stories of a component using the `parameters` key on the default CSF export:
 
 ```js
-// Button.stories.js | Button.stories.ts
+// Button.stories.js | Button.stories.ts | Button.stories.jsx | Button.stories.tsx 
 
 import Button from './Button';
 


### PR DESCRIPTION
With this pull request the documentation's snippets are updated to mention `.jsx`or `.tsx` as supported formats.

Follows up on #14650

What was done:
- React snippets were updated to mention the usage of `jsx` or `tsx` in their stories. I maintained both `js` and `ts` as well to users know that js based stories are also supported.
- Common snippets were also updated.