### PR TITLE
#15509: Copy Canvas Link URL Fix - Include Main Base URL

### DIFF
--- a/lib/ui/src/components/preview/tools/copy.tsx
+++ b/lib/ui/src/components/preview/tools/copy.tsx
@@ -9,12 +9,11 @@ import { stringifyQueryParams } from '../utils/stringifyQueryParams';
 const { PREVIEW_URL } = global;
 
 const copyMapper = ({ state }: Combo) => {
-  const { storyId, refId, refs } = state;
-  const ref = refs[refId];
+  const { storyId, location } = state;
+  const originUrl = location.origin;
 
   return {
-    refId,
-    baseUrl: ref ? `${ref.url}/iframe.html` : (PREVIEW_URL as string) || 'iframe.html',
+    baseUrl: originUrl ? `${originUrl}/iframe.html` : (PREVIEW_URL as string) || 'iframe.html',
     storyId,
     queryParams: state.customQueryParams,
   };


### PR DESCRIPTION
Issue: #15509
The "Copy Canvas Link" leaves out the base url and only gives the iframe information making it useless

## What I did
- [x] The base URL `location.origin` is prepended which we can get from the state of `copyTool` add-on component. (the `refs` apparently returns an empty object)
- This PR fixes this issue.
- This fix was discussed [here](https://discord.com/channels/486522875931656193/839297503446695956/864458263922606080) before I went with this change.

![ScreenRecord](https://user-images.githubusercontent.com/64563418/125925028-cc0d1e33-9f1f-4d4e-889d-cf01b7b216ef.gif)


## How to test
1. `yarn build` on the root directory => watch mode `yes` => and select project `@storybook/ui` (and probably `@storybook/react`)
2. New terminal window:
i. `cd examples/cra-ts-essentials`
ii. then `yarn storybook`
3. The browser pops up with URL: http://localhost:9009/
4. Click the Copy Canvas Icon link. You should be getting: `http://localhost:9009/iframe.html?id=welcome--to-storybook`


- Is this testable with Jest or Chromatic screenshots? No (However, it can be with a combination of add-on tools)
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
