### PR TITLE
Documentation change: Update vue-specific readme for .use instructions

### DIFF
--- a/app/vue/README.md
+++ b/app/vue/README.md
@@ -28,7 +28,13 @@ You can also build a [static version](https://storybook.js.org/docs/vue/workflow
 
 ## Vue Notes
 
-- When using global custom components or extensions (e.g., `Vue.use`). You will need to declare those in the `./storybook/preview.js`.
+When using global custom components or extensions, you will need to declare those in the `./storybook/preview.js` like so:
+
+```js
+import { app } from "@storybook/vue3";
+import VueExtensionOrComponent from ...;
+app.use(VueExtensionOrComponent);
+```
 
 ## Known Limitations
 


### PR DESCRIPTION
## What I did

This updates the section that discusses how to specifically deal with ".use" use cases. The previous version referenced the old Vue.use syntax and I took a long time to figure out which "app" to import, so I think this example makes it clearer. Thanks to @euvic-grzegorz for the pair-programming session that found this.

## How to test

Read the new readme.md text and acknowledge that this is the way to go =)
