### PR TITLE
other: accordion component

### DIFF
--- a/examples/svelte-kitchen-sink/src/stories/__snapshots__/addon-controls.stories.storyshot
+++ b/examples/svelte-kitchen-sink/src/stories/__snapshots__/addon-controls.stories.storyshot
@@ -41,7 +41,7 @@ exports[`Storyshots Addon/Controls Show Case 1`] = `
     max="100"
     min="0"
     step="1"
-    value={0}
+    value="0"
   />
    
   <h2>

--- a/jest.config.js
+++ b/jest.config.js
@@ -84,7 +84,7 @@ module.exports = {
   coverageDirectory: 'coverage',
   setupFilesAfterEnv: ['./scripts/jest.init.ts'],
   coverageReporters: ['lcov'],
-  // testEnvironment: 'jest-environment-jsdom-thirteen',
+  testEnvironment: 'jest-environment-jsdom',
   setupFiles: ['raf/polyfill'],
   testURL: 'http://localhost',
   modulePathIgnorePatterns: ['/dist/.*/__mocks__/'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -84,7 +84,7 @@ module.exports = {
   coverageDirectory: 'coverage',
   setupFilesAfterEnv: ['./scripts/jest.init.ts'],
   coverageReporters: ['lcov'],
-  testEnvironment: 'jest-environment-jsdom-thirteen',
+  // testEnvironment: 'jest-environment-jsdom-thirteen',
   setupFiles: ['raf/polyfill'],
   testURL: 'http://localhost',
   modulePathIgnorePatterns: ['/dist/.*/__mocks__/'],

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -54,6 +54,7 @@
     "lodash": "^4.17.20",
     "markdown-to-jsx": "^7.1.3",
     "memoizerific": "^1.11.3",
+    "nanoid": "^3.1.23",
     "overlayscrollbars": "^1.13.1",
     "polished": "^4.0.5",
     "prop-types": "^15.7.2",

--- a/lib/components/src/Accordion/Accordion.tsx
+++ b/lib/components/src/Accordion/Accordion.tsx
@@ -1,0 +1,210 @@
+import React, { Children, useCallback, useEffect, useRef, useState } from 'react';
+import { styled } from '@storybook/theming';
+import { AccordionContext } from './AccordionContext';
+
+/* eslint-disable import/order */
+import type { FC } from 'react';
+import type { AddToMapFn, OpenMap } from './AccordionContext';
+
+type AccordionMap = Record<string, { index: number; id: string }>;
+
+interface StateChange {
+  id: string;
+  index: number;
+}
+
+export type AccordionProps = {
+  /** Set to true to allow for more than one AccordionItem open at the time */
+  allowMultipleOpen?: boolean;
+  /** Ability to control which panel(s) are open or closed externally - or use to set default opens */
+  open?: number | number[];
+  /** Set to true to add theme border around the Accordion */
+  bordered?: boolean;
+  /** Set to true to add rounded borders from theme to Accordion */
+  rounded?: boolean;
+  /**
+   * Set to true to add theme borders between AccordionItem's
+   * Note: can be overridden on AccordionItem
+   */
+  lined?: boolean;
+  /**
+   * Set to true to indent AccordionBody content left to match the AccordionHeader text
+   * Note: can be overridden on AccordionItem
+   */
+  indentBody?: boolean;
+  /**
+   * Set to true to apply narrow paddings and smaller text in all AccordionItem's
+   * Note: can be overridden on AccordionItem
+   */
+  narrow?: boolean;
+  /**
+   * Set to true to prevent toggle between open and close for all AccordionItem's
+   * Note: can be overridden on AccordionItem
+   */
+  preventToggle?: boolean;
+  /** Courtesy callback prop for when a new accordion opens */
+  onOpen?: (change: StateChange) => void;
+  /** Courtesy callback prop for when an accordion closes */
+  onClose?: (change: StateChange) => void;
+} & React.HTMLAttributes<HTMLUListElement>;
+
+/**
+ *
+ * Controlling wrapper component that will control the open/close functionality to
+ * child ```<AccordionItem />```'s and style the other support components
+ * ```<AccordionHeader />``` and ```<AccordionBody />```
+ *
+ * Although each component can work independently and be controlled from the outside
+ * via an **open** prop, it is not recommended to use ```<AccordionItem />```,
+ *  ```<AccordionHeader />``` and ```<AccordionBody />``` without this controller
+ *
+ * If no ```<AccordionBody />``` is inside an ```<AccordionItem />``` the open/close
+ * functionality will be removed by default, as well as the icon and pointer cursor.
+ */
+export const Accordion: FC<AccordionProps> = ({
+  allowMultipleOpen,
+  children,
+  open,
+  rounded = false,
+  bordered = false,
+  narrow, // To be carried to AccordionItem children via context
+  lined, // To be carried to AccordionItem children via context
+  indentBody, // To be carried to AccordionItem children via context
+  preventToggle, // To be carried to AccordionItem children via context
+  onOpen,
+  onClose,
+  ...rest
+}) => {
+  const [openState, setOpenState] = useState<OpenMap>({});
+  const openStateMap = useRef<OpenMap>({});
+  const accordionMap = useRef<AccordionMap>({});
+  const accordionMapIndex = useRef(0);
+
+  const addToMap: AddToMapFn = useCallback(
+    (id) => {
+      const index = accordionMapIndex.current + 1;
+      accordionMap.current = { ...accordionMap.current, [id]: { id, index } };
+      accordionMapIndex.current = index;
+
+      if (typeof open === 'number') {
+        openStateMap.current = { ...openStateMap.current, [id]: open === index };
+      } else if (Array.isArray(open)) {
+        const isExpanded = open.includes(index);
+        openStateMap.current = { ...openStateMap.current, [id]: isExpanded };
+      } else {
+        openStateMap.current = { ...openStateMap.current, [id]: false };
+      }
+    },
+    [accordionMap, openStateMap, open]
+  );
+
+  const onItemClose = useCallback(
+    (id: string) => {
+      setOpenState({ ...openState, [id]: false });
+
+      if (onClose) {
+        onClose({ id, index: accordionMap.current[id].index });
+      }
+    },
+    [openState, setOpenState, onClose, accordionMap]
+  );
+
+  const onItemOpen = useCallback(
+    (id: string) => {
+      const newOpen = { ...openState };
+      let oldOpen: StateChange | undefined;
+
+      if (allowMultipleOpen) {
+        newOpen[id] = true;
+      } else {
+        Object.keys(openState).forEach((key) => {
+          if (openState[key]) {
+            oldOpen = { id: key, index: accordionMap.current[key].index };
+          }
+
+          newOpen[key] = id === key;
+        });
+      }
+
+      if (oldOpen && onClose) {
+        onClose(oldOpen);
+      }
+
+      setOpenState({ ...openState, ...newOpen });
+
+      if (onOpen) {
+        onOpen({ id, index: accordionMap.current[id].index });
+      }
+    },
+    [openState, setOpenState, onOpen, accordionMap]
+  );
+
+  useEffect(() => {
+    if (Object.keys(accordionMap.current).length === Children.count(children)) {
+      setOpenState({ ...openState, ...openStateMap.current });
+    }
+  }, [accordionMap, openStateMap]);
+
+  useEffect(() => {
+    let newOpen: number[] = [];
+
+    if (typeof open === 'number') {
+      newOpen.push(open);
+    } else if (Array.isArray(open)) {
+      newOpen = open;
+    }
+
+    let newOpenState = { ...openState };
+
+    Object.keys(accordionMap.current).forEach((key) => {
+      const item = accordionMap.current[key];
+
+      newOpenState = { ...newOpenState, [item.id]: newOpen.includes(item.index) };
+    });
+
+    setOpenState({ ...openState, ...newOpenState });
+  }, [open]);
+
+  return (
+    <AccordionContext.Provider
+      value={{
+        addToMap,
+        onClose: onItemClose,
+        onOpen: onItemOpen,
+        bordered,
+        openState,
+        indentBody,
+        lined,
+        narrow,
+        preventToggle,
+      }}
+    >
+      <Wrapper data-sb-accordion="" bordered={bordered} rounded={rounded} {...rest}>
+        {children}
+      </Wrapper>
+    </AccordionContext.Provider>
+  );
+};
+
+interface WrapperProps {
+  bordered: boolean;
+  rounded: boolean;
+}
+
+const Wrapper = styled.ul<WrapperProps>(
+  ({ theme }) => ({
+    overflow: 'hidden',
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    backgroundColor: theme.background.content,
+  }),
+  ({ theme, bordered }) =>
+    bordered && {
+      border: `1px solid ${theme.appBorderColor}`,
+    },
+  ({ theme, rounded }) =>
+    rounded && {
+      borderRadius: theme.appBorderRadius,
+    }
+);

--- a/lib/components/src/Accordion/Accordion.tsx
+++ b/lib/components/src/Accordion/Accordion.tsx
@@ -1,10 +1,7 @@
-import React, { Children, useCallback, useEffect, useRef, useState } from 'react';
 import { styled } from '@storybook/theming';
-import { AccordionContext } from './AccordionContext';
-
-/* eslint-disable import/order */
-import type { FC } from 'react';
+import React, { Children, useCallback, useEffect, useRef, useState, FC } from 'react';
 import type { AddToMapFn, OpenMap } from './AccordionContext';
+import { AccordionContext } from './AccordionContext';
 
 type AccordionMap = Record<string, { index: number; id: string }>;
 

--- a/lib/components/src/Accordion/AccordionBody.tsx
+++ b/lib/components/src/Accordion/AccordionBody.tsx
@@ -1,9 +1,6 @@
-import React, { useContext } from 'react';
 import { styled } from '@storybook/theming';
+import React, { FC, useContext } from 'react';
 import { AccordionItemContext } from './AccordionItemContext';
-
-/* eslint-disable import/order */
-import type { FC } from 'react';
 
 export type AccordionBodyProps = {
   open?: boolean;

--- a/lib/components/src/Accordion/AccordionBody.tsx
+++ b/lib/components/src/Accordion/AccordionBody.tsx
@@ -1,0 +1,43 @@
+import React, { useContext } from 'react';
+import { styled } from '@storybook/theming';
+import { AccordionItemContext } from './AccordionItemContext';
+
+/* eslint-disable import/order */
+import type { FC } from 'react';
+
+export type AccordionBodyProps = {
+  open?: boolean;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+export const AccordionBody: FC<AccordionBodyProps> = ({ children, open: _open, ...rest }) => {
+  const context = useContext(AccordionItemContext);
+
+  let open = _open;
+
+  if (context !== null) {
+    open = context.open;
+  }
+
+  return (
+    <Wrapper data-sb-accordion-body="" {...rest}>
+      <InnerWrapper data-sb-accordion-body-inner="" isOpen={open}>
+        {children}
+      </InnerWrapper>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  overflow: hidden;
+`;
+
+interface InnerWrapperProps {
+  isOpen: boolean;
+}
+
+const InnerWrapper = styled.div<InnerWrapperProps>(({ isOpen, theme }) => ({
+  height: isOpen ? 'auto' : 0,
+  display: isOpen ? 'block' : 'none',
+  transition: `height 175ms ease-in-out`,
+  color: theme.color.defaultText,
+}));

--- a/lib/components/src/Accordion/AccordionContext.tsx
+++ b/lib/components/src/Accordion/AccordionContext.tsx
@@ -1,0 +1,19 @@
+import { createContext } from 'react';
+
+export type AddToMapFn = (id: string) => void;
+
+export type OpenMap = Record<string, boolean>;
+
+interface AccordionContextProps {
+  openState: OpenMap;
+  addToMap: AddToMapFn;
+  onOpen: (id: string) => void;
+  onClose: (id: string) => void;
+  lined: boolean | undefined;
+  bordered: boolean | undefined;
+  indentBody: boolean | undefined;
+  narrow: boolean | undefined;
+  preventToggle: boolean | undefined;
+}
+
+export const AccordionContext = createContext<AccordionContextProps | null>(null);

--- a/lib/components/src/Accordion/AccordionHeader.tsx
+++ b/lib/components/src/Accordion/AccordionHeader.tsx
@@ -1,10 +1,7 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
 import { styled } from '@storybook/theming';
+import React, { FC, useContext, useEffect, useRef, useState } from 'react';
 import { Icons } from '../icon/icon';
 import { AccordionItemContext } from './AccordionItemContext';
-
-/* eslint-disable import/order */
-import type { FC } from 'react';
 
 export type AccordionHeaderProps = {
   label?: string;

--- a/lib/components/src/Accordion/AccordionHeader.tsx
+++ b/lib/components/src/Accordion/AccordionHeader.tsx
@@ -1,0 +1,202 @@
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { styled } from '@storybook/theming';
+import { Icons } from '../icon/icon';
+import { AccordionItemContext } from './AccordionItemContext';
+
+/* eslint-disable import/order */
+import type { FC } from 'react';
+
+export type AccordionHeaderProps = {
+  label?: string;
+  hideIcon?: boolean;
+  Icon?: React.ReactNode;
+  LabelProps?: React.HTMLAttributes<HTMLDivElement>;
+  onOpen?: () => {};
+  onClose?: () => {};
+  open?: boolean;
+  preventToggle?: boolean;
+} & React.HTMLAttributes<HTMLButtonElement>;
+
+export const AccordionHeader: FC<AccordionHeaderProps> = ({
+  label,
+  children,
+  Icon,
+  hideIcon,
+  LabelProps: _LabelProps = {},
+  onOpen,
+  onClose,
+  open: _open,
+  preventToggle: _preventToggle,
+  ...rest
+}) => {
+  const [open, setOpen] = useState(_open);
+  const context = useContext(AccordionItemContext);
+  const id = useRef('');
+
+  const handleOnClick = () => {
+    let newOpenState = !open;
+
+    if (context !== null && !preventToggle) {
+      // Context provider will take care of it and send new state back
+      if (!context.preventOpen) {
+        if (open) {
+          context.onClose();
+          newOpenState = false;
+        } else {
+          context.onOpen();
+          newOpenState = true;
+        }
+      }
+    } else if (!preventToggle) {
+      // No context provider so we handle this ourselves
+      setOpen(newOpenState);
+    }
+
+    // Handle our own events to send up through props
+    if (newOpenState === true && !preventToggle) {
+      // eslint-disable-next-line no-unused-expressions
+      onOpen && onOpen();
+    } else if (!preventToggle) {
+      // eslint-disable-next-line no-unused-expressions
+      onClose && onClose();
+    }
+  };
+
+  useEffect(() => {
+    if (_open !== open) {
+      setOpen(_open);
+    }
+  }, [_open]);
+
+  useEffect(() => {
+    if (context !== null) {
+      if (_open !== true && context.open !== open) {
+        setOpen(context.open);
+      }
+
+      id.current = `${context.id}-label`;
+    }
+  }, [context, setOpen, _open, id]);
+
+  // If custom DOM is provided in the header, then we can no longer automate
+  // aria-labelledby="" for the <AccordionItem /> and user has to provide both the
+  // id for the label and add aria-labelledby on <AccordionItem /> to match
+  const LabelProps: React.HTMLAttributes<HTMLDivElement> = { ..._LabelProps };
+
+  if (id.current) {
+    LabelProps.id = id.current;
+  }
+
+  let preventToggle = _preventToggle;
+  let preventOpen = false;
+  let preventIcon = false;
+  const hasCustomIcon = Icon !== undefined;
+
+  if (context !== null) {
+    preventToggle = _preventToggle === true ? true : context.preventToggle;
+    preventOpen = context.preventOpen || false;
+    preventIcon = preventOpen;
+  }
+
+  return (
+    <Wrapper
+      data-sb-accordion-header=""
+      onClick={handleOnClick}
+      preventToggle={preventToggle}
+      preventOpen={preventOpen}
+      disabled={preventToggle || preventOpen}
+      {...rest}
+    >
+      <ExpanderWrapper
+        data-sb-accordion-expander-wrapper=""
+        hideIcon={hideIcon}
+        hasCustomIcon={hasCustomIcon}
+        preventIcon={preventIcon}
+      >
+        <Expander data-sb-accordion-expander="" isOpen={open} preventToggle={preventToggle}>
+          {hasCustomIcon ? (
+            Icon
+          ) : (
+            <Chevron
+              data-sb-accordion-chevron=""
+              role="img"
+              aria-label="expander"
+              icon="chevrondown"
+            />
+          )}
+        </Expander>
+      </ExpanderWrapper>
+      <Label data-sb-accordion-label="" {...LabelProps}>
+        {label || children}
+      </Label>
+    </Wrapper>
+  );
+};
+
+interface WrapperProps {
+  preventToggle: boolean;
+  preventOpen: boolean;
+}
+
+const Wrapper = styled.button<WrapperProps>(({ theme, preventToggle, preventOpen }) => ({
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  padding: 0,
+  margin: 0,
+  border: '0 none',
+  textAlign: 'left',
+  backgroundColor: 'transparent',
+  cursor: preventToggle || preventOpen ? 'default' : 'pointer',
+  fontSize: theme.typography.size.s2 - 1,
+}));
+
+interface ExpanderWrapperProps {
+  hideIcon: boolean;
+  preventIcon: boolean;
+  hasCustomIcon: boolean;
+}
+
+const ExpanderWrapper = styled.div<ExpanderWrapperProps>(
+  {
+    alignSelf: 'flex-start',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ({ hasCustomIcon, preventIcon }) =>
+    !hasCustomIcon &&
+    preventIcon && {
+      display: 'none',
+    },
+  ({ hideIcon }) =>
+    hideIcon && {
+      display: 'none',
+    }
+);
+
+interface ExpanderProps {
+  isOpen: boolean;
+  preventToggle: boolean;
+}
+
+const Expander = styled.div<ExpanderProps>(({ theme, isOpen, preventToggle }) => ({
+  color: theme.color.mediumdark,
+  transform: preventToggle ? 'rotate(0deg)' : `rotate(${isOpen ? 90 : 0}deg)`,
+  transition: 'transform 0.1s ease-in-out',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  alignSelf: 'stretch',
+}));
+
+const Chevron = styled(Icons)({
+  transform: 'rotate(-90deg)',
+  height: 12,
+  width: 12,
+});
+
+const Label = styled.div(({ theme }) => ({
+  color: theme.color.defaultText,
+  width: '100%',
+}));

--- a/lib/components/src/Accordion/AccordionItem.tsx
+++ b/lib/components/src/Accordion/AccordionItem.tsx
@@ -1,0 +1,205 @@
+import React, { useCallback, useContext, useEffect, useRef, useState, Children } from 'react';
+// @TODO get rid of lodash usage
+// shilman wish to get rid of lodash for bundle size, so maybe "nanoid" can be
+// added for unique id requirements?
+import uniqueId from 'lodash/uniqueId';
+import { styled } from '@storybook/theming';
+import { AccordionContext } from './AccordionContext';
+import { AccordionItemContext } from './AccordionItemContext';
+
+/* eslint-disable import/order */
+import type { FC } from 'react';
+
+// Props are also available from Accordion context provider, but local props
+// takes precedence for scope control
+export type AccordionItemProps = {
+  open?: boolean;
+  indentBody?: boolean;
+  lined?: boolean;
+  narrow?: boolean;
+  preventToggle?: boolean;
+} & React.HTMLAttributes<HTMLLIElement>;
+
+export const AccordionItem: FC<AccordionItemProps> = ({
+  children,
+  open: _open,
+  indentBody: _indentBody,
+  narrow: _narrow,
+  lined: _lined,
+  preventToggle: _preventToggle,
+  ...rest
+}) => {
+  const [open, setOpen] = useState(_open);
+  const context = useContext(AccordionContext);
+  const id = useRef(uniqueId('AccordionItem-'));
+  const preventOpen = Children.count(children) < 2;
+  const initialOpen = useRef(_open);
+  const allowDynamicOpen = !preventOpen && _open !== true;
+
+  const onExpand = useCallback(() => {
+    if (allowDynamicOpen) {
+      if (context !== null) {
+        context.onOpen(id.current);
+      } else {
+        setOpen(true);
+      }
+    }
+  }, [setOpen, context]);
+
+  const onCollapse = useCallback(() => {
+    if (allowDynamicOpen) {
+      if (context !== null) {
+        context.onClose(id.current);
+      } else {
+        setOpen(false);
+      }
+    }
+  }, [setOpen, context]);
+
+  // If we have an accordion container context provider we need to register
+  // this accordion item to work as a part of a team
+  useEffect(() => {
+    if (context !== null) {
+      context.addToMap(id.current);
+    }
+  }, []);
+
+  // Possible outside influences such as from prop or from context provider
+  useEffect(() => {
+    if (allowDynamicOpen) {
+      let newOpen = open;
+
+      if (_open !== open) {
+        newOpen = _open;
+      }
+
+      if (context !== null) {
+        newOpen = context.openState[id.current];
+      }
+
+      setOpen(newOpen);
+    }
+  }, [context, _open, preventOpen]);
+
+  let indentBody = _indentBody;
+  let narrow = _narrow;
+  let lined = _lined;
+  let preventToggle = _preventToggle;
+  let bordered = false;
+
+  if (context) {
+    indentBody = _indentBody === true ? true : context.indentBody;
+    narrow = _narrow === true ? true : context.narrow;
+    lined = _lined === true ? true : context.lined;
+    preventToggle = _preventToggle === true ? true : context.preventToggle || initialOpen.current;
+    bordered = context.bordered;
+  }
+
+  return (
+    <AccordionItemContext.Provider
+      value={{
+        id: id.current,
+        open,
+        preventOpen,
+        preventToggle,
+        onClose: onCollapse,
+        onOpen: onExpand,
+      }}
+    >
+      <Wrapper
+        aria-labelledby={`${id.current}-label`}
+        aria-expanded={open ? 'true' : 'false'}
+        data-sb-accordion-item=""
+        bordered={bordered}
+        lined={lined}
+        indentBody={indentBody}
+        narrow={narrow}
+        preventOpen={preventOpen}
+        {...rest}
+      >
+        {children}
+      </Wrapper>
+    </AccordionItemContext.Provider>
+  );
+};
+
+interface WrapperProps {
+  bordered: boolean;
+  lined: boolean;
+  indentBody: boolean;
+  preventOpen: boolean;
+  narrow: boolean;
+}
+
+const Wrapper = styled.li<WrapperProps>(
+  {
+    padding: 0,
+    margin: 0,
+    listStyle: 'none',
+  },
+  ({ theme, narrow, indentBody }) => ({
+    '[data-sb-accordion-header]': {
+      padding: narrow ? '10px 15px' : 15,
+      fontSize: theme.typography.size.s2 - 1,
+      border: '1px solid transparent',
+      '&:hover': {
+        backgroundColor: theme.background.hoverable,
+      },
+    },
+    '[data-sb-accordion-expander-wrapper]': {
+      marginRight: narrow ? 12 : 16,
+      paddingTop: 3,
+    },
+    '[data-sb-accordion-expander]': {
+      minWidth: narrow ? 14 : 16,
+      minHeight: narrow ? 14 : 16,
+      svg: {
+        height: narrow ? 14 : 16,
+        width: 'auto',
+      },
+      'svg[data-sb-accordion-chevron]': {
+        width: narrow ? 10 : 12,
+        height: narrow ? 10 : 12,
+      },
+    },
+    '[data-sb-accordion-body]': {
+      fontSize: theme.typography.size.s2 - 1,
+      backgroundColor: theme.background.app,
+    },
+    '&[aria-expanded="true"]': {
+      '[data-sb-accordion-body-inner]': {
+        padding: narrow
+          ? `20px 16px 20px ${indentBody ? '43px' : '17px'}`
+          : `24px 16px 24px ${indentBody ? '49px' : '17px'}`,
+      },
+    },
+    '&:hover': {
+      '[data-sb-accordion-body]': {
+        // backgroundColor: theme.background.app,
+      },
+    },
+  }),
+  ({ preventOpen }) =>
+    preventOpen && {
+      '[data-sb-accordion-header]': {
+        cursor: 'default',
+        '&:hover': {
+          backgroundColor: 'transparent',
+        },
+      },
+    },
+  ({ theme, lined, bordered }) =>
+    lined
+      ? {
+          borderBottom: `1px solid ${theme.appBorderColor}`,
+          '&:last-child': {
+            borderBottomWidth: bordered ? 0 : 1,
+          },
+          '&[aria-expanded="true"]': {
+            '& > [data-sb-accordion-header]': {
+              borderBottom: `1px solid ${theme.appBorderColor}`,
+            },
+          },
+        }
+      : {}
+);

--- a/lib/components/src/Accordion/AccordionItem.tsx
+++ b/lib/components/src/Accordion/AccordionItem.tsx
@@ -1,14 +1,8 @@
-import React, { useCallback, useContext, useEffect, useRef, useState, Children } from 'react';
-// @TODO get rid of lodash usage
-// shilman wish to get rid of lodash for bundle size, so maybe "nanoid" can be
-// added for unique id requirements?
-import uniqueId from 'lodash/uniqueId';
 import { styled } from '@storybook/theming';
+import { nanoid } from 'nanoid';
+import React, { Children, FC, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { AccordionContext } from './AccordionContext';
 import { AccordionItemContext } from './AccordionItemContext';
-
-/* eslint-disable import/order */
-import type { FC } from 'react';
 
 // Props are also available from Accordion context provider, but local props
 // takes precedence for scope control
@@ -31,7 +25,7 @@ export const AccordionItem: FC<AccordionItemProps> = ({
 }) => {
   const [open, setOpen] = useState(_open);
   const context = useContext(AccordionContext);
-  const id = useRef(uniqueId('AccordionItem-'));
+  const id = useRef(nanoid());
   const preventOpen = Children.count(children) < 2;
   const initialOpen = useRef(_open);
   const allowDynamicOpen = !preventOpen && _open !== true;

--- a/lib/components/src/Accordion/AccordionItemContext.tsx
+++ b/lib/components/src/Accordion/AccordionItemContext.tsx
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+
+interface AccordionItemContextProps {
+  id: string;
+  onOpen: () => void;
+  onClose: () => void;
+  /**
+   * Carries down to AccordionItem children and is used by AccordionHeader
+   */
+  preventOpen: boolean | undefined;
+  /**
+   * Carries down to AccordionItem children and ise used by AccordionHeader
+   */
+  preventToggle: boolean | undefined;
+  /**
+   * Used by AccordionHeader and AccordionBody for state control by AccordionItem's parent
+   * or self control
+   */
+  open: boolean | undefined;
+}
+
+export const AccordionItemContext = createContext<AccordionItemContextProps | null>(null);

--- a/lib/components/src/Accordion/index.ts
+++ b/lib/components/src/Accordion/index.ts
@@ -1,0 +1,9 @@
+export { Accordion } from './Accordion';
+export { AccordionBody } from './AccordionBody';
+export { AccordionHeader } from './AccordionHeader';
+export { AccordionItem } from './AccordionItem';
+
+export type { AccordionProps } from './Accordion';
+export type { AccordionBodyProps } from './AccordionBody';
+export type { AccordionHeaderProps } from './AccordionHeader';
+export type { AccordionItemProps } from './AccordionItem';

--- a/lib/components/src/Accordion/stories/Accordion.stories.tsx
+++ b/lib/components/src/Accordion/stories/Accordion.stories.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Accordion } from '../Accordion';
+import { AccordionItem } from '../AccordionItem';
+import { AccordionHeader } from '../AccordionHeader';
+import { AccordionBody } from '../AccordionBody';
+import { Icons } from '../../icon/icon';
+
+// eslint-disable-next-line import/order
+import type { ComponentStory, Meta } from '@storybook/react';
+
+export default {
+  title: 'Basics/Accordion',
+  component: Accordion,
+  argTypes: { onOpen: { action: 'open' }, onClose: { action: 'close' } },
+  parameters: {
+    test: { disable: true },
+    storysource: { disable: true },
+  },
+} as Meta;
+
+const Template: ComponentStory<typeof Accordion> = (args) => (
+  <Accordion {...args}>
+    <AccordionItem>
+      <AccordionHeader>Default AccordionItem</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader>
+        Normal deafult AccordionItem with a very long title so we can check if the label will wrap
+        correctly with the expander icon. You may have to resize the viewport to make this happen -
+        but this thext should be long enough.
+      </AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader Icon={<Icons icon="lightning" />}>
+        Custom icon in AccordionHeader
+      </AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader>AccordionHeader only - can not be opened</AccordionHeader>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader hideIcon>Can be opened - but icon hidden</AccordionHeader>
+      <AccordionBody>
+        This is a normal AccordionIcon, but with hideIcon set on AccordionHeader
+      </AccordionBody>
+    </AccordionItem>
+  </Accordion>
+);
+
+export const Controllable = Template.bind({});
+Controllable.args = {
+  allowMultipleOpen: false,
+  bordered: true,
+  rounded: true,
+  lined: true,
+  indentBody: true,
+  narrow: false,
+  preventToggle: false,
+};

--- a/lib/components/src/Accordion/stories/Accordion.stories.tsx
+++ b/lib/components/src/Accordion/stories/Accordion.stories.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
-import { Accordion } from '../Accordion';
-import { AccordionItem } from '../AccordionItem';
-import { AccordionHeader } from '../AccordionHeader';
-import { AccordionBody } from '../AccordionBody';
-import { Icons } from '../../icon/icon';
-
-// eslint-disable-next-line import/order
 import type { ComponentStory, Meta } from '@storybook/react';
+import React from 'react';
+import { Icons } from '../../icon/icon';
+import { Accordion } from '../Accordion';
+import { AccordionBody } from '../AccordionBody';
+import { AccordionHeader } from '../AccordionHeader';
+import { AccordionItem } from '../AccordionItem';
 
 export default {
   title: 'Basics/Accordion',

--- a/lib/components/src/Accordion/stories/AccordionBody.stories.tsx
+++ b/lib/components/src/Accordion/stories/AccordionBody.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { AccordionBody } from '../AccordionBody';
+
+// eslint-disable-next-line import/order
+import type { ComponentStory, Meta } from '@storybook/react';
+
+export default {
+  title: 'Basics/Accordion/AccordionBody',
+  component: AccordionBody,
+} as Meta;
+
+const Template: ComponentStory<typeof AccordionBody> = (args) => (
+  <AccordionBody {...args}>
+    Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse amet.
+    Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat excepteur. Magna
+    nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit ipsum.
+  </AccordionBody>
+);
+
+export const Controllable = Template.bind({});
+Controllable.args = {
+  open: true,
+};

--- a/lib/components/src/Accordion/stories/AccordionBody.stories.tsx
+++ b/lib/components/src/Accordion/stories/AccordionBody.stories.tsx
@@ -1,8 +1,6 @@
+import type { ComponentStory, Meta } from '@storybook/react';
 import React from 'react';
 import { AccordionBody } from '../AccordionBody';
-
-// eslint-disable-next-line import/order
-import type { ComponentStory, Meta } from '@storybook/react';
 
 export default {
   title: 'Basics/Accordion/AccordionBody',

--- a/lib/components/src/Accordion/stories/AccordionHeader.stories.tsx
+++ b/lib/components/src/Accordion/stories/AccordionHeader.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { AccordionHeader } from '../AccordionHeader';
+
+// eslint-disable-next-line import/order
+import type { ComponentStory, Meta } from '@storybook/react';
+
+export default {
+  title: 'Basics/Accordion/AccordionHeader',
+  component: AccordionHeader,
+  argTypes: { onOpen: { action: 'open' }, onClose: { action: 'close' } },
+} as Meta;
+
+const Template: ComponentStory<typeof AccordionHeader> = (args) => (
+  <AccordionHeader {...args}>Item 1</AccordionHeader>
+);
+
+export const Controllable = Template.bind({});
+Controllable.args = {
+  open: false,
+  hideIcon: false,
+  preventToggle: false,
+};

--- a/lib/components/src/Accordion/stories/AccordionHeader.stories.tsx
+++ b/lib/components/src/Accordion/stories/AccordionHeader.stories.tsx
@@ -1,8 +1,6 @@
+import type { ComponentStory, Meta } from '@storybook/react';
 import React from 'react';
 import { AccordionHeader } from '../AccordionHeader';
-
-// eslint-disable-next-line import/order
-import type { ComponentStory, Meta } from '@storybook/react';
 
 export default {
   title: 'Basics/Accordion/AccordionHeader',

--- a/lib/components/src/Accordion/stories/AccordionItem.stories.tsx
+++ b/lib/components/src/Accordion/stories/AccordionItem.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { AccordionItem } from '../AccordionItem';
+import { AccordionHeader } from '../AccordionHeader';
+import { AccordionBody } from '../AccordionBody';
+
+// eslint-disable-next-line import/order
+import type { ComponentStory, Meta } from '@storybook/react';
+
+export default {
+  title: 'Basics/Accordion/AccordionItem',
+  component: AccordionItem,
+} as Meta;
+
+const Template: ComponentStory<typeof AccordionItem> = (args) => (
+  <AccordionItem {...args}>
+    <AccordionHeader>Item 1</AccordionHeader>
+    <AccordionBody>
+      Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse amet.
+      Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat excepteur.
+      Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit ipsum.
+    </AccordionBody>
+  </AccordionItem>
+);
+
+export const Controllable = Template.bind({});
+Controllable.args = {
+  open: false,
+  narrow: false,
+  indentBody: false,
+  preventToggle: false,
+};

--- a/lib/components/src/Accordion/stories/AccordionItem.stories.tsx
+++ b/lib/components/src/Accordion/stories/AccordionItem.stories.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-import { AccordionItem } from '../AccordionItem';
-import { AccordionHeader } from '../AccordionHeader';
-import { AccordionBody } from '../AccordionBody';
-
-// eslint-disable-next-line import/order
 import type { ComponentStory, Meta } from '@storybook/react';
+import React from 'react';
+import { AccordionBody } from '../AccordionBody';
+import { AccordionHeader } from '../AccordionHeader';
+import { AccordionItem } from '../AccordionItem';
 
 export default {
   title: 'Basics/Accordion/AccordionItem',

--- a/lib/components/src/Accordion/stories/AccordionStories.stories.tsx
+++ b/lib/components/src/Accordion/stories/AccordionStories.stories.tsx
@@ -1,11 +1,9 @@
+import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 import { Accordion } from '../Accordion';
-import { AccordionItem } from '../AccordionItem';
-import { AccordionHeader } from '../AccordionHeader';
 import { AccordionBody } from '../AccordionBody';
-
-// eslint-disable-next-line import/order
-import type { Story, Meta } from '@storybook/react';
+import { AccordionHeader } from '../AccordionHeader';
+import { AccordionItem } from '../AccordionItem';
 
 export default {
   title: 'Basics/Accordion/Stories',

--- a/lib/components/src/Accordion/stories/AccordionStories.stories.tsx
+++ b/lib/components/src/Accordion/stories/AccordionStories.stories.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Accordion } from '../Accordion';
+import { AccordionItem } from '../AccordionItem';
+import { AccordionHeader } from '../AccordionHeader';
+import { AccordionBody } from '../AccordionBody';
+
+// eslint-disable-next-line import/order
+import type { Story, Meta } from '@storybook/react';
+
+export default {
+  title: 'Basics/Accordion/Stories',
+  component: Accordion,
+  parameters: {
+    actions: { disable: true },
+    test: { disable: true },
+    controls: { disable: true },
+  },
+} as Meta;
+
+export const OneDefaultOpen: Story = () => (
+  <Accordion open={1}>
+    <AccordionItem>
+      <AccordionHeader>Item 1 - Default open</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader>Item 2</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader>Item 3</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader>Item 4</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+  </Accordion>
+);
+
+export const MultipleDefaultOpen: Story = () => (
+  <Accordion open={[1, 2]} allowMultipleOpen>
+    <AccordionItem>
+      <AccordionHeader>Item 1 - Default open</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader>Item 2 - Default open</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader>Item 3</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionHeader>Item 4</AccordionHeader>
+      <AccordionBody>
+        Minim proident eu aliqua irure tempor incididunt fugiat. Adipisicing aliquip cillum esse
+        amet. Consequat qui consectetur duis laboris aliqua fugiat Lorem eiusmod ut cupidatat
+        excepteur. Magna nulla nulla velit voluptate duis nulla quis Lorem dolore labore aliqua sit
+        ipsum.
+      </AccordionBody>
+    </AccordionItem>
+  </Accordion>
+);

--- a/lib/components/src/Accordion/tests/AccordionBody.test.tsx
+++ b/lib/components/src/Accordion/tests/AccordionBody.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { ThemeProvider, themes, convert } from '@storybook/theming';
+import { AccordionBody } from '../AccordionBody';
+
+afterEach(cleanup);
+
+describe('<AccordionBody />', () => {
+  it('can perform an empty shallow render', () => {
+    const { findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionBody data-test-id="accordion-body" />
+      </ThemeProvider>
+    );
+
+    expect(findByTestId('accordion-body')).toBeDefined();
+  });
+
+  it('will render given children', () => {
+    const { findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionBody data-test-id="accordion-body">
+          <div data-test-id="accordion-body-child">Hello</div>
+        </AccordionBody>
+      </ThemeProvider>
+    );
+
+    expect(findByTestId('accordion-body')).toBeDefined();
+    expect(findByTestId('accordion-body-child')).toBeDefined();
+  });
+
+  it('will have height "auto" if open', () => {
+    const { container } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionBody open>
+          <div style={{ height: 200 }}>Hello</div>
+        </AccordionBody>
+      </ThemeProvider>
+    );
+
+    const inner = container.querySelector('[data-sb-accordion-body-inner=""]');
+
+    expect(container).toBeDefined();
+    expect(inner).toHaveStyle('height: auto');
+  });
+
+  it('will have height "0" if not open', () => {
+    const { container } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionBody>
+          <div style={{ height: 200 }}>Hello</div>
+        </AccordionBody>
+      </ThemeProvider>
+    );
+
+    const inner = container.querySelector('[data-sb-accordion-body-inner=""]');
+
+    expect(container).toBeDefined();
+    expect(inner).toHaveStyle('height: 0');
+  });
+});

--- a/lib/components/src/Accordion/tests/AccordionHeader.test.tsx
+++ b/lib/components/src/Accordion/tests/AccordionHeader.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { ThemeProvider, themes, convert } from '@storybook/theming';
+import { AccordionHeader } from '../AccordionHeader';
+
+afterEach(cleanup);
+
+describe('<AccordionHeader />', () => {
+  it('can perform an empty shallow render', () => {
+    const { findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionHeader data-test-id="accordion-header" />
+      </ThemeProvider>
+    );
+
+    expect(findByTestId('accordion-header')).toBeDefined();
+  });
+
+  it('will render given children', () => {
+    const { findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionHeader data-test-id="accordion-header">
+          <div data-test-id="accordion-header-child">Hello</div>
+        </AccordionHeader>
+      </ThemeProvider>
+    );
+
+    expect(findByTestId('accordion-header')).toBeDefined();
+    expect(findByTestId('accordion-header-child')).toBeDefined();
+  });
+
+  it('will render icon', () => {
+    const { findByTestId, findByRole } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionHeader data-test-id="accordion-header">
+          <div data-test-id="accordion-header-child">Hello</div>
+        </AccordionHeader>
+      </ThemeProvider>
+    );
+
+    expect(findByTestId('accordion-header')).toBeDefined();
+    expect(findByRole('img')).toBeDefined();
+  });
+
+  it('will rotate expander 0deg when not open', () => {
+    const { container, findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionHeader data-test-id="accordion-header">
+          <div data-test-id="accordion-header-child">Hello</div>
+        </AccordionHeader>
+      </ThemeProvider>
+    );
+
+    const expander = container.querySelector('[data-sb-accordion-expander=""]');
+
+    expect(findByTestId('accordion-header')).toBeDefined();
+    expect(expander).toBeDefined();
+    expect(expander).toHaveStyle('transform: rotate(0deg)');
+  });
+
+  it('will rotate expander 90deg when open', () => {
+    const { container, findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionHeader open data-test-id="accordion-header">
+          <div data-test-id="accordion-header-child">Hello</div>
+        </AccordionHeader>
+      </ThemeProvider>
+    );
+
+    const expander = container.querySelector('[data-sb-accordion-expander=""]');
+
+    expect(findByTestId('accordion-header')).toBeDefined();
+    expect(expander).toBeDefined();
+    expect(expander).toHaveStyle('transform: rotate(90deg)');
+  });
+});

--- a/lib/components/src/Accordion/tests/AccordionItem.test.tsx
+++ b/lib/components/src/Accordion/tests/AccordionItem.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { ThemeProvider, themes, convert } from '@storybook/theming';
+import { AccordionItem } from '../AccordionItem';
+import { AccordionHeader } from '../AccordionHeader';
+import { AccordionBody } from '../AccordionBody';
+
+afterEach(cleanup);
+
+describe('<AccordionItem />', () => {
+  it('can perform an shallow render', () => {
+    const { findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionItem data-test-id="accordion-item" />
+      </ThemeProvider>
+    );
+
+    expect(findByTestId('accordion-item')).toBeDefined();
+  });
+
+  it('can perform an shallow render with empty children', () => {
+    const { findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionItem data-test-id="accordion-item">
+          <AccordionHeader />
+          <AccordionBody />
+        </AccordionItem>
+      </ThemeProvider>
+    );
+
+    expect(findByTestId('accordion-item')).toBeDefined();
+    expect(findByTestId('accordion-item-child')).toBeDefined();
+  });
+
+  it('will rotate expander 0deg when not open', () => {
+    const { container, findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionItem data-test-id="accordion-item">
+          <AccordionHeader />
+          <AccordionBody />
+        </AccordionItem>
+      </ThemeProvider>
+    );
+
+    const expander = container.querySelector('[data-sb-accordion-expander=""]');
+
+    expect(findByTestId('accordion-header')).toBeDefined();
+    expect(expander).toBeDefined();
+    expect(expander).toHaveStyle('transform: rotate(0deg)');
+  });
+
+  it('will rotate expander 90deg when open', () => {
+    const { container, findByTestId } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionItem>
+          <AccordionHeader />
+          <AccordionBody />
+        </AccordionItem>
+      </ThemeProvider>
+    );
+
+    const expander = container.querySelector('[data-sb-accordion-expander=""]');
+
+    expect(findByTestId('accordion-header')).toBeDefined();
+    expect(expander).toBeDefined();
+    expect(expander).toHaveStyle('transform: rotate(0deg)');
+  });
+
+  it('body will have height "auto" if open', () => {
+    const { container } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionItem open>
+          <AccordionHeader />
+          <AccordionBody>
+            <div style={{ height: 200 }}>Hello</div>
+          </AccordionBody>
+        </AccordionItem>
+      </ThemeProvider>
+    );
+
+    const bodyInner = container.querySelector('[data-sb-accordion-body-inner=""]');
+
+    expect(container).toBeDefined();
+    expect(bodyInner).toHaveStyle('height: auto');
+  });
+
+  it('body will have height "0" if not open', () => {
+    const { container } = render(
+      <ThemeProvider theme={convert(themes.light)}>
+        <AccordionItem>
+          <AccordionHeader />
+          <AccordionBody>
+            <div style={{ height: 200 }}>Hello</div>
+          </AccordionBody>
+        </AccordionItem>
+      </ThemeProvider>
+    );
+
+    const bodyInner = container.querySelector('[data-sb-accordion-body-inner=""]');
+
+    expect(container).toBeDefined();
+    expect(bodyInner).toHaveStyle('height: 0');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -228,7 +228,6 @@
     "jest": "^26.6.3",
     "jest-emotion": "^10.0.32",
     "jest-environment-jsdom": "^26.6.2",
-    "jest-environment-jsdom-thirteen": "^1.0.1",
     "jest-enzyme": "^7.1.2",
     "jest-image-snapshot": "^4.3.0",
     "jest-jasmine2": "^26.6.3",
@@ -269,6 +268,42 @@
     "webpack": "4",
     "webpack-dev-middleware": "^3.7.3",
     "window-size": "^1.1.1"
+  },
+  "dependenciesMeta": {
+    "@compodoc/compodoc": {
+      "built": false
+    },
+    "core-js": {
+      "built": false
+    },
+    "core-js-pure": {
+      "built": false
+    },
+    "ejs": {
+      "built": false
+    },
+    "level": {
+      "built": false
+    },
+    "node-uuid": {
+      "built": false,
+      "unplugged": false
+    },
+    "nodemon": {
+      "built": false
+    },
+    "parcel": {
+      "built": false
+    },
+    "preact": {
+      "built": false
+    },
+    "styled-components": {
+      "built": false
+    },
+    "yorkie": {
+      "built": false
+    }
   },
   "optionalDependencies": {
     "@cypress/webpack-preprocessor": "^5.7.0",
@@ -323,41 +358,5 @@
         "Other"
       ]
     ]
-  },
-  "dependenciesMeta": {
-    "@compodoc/compodoc": {
-      "built": false
-    },
-    "core-js": {
-      "built": false
-    },
-    "core-js-pure": {
-      "built": false
-    },
-    "ejs": {
-      "built": false
-    },
-    "level": {
-      "built": false
-    },
-    "node-uuid": {
-      "built": false,
-      "unplugged": false
-    },
-    "nodemon": {
-      "built": false
-    },
-    "parcel": {
-      "built": false
-    },
-    "preact": {
-      "built": false
-    },
-    "styled-components": {
-      "built": false
-    },
-    "yorkie": {
-      "built": false
-    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7455,7 +7455,6 @@ __metadata:
     jest: ^26.6.3
     jest-emotion: ^10.0.32
     jest-environment-jsdom: ^26.6.2
-    jest-environment-jsdom-thirteen: ^1.0.1
     jest-enzyme: ^7.1.2
     jest-image-snapshot: ^4.3.0
     jest-jasmine2: ^26.6.3
@@ -26231,17 +26230,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jest-environment-jsdom-thirteen@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "jest-environment-jsdom-thirteen@npm:1.0.1"
-  dependencies:
-    jest-mock: ^24.0.0
-    jest-util: ^24.0.0
-    jsdom: ^13.0.0
-  checksum: bd067dcdf9c8ac019911abaf7db8f98dd554a65b0c33317e8b8143bf9f413ce3fb3d4c1ac0e3c62fbe187c4b7e3e3bad6bee2103a22eb53b663451b4f92ebc64
-  languageName: node
-  linkType: hard
-
 "jest-environment-jsdom@npm:^24.0.0, jest-environment-jsdom@npm:^24.9.0":
   version: 24.9.0
   resolution: "jest-environment-jsdom@npm:24.9.0"
@@ -27338,40 +27326,6 @@ fsevents@^1.2.7:
     ws: ^5.2.0
     xml-name-validator: ^3.0.0
   checksum: a909aa35527a337a55ddd66f99a0993d24e5a42ce5ef1ae0724a5fef5c9b4799f763dfd65d33798ca1feb83c604716aa054241e2b4b2274de2caa9566156566a
-  languageName: node
-  linkType: hard
-
-"jsdom@npm:^13.0.0":
-  version: 13.2.0
-  resolution: "jsdom@npm:13.2.0"
-  dependencies:
-    abab: ^2.0.0
-    acorn: ^6.0.4
-    acorn-globals: ^4.3.0
-    array-equal: ^1.0.0
-    cssom: ^0.3.4
-    cssstyle: ^1.1.1
-    data-urls: ^1.1.0
-    domexception: ^1.0.1
-    escodegen: ^1.11.0
-    html-encoding-sniffer: ^1.0.2
-    nwsapi: ^2.0.9
-    parse5: 5.1.0
-    pn: ^1.1.0
-    request: ^2.88.0
-    request-promise-native: ^1.0.5
-    saxes: ^3.1.5
-    symbol-tree: ^3.2.2
-    tough-cookie: ^2.5.0
-    w3c-hr-time: ^1.0.1
-    w3c-xmlserializer: ^1.0.1
-    webidl-conversions: ^4.0.2
-    whatwg-encoding: ^1.0.5
-    whatwg-mimetype: ^2.3.0
-    whatwg-url: ^7.0.0
-    ws: ^6.1.2
-    xml-name-validator: ^3.0.0
-  checksum: e4bd3120f5c1077f6ace1ac2e069a104f48ff4df6507097b6740990c783ecec6017122dd9904f2500805d8003932020d32c9f922b21c3009864dfb70fbeac6bf
   languageName: node
   linkType: hard
 
@@ -31455,7 +31409,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"nwsapi@npm:^2.0.7, nwsapi@npm:^2.0.9, nwsapi@npm:^2.1.3, nwsapi@npm:^2.2.0":
+"nwsapi@npm:^2.0.7, nwsapi@npm:^2.1.3, nwsapi@npm:^2.2.0":
   version: 2.2.0
   resolution: "nwsapi@npm:2.2.0"
   checksum: 1fd5adff9c6ab56b2e668dfb35a3f7517a5bd7a8817cd2af01037797fd1cb2fc6b22c2af1b06c1a66dd0536e36df1202a9fc21d8c37a0f24189b19d00606a091
@@ -38309,7 +38263,7 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"saxes@npm:^3.1.5, saxes@npm:^3.1.9":
+"saxes@npm:^3.1.9":
   version: 3.1.11
   resolution: "saxes@npm:3.1.11"
   dependencies:
@@ -43571,7 +43525,7 @@ typescript@2.9.1:
   languageName: node
   linkType: hard
 
-"w3c-xmlserializer@npm:^1.0.1, w3c-xmlserializer@npm:^1.1.2":
+"w3c-xmlserializer@npm:^1.1.2":
   version: 1.1.2
   resolution: "w3c-xmlserializer@npm:1.1.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6619,6 +6619,7 @@ __metadata:
     lodash: ^4.17.20
     markdown-to-jsx: ^7.1.3
     memoizerific: ^1.11.3
+    nanoid: ^3.1.23
     overlayscrollbars: ^1.13.1
     polished: ^4.0.5
     prop-types: ^15.7.2
@@ -30590,6 +30591,15 @@ fsevents@^1.2.7:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 58bc86b5f6c77fb4052ca6d29bb498120facde6318d7d29de9cd41c12a5183925d68e0284133b12cdd9865ce5eec195e3764d98bf6620e4ad4ec3c15fa57aa43
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.1.23":
+  version: 3.1.23
+  resolution: "nanoid@npm:3.1.23"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: a3207f946e2db59f8095118d5c57615f217e7f8a743bdb83212e222bd263516dbd83db226675d9b8634ed928ff2019db96ca06825a391af4256b02f7bec4b443
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did
Created the new components `<Accordion />`, `<AccordionItem />`, `<AccordionHeader />`, `<AccordionBody />`

The aim came from a wish to make the list feature used in a11y add-on commonly accessible with a uniform visual expression.

More documentation can be found in the ```official-storybook```

NOTE: Ported this over from my fork



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200539748475788/1200550416981061) by [Unito](https://www.unito.io)
