### PR TITLE
Addon-docs: Fix refs support in Docs pages

### DIFF
--- a/examples/official-storybook/stories/addon-docs/ref.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/ref.stories.mdx
@@ -1,0 +1,20 @@
+import { useRef } from 'react';
+import { Meta, DocsContainer, Story } from '@storybook/addon-docs';
+
+<Meta
+  title="Addons/Docs/ref"
+/>
+
+## Passing React ref
+
+<Story name="ref">
+    {() => { 
+      const ref = useRef(null);
+      return (
+        <>
+          <div ref={ref} style={{ overflow: "hidden" }} />
+          <button onClick={() => console.log(ref.current)}>Log ref value</button>
+        </>
+      );
+    }}
+  </Story>

--- a/examples/official-storybook/stories/addon-docs/ref.stories.mdx
+++ b/examples/official-storybook/stories/addon-docs/ref.stories.mdx
@@ -1,20 +1,18 @@
 import { useRef } from 'react';
 import { Meta, DocsContainer, Story } from '@storybook/addon-docs';
 
-<Meta
-  title="Addons/Docs/ref"
-/>
+<Meta title="Addons/Docs/ref" />
 
 ## Passing React ref
 
 <Story name="ref">
-    {() => { 
-      const ref = useRef(null);
-      return (
-        <>
-          <div ref={ref} style={{ overflow: "hidden" }} />
-          <button onClick={() => console.log(ref.current)}>Log ref value</button>
-        </>
-      );
-    }}
-  </Story>
+  {() => {
+    const ref = useRef(null);
+    return (
+      <>
+        <div ref={ref} style={{ overflow: 'hidden' }} />
+        <button onClick={() => console.log(ref.current)}>Log ref value</button>
+      </>
+    );
+  }}
+</Story>

--- a/lib/components/src/index.ts
+++ b/lib/components/src/index.ts
@@ -1,4 +1,4 @@
-import { createElement, ElementType } from 'react';
+import { createElement, forwardRef, ElementType } from 'react';
 import { components as rawComponents } from './typography/DocumentFormatting';
 
 export { Badge } from './Badge/Badge';
@@ -56,7 +56,7 @@ export { rawComponents as components };
 const resetComponents: Record<string, ElementType> = {};
 
 Object.keys(rawComponents).forEach((key) => {
-  resetComponents[key] = (props: any) => createElement(key, props);
+  resetComponents[key] = forwardRef((props, ref) => createElement(key, { ...props, ref }));
 });
 
 export { resetComponents };


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/10446



## What I did

I wrapped components for Docs pages into [React.forwardRef](https://reactjs.org/docs/react-api.html#reactforwardref). Currently it's impossible to pass ref into `<span>blah blah</span>` for example because we override normal dom nodes [here](https://github.com/storybookjs/storybook/blob/7064642e1aee7786c77fe735c064c0c29dbcee01/lib/components/src/typography/DocumentFormatting.tsx#L366-L392).

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? — Not sure
- [X] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

--------

### Before:

![image](https://user-images.githubusercontent.com/5969049/130247485-2ebb5ada-ac82-4fc0-baed-6c7c69805f18.png)

### After: 
![image](https://user-images.githubusercontent.com/5969049/130247694-a2965017-d858-4018-86ba-6aea0f8075e7.png)


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
