### PR TITLE
Controls: Fix boolean toggle style to match underlying value

### DIFF
--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -70,7 +70,7 @@ const Label = styled.label(({ theme }) => ({
     },
   },
 
-  'input:checked ~ span:first-of-type, input:not(:checked) ~ span:last-of-type': {
+  'input:checked ~ span:last-of-type, input:not(:checked) ~ span:first-of-type': {
     background: theme.background.app,
     boxShadow: `${opacify(0.1, theme.appBorderColor)} 0 0 2px`,
     color: theme.color.defaultText,


### PR DESCRIPTION
Issue: N/A (I tried to search open issues on the boolean control but didn't find anything.)

## What I did
The toggle slider on the boolean control doesn't visualise the actual control value. For example, when the value is `true`, the slider is expected to rest on the "True" label, but it's resting on "False". See screenshots below for before / after.

**Before**

![storybook-boolean-fix-before](https://user-images.githubusercontent.com/456562/126882770-6cfe5dc6-8782-4ed4-94ee-3fd63e7f6fc7.png)

**After**

![storybook-boolean-fix-after](https://user-images.githubusercontent.com/456562/126882792-99287e06-c38d-43f8-9a87-7711ea9c4292.png)

## How to test

- Is this testable with Jest or Chromatic screenshots? Control components don't seem to have tests but I can add one if required?
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
