### PR TITLE
Angular: Fix Cannot read property 'selector' of undefined

### DIFF
--- a/app/angular/src/client/preview/angular-beta/utils/NgComponentAnalyzer.test.ts
+++ b/app/angular/src/client/preview/angular-beta/utils/NgComponentAnalyzer.test.ts
@@ -13,7 +13,12 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
-import { getComponentInputsOutputs, isComponent, isDeclarable } from './NgComponentAnalyzer';
+import {
+  getComponentInputsOutputs,
+  isComponent,
+  isDeclarable,
+  getComponentDecoratorMetadata,
+} from './NgComponentAnalyzer';
 
 describe('getComponentInputsOutputs', () => {
   it('should return empty if no I/O found', () => {
@@ -156,6 +161,15 @@ describe('isComponent', () => {
     class FooDirective {}
 
     expect(isComponent(FooDirective)).toEqual(false);
+  });
+});
+
+describe('getComponentDecoratorMetadata', () => {
+  it('should return Component with a Component', () => {
+    @Component({})
+    class FooComponent {}
+
+    expect(getComponentDecoratorMetadata(FooComponent)).toBeInstanceOf(Component);
   });
 });
 

--- a/app/angular/src/client/preview/angular-beta/utils/NgComponentAnalyzer.ts
+++ b/app/angular/src/client/preview/angular-beta/utils/NgComponentAnalyzer.ts
@@ -136,5 +136,14 @@ export const getComponentDecoratorMetadata = (component: any): Component | undef
       ? Reflect.getOwnPropertyDescriptor(component, decoratorKey).value
       : component[decoratorKey];
 
-  return (decorators || []).find((d) => d instanceof Component);
+  if (!decorators) {
+    return (
+      component.decorators &&
+      component.decorators[0] &&
+      component.decorators[0].args &&
+      component.decorators[0].args[0]
+    );
+  }
+
+  return decorators.find((d) => d instanceof Component);
 };


### PR DESCRIPTION
Issue: #14828

## What I did

This fixes the [issue 14828](https://github.com/storybookjs/storybook/issues/14828). 
```
 Cannot read property 'selector' of undefined
```
This issue happens when trying to import an Angular component which has been already compiled. The Issue is explained [here](https://github.com/storybookjs/storybook/issues/14828#issuecomment-882118035) by @KondakovArtem. 

Here is a [reproduction of the issue](https://github.com/saulodias/storybook-i14828). All the code except for the last commit, where I created the `my-lib.stories.ts` file has been automatically generated with the following commands, using the `@angular/cli@11.2.14`.

```
ng new storybook-i14828 --create-application=false
cd storybook-i14828
ng generate library my-lib
npx sb init
```

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
  - The previous Jest test already safisfies the condition. I made sure the method will still return undefined, which was already a valid tested return type, if it doesn't find any decorators.

- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
