### PR TITLE
Types: Export BaseStoryFn and  BaseStoryObject

### DIFF
--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -273,14 +273,14 @@ export interface BaseMeta<ComponentType> {
   subcomponents?: Record<string, ComponentType>;
 }
 
-type BaseStoryObject<Args, StoryFnReturnType> = {
+export type BaseStoryObject<Args, StoryFnReturnType> = {
   /**
    * Override the display name in the UI
    */
   storyName?: string;
 };
 
-type BaseStoryFn<Args, StoryFnReturnType> = {
+export type BaseStoryFn<Args, StoryFnReturnType> = {
   (args: Args, context: StoryContext): StoryFnReturnType;
 } & BaseStoryObject<Args, StoryFnReturnType>;
 


### PR DESCRIPTION
Issue: N/A

## What I did

With CSF3, the Story type is now a union of two base types: `BaseStoryFn` and `BaseStoryObject`. This makes it so that `Story` is not directly callable, as it can be just an object.
Some libraries (such as @storybook/testing-react) might need to have a return type that is not `Story` anymore, but rather `BaseStoryFn`, in order to return something that can be called like `<Story/>`. 

This PR export these types, in order to help other libraries do proper inferring or typecasting.
