### PR TITLE
Addon-docs: Fix single line code snippet not rendered with style

### DIFF
--- a/lib/components/src/blocks/Description.stories.tsx
+++ b/lib/components/src/blocks/Description.stories.tsx
@@ -47,6 +47,12 @@ const a = fn({
   b: 2,
 });
 \`\`\`
+
+A single line block:
+
+\`\`\`jsx
+import React from 'react'
+\`\`\`
 `;
 
 const Template = (args: React.ComponentProps<typeof Description>) => <Description {...args} />;

--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -345,7 +345,7 @@ export const Code = ({
     .filter(isReactChildString)
     .some((child) => child.match(isInlineCodeRegex));
 
-  if (isInlineCode) {
+  if (isInlineCode && !language) {
     return (
       <DefaultCodeBlock {...props} className={className}>
         {childrenArray}


### PR DESCRIPTION
Issue: #15458

## What I did

Added back checking `language` for single line code formatting

## How to test

Reproduction repo https://github.com/pouretrebelle/sb-syntax-highlight-bug-repro

- Is this testable with Jest or Chromatic screenshots? Not sure
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
