### PR TITLE
Core: Fix main.js glob resolution for direct paths in stories

### DIFF
--- a/lib/core-common/src/utils/__tests__/to-require-context.test.ts
+++ b/lib/core-common/src/utils/__tests__/to-require-context.test.ts
@@ -142,6 +142,23 @@ const testCases = [
       '../src/stories/components/Icon/Icon.mdx',
     ],
   },
+  {
+    glob: '../src/stories/components/Icon.stories.js',
+    recursive: false,
+    validPaths: ['../src/stories/components/Icon.stories.js'],
+    invalidPaths: [
+      '../src/Icon.stories.mdx',
+      '../src/stories/components/Icon.stories/Icon.stories.mdx',
+      '../src/stories/components/Icon/Icon.mdx',
+      '../src/stories/components/Icon/Icon.stories.js',
+      '../src/stories/components/Icon/Icon.stories.ts',
+      '../src/stories/Icon.stories.js',
+      '../src/stories/Icon.stories.mdx',
+      './Icon.stories.js',
+      './src/stories/Icon.stories.js',
+      './stories.js',
+    ],
+  },
   // DUMB GLOB
   {
     glob: '../src/stories/**/*.stories.[tj]sx',

--- a/lib/core-common/src/utils/to-require-context.ts
+++ b/lib/core-common/src/utils/to-require-context.ts
@@ -33,7 +33,7 @@ export const toRequireContext = (input: any) => {
       const base = globResult.isGlob
         ? globResult.prefix + globResult.base
         : path.dirname(fixedInput);
-      const globFallback = base !== '.' ? fixedInput.substr(base.length) : fixedInput;
+      const globFallback = base !== '.' ? fixedInput.substr(base.length + 1) : fixedInput;
       const glob = globResult.isGlob ? globResult.glob : globFallback;
 
       const regex = makeRe(glob, {


### PR DESCRIPTION
Issue: #15746

## What I did

I extended the fallback variant to exclude the slash directly after the base path as recommended by @dcwarwick in the linked issue.
There is now also a test for this case.