### PR TITLE
Fix docs on granular viewports

### DIFF
--- a/docs/snippets/common/storybook-preview-granular-viewports.js.mdx
+++ b/docs/snippets/common/storybook-preview-granular-viewports.js.mdx
@@ -1,11 +1,11 @@
 ```js
 // .storybook/preview.js
 
-import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 export const parameters = {
   viewport: {
-    viewports: MINIMAL_VIEWPORTS,
+    viewports: INITIAL_VIEWPORTS,
   },
 };
 ```


### PR DESCRIPTION
Issue: Docs on viewports pertaining to more granular imports reference `MINIMAL_VIEWPORTS` instead of `INITIAL_VIEWPORTS`

## What I did
Fixed the above

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
