### PR TITLE
Build: Fix cache setup in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -7,11 +7,11 @@ jobs:
     name: Core Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           cache: yarn
-      - uses: actions/checkout@v2
       - name: install, bootstrap
         run: |
           yarn install --immutable

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -7,7 +7,7 @@ jobs:
     name: Core Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           cache: yarn


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- [x] Bump `actions/setup-node` to `v2` in `tests-unit.yml`
- [x] Move `actions/checkout` as first step in `tests-unit.yml`

## ⛱ Motivation and Context
Considering it was added in 2.2.0 you would need to update this to v2, you also need to checkout the code before setting up node so it can actually get the cache folder

Fix #15522 