### PR TITLE
a11y addon: Reverse label and description content in Accordion

### DIFF
--- a/addons/a11y/src/components/A11YPanel.test.tsx
+++ b/addons/a11y/src/components/A11YPanel.test.tsx
@@ -16,9 +16,9 @@ const axeResult = {
       id: 'color-contrast',
       impact: 'serious',
       tags: ['cat.color', 'wcag2aa', 'wcag143'],
-      description:
+      description: 'Elements must have sufficient color contrast',
+      help:
         'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
-      help: 'Elements must have sufficient color contrast',
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=axeAPI',
       nodes: [],
     },
@@ -28,8 +28,8 @@ const axeResult = {
       id: 'aria-allowed-attr',
       impact: null,
       tags: ['cat.aria', 'wcag2a', 'wcag412'],
-      description: "Ensures ARIA attributes are allowed for an element's role",
-      help: 'Elements must only use allowed ARIA attributes',
+      description: 'Elements must only use allowed ARIA attributes',
+      help: "Ensures ARIA attributes are allowed for an element's role",
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/aria-allowed-attr?application=axeAPI',
       nodes: [],
     },
@@ -39,9 +39,9 @@ const axeResult = {
       id: 'color-contrast',
       impact: 'serious',
       tags: ['cat.color', 'wcag2aa', 'wcag143'],
-      description:
+      description: 'Elements must have sufficient color contrast',
+      help:
         'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
-      help: 'Elements must have sufficient color contrast',
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=axeAPI',
       nodes: [],
     },

--- a/addons/a11y/src/components/A11yContext.test.tsx
+++ b/addons/a11y/src/components/A11yContext.test.tsx
@@ -17,9 +17,9 @@ const axeResult: Partial<AxeResults> = {
       id: 'color-contrast',
       impact: 'serious',
       tags: [],
-      description:
+      description: 'Elements must have sufficient color contrast',
+      help:
         'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
-      help: 'Elements must have sufficient color contrast',
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=axeAPI',
       nodes: [],
     },
@@ -29,8 +29,8 @@ const axeResult: Partial<AxeResults> = {
       id: 'aria-allowed-attr',
       impact: undefined,
       tags: [],
-      description: "Ensures ARIA attributes are allowed for an element's role",
-      help: 'Elements must only use allowed ARIA attributes',
+      description: 'Elements must only use allowed ARIA attributes',
+      help: "Ensures ARIA attributes are allowed for an element's role",
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/aria-allowed-attr?application=axeAPI',
       nodes: [],
     },
@@ -40,9 +40,9 @@ const axeResult: Partial<AxeResults> = {
       id: 'color-contrast',
       impact: 'serious',
       tags: [],
-      description:
+      description: 'Elements must have sufficient color contrast',
+      help:
         'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
-      help: 'Elements must have sufficient color contrast',
       helpUrl: 'https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=axeAPI',
       nodes: [],
     },


### PR DESCRIPTION
Issue: [A11y addon: Reverse the label and description content in the Accordion #15445](https://github.com/storybookjs/storybook/issues/15445)

## What I did

Swapped content of `description` and `help` by renaming `description` to `help` and `help` to `description`.