### PR TITLE
CLI: Fix debug webpack output in static build

### DIFF
--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -15,6 +15,7 @@ import {
   StorybookConfig,
   cache,
   normalizeStories,
+  logConfig,
 } from '@storybook/core-common';
 
 import { getProdCli } from './cli';
@@ -85,6 +86,11 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
     presets,
     features,
   };
+
+  if (options.debugWebpack) {
+    logConfig('Preview webpack config', await previewBuilder.getConfig(fullOptions));
+    logConfig('Manager webpack config', await managerBuilder.getConfig(fullOptions));
+  }
 
   const core = await presets.apply<{ builder?: string }>('core');
 


### PR DESCRIPTION
Issue: [#15600](https://github.com/storybookjs/storybook/issues/15600)

## What I did

Added missing log outputs for the `--debug-webpack` cli option in the static build.

## How to test

- build `core-server` from root -  `yarn build core-server`
- go inside `examples/web-components-kitchen-sink`
- Execute command `yarn build-storybook --debug-webpack` and the debug webpack output will be shown.
