### PR TITLE
Webpack5: Quit process after finishing a static build

### DIFF
--- a/app/angular/src/server/build.ts
+++ b/app/angular/src/server/build.ts
@@ -5,9 +5,6 @@ import options from './options';
 async function build() {
   try {
     await buildStatic(options);
-
-    // #15227
-    process.exit(0);
   } catch (error) {
     logger.error(error);
   }

--- a/app/angular/src/server/build.ts
+++ b/app/angular/src/server/build.ts
@@ -1,4 +1,16 @@
 import { buildStatic } from '@storybook/core/server';
+import { logger } from '@storybook/node-logger';
 import options from './options';
 
-buildStatic(options);
+async function build() {
+  try {
+    await buildStatic(options);
+
+    // #15227
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+  }
+}
+
+build();


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/15227

## What I did

I added a `try`/`catch` around Angular's build process and made sure webpack compiler `close` method gets called. See https://github.com/angular/angular-cli/issues/21261#issuecomment-875153057 for reference.

## How to test

It's best to test the change against https://github.com/hoffination/storybook-timeout-repro . Ideally a subset of that would be pulled here as a test somehow.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
