### PR TITLE
Fix resetArgs example snippet

### DIFF
--- a/docs/snippets/common/args-usage-with-addons.js.mdx
+++ b/docs/snippets/common/args-usage-with-addons.js.mdx
@@ -9,7 +9,7 @@ const [args, updateArgs, resetArgs] = useArgs();
 updateArgs({ key: 'value' });
 
 // To reset one (or more) args:
-resetArgs((argNames: ['key']));
+resetArgs(['key']);
 
 // To reset all args
 resetArgs();


### PR DESCRIPTION
The example for `resetArgs` was cut-n-paste from typings without fixing
it to be valid code.