### PR TITLE
typo(cli): fix error message (yarn → npm)

### DIFF
--- a/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -60,7 +60,7 @@ export class NPMProxy extends JsPackageManager {
         return parsedOutput;
       }
     } catch (e) {
-      throw new Error(`Unable to find versions of ${packageName} using yarn`);
+      throw new Error(`Unable to find versions of ${packageName} using npm`);
     }
   }
 }


### PR DESCRIPTION
Fix the error message in `NPMProxy.runGetVersions` to refer to "npm" instead of "yarn".

I ran into this while troubleshooting problems with `sb init`.