### PR TITLE
Examples: Add no-manager-cache to all examples

### DIFF
--- a/examples/angular-cli/package.json
+++ b/examples/angular-cli/package.json
@@ -10,7 +10,7 @@
     "e2e": "ng e2e",
     "ng": "ng",
     "start": "ng serve",
-    "storybook": "yarn storybook-prebuild && start-storybook -p 9008 -s src/assets",
+    "storybook": "yarn storybook-prebuild && start-storybook -p 9008 -s src/assets --no-manager-cache",
     "storybook-prebuild": "yarn test:generate-output && yarn docs:json",
     "test": "jest",
     "test:coverage": "jest --coverage",

--- a/examples/cra-kitchen-sink/package.json
+++ b/examples/cra-kitchen-sink/package.json
@@ -7,7 +7,7 @@
     "build-storybook": "build-storybook -s public",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "storybook": "start-storybook -p 9010 -s public",
+    "storybook": "start-storybook -p 9010 -s public --no-manager-cache",
     "test": "react-scripts test --env=jsdom"
   },
   "dependencies": {

--- a/examples/cra-react15/package.json
+++ b/examples/cra-react15/package.json
@@ -7,7 +7,7 @@
     "build-storybook": "build-storybook -s public",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "storybook": "start-storybook -p 9009 -s public",
+    "storybook": "start-storybook -p 9009 -s public --no-manager-cache",
     "test": "react-scripts test --env=jsdom"
   },
   "dependencies": {

--- a/examples/cra-ts-essentials/package.json
+++ b/examples/cra-ts-essentials/package.json
@@ -7,7 +7,7 @@
     "build-storybook": "build-storybook -s public",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "storybook": "start-storybook -p 9009 -s public",
+    "storybook": "start-storybook -p 9009 -s public --no-manager-cache",
     "test": "react-scripts test"
   },
   "browserslist": {

--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -7,7 +7,7 @@
     "build-storybook": "build-storybook -s public",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "storybook": "start-storybook -p 9009 -s public",
+    "storybook": "start-storybook -p 9009 -s public --no-manager-cache",
     "test": "react-scripts test"
   },
   "browserslist": {

--- a/examples/ember-cli/package.json
+++ b/examples/ember-cli/package.json
@@ -6,7 +6,7 @@
     "build": "ember build --output-path ember-output",
     "build-storybook": "yarn storybook-prebuild && build-storybook -s ember-output",
     "dev": "ember serve",
-    "storybook": "yarn build && start-storybook -p 9009 -s ember-output",
+    "storybook": "yarn build && start-storybook -p 9009 -s ember-output --no-manager-cache",
     "storybook-prebuild": "yarn build && shx cp -r public/* ember-output",
     "storybook:dev": "yarn dev & start-storybook -p 9009 -s ember-output"
   },

--- a/examples/html-kitchen-sink/package.json
+++ b/examples/html-kitchen-sink/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build-storybook": "build-storybook",
     "generate-addon-jest-testresults": "jest --config=tests/addon-jest.config.json --json --outputFile=stories/addon-jest.testresults.json",
-    "storybook": "start-storybook -p 9006"
+    "storybook": "start-storybook -p 9006 --no-manager-cache"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "6.4.0-alpha.13",

--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -8,7 +8,7 @@
     "do-storyshots-puppeteer": "../../node_modules/.bin/jest --projects=./storyshots-puppeteer",
     "generate-addon-jest-testresults": "jest --config=tests/addon-jest.config.json --json --outputFile=stories/addon-jest.testresults.json",
     "packtracker": "yarn storybook --smoke-test --webpack-stats-json /tmp --quiet && cross-env PT_PROJECT_TOKEN=1af1d41b-d737-41d4-ac00-53c8f3913b53 packtracker-upload --stats=/tmp/manager-stats.json",
-    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./",
+    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./ --no-manager-cache",
     "storyshots-puppeteer": "yarn run build-storybook && yarn run do-storyshots-puppeteer"
   },
   "devDependencies": {

--- a/examples/preact-kitchen-sink/package.json
+++ b/examples/preact-kitchen-sink/package.json
@@ -6,7 +6,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "build-storybook": "build-storybook -s public",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
-    "storybook": "start-storybook -p 9009 -s public"
+    "storybook": "start-storybook -p 9009 -s public --no-manager-cache"
   },
   "dependencies": {
     "global": "^4.4.0",

--- a/examples/react-ts-webpack4/package.json
+++ b/examples/react-ts-webpack4/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build-storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true build-storybook -c ./",
     "debug": "cross-env NODE_OPTIONS=--inspect-brk STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./",
-    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./"
+    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./ --no-manager-cache"
   },
   "dependencies": {
     "@storybook/addon-controls": "6.4.0-alpha.13",

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build-storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true build-storybook -c ./",
     "debug": "cross-env NODE_OPTIONS=--inspect-brk STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./",
-    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./"
+    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./ --no-manager-cache"
   },
   "dependencies": {
     "@storybook/addon-controls": "6.4.0-alpha.13",

--- a/examples/svelte-kitchen-sink/package.json
+++ b/examples/svelte-kitchen-sink/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build-storybook": "build-storybook -s public",
-    "storybook": "start-storybook -p 9009 -s public"
+    "storybook": "start-storybook -p 9009 -s public --no-manager-cache"
   },
   "dependencies": {
     "global": "^4.4.0"

--- a/examples/vue-3-cli/package.json
+++ b/examples/vue-3-cli/package.json
@@ -6,7 +6,7 @@
     "build": "vue-cli-service build",
     "build-storybook": "build-storybook",
     "serve": "vue-cli-service serve",
-    "storybook": "start-storybook -p 6006"
+    "storybook": "start-storybook -p 6006 --no-manager-cache"
   },
   "dependencies": {
     "core-js": "^3.8.2",

--- a/examples/vue-cli/package.json
+++ b/examples/vue-cli/package.json
@@ -6,7 +6,7 @@
     "build": "vue-cli-service build",
     "build-storybook": "build-storybook",
     "serve": "vue-cli-service serve",
-    "storybook": "start-storybook -p 9009"
+    "storybook": "start-storybook -p 9009 --no-manager-cache"
   },
   "dependencies": {
     "core-js": "^3.8.2",

--- a/examples/vue-kitchen-sink/package.json
+++ b/examples/vue-kitchen-sink/package.json
@@ -6,7 +6,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "build-storybook": "build-storybook -s public",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
-    "storybook": "start-storybook -p 9009 -s public"
+    "storybook": "start-storybook -p 9009 -s public --no-manager-cache"
   },
   "dependencies": {
     "vue": "^2.6.12",

--- a/examples/web-components-kitchen-sink/package.json
+++ b/examples/web-components-kitchen-sink/package.json
@@ -9,7 +9,7 @@
   "main": "index.js",
   "scripts": {
     "build-storybook": "build-storybook",
-    "storybook": "start-storybook -p 9006",
+    "storybook": "start-storybook -p 9006 --no-manager-cache",
     "generate-custom-elements-manifest": "yarn custom-elements-manifest analyze --litelement --dev --exclude \"./**/*.stories.ts\""
   },
   "resolutions": {


### PR DESCRIPTION
Issue: N/A

## What I did

Add `--no-manager-cache` to all examples for dev mode so that contributors won't hit issues with their changes not showing up in the examples due to caching

self-merging @ndelangen 

## How to test

- [ ] CI passes