### PR TITLE
CLI/Storyshots: Specify custom sb extract Chromium exe

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/README.md
+++ b/addons/storyshots/storyshots-puppeteer/README.md
@@ -123,6 +123,8 @@ initStoryshots({
 });
 ```
 
+Alternatively, you may set the `SB_CHROMIUM_PATH` environment variable. If both are set, then `chromeExecutablePath` will take precedence.
+
 ### Specifying a custom Puppeteer `browser` instance
 
 You might use the async `getCustomBrowser` function to obtain a custom instance of a Puppeteer `browser` object. This will prevent `storyshots-puppeteer` from creating its own `browser`. It will create and close pages within the `browser`, and it is your responsibility to manage the lifecycle of the `browser` itself.

--- a/addons/storyshots/storyshots-puppeteer/src/config.ts
+++ b/addons/storyshots/storyshots-puppeteer/src/config.ts
@@ -52,7 +52,7 @@ const asyncNoop: () => Promise<undefined> = async () => undefined;
 
 export const defaultCommonConfig: CommonConfig = {
   storybookUrl: 'http://localhost:6006',
-  chromeExecutablePath: undefined,
+  chromeExecutablePath: process.env.SB_CHROMIUM_PATH,
   getGotoOptions: noop,
   customizePage: asyncNoop,
   getCustomBrowser: undefined,

--- a/docs/workflows/storybook-composition.md
+++ b/docs/workflows/storybook-composition.md
@@ -23,7 +23,7 @@ In your [`storybook/main.js`](../configure/overview.md#configure-story-rendering
 <!-- prettier-ignore-end -->
 
 <div class="aside">
- We would like to point out that there's some limitations to composition. For now addons in composed Storybooks will not work as they do in non composed Storybooks. 
+ We would like to point out that there's some limitations to composition. For now addons in composed Storybooks will not work as they do in non composed Storybooks.
 </div>
 
 ## Compose local Storybooks
@@ -69,6 +69,12 @@ So far we've covered how we can use composition with local or published Storyboo
 ```shell
 npx sb extract
 ```
+
+<div class="aside">
+
+`sb extract` uses [Puppeteer](https://www.npmjs.com/package/puppeteer), which downloads and installs Chromium. Specify your own locally-installed Chromium executable by setting the environment variable `SB_CHROMIUM_PATH`.
+
+</div>
 
 Using this command will generate a `stories.json` file in the default build directory (`storybook-static`) with information regarding your Storybook. Here's how it might look:
 

--- a/lib/cli/src/extract.ts
+++ b/lib/cli/src/extract.ts
@@ -52,7 +52,7 @@ const useLocation: (input: string) => Promise<[string, () => void]> = async (inp
 const usePuppeteerBrowser: () => Promise<puppeteerCore.Browser> = async () => {
   const args = ['--no-sandbox ', '--disable-setuid-sandbox'];
   try {
-    return await puppeteerCore.launch({ args });
+    return await puppeteerCore.launch({ args, executablePath: process.env.SB_CHROMIUM_PATH });
   } catch (e) {
     // it's not installed
     logger.info('installing puppeteer...');


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13724

## What I did

Added environment variable `SB_CHROMIUM_PATH`, which enables a way to customize the Chromium executable used by `sb extract` and StoryShots, without an automatic download. StoryShots' existing config-based way of doing this will still work and will take precedence when both are used.

## How to test

1. Download Chromium (you can use Puppeteer's copy in `node_modules`).
2. Set the var. It can be an absolute or relative path to the executable.
3. Run `sb extract` / a StoryShots + Puppeteer test.

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [X] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
