### PR TITLE
[Documentation : Configure Addons] fix broken link to withRoundTrip example

### DIFF
--- a/docs/addons/configure-addons.md
+++ b/docs/addons/configure-addons.md
@@ -35,4 +35,4 @@ For example, the [Actions addon](https://storybook.js.org/addons/@storybook/addo
 
 Use the [`useChannel`](./addons-api#usechannel) hook to access the channel data within your addon.
 
-For a complete example, check out [storybookjs/addon-kit/withRoundTrip.js](https://github.com/storybookjs/addon-kit/blob/main/src/withRoundTrip.js)
+For a complete example, check out [storybookjs/addon-kit/withRoundTrip.ts](https://github.com/storybookjs/addon-kit/blob/main/src/withRoundTrip.ts)


### PR DESCRIPTION
## What I did
Change link from .js to .ts for the `withRoundTrip` example to avoid dead links

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
