### PR TITLE
feat: support to change the lang attribute in a preview HTML

### DIFF
--- a/examples/angular-cli/src/stories/__snapshots__/welcome-storybook.stories.storyshot
+++ b/examples/angular-cli/src/stories/__snapshots__/welcome-storybook.stories.storyshot
@@ -3,47 +3,47 @@
 exports[`Storyshots Welcome/ To Storybook To Storybook 1`] = `
 <storybook-wrapper>
   <storybook-welcome-component
-    _nghost-a-c151=""
+    _nghost-a-c152=""
   >
     <main
-      _ngcontent-a-c151=""
+      _ngcontent-a-c152=""
     >
       <h1
-        _ngcontent-a-c151=""
+        _ngcontent-a-c152=""
       >
         Welcome to storybook
       </h1>
       <p
-        _ngcontent-a-c151=""
+        _ngcontent-a-c152=""
       >
         This is a UI component dev environment for your app.
       </p>
       <p
-        _ngcontent-a-c151=""
+        _ngcontent-a-c152=""
       >
          We've added some basic stories inside the 
         <span
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
           class="inline-code"
         >
           src/stories
         </span>
          directory. 
         <br
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
         />
          A story is a single state of one or more UI components. You can have as many stories as you want. 
         <br
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
         />
          (Basically a story is like a visual test case.) 
       </p>
       <p
-        _ngcontent-a-c151=""
+        _ngcontent-a-c152=""
       >
          See these sample 
         <a
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
           role="button"
           tabindex="0"
         >
@@ -51,7 +51,7 @@ exports[`Storyshots Welcome/ To Storybook To Storybook 1`] = `
         </a>
          for a component called 
         <span
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
           class="inline-code"
         >
           Button
@@ -59,26 +59,26 @@ exports[`Storyshots Welcome/ To Storybook To Storybook 1`] = `
          . 
       </p>
       <p
-        _ngcontent-a-c151=""
+        _ngcontent-a-c152=""
       >
          Just like that, you can add your own components as stories. 
         <br
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
         />
          You can also edit those components and see changes right away. 
         <br
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
         />
          (Try editing the 
         <span
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
           class="inline-code"
         >
           Button
         </span>
          stories located at 
         <span
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
           class="inline-code"
         >
           src/stories/index.js
@@ -86,15 +86,15 @@ exports[`Storyshots Welcome/ To Storybook To Storybook 1`] = `
         .) 
       </p>
       <p
-        _ngcontent-a-c151=""
+        _ngcontent-a-c152=""
       >
          Usually we create stories with smaller UI components in the app.
         <br
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
         />
          Have a look at the 
         <a
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
           href="https://storybook.js.org/basics/writing-stories"
           rel="noopener noreferrer"
           target="_blank"
@@ -104,20 +104,20 @@ exports[`Storyshots Welcome/ To Storybook To Storybook 1`] = `
          section in our documentation. 
       </p>
       <p
-        _ngcontent-a-c151=""
+        _ngcontent-a-c152=""
         class="note"
       >
         <b
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
         >
           NOTE:
         </b>
         <br
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
         />
          Have a look at the 
         <span
-          _ngcontent-a-c151=""
+          _ngcontent-a-c152=""
           class="inline-code"
         >
           .storybook/webpack.config.js

--- a/examples/angular-cli/src/stories/core/styles/__snapshots__/story-styles.stories.storyshot
+++ b/examples/angular-cli/src/stories/core/styles/__snapshots__/story-styles.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Core / Story host styles With Args 1`] = `
 <storybook-wrapper>
   <storybook-button-component
-    _ngcontent-a-c144=""
+    _ngcontent-a-c145=""
     _nghost-a-c43=""
     ng-reflect-text="Button with custom styles"
   >
@@ -19,7 +19,7 @@ exports[`Storyshots Core / Story host styles With Args 1`] = `
 exports[`Storyshots Core / Story host styles With story template 1`] = `
 <storybook-wrapper>
   <storybook-button-component
-    _ngcontent-a-c143=""
+    _ngcontent-a-c144=""
     _nghost-a-c43=""
     ng-reflect-text="Button with custom styles"
   >

--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -15,7 +15,6 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import FilterWarningsPlugin from 'webpack-filter-warnings-plugin';
 
 import themingPaths from '@storybook/theming/paths';
-
 import {
   toRequireContextString,
   stringifyEnvs,
@@ -166,6 +165,7 @@ export default async ({
           },
           headHtmlSnippet,
           bodyHtmlSnippet,
+          lang: envs.STORYBOOK_PREVIEW_HTML_LANG || 'en',
         }),
         minify: {
           collapseWhitespace: true,

--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -15,6 +15,7 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import FilterWarningsPlugin from 'webpack-filter-warnings-plugin';
 
 import themingPaths from '@storybook/theming/paths';
+
 import {
   toRequireContextString,
   stringifyEnvs,

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -166,6 +166,7 @@ export default async ({
           },
           headHtmlSnippet,
           bodyHtmlSnippet,
+          lang: envs.STORYBOOK_PREVIEW_HTML_LANG || 'en',
         }),
         minify: {
           collapseWhitespace: true,

--- a/lib/core-common/src/templates/index.ejs
+++ b/lib/core-common/src/templates/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= lang %>">
   <head>
     <meta charset="utf-8" />
     <title><%= options.title || 'Storybook'%></title>

--- a/lib/manager-webpack4/src/manager-webpack.config.ts
+++ b/lib/manager-webpack4/src/manager-webpack.config.ts
@@ -99,6 +99,7 @@ export default async ({
             PREVIEW_URL: previewUrl, // global preview URL
           },
           headHtmlSnippet,
+          lang: envs.STORYBOOK_PREVIEW_HTML_LANG || 'en',
         }),
         template,
       }) as any) as WebpackPluginInstance,

--- a/lib/manager-webpack5/src/manager-webpack.config.ts
+++ b/lib/manager-webpack5/src/manager-webpack.config.ts
@@ -99,6 +99,7 @@ export default async ({
             PREVIEW_URL: previewUrl, // global preview URL
           },
           headHtmlSnippet,
+          lang: envs.STORYBOOK_PREVIEW_HTML_LANG || 'en',
         }),
         template,
       }) as any) as WebpackPluginInstance,


### PR DESCRIPTION
Issue: #11706

## What I did

I've added the `STORYBOOK_PREVIEW_HTML_LANG` environment variable to update the lang attribute in the preview html because I'd like to use storybook for non-English applications.

I've used an environment variable for this because the lang attribute is defined in a template for `html-webpack-plugin` and I didn't come up with a better way.

## How to test

Should I add the documentation for `STORYBOOK_PREVIEW_HTML_LANG` to merge this PR? 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
