### PR TITLE
Addon-a11y: Reverse help and description labels in accordion

### DIFF
--- a/addons/a11y/src/components/Report/Info.tsx
+++ b/addons/a11y/src/components/Report/Info.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled.div({
   padding: 12,
   marginBottom: 10,
 });
-const Help = styled.p({
+const Description = styled.p({
   margin: '0 0 12px',
 });
 const Link = styled.a({
@@ -24,7 +24,7 @@ interface InfoProps {
 export const Info: FunctionComponent<InfoProps> = ({ item }) => {
   return (
     <Wrapper>
-      <Help>{item.help}</Help>
+      <Description>{item.description}</Description>
       <Link href={item.helpUrl} target="_blank">
         More info...
       </Link>

--- a/addons/a11y/src/components/Report/Item.tsx
+++ b/addons/a11y/src/components/Report/Item.tsx
@@ -82,7 +82,7 @@ export const Item = (props: ItemProps) => {
               transform: `rotate(${open ? 0 : -90}deg)`,
             }}
           />
-          {item.description}
+          {item.help}
         </HeaderBar>
         <HighlightToggleElement>
           <HighlightToggle toggleId={highlightToggleId} elementsToHighlight={item.nodes} />


### PR DESCRIPTION
Issue: [A11y addon: Reverse the label and description content in the Accordion #15445](https://github.com/storybookjs/storybook/issues/15445)


## What I did

Swap a11y accordion header help label and description content.
