### PR TITLE
Chore: (Docs) Adds measure and outline main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ For additional help, join us in the [Storybook Discord](https://discord.gg/story
 | [storyshots](addons/storyshots/)                                          | Snapshot testing for components in Storybook                               |
 | [storysource](addons/storysource/)                                        | View the code of your stories within the Storybook UI                      |
 | [viewport](addons/viewport/)                                              | Change display sizes and layouts for responsive components using Storybook |
+| [outline](addons/outline/)                                                | Visuallly debug the CSS layout and alignment within the Storybook UI       |
+| [measure](addons/measure/)                                                | Visually inspect the layout and box model within the Storybook UI          |
 
 See [Addon / Framework Support Table](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 


### PR DESCRIPTION
With this small pull request, the measure and outline addons are introduced into the main Readme file.
