### PR TITLE
Examples: Fix react-ts to be runnable standalone

### DIFF
--- a/examples/react-ts/.babelrc
+++ b/examples/react-ts/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@babel/preset-typescript"
+  ]
+}

--- a/examples/react-ts/main.ts
+++ b/examples/react-ts/main.ts
@@ -5,17 +5,7 @@ const config: StorybookConfig = {
   logLevel: 'debug',
   addons: [
     '@storybook/addon-essentials',
-    '@storybook/addon-controls',
     '@storybook/addon-storysource',
-    {
-      name: '@storybook/addon-docs',
-      options: {
-        sourceLoaderOptions: {
-          parser: 'typescript',
-          injectStoryParameters: false,
-        },
-      },
-    },
     '@storybook/addon-storyshots',
   ],
   typescript: {

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -14,9 +14,9 @@
     "react-dom": "16.14.0"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.14.7",
-    "@babel/preset-react": "^7.14.5",
-    "@babel/preset-typescript": "^7.14.5",
+    "@babel/preset-env": "^7.12.11",
+    "@babel/preset-react": "^7.12.10",
+    "@babel/preset-typescript": "^7.12.7",
     "@storybook/addon-essentials": "6.4.0-alpha.18",
     "@storybook/addon-storyshots": "6.4.0-alpha.18",
     "@storybook/addon-storysource": "6.4.0-alpha.18",

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -8,23 +8,28 @@
     "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9011 -c ./ --no-manager-cache"
   },
   "dependencies": {
-    "@storybook/addon-controls": "6.4.0-alpha.18",
-    "@storybook/addon-essentials": "6.4.0-alpha.18",
-    "@storybook/components": "6.4.0-alpha.18",
-    "@storybook/react": "6.4.0-alpha.18",
-    "@storybook/theming": "6.4.0-alpha.18",
-    "@types/react": "^16.14.2",
-    "@types/react-dom": "^16.9.10",
     "formik": "^2.2.9",
     "prop-types": "15.7.2",
     "react": "16.14.0",
-    "react-dom": "16.14.0",
-    "typescript": "^3.9.7",
-    "webpack": "4"
+    "react-dom": "16.14.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.14.7",
+    "@babel/preset-react": "^7.14.5",
+    "@babel/preset-typescript": "^7.14.5",
+    "@storybook/addon-essentials": "6.4.0-alpha.18",
+    "@storybook/addon-storyshots": "6.4.0-alpha.18",
+    "@storybook/addon-storysource": "6.4.0-alpha.18",
+    "@storybook/components": "6.4.0-alpha.18",
+    "@storybook/react": "6.4.0-alpha.18",
+    "@storybook/theming": "6.4.0-alpha.18",
     "@testing-library/dom": "^7.31.2",
     "@testing-library/user-event": "^13.1.9",
-    "cross-env": "^7.0.3"
+    "@types/babel__preset-env": "^7",
+    "@types/react": "^16.14.2",
+    "@types/react-dom": "^16.9.10",
+    "cross-env": "^7.0.3",
+    "typescript": "^3.9.7",
+    "webpack": "4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6897,13 +6897,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/example-react-ts@workspace:examples/react-ts"
   dependencies:
-    "@storybook/addon-controls": 6.4.0-alpha.18
+    "@babel/preset-env": ^7.12.11
+    "@babel/preset-react": ^7.12.10
+    "@babel/preset-typescript": ^7.12.7
     "@storybook/addon-essentials": 6.4.0-alpha.18
+    "@storybook/addon-storyshots": 6.4.0-alpha.18
+    "@storybook/addon-storysource": 6.4.0-alpha.18
     "@storybook/components": 6.4.0-alpha.18
     "@storybook/react": 6.4.0-alpha.18
     "@storybook/theming": 6.4.0-alpha.18
     "@testing-library/dom": ^7.31.2
     "@testing-library/user-event": ^13.1.9
+    "@types/babel__preset-env": ^7
     "@types/react": ^16.14.2
     "@types/react-dom": ^16.9.10
     cross-env: ^7.0.3
@@ -8164,6 +8169,13 @@ __metadata:
   dependencies:
     "@babel/types": ^7.0.0
   checksum: 2ef998351d857fc76bc739ade10184300d1c8d12bb0d634333a42e927182390968ce78185f1e6c31214540515cdb232a7cb416c20eccc119837c6137f039ea73
+  languageName: node
+  linkType: hard
+
+"@types/babel__preset-env@npm:^7":
+  version: 7.9.2
+  resolution: "@types/babel__preset-env@npm:7.9.2"
+  checksum: 89d389de7fb2b4be8f43b021899b1fd8bdc85e912cc01b1b5a2504b033ada58b034d44131561c56ab6781c31913a21b769d33a05b549549bbc49bb92537e2dfb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: the react-ts example is not runnable standalone

## What I did

- Added babelrc (this fixes the issue)
- Cleaned up main.ts (removed addons already included in essentials)
- Reordered package.json dependencies

## How to test

Building the example is part of the E2E tests