### PR TITLE
fix: shortcut for navigating to previous language in official-storybook example

### DIFF
--- a/examples/official-storybook/preview.js
+++ b/examples/official-storybook/preview.js
@@ -222,7 +222,7 @@ export const globalTypes = {
         },
         previous: {
           label: 'Go to previous language',
-          keys: ['shift', 'L'],
+          keys: ['K'],
         },
         reset: {
           label: 'Reset language',


### PR DESCRIPTION
Issue:
The instructions to navigate between languages is misleading in the [Locale toolbar story](https://github.com/storybookjs/storybook/blob/next/examples/official-storybook/stories/addon-toolbars.stories.js#L31). The wording states that `K` will navigate to the previous language, but the configuration defined `SHIFT + L` as the shortcut.

## What I did
* Updated the shortcut to `K` to match the language used in the story to prevent confusion

## How to test
* Run `yarn storybook` from `example/official-storybook`, view the `Locale` story under Addons > Toolbars.
* Hit `K` and navigate to the previous language

- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

## Screenshots
![shortcuts](https://user-images.githubusercontent.com/17681528/124523317-39e79300-ddbc-11eb-85f8-4619772d2d3f.gif)

