### PR TITLE
Allow Button to accept href attribute

### DIFF
--- a/lib/components/src/Button/Button.stories.tsx
+++ b/lib/components/src/Button/Button.stories.tsx
@@ -52,5 +52,8 @@ storiesOf('Basics/Button', module).add('all buttons', () => (
       <Icons icon="link" />
       Link
     </Button>
+    <Button primary small isLink href="#">
+      <Icons icon="link" /> Link
+    </Button>
   </div>
 ));

--- a/lib/components/src/Button/Button.tsx
+++ b/lib/components/src/Button/Button.tsx
@@ -14,6 +14,7 @@ export interface ButtonProps {
   outline?: boolean;
   containsIcon?: boolean;
   children?: React.ReactNode;
+  href?: string;
 }
 
 type ButtonWrapperProps = ButtonProps;


### PR DESCRIPTION
Issue: N/A

References: #4667 

## What I did

While I am _strongly_ against the practice of having links appear as buttons (and vice versa), this PR aims to fix a TypeScript error when trying to use `<Button isLink />`.

## How to test
1. Pull down branch, `yarn build --core`, `yarn start`
2. Navigate to Button story
3. Last button is a "ButtonLink" that accepts an `href` prop

- Is this testable with Jest or Chromatic screenshots? Yep, new story added (see Button stories)
- Does this need a new example in the kitchen sink apps? Nope
- Does this need an update to the documentation? Nope

If your answer is yes to any of these, please make sure to include it in your PR.

