### PR TITLE
Angular: Fix void element selectors

### DIFF
--- a/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.test.ts
+++ b/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.test.ts
@@ -77,6 +77,22 @@ describe('angular source decorator', () => {
     });
   });
 
+  describe('with component with void element and attribute selector', () => {
+    @Component({
+      selector: 'input[foo]',
+      template: '<button></button>',
+    })
+    class VoidElementWithAttributeComponent {}
+
+    it('should create without separate closing tag', async () => {
+      const component = VoidElementWithAttributeComponent;
+      const props = {};
+      const argTypes: ArgTypes = {};
+      const source = computesTemplateSourceFromComponent(component, props, argTypes);
+      expect(source).toEqual(`<input foo />`);
+    });
+  });
+
   describe('with component with attribute and value only selector', () => {
     @Component({
       selector: '[foo="bar"]',
@@ -90,6 +106,22 @@ describe('angular source decorator', () => {
       const argTypes: ArgTypes = {};
       const source = computesTemplateSourceFromComponent(component, props, argTypes);
       expect(source).toEqual(`<div foo="bar"></div>`);
+    });
+  });
+
+  describe('with component with void element, attribute and value only selector', () => {
+    @Component({
+      selector: 'input[foo="bar"]',
+      template: '<button></button>',
+    })
+    class VoidElementWithAttributeComponent {}
+
+    it('should create and add attribute to template without separate closing tag', async () => {
+      const component = VoidElementWithAttributeComponent;
+      const props = {};
+      const argTypes: ArgTypes = {};
+      const source = computesTemplateSourceFromComponent(component, props, argTypes);
+      expect(source).toEqual(`<input foo="bar" />`);
     });
   });
 

--- a/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.ts
+++ b/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.ts
@@ -141,6 +141,26 @@ const buildTemplate = (
   inputs: string,
   outputs: string
 ) => {
+  // https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements
+  const voidElements = [
+    'area',
+    'base',
+    'br',
+    'col',
+    'command',
+    'embed',
+    'hr',
+    'img',
+    'input',
+    'keygen',
+    'link',
+    'meta',
+    'param',
+    'source',
+    'track',
+    'wbr',
+  ];
+
   const firstSelector = selector.split(',')[0];
   const templateReplacers: [
     string | RegExp,
@@ -153,7 +173,14 @@ const buildTemplate = (
     [/#([\w-]+)/, ` id="$1"`],
     [/((\.[\w-]+)+)/, (_, c) => ` class="${c.split`.`.join` `.trim()}"`],
     [/(\[.+?])/g, (_, a) => ` ${a.slice(1, -1)}`],
-    [/([\S]+)(.*)/, `<$1$2${inputs}${outputs}>${innerTemplate}</$1>`],
+    [
+      /([\S]+)(.*)/,
+      (template, elementSelector) => {
+        return voidElements.some((element) => elementSelector === element)
+          ? template.replace(/([\S]+)(.*)/, `<$1$2${inputs}${outputs} />`)
+          : template.replace(/([\S]+)(.*)/, `<$1$2${inputs}${outputs}>${innerTemplate}</$1>`);
+      },
+    ],
   ];
 
   return templateReplacers.reduce(


### PR DESCRIPTION
Issue: #15494

## What I did
Check during `buildTemplate` if the element is a void element and use a different replacement strategy for it.

## How to test

- Is this testable with Jest or Chromatic screenshots?
I've added two basic jest tests for this