### PR TITLE
feat: allow aliasing require

### DIFF
--- a/app/ember/src/client/preview/globals.ts
+++ b/app/ember/src/client/preview/globals.ts
@@ -4,3 +4,4 @@ const { window: globalWindow } = global;
 
 globalWindow.STORYBOOK_NAME = process.env.STORYBOOK_NAME;
 globalWindow.STORYBOOK_ENV = 'ember';
+globalWindow.STORYBOOK_REQUIRE_ALIAS = process.env.STORYBOOK_REQUIRE_ALIAS;

--- a/app/ember/src/client/preview/render.ts
+++ b/app/ember/src/client/preview/render.ts
@@ -8,8 +8,11 @@ declare let Ember: any;
 
 const rootEl = document.getElementById('root');
 
-const config = globalWindow.require(`${globalWindow.STORYBOOK_NAME}/config/environment`);
-const app = globalWindow.require(`${globalWindow.STORYBOOK_NAME}/app`).default.create({
+const requireFuncName = globalWindow.STORYBOOK_REQUIRE_ALIAS || 'require';
+const requireFunc = globalWindow[requireFuncName];
+
+const config = requireFunc(`${globalWindow.STORYBOOK_NAME}/config/environment`);
+const app = requireFunc(`${globalWindow.STORYBOOK_NAME}/app`).default.create({
   autoboot: false,
   rootElement: rootEl,
   ...config.APP,


### PR DESCRIPTION
Issue: We have a somewhat unique situation in our ember app where `require` is aliased so it is not available on the `window` when the storybook preview attempts to load. This causes the preview to fail to load.

## What I did

I check for an environment variable, `STORYBOOK_REQUIRE_ALIAS`, and, if present, I use that as the name of the `require` function. If the environment variable is not present, I just use `require`. I am certainly open to other suggestions.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
