### PR TITLE
Avoid slow regex.match call in renderJsx

### DIFF
--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -115,12 +115,14 @@ export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
     // @ts-ignore FIXME: workaround react-element-to-jsx-string
     const child = typeof c === 'number' ? c.toString() : c;
     let string = applyBeforeRender(reactElementToJSXString(child, opts as Options), options);
-    const matches = string.match(/\S+=\\"([^"]*)\\"/g);
 
-    if (matches) {
-      matches.forEach((match) => {
-        string = string.replace(match, match.replace(/&quot;/g, "'"));
-      });
+    if (string.indexOf('&quot;') > -1) {
+      const matches = string.match(/\S+=\\"([^"]*)\\"/g);
+        if (matches) {
+          matches.forEach((match) => {
+            string = string.replace(match, match.replace(/&quot;/g, "'"));
+          });
+        }
     }
 
     return string;


### PR DESCRIPTION
Issue:

## What I did

Added: a faster `indexOf` check to see if a slower regex `match` can be avoided.

The regex can cause slow renders if images are passed in base64 encoded format. The regex will then attempt to find the string 'quot&' in the entire base64 string.

## How to test

This should not impact behavior, other than performance.
Storybook > Docs  > Show Code should now be a little faster when passing long base64 strings as props.