### PR TITLE
Addon-docs: Cache DocsContext on window to prevent duplication

### DIFF
--- a/addons/docs/src/blocks/DocsContext.ts
+++ b/addons/docs/src/blocks/DocsContext.ts
@@ -1,4 +1,5 @@
 import { Context, createContext } from 'react';
+import { window as globalWindow } from 'global';
 
 export interface DocsContextProps {
   id?: string;
@@ -17,4 +18,15 @@ export interface DocsContextProps {
   forceRender?: () => void;
 }
 
-export const DocsContext: Context<DocsContextProps> = createContext({});
+// We add DocsContext to window. The reason is that in case DocsContext.ts is
+// imported multiple times (maybe once directly, and another time from a minified bundle)
+// we will have multiple DocsContext definitions - leading to lost context in
+// the React component tree.
+// This was specifically a problem with the Vite builder.
+/* eslint-disable no-underscore-dangle */
+if (globalWindow.__DOCS_CONTEXT__ === undefined) {
+  globalWindow.__DOCS_CONTEXT__ = createContext({});
+  globalWindow.__DOCS_CONTEXT__.displayName = 'DocsContext';
+}
+
+export const DocsContext: Context<DocsContextProps> = globalWindow.__DOCS_CONTEXT__;


### PR DESCRIPTION
This is intended to solve https://github.com/eirslett/storybook-builder-vite/issues/40
and related issues.

## How to test

Look at the linked issue.
Hopefully this shouldn't break any existing functionality in addon-docs, but looking at the code I don't think it will.

It would be nice to have this backported to the 6.3 release as well!

Arguably, the actual problem here is that Vite is making untrue assumptions, so ideally it should be fixed there. I think it's 