### PR TITLE
Build: Update Yarn cache setup in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "12.x"
-          cache: npm
+          cache: yarn
       - uses: actions/checkout@v2
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -7,19 +7,20 @@ jobs:
     name: Core Unit Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-    - uses: actions/checkout@v2
-    - name: Cache node modules
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: yarn-2-cache-v1-${{ hashFiles('**/yarn.lock') }}
-    - name: install, bootstrap
-      run: |
-        yarn install --immutable
-        yarn bootstrap --core
-    - name: test
-      run: |
-        yarn test --runInBand --ci
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          cache: npm
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: yarn-2-cache-v1-${{ hashFiles('**/yarn.lock') }}
+      - name: install, bootstrap
+        run: |
+          yarn install --immutable
+          yarn bootstrap --core
+      - name: test
+        run: |
+          yarn test --runInBand --ci

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -12,11 +12,6 @@ jobs:
           node-version: "12.x"
           cache: yarn
       - uses: actions/checkout@v2
-      - name: Cache node modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: yarn-2-cache-v1-${{ hashFiles('**/yarn.lock') }}
       - name: install, bootstrap
         run: |
           yarn install --immutable


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Fix #15484

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
