### PR TITLE
Build: Fix `publish` step on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
           command: yarn test:e2e-framework --clean --all --skip angular11 --skip angular --skip vue3 --skip web_components_typescript --skip cra
           no_output_timeout: 5m
       - store_artifacts:
-          path: /tmp/storybook/cypress
+          path: /tmp/cypress-record
           destination: cypress
   e2e-tests-core:
     executor:
@@ -224,7 +224,7 @@ jobs:
           command: yarn test:e2e-framework vue3 angular angular11 web_components_typescript web_components_lit2
           no_output_timeout: 5m
       - store_artifacts:
-          path: /tmp/storybook/cypress
+          path: /tmp/cypress-record
           destination: cypress
   cra-bench:
     executor:
@@ -271,7 +271,7 @@ jobs:
           name: run e2e tests
           command: yarn test:e2e-framework --pnp sfcVue cra
       - store_artifacts:
-          path: /tmp/storybook/cypress
+          path: /tmp/cypress-record
           destination: cypress
   e2e-tests-examples:
     executor:
@@ -293,7 +293,7 @@ jobs:
           name: cypress run
           command: yarn test:e2e-examples
       - store_artifacts:
-          path: /tmp/storybook/cypress
+          path: /tmp/cypress-record
           destination: cypress
   smoke-tests:
     executor:

--- a/addons/docs/src/frameworks/angular/__testfixtures__/doc-button/argtypes.snapshot
+++ b/addons/docs/src/frameworks/angular/__testfixtures__/doc-button/argtypes.snapshot
@@ -14,7 +14,7 @@ Object {
       },
     },
     "type": Object {
-      "name": "void",
+      "name": "string",
     },
   },
   "_value": Object {
@@ -30,7 +30,7 @@ Object {
       },
     },
     "type": Object {
-      "name": "void",
+      "name": "string",
     },
   },
   "accent": Object {
@@ -129,7 +129,7 @@ Object {
       },
     },
     "type": Object {
-      "name": "void",
+      "name": "string",
     },
   },
   "isDisabled": Object {
@@ -225,7 +225,7 @@ Object {
       },
     },
     "type": Object {
-      "name": "void",
+      "name": "object",
     },
   },
   "protectedMethod": Object {

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -190,7 +190,7 @@ export const extractArgTypesFromData = (componentData: Class | Directive | Injec
       const section = mapItemToSection(key, item);
       const defaultValue = isMethod(item) ? undefined : extractDefaultValue(item as Property);
       const type =
-        isMethod(item) || section !== 'inputs'
+        isMethod(item) || (section !== 'inputs' && section !== 'properties')
           ? { name: 'void' }
           : extractType(item as Property, defaultValue);
       const action = section === 'outputs' ? { action: item.name } : {};

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -53,10 +53,10 @@ const serveStorybook = async ({ cwd }: Options, port: string) => {
   return serve(staticDirectory, port);
 };
 
-const runCypress = async (location: string) => {
+const runCypress = async (location: string, name: string) => {
   const cypressCommand = openCypressInUIMode ? 'open' : 'run';
   await exec(
-    `yarn cypress ${cypressCommand} --config pageLoadTimeout=4000,execTimeout=4000,taskTimeout=4000,responseTimeout=4000,integrationFolder="cypress/generated" --env location="${location}"`,
+    `yarn cypress ${cypressCommand} --config pageLoadTimeout=4000,execTimeout=4000,taskTimeout=4000,responseTimeout=4000,defaultCommandTimeout=4000,integrationFolder="cypress/generated",videosFolder="/tmp/cypress-record/${name}" --env location="${location}"`,
     { cwd: rootDir },
     {
       startMessage: `🤖 Running Cypress tests`,
@@ -115,7 +115,7 @@ const runTests = async ({ name, ...rest }: Parameters) => {
   logger.log();
 
   try {
-    await runCypress('http://localhost:4000');
+    await runCypress('http://localhost:4000', name);
     logger.info(`🎉 Storybook is working great with ${name}!`);
   } catch (e) {
     logger.info(`🥺 Storybook has some issues with ${name}!`);

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -59,10 +59,6 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
-  '@storybook/addon-measure':
-    access: $all
-    publish: $all
-    proxy: npmjs
 
   # storybook packages are NOT proxied to global registry
   # allowing us to republish any version during tests


### PR DESCRIPTION
## What I did

 - Fix Verdaccio config for `addon-measure`: as it is now on the monorepo there is no need to add a custom verdaccio rule for it 
 - Also improve the way Cypress records are stored as CircleCI artefacts by using specific folder for each framework, for instance: https://app.circleci.com/pipelines/github/storybookjs/storybook/19873/workflows/b7b2686a-52c6-4c80-a99a-576afd9f61a1/jobs/330350/artifacts
![image](https://user-images.githubusercontent.com/4112568/125348080-109aaa00-e35c-11eb-9bfe-8fa85a9880ef.png)


## How to test

- `publish` CI step should be 🟢 