### PR TITLE
Ensuring that viewMode is taken into account when routing routes that include 'settings'

### DIFF
--- a/lib/ui/src/app.tsx
+++ b/lib/ui/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import sizeMe from 'react-sizeme';
 
 import { State } from '@storybook/api';
@@ -47,15 +47,21 @@ const App = React.memo<AppProps>(
           {
             key: 'settings',
             render: () => <SettingsPages />,
-            route: (({ children }) => (
-              <Route path="/settings" startsWith>
-                {children}
-              </Route>
-            )) as FunctionComponent,
+            route: ({ children }: { children: JSX.Element }) => {
+              if (viewMode === 'settings') {
+                return (
+                  <Route path="/settings" startsWith>
+                    {children}
+                  </Route>
+                );
+              }
+
+              return null;
+            },
           },
         ],
       }),
-      []
+      [viewMode]
     );
 
     if (!width || !height) {


### PR DESCRIPTION
Issue: [#14718](https://github.com/storybookjs/storybook/issues/14718)

## What I did
Added a check on `viewMode` to ensure that we only render the `/settings` routes if the `viewMode` is set to `settings`, this has also been added to the `useMemo()` dependencies so that it will be updated correctly.

From the local testing that I have done, there was no noticeable performance impact from adding `viewMode` as a dependency of `useMemo()`.

## How to test
There are three test scenarios that should be considered:

1. Go to any story, the actions panel should render correctly and be able to be interacted with.
2. Go to a story that has a name starting with the text "Settings" or "settings", the actions panel should render correctly and be able to be interacted with.
3. Navigate to one of the settings routes, this should render correctly.
