### PR TITLE
fix warning when default exports exists

### DIFF
--- a/addons/controls/src/preset/ensureDocsBeforeControls.ts
+++ b/addons/controls/src/preset/ensureDocsBeforeControls.ts
@@ -30,11 +30,12 @@ export const ensureDocsBeforeControls = (configDir: string) => {
   try {
     // eslint-disable-next-line global-require,import/no-dynamic-require
     const main = require(mainFile);
-    if (!main?.addons) {
+    const addons = main?.addons || main?.default?.addons;
+    if (!addons) {
       logger.warn(`Unable to find main.js addons: ${mainFile}`);
       return;
     }
-    if (!verifyDocsBeforeControls(main.addons)) {
+    if (!verifyDocsBeforeControls(addons)) {
       logger.warn(dedent`
         Expected '@storybook/addon-docs' to be listed before '@storybook/addon-controls' (or '@storybook/addon-essentials'). Check your main.js?
         If addon-docs or addon-essentials is included by another addon/preset you can safely ignore this warning.


### PR DESCRIPTION
Issue: None

## What I did

- When using `.storybook/main.js`, it does not change anything.
- When using `.storybook/main.ts`, it removes unnecessary warnings.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

## Description

```text
WARN Unable to find main.js addons: /path/to/.storybook/main
```

I found an unnecessary warning above during `start-storybook`. I surely had `addons` field, but the warning was not removed.

I debugged for minutes, and I found out `.storybook/main.ts` with below made the warning:

```typescript
// .storybook/main.ts
export default {
  stories: ['../src/**/*.stories.tsx'],
  addons: ['@storybook/addon-essentials'],
};
```

Since it is es module, the properties (ex `stories`, `addons`) cannot be access directly with `require(mainFile)`. It is nested.

```javascript
// ideally `require(mainFile)`
{
  stories: [/* storybook stories */],
  addons: [/* storybook addons */]
}

// actually `require(mainFile)`
{
  default: {
    stories: [/* storybook stories */],
    addons: [/* storybook addons */]
  }
}
```

This PR adds simple guards for this case.
