### PR TITLE
Update babel.ts

### DIFF
--- a/lib/core-common/src/utils/babel.ts
+++ b/lib/core-common/src/utils/babel.ts
@@ -8,8 +8,6 @@ const plugins = [
    * https://babeljs.io/docs/en/babel-plugin-transform-typescript#typescript-compiler-options
    */
   [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
-  [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
-  [require.resolve('@babel/plugin-proposal-private-methods'), { loose: true }],
   require.resolve('@babel/plugin-proposal-export-default-from'),
   require.resolve('@babel/plugin-syntax-dynamic-import'),
   [


### PR DESCRIPTION
Issue:  https://github.com/storybookjs/storybook/issues/15840

Removed `@babel/plugin-proposal-class-properties` and `@babel/plugin-proposal-private-methods`, since they are now enabled by default in `@babel/preset-env` in babel `7.14.0`

## What I did

Removed `@babel/plugin-proposal-class-properties` and `@babel/plugin-proposal-private-methods`, from `lib/core-common/src/utils/babel.ts` since they are now enabled by default in `@babel/preset-env` in babel `7.14.0`

## Note

This is my first PR to storybook so I'm not 100% sure if this is the right approach

