### PR TITLE
Document how to add individual story description, see #8527 #10823

### DIFF
--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -339,7 +339,7 @@ Rest of your file...
 
 ## Add description to individual stories
 
-Add `storyDescription` to `parameters.docs`
+Add `story` to `docs.description` parameter
 
 ```js
 const Example = () => <Button />;

--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -336,6 +336,22 @@ import { theme } from '../path/to/theme'
 Rest of your file...
 ```
 
+## Add doc to individual stories
+
+Add `storyDescription` to `parameters.docs`
+
+```js
+const Example = () => <Button />;
+
+Example.parameters = {
+  docs: {
+    storyDescription: "Individiual story description, may conatin `markdown` markup",
+  },
+};
+```
+
+There is also an webpack loader package that extracts descriptions from jsdoc comments [story-description-loader](https://www.npmjs.com/package/story-description-loader)
+
 ## More resources
 
 - References: [README](../README.md) / [DocsPage](docspage.md) / [MDX](mdx.md) / [FAQ](faq.md) / [Recipes](recipes.md) / [Theming](theming.md) / [Props](props-tables.md)

--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -346,7 +346,9 @@ const Example = () => <Button />;
 
 Example.parameters = {
   docs: {
-    storyDescription: "Individiual story description, may conatin `markdown` markup",
+    description: {
+      story: "Individiual story description, may conatin `markdown` markup"
+    },
   },
 };
 ```

--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -17,6 +17,7 @@
 - [Reordering Docs tab first](#reordering-docs-tab-first)
 - [Customizing source snippets](#customizing-source-snippets)
 - [Overwriting docs container](#overwriting-docs-container)
+- [Add doc to individual stories](#add-doc-to-individual-stories)
 - [More resources](#more-resources)
 
 ## Component Story Format (CSF) with DocsPage

--- a/addons/docs/docs/recipes.md
+++ b/addons/docs/docs/recipes.md
@@ -17,7 +17,7 @@
 - [Reordering Docs tab first](#reordering-docs-tab-first)
 - [Customizing source snippets](#customizing-source-snippets)
 - [Overwriting docs container](#overwriting-docs-container)
-- [Add doc to individual stories](#add-doc-to-individual-stories)
+- [Add description to individual stories](#add-description-to-individual-stories)
 - [More resources](#more-resources)
 
 ## Component Story Format (CSF) with DocsPage
@@ -337,7 +337,7 @@ import { theme } from '../path/to/theme'
 Rest of your file...
 ```
 
-## Add doc to individual stories
+## Add description to individual stories
 
 Add `storyDescription` to `parameters.docs`
 


### PR DESCRIPTION
Issue:

## What I did
Update docs to show how to add individual story description in `CSF` see #8527 #10823

\- I spent a silly amount of time trying to find this piece of info, I want to save the next person the trouble

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need an update to the documentation? n/a


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
