### PR TITLE
Addon-docs/Angular: Use compodoc rawdescription where available

### DIFF
--- a/addons/docs/src/frameworks/angular/__testfixtures__/doc-button/argtypes.snapshot
+++ b/addons/docs/src/frameworks/angular/__testfixtures__/doc-button/argtypes.snapshot
@@ -19,8 +19,8 @@ Object {
   },
   "_value": Object {
     "defaultValue": "Private hello",
-    "description": "<p>Private value. </p>
-",
+    "description": "
+Private value.",
     "name": "_value",
     "table": Object {
       "category": "properties",
@@ -35,8 +35,7 @@ Object {
   },
   "accent": Object {
     "defaultValue": undefined,
-    "description": "<p>Specify the accent-type of the button </p>
-",
+    "description": "Specify the accent-type of the button",
     "name": "accent",
     "table": Object {
       "category": "inputs",
@@ -51,8 +50,7 @@ Object {
   },
   "appearance": Object {
     "defaultValue": "secondary",
-    "description": "<p>Appearance style of the button. </p>
-",
+    "description": "Appearance style of the button.",
     "name": "appearance",
     "table": Object {
       "category": "inputs",
@@ -86,7 +84,10 @@ Object {
   },
   "calc": Object {
     "defaultValue": undefined,
-    "description": "<p>An internal calculation method which adds <code>x</code> and <code>y</code> together.</p>
+    "description": "
+
+An internal calculation method which adds \`x\` and \`y\` together.
+
 ",
     "name": "calc",
     "table": Object {
@@ -100,10 +101,24 @@ Object {
       "name": "void",
     },
   },
+  "focus": Object {
+    "defaultValue": false,
+    "description": "",
+    "name": "focus",
+    "table": Object {
+      "category": "properties",
+      "type": Object {
+        "required": true,
+        "summary": "",
+      },
+    },
+    "type": Object {
+      "name": "boolean",
+    },
+  },
   "inputValue": Object {
     "defaultValue": undefined,
-    "description": "<p>Setter for <code>inputValue</code> that is also an <code>@Input</code>. </p>
-",
+    "description": "Setter for \`inputValue\` that is also an \`@Input\`.",
     "name": "inputValue",
     "table": Object {
       "category": "inputs",
@@ -118,8 +133,8 @@ Object {
   },
   "internalProperty": Object {
     "defaultValue": "Public hello",
-    "description": "<p>Public value. </p>
-",
+    "description": "
+Public value.",
     "name": "internalProperty",
     "table": Object {
       "category": "properties",
@@ -134,14 +149,13 @@ Object {
   },
   "isDisabled": Object {
     "defaultValue": false,
-    "description": "<p>Sets the button to a disabled state. </p>
-",
+    "description": "Sets the button to a disabled state.",
     "name": "isDisabled",
     "table": Object {
       "category": "inputs",
       "type": Object {
         "required": true,
-        "summary": undefined,
+        "summary": "boolean",
       },
     },
     "type": Object {
@@ -165,8 +179,7 @@ Object {
   },
   "label": Object {
     "defaultValue": undefined,
-    "description": "<p>The inner text of the button.</p>
-",
+    "description": "The inner text of the button.",
     "name": "label",
     "table": Object {
       "category": "inputs",
@@ -182,8 +195,11 @@ Object {
   "onClick": Object {
     "action": "onClick",
     "defaultValue": undefined,
-    "description": "<p>Handler to be called when the button is clicked by a user.</p>
-<p>Will also block the emission of the event if <code>isDisabled</code> is true.</p>
+    "description": "
+
+Handler to be called when the button is clicked by a user.
+
+Will also block the emission of the event if \`isDisabled\` is true.
 ",
     "name": "onClick",
     "table": Object {
@@ -197,9 +213,27 @@ Object {
       "name": "void",
     },
   },
+  "onClickListener": Object {
+    "defaultValue": undefined,
+    "description": undefined,
+    "name": "onClickListener",
+    "table": Object {
+      "category": "methods",
+      "type": Object {
+        "required": false,
+        "summary": "(btn: ) => void",
+      },
+    },
+    "type": Object {
+      "name": "void",
+    },
+  },
   "privateMethod": Object {
     "defaultValue": undefined,
-    "description": "<p>A private method.</p>
+    "description": "
+
+A private method.
+
 ",
     "name": "privateMethod",
     "table": Object {
@@ -230,7 +264,10 @@ Object {
   },
   "protectedMethod": Object {
     "defaultValue": undefined,
-    "description": "<p>A protected method.</p>
+    "description": "
+
+A protected method.
+
 ",
     "name": "protectedMethod",
     "table": Object {
@@ -246,8 +283,8 @@ Object {
   },
   "publicMethod": Object {
     "defaultValue": undefined,
-    "description": "<p>A public method using an interface. </p>
-",
+    "description": "
+A public method using an interface.",
     "name": "publicMethod",
     "table": Object {
       "category": "methods",
@@ -277,8 +314,7 @@ Object {
   },
   "size": Object {
     "defaultValue": "medium",
-    "description": "<p>Size of the button. </p>
-",
+    "description": "Size of the button.",
     "name": "size",
     "table": Object {
       "category": "inputs",
@@ -293,8 +329,7 @@ Object {
   },
   "someDataObject": Object {
     "defaultValue": undefined,
-    "description": "<p>Specifies some arbitrary object </p>
-",
+    "description": "Specifies some arbitrary object",
     "name": "someDataObject",
     "table": Object {
       "category": "inputs",
@@ -309,14 +344,13 @@ Object {
   },
   "somethingYouShouldNotUse": Object {
     "defaultValue": false,
-    "description": "<p>Some input you shouldn&#39;t use.</p>
-",
+    "description": "Some input you shouldn't use.",
     "name": "somethingYouShouldNotUse",
     "table": Object {
       "category": "inputs",
       "type": Object {
         "required": true,
-        "summary": undefined,
+        "summary": "boolean",
       },
     },
     "type": Object {

--- a/addons/docs/src/frameworks/angular/__testfixtures__/doc-button/compodoc.snapshot
+++ b/addons/docs/src/frameworks/angular/__testfixtures__/doc-button/compodoc.snapshot
@@ -8,10 +8,11 @@ Object {
       "accessors": Object {
         "inputValue": Object {
           "getSignature": Object {
-            "description": "<p>Getter for <code>inputValue</code>. </p>
+            "description": "<p>Getter for <code>inputValue</code>.</p>
 ",
             "line": 115,
             "name": "inputValue",
+            "rawdescription": "Getter for \`inputValue\`.",
             "returnType": "",
             "type": "",
           },
@@ -19,14 +20,20 @@ Object {
           "setSignature": Object {
             "args": Array [
               Object {
+                "deprecated": false,
+                "deprecationMessage": "",
                 "name": "value",
                 "type": "string",
               },
             ],
-            "description": "<p>Setter for <code>inputValue</code> that is also an <code>@Input</code>. </p>
+            "deprecated": false,
+            "deprecationMessage": "",
+            "description": "<p>Setter for <code>inputValue</code> that is also an <code>@Input</code>.</p>
 ",
             "jsdoctags": Array [
               Object {
+                "deprecated": false,
+                "deprecationMessage": "",
                 "name": "value",
                 "tagName": Object {
                   "text": "param",
@@ -36,6 +43,7 @@ Object {
             ],
             "line": 110,
             "name": "inputValue",
+            "rawdescription": "Setter for \`inputValue\` that is also an \`@Input\`.",
             "returnType": "void",
             "type": "void",
           },
@@ -45,17 +53,23 @@ Object {
           "setSignature": Object {
             "args": Array [
               Object {
+                "deprecated": false,
+                "deprecationMessage": "",
                 "name": "item",
-                "type": "[]",
+                "type": "T[]",
               },
             ],
+            "deprecated": false,
+            "deprecationMessage": "",
             "jsdoctags": Array [
               Object {
+                "deprecated": false,
+                "deprecationMessage": "",
                 "name": "item",
                 "tagName": Object {
                   "text": "param",
                 },
-                "type": "[]",
+                "type": "T[]",
               },
             ],
             "line": 195,
@@ -66,10 +80,11 @@ Object {
         },
         "value": Object {
           "getSignature": Object {
-            "description": "<p>Get the private value. </p>
+            "description": "<p>Get the private value.</p>
 ",
             "line": 154,
             "name": "value",
+            "rawdescription": "Get the private value.",
             "returnType": "string | number",
             "type": "",
           },
@@ -77,29 +92,38 @@ Object {
           "setSignature": Object {
             "args": Array [
               Object {
+                "deprecated": false,
+                "deprecationMessage": "",
                 "name": "value",
-                "type": "",
+                "type": "string | number",
               },
             ],
-            "description": "<p>Set the private value. </p>
+            "deprecated": false,
+            "deprecationMessage": "",
+            "description": "<p>Set the private value.</p>
 ",
             "jsdoctags": Array [
               Object {
+                "deprecated": false,
+                "deprecationMessage": "",
                 "name": "value",
                 "tagName": Object {
                   "text": "param",
                 },
-                "type": "",
+                "type": "string | number",
               },
             ],
             "line": 149,
             "name": "value",
+            "rawdescription": "Set the private value.",
             "returnType": "void",
             "type": "void",
           },
         },
       },
       "assetsDirs": Array [],
+      "deprecated": false,
+      "deprecationMessage": "",
       "description": "<p>This is a simple button that demonstrates various JSDoc handling in Storybook Docs for Angular.</p>
 <p>It supports <a href=\\"https://en.wikipedia.org/wiki/Markdown\\">markdown</a>, so you can embed formatted text,
 like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
@@ -113,14 +137,19 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
       "hostBindings": Array [
         Object {
           "defaultValue": "false",
+          "deprecated": false,
+          "deprecationMessage": "",
           "line": 124,
           "name": "class.focused",
+          "type": "boolean",
         },
       ],
       "hostListeners": Array [
         Object {
           "args": Array [
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "btn",
               "type": "",
             },
@@ -128,6 +157,8 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
           "argsDecorator": Array [
             "$event.target",
           ],
+          "deprecated": false,
+          "deprecationMessage": "",
           "line": 120,
           "name": "click",
         },
@@ -136,298 +167,391 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
       "inputs": Array [],
       "inputsClass": Array [
         Object {
-          "description": "<p>Specify the accent-type of the button </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>Specify the accent-type of the button</p>
 ",
           "line": 56,
           "name": "accent",
+          "rawdescription": "Specify the accent-type of the button",
           "type": "ButtonAccent",
         },
         Object {
           "defaultValue": "'secondary'",
-          "description": "<p>Appearance style of the button. </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>Appearance style of the button.</p>
 ",
           "line": 52,
           "name": "appearance",
+          "rawdescription": "Appearance style of the button.",
           "type": "\\"primary\\" | \\"secondary\\"",
         },
         Object {
-          "description": "<p>Setter for <code>inputValue</code> that is also an <code>@Input</code>. </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>Setter for <code>inputValue</code> that is also an <code>@Input</code>.</p>
 ",
           "line": 110,
           "name": "inputValue",
+          "rawdescription": "Setter for \`inputValue\` that is also an \`@Input\`.",
           "type": "string",
         },
         Object {
           "defaultValue": "false",
-          "description": "<p>Sets the button to a disabled state. </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>Sets the button to a disabled state.</p>
 ",
           "line": 60,
           "name": "isDisabled",
+          "rawdescription": "Sets the button to a disabled state.",
+          "type": "boolean",
         },
         Object {
+          "deprecated": false,
+          "deprecationMessage": "",
           "line": 195,
           "name": "item",
           "type": "[]",
         },
         Object {
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "<p>The inner text of the button.</p>
 ",
+          "jsdoctags": Array [
+            Object {
+              "comment": "",
+              "end": 1525,
+              "flags": 4227072,
+              "kind": 317,
+              "modifierFlagsCache": 0,
+              "pos": 1512,
+              "tagName": Object {
+                "end": 1521,
+                "escapedText": "required",
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
+                "pos": 1513,
+                "transformFlags": 0,
+              },
+              "transformFlags": 0,
+            },
+          ],
           "line": 68,
           "name": "label",
+          "rawdescription": "The inner text of the button.",
           "type": "string",
         },
         Object {
+          "deprecated": false,
+          "deprecationMessage": "",
           "line": 192,
           "name": "showKeyAlias",
           "type": "",
         },
         Object {
           "defaultValue": "'medium'",
-          "description": "<p>Size of the button. </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>Size of the button.</p>
 ",
           "line": 72,
           "name": "size",
+          "rawdescription": "Size of the button.",
           "type": "ButtonSize",
         },
         Object {
-          "description": "<p>Specifies some arbitrary object </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>Specifies some arbitrary object</p>
 ",
           "line": 75,
           "name": "someDataObject",
+          "rawdescription": "Specifies some arbitrary object",
           "type": "ISomeInterface",
         },
         Object {
           "defaultValue": "false",
+          "deprecated": true,
+          "deprecationMessage": "",
           "description": "<p>Some input you shouldn&#39;t use.</p>
 ",
+          "jsdoctags": Array [
+            Object {
+              "comment": "",
+              "end": 1802,
+              "flags": 4227072,
+              "kind": 321,
+              "modifierFlagsCache": 0,
+              "pos": 1787,
+              "tagName": Object {
+                "end": 1798,
+                "escapedText": "deprecated",
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
+                "pos": 1788,
+                "transformFlags": 0,
+              },
+              "transformFlags": 0,
+            },
+          ],
           "line": 83,
           "name": "somethingYouShouldNotUse",
-        },
-      ],
-      "jsdoctags": Array [
-        Object {
-          "atToken": Object {
-            "end": 859,
-            "flags": 0,
-            "kind": 57,
-            "pos": 858,
-          },
-          "comment": "Hello world",
-          "end": 866,
-          "flags": 0,
-          "kind": 288,
-          "pos": 858,
-          "tagName": Object {
-            "end": 865,
-            "escapedText": "string",
-            "flags": 0,
-            "pos": 859,
-          },
-        },
-        Object {
-          "atToken": Object {
-            "end": 882,
-            "flags": 0,
-            "kind": 57,
-            "pos": 881,
-          },
-          "comment": "[Example](http://example.com)",
-          "end": 887,
-          "flags": 0,
-          "kind": 288,
-          "pos": 881,
-          "tagName": Object {
-            "end": 886,
-            "escapedText": "link",
-            "flags": 0,
-            "pos": 882,
-          },
-        },
-        Object {
-          "atToken": Object {
-            "end": 921,
-            "flags": 0,
-            "kind": 57,
-            "pos": 920,
-          },
-          "comment": "\`ThingThing\`",
-          "end": 926,
-          "flags": 0,
-          "kind": 288,
-          "pos": 920,
-          "tagName": Object {
-            "end": 925,
-            "escapedText": "code",
-            "flags": 0,
-            "pos": 921,
-          },
-        },
-        Object {
-          "atToken": Object {
-            "end": 943,
-            "flags": 0,
-            "kind": 57,
-            "pos": 942,
-          },
-          "comment": "<span class=\\"badge\\">aaa</span>",
-          "end": 948,
-          "flags": 0,
-          "kind": 288,
-          "pos": 942,
-          "tagName": Object {
-            "end": 947,
-            "escapedText": "html",
-            "flags": 0,
-            "pos": 943,
-          },
+          "rawdescription": "Some input you shouldn't use.",
+          "type": "boolean",
         },
       ],
       "methodsClass": Array [
         Object {
           "args": Array [
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "x",
               "type": "number",
             },
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "y",
               "type": "string | number",
             },
           ],
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "<p>An internal calculation method which adds <code>x</code> and <code>y</code> together.</p>
 ",
           "jsdoctags": Array [
             Object {
               "comment": "<p>Some number you&#39;d like to use.</p>
 ",
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": Object {
                 "end": 3518,
                 "escapedText": "x",
-                "flags": 0,
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
                 "pos": 3517,
+                "transformFlags": 0,
               },
               "tagName": Object {
                 "end": 3516,
                 "escapedText": "param",
-                "flags": 0,
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
                 "pos": 3511,
+                "transformFlags": 0,
               },
               "type": "number",
             },
             Object {
               "comment": "<p>Some other number or string you&#39;d like to use, will have <code>parseInt()</code> applied before calculation.</p>
 ",
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": Object {
                 "end": 3563,
                 "escapedText": "y",
-                "flags": 0,
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
                 "pos": 3562,
+                "transformFlags": 0,
               },
               "tagName": Object {
                 "end": 3561,
                 "escapedText": "param",
-                "flags": 0,
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
                 "pos": 3556,
+                "transformFlags": 0,
               },
               "type": "string | number",
             },
           ],
           "line": 164,
           "modifierKind": Array [
-            114,
+            122,
           ],
           "name": "calc",
           "optional": false,
+          "rawdescription": "
+
+An internal calculation method which adds \`x\` and \`y\` together.
+
+",
           "returnType": "number",
           "typeParameters": Array [],
         },
         Object {
           "args": Array [
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
+              "name": "btn",
+              "type": "",
+            },
+          ],
+          "decorators": Array [
+            Object {
+              "name": "HostListener",
+              "stringifiedArguments": "'click', ['$event.target']",
+            },
+          ],
+          "deprecated": false,
+          "deprecationMessage": "",
+          "jsdoctags": Array [
+            Object {
+              "deprecated": false,
+              "deprecationMessage": "",
+              "name": "btn",
+              "tagName": Object {
+                "text": "param",
+              },
+              "type": "",
+            },
+          ],
+          "line": 120,
+          "name": "onClickListener",
+          "optional": false,
+          "returnType": "void",
+          "typeParameters": Array [],
+        },
+        Object {
+          "args": Array [
+            Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "password",
               "type": "string",
             },
           ],
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "<p>A private method.</p>
 ",
           "jsdoctags": Array [
             Object {
               "comment": "<p>Some <code>password</code>.</p>
 ",
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": Object {
                 "end": 4079,
                 "escapedText": "password",
-                "flags": 0,
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
                 "pos": 4071,
+                "transformFlags": 0,
               },
               "tagName": Object {
                 "end": 4070,
                 "escapedText": "param",
-                "flags": 0,
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
                 "pos": 4065,
+                "transformFlags": 0,
               },
               "type": "string",
             },
           ],
           "line": 187,
           "modifierKind": Array [
-            112,
+            120,
           ],
           "name": "privateMethod",
           "optional": false,
+          "rawdescription": "
+
+A private method.
+
+",
           "returnType": "void",
           "typeParameters": Array [],
         },
         Object {
           "args": Array [
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "id",
               "optional": true,
               "type": "number",
             },
           ],
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "<p>A protected method.</p>
 ",
           "jsdoctags": Array [
             Object {
               "comment": "<p>Some <code>id</code>.</p>
 ",
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": Object {
                 "end": 3938,
                 "escapedText": "id",
-                "flags": 0,
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
                 "pos": 3936,
+                "transformFlags": 0,
               },
               "optional": true,
               "tagName": Object {
                 "end": 3935,
                 "escapedText": "param",
-                "flags": 0,
+                "flags": 4227072,
+                "kind": 78,
+                "modifierFlagsCache": 0,
                 "pos": 3930,
+                "transformFlags": 0,
               },
               "type": "number",
             },
           ],
           "line": 178,
           "modifierKind": Array [
-            113,
+            121,
           ],
           "name": "protectedMethod",
           "optional": false,
+          "rawdescription": "
+
+A protected method.
+
+",
           "returnType": "void",
           "typeParameters": Array [],
         },
         Object {
           "args": Array [
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "things",
               "type": "ISomeInterface",
             },
           ],
-          "description": "<p>A public method using an interface. </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>A public method using an interface.</p>
 ",
           "jsdoctags": Array [
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "things",
               "tagName": Object {
                 "text": "param",
@@ -437,10 +561,12 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
           ],
           "line": 169,
           "modifierKind": Array [
-            114,
+            122,
           ],
           "name": "publicMethod",
           "optional": false,
+          "rawdescription": "
+A public method using an interface.",
           "returnType": "void",
           "typeParameters": Array [],
         },
@@ -450,21 +576,31 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
       "outputsClass": Array [
         Object {
           "defaultValue": "new EventEmitter<Event>()",
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "<p>Handler to be called when the button is clicked by a user.</p>
 <p>Will also block the emission of the event if <code>isDisabled</code> is true.</p>
 ",
           "line": 91,
           "name": "onClick",
+          "rawdescription": "
+
+Handler to be called when the button is clicked by a user.
+
+Will also block the emission of the event if \`isDisabled\` is true.
+",
           "type": "EventEmitter",
         },
       ],
       "propertiesClass": Array [
         Object {
           "defaultValue": "'some value'",
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "",
           "line": 106,
           "modifierKind": Array [
-            112,
+            120,
           ],
           "name": "_inputValue",
           "optional": false,
@@ -472,14 +608,18 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
         },
         Object {
           "defaultValue": "'Private hello'",
-          "description": "<p>Private value. </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>Private value.</p>
 ",
           "line": 146,
           "modifierKind": Array [
-            112,
+            120,
           ],
           "name": "_value",
           "optional": false,
+          "rawdescription": "
+Private value.",
           "type": "string",
         },
         Object {
@@ -489,6 +629,8 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
               "stringifiedArguments": "'buttonRef', {static: false}",
             },
           ],
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "",
           "line": 48,
           "name": "buttonRef",
@@ -496,22 +638,44 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
           "type": "ElementRef",
         },
         Object {
+          "decorators": Array [
+            Object {
+              "name": "HostBinding",
+              "stringifiedArguments": "'class.focused'",
+            },
+          ],
+          "defaultValue": "false",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "",
+          "line": 124,
+          "name": "focus",
+          "optional": false,
+          "type": "",
+        },
+        Object {
           "defaultValue": "'Public hello'",
-          "description": "<p>Public value. </p>
+          "deprecated": false,
+          "deprecationMessage": "",
+          "description": "<p>Public value.</p>
 ",
           "line": 143,
           "modifierKind": Array [
-            114,
+            122,
           ],
           "name": "internalProperty",
           "optional": false,
+          "rawdescription": "
+Public value.",
           "type": "string",
         },
         Object {
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "",
           "line": 199,
           "modifierKind": Array [
-            114,
+            122,
           ],
           "name": "processedItem",
           "optional": false,
@@ -519,12 +683,16 @@ like <strong>bold</strong>, <em>italic</em>, and <code>inline code</code>.</p>
         },
       ],
       "providers": Array [],
-      "rawdescription": "This is a simple button that demonstrates various JSDoc handling in Storybook Docs for Angular.
+      "rawdescription": "
+
+This is a simple button that demonstrates various JSDoc handling in Storybook Docs for Angular.
 
 It supports [markdown](https://en.wikipedia.org/wiki/Markdown), so you can embed formatted text,
 like **bold**, _italic_, and \`inline code\`.
 
-> How you like dem apples?! It's never been easier to document all your components.",
+> How you like dem apples?! It's never been easier to document all your components.
+
+",
       "selector": "doc-button",
       "sourceCode": "import {
   Component,
@@ -735,11 +903,11 @@ export class InputComponent<T> {
     },
   ],
   "coverage": Object {
-    "count": 23,
+    "count": 21,
     "files": Array [
       Object {
-        "coverageCount": "16/23",
-        "coveragePercent": 69,
+        "coverageCount": "16/25",
+        "coveragePercent": 64,
         "filePath": "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts",
         "linktype": "component",
         "name": "InputComponent",
@@ -769,17 +937,23 @@ export class InputComponent<T> {
     "status": "low",
   },
   "directives": Array [],
+  "guards": Array [],
   "injectables": Array [],
+  "interceptors": Array [],
   "interfaces": Array [
     Object {
+      "deprecated": false,
+      "deprecationMessage": "",
       "file": "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts",
       "id": "interface-ISomeInterface-568feeafa68e593b062061c27c4625a9",
       "indexSignatures": Array [],
-      "kind": 150,
+      "kind": 163,
       "methods": Array [],
       "name": "ISomeInterface",
       "properties": Array [
         Object {
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "",
           "line": 25,
           "name": "one",
@@ -787,6 +961,8 @@ export class InputComponent<T> {
           "type": "string",
         },
         Object {
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "",
           "line": 27,
           "name": "three",
@@ -794,6 +970,8 @@ export class InputComponent<T> {
           "type": "any[]",
         },
         Object {
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "",
           "line": 26,
           "name": "two",
@@ -1007,15 +1185,21 @@ export class InputComponent<T> {
       Object {
         "childs": Array [
           Object {
+            "deprecated": false,
+            "deprecationMessage": "",
             "name": "Normal",
             "value": "Normal",
           },
           Object {
+            "deprecated": false,
+            "deprecationMessage": "",
             "name": "High",
             "value": "High",
           },
         ],
         "ctype": "miscellaneous",
+        "deprecated": false,
+        "deprecationMessage": "",
         "description": "",
         "file": "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts",
         "name": "ButtonAccent",
@@ -1028,15 +1212,21 @@ export class InputComponent<T> {
         Object {
           "childs": Array [
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "Normal",
               "value": "Normal",
             },
             Object {
+              "deprecated": false,
+              "deprecationMessage": "",
               "name": "High",
               "value": "High",
             },
           ],
           "ctype": "miscellaneous",
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "",
           "file": "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts",
           "name": "ButtonAccent",
@@ -1049,9 +1239,11 @@ export class InputComponent<T> {
       "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts": Array [
         Object {
           "ctype": "miscellaneous",
+          "deprecated": false,
+          "deprecationMessage": "",
           "description": "",
           "file": "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts",
-          "kind": 168,
+          "kind": 183,
           "name": "ButtonSize",
           "rawtype": "\\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\"",
           "subtype": "typealias",
@@ -1063,6 +1255,8 @@ export class InputComponent<T> {
         Object {
           "ctype": "miscellaneous",
           "defaultValue": "'An exported constant'",
+          "deprecated": false,
+          "deprecationMessage": "",
           "file": "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts",
           "name": "exportedConstant",
           "subtype": "variable",
@@ -1073,9 +1267,11 @@ export class InputComponent<T> {
     "typealiases": Array [
       Object {
         "ctype": "miscellaneous",
+        "deprecated": false,
+        "deprecationMessage": "",
         "description": "",
         "file": "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts",
-        "kind": 168,
+        "kind": 183,
         "name": "ButtonSize",
         "rawtype": "\\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\"",
         "subtype": "typealias",
@@ -1085,6 +1281,8 @@ export class InputComponent<T> {
       Object {
         "ctype": "miscellaneous",
         "defaultValue": "'An exported constant'",
+        "deprecated": false,
+        "deprecationMessage": "",
         "file": "addons/docs/src/frameworks/angular/__testfixtures__/doc-button/input.ts",
         "name": "exportedConstant",
         "subtype": "variable",

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -196,7 +196,7 @@ export const extractArgTypesFromData = (componentData: Class | Directive | Injec
       const action = section === 'outputs' ? { action: item.name } : {};
       const argType = {
         name: item.name,
-        description: item.description,
+        description: item.rawdescription || item.description,
         defaultValue,
         type,
         ...action,

--- a/addons/docs/src/frameworks/angular/types.ts
+++ b/addons/docs/src/frameworks/angular/types.ts
@@ -4,6 +4,7 @@ export interface Method {
   returnType: string;
   decorators?: Decorator[];
   description?: string;
+  rawdescription?: string;
 }
 
 export interface Property {
@@ -13,6 +14,7 @@ export interface Property {
   optional: boolean;
   defaultValue?: string;
   description?: string;
+  rawdescription?: string;
 }
 
 export interface Class {

--- a/examples/angular-cli/package.json
+++ b/examples/angular-cli/package.json
@@ -38,7 +38,7 @@
     "@angular/cli": "^11.2.13",
     "@angular/compiler-cli": "^11.2.14",
     "@angular/elements": "^11.2.14",
-    "@compodoc/compodoc": "^1.1.11",
+    "@compodoc/compodoc": "^1.1.14",
     "@storybook/addon-a11y": "6.4.0-alpha.24",
     "@storybook/addon-actions": "6.4.0-alpha.24",
     "@storybook/addon-backgrounds": "6.4.0-alpha.24",

--- a/examples/angular-cli/src/stories/addons/docs/doc-button/doc-button.component.ts
+++ b/examples/angular-cli/src/stories/addons/docs/doc-button/doc-button.component.ts
@@ -59,7 +59,7 @@ export class DocButtonComponent<T> {
   @Input()
   public accent: ButtonAccent = ButtonAccent.Normal;
 
-  /** Specifies some arbitrary object */
+  /** Specifies some arbitrary object. This comment is to test certain chars like apostrophes - it's working */
   @Input() public someDataObject: ISomeInterface;
 
   /**

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
     "@babel/runtime": "^7.12.5",
-    "@compodoc/compodoc": "^1.1.11",
+    "@compodoc/compodoc": "^1.1.14",
     "@emotion/snapshot-serializer": "^0.8.2",
     "@nicolo-ribaudo/chokidar-2": "^2.1.8",
     "@nrwl/cli": "12.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,6 +453,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.14.7, @babel/compat-data@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/compat-data@npm:7.15.0"
+  checksum: 2b709dddd224be81b9ab2bd8b5b218e5b94ce7678fc04144c98bd0a769df2ee13738ea5f639d585d3847897e208e03e919750fa6b208c32bfeba5f9fe67cec9c
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.14.5":
   version: 7.14.7
   resolution: "@babel/compat-data@npm:7.14.7"
@@ -578,6 +585,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:7.15.0, @babel/core@npm:^7.14.6":
+  version: 7.15.0
+  resolution: "@babel/core@npm:7.15.0"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.15.0
+    "@babel/helper-compilation-targets": ^7.15.0
+    "@babel/helper-module-transforms": ^7.15.0
+    "@babel/helpers": ^7.14.8
+    "@babel/parser": ^7.15.0
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.15.0
+    "@babel/types": ^7.15.0
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: eac89834892358fb3d4731b89f6e4c3bfcc6ee742841abf4dc231f2f2181479f77490815e9677dbb77d8cafac2f7f5cf5ea726c4eb105cc425d00d09e3d9a53b
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:7.9.0":
   version: 7.9.0
   resolution: "@babel/core@npm:7.9.0"
@@ -646,12 +676,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/generator@npm:7.15.0"
+  dependencies:
+    "@babel/types": ^7.15.0
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 7635fc11ac7b85c80d43aecbfa6d61835957327ccf416ef624c7f5629e0f4f92fd298f1d86e7a79d294a53c406868a40614b890c75996470ab8512be5e8d953d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.0.0, @babel/helper-annotate-as-pure@npm:^7.10.4, @babel/helper-annotate-as-pure@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/helper-annotate-as-pure@npm:7.12.13"
   dependencies:
     "@babel/types": ^7.12.13
   checksum: 9c4c0e738d42dedd40c87757bffb1454d1bdcaf1e6318f9768bc71874319c4ca5c45d5ed38b9dfb3b9980b27658fd0bf8fc44e53a2a43652a25d9a66c649f98a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-annotate-as-pure@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-annotate-as-pure@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: e3ade3ed47dd5e12f2616058fd062ed54a9cb70872d8a09155c6fefe230c8e964a31868c9bfa7dccb87345c55332aab34f40bf61e1eb5b419eb02d3b158373f2
   languageName: node
   linkType: hard
 
@@ -662,6 +712,16 @@ __metadata:
     "@babel/helper-explode-assignable-expression": ^7.12.13
     "@babel/types": ^7.12.13
   checksum: eda7c1f96c91229ab8b9f28a13104405278fe6a9a439e8db03cb073199e085291214ae85e360e4e5c8e320e3cb1f9e94bdc0f228b1bd66cbfc15e29e2b653d84
+  languageName: node
+  linkType: hard
+
+"@babel/helper-builder-binary-assignment-operator-visitor@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-builder-binary-assignment-operator-visitor@npm:7.14.5"
+  dependencies:
+    "@babel/helper-explode-assignable-expression": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: 76f5ddd614bcb151eb8e950f6dd9434c1ea020b39ec00cde7fc6304edd82b14d226e6305aa53f8d7e6815895db8a8233016512d9745284420a9d2d1af468006d
   languageName: node
   linkType: hard
 
@@ -693,6 +753,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-compilation-targets@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/helper-compilation-targets@npm:7.15.0"
+  dependencies:
+    "@babel/compat-data": ^7.15.0
+    "@babel/helper-validator-option": ^7.14.5
+    browserslist: ^4.16.6
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: ec59e48a17c6df9ae4c66452ae1c25843ade3514a975284ab3ec533918fae2be6824e2937525d81a3138579cb03dfeff1723b9ee370484e1f0cc40860e5a00ea
+  languageName: node
+  linkType: hard
+
 "@babel/helper-create-class-features-plugin@npm:^7.12.1, @babel/helper-create-class-features-plugin@npm:^7.13.0, @babel/helper-create-class-features-plugin@npm:^7.8.3":
   version: 7.13.0
   resolution: "@babel/helper-create-class-features-plugin@npm:7.13.0"
@@ -708,6 +782,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-create-class-features-plugin@npm:^7.14.5":
+  version: 7.15.0
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.15.0"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.14.5
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/helper-member-expression-to-functions": ^7.15.0
+    "@babel/helper-optimise-call-expression": ^7.14.5
+    "@babel/helper-replace-supers": ^7.15.0
+    "@babel/helper-split-export-declaration": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 2355952c5edbd35835e47d2ce3dad40e8836b104303f8c88a14c8c32b903b9e1e6d9981823c9e174a281966caec269934f61713af2da791e431329ec527f7769
+  languageName: node
+  linkType: hard
+
 "@babel/helper-create-regexp-features-plugin@npm:^7.12.13":
   version: 7.12.17
   resolution: "@babel/helper-create-regexp-features-plugin@npm:7.12.17"
@@ -717,6 +807,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 771a4aaf9d1e25872d7aa40c222cb0c1e603ea968441385dae9d35aeeb6ee5b568a5cee73b5922fe5a74768cb313be92219d65101dba7ee509a9711a0022403c
+  languageName: node
+  linkType: hard
+
+"@babel/helper-create-regexp-features-plugin@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.14.5"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.14.5
+    regexpu-core: ^4.7.1
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 19e45c0a8cd1836878685f4be53503c5892127c640609a24c67ccc7850cb4a28668abc2d55752cf57ada856d416b21553173c736dfe04b6b16e2472295e99e35
   languageName: node
   linkType: hard
 
@@ -738,12 +840,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-define-polyfill-provider@npm:^0.2.2":
+  version: 0.2.3
+  resolution: "@babel/helper-define-polyfill-provider@npm:0.2.3"
+  dependencies:
+    "@babel/helper-compilation-targets": ^7.13.0
+    "@babel/helper-module-imports": ^7.12.13
+    "@babel/helper-plugin-utils": ^7.13.0
+    "@babel/traverse": ^7.13.0
+    debug: ^4.1.1
+    lodash.debounce: ^4.0.8
+    resolve: ^1.14.2
+    semver: ^6.1.2
+  peerDependencies:
+    "@babel/core": ^7.4.0-0
+  checksum: 4070639e48e397d05efbb147c305b0a7a7bfb8004b65b2a18d33b55b4d3366f7494e398af9fd026687fefc78d39d34cd7ba3ddcb24b6acf5e11dfeea14998e9a
+  languageName: node
+  linkType: hard
+
 "@babel/helper-explode-assignable-expression@npm:^7.12.13":
   version: 7.13.0
   resolution: "@babel/helper-explode-assignable-expression@npm:7.13.0"
   dependencies:
     "@babel/types": ^7.13.0
   checksum: 9c9369110b0b29f8fdb40ebec1cecdc5f52d23ce39e7fb63281579515df30c7fee4c2f14881bf3d1d342c5981f6ba55f56e382cbe88f95b586ae9f5d9c541591
+  languageName: node
+  linkType: hard
+
+"@babel/helper-explode-assignable-expression@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-explode-assignable-expression@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 14bddde84eb099e7de995a6f9d41a7617aa8a42d2932cd7025516e7770ebed06812fe32eaba245638e9be9c1caf59657e511ed2a5dfcb3e89f0036b1658f4beb
   languageName: node
   linkType: hard
 
@@ -824,6 +953,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-member-expression-to-functions@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.15.0"
+  dependencies:
+    "@babel/types": ^7.15.0
+  checksum: 6db9f3690c60f4e3a186dc646b3e23b7fcc2a2c7c1b1bb7662151172808bde63c0937c3756427311a64bdb05704830b49af10fc45404a568e5a9678b840f9e4b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.12.1, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.12.5, @babel/helper-module-imports@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/helper-module-imports@npm:7.12.13"
@@ -856,6 +994,22 @@ __metadata:
     "@babel/types": ^7.13.0
     lodash: ^4.17.19
   checksum: ef54b290f5bc87c868fbec6aa1556f9669ba7caf7d05d3b8fcb5b502bec144b67ad1a0ceab26e0b4f5e29c5b6f416c1bf0b8e32c6f87b69fbeae99bc376e6ccd
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.14.5, @babel/helper-module-transforms@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/helper-module-transforms@npm:7.15.0"
+  dependencies:
+    "@babel/helper-module-imports": ^7.14.5
+    "@babel/helper-replace-supers": ^7.15.0
+    "@babel/helper-simple-access": ^7.14.8
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/helper-validator-identifier": ^7.14.9
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.15.0
+    "@babel/types": ^7.15.0
+  checksum: 66493d4a98d36aaf48dd374c88e78a1fa3020abd22c645db64d09165e70efb497c4c2776db3fcb8571a7bfa877dd764188d4f2c0d4bed1b5e53f3ab774c60ea5
   languageName: node
   linkType: hard
 
@@ -907,6 +1061,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-plugin-utils@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-plugin-utils@npm:7.14.5"
+  checksum: de33dc7c7b4b334f87a78c6ad2cbab3e25eaef07edcc7941bc03907eed12833fa222890bb3fe83968b108d90898946756caec42d8a51ac3783c77299736de977
+  languageName: node
+  linkType: hard
+
 "@babel/helper-remap-async-to-generator@npm:^7.12.1, @babel/helper-remap-async-to-generator@npm:^7.13.0":
   version: 7.13.0
   resolution: "@babel/helper-remap-async-to-generator@npm:7.13.0"
@@ -915,6 +1076,17 @@ __metadata:
     "@babel/helper-wrap-function": ^7.13.0
     "@babel/types": ^7.13.0
   checksum: ad41b8b8e152ab1a4713369cbe1aa75974ba6971bd3f104d606b512a952284baef3d4c919fc12066c82a55fd4aad9ff5d87e93d440b10a5eb2fa8cf7f076b0c5
+  languageName: node
+  linkType: hard
+
+"@babel/helper-remap-async-to-generator@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-remap-async-to-generator@npm:7.14.5"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.14.5
+    "@babel/helper-wrap-function": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: 808d10467a90449210c59bc2fa92facf20bb920a2db9d06f277ec00d0ce9b7bcef73d455ec7fd4c6e0eb5b5649ea37c611267fa51067845105c8f5a595ea219a
   languageName: node
   linkType: hard
 
@@ -942,6 +1114,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-replace-supers@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/helper-replace-supers@npm:7.15.0"
+  dependencies:
+    "@babel/helper-member-expression-to-functions": ^7.15.0
+    "@babel/helper-optimise-call-expression": ^7.14.5
+    "@babel/traverse": ^7.15.0
+    "@babel/types": ^7.15.0
+  checksum: 3e2aad2255345a4c8a60974e5f6eb412e4f6ef729e3796554defdce670bdda3b34cf97f312ed4f29a4a519e2255adfd12530fddb33e70d765db889c41c72ddcc
+  languageName: node
+  linkType: hard
+
 "@babel/helper-simple-access@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/helper-simple-access@npm:7.12.13"
@@ -966,6 +1150,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.12.1
   checksum: ce2f7aa07f625d985e7f9783d552826d1645f7a29e57452691512feae7948f9f1c0ec7657c584a30b63f894cdb290e182b7596b0b77f332878ba0715adb3bb86
+  languageName: node
+  linkType: hard
+
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: daa1bf7c049d2aa93d5ba9a3ba9ea7030c7c2665dc889477f8a6e4d75e97dee3d4e503ebe32048ef9b0ba95e325638b93089f7cfa19b89e3f243c17ae523d7e0
   languageName: node
   linkType: hard
 
@@ -1008,6 +1201,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.14.9":
+  version: 7.14.9
+  resolution: "@babel/helper-validator-identifier@npm:7.14.9"
+  checksum: bedd645277d08780797b7a190d945e2f5641de7b764040fec79b1d0ba5d8398e5ab747c2218314632a56f992012ad4a0de55eb6de788fa14a8e16eff7ea31319
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.12.1, @babel/helper-validator-option@npm:^7.12.11, @babel/helper-validator-option@npm:^7.12.17":
   version: 7.12.17
   resolution: "@babel/helper-validator-option@npm:7.12.17"
@@ -1031,6 +1231,18 @@ __metadata:
     "@babel/traverse": ^7.13.0
     "@babel/types": ^7.13.0
   checksum: 85d229c68510dc07e876e70f4055b198700a0b8d7e0d7321c08494a2749b21257e81e4242096b7d50522aa06e6bfc5f0c694e7367063ea1be21cbc2ab39b0720
+  languageName: node
+  linkType: hard
+
+"@babel/helper-wrap-function@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-wrap-function@npm:7.14.5"
+  dependencies:
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: b6e06013de79b2fa6106b62207b15d195daff50983faa482912a271100030e2019e11f14cfc1fed0bc4329e2211ce0402a56c939079fc70b944a40b0c1710385
   languageName: node
   linkType: hard
 
@@ -1114,6 +1326,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/parser@npm:7.15.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 7b17dd05945069d807e1f03b8a50840dc3d0f97cf9860bcdd2eb912110b8229235022da0c7ac94dce3ddba8a14e51db23b592c9bfd041f7618d58660c8ab3121
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.14.5
+    "@babel/plugin-proposal-optional-chaining": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.13.0
+  checksum: cf5586c3cc6d2402c49f26085dcdf673f693f948599b7d064834b1ce79aa1bb76963474e1d84d850aaa1ba18664906999ca62bba52f37eceeadcd4f7028f8078
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-async-generator-functions@npm:^7.12.1, @babel/plugin-proposal-async-generator-functions@npm:^7.13.5, @babel/plugin-proposal-async-generator-functions@npm:^7.8.3":
   version: 7.13.5
   resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.13.5"
@@ -1124,6 +1358,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 0da1aa53d8f047934db60162e421e6bc8642f0b667bd472f90c09db83c23ab96274efa6ef7b63f77fbf43b9c47c333c5ec11cecc2610c669a4f8141690c72432
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-async-generator-functions@npm:^7.14.9":
+  version: 7.14.9
+  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.14.9"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-remap-async-to-generator": ^7.14.5
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0107f81129b2d1ccabfa7c785b1cb305125ad4f68fd5a4421c92e53a77d397114ea7b57a6c4e8ba1f9f4fdd281408979de2e95ae35e6e9c5ad5092f839328ed1
   languageName: node
   linkType: hard
 
@@ -1160,6 +1407,31 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 6d17cb4a92acc11212d4590141b96f6e242f52fb9e34d7f874237077983284fba1c31856860bf8d31aff5a2578828cf6b9276d29be29c03ad1e6956676ecc2bf
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-class-properties@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-class-properties@npm:7.14.5"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 11650465820d31d40445529f64ccf084b031f681970ce57774ac1fb6fbd28b3306a86b3546d520ca31d2dae06a6004f9bd1ffff0e44d5c3ce54519620ebc6e57
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-class-static-block@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-class-static-block@npm:7.14.5"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-class-static-block": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.12.0
+  checksum: 52bd9cc9cb627809b090fff3fec05fa8858ba0fd5c0e4fcb2cfc572f9e9d8b9522939c0116ccc558a9cc5b3bc7c77ca1cbbb8717ff60fe23e65e74b9345c6cc7
   languageName: node
   linkType: hard
 
@@ -1214,6 +1486,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-dynamic-import@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-dynamic-import@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: ae31845d4b7178ce24f89357d511105ab3ff29711e09b62ccbb7226c458c25ce9c19e1c9002682e7c07e8589224b53b4afd0efaa6c1a00cbf49c77d68da226fc
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-export-default-from@npm:^7.12.1":
   version: 7.12.13
   resolution: "@babel/plugin-proposal-export-default-from@npm:7.12.13"
@@ -1238,6 +1522,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-export-namespace-from@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-export-namespace-from@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0f775df669110de212910ce7c6287079dd07d578afae9746cd2059afad2ea0d7d4bb5376de520c78fb5364a1f633ecc623998d39956919d922cffcfb3ed1653f
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-json-strings@npm:^7.12.1, @babel/plugin-proposal-json-strings@npm:^7.12.13, @babel/plugin-proposal-json-strings@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-proposal-json-strings@npm:7.12.13"
@@ -1250,6 +1546,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-json-strings@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-json-strings@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-json-strings": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 06f63ca10c6cb8c66a3446d4bcde780f304771effc586cfa57bf7bfd510d213a2886dd922bcf79944cc0788fc96da72bae116980ff04319d20395f66823608b1
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-logical-assignment-operators@npm:^7.12.1, @babel/plugin-proposal-logical-assignment-operators@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/plugin-proposal-logical-assignment-operators@npm:7.12.13"
@@ -1259,6 +1567,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 58c61df0dd1afbb56084f84bef9b54044a035ade6008d3162964a5050bc58c2bff89bd0e8651c7fcd7b73bbf550e6c96a0d0ca28ec75bd620b18ba98402011d4
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-logical-assignment-operators@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-logical-assignment-operators@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3e30b19b4f3f8b85ccd3fccd1b0db5dd6ad10738fed88087c22d7464de952ce5eb94a60fa7a081c511b841248e5c9bb159f814220990a07fdaabe07b1468c6e0
   languageName: node
   linkType: hard
 
@@ -1298,6 +1618,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-nullish-coalescing-operator@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-nullish-coalescing-operator@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 15b2b7fb3bea6aa0f5be7c807a63b636f9717ee4a6cd37d7100acecf8ff9c684cd01d8a2114cc8e597734d7fe49ff06d35d3d809ae49c2f0979843efc6ddfbef
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-numeric-separator@npm:7.12.1":
   version: 7.12.1
   resolution: "@babel/plugin-proposal-numeric-separator@npm:7.12.1"
@@ -1334,6 +1666,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-numeric-separator@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-numeric-separator@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 97e5345f3ecc6de43273632815f74d2dd4548ed5e3d75724f67c703b064d1e6edce5f76e144e500825a9ceb94c510e1943fd5ee454ed83364e74370587a07f75
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-object-rest-spread@npm:7.12.1":
   version: 7.12.1
   resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.12.1"
@@ -1360,6 +1704,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-object-rest-spread@npm:^7.14.7":
+  version: 7.14.7
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.14.7"
+  dependencies:
+    "@babel/compat-data": ^7.14.7
+    "@babel/helper-compilation-targets": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
+    "@babel/plugin-transform-parameters": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 861c81bcf70d873ae5eea79b59548f6f9604602ea3cc97481b1645ce82af383927b1c454ace3abaa198ba6c6577d5eb90e589db21f65f6f4f43a2fb5f951f620
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-optional-catch-binding@npm:^7.12.1, @babel/plugin-proposal-optional-catch-binding@npm:^7.12.13, @babel/plugin-proposal-optional-catch-binding@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-proposal-optional-catch-binding@npm:7.12.13"
@@ -1369,6 +1728,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: db8715650c31a6a75869b058491fd2764747d049fc254e3b6f6556242f4de0db9d788b18cdd7aec8efd23cb11dd8905821cac120495d81d46ff8f6db462b0911
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-optional-catch-binding@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-optional-catch-binding@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4eb3f503525eb9bfb96fd8598de2f7b64caa5cc0fc109f385f9bd27306c6ddaaa7a9f4b6d3057e4050f9b0d43fd8dc123f531954d42ef8a5537e848567ab7f1c
   languageName: node
   linkType: hard
 
@@ -1410,6 +1781,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-optional-chaining@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.14.5
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7037d4e3e3751a7d25ccb969f72541992c7eb960284904d2ca7fe7a8f6603f9ca5abc8ee592938b9701efed5f5a944b094c78f81225d13b27da68b68c6b17a51
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-private-methods@npm:^7.12.1, @babel/plugin-proposal-private-methods@npm:^7.13.0":
   version: 7.13.0
   resolution: "@babel/plugin-proposal-private-methods@npm:7.13.0"
@@ -1422,6 +1806,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-private-methods@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-private-methods@npm:7.14.5"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: df596f2a1efa7efb578ebecac6b718e1e9c3d9b1ff943f34e26a997e0de9e9ac435ea4b49f7b11979cff65ed6a4dfe171400cf8af351c9874efa249bc7311908
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-property-in-object@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.14.5"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.14.5
+    "@babel/helper-create-class-features-plugin": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7000b403a6154de47ca3f7b88a01b20c78f963e5c487d572b5b68794d37924cc41551f7fa1573147f468bfe81174d367ea34b4d32d916286cda31397e7a8287b
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-unicode-property-regex@npm:^7.12.1, @babel/plugin-proposal-unicode-property-regex@npm:^7.12.13, @babel/plugin-proposal-unicode-property-regex@npm:^7.4.4, @babel/plugin-proposal-unicode-property-regex@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-proposal-unicode-property-regex@npm:7.12.13"
@@ -1431,6 +1841,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: e1474b4394627c588051886d28c5c53b23b0e5da23c64aa7ecd10517722e359d1c1eb3af7480774b6240d77e0f3aa84f7f5b0e1424a9afcca2fab1f2e47fab82
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-unicode-property-regex@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-proposal-unicode-property-regex@npm:7.14.5"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4047f4085eed41feb8209875083b4300421f413b08be299ebaa98007b2e052859be23b6749be379e98287d0f3a35c43755c17f3fc741afdc445a3addc338983e
   languageName: node
   linkType: hard
 
@@ -1464,6 +1886,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 95168fa186416195280b1264fb18afcdcdcea780b3515537b766cb90de6ce042d42dd6a204a39002f794ae5845b02afb0fd4861a3308a861204a55e68310a120
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-class-static-block@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-class-static-block@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4464bf9115f4a2d02ce1454411baf9cfb665af1da53709c5c56953e5e2913745b0fcce82982a00463d6facbdd93445c691024e310b91431a1e2f024b158f6371
   languageName: node
   linkType: hard
 
@@ -1632,6 +2065,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-syntax-private-property-in-object@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-private-property-in-object@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 69822772561706c87f0a65bc92d0772cea74d6bc0911537904a676d5ff496a6d3ac4e05a166d8125fce4a16605bace141afc3611074e170a994e66e5397787f3
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-top-level-await@npm:^7.12.1, @babel/plugin-syntax-top-level-await@npm:^7.12.13, @babel/plugin-syntax-top-level-await@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-syntax-top-level-await@npm:7.12.13"
@@ -1640,6 +2084,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: a74e6954c784d7ae44009f06195dd6a8166ce43e3c3edda23af5c8b319733a4b3e1fe8cee12404f7662285273e7eb1f76727b2b28a8a098bf0bce54683cbe1ab
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-top-level-await@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-syntax-top-level-await@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 14bf6e65d5bc1231ffa9def5f0ef30b19b51c218fcecaa78cd1bdf7939dfdf23f90336080b7f5196916368e399934ce5d581492d8292b46a2fb569d8b2da106f
   languageName: node
   linkType: hard
 
@@ -1662,6 +2117,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: f648eba00af332928bb4e105b0df207c1e0cc95934f9e76694d86def2c61bf449e2b0e45298d1bdfb3fdd8c60e2594785a999e2277979bc554325cbf54bc5e0f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-arrow-functions@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-arrow-functions@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d1e9bf5a026161f4133b7142ae1abb88b835b5394d9f7dda03c3f53c57d28f1673414ed81a8679b6d06ce60eb3dc25931cf4659d60f6a6c16c39da988c0d8359
   languageName: node
   linkType: hard
 
@@ -1691,6 +2157,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-async-to-generator@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-async-to-generator@npm:7.14.5"
+  dependencies:
+    "@babel/helper-module-imports": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-remap-async-to-generator": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 5d71c1fe91dc69db7a4b598edb6480d6658f2f57fbe4add1bbc9a6885c9ed708f73192957bb9caee19e5ae4d9d1f8e940253a337eddcb941b73678555d224596
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-block-scoped-functions@npm:^7.12.1, @babel/plugin-transform-block-scoped-functions@npm:^7.12.13, @babel/plugin-transform-block-scoped-functions@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.12.13"
@@ -1699,6 +2178,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 79006bbfc62c7bc38493b5944de5bd6ec5231af25cff0abc00ad9b8bc430743ff011adeace60db3e3b3fef2d2174d8680169e87731b078a0066d018a6943be9e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-block-scoped-functions@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 864f35c311b6e56307f3a48a419a6bfd11687d4287590b3795318754006a97ad72b8eebf65a74b88c2fcb1624676aad420ca2a590713b267dc94c00bdeae0df7
   languageName: node
   linkType: hard
 
@@ -1724,6 +2214,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-block-scoping@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9e7c334b6180ba92e49c263cfcac969800f113c3328847f46c1d0bd74a245964b655270953ee1db7826c8a8302589418e1c1be428d0c7bd6aced849e23300262
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-classes@npm:^7.12.1, @babel/plugin-transform-classes@npm:^7.13.0, @babel/plugin-transform-classes@npm:^7.9.0":
   version: 7.13.0
   resolution: "@babel/plugin-transform-classes@npm:7.13.0"
@@ -1741,6 +2242,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-classes@npm:^7.14.9":
+  version: 7.14.9
+  resolution: "@babel/plugin-transform-classes@npm:7.14.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.14.5
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/helper-optimise-call-expression": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-replace-supers": ^7.14.5
+    "@babel/helper-split-export-declaration": ^7.14.5
+    globals: ^11.1.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: dfcbe1a80af755a45be29b61d9d2f1476f1c0353e27265cccd79015bab434c69b5e5b8e159010e7c857c8cbd53a543923f2c8c464aa53bceb8c784a2f6ce5a51
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-computed-properties@npm:^7.12.1, @babel/plugin-transform-computed-properties@npm:^7.13.0, @babel/plugin-transform-computed-properties@npm:^7.8.3":
   version: 7.13.0
   resolution: "@babel/plugin-transform-computed-properties@npm:7.13.0"
@@ -1749,6 +2267,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 923d090b8085d842ad5e2d8682a78d2e1830f7390107dd4e58249bdba9f8c523e0982f8a859745fe5a89c09276c2ea7ec5fa7d8fbc83b23988b92a2e399a5668
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-computed-properties@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-computed-properties@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3eed440f30bae21f5b11d8dea0f12d3ac0e0c623409161c49aae264b77736e60f0385dfbcf3c6deb03cf7ba2505f2769e21b7c5cb07cfb92d90e9f5d46a91436
   languageName: node
   linkType: hard
 
@@ -1774,6 +2303,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-destructuring@npm:^7.14.7":
+  version: 7.14.7
+  resolution: "@babel/plugin-transform-destructuring@npm:7.14.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: fc62688948b23d59c8286602757999bd4f551e7171619fb0750f804d9725f3d79d87a51f7fe4f4e12064c4e86f24a4616d6c2a537ca8f2ecf1b54482a3fc0356
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-dotall-regex@npm:^7.12.1, @babel/plugin-transform-dotall-regex@npm:^7.12.13, @babel/plugin-transform-dotall-regex@npm:^7.4.4, @babel/plugin-transform-dotall-regex@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-dotall-regex@npm:7.12.13"
@@ -1783,6 +2323,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 40d79120e22e2533bc424bd3afff8cc5fada593c8f12b30e4df3e1f5409b75d9da37ca7626d700c6e29f7017d5b43eef32e5130bf72f5daa292e43b83a4756e5
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-dotall-regex@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-dotall-regex@npm:7.14.5"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7ce77cb4565e37b9ef3b9171953bf7243c80fbf62d4c1031234f46b1ebdaa84128018dc0a9e86aaa9f1a862408f9d8955c93f019b4b7e7198a96b8d147f2b0e9
   languageName: node
   linkType: hard
 
@@ -1797,6 +2349,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-duplicate-keys@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-duplicate-keys@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c7111a67bec29ba27fd01105a0b1b613ad0c76597934302ef1e56be1b8b32943df05c75a5be490e0ae55148d6ebd5bf2007249213b75e8d35c10160114a883ba
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-exponentiation-operator@npm:^7.12.1, @babel/plugin-transform-exponentiation-operator@npm:^7.12.13, @babel/plugin-transform-exponentiation-operator@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.12.13"
@@ -1806,6 +2369,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1d19053b6ab15d140dbeee9a0015333bdd28b47b4bb247059f676ff425f95dbd4cc97ba43b4b47ee5d0e571c56a8d717ccb3039104f353479aa7a31429dcb66a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-exponentiation-operator@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.14.5"
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 876f072ab2fdbcd9e2cc786b7f7e40359dcf165c035bd1619e79bdcc27a250e2aca46e02c0b8c290ffbc354d12d32f43b589265d9ca0e53be6f7d0fd34da5ee2
   languageName: node
   linkType: hard
 
@@ -1856,6 +2431,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-for-of@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-for-of@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6784a661e828fe1652484a47555fb0ad3e3c236bef8359cbe363e443b91e4ee1d254c1fa88bde6e9c49e936eb741447d80e7b1a1a44006707be69358a40ef458
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-function-name@npm:^7.12.1, @babel/plugin-transform-function-name@npm:^7.12.13, @babel/plugin-transform-function-name@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-function-name@npm:7.12.13"
@@ -1865,6 +2451,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: ad12739bd44c1d545775bcfebc75b905e3ee6b358a36534d8d3e2b923aff652ebba13960b34e15dc4d9aaed0e45ef04291d9fdf79d0c005a64837122013a479f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-function-name@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-function-name@npm:7.14.5"
+  dependencies:
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 18d61764d911a96319ec6accaa281d0691084443b452478e1d9bf82fe011eb62c8c8a0bacecbfac6fcee83e4d53e777bccd6ff46718a1c1b2f52fdc7e8509ec5
   languageName: node
   linkType: hard
 
@@ -1879,6 +2477,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-literals@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-literals@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a9383db99026a44d2373ca2e3048c566d66f436aca326d1dc4e07ec90953a075ab4897c54c7adbd52fbd1ef538b4cee346cc0db96bfeae70969b89e995c2a86d
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-member-expression-literals@npm:^7.12.1, @babel/plugin-transform-member-expression-literals@npm:^7.12.13, @babel/plugin-transform-member-expression-literals@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-member-expression-literals@npm:7.12.13"
@@ -1887,6 +2496,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 0f974b47a199883b00a49faff71368c66128f5dd7f74e3f3d447760cd5fcb389c5f3020672d2115b1a8ec2030c785031d9ed6440df8cf3d1208dfa552e7857b0
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-member-expression-literals@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-member-expression-literals@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b322fa6c7f2dedf2f9c8b5ed33d1dcb377ec04375f348aaf33f3bf98fe3e3a96c008e623c7de7da47f0ddb5c63c57e8b233986a53e58f951b010ff1078de62b1
   languageName: node
   linkType: hard
 
@@ -1903,6 +2523,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-modules-amd@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-modules-amd@npm:7.14.5"
+  dependencies:
+    "@babel/helper-module-transforms": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+    babel-plugin-dynamic-import-node: ^2.3.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: e9e4be72bee9312e47d75b6e673d2986b6a0ddfd6d2638ce98b91014c3ffff4e2084d1b9b4f401bbbfc030b79770afe4f49cbe4a8b6d24df9ac910695c0ddea2
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-modules-commonjs@npm:^7.1.0, @babel/plugin-transform-modules-commonjs@npm:^7.12.1, @babel/plugin-transform-modules-commonjs@npm:^7.13.0, @babel/plugin-transform-modules-commonjs@npm:^7.2.0, @babel/plugin-transform-modules-commonjs@npm:^7.4.4, @babel/plugin-transform-modules-commonjs@npm:^7.9.0":
   version: 7.13.0
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.13.0"
@@ -1914,6 +2547,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: d1f64c5013aacd74da619b1d4fdbe5b1fcfc36913cf4952162f71e904d5a55a03905aff58bc30a137f7114e5edf3fc66c1a134e1e7e012eaac54b5ff82000020
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-commonjs@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.15.0"
+  dependencies:
+    "@babel/helper-module-transforms": ^7.15.0
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-simple-access": ^7.14.8
+    babel-plugin-dynamic-import-node: ^2.3.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 34f059fb48c69d492fb6d23f817eb8adf49060ad53c785f7de370cdb185a4cc2c1ac32bb39c989f29a2f1381ea854a277c5c4a6b0d95fc05a233b0bb35eea7ea
   languageName: node
   linkType: hard
 
@@ -1932,6 +2579,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-modules-systemjs@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.14.5"
+  dependencies:
+    "@babel/helper-hoist-variables": ^7.14.5
+    "@babel/helper-module-transforms": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-validator-identifier": ^7.14.5
+    babel-plugin-dynamic-import-node: ^2.3.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 52cd1a11c27c82718712fa753040f1d196576e9a405c40dcafec1ec9dc93b76c4658e112aa22e6c5c09de79608df0468d9b0dcd795705f5ca56d3c595eadab81
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-modules-umd@npm:^7.12.1, @babel/plugin-transform-modules-umd@npm:^7.13.0, @babel/plugin-transform-modules-umd@npm:^7.9.0":
   version: 7.13.0
   resolution: "@babel/plugin-transform-modules-umd@npm:7.13.0"
@@ -1941,6 +2603,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9fd6801d78dfe18b4a1aed2ab9d8c7cec20083aade42b1a00dfd2275ed6461d3cba5fe666b074c5d604dc22e4923325814f95897abfe9543fb87ce7a72f732ac
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-umd@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-modules-umd@npm:7.14.5"
+  dependencies:
+    "@babel/helper-module-transforms": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d622f8398673472b65345b58bb226523ad75118c34c591b23a369f53c75f3831e9bdb6a309aec6af631b6446bc6a6460cae920933ef2d7e6e0940b0f6684fa94
   languageName: node
   linkType: hard
 
@@ -1955,6 +2629,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.14.9":
+  version: 7.14.9
+  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.14.9"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 8e1709cd82f831b81ad8b9ec246fdf530e4c52e72d311c9825ae72674251f7b4890e4d8d1e09b8a71dc1660e3020fce4fe3234f07b05b7de9f9a419181b2b549
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-new-target@npm:^7.12.1, @babel/plugin-transform-new-target@npm:^7.12.13, @babel/plugin-transform-new-target@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-new-target@npm:7.12.13"
@@ -1963,6 +2648,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 6fd374379dee6430163b4e0ed7a4dc86343dd5e4dfb6b0310a3699cda7ae06193cd4b78a1d5c40395f20cecf235adc6d2377edf2eff69f598eaa73f2df08060c
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-new-target@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-new-target@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6efea7d9749fd7e6a78b02c561a4b42a231867469b2814b5962d168803a240ef6b947262799c407fbe0e055c6c3a342f03c43a677744469f2e703ef388444915
   languageName: node
   linkType: hard
 
@@ -1989,6 +2685,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-object-super@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-object-super@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-replace-supers": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 259b6937a816ea533ba971a885127a66a0ea5a6707c0f677911f69d3b2ec530801542eb61e851518578a67d00fe26a87d9cd9151495474423e722d72c6192dc5
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-parameters@npm:^7.12.1, @babel/plugin-transform-parameters@npm:^7.13.0, @babel/plugin-transform-parameters@npm:^7.8.7":
   version: 7.13.0
   resolution: "@babel/plugin-transform-parameters@npm:7.13.0"
@@ -2000,6 +2708,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-parameters@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-parameters@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d895ece369eba57591529369192b9e0cfdb09dfc132d2ec96d7f17a8b9ef919f20dd39859c61a46e047a0573e2329cfb729296f56f8316057b6f6cc08122277c
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-property-literals@npm:^7.12.1, @babel/plugin-transform-property-literals@npm:^7.12.13, @babel/plugin-transform-property-literals@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-property-literals@npm:7.12.13"
@@ -2008,6 +2727,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: a9115ed5633d26ab7cc852093012e3dd209d205f2568431cea157ea4aa30c622717b1a0870a8eedeb1d15835b59dfeec272080d7f9de6f013bf2a69e8f410113
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-property-literals@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-property-literals@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 68cc043bdd1b1b4e445bea81d6ea592b15c20c3de02d245fa32972086a8aab1adc02085bdcef60c5faab735d2d3253a692aebfdeceddf77f715b1e6403868d9b
   languageName: node
   linkType: hard
 
@@ -2126,6 +2856,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-regenerator@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-regenerator@npm:7.14.5"
+  dependencies:
+    regenerator-transform: ^0.14.2
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6e47168c1a838b751315632fcc4f2cbd39a478dbdd884b8d0da22a63f8912a6bdafce8b581fe372abbf39d9df028383c69c16bd674afd484d28de3f74d2ee2df
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-reserved-words@npm:^7.12.1, @babel/plugin-transform-reserved-words@npm:^7.12.13, @babel/plugin-transform-reserved-words@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-reserved-words@npm:7.12.13"
@@ -2134,6 +2875,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 681f4a5e735d2db25ab83dda5957630a40767e4a5f736d60af2d926fb65721c96f26e48071010dadacd5811f879454a5db555ff767c7b1fea761e7da30fc160e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-reserved-words@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-reserved-words@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a5b01e11babae05dec3203b3b96f757c266f3d8287620bd7ed020660066141c97cbfdd99e96aa81723b3fe6e02f947cfc5b1231d0b72e5c521ce564e5cca7cbe
   languageName: node
   linkType: hard
 
@@ -2205,6 +2957,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-shorthand-properties@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-shorthand-properties@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0d6f6ed31d4dc45e6b1a495cf5164bbf0a7efa6be280df6f33ce640fc5aedfb780dc1bc56906d198afe1ddf9b3e23d251cee0b07f8c7e460483b3793574d9670
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-spread@npm:^7.12.1, @babel/plugin-transform-spread@npm:^7.13.0, @babel/plugin-transform-spread@npm:^7.8.3":
   version: 7.13.0
   resolution: "@babel/plugin-transform-spread@npm:7.13.0"
@@ -2214,6 +2977,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 21ef3bf0c51da85dc2c0762260f8bfba9157e14a6c2ee9b21197b3c81969a2a979d0aa6945fc2342e7a5bc4fdb05b7af7bdc0ca0796cf187346832633b0b3f07
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-spread@npm:^7.14.6":
+  version: 7.14.6
+  resolution: "@babel/plugin-transform-spread@npm:7.14.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b1e95038fdd21dcac4c2c613b4206b16fb7e87a51897f52566f4b736d42fadfddb88a67d79e3ab2c8e16b126a4e2843f85d858d3f535bc426aae8d822457651e
   languageName: node
   linkType: hard
 
@@ -2228,6 +3003,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-sticky-regex@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-sticky-regex@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2f8276fe352b180852d986a8d899db4da3522bb3fa811fee3fc84d5b84ae5a616f3cf771690cc6e34c840c3b09685fed0b2de04be48adfd749344b12640cef61
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-template-literals@npm:^7.12.1, @babel/plugin-transform-template-literals@npm:^7.13.0, @babel/plugin-transform-template-literals@npm:^7.8.3":
   version: 7.13.0
   resolution: "@babel/plugin-transform-template-literals@npm:7.13.0"
@@ -2239,6 +3025,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-template-literals@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-template-literals@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 58f5f70ae5343331b3840c423044cd788e0f9628deae73b4b1584a98f36c9d4184a49667e0f8640cb50f349e47fa7e78bb8f2344a4210ed84236324cbf758725
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-typeof-symbol@npm:^7.12.1, @babel/plugin-transform-typeof-symbol@npm:^7.12.10, @babel/plugin-transform-typeof-symbol@npm:^7.12.13, @babel/plugin-transform-typeof-symbol@npm:^7.8.4":
   version: 7.12.13
   resolution: "@babel/plugin-transform-typeof-symbol@npm:7.12.13"
@@ -2247,6 +3044,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1696a271b6c59c4ec2ce76f57937471b993d80d9207ef157b7c0caa995c4273eb803b4c7e8c4e86163a6ae0c6bb85b93485dd9c38abbed136884f321f9807384
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-typeof-symbol@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-typeof-symbol@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 380d6b382e470cbdd2a89430415016cfac20f3b78a0742107fffa17f7bc211be78e6cfa207df6e19345298a7100b6fe8f2275714338b25785ab1d46b638a9f91
   languageName: node
   linkType: hard
 
@@ -2299,6 +3107,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-unicode-escapes@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-unicode-escapes@npm:7.14.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: bcc79f236c351740d3b1b9c262457d8f24ab80d9ce99291d1d259d84d379fbca60055b145bb625f1661ca76fdc886f10145d563aad823e17e278d8145a7b0319
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-unicode-regex@npm:^7.12.1, @babel/plugin-transform-unicode-regex@npm:^7.12.13, @babel/plugin-transform-unicode-regex@npm:^7.8.3":
   version: 7.12.13
   resolution: "@babel/plugin-transform-unicode-regex@npm:7.12.13"
@@ -2308,6 +3127,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1b4ec3e89b7c16d3ab0ae687fb69194b28144c27a82dcaea1ff24c93387ece7d2a0017f45b49e3e376d13f1521a3556069f7aae36e08dfac6fe01518dba7092c
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-unicode-regex@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-unicode-regex@npm:7.14.5"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f02a91fcbf98707d6d00f8130a1c260e512c6fcf4cd97d110d9161156427118c91146bdc0455fd4098d15e4128030465a5abd828472d11b32090eff4a291afe5
   languageName: node
   linkType: hard
 
@@ -2621,6 +3452,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-env@npm:^7.14.7":
+  version: 7.15.0
+  resolution: "@babel/preset-env@npm:7.15.0"
+  dependencies:
+    "@babel/compat-data": ^7.15.0
+    "@babel/helper-compilation-targets": ^7.15.0
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-validator-option": ^7.14.5
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.14.5
+    "@babel/plugin-proposal-async-generator-functions": ^7.14.9
+    "@babel/plugin-proposal-class-properties": ^7.14.5
+    "@babel/plugin-proposal-class-static-block": ^7.14.5
+    "@babel/plugin-proposal-dynamic-import": ^7.14.5
+    "@babel/plugin-proposal-export-namespace-from": ^7.14.5
+    "@babel/plugin-proposal-json-strings": ^7.14.5
+    "@babel/plugin-proposal-logical-assignment-operators": ^7.14.5
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.14.5
+    "@babel/plugin-proposal-numeric-separator": ^7.14.5
+    "@babel/plugin-proposal-object-rest-spread": ^7.14.7
+    "@babel/plugin-proposal-optional-catch-binding": ^7.14.5
+    "@babel/plugin-proposal-optional-chaining": ^7.14.5
+    "@babel/plugin-proposal-private-methods": ^7.14.5
+    "@babel/plugin-proposal-private-property-in-object": ^7.14.5
+    "@babel/plugin-proposal-unicode-property-regex": ^7.14.5
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+    "@babel/plugin-syntax-class-properties": ^7.12.13
+    "@babel/plugin-syntax-class-static-block": ^7.14.5
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+    "@babel/plugin-syntax-json-strings": ^7.8.3
+    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+    "@babel/plugin-syntax-top-level-await": ^7.14.5
+    "@babel/plugin-transform-arrow-functions": ^7.14.5
+    "@babel/plugin-transform-async-to-generator": ^7.14.5
+    "@babel/plugin-transform-block-scoped-functions": ^7.14.5
+    "@babel/plugin-transform-block-scoping": ^7.14.5
+    "@babel/plugin-transform-classes": ^7.14.9
+    "@babel/plugin-transform-computed-properties": ^7.14.5
+    "@babel/plugin-transform-destructuring": ^7.14.7
+    "@babel/plugin-transform-dotall-regex": ^7.14.5
+    "@babel/plugin-transform-duplicate-keys": ^7.14.5
+    "@babel/plugin-transform-exponentiation-operator": ^7.14.5
+    "@babel/plugin-transform-for-of": ^7.14.5
+    "@babel/plugin-transform-function-name": ^7.14.5
+    "@babel/plugin-transform-literals": ^7.14.5
+    "@babel/plugin-transform-member-expression-literals": ^7.14.5
+    "@babel/plugin-transform-modules-amd": ^7.14.5
+    "@babel/plugin-transform-modules-commonjs": ^7.15.0
+    "@babel/plugin-transform-modules-systemjs": ^7.14.5
+    "@babel/plugin-transform-modules-umd": ^7.14.5
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.14.9
+    "@babel/plugin-transform-new-target": ^7.14.5
+    "@babel/plugin-transform-object-super": ^7.14.5
+    "@babel/plugin-transform-parameters": ^7.14.5
+    "@babel/plugin-transform-property-literals": ^7.14.5
+    "@babel/plugin-transform-regenerator": ^7.14.5
+    "@babel/plugin-transform-reserved-words": ^7.14.5
+    "@babel/plugin-transform-shorthand-properties": ^7.14.5
+    "@babel/plugin-transform-spread": ^7.14.6
+    "@babel/plugin-transform-sticky-regex": ^7.14.5
+    "@babel/plugin-transform-template-literals": ^7.14.5
+    "@babel/plugin-transform-typeof-symbol": ^7.14.5
+    "@babel/plugin-transform-unicode-escapes": ^7.14.5
+    "@babel/plugin-transform-unicode-regex": ^7.14.5
+    "@babel/preset-modules": ^0.1.4
+    "@babel/types": ^7.15.0
+    babel-plugin-polyfill-corejs2: ^0.2.2
+    babel-plugin-polyfill-corejs3: ^0.2.2
+    babel-plugin-polyfill-regenerator: ^0.2.2
+    core-js-compat: ^3.16.0
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4228b1f6f33ae420593799d12428fc42db8083955ee421f96efd2aac9ba80ada7ef93b0c0c6e2a43a9a28e06323d40875ece923f093bf320776c79c5b7b64f0e
+  languageName: node
+  linkType: hard
+
 "@babel/preset-flow@npm:^7.0.0, @babel/preset-flow@npm:^7.12.1":
   version: 7.12.13
   resolution: "@babel/preset-flow@npm:7.12.13"
@@ -2633,7 +3547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-modules@npm:^0.1.3":
+"@babel/preset-modules@npm:^0.1.3, @babel/preset-modules@npm:^0.1.4":
   version: 0.1.4
   resolution: "@babel/preset-modules@npm:0.1.4"
   dependencies:
@@ -2892,6 +3806,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/traverse@npm:7.15.0"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.15.0
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/helper-hoist-variables": ^7.14.5
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/parser": ^7.15.0
+    "@babel/types": ^7.15.0
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 767c17230ff789e2005cd75e96287331833f933f640da8bfe4beab5321b274322ee20289659b0a13bacd4b5756ea5015e39ec8fb5dfd723beb31e2bc515fef64
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.0, @babel/types@npm:^7.12.1, @babel/types@npm:^7.12.10, @babel/types@npm:^7.12.11, @babel/types@npm:^7.12.13, @babel/types@npm:^7.12.17, @babel/types@npm:^7.12.6, @babel/types@npm:^7.12.7, @babel/types@npm:^7.13.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.6.1, @babel/types@npm:^7.7.0, @babel/types@npm:^7.7.2, @babel/types@npm:^7.8.3, @babel/types@npm:^7.8.6, @babel/types@npm:^7.9.0, @babel/types@npm:^7.9.6":
   version: 7.13.0
   resolution: "@babel/types@npm:7.13.0"
@@ -2931,6 +3862,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.14.8
     to-fast-properties: ^2.0.0
   checksum: d03b05599a2cba3046ae982bc3ebf4709a91d6e35208650b0aed8a344d3d97520fc68ce62008c389d06f51d13da20b8b137f8994a53d853092d24ab6b087091e
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/types@npm:7.15.0"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.9
+    to-fast-properties: ^2.0.0
+  checksum: 94e8f9eae94296f16cb0fbb9697b51e84c14649cb48c9a1a671f17a2456b625232e97febf509567670e260bd44c7e2c00cb37df6b96f1883717fecc0796bc90a
   languageName: node
   linkType: hard
 
@@ -2974,44 +3915,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@compodoc/compodoc@npm:^1.1.11":
-  version: 1.1.11
-  resolution: "@compodoc/compodoc@npm:1.1.11"
+"@compodoc/compodoc@npm:^1.1.14":
+  version: 1.1.14
+  resolution: "@compodoc/compodoc@npm:1.1.14"
   dependencies:
-    "@compodoc/ngd-transformer": ^2.0.0
-    chalk: ^2.4.2
-    cheerio: ^1.0.0-rc.3
-    chokidar: ^3.1.1
+    "@babel/core": ^7.14.6
+    "@babel/preset-env": ^7.14.7
+    "@compodoc/live-server": ^1.2.2
+    "@compodoc/ngd-transformer": ^2.1.0
+    chalk: ^4.1.1
+    cheerio: ^1.0.0-rc.10
+    chokidar: ^3.5.2
     colors: ^1.4.0
-    commander: ^3.0.2
-    cosmiconfig: ^5.2.1
-    decache: ^4.5.1
+    commander: ^8.0.0
+    cosmiconfig: ^7.0.0
+    decache: ^4.6.0
     fancy-log: ^1.3.3
     findit2: ^2.2.3
-    fs-extra: ^8.0.1
-    glob: ^7.1.4
-    handlebars: ^4.3.3
-    html-entities: ^1.2.1
-    i18next: ^17.0.16
+    fs-extra: ^10.0.0
+    glob: ^7.1.7
+    handlebars: ^4.7.7
+    html-entities: ^2.3.2
+    i18next: ^20.3.2
     inside: ^1.0.0
-    json5: ^2.1.0
-    live-server: ^1.2.1
-    lodash: ^4.17.15
-    loglevel: ^1.6.4
+    json5: ^2.2.0
+    lodash: ^4.17.21
+    loglevel: ^1.7.1
     loglevel-plugin-prefix: ^0.8.4
-    lunr: ^2.3.6
-    marked: ^0.7.0
-    minimist: ^1.2.0
-    opencollective-postinstall: ^2.0.2
-    os-name: ^3.1.0
-    pdfmake: ^0.1.60
-    semver: ^6.3.0
+    lunr: ^2.3.9
+    marked: ^2.1.3
+    minimist: ^1.2.5
+    opencollective-postinstall: ^2.0.3
+    os-name: ^4.0.0
+    pdfmake: ^0.2.0
+    semver: ^7.3.5
     traverse: ^0.6.6
-    ts-simple-ast: 12.4.0
-    uuid: ^3.3.3
+    ts-morph: ^11.0.3
+    uuid: ^8.3.2
   bin:
-    compodoc: ./bin/index-cli.js
-  checksum: 234674dd487d14fc7cfb6ffc06e70b0dd365e39b94524b948125bf042de98b427cf5bbe7fa8564779c8c6413d06e1b2e4a500db2ea73cdcff2e775399648f18f
+    compodoc: bin/index-cli.js
+  checksum: 6330d05f10bedf6b05a720e4e1629c1f50211b48b4bc310cf1fdeae65030b7b4ad47ac54a35efb9f7df5c6c61078b5ba9e954e0c9ed2f5fbb2d5c83f012ddbc5
+  languageName: node
+  linkType: hard
+
+"@compodoc/live-server@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@compodoc/live-server@npm:1.2.2"
+  dependencies:
+    chokidar: ^3.5.2
+    colors: latest
+    connect: ^3.7.0
+    cors: latest
+    event-stream: 4.0.1
+    faye-websocket: 0.11.x
+    http-auth: 4.1.7
+    http-auth-connect: ^1.0.5
+    morgan: ^1.10.0
+    object-assign: latest
+    open: 8.2.1
+    proxy-middleware: latest
+    send: latest
+    serve-index: ^1.9.1
+  bin:
+    live-server: live-server.js
+  checksum: 1f2ebdf889dbe55e2c810dddaa921b9e697e1a02ef3ada7bb3cea577a661c6f592573db5a2de6c6b3f68dea9f2ebed6cc022d7587f355cd40aeb23ddf82cad8c
   languageName: node
   linkType: hard
 
@@ -3026,7 +3993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@compodoc/ngd-transformer@npm:^2.0.0":
+"@compodoc/ngd-transformer@npm:^2.1.0":
   version: 2.1.0
   resolution: "@compodoc/ngd-transformer@npm:2.1.0"
   dependencies:
@@ -3122,16 +4089,6 @@ __metadata:
   version: 0.5.2
   resolution: "@discoveryjs/json-ext@npm:0.5.2"
   checksum: 9b6853c13ebbc1e1eee713be9eb71292d0623b76138f22d85cb86f15c8cd7e4c74945079db3176d344428d221817b2b544641d86da8d79d7c66edbe44feb5b0c
-  languageName: node
-  linkType: hard
-
-"@dsherret/to-absolute-glob@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@dsherret/to-absolute-glob@npm:2.0.2"
-  dependencies:
-    is-absolute: ^1.0.0
-    is-negated-glob: ^1.0.0
-  checksum: 3fb8b26897d14baec9bf0c28977d539299c964465fd631ac0f79de33fc324936092987f58a5378483d4400cb735faf527fef6edffc4f90ac6e67bb6a49af7ac5
   languageName: node
   linkType: hard
 
@@ -3435,6 +4392,54 @@ __metadata:
     unique-filename: ^1.1.1
     which: ^1.3.1
   checksum: 5df83645b4743f3f7c780f3d3242da62aaec0b4ac9d5e39d63ffdb11132a6251c134e02c45604ae09871d0ae94b4869d81356b112145ea173647e69d45a30105
+  languageName: node
+  linkType: hard
+
+"@foliojs-fork/fontkit@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@foliojs-fork/fontkit@npm:1.9.1"
+  dependencies:
+    "@foliojs-fork/restructure": ^2.0.2
+    brfs: ^2.0.0
+    brotli: ^1.2.0
+    browserify-optional: ^1.0.1
+    clone: ^1.0.4
+    deep-equal: ^1.0.0
+    dfa: ^1.2.0
+    tiny-inflate: ^1.0.2
+    unicode-properties: ^1.2.2
+    unicode-trie: ^2.0.0
+  checksum: 3db696a3bbda40d630ebc38ba623646417147abae4c2bb275b87ba84b3976e4b6afa271da35098c78c28da83f5376ca478fdecb972dfcf1761f2fdc4ad35ae11
+  languageName: node
+  linkType: hard
+
+"@foliojs-fork/linebreak@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@foliojs-fork/linebreak@npm:1.1.1"
+  dependencies:
+    base64-js: 1.3.1
+    brfs: ^2.0.2
+    unicode-trie: ^2.0.0
+  checksum: fdf10827423bdf235a3df10c1b57040088f6741a5bdd799cef6999f28042fc0a611b7dcd33bf050dd638a404c1f9be23fb02d991165e0c235a260b7a4af6c5b7
+  languageName: node
+  linkType: hard
+
+"@foliojs-fork/pdfkit@npm:^0.12.3":
+  version: 0.12.3
+  resolution: "@foliojs-fork/pdfkit@npm:0.12.3"
+  dependencies:
+    "@foliojs-fork/fontkit": ^1.9.1
+    "@foliojs-fork/linebreak": ^1.1.1
+    crypto-js: ^4.0.0
+    png-js: ^1.0.0
+  checksum: ee9395a3e1ffbc70440b2aa026efd4742c104d5844a4863c1c233b5563927b1365e5f0856c1b8cda1c1d92327cd859c52bc7bce2f4b7a8be8e6ad0d1db2fd575
+  languageName: node
+  linkType: hard
+
+"@foliojs-fork/restructure@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@foliojs-fork/restructure@npm:2.0.2"
+  checksum: f9e6e94f7377f467a93988ee85cf326f2db3edd3029530791aced6d530fd7862efb27b00212beb8df6f7458cbec4acb6b198b36535d1acee3fb413c1d5ac55ac
   languageName: node
   linkType: hard
 
@@ -7549,7 +8554,7 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/runtime": ^7.12.5
-    "@compodoc/compodoc": ^1.1.11
+    "@compodoc/compodoc": ^1.1.14
     "@cypress/webpack-preprocessor": ^5.7.0
     "@emotion/snapshot-serializer": ^0.8.2
     "@nicolo-ribaudo/chokidar-2": ^2.1.8
@@ -8408,6 +9413,18 @@ __metadata:
   version: 0.1.1
   resolution: "@trysound/sax@npm:0.1.1"
   checksum: ccb036685c5b9eb719e1fb73af640b7e09e408bcc1dee6f015637cfefe5910be58baaf5c5c38d55b7202dcb311aa2ba27b5adc6c1a24ca0f05e8358d182d972e
+  languageName: node
+  linkType: hard
+
+"@ts-morph/common@npm:~0.10.1":
+  version: 0.10.1
+  resolution: "@ts-morph/common@npm:0.10.1"
+  dependencies:
+    fast-glob: ^3.2.5
+    minimatch: ^3.0.4
+    mkdirp: ^1.0.4
+    path-browserify: ^1.0.1
+  checksum: 58d9f75ace30cdcd3db193664c6610f24a13ccab9550a58e4c0d86f52221af4d09a272a5ee389adf150f4b5254404b143d7fc46954a910f69c4653a138fd6e92
   languageName: node
   linkType: hard
 
@@ -11620,7 +12637,7 @@ __metadata:
     "@angular/forms": ^11.2.14
     "@angular/platform-browser": ^11.2.14
     "@angular/platform-browser-dynamic": ^11.2.14
-    "@compodoc/compodoc": ^1.1.11
+    "@compodoc/compodoc": ^1.1.14
     "@ngrx/store": ^10.1.2
     "@storybook/addon-a11y": 6.4.0-alpha.24
     "@storybook/addon-actions": 6.4.0-alpha.24
@@ -11827,6 +12844,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"anymatch@npm:~3.1.2":
+  version: 3.1.2
+  resolution: "anymatch@npm:3.1.2"
+  dependencies:
+    normalize-path: ^3.0.0
+    picomatch: ^2.0.4
+  checksum: 900645535aee46ed7958f4f5b5e38abcbf474b5230406e913de15fc9a1310f0d5322775deb609688efe31010fa57831e55d36040b19826c22ce61d537e9b9759
+  languageName: node
+  linkType: hard
+
 "apache-crypt@npm:^1.1.2":
   version: 1.2.4
   resolution: "apache-crypt@npm:1.2.4"
@@ -11963,13 +12990,6 @@ __metadata:
   version: 3.1.0
   resolution: "arr-union@npm:3.1.0"
   checksum: 7d5aa05894e54aa93c77c5726c1dd5d8e8d3afe4f77983c0aa8a14a8a5cbe8b18f0cf4ecaa4ac8c908ef5f744d2cbbdaa83fd6e96724d15fea56cfa7f5efdd51
-  languageName: node
-  linkType: hard
-
-"array-differ@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "array-differ@npm:1.0.0"
-  checksum: 8782c01cfe58555416fbf63ceb30d8e17076297f067357a5a9eff9b4cc9aa02731aa27c06966758d09a18b1740f9643e1ff563f1a7040428ba1c796e2ad75050
   languageName: node
   linkType: hard
 
@@ -12921,6 +13941,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-polyfill-corejs2@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "babel-plugin-polyfill-corejs2@npm:0.2.2"
+  dependencies:
+    "@babel/compat-data": ^7.13.11
+    "@babel/helper-define-polyfill-provider": ^0.2.2
+    semver: ^6.1.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7fb5129204c31d46474b78f7ceaa117b6e740edc8dfc7a32aeb82d766f8815b06bcee09b95d0ddcfd71dbf9b237887b16adf06d18e1ef0e4689213bb2b2bf9ee
+  languageName: node
+  linkType: hard
+
 "babel-plugin-polyfill-corejs3@npm:^0.1.0, babel-plugin-polyfill-corejs3@npm:^0.1.3":
   version: 0.1.4
   resolution: "babel-plugin-polyfill-corejs3@npm:0.1.4"
@@ -12933,6 +13966,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-polyfill-corejs3@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.2.4"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": ^0.2.2
+    core-js-compat: ^3.14.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 8e5fe8241da26ddea7322782906df9d38f6e42362e0eee5ad3be7d23398b107826c894f5714e14391709a2d4319ee643678130897394190640c25efdf78847c0
+  languageName: node
+  linkType: hard
+
 "babel-plugin-polyfill-regenerator@npm:^0.1.2":
   version: 0.1.3
   resolution: "babel-plugin-polyfill-regenerator@npm:0.1.3"
@@ -12941,6 +13986,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 8a8d232543938bcc5e32e4e15aec098c229bcdc3576242d9c70d4988d2a4192a8983b9f30b4aea7c0bf685eb9c1f7a067f9287a3c5b8ca3c38faca6e8ecf17d7
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-regenerator@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "babel-plugin-polyfill-regenerator@npm:0.2.2"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": ^0.2.2
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 87ca62b1bcb67cd4d9b0076683203bca985a7e5a9702533a60363d2fef8a5471aa0e2411555fb9623d3a1a0987315199a99221bcf07fa2c89cf444a7aac5fd32
   languageName: node
   linkType: hard
 
@@ -13259,6 +14315,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64-js@npm:1.3.1":
+  version: 1.3.1
+  resolution: "base64-js@npm:1.3.1"
+  checksum: f111a2c2b105eb9ee3818c30154e047fb00370699a03c2130d0944f10914697677ceb5faec64ea851e00710b80539afb03e9aa098e19c183a5e7a1cdc18abb29
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.0.2, base64-js@npm:^1.1.2, base64-js@npm:^1.3.0, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -13327,7 +14390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcryptjs@npm:2.4.3, bcryptjs@npm:^2.3.0":
+"bcryptjs@npm:2.4.3, bcryptjs@npm:^2.4.3":
   version: 2.4.3
   resolution: "bcryptjs@npm:2.4.3"
   checksum: b969467087ed7a01ff905a1c6a0c45014ec586248a448ea08370c8ed8bb314bda16a870ca23e0961d7d23bdce1a04c76fa70a9d680be814fa9ac7d8fc61870a3
@@ -15019,6 +16082,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^4.1.1":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: 4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
 "char-regex@npm:^1.0.2":
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
@@ -15120,6 +16193,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cheerio-select@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "cheerio-select@npm:1.5.0"
+  dependencies:
+    css-select: ^4.1.3
+    css-what: ^5.0.1
+    domelementtype: ^2.2.0
+    domhandler: ^4.2.0
+    domutils: ^2.7.0
+  checksum: 851c8f9bb74823e63547ad5a39b7e301aac88950081ecf5a253e0a8c47a813f7f3428903d35c6ad78a0518b0e9c31dd0c863296f60ab4d53363612c564f863c3
+  languageName: node
+  linkType: hard
+
+"cheerio@npm:^1.0.0-rc.10":
+  version: 1.0.0-rc.10
+  resolution: "cheerio@npm:1.0.0-rc.10"
+  dependencies:
+    cheerio-select: ^1.5.0
+    dom-serializer: ^1.3.2
+    domhandler: ^4.2.0
+    htmlparser2: ^6.1.0
+    parse5: ^6.0.1
+    parse5-htmlparser2-tree-adapter: ^6.0.1
+    tslib: ^2.2.0
+  checksum: 2bb0fae8b1941949f506ddc4df75e3c2d0e5cc6c05478f918dd64a4d2c5282ec84b243890f6a809052a8eb6214641084922c07f726b5287b5dba114b10e52cb9
+  languageName: node
+  linkType: hard
+
 "cheerio@npm:^1.0.0-rc.2, cheerio@npm:^1.0.0-rc.3":
   version: 1.0.0-rc.5
   resolution: "cheerio@npm:1.0.0-rc.5"
@@ -15135,7 +16236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:2.1.8, chokidar@npm:^2.0.4, chokidar@npm:^2.1.5, chokidar@npm:^2.1.8":
+"chokidar@npm:2.1.8, chokidar@npm:^2.1.5, chokidar@npm:^2.1.8":
   version: 2.1.8
   resolution: "chokidar@npm:2.1.8"
   dependencies:
@@ -15158,7 +16259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:>=2.0.0 <4.0.0, chokidar@npm:^3.0.0, chokidar@npm:^3.1.1, chokidar@npm:^3.2.2, chokidar@npm:^3.3.0, chokidar@npm:^3.4.0, chokidar@npm:^3.4.1, chokidar@npm:^3.4.2":
+"chokidar@npm:>=2.0.0 <4.0.0, chokidar@npm:^3.0.0, chokidar@npm:^3.2.2, chokidar@npm:^3.3.0, chokidar@npm:^3.4.0, chokidar@npm:^3.4.1, chokidar@npm:^3.4.2":
   version: 3.5.1
   resolution: "chokidar@npm:3.5.1"
   dependencies:
@@ -15174,6 +16275,25 @@ __metadata:
     fsevents:
       optional: true
   checksum: 894d2fdeeef6a0bc61993a20b864e29e9296f2308628b8b2edf1bef2d59ab11f21938eebbbcbf581f15d16d3e030c08860d2fb035f7b9f3baebac57049a37959
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "chokidar@npm:3.5.2"
+  dependencies:
+    anymatch: ~3.1.2
+    braces: ~3.0.2
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
+    is-binary-path: ~2.1.0
+    is-glob: ~4.0.1
+    normalize-path: ~3.0.0
+    readdirp: ~3.6.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: e7179a9dc4ce54c1ba660652319039b7ca0817a442dd05a45afcbdefcd4848b4276debfa9cf321798c2c567c6289da14dd48d9a1ee92056a7b526c554cffe129
   languageName: node
   linkType: hard
 
@@ -15614,10 +16734,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"code-block-writer@npm:^7.2.0":
-  version: 7.3.1
-  resolution: "code-block-writer@npm:7.3.1"
-  checksum: 3f1683603c10686d79b8ba31dcf9a1fc3f06c9078aac42c1012a89d6d77904bcb72c0f02cce9a7ad4bdf25ab88e80a0995c9e9b7ae321287b6a24992aad8100c
+"code-block-writer@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "code-block-writer@npm:10.1.1"
+  checksum: 8573816797ac20256b22d0c9c72743f6dcbcef2cb7e08e7761b3f7a3f2cdd3abe1c66ed9dda123f7c1e5e3746a5528fe3c09473758f1d1555fe4c69add334b28
   languageName: node
   linkType: hard
 
@@ -15814,7 +16934,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:3.0.2, commander@npm:^3.0.2":
+"commander@npm:3.0.2":
   version: 3.0.2
   resolution: "commander@npm:3.0.2"
   checksum: 8a279b4bacde68f03664086260ccb623122d2bdae6f380a41c9e06b646e830372c30a4b88261238550e0ad69d53f7af8883cb705d8237fdd22947e84913b149c
@@ -15860,6 +16980,13 @@ __metadata:
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
+  languageName: node
+  linkType: hard
+
+"commander@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "commander@npm:8.1.0"
+  checksum: 7a04521c6abf964912daff2eddf88840b7a0501b527feab73dd0cabd8daa0c36b76f7ddb88f7efcce16e2adaa30b8660b8ca9a42566e37ec5fcc038c0bad0238
   languageName: node
   linkType: hard
 
@@ -16057,7 +17184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"connect@npm:^3.6.6":
+"connect@npm:^3.6.6, connect@npm:^3.7.0":
   version: 3.7.0
   resolution: "connect@npm:3.7.0"
   dependencies:
@@ -16397,6 +17524,16 @@ __metadata:
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: 8c417b596c6063427491bebf72328f4baa0d232dcdbad1fe0cf9e0bdd21bbc04351217ae60f8078acc73e0200d6a0700e0547cfaf3a4f8d22394a301b2b98409
+  languageName: node
+  linkType: hard
+
+"core-js-compat@npm:^3.14.0, core-js-compat@npm:^3.16.0":
+  version: 3.16.0
+  resolution: "core-js-compat@npm:3.16.0"
+  dependencies:
+    browserslist: ^4.16.6
+    semver: 7.0.0
+  checksum: ba5db553ede1d21165cdd55121b480624619bf57529bfc972e90714ee2ef6c13b9780b918da6385eaba138b46787898c9748e594d04425e1f14768f4369ff18d
   languageName: node
   linkType: hard
 
@@ -16851,6 +17988,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crypto-js@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "crypto-js@npm:4.1.1"
+  checksum: 50cc66a35f2738171d9a6d80c85ba7d00cb6440b756db035ba9ccd03032c0a803029a62969ecd4c844106c980af87687c64b204dd967989379c4f354fb482d37
+  languageName: node
+  linkType: hard
+
 "crypto-random-string@npm:^1.0.0":
   version: 1.0.0
   resolution: "crypto-random-string@npm:1.0.0"
@@ -17107,6 +18251,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-select@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "css-select@npm:4.1.3"
+  dependencies:
+    boolbase: ^1.0.0
+    css-what: ^5.0.0
+    domhandler: ^4.2.0
+    domutils: ^2.6.0
+    nth-check: ^2.0.0
+  checksum: f6751ce514ecf89315af5157dbd4463ed0461d7194d02fc8b5dcd5b36e8d3ab79f49199fb712437cef3530b769717000babf7de3d8969d7ea08d8d940482501c
+  languageName: node
+  linkType: hard
+
 "css-selector-tokenizer@npm:^0.7.0":
   version: 0.7.3
   resolution: "css-selector-tokenizer@npm:0.7.3"
@@ -17170,6 +18327,13 @@ __metadata:
   version: 4.0.0
   resolution: "css-what@npm:4.0.0"
   checksum: d00bdd49bdf62010ab9b2c5e4bb9189af7c6d3103f3e397a41a4f3e9ca54d1a009bc6ea6e27906b16a6d0017acd3f542881f0e28515f40e420045bc7d783c259
+  languageName: node
+  linkType: hard
+
+"css-what@npm:^5.0.0, css-what@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "css-what@npm:5.0.1"
+  checksum: a1bec4996f51e416a28efe3b003a7fd33ff0d6a91cb97be483c647df1c499e0ae6a84849c01ae87a323fc45fdb77509da773dc9a8ebab652f0a81ac47ebbf80c
   languageName: node
   linkType: hard
 
@@ -17748,7 +18912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decache@npm:^4.5.1":
+"decache@npm:^4.6.0":
   version: 4.6.0
   resolution: "decache@npm:4.6.0"
   dependencies:
@@ -17911,6 +19075,13 @@ __metadata:
     abstract-leveldown: ~6.2.1
     inherits: ^2.0.3
   checksum: b1021314bfd5875b10e4c8c69429a69d37affc79df53aedf3c18a4bcd7460619220fa6b1bc309bcd85851c2c9c2b4da6cb03127abc08b715ff56da8aeae6b74f
+  languageName: node
+  linkType: hard
+
+"define-lazy-prop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "define-lazy-prop@npm:2.0.0"
+  checksum: db6c63864a9d3b7dc9def55d52764968a5af296de87c1b2cc71d8be8142e445208071953649e0386a8cc37cfcf9a2067a47207f1eb9ff250c2a269658fdae422
   languageName: node
   linkType: hard
 
@@ -18345,6 +19516,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-serializer@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "dom-serializer@npm:1.3.2"
+  dependencies:
+    domelementtype: ^2.0.1
+    domhandler: ^4.2.0
+    entities: ^2.0.0
+  checksum: 0a39ff0634da807b0e7b4e28d20305658e366d920050296ea6a306c29eb4094a1bf942a72ec2e51145f01efcff93e98eaa1eef4c299ca398e326a2e1c4641220
+  languageName: node
+  linkType: hard
+
 "dom-walk@npm:^0.1.0":
   version: 0.1.2
   resolution: "dom-walk@npm:0.1.2"
@@ -18370,6 +19552,13 @@ __metadata:
   version: 2.1.0
   resolution: "domelementtype@npm:2.1.0"
   checksum: 3d558e6bb66f0ca0cb08befb9ae3ee2844c88547e1ae56aa8e8b7fc16086b17073e81707a527e8555ebb06eaab354f73d28b6f0296bfca1a7b38e8ae75236561
+  languageName: node
+  linkType: hard
+
+"domelementtype@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "domelementtype@npm:2.2.0"
+  checksum: 0e3824e21fb9ff2cda9579ad04ef0068c58cc1746cf723560e1b4cb73ccae324062d468b25a576948459df7dd99e42d8a100b7fcfc6e05c8eefa2e6fed3f8f7d
   languageName: node
   linkType: hard
 
@@ -18418,6 +19607,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"domhandler@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "domhandler@npm:4.2.0"
+  dependencies:
+    domelementtype: ^2.2.0
+  checksum: fd4e6f1c986402e7a703b671c4f7bdb1dcf278d613ca02a38374eae9d1bba9b3b4d5983519ad902e43c5bd1281456d11f226694e7bb4cfc00dde6f1d5f3aa13e
+  languageName: node
+  linkType: hard
+
 "dompurify@npm:2.0.8":
   version: 2.0.8
   resolution: "dompurify@npm:2.0.8"
@@ -18443,6 +19641,17 @@ __metadata:
     domelementtype: ^2.0.1
     domhandler: ^4.0.0
   checksum: 123f0646a6e8977d85966b97a321c05da257250d9a1c0e4752d84dbe5f2a4e633629645213974c220f5882de19f1f1c05455cc194755b3c14f6782de6b95cd2f
+  languageName: node
+  linkType: hard
+
+"domutils@npm:^2.5.2, domutils@npm:^2.6.0, domutils@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "domutils@npm:2.7.0"
+  dependencies:
+    dom-serializer: ^1.0.1
+    domelementtype: ^2.2.0
+    domhandler: ^4.2.0
+  checksum: 0836bbec011ae7c19eea8653d9f924a0954e3af928b94d10856a4bc6169cf927b50b059255e230aa0444e46ecf05177dcfb75857cfdfd764c7b92c5d35a03a0c
   languageName: node
   linkType: hard
 
@@ -20830,18 +22039,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"event-stream@npm:3.3.4":
-  version: 3.3.4
-  resolution: "event-stream@npm:3.3.4"
+"event-stream@npm:4.0.1":
+  version: 4.0.1
+  resolution: "event-stream@npm:4.0.1"
   dependencies:
-    duplexer: ~0.1.1
-    from: ~0
-    map-stream: ~0.1.0
-    pause-stream: 0.0.11
-    split: 0.3
-    stream-combiner: ~0.0.4
-    through: ~2.3.1
-  checksum: c3ec4e1efc27ab3e73a98923f0a2fa9a19051b87068fea2f3d53d2e4e8c5cfdadf8c8a115b17f3d90b16a46432d396bad91b6e8d0cceb3e449be717a03b75209
+    duplexer: ^0.1.1
+    from: ^0.1.7
+    map-stream: 0.0.7
+    pause-stream: ^0.0.11
+    split: ^1.0.1
+    stream-combiner: ^0.2.2
+    through: ^2.3.8
+  checksum: cedb3f7ffda81f1524b66c284b4a41bb8407246bd7fe461b89a07807d28753460596e430f1346c135a64c5ba88d2a5d0711d072379b39c2266756125877aebd5
   languageName: node
   linkType: hard
 
@@ -21309,6 +22518,19 @@ __metadata:
     micromatch: ^4.0.2
     picomatch: ^2.2.1
   checksum: d3b90c1debb01a3f359491fd04ad474f2e5030a37245971b32d5c967a920c4efca74ebba786f1ebcb602442af1f88815af792b8a662125f74be24b98f2235bb4
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.2.5":
+  version: 3.2.7
+  resolution: "fast-glob@npm:3.2.7"
+  dependencies:
+    "@nodelib/fs.stat": ^2.0.2
+    "@nodelib/fs.walk": ^1.2.3
+    glob-parent: ^5.1.2
+    merge2: ^1.3.0
+    micromatch: ^4.0.4
+  checksum: cc820a9acbd99c51267d525ed3c0c368b57d273f8d34e2401eef824390ff38ff419af3c0308d4ec1aef3dae0e24d1ac1dfe3156e5c702d63416a4c877ab7e0c4
   languageName: node
   linkType: hard
 
@@ -22175,7 +23397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"from@npm:~0":
+"from@npm:^0.1.7":
   version: 0.1.7
   resolution: "from@npm:0.1.7"
   checksum: 3aab5aea8fe8e1f12a5dee7f390d46a93431ce691b6222dcd5701c5d34378e51ca59b44967da1105a0f90fcdf5d7629d963d51e7ccd79827d19693bdcfb688d4
@@ -22236,6 +23458,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "fs-extra@npm:10.0.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 85802f3d9e49d197744a8372f0d78d5a1faa3df73f4c5375d6366a4b9f745197d3da1f095841443d50f29a9f81cdc01363eb6d17bef2ba70c268559368211040
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^4.0.2":
   version: 4.0.3
   resolution: "fs-extra@npm:4.0.3"
@@ -22255,17 +23488,6 @@ __metadata:
     jsonfile: ^4.0.0
     universalify: ^0.1.0
   checksum: c67598fb6060101787b0389186db2fdcd8f706dc5dda450cac4f1d171f9a6118f390e7cf9af752fe1c3056ce554380a68fa7ed6a162199dc48087c74e0f96484
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "fs-extra@npm:6.0.1"
-  dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^4.0.0
-    universalify: ^0.1.0
-  checksum: 553145c864b620f6d421104203231fe25adfbeaf6dfb44bd494fbb73cafa7efaa90393aa020ee94ee300a2a17f01c6cd75903ef4be342f43090dfa5082c9309e
   languageName: node
   linkType: hard
 
@@ -22414,7 +23636,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@^2.1.2, fsevents@^2.1.3, fsevents@~2.3.1":
+"fsevents@^2.1.2, fsevents@^2.1.3, fsevents@~2.3.1, fsevents@~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -22442,7 +23664,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.1.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.1.3#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.1.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.1.3#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=1cc4b2"
   dependencies:
@@ -22849,6 +24071,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
+  version: 5.1.2
+  resolution: "glob-parent@npm:5.1.2"
+  dependencies:
+    is-glob: ^4.0.1
+  checksum: cab87638e2112bee3f839ef5f6e0765057163d39c66be8ec1602f3823da4692297ad4e972de876ea17c44d652978638d2fd583c6713d0eb6591706825020c9ee
+  languageName: node
+  linkType: hard
+
 "glob-promise@npm:^3.4.0":
   version: 3.4.0
   resolution: "glob-promise@npm:3.4.0"
@@ -22925,6 +24156,20 @@ fsevents@^1.2.7:
     once: ^1.3.0
     path-is-absolute: ^1.0.0
   checksum: 520146ebce0f4594b8357338f86281b38ee14214debce398a2902176a28f18e0f98911ea48516d85022de64fbbaa57f074aa13715d1daa5d70e21b82cea22183
+  languageName: node
+  linkType: hard
+
+"glob@npm:^7.1.7":
+  version: 7.1.7
+  resolution: "glob@npm:7.1.7"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.0.4
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 173245e6f9ccf904309eb7ef4a44a11f3bf68e9e341dff5a28b5db0dd7123b7506daf41497f3437a0710f57198187b758c2351eeaabce4d16935e956920da6a4
   languageName: node
   linkType: hard
 
@@ -23053,7 +24298,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"globby@npm:8.0.2, globby@npm:^8.0.1":
+"globby@npm:8.0.2":
   version: 8.0.2
   resolution: "globby@npm:8.0.2"
   dependencies:
@@ -23274,7 +24519,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.0.4, handlebars@npm:^4.3.3, handlebars@npm:^4.7.3, handlebars@npm:^4.7.6":
+"handlebars@npm:^4.0.4, handlebars@npm:^4.7.3, handlebars@npm:^4.7.6, handlebars@npm:^4.7.7":
   version: 4.7.7
   resolution: "handlebars@npm:4.7.7"
   dependencies:
@@ -23824,7 +25069,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"html-entities@npm:^2.1.0":
+"html-entities@npm:^2.1.0, html-entities@npm:^2.3.2":
   version: 2.3.2
   resolution: "html-entities@npm:2.3.2"
   checksum: 69b50d032435e02765175d40ac3d94ceeb19b3ee32b869f79804f24f8efadf7928a1c3c4eddb85273809f95f7cffa416d05ca43e88d219575e8c5f6dd75bfc8d
@@ -24111,15 +25356,34 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"http-auth@npm:3.1.x":
-  version: 3.1.3
-  resolution: "http-auth@npm:3.1.3"
+"htmlparser2@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "htmlparser2@npm:6.1.0"
+  dependencies:
+    domelementtype: ^2.0.1
+    domhandler: ^4.0.0
+    domutils: ^2.5.2
+    entities: ^2.0.0
+  checksum: 3058499c95634f04dc66be8c2e0927cd86799413b2d6989d8ae542ca4dbf5fa948695d02c27d573acf44843af977aec6d9a7bdd0f6faa6b2d99e2a729b2a31b6
+  languageName: node
+  linkType: hard
+
+"http-auth-connect@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "http-auth-connect@npm:1.0.5"
+  checksum: 93e07fc89241b30b990cb6599fe240de0974b8cbcfee65b18b545afd485f1d1577563e88f4da6bea3954e36baa3caa5579b9f636e35610b431742a93c5d8c57a
+  languageName: node
+  linkType: hard
+
+"http-auth@npm:4.1.7":
+  version: 4.1.7
+  resolution: "http-auth@npm:4.1.7"
   dependencies:
     apache-crypt: ^1.1.2
     apache-md5: ^1.0.6
-    bcryptjs: ^2.3.0
-    uuid: ^3.0.0
-  checksum: 3c96d9c87724ba78e01fb7ca22e5bb4b9a6fd914d73c5317fc6b460a270d7eed21a2eb6215498d64cbeae35785637917a3f96cfaa2f95f9382ba7e51c49fb9e2
+    bcryptjs: ^2.4.3
+    uuid: ^3.4.0
+  checksum: 2d8082ab41e74109b8984f5edf8c4e5ebd87022adba3b7da81b580440b59b6916bad10197fc1cabb1275def9be78051da85ad58ec751f3a4592b7b53ae721a8b
   languageName: node
   linkType: hard
 
@@ -24398,12 +25662,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"i18next@npm:^17.0.16":
-  version: 17.3.1
-  resolution: "i18next@npm:17.3.1"
+"i18next@npm:^20.3.2":
+  version: 20.3.5
+  resolution: "i18next@npm:20.3.5"
   dependencies:
-    "@babel/runtime": ^7.3.1
-  checksum: 214cf7279ebdf3f40e41b7b19f1a621f41a32007eb9098008181e804f8e0c2cb8f5600a471d522f2337a6304bae289a10a962e1c14d15f95abc52eaf42f5fb5f
+    "@babel/runtime": ^7.12.0
+  checksum: 87bb515479d8c8b4155638c52059ce59dac6d619625a7e31a8a44f89024d11882793129646d3ed62183a4f693f2bef10be8bdc2db5e7b420a114596d45493108
   languageName: node
   linkType: hard
 
@@ -24422,6 +25686,15 @@ fsevents@^1.2.7:
   dependencies:
     safer-buffer: ">= 2.1.2 < 3.0.0"
   checksum: e2655b4185225d25f9b69d736d0224f91275a5bd7bb27a37d0d1adc0727d32d28c428a9a48c8046b49588f2ab34d37f53ea8d5652dcf3afadc10261f343cde1c
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "iconv-lite@npm:0.6.3"
+  dependencies:
+    safer-buffer: ">= 2.1.2 < 3.0.0"
+  checksum: 98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
   languageName: node
   linkType: hard
 
@@ -24958,16 +26231,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-absolute@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-absolute@npm:1.0.0"
-  dependencies:
-    is-relative: ^1.0.0
-    is-windows: ^1.0.1
-  checksum: 422302ce879d4f3ca6848499b6f3ddcc8fd2dc9f3e9cad3f6bcedff58cdfbbbd7f4c28600fffa7c59a858f1b15c27fb6cfe1d5275e58a36d2bf098a44ef5abc4
-  languageName: node
-  linkType: hard
-
 "is-accessor-descriptor@npm:^0.1.6":
   version: 0.1.6
   resolution: "is-accessor-descriptor@npm:0.1.6"
@@ -25196,6 +26459,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"is-docker@npm:^2.1.1":
+  version: 2.2.1
+  resolution: "is-docker@npm:2.2.1"
+  bin:
+    is-docker: cli.js
+  checksum: e828365958d155f90c409cdbe958f64051d99e8aedc2c8c4cd7c89dcf35329daed42f7b99346f7828df013e27deb8f721cf9408ba878c76eb9e8290235fbcdcc
+  languageName: node
+  linkType: hard
+
 "is-dom@npm:^1.0.0":
   version: 1.1.0
   resolution: "is-dom@npm:1.1.0"
@@ -25373,13 +26645,6 @@ fsevents@^1.2.7:
   version: 1.0.0
   resolution: "is-module@npm:1.0.0"
   checksum: 795a3914bcae7c26a1c23a1e5574c42eac13429625045737bf3e324ce865c0601d61aee7a5afbca1bee8cb300c7d9647e7dc98860c9bdbc3b7fdc51d8ac0bffc
-  languageName: node
-  linkType: hard
-
-"is-negated-glob@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-negated-glob@npm:1.0.0"
-  checksum: f9d4fb2effd7a6d0e4770463e4cf708fbff2d5b660ab2043e5703e21e3234dfbe9974fdd8c08eb80f9898d5dd3d21b020e8d07fce387cd394a79991f01cd8d1c
   languageName: node
   linkType: hard
 
@@ -25585,15 +26850,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-relative@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-relative@npm:1.0.0"
-  dependencies:
-    is-unc-path: ^1.0.0
-  checksum: 61157c4be8594dd25ac6f0ef29b1218c36667259ea26698367a4d9f39ff9018368bc365c490b3c79be92dfb1e389e43c4b865c95709e7b3bc72c5932f751fb60
-  languageName: node
-  linkType: hard
-
 "is-resolvable@npm:^1.0.0, is-resolvable@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-resolvable@npm:1.1.0"
@@ -25692,15 +26948,6 @@ fsevents@^1.2.7:
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 4c096275ba041a17a13cca33ac21c16bc4fd2d7d7eb94525e7cd2c2f2c1a3ab956e37622290642501ff4310601e413b675cf399ad6db49855527d2163b3eeeec
-  languageName: node
-  linkType: hard
-
-"is-unc-path@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-unc-path@npm:1.0.0"
-  dependencies:
-    unc-path-regex: ^0.1.2
-  checksum: ac1b78f9b748196e3be3d0e722cd4b0f98639247a130a8f2473a58b29baf63fdb1b1c5a12c830660c5ee6ef0279c5418ca8e346f98cbe1a29e433d7ae531d42e
   languageName: node
   linkType: hard
 
@@ -27703,7 +28950,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"json5@npm:2.x, json5@npm:^2.0.0, json5@npm:^2.1.0, json5@npm:^2.1.2, json5@npm:^2.1.3":
+"json5@npm:2.x, json5@npm:^2.0.0, json5@npm:^2.1.0, json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.0":
   version: 2.2.0
   resolution: "json5@npm:2.2.0"
   dependencies:
@@ -28561,29 +29808,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"live-server@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "live-server@npm:1.2.1"
-  dependencies:
-    chokidar: ^2.0.4
-    colors: latest
-    connect: ^3.6.6
-    cors: latest
-    event-stream: 3.3.4
-    faye-websocket: 0.11.x
-    http-auth: 3.1.x
-    morgan: ^1.9.1
-    object-assign: latest
-    opn: latest
-    proxy-middleware: latest
-    send: latest
-    serve-index: ^1.9.1
-  bin:
-    live-server: ./live-server.js
-  checksum: 4c92b1bba674fc54f9568fd77c046510de57f0e35a0a143b2850e8de55b9a82ba7273f8dfc0d81a2bf870b28dd4f0169c7bfa74c2e54e1bd7db5bf53c85af98b
-  languageName: node
-  linkType: hard
-
 "livereload-js@npm:^3.3.1":
   version: 3.3.1
   resolution: "livereload-js@npm:3.3.1"
@@ -29258,7 +30482,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"loglevel@npm:^1.6.2, loglevel@npm:^1.6.4, loglevel@npm:^1.6.8":
+"loglevel@npm:^1.6.2, loglevel@npm:^1.6.8, loglevel@npm:^1.7.1":
   version: 1.7.1
   resolution: "loglevel@npm:1.7.1"
   checksum: 14b481b7f5a3e2405f2c54c7a5914ba0e65c6cbc961dc90dc8ec67e1cf0ce549330ff5ab9024e52f232f8f2ca78ef27286f72c38f495ba8ab281aff18763b53c
@@ -29377,7 +30601,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lunr@npm:>= 2.3.0 < 2.4.0, lunr@npm:^2.3.6":
+"lunr@npm:>= 2.3.0 < 2.4.0, lunr@npm:^2.3.9":
   version: 2.3.9
   resolution: "lunr@npm:2.3.9"
   checksum: 77d7dbb4fbd602aac161e2b50887d8eda28c0fa3b799159cee380fbb311f1e614219126ecbbd2c3a9c685f1720a8109b3c1ca85cc893c39b6c9cc6a62a1d8a8b
@@ -29397,6 +30621,13 @@ fsevents@^1.2.7:
   version: 2.4.1
   resolution: "macos-release@npm:2.4.1"
   checksum: bef96f10ba72c34921ff509e466391a5d3dbacfc04bb5d1933bae9e5d268f37cd221508e8a7e3ec7b9f2127362a48677ca9aee591031563966a8d33d7176f4e7
+  languageName: node
+  linkType: hard
+
+"macos-release@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "macos-release@npm:2.5.0"
+  checksum: afc644cccd509b1275a479ca695d7c254b910b156e8d6311a7864b954f004f8e4a20e65f976e456b95046717de1d15d87f08c37ea64b418292abc75622ea2e96
   languageName: node
   linkType: hard
 
@@ -29564,10 +30795,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"map-stream@npm:~0.1.0":
-  version: 0.1.0
-  resolution: "map-stream@npm:0.1.0"
-  checksum: 7dd6debe511c1b55d9da75e1efa65a28b1252a2d8357938d2e49b412713c478efbaefb0cdf0ee0533540c3bf733e8f9f71e1a15aa0fe74bf71b64e75bf1576bd
+"map-stream@npm:0.0.7":
+  version: 0.0.7
+  resolution: "map-stream@npm:0.0.7"
+  checksum: 77da244656dad5013bd147b0eef6f0343a212f14761332b97364fe348d4d70f0b8a0903457d6fc88772ec7c3d4d048b24f8db3aa5c0f77a8ce8bf2391473b8ec
   languageName: node
   linkType: hard
 
@@ -29688,12 +30919,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"marked@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "marked@npm:0.7.0"
+"marked@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "marked@npm:2.1.3"
   bin:
-    marked: ./bin/marked
-  checksum: dc888ca89cfdab52ae46f198deef361c89639d064f47cc9627544142a39877cff953e796362259d6867deb05d18696f611522b2c948a1530117699ccff55a699
+    marked: bin/marked
+  checksum: 1f520ee847911284d7992966aeb46bd9fba09f1f6ada753cb20b0ad5c0d802accd07ef1596abe45d9221cac6bdc106d7487e39dee1249b345b71a354e124a13d
   languageName: node
   linkType: hard
 
@@ -30132,6 +31363,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"micromatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "micromatch@npm:4.0.4"
+  dependencies:
+    braces: ^3.0.1
+    picomatch: ^2.2.3
+  checksum: 87bc95e3e52ebe413dbadd43c96e797c736bf238f154e3b546859493e83781b6f7fa4dfa54e423034fb9aeea65259ee6480551581271c348d8e19214910a5a64
+  languageName: node
+  linkType: hard
+
 "miller-rabin@npm:^4.0.0":
   version: 4.0.1
   resolution: "miller-rabin@npm:4.0.1"
@@ -30552,7 +31793,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"morgan@npm:^1.10.0, morgan@npm:^1.9.1":
+"morgan@npm:^1.10.0":
   version: 1.10.0
   resolution: "morgan@npm:1.10.0"
   dependencies:
@@ -30650,18 +31891,6 @@ fsevents@^1.2.7:
   bin:
     multicast-dns: cli.js
   checksum: 972fc50869e922d80d66eeb91ad39fd2e107241e0c791fc914e76578e4f7f3dfe3bf007020dd4d7ed4d0ffd69d9aa2238a9f8bbb4d160bd6eb3f35dde0c2c513
-  languageName: node
-  linkType: hard
-
-"multimatch@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "multimatch@npm:2.1.0"
-  dependencies:
-    array-differ: ^1.0.0
-    array-union: ^1.0.1
-    arrify: ^1.0.0
-    minimatch: ^3.0.0
-  checksum: acfdecb0bb259009abb4c484f2107c99974d7c4fb590fb2e4e170456ca4ced322335883e26ef874afaa6a6189cc9325a3c68498371644a3b6776f08a6820fbb1
   languageName: node
   linkType: hard
 
@@ -31889,6 +33118,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"open@npm:8.2.1":
+  version: 8.2.1
+  resolution: "open@npm:8.2.1"
+  dependencies:
+    define-lazy-prop: ^2.0.0
+    is-docker: ^2.1.1
+    is-wsl: ^2.2.0
+  checksum: 341f89950df8868ee957fe2370121f6ff1e4359b4cec84a48ed38153d16cb7abb8770102a80fd25c8f5dd10c40eae4ad107c396026c7d7ba4582ec7ecb1e9f8e
+  languageName: node
+  linkType: hard
+
 "open@npm:^6.3.0":
   version: 6.4.0
   resolution: "open@npm:6.4.0"
@@ -31908,7 +33148,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"opencollective-postinstall@npm:^2.0.0, opencollective-postinstall@npm:^2.0.2":
+"opencollective-postinstall@npm:^2.0.0, opencollective-postinstall@npm:^2.0.2, opencollective-postinstall@npm:^2.0.3":
   version: 2.0.3
   resolution: "opencollective-postinstall@npm:2.0.3"
   bin:
@@ -31939,15 +33179,6 @@ fsevents@^1.2.7:
   dependencies:
     is-wsl: ^1.1.0
   checksum: 03f78b1ab464fd0d97543e2a90e47ca872e2324696bc13f741467693060fe058e87e38e9cfc9f3b568e60dfb31579fbe664d8e806b2f219262c423da953bba4c
-  languageName: node
-  linkType: hard
-
-"opn@npm:latest":
-  version: 6.0.0
-  resolution: "opn@npm:6.0.0"
-  dependencies:
-    is-wsl: ^1.1.0
-  checksum: a1097314e18e455849917391df8df61ec32699b0e7ef974b400815cc4f43c4d954b9e2009252a08c5e65bf2a8995e1205ae14dc5d72b663bda90e2bb4a3d56be
   languageName: node
   linkType: hard
 
@@ -32077,6 +33308,16 @@ fsevents@^1.2.7:
     macos-release: ^2.2.0
     windows-release: ^3.1.0
   checksum: da45495c391606afbefc4fcc5bf2ac37f92a32280a2ec8ed66d723b52a71783d65c1ad9e63f5f4a6d172f90e904de854627588cce9555bcad417d0e615d7e217
+  languageName: node
+  linkType: hard
+
+"os-name@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "os-name@npm:4.0.1"
+  dependencies:
+    macos-release: ^2.5.0
+    windows-release: ^4.0.0
+  checksum: 2a78bb1a25afa04ec53a972ed164948432fee93d9e039afaec3a27ffe30473ffc85afb03c0776ca3e01c8d806f99f61cb85ad3fbc060bc3e37a549c0a4867f3f
   languageName: node
   linkType: hard
 
@@ -32767,6 +34008,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"path-browserify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "path-browserify@npm:1.0.1"
+  checksum: 8b8c3fd5c66bd340272180590ae4ff139769e9ab79522e2eb82e3d571a89b8117c04147f65ad066dccfb42fcad902e5b7d794b3d35e0fd840491a8ddbedf8c66
+  languageName: node
+  linkType: hard
+
 "path-dirname@npm:^1.0.0":
   version: 1.0.2
   resolution: "path-dirname@npm:1.0.2"
@@ -32909,7 +34157,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pause-stream@npm:0.0.11":
+"pause-stream@npm:^0.0.11":
   version: 0.0.11
   resolution: "pause-stream@npm:0.0.11"
   dependencies:
@@ -32931,7 +34179,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pdfkit@npm:>=0.8.1, pdfkit@npm:^0.11.0":
+"pdfkit@npm:>=0.8.1":
   version: 0.11.0
   resolution: "pdfkit@npm:0.11.0"
   dependencies:
@@ -32943,16 +34191,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pdfmake@npm:^0.1.60":
-  version: 0.1.70
-  resolution: "pdfmake@npm:0.1.70"
+"pdfmake@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "pdfmake@npm:0.2.2"
   dependencies:
-    iconv-lite: ^0.6.2
-    linebreak: ^1.0.2
-    pdfkit: ^0.11.0
+    "@foliojs-fork/linebreak": ^1.1.1
+    "@foliojs-fork/pdfkit": ^0.12.3
+    iconv-lite: ^0.6.3
     svg-to-pdfkit: ^0.1.8
     xmldoc: ^1.1.2
-  checksum: ddd5c33b8c26c9930495390c95e091a3c2ac6a310881f3a6f47e8c41511a23af0f1ddb96dce6a9af55ad9f0b4f3616a493aa66222d50882088b0d9f60b220d30
+  checksum: 3f5456a49fc5da445e639d38c2649e415b0a6aa09e03215acbfe63f926a81e95fa912e866683289a3d38c4ff37e4fea685c6bb5871ac2d11141c19b633fa8cf7
   languageName: node
   linkType: hard
 
@@ -32981,6 +34229,13 @@ fsevents@^1.2.7:
   version: 2.2.2
   resolution: "picomatch@npm:2.2.2"
   checksum: 0fa37cfc2ceaf7cc1021ec1936841351a2fcbcfbb50540994a4531c77ac613dd78ef9d2ee93b1afc18c02642a9a51e5115c728427fc1f1df2b5d231b720569f0
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^2.2.3":
+  version: 2.3.0
+  resolution: "picomatch@npm:2.3.0"
+  checksum: a65bde78212368e16afb82429a0ea033d20a836270446acb53ec6e31d939bccf1213f788bc49361f7aff47b67c1fb74d898f99964f67f26ca07a3cd815ddbcbb
   languageName: node
   linkType: hard
 
@@ -36718,6 +37973,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: ^2.2.1
+  checksum: 6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
+  languageName: node
+  linkType: hard
+
 "readjson@npm:^2.0.1":
   version: 2.2.2
   resolution: "readjson@npm:2.2.2"
@@ -38694,6 +39958,17 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.3.5":
+  version: 7.3.5
+  resolution: "semver@npm:7.3.5"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: d450455b2601396dbc7d9f058a6709b1c0b99d74a911f9436c77887600ffcdb5f63d5adffa0c3b8f0092937d8a41cc61c6437bcba375ef4151cb1335ebe4f1f9
+  languageName: node
+  linkType: hard
+
 "semver@npm:~5.3.0":
   version: 5.3.0
   resolution: "semver@npm:5.3.0"
@@ -39608,16 +40883,7 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"split@npm:0.3":
-  version: 0.3.3
-  resolution: "split@npm:0.3.3"
-  dependencies:
-    through: 2
-  checksum: 88c09b1b4de84953bf5d6c153123a1fbb20addfea9381f70d27b4eb6b2bfbadf25d313f8f5d3fd727d5679b97bfe54da04766b91010f131635bf49e51d5db3fc
-  languageName: node
-  linkType: hard
-
-"split@npm:^1.0.0":
+"split@npm:^1.0.0, split@npm:^1.0.1":
   version: 1.0.1
   resolution: "split@npm:1.0.1"
   dependencies:
@@ -39900,12 +41166,13 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"stream-combiner@npm:~0.0.4":
-  version: 0.0.4
-  resolution: "stream-combiner@npm:0.0.4"
+"stream-combiner@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "stream-combiner@npm:0.2.2"
   dependencies:
     duplexer: ~0.1.1
-  checksum: 8075a94c0eb0f20450a8236cb99d4ce3ea6e6a4b36d8baa7440b1a08cde6ffd227debadffaecd80993bd334282875d0e927ab5b88484625e01970dd251004ff5
+    through: ~2.3.4
+  checksum: b5d2782fbfa9251c88e01af1b1f54bc183673a776989dce2842b345be7fc3ce7eb2eade363b3c198ba0e5153a20a96e0014d0d0e884153f885d7ee919f22b639
   languageName: node
   linkType: hard
 
@@ -41362,7 +42629,7 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.4, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.1, through@npm:~2.3.4":
+"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.4, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.4":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
@@ -41924,6 +43191,16 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
+"ts-morph@npm:^11.0.3":
+  version: 11.0.3
+  resolution: "ts-morph@npm:11.0.3"
+  dependencies:
+    "@ts-morph/common": ~0.10.1
+    code-block-writer: ^10.1.1
+  checksum: 007cbfabe1bafa8901603ba069997ca3af349548e5e973d37784776eafcb692fa03eac46fa662b226c2a891409f7739177a1ebd56e561950f24e52c22bf376a5
+  languageName: node
+  linkType: hard
+
 "ts-node@npm:^9.1.0":
   version: 9.1.1
   resolution: "ts-node@npm:9.1.1"
@@ -41962,24 +43239,6 @@ resolve@1.19.0:
     typescript:
       optional: true
   checksum: ff32b4f810f9d99f676d70fe2c0e327cb6c812214bd4fc7135870b039f9e85a85b2c20f8fe030d9bd36e9598a12faa391f10aecb95df624b92f1af6bd47dc397
-  languageName: node
-  linkType: hard
-
-"ts-simple-ast@npm:12.4.0":
-  version: 12.4.0
-  resolution: "ts-simple-ast@npm:12.4.0"
-  dependencies:
-    "@dsherret/to-absolute-glob": ^2.0.2
-    code-block-writer: ^7.2.0
-    fs-extra: ^6.0.1
-    glob-parent: ^3.1.0
-    globby: ^8.0.1
-    is-negated-glob: ^1.0.0
-    multimatch: ^2.1.0
-    object-assign: ^4.1.1
-    tslib: ^1.9.0
-    typescript: 2.9.1
-  checksum: f25fdf249c5e83bc405318e5919501b5248b973b5671dcc8ffa11e2f5b4de6339e23418cc4616b6b693a1dcc1a7278c3080754397173c3d1c433041b3a7cf401
   languageName: node
   linkType: hard
 
@@ -42036,6 +43295,13 @@ resolve@1.19.0:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "tslib@npm:2.3.0"
+  checksum: a845aed84e7e7dbb4c774582da60d7030ea39d67307250442d35c4c5dd77e4b44007098c37dd079e100029c76055f2a362734b8442ba828f8cc934f15ed9be61
   languageName: node
   linkType: hard
 
@@ -42237,16 +43503,6 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-typescript@2.9.1:
-  version: 2.9.1
-  resolution: "typescript@npm:2.9.1"
-  bin:
-    tsc: ./bin/tsc
-    tsserver: ./bin/tsserver
-  checksum: 755e51418a4d579e084f5e749d9c1f7596efc28129fe6fb5067b19112a92acde0b4c5bf87e2698e3fee265047e6536e4124edd80398f667de811bb9956301932
-  languageName: node
-  linkType: hard
-
 "typescript@4.1.5, typescript@^4.0.3, typescript@^4.1.0-dev.20200804, typescript@^4.1.3":
   version: 4.1.5
   resolution: "typescript@npm:4.1.5"
@@ -42264,16 +43520,6 @@ typescript@2.9.1:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 821fc1088d34269af54845094497784ede68fc68417b5f4a174b8ec48bafb8c558177b05a0cc151830ef8110de09dd5bd0e8f29c1124b395af47319110fd1ef4
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@2.9.1#~builtin<compat/typescript>":
-  version: 2.9.1
-  resolution: "typescript@patch:typescript@npm%3A2.9.1#~builtin<compat/typescript>::version=2.9.1&hash=d8b4e7"
-  bin:
-    tsc: ./bin/tsc
-    tsserver: ./bin/tsserver
-  checksum: 2503d140c47fb6a6aab1e85467c53f0154cb98dbe8e8b4eb21160e57803ebfe0bc1e9bc8ea5a6d3c2b347d1d54fce1782f5285128261092e4d82ae6716cc5e9d
   languageName: node
   linkType: hard
 
@@ -42343,13 +43589,6 @@ typescript@2.9.1:
   version: 1.1.0
   resolution: "umask@npm:1.1.0"
   checksum: 22f308853eb94f919c18d5be155ad5182416841e9e95921d8f056d70df023fa02ec861dd23687243eeaf16bb5aea09a4690539fe50ed9562bb818432f554c638
-  languageName: node
-  linkType: hard
-
-"unc-path-regex@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "unc-path-regex@npm:0.1.2"
-  checksum: bf9c781c4e2f38e6613ea17a51072e4b416840fbe6eeb244597ce9b028fac2fb6cfd3dde1f14111b02c245e665dc461aab8168ecc30b14364d02caa37f812996
   languageName: node
   linkType: hard
 
@@ -44604,6 +45843,15 @@ typescript@2.9.1:
   dependencies:
     execa: ^1.0.0
   checksum: d81add605d94583724f0e7f4257e5f074cc3e6583b69ff79852cc191fa9e4686412476928adb28799fb27929db7eb1f07b282348ae072c80f6973ea42dc6dc74
+  languageName: node
+  linkType: hard
+
+"windows-release@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "windows-release@npm:4.0.0"
+  dependencies:
+    execa: ^4.0.2
+  checksum: 5c0ce2603a85e25e9a5c78eb1ef646aac7036da2fb942643f2120b11fc33ed94fbcdd340b2abbf27daa522efc9e52df36fe95b1c03cd9acd8d6c6c39f88f106b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #15591 #14116

## What I did

Use rawdescription over description for generated comments when available. rawdescription has no HTML tags and escaped characters so the Storybook comments. This will also fix the nested <p> error in console logs 

This fixes #15591 & #14116

Compodoc also updated to 1.1.14 to allow this change.

## How to test

I updated a Story property comment to include an apostrophe. Snapshots also had to be updated as HTML formatting is now removed when using rawdescription 

