### PR TITLE
CSF: Infer defaultValue of argtype based on arg

### DIFF
--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -36,16 +36,20 @@ export interface Args {
   [key: string]: any;
 }
 
-export interface ArgType {
+export interface ArgType<Arg = unknown> {
   name?: string;
   description?: string;
-  defaultValue?: any;
+  defaultValue?: Arg;
   [key: string]: any;
 }
 
-export type ArgTypes<Args = Record<string, any>> = {
-  [key in keyof Partial<Args>]: ArgType;
-};
+export type ArgTypes<GenericArgs = Args> = {
+  [key in keyof Partial<GenericArgs>]: ArgType<GenericArgs[key]>;
+} &
+  {
+    // for custom defined args
+    [key in string]: ArgType<unknown>;
+  };
 
 export interface StoryIdentifier {
   id: StoryId;


### PR DESCRIPTION
An extension on top of #14356

## What I did

ArgTypes is now able to infer the values based on the Args being passed.
If a custom argtype is being passed (that's not a key of passed down Args), it will still infer the correct properties, but `defaultValue` will be of type `unknown`.


## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? not necessarily
- Does this need an update to the documentation? not sure [?]

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
