### PR TITLE
Fix/12745 babel config loading

### DIFF
--- a/docs/configure/babel.md
+++ b/docs/configure/babel.md
@@ -18,9 +18,7 @@ Check out our [source](https://github.com/storybookjs/storybook/blob/next/lib/co
 
 ### Custom config file
 
-If your project has a `.babelrc` file, we'll use that instead of the default config file.
-
-You can also place a `.storybook/.babelrc` file to use a special configuration for Storybook only.
+If your project has a `.storybook/.babelrc` file, we'll use that instead of the default config file.
 
 ### Custom configuration
 

--- a/lib/core-common/src/utils/babel.ts
+++ b/lib/core-common/src/utils/babel.ts
@@ -50,6 +50,8 @@ const presets = [
 export const babelConfig: () => TransformOptions = () => {
   return {
     sourceType: 'unambiguous',
+    babelrc: false,
+    configFile: false,
     presets: [...presets],
     plugins: [...plugins],
   };

--- a/lib/core-common/src/utils/load-custom-babel-config.ts
+++ b/lib/core-common/src/utils/load-custom-babel-config.ts
@@ -87,6 +87,7 @@ export const loadCustomBabelConfig = async (
     loadFromPath(path.resolve(configDir, '.babelrc.json')) ||
     loadFromPath(path.resolve(configDir, '.babelrc.js')) ||
     loadFromPath(path.resolve(configDir, 'babel.config.json')) ||
+    loadFromPath(path.resolve(configDir, 'babel.config.ts')) ||
     loadFromPath(path.resolve(configDir, 'babel.config.js'));
 
   if (babelConfig) {

--- a/lib/core-common/src/utils/load-custom-babel-config.ts
+++ b/lib/core-common/src/utils/load-custom-babel-config.ts
@@ -48,10 +48,16 @@ function loadFromPath(babelConfigPath: string): TransformOptions {
       throw error.js;
     }
 
+    if (config instanceof Function) {
+      config = config();
+    }
+
     config = { ...config, babelrc: false };
   }
 
-  if (!config) return null;
+  if (!config) {
+    return null;
+  }
 
   // Remove react-hmre preset.
   // It causes issues with react-storybook.
@@ -69,10 +75,10 @@ function loadFromPath(babelConfigPath: string): TransformOptions {
   return config;
 }
 
-export const loadCustomBabelConfig = async function (
+export const loadCustomBabelConfig = async (
   configDir: string,
   getDefaultConfig: () => TransformOptions
-) {
+) => {
   // Between versions 5.1.0 - 5.1.9 this loaded babel.config.js from the project
   // root, which was an unintentional breaking change. We can add back project support
   // in 6.0.

--- a/lib/core-common/src/utils/load-custom-babel-config.ts
+++ b/lib/core-common/src/utils/load-custom-babel-config.ts
@@ -4,6 +4,7 @@ import JSON5 from 'json5';
 
 import { logger } from '@storybook/node-logger';
 import { TransformOptions } from '@babel/core';
+import { serverRequire } from '..';
 
 function removeReactHmre(presets: TransformOptions['presets']) {
   const index = presets.indexOf('react-hmre');
@@ -25,7 +26,7 @@ function loadFromPath(babelConfigPath: string): TransformOptions {
 
     try {
       // eslint-disable-next-line global-require, import/no-dynamic-require
-      config = require(babelConfigPath);
+      config = serverRequire(babelConfigPath);
       logger.info('=> Loading custom babel config as JS');
     } catch (e) {
       error.js = e;
@@ -52,7 +53,7 @@ function loadFromPath(babelConfigPath: string): TransformOptions {
       config = config();
     }
 
-    config = { ...config, babelrc: false };
+    config = { ...config, babelrc: false, configFile: false };
   }
 
   if (!config) {

--- a/lib/core-common/src/utils/load-custom-babel-config.ts
+++ b/lib/core-common/src/utils/load-custom-babel-config.ts
@@ -75,10 +75,7 @@ function loadFromPath(babelConfigPath: string): TransformOptions {
   return config;
 }
 
-export const loadCustomBabelConfig = async (
-  configDir: string,
-  getDefaultConfig: () => TransformOptions
-) => {
+export const loadCustomBabelConfig = async (configDir: string) => {
   // Between versions 5.1.0 - 5.1.9 this loaded babel.config.js from the project
   // root, which was an unintentional breaking change. We can add back project support
   // in 6.0.
@@ -99,5 +96,5 @@ export const loadCustomBabelConfig = async (
     return babelConfig;
   }
 
-  return getDefaultConfig();
+  return null;
 };

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
@@ -46,7 +46,9 @@ Object {
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
             "options": Object {
+              "babelrc": false,
               "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
               "plugins": Array [
                 "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
                 "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
@@ -45,7 +45,9 @@ Object {
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
             "options": Object {
+              "babelrc": false,
               "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
               "plugins": Array [
                 "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
                 "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
@@ -46,7 +46,9 @@ Object {
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
             "options": Object {
+              "babelrc": false,
               "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
               "plugins": Array [
                 "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
                 "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
@@ -45,7 +45,9 @@ Object {
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
             "options": Object {
+              "babelrc": false,
               "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
               "plugins": Array [
                 "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
                 "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
@@ -46,7 +46,9 @@ Object {
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
             "options": Object {
+              "babelrc": false,
               "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
               "plugins": Array [
                 "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
                 "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
@@ -45,7 +45,9 @@ Object {
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
             "options": Object {
+              "babelrc": false,
               "cacheDirectory": "NODE_MODULES/.cache/storybook/babel",
+              "configFile": false,
               "plugins": Array [
                 "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
                 "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",

--- a/lib/core-server/src/presets/common-preset.ts
+++ b/lib/core-server/src/presets/common-preset.ts
@@ -4,7 +4,7 @@ import {
   getManagerMainTemplate,
   getPreviewMainTemplate,
   loadCustomBabelConfig,
-  babelConfig,
+  babelConfig as getDefaultBabelConfig,
   loadEnvs,
   Options,
 } from '@storybook/core-common';
@@ -12,10 +12,10 @@ import {
 export const babel = async (_: unknown, options: Options) => {
   const { configDir, presets } = options;
 
-  return loadCustomBabelConfig(
-    configDir,
-    () => presets.apply('babelDefault', babelConfig(), options) as any
-  );
+  const babelConfigFromFile = await loadCustomBabelConfig(configDir);
+  const defaultBabelConfig = await getDefaultBabelConfig();
+
+  return presets.apply('babelDefault', babelConfigFromFile || defaultBabelConfig, options);
 };
 
 export const logLevel = (previous: any, options: Options) => previous || options.loglevel || 'info';


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/14425 https://github.com/storybookjs/storybook/issues/2758 https://github.com/storybookjs/storybook/issues/12745 https://github.com/storybookjs/storybook/issues/15502

## What I did
* removed the docs telling users babelrc in project root would be loaded (it isn't)
* added support for loading babel.config.ts files in storybook config directory
* added support for the babel config file exporting a function
* layer the config resolution from main.js and the babel config files

## How to test
1. create a storybook
1. expect the babelconfig to be the default
1. add a `.storybook/babel.config.ts` which exports a function (returning valid babel config)
1. run storybook and expect the babel config to be used which was specified in the above config file; the default config is not used
1. add a babel export to `main.js` with valid babel config ( a function that takes config and returns changed config)
1. run storybook and expect a the babel config to be merged with `main.js` overriding `babel.config.ts`; the default config is not used

