### PR TITLE
Angular: Fix actions argType auto generation

### DIFF
--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -217,9 +217,9 @@ export const extractArgTypesFromData = (componentData: Class | Directive | Injec
   });
 
   const SECTIONS = [
+    'properties',
     'inputs',
     'outputs',
-    'properties',
     'methods',
     'view child',
     'view children',


### PR DESCRIPTION
Issue: #15537

## What I did
- The order in the sections matters because properties are overridden, and actions were being lost now that there's a new property coming from compodoc

## How to test
- yarn boostrap --core
- yarn workspace angular-cli start-storybook
- Test the actions addon. Should work!