### PR TITLE
CLI: Fix Svelte CLI template markup

### DIFF
--- a/lib/cli/src/frameworks/svelte/Header.svelte
+++ b/lib/cli/src/frameworks/svelte/Header.svelte
@@ -23,7 +23,7 @@
   <div class="wrapper">
     <div>
       <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-        <g fill="none" fillRule="evenodd">
+        <g fill="none" fill-rule="evenodd">
           <path
             d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
             fill="#FFF" />

--- a/lib/cli/src/frameworks/svelte/Page.svelte
+++ b/lib/cli/src/frameworks/svelte/Page.svelte
@@ -62,7 +62,7 @@
       <span class="tip">Tip</span>
       Adjust the width of the canvas with the
       <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
-        <g fill="none" fillRule="evenodd">
+        <g fill="none" fill-rule="evenodd">
           <path
             d="M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0
             01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0


### PR DESCRIPTION
Issue:
Svelte examples using JSX-notation for the SVGs. Svelte uses HTML and not JSX. So this fixes those small errors.
