### PR TITLE
CSF: Fix auto-title generation for standard config dir

### DIFF
--- a/examples/cra-ts-kitchen-sink/.storybook/main.ts
+++ b/examples/cra-ts-kitchen-sink/.storybook/main.ts
@@ -3,7 +3,7 @@ import { Configuration } from 'webpack';
 const path = require('path');
 
 module.exports = {
-  stories: ['../src/**/*.stories.@(mdx|tsx|ts|jsx|js)'],
+  stories: ['../src/components', '../src/stories'],
   logLevel: 'debug',
   addons: [
     '@storybook/preset-create-react-app',
@@ -27,5 +27,8 @@ module.exports = {
   },
   core: {
     builder: 'webpack4',
+  },
+  features: {
+    previewCsfV3: true,
   },
 };

--- a/examples/cra-ts-kitchen-sink/src/stories/1-Button.stories.tsx
+++ b/examples/cra-ts-kitchen-sink/src/stories/1-Button.stories.tsx
@@ -3,7 +3,6 @@ import { action } from '@storybook/addon-actions';
 import { Button } from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
 };
 

--- a/lib/builder-webpack4/src/index.ts
+++ b/lib/builder-webpack4/src/index.ts
@@ -33,7 +33,10 @@ export const getConfig: WebpackBuilder['getConfig'] = async (options) => {
   const typescriptOptions = await presets.apply('typescript', {}, options);
   const babelOptions = await presets.apply('babel', {}, { ...options, typescriptOptions });
   const entries = await presets.apply('entries', [], options);
-  const stories = normalizeStories(await presets.apply('stories', [], options), options.configDir);
+  const stories = normalizeStories(await presets.apply('stories', [], options), {
+    configDir: options.configDir,
+    workingDir: process.cwd(),
+  });
   const frameworkOptions = await presets.apply(`${options.framework}Options`, {}, options);
 
   return presets.apply(

--- a/lib/builder-webpack4/src/preview/entries.ts
+++ b/lib/builder-webpack4/src/preview/entries.ts
@@ -41,7 +41,10 @@ export async function createPreviewEntry(options: { configDir: string; presets: 
 
   const configs = getMainConfigs(options);
   const other: string[] = await presets.apply('config', [], options);
-  const stories = normalizeStories(await presets.apply('stories', [], options), configDir);
+  const stories = normalizeStories(await presets.apply('stories', [], options), {
+    configDir: options.configDir,
+    workingDir: process.cwd(),
+  });
 
   if (configs.length > 0) {
     const noun = configs.length === 1 ? 'file' : 'files';

--- a/lib/builder-webpack5/src/index.ts
+++ b/lib/builder-webpack5/src/index.ts
@@ -23,7 +23,10 @@ export const getConfig: WebpackBuilder['getConfig'] = async (options) => {
   const entries = await presets.apply('entries', [], options);
   const stories = normalizeStories(
     (await presets.apply('stories', [], options)) as StoriesEntry[],
-    options.configDir
+    {
+      configDir: options.configDir,
+      workingDir: process.cwd(),
+    }
   );
   const frameworkOptions = await presets.apply(`${options.framework}Options`, {}, options);
 

--- a/lib/builder-webpack5/src/preview/entries.ts
+++ b/lib/builder-webpack5/src/preview/entries.ts
@@ -41,7 +41,10 @@ export async function createPreviewEntry(options: { configDir: string; presets: 
 
   const configs = getMainConfigs(options);
   const other: string[] = await presets.apply('config', [], options);
-  const stories = normalizeStories(await presets.apply('stories', [], options), options.configDir);
+  const stories = normalizeStories(await presets.apply('stories', [], options), {
+    configDir: options.configDir,
+    workingDir: process.cwd(),
+  });
 
   if (configs.length > 0) {
     const noun = configs.length === 1 ? 'file' : 'files';

--- a/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
+++ b/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
@@ -1,13 +1,9 @@
-import { normalizeStoriesEntry } from '../normalize-stories';
+import { normalizeStoriesEntry, normalizeDirectory } from '../normalize-stories';
 
 expect.addSnapshotSerializer({
   print: (val: any) => JSON.stringify(val, null, 2),
   test: (val) => typeof val !== 'string',
 });
-
-jest.mock('path', () => ({
-  resolve: () => 'dummy',
-}));
 
 jest.mock('fs', () => ({
   lstatSync: () => ({
@@ -88,6 +84,32 @@ describe('normalizeStoriesEntry', () => {
           "directory": "..",
           "titlePrefix": "atoms",
           "files": "*.stories.mdx"
+        }
+      }
+    `);
+  });
+});
+
+describe('normalizeDirectory', () => {
+  it('.storybook config', () => {
+    expect(
+      normalizeDirectory(
+        {
+          glob: '../src/**/*.stories.*',
+          specifier: {
+            directory: '../src',
+          },
+        },
+        {
+          configDir: '/project/.storybook',
+          workingDir: '/project',
+        }
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "glob": "../src/**/*.stories.*",
+        "specifier": {
+          "directory": "./src"
         }
       }
     `);

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -69,7 +69,10 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
 
   const features = await presets.apply<StorybookConfig['features']>('features');
   if (features?.buildStoriesJson) {
-    const stories = normalizeStories(await presets.apply('stories'), options.configDir);
+    const stories = normalizeStories(await presets.apply('stories'), {
+      configDir: options.configDir,
+      workingDir: process.cwd(),
+    });
     await extractStoriesJson(
       path.join(options.outputDir, 'stories.json'),
       stories.map((s) => s.glob),

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -64,7 +64,10 @@ const step = 100; // .1s
 export async function useStoriesJson(router: any, options: Options) {
   const storiesJson = resolvePathInStorybookCache('stories.json');
   await fs.remove(storiesJson);
-  const stories = normalizeStories(await options.presets.apply('stories'), options.configDir);
+  const stories = normalizeStories(await options.presets.apply('stories'), {
+    configDir: options.configDir,
+    workingDir: process.cwd(),
+  });
   const globs = stories.map((s) => s.glob);
   extractStoriesJson(storiesJson, globs, options.configDir);
   router.use('/stories.json', async (_req: any, res: any) => {


### PR DESCRIPTION
Issue: N/A

## What I did

The previous auto-title PR #15376 failed for a typical Storybook setup in which the configDir is different from the current working directory. I didn't catch it because my test case was `examples/react-ts` which is a corner case where the configDir IS the current directory.

To address this:
- [x] Added logic to rewrite the `directory` specifier to match webpack's `fileName`
- [x] Added a unit test
- [x] Added a new example, `examples/cra-ts-kitchen-sink`, which uses the typical config structure

self-merging @tmeasday 

## How to test

See attached tests