### PR TITLE
CLI: Improve typings of Angular components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
           destination: cypress
   e2e-tests-core:
     executor:
-      class: medium
+      class: large
       name: sb_cypress_6_node_12
     parallelism: 2
     steps:

--- a/lib/cli/src/frameworks/angular/User.ts
+++ b/lib/cli/src/frameworks/angular/User.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface User {}

--- a/lib/cli/src/frameworks/angular/header.component.ts
+++ b/lib/cli/src/frameworks/angular/header.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { User } from './User';
 
 @Component({
   selector: 'storybook-header',
@@ -50,7 +51,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 })
 export default class HeaderComponent {
   @Input()
-  user: unknown = null;
+  user: User | null = null;
 
   @Output()
   onLogin = new EventEmitter<Event>();

--- a/lib/cli/src/frameworks/angular/page.component.ts
+++ b/lib/cli/src/frameworks/angular/page.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { User } from './User';
 
 @Component({
   selector: 'storybook-page',
@@ -61,7 +62,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 })
 export default class PageComponent {
   @Input()
-  user: unknown = null;
+  user: User | null = null;
 
   @Output()
   onLogin = new EventEmitter<Event>();


### PR DESCRIPTION
## What I did

Follows https://github.com/storybookjs/storybook/pull/15812 in order to fix e2e tests.

I improved the types of `user` input in the angular components used as templates when running `sb init`.
Using an `unknown` type was breaking the SB control when the latest version of `compodoc` is used.

## How to test

- Angular e2e tests should be 🟢  on CI
