### PR TITLE
Chore: (Docs) Polishes the Essentials intro documentation

### DIFF
--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -2,7 +2,7 @@
 title: 'Essential addons'
 ---
 
-A major strength of Storybook are [addons](/addons/) that extend Storybook’s UI and behavior. There are many third-party addons as well as “official” addons developed by the Storybook core team. Storybook ships by default with a set of “essential” addons that add to the initial user experience.
+A major strength of Storybook are [addons](/addons/) that extend Storybook’s UI and behavior. Storybook ships by default with a set of “essential” addons that add to the initial user experience. There are many third-party addons as well as “official” addons developed by the Storybook core team.
 
 - [Docs](../writing-docs/introduction.md)
 - [Controls](./controls.md)
@@ -14,7 +14,8 @@ A major strength of Storybook are [addons](/addons/) that extend Storybook’s U
 - [Outline](/addons/storybook-addon-outline)
 
 ### Installation
-If you're running `sb init` to add Storybook to your project, the essentials package (`@storybook/addon-essentials`) is already installed and configured for you . You can skip the rest of this section.
+
+If you ran `sb init` to include Storybook in your project, the Essentials addon (`@storybook/addon-essentials`) is already installed and configured for you. You can skip the rest of this section.
 
 If you're upgrading from a previous Storybook version, you'll need to run the following command in your terminal:
 
@@ -26,7 +27,7 @@ npm install --save-dev @storybook/addon-essentials
 💡 <strong>Note</strong>: If you're using <a href="https://yarnpkg.com/">yarn</a> as a package manager, you'll need to adjust the command accordingly.
 </div>
 
-Update your Storybook configuration (in `.storybook/main.js`) to include the essentials addon.
+Update your Storybook configuration (in `.storybook/main.js`) to include the Essentials addon.
 
 ```js
 // .storybook/main.js
@@ -36,20 +37,19 @@ module.exports = {
 };
 ```
 
-
 ### Configuration
 
-Essentials is "zero config”, it comes with a recommended configuration out of the box.
+Essentials is "zero-config”. It comes with a recommended configuration out of the box.
 
-If you need to reconfigure any of the essential addons, install it manually, following the installation instructions and adjust the configuration to your needs.
+If you need to reconfigure any of the individual essential addons, install them manually by following its installation instructions and adjusting its configuration to suit your needs.
 
-When you start Storybook, Essentials will override its configuration with your own.
+When you start Storybook, your custom configuration will override the default.
 
 ### Disabling addons
 
 If you need to disable any of the Essential's addons, you can do it by changing your [`.storybook/main.js`](../configure/overview.md#configure-story-rendering) file.
 
-As an example, if the background addon wasn't necessary to your work, you would need to make the following change:
+For example, if you wanted to disable the [backgrounds addon](./backgrounds.md), you would apply the following change to your Storybook configuration:
 
 <!-- prettier-ignore-start -->
 
@@ -63,6 +63,6 @@ As an example, if the background addon wasn't necessary to your work, you would 
 
 <div class="aside">
 
-You can use the following keys for each individual addon: `actions`, `backgrounds`, `controls`, `docs`, `viewport`, `toolbars`.
+💡 You can use the following keys for each individual addon: `actions`, `backgrounds`, `controls`, `docs`, `viewport`, `toolbars`, `measure`, `outline`.
 
 </div>


### PR DESCRIPTION
With this pull request, the Essentials (Introduction) is updated and polished a bit for clarity. Also in this is one small adjustment to the aside at the bottom of the page to mention how to disable the measure and outline addon individually.

Feel free to provide feedback