### PR TITLE
Controls: Don't set arg in validateOptions if it would be `undefined`

### DIFF
--- a/lib/client-api/src/args.test.ts
+++ b/lib/client-api/src/args.test.ts
@@ -185,6 +185,11 @@ describe('combineArgs', () => {
 });
 
 describe('validateOptions', () => {
+  // https://github.com/storybookjs/storybook/issues/15630
+  it('does not set args to `undefined` if they are unset', () => {
+    expect(validateOptions({}, { a: {} })).toStrictEqual({});
+  });
+
   it('omits arg and warns if value is not one of options', () => {
     expect(validateOptions({ a: 1 }, { a: { options: [2, 3] } })).toStrictEqual({});
     expect(once.warn).toHaveBeenCalledWith(

--- a/lib/client-api/src/args.ts
+++ b/lib/client-api/src/args.ts
@@ -72,7 +72,9 @@ export const combineArgs = (value: any, update: any): Args => {
 export const validateOptions = (args: Args, argTypes: ArgTypes): Args => {
   return Object.entries(argTypes).reduce((acc, [key, { options }]) => {
     if (!options) {
-      acc[key] = args[key];
+      if (key in args) {
+        acc[key] = args[key];
+      }
       return acc;
     }
 


### PR DESCRIPTION
Fixes #15630

Issue:

Code set `args[X] = undefined` if it wasn't already defined. This was made much more obvious by the removal of default values from args.

## What I did

Ensure the `args` has the key.

## How to test

- Is this testable with Jest or Chromatic screenshots?
Yes, Jest test.
