### PR TITLE
docs(@storybook/server): fix typo in server README

### DIFF
--- a/app/server/README.md
+++ b/app/server/README.md
@@ -202,7 +202,7 @@ Just like CSF stories we can define `argTypes` to specify the controls used in t
 ```json
 {
   "title": "Buttons",
-  "argTypess": {
+  "argTypes": {
     "color": { "control": { "type": "color" } }
   },
   "stories": [


### PR DESCRIPTION
Issue:

## What I did

I found a typo while reading the docs on the server setup.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
