### PR TITLE
UI: Only render settings page when viewMode is settings

### DIFF
--- a/lib/ui/src/app.tsx
+++ b/lib/ui/src/app.tsx
@@ -47,15 +47,20 @@ const App = React.memo<AppProps>(
           {
             key: 'settings',
             render: () => <SettingsPages />,
-            route: (({ children }) => (
-              <Route path="/settings" startsWith>
-                {children}
-              </Route>
-            )) as FunctionComponent,
+            route: (({ children }) => {
+              if (viewMode === 'settings') {
+                return (
+                  <Route path="/settings" startsWith>
+                    {children}
+                  </Route>
+                );
+              }
+              return null;
+            }) as FunctionComponent,
           },
         ],
       }),
-      []
+      [viewMode]
     );
 
     if (!width || !height) {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/14718

## What I did
Taking reference from https://github.com/storybookjs/storybook/pull/14822
I re-added the if check and added viewMode as a dependency for `useMemo`

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
