### PR TITLE
CSF3: Add auto-titles from standard glob patterns

### DIFF
--- a/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
+++ b/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
@@ -12,10 +12,31 @@ jest.mock('fs', () => ({
 }));
 
 describe('normalizeStoriesEntry', () => {
-  it('glob', () => {
+  it('directory/files glob', () => {
     expect(normalizeStoriesEntry('../**/*.stories.mdx', '')).toMatchInlineSnapshot(`
       {
-        "glob": "../**/*.stories.mdx"
+        "glob": "../**/*.stories.mdx",
+        "specifier": {
+          "directory": "..",
+          "titlePrefix": "",
+          "files": "*.stories.mdx"
+        }
+      }
+    `);
+  });
+
+  it('too many stars glob', () => {
+    expect(normalizeStoriesEntry('../**/foo/**/*.stories.mdx', '')).toMatchInlineSnapshot(`
+      {
+        "glob": "../**/foo/**/*.stories.mdx"
+      }
+    `);
+  });
+
+  it('intermediate directory glob', () => {
+    expect(normalizeStoriesEntry('../**/foo/*.stories.mdx', '')).toMatchInlineSnapshot(`
+      {
+        "glob": "../**/foo/*.stories.mdx"
       }
     `);
   });

--- a/lib/core-common/src/utils/normalize-stories.ts
+++ b/lib/core-common/src/utils/normalize-stories.ts
@@ -4,6 +4,9 @@ import type { StoriesEntry, NormalizedStoriesEntry } from '../types';
 
 const DEFAULT_FILES = '*.stories.@(mdx|tsx|ts|jsx|js)';
 const DEFAULT_TITLE_PREFIX = '';
+// Escaping regexes for glob regexes is fun
+// Mathing things like '../**/*.stories.mdx'
+const GLOB_REGEX = /^(?<directory>[^*]*)\/\*\*\/(?<files>\*\..*)/;
 
 const isDirectory = (configDir: string, entry: string) => {
   try {
@@ -24,10 +27,17 @@ export const normalizeStoriesEntry = (
   if (typeof entry === 'string') {
     if (!entry.includes('**') && isDirectory(configDir, entry)) {
       directory = entry;
-      titlePrefix = DEFAULT_TITLE_PREFIX;
       files = DEFAULT_FILES;
+      titlePrefix = DEFAULT_TITLE_PREFIX;
     } else {
-      glob = entry;
+      const match = entry.match(GLOB_REGEX);
+      if (match) {
+        directory = match.groups.directory;
+        files = match.groups.files;
+        titlePrefix = DEFAULT_TITLE_PREFIX;
+      } else {
+        glob = entry;
+      }
     }
   } else {
     directory = entry.directory;


### PR DESCRIPTION
## What I did

Breaking out the glob processing from #15612 

glob patterns like `dir/**/*.stories.js` now support story auto titles in CSF3.
