### PR TITLE
Fix some transitive peer dependency warnings

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -46,7 +46,8 @@
   "peerDependencies": {
     "@storybook/builder-webpack5": "6.4.0-alpha.21",
     "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react-dom": "^16.8.0 || ^17.0.0",
+    "webpack": "*"
   },
   "peerDependenciesMeta": {
     "@storybook/builder-webpack5": {

--- a/lib/csf-tools/package.json
+++ b/lib/csf-tools/package.json
@@ -40,6 +40,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
+    "@babel/core": "^7.12.10",
     "@babel/generator": "^7.12.11",
     "@babel/parser": "^7.12.11",
     "@babel/plugin-transform-react-jsx": "^7.12.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6799,6 +6799,7 @@ __metadata:
     "@storybook/builder-webpack5": 6.4.0-alpha.21
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
+    webpack: "*"
   peerDependenciesMeta:
     "@storybook/builder-webpack5":
       optional: true
@@ -6811,6 +6812,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/csf-tools@workspace:lib/csf-tools"
   dependencies:
+    "@babel/core": ^7.12.10
     "@babel/generator": ^7.12.11
     "@babel/parser": ^7.12.11
     "@babel/plugin-transform-react-jsx": ^7.12.12


### PR DESCRIPTION
Issue: related to https://github.com/storybookjs/storybook/issues/14838

## What I did

Fixed these [implicit transitive peer dependency](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0) warnings:

```
➤ YN0002: │ @storybook/core@npm:6.3.5 [0544e] doesn't provide webpack, requested by @storybook/core-client
➤ YN0002: │ @storybook/csf-tools@npm:6.3.5 doesn't provide @babel/core, requested by @babel/plugin-transform-react-jsx
➤ YN0002: │ @storybook/csf-tools@npm:6.3.5 doesn't provide @babel/core, requested by @babel/preset-env
```

## How to test

- Is this testable with Jest or Chromatic screenshots? No.
- Does this need a new example in the kitchen sink apps? No.
- Does this need an update to the documentation? No.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
