### PR TITLE
Chore: (Docs) Adjusts the docs for syntax highlighting

### DIFF
--- a/docs/snippets/common/my-component-with-custom-syntax-highlight.mdx.mdx
+++ b/docs/snippets/common/my-component-with-custom-syntax-highlight.mdx.mdx
@@ -1,0 +1,31 @@
+````md
+<!-- MyComponent.stories.mdx -->
+
+import { Meta } from '@storybook/addon-docs';
+
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+
+<Meta title="A Storybook story with a custom syntax highlight for SCSS" />
+
+# SCSS example
+
+This is a sample SCSS code block example highlighted in Storybook
+
+<!-- Don't forget to replace (") with (```) when you copy the snippet to your own app -->
+
+"scss
+$font-stack: Helvetica, sans-serif;
+$primary-color: #333;
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+"
+
+<!-- The usage of this "Component" is intentional to enable react-syntax-highlighter's own highlighter -->
+
+export const Component = () => {
+  return <SyntaxHighlighter/>;
+};
+````

--- a/docs/workflows/faq.md
+++ b/docs/workflows/faq.md
@@ -322,3 +322,23 @@ Yes, check the [addon's examples](https://github.com/mswjs/msw-storybook-addon/t
 ### Can I mock GraphQL mutations with Storybook's MSW addon?
 
 No, currently, the MSW addon only has support for GraphQL queries. If you're interested in including this feature, open an issue in the [MSW addon repository](https://github.com/mswjs/msw-storybook-addon) and follow up with the maintainer.
+
+### Why aren't my code blocks highlighted with Storybook MDX
+
+Out of the box, Storybook provides syntax highlighting for a set of languages (e.g., Javascript, Markdown, CSS, HTML, Typescript, GraphQL) that you can use with your code blocks. If you're writing your custom code blocks with MDX, you'll need to import the syntax highlighter manually. For example, if you're adding a code block for SCSS, adjust your story to the following:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+   'common/my-component-with-custom-syntax-highlight.mdx.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+<div class="aside">
+💡 Check <code>react-syntax-highlighter</code>'s <a href="https://github.com/react-syntax-highlighter/react-syntax-highlighter">documentation</a> for a list of available languages.
+</div>
+
+Applying this small change will enable you to add syntax highlight for SCSS or any other language available.

--- a/docs/writing-docs/mdx.md
+++ b/docs/writing-docs/mdx.md
@@ -169,7 +169,7 @@ To get a "documentation-only story" in your UI, define a `<Meta>` as you normall
 
 ### Syntax highlighting
 
-When writing your documentation with Storybook and MDX, you get syntax highlighting out of the box for most available languages (e.g., Javascript, Markdown, CSS, HTML, Typescript, GraphQL). For other formats, for instance, SCSS, you'll need to activate the syntax highlighter manually as such:
+When writing your documentation with Storybook and MDX, you get syntax highlighting out of the box for a handful of popular languages (Javascript, Markdown, CSS, HTML, Typescript, GraphQL). For other formats, for instance, SCSS, you'll need to extend the syntax highlighter manually:
 
 <!-- prettier-ignore-start -->
 

--- a/docs/writing-docs/mdx.md
+++ b/docs/writing-docs/mdx.md
@@ -8,7 +8,7 @@ title: 'MDX'
 
 </div>
 
-MDX is a [standard file format](https://mdxjs.com/) that combines Markdown with JSX. This means you can use Markdown’s terse syntax (such as # heading) for your documentation, write stories that compile to our component story format, and freely embed JSX component blocks at any point in the file. All at once.
+MDX is a [standard file format](https://mdxjs.com/) that combines Markdown with JSX. It means you can use Markdown’s terse syntax (such as # heading) for your documentation, write stories that compile to our component story format, and freely embed JSX component blocks at any point in the file. All at once.
 
 In addition, you can write pure documentation pages in MDX and add them to Storybook alongside your stories.
 
@@ -36,7 +36,7 @@ And here's how that's rendered in Storybook:
 
 ![MDX simple example result](./mdx-simple.png)
 
-As you can see there's a lot going on here. We're writing Markdown, we're writing JSX, and we're also defining Storybook stories that are drop-in compatible with the entire Storybook ecosystem.
+As you can see, a lot is going on here. We're writing Markdown, we're writing JSX, and we're also defining Storybook stories that are drop-in compatible with the entire Storybook ecosystem.
 
 Let's break it down.
 
@@ -96,8 +96,7 @@ Based on this principle, if the Badge story included the following `ArgTypes`:
 
 <!-- prettier-ignore-end -->
 
-
-Transitioning them into MDX format is quite seamless and would only require the following change to the story:
+Transitioning them into MDX format is relatively seamless and would only require the following change to the story:
 
 <!-- prettier-ignore-start -->
 
@@ -158,31 +157,54 @@ Global parameters and decorators work just like before.
 
 ## Documentation-only MDX
 
-Typically, when you use Storybook MDX, you define stories in the MDX and documentation is automatically associated with those stories. But what if you want to write Markdown-style documentation without any stories inside?
+Typically, when you use Storybook MDX, you define stories in the MDX, and documentation is automatically associated with those stories. But what if you want to write Markdown-style documentation without any stories inside?
 
-If you don't define stories in your MDX, you can write MDX documentation and associate it with an existing story, or embed that MDX as its own documentation node in your Storybook's navigation.
+Suppose you don't define stories in your MDX. In that case, you can write MDX documentation and associate it with an existing story or embed that MDX as its own documentation node in your Storybook's navigation.
 
 If you don't define a Meta, you can write Markdown and associate with an existing story. See ["CSF Stories with MDX Docs"](../../addons/docs/docs/recipes.md#csf-stories-with-mdx-docs).
 
-To get a "documentation-only story", in your UI, define a `<Meta>` as you normally would, but don't define any stories. It will show up in your UI as a documentation node:
+To get a "documentation-only story" in your UI, define a `<Meta>` as you normally would, but don't define any stories. It will show up in your UI as a documentation node:
 
 ![MDX docs only story](./mdx-documentation-only.png)
+
+### Syntax highlighting
+
+When writing your documentation with Storybook and MDX, you get syntax highlighting out of the box for most available languages (e.g., Javascript, Markdown, CSS, HTML, Typescript, GraphQL). For other formats, for instance, SCSS, you'll need to activate the syntax highlighter manually as such:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+   'common/my-component-with-custom-syntax-highlight.mdx.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+<div class="aside">
+💡 For a list of available languages, check <code>react-syntax-highlighter</code>'s <a href="https://github.com/react-syntax-highlighter/react-syntax-highlighter">documentation</a>.
+</div>
+
+Once you've updated your documentation, you'll see the code block properly highlighted. You can also apply the same principle to other unsupported formats (i.e., `diff`, `hbs`).
 
 ## Linking to other stories and pages
 
 When writing MDX, you may want to provide links to other stories or documentation pages and sections. You can use the `path` query string.
 
 Considering a story with ID `some--id`, this redirects to the **Docs** tab of the story:
+
 ```md
 [Go to specific documentation page](?path=/docs/some--id)
 ```
 
 This redirects to the **Canvas** tab of the story:
+
 ```md
 [Go to specific story canvas](?path=/story/some--id)
 ```
 
 You can also use anchors to target a specific section of a page:
+
 ```md
 [Go to the conclusion of the documentation page](?path=/docs/some--id#conclusion)
 ```


### PR DESCRIPTION
With this pull request, the documentation is updated to mention how to add syntax highlighting to MDX documentation.

Closes #15619, #13254 and #14605

What was done:
- The FAQ and MDX docs were updated to include documentation on how to further customize the documentation with custom docs blocks that are not supported out of the box in terms of syntax highlighting. And polished.
- Created a small snippet for the documentation.


Repo is [here](https://github.com/jonniebigodes/custom-syntax-highlighting-storybook) and deployment [here](https://6112dee55680f20039350558-nqmeqjdwct.chromatic.com/?path=/story/testing-syntax-highlight--page).

One caveat to this is the following, to prevent an incorrect parsing of the snippet used I replaced (```) with ("), left a note in there mentioning the fact.

Feel free to provide feedback