### PR TITLE
Replace uuid and uuid-browser with nanoid

### DIFF
--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -51,13 +51,13 @@
     "fast-deep-equal": "^3.1.3",
     "global": "^4.4.0",
     "lodash": "^4.17.20",
+    "nanoid": "^3.1.23",
     "polished": "^4.0.5",
     "prop-types": "^15.7.2",
     "react-inspector": "^5.1.0",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0",
-    "util-deprecate": "^1.0.2",
-    "uuid-browser": "^3.1.0"
+    "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.167",

--- a/addons/actions/src/preview/action.ts
+++ b/addons/actions/src/preview/action.ts
@@ -1,5 +1,5 @@
-import uuidv4 from 'uuid-browser/v4';
 import { addons } from '@storybook/addons';
+import { nanoid } from 'nanoid';
 import { EVENT_ID } from '../constants';
 import { ActionDisplay, ActionOptions, HandlerFunction } from '../models';
 import { config } from './configureActions';
@@ -12,7 +12,7 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
 
   const handler = function actionHandler(...args: any[]) {
     const channel = addons.getChannel();
-    const id = uuidv4();
+    const id = nanoid();
     const minDepth = 5; // anything less is really just storybook internals
     const normalizedArgs = args.length > 1 ? args : args[0];
 

--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -52,8 +52,6 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "terser-webpack-plugin": "^5.0.3",
-    "uuid": "^8.3.2",
-    "uuid-browser": "^3.1.0",
     "webpack": "4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5575,13 +5575,13 @@ __metadata:
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
     lodash: ^4.17.20
+    nanoid: ^3.1.23
     polished: ^4.0.5
     prop-types: ^15.7.2
     react-inspector: ^5.1.0
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-    uuid-browser: ^3.1.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
@@ -30639,6 +30639,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.1.23":
+  version: 3.1.23
+  resolution: "nanoid@npm:3.1.23"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: a3207f946e2db59f8095118d5c57615f217e7f8a743bdb83212e222bd263516dbd83db226675d9b8634ed928ff2019db96ca06825a391af4256b02f7bec4b443
+  languageName: node
+  linkType: hard
+
 "nanomatch@npm:^1.2.9":
   version: 1.2.13
   resolution: "nanomatch@npm:1.2.13"
@@ -31681,8 +31690,6 @@ fsevents@^1.2.7:
     react: 16.14.0
     react-dom: 16.14.0
     terser-webpack-plugin: ^5.0.3
-    uuid: ^8.3.2
-    uuid-browser: ^3.1.0
     webpack: 4
   peerDependencies:
     puppeteer: ^2.0.0 || ^3.0.0
@@ -43006,13 +43013,6 @@ typescript@2.9.1:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
-  languageName: node
-  linkType: hard
-
-"uuid-browser@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "uuid-browser@npm:3.1.0"
-  checksum: bfb6bcc8cc75c1adf776370c4f86d00ee5682f7315c8bccb99938e53dafae189ef6a4dc125e67abd2a2cdfaad6020690fe4cb67dbd5b39f32d3ba75fb713d807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

Removed the two packages [uuid](https://www.npmjs.com/package/uuid) and [uuid-browser](https://www.npmjs.com/package/uuid-browser) for [nanoid](https://www.npmjs.com/package/nanoid)

## Why I did it

We do have a unique id requirement in places, and nanoid provides an easier to use interface and has less bells and whistles and comes in at half the cost in unpacked size (52.7 kB vs 116 kB) - and is only 108 bytes minified/gzipped and they claim it is 60% faster than UUID

## How to test

Pipeline tests should be enough