### PR TITLE
Addon-backgrounds: Add inital color to globals

### DIFF
--- a/addons/backgrounds/src/decorators/withBackground.ts
+++ b/addons/backgrounds/src/decorators/withBackground.ts
@@ -1,4 +1,10 @@
-import { StoryFn as StoryFunction, StoryContext, useMemo, useEffect } from '@storybook/addons';
+import {
+  StoryFn as StoryFunction,
+  StoryContext,
+  useMemo,
+  useEffect,
+  useGlobals,
+} from '@storybook/addons';
 
 import { PARAM_KEY as BACKGROUNDS_PARAM_KEY } from '../constants';
 import {
@@ -12,6 +18,7 @@ export const withBackground = (StoryFn: StoryFunction, context: StoryContext) =>
   const { globals, parameters } = context;
   const globalsBackgroundColor = globals[BACKGROUNDS_PARAM_KEY]?.value;
   const backgroundsConfig = parameters[BACKGROUNDS_PARAM_KEY];
+  const [, updateGlobals] = useGlobals();
 
   const selectedBackgroundColor = useMemo(() => {
     if (backgroundsConfig.disable) {
@@ -42,6 +49,17 @@ export const withBackground = (StoryFn: StoryFunction, context: StoryContext) =>
       }
     `;
   }, [selectedBackgroundColor, selector]);
+
+  useEffect(() => {
+    if (selectedBackgroundColor !== globalsBackgroundColor) {
+      updateGlobals({
+        [BACKGROUNDS_PARAM_KEY]: {
+          ...globals[BACKGROUNDS_PARAM_KEY],
+          value: selectedBackgroundColor,
+        },
+      });
+    }
+  }, []);
 
   useEffect(() => {
     const selectorId =


### PR DESCRIPTION
fixes #15632

## What I did

Call `updateGlobals` on first load if global background color is different than selected background color. 

## How to test

Pull down PR and run against repro...

```bash
npx sb@next link https://github.com/nickofthyme/repro-sb-15632.git
```

![image](https://user-images.githubusercontent.com/19007109/126382616-35e43716-28f9-48da-9bdd-053d662ee4e6.png)

> Notice first `globals` is empty (I didn't see a mechanism within addons to update this on `MOUNT`), then the second `globals` prints the initial value of `globals.backgrounds.value`.

- Is this testable with Jest or Chromatic screenshots? No jest tests for background addon yet 😞 
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No
