### PR TITLE
CSF3: Add startCase to auto-generated titles

### DIFF
--- a/lib/core-client/src/preview/autoTitle.test.ts
+++ b/lib/core-client/src/preview/autoTitle.test.ts
@@ -18,13 +18,13 @@ describe('autoTitle', () => {
     it('match with no titlePrefix', () => {
       expect(
         auto('/path/to/file', { glob: '', specifier: { directory: '/path' } })
-      ).toMatchInlineSnapshot(`to/file`);
+      ).toMatchInlineSnapshot(`To/File`);
     });
 
     it('match with titlePrefix', () => {
       expect(
         auto('/path/to/file', { glob: '', specifier: { directory: '/path', titlePrefix: 'atoms' } })
-      ).toMatchInlineSnapshot(`atoms/to/file`);
+      ).toMatchInlineSnapshot(`Atoms/To/File`);
     });
 
     it('match with extension', () => {
@@ -33,7 +33,19 @@ describe('autoTitle', () => {
           glob: '',
           specifier: { directory: '/path', titlePrefix: 'atoms' },
         })
-      ).toMatchInlineSnapshot(`atoms/to/file`);
+      ).toMatchInlineSnapshot(`Atoms/To/File`);
+    });
+
+    it('match with hyphen path', () => {
+      expect(
+        auto('/path/to-my/file', { glob: '', specifier: { directory: '/path' } })
+      ).toMatchInlineSnapshot(`To My/File`);
+    });
+
+    it('match with underscore path', () => {
+      expect(
+        auto('/path/to_my/file', { glob: '', specifier: { directory: '/path' } })
+      ).toMatchInlineSnapshot(`To My/File`);
     });
   });
 
@@ -41,7 +53,7 @@ describe('autoTitle', () => {
     it('match with no titlePrefix', () => {
       expect(
         auto('/path/to/file', { glob: '', specifier: { directory: '/path/' } })
-      ).toMatchInlineSnapshot(`to/file`);
+      ).toMatchInlineSnapshot(`To/File`);
     });
 
     it('match with titlePrefix', () => {
@@ -50,7 +62,7 @@ describe('autoTitle', () => {
           glob: '',
           specifier: { directory: '/path/', titlePrefix: 'atoms' },
         })
-      ).toMatchInlineSnapshot(`atoms/to/file`);
+      ).toMatchInlineSnapshot(`Atoms/To/File`);
     });
 
     it('match with extension', () => {
@@ -59,7 +71,19 @@ describe('autoTitle', () => {
           glob: '',
           specifier: { directory: '/path/', titlePrefix: 'atoms' },
         })
-      ).toMatchInlineSnapshot(`atoms/to/file`);
+      ).toMatchInlineSnapshot(`Atoms/To/File`);
+    });
+
+    it('match with hyphen path', () => {
+      expect(
+        auto('/path/to-my/file', { glob: '', specifier: { directory: '/path/' } })
+      ).toMatchInlineSnapshot(`To My/File`);
+    });
+
+    it('match with underscore path', () => {
+      expect(
+        auto('/path/to_my/file', { glob: '', specifier: { directory: '/path/' } })
+      ).toMatchInlineSnapshot(`To My/File`);
     });
   });
 });

--- a/lib/core-client/src/preview/autoTitle.ts
+++ b/lib/core-client/src/preview/autoTitle.ts
@@ -1,5 +1,6 @@
 import global from 'global';
 import path from 'path';
+import startCase from 'lodash/startCase';
 import type { NormalizedStoriesEntry } from '@storybook/core-common';
 
 const { FEATURES = {}, STORIES = [] } = global;
@@ -25,11 +26,15 @@ const stripExtension = (titleWithExtension: string) => {
   return parts.join('/');
 };
 
+const startCaseTitle = (title: string) => {
+  return title.split('/').map(startCase).join('/');
+};
+
 export const autoTitleFromEntry = (fileName: string, entry: NormalizedStoriesEntry) => {
   const { directory, titlePrefix = '' } = entry.specifier || {};
   if (fileName.startsWith(directory)) {
     const suffix = fileName.replace(directory, '');
-    return stripExtension(path.join(titlePrefix, suffix));
+    return startCaseTitle(stripExtension(path.join(titlePrefix, suffix)));
   }
   return undefined;
 };


### PR DESCRIPTION
## What I did

Lodash startCasing of CSF3 autoTitles

CSF does something very similar when auto generating Story names from exported story. Now we do the same with auto titles

```javascript
module.exports = {
  stories: [
   { directory: '../src', files: '*.story.tsx' }
  ]
};
```

a story with path `src/design-system/large-button.story.tsx` will get a title of "Design System/Large Button"
