### PR TITLE
UI: Fix sidebar toggle in fullscreen mode

### DIFF
--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -156,14 +156,14 @@ export const init: ModuleFn = ({ store, provider, singleStory }) => {
           if (singleStory) return { layout: state.layout };
 
           const { showPanel, isFullscreen } = state.layout;
-          const value = typeof toggled !== 'undefined' ? toggled : !state.layout.showNav;
-          const shouldToggleFullScreen = showPanel === false && value === false;
+          const showNav = typeof toggled !== 'undefined' ? toggled : !state.layout.showNav;
+          const shouldToggleFullScreen = showPanel === false && showNav === false;
 
           return {
             layout: {
               ...state.layout,
-              showNav: value,
-              isFullscreen: shouldToggleFullScreen ? true : isFullscreen,
+              showNav,
+              isFullscreen: shouldToggleFullScreen ? true : !showNav && isFullscreen,
             },
           };
         },

--- a/lib/ui/src/components/preview/tools/menu.tsx
+++ b/lib/ui/src/components/preview/tools/menu.tsx
@@ -5,7 +5,7 @@ import { Addon } from '@storybook/addons';
 
 const menuMapper = ({ api, state }: Combo) => ({
   isVisible: state.layout.showNav,
-  toggle: api.toggleNav,
+  toggle: () => api.toggleNav(),
 });
 
 export const menuTool: Addon = {
@@ -13,24 +13,17 @@ export const menuTool: Addon = {
   id: 'menu',
   match: ({ viewMode }) => viewMode === 'story',
   render: () => (
-    <>
-      <Consumer filter={menuMapper}>
-        {({ isVisible, toggle }) =>
-          !isVisible && (
-            <>
-              <IconButton
-                aria-label="Show sidebar"
-                key="menu"
-                onClick={toggle as any}
-                title="Show sidebar"
-              >
-                <Icons icon="menu" />
-              </IconButton>
-              <Separator />
-            </>
-          )
-        }
-      </Consumer>
-    </>
+    <Consumer filter={menuMapper}>
+      {({ isVisible, toggle }) =>
+        !isVisible && (
+          <>
+            <IconButton aria-label="Show sidebar" key="menu" onClick={toggle} title="Show sidebar">
+              <Icons icon="menu" />
+            </IconButton>
+            <Separator />
+          </>
+        )
+      }
+    </Consumer>
   ),
 };


### PR DESCRIPTION
Issue: related to #15369

The toggle functionality didn't work when in fullscreen.

## What I did

Fixed so that when clicking on the toggle icon when in fullscreen mode, it will show the sidebar correctly.

## How to test

- run storybook
- Press A then S (to hide both addons panel and sidebar, effectively going to fullscreen)
- Click in the hamburger icon on top left. It should open the sidebar

- Is this testable with Jest or Chromatic screenshots? I guess better if tested in Cypress
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no
