### PR TITLE
Chore: (Docs) Snippets updates for 6.4

### DIFF
--- a/docs/snippets/angular/app-story-with-mock.ts.mdx
+++ b/docs/snippets/angular/app-story-with-mock.ts.mdx
@@ -1,32 +1,27 @@
 ```ts
 // App.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
 import { AppComponent } from './app.component';
 
 export default {
   component: AppComponent,
-  title: 'App',
-} as Meta;
+};
 
-const Template: Story<AppComponent> = (args) => ({
-  props: args,
-});
-
-export const Success = Template.bind({});
-Success.parameters = {
-  fetch: {
-    json: {
-      JavaScript: 3390991,
-      'C++': 44974,
-      TypeScript: 15530,
-      CoffeeScript: 12253,
-      Python: 9383,
-      C: 5341,
-      Shell: 5115,
-      HTML: 3420,
-      CSS: 3171,
-      Makefile: 189,
+export const Success = {
+  parameters: {
+    fetch: {
+      json: {
+        JavaScript: 3390991,
+        'C++': 44974,
+        TypeScript: 15530,
+        CoffeeScript: 12253,
+        Python: 9383,
+        C: 5341,
+        Shell: 5115,
+        HTML: 3420,
+        CSS: 3171,
+        Makefile: 189,
+      },
     },
   },
 };

--- a/docs/snippets/angular/button-component-with-proptypes.ts.mdx
+++ b/docs/snippets/angular/button-component-with-proptypes.ts.mdx
@@ -5,12 +5,13 @@ import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'my-button',
-  template: ` <button type="button" [disabled]="isDisabled">
-    {{ content }}
-  </button>`,
+  template: `
+    <button type="button" [disabled]="isDisabled">
+      {{ content }}
+    </button>`,
   styleUrls: ['./button.css'],
 })
-export default class ButtonComponent {
+export class ButtonComponent {
   /**
    * Checks if the button should be disabled
    */

--- a/docs/snippets/angular/button-group-story.ts.mdx
+++ b/docs/snippets/angular/button-group-story.ts.mdx
@@ -1,8 +1,6 @@
 ```ts
 // ButtonGroup.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
-
 import { moduleMetadata } from '@storybook/angular';
 import { CommonModule } from '@angular/common';
 
@@ -13,7 +11,6 @@ import Button from './button.component';
 import * as ButtonStories from './Button.stories';
 
 export default {
-  title: 'ButtonGroup',
   component: ButtonGroup,
   decorators: [
     moduleMetadata({
@@ -21,18 +18,12 @@ export default {
       imports: [CommonModule],
     }),
   ],
-} as Meta;
+};
 
-const Template: Story<ButtonGroup> = (args) => ({
-  props: args,
-});
-
-export const Pair = Template.bind({});
-Pair.args = {
-  buttons: [
-    { ...ButtonStories.Primary.args },
-    { ...ButtonStories.Secondary.args },
-  ],
-  orientation: 'horizontal',
+export const Pair = {
+  args: {
+    buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
+    orientation: 'horizontal',
+  },
 };
 ```

--- a/docs/snippets/angular/button-group-story.ts.mdx
+++ b/docs/snippets/angular/button-group-story.ts.mdx
@@ -4,8 +4,8 @@
 import { moduleMetadata } from '@storybook/angular';
 import { CommonModule } from '@angular/common';
 
-import ButtonGroup from './ButtonGroup.component';
-import Button from './button.component';
+import { ButtonGroup } from './ButtonGroup.component';
+import { Button } from './button.component';
 
 //👇 Imports the Button stories
 import * as ButtonStories from './Button.stories';

--- a/docs/snippets/angular/button-implementation.ts.mdx
+++ b/docs/snippets/angular/button-implementation.ts.mdx
@@ -7,7 +7,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
   selector: 'button',
   template: `the component implementation markup`,
 })
-export default class ButtonComponent {
+export class ButtonComponent {
   /**
    * Is this the principal call to action on the page?
    */

--- a/docs/snippets/angular/button-story-click-handler-args.ts.mdx
+++ b/docs/snippets/angular/button-story-click-handler-args.ts.mdx
@@ -1,0 +1,22 @@
+```ts
+//  Button.stories.ts
+
+import { action } from '@storybook/addon-actions';
+
+import Button from './button.component';
+
+export default {
+  component: Button,
+};
+
+export const Text = {
+  args: {
+    label: 'Hello',
+    onClick: action('clicked'),
+  },
+  render: (args) => ({
+    props: args,
+    template: `<storybook-button [label]="label" (onClick)="onClick()"></storybook-button>`,
+  }),
+};
+```

--- a/docs/snippets/angular/button-story-click-handler-args.ts.mdx
+++ b/docs/snippets/angular/button-story-click-handler-args.ts.mdx
@@ -3,7 +3,7 @@
 
 import { action } from '@storybook/addon-actions';
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-click-handler.ts.mdx
+++ b/docs/snippets/angular/button-story-click-handler.ts.mdx
@@ -1,7 +1,7 @@
-```js
-// Button.stories.js
+```ts
+// Button.stories.ts
 
-import Button from 'Button.vue';
+import Button from './Button.component';
 
 import { action } from '@storybook/addon-actions';
 
@@ -11,9 +11,8 @@ export default {
 
 export const Text = {
   render: () => ({
-    components: { Button },
-    template: '<Button label="Hello" @click="onClick" />',
-    methods: {
+    props: {
+      label: 'Button',
       onClick: action('clicked'),
     },
   }),

--- a/docs/snippets/angular/button-story-click-handler.ts.mdx
+++ b/docs/snippets/angular/button-story-click-handler.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './Button.component';
+import { Button } from './button.component';
 
 import { action } from '@storybook/addon-actions';
 

--- a/docs/snippets/angular/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/angular/button-story-component-args-primary.ts.mdx
@@ -1,12 +1,9 @@
 ```ts
 // Button.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific argTypes
   argTypes: {
@@ -16,5 +13,5 @@ export default {
     //👇 Now all Button stories will be primary.
     primary: true,
   },
-} as Meta;
+};
 ```

--- a/docs/snippets/angular/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/angular/button-story-component-args-primary.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-component-decorator.ts.mdx
@@ -3,8 +3,8 @@
 
 import { componentWrapperDecorator, moduleMetadata } from '@storybook/angular';
 
-import Button from './button.component';
-import ParentComponent from './parent.component'; // ParentComponent contains ng-content
+import { Button } from './button.component';
+import { ParentComponent } from './parent.component'; // ParentComponent contains ng-content
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-component-decorator.ts.mdx
@@ -4,7 +4,7 @@
 import { componentWrapperDecorator, moduleMetadata } from '@storybook/angular';
 
 import { Button } from './button.component';
-import { ParentComponent } from './parent.component'; // ParentComponent contains ng-content
+import { Parent } from './parent.component'; // Parent contains ng-content
 
 export default {
   component: Button,
@@ -15,7 +15,7 @@ export default {
     // With template
     componentWrapperDecorator((story) => `<div style="margin: 3em">${story}</div>`),
     // With component which contains ng-content
-    componentWrapperDecorator(ParentComponent),
+    componentWrapperDecorator(Parent),
   ],
 };
 ```

--- a/docs/snippets/angular/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-component-decorator.ts.mdx
@@ -1,14 +1,13 @@
 ```ts
 // Button.stories.ts
 
-import { componentWrapperDecorator, Meta, moduleMetadata, Story } from '@storybook/angular';
+import { componentWrapperDecorator, moduleMetadata } from '@storybook/angular';
 
-import { ButtonComponent } from './button.component';
-import { ParentComponent } from './parent.component';
+import Button from './button.component';
+import ParentComponent from './parent.component'; // ParentComponent contains ng-content
 
 export default {
-  title: 'Components/Button',
-  component: ButtonComponent,
+  component: Button,
   decorators: [
     moduleMetadata({
       declarations: [ParentComponent],
@@ -18,14 +17,5 @@ export default {
     // With component which contains ng-content
     componentWrapperDecorator(ParentComponent),
   ],
-} as Meta;
-
-const Template: Story<ButtonComponent> = (args) => ({
-  props: args,
-  template: '<app-button label="Submit"></app-button>',
-});
-
-const Component: Story<ButtonComponent> = (args) => ({
-  props: args,
-});
+};
 ```

--- a/docs/snippets/angular/button-story-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-decorator.ts.mdx
@@ -3,8 +3,8 @@
 
 import { componentWrapperDecorator, moduleMetadata } from '@storybook/angular';
 
-import Button from './button.component';
-import ParentComponent from './parent.component'; // ParentComponent contains ng-content
+import { Button } from './button.component';
+import { ParentComponent } from './parent.component'; // ParentComponent contains ng-content
 
 export default {
   component: ButtonComponent,

--- a/docs/snippets/angular/button-story-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-decorator.ts.mdx
@@ -4,10 +4,10 @@
 import { componentWrapperDecorator, moduleMetadata } from '@storybook/angular';
 
 import { Button } from './button.component';
-import { ParentComponent } from './parent.component'; // ParentComponent contains ng-content
+import { Parent } from './parent.component'; // Parent contains ng-content
 
 export default {
-  component: ButtonComponent,
+  component: Button,
 };
 
 export const Primary = {
@@ -17,9 +17,9 @@ export const Primary = {
 export const InsideParent = {
   decorators: [
     moduleMetadata({
-      declarations: [ParentComponent],
+      declarations: [Parent],
     }),
-    componentWrapperDecorator(ParentComponent),
+    componentWrapperDecorator(Parent),
   ],
 };
 ```

--- a/docs/snippets/angular/button-story-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-decorator.ts.mdx
@@ -1,30 +1,25 @@
 ```ts
 // button.stories.ts
 
-import { Meta, Story, componentWrapperDecorator, moduleMetadata } from '@storybook/angular';
+import { componentWrapperDecorator, moduleMetadata } from '@storybook/angular';
 
-import { ButtonComponent } from './button.component';
-import { ParentComponent } from './parent.component'; // ParentComponent contains ng-content
+import Button from './button.component';
+import ParentComponent from './parent.component'; // ParentComponent contains ng-content
 
 export default {
-  title: 'Components/Button',
   component: ButtonComponent,
-} as Meta;
+};
 
-export const Primary: Story<ButtonComponent> = () => ({
-  template: '<app-button label="Submit"></app-button>',
-});
-Primary.decorators = [
-  componentWrapperDecorator((story) => `<div style="margin: 3em">${story}</div>`),
-];
+export const Primary = {
+  decorators: [componentWrapperDecorator((story) => `<div style="margin: 3em">${story}</div>`)],
+};
 
-export const InsideParent: Story<ButtonComponent> = () => ({
-  template: '<app-button label="Submit"></app-button>',
-});
-InsideParent.decorators = [
-  moduleMetadata({
-    declarations: [ParentComponent],
-  }),
-  componentWrapperDecorator(ParentComponent),
-];
+export const InsideParent = {
+  decorators: [
+    moduleMetadata({
+      declarations: [ParentComponent],
+    }),
+    componentWrapperDecorator(ParentComponent),
+  ],
+};
 ```

--- a/docs/snippets/angular/button-story-default-docs-code.ts.mdx
+++ b/docs/snippets/angular/button-story-default-docs-code.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-default-docs-code.ts.mdx
+++ b/docs/snippets/angular/button-story-default-docs-code.ts.mdx
@@ -12,7 +12,7 @@ export default {
 };
 
 //👇 Some function to demonstrate the behavior
-const someFunction = (someValue: String) => {
+const someFunction = (someValue: string) => {
   return `i am a ${someValue}`;
 };
 

--- a/docs/snippets/angular/button-story-default-docs-code.ts.mdx
+++ b/docs/snippets/angular/button-story-default-docs-code.ts.mdx
@@ -1,40 +1,39 @@
 ```ts
 // Button.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific argTypes
   argTypes: {
-    backgroundColor: { control: 'color' }
-  }
-} as Meta;
+    backgroundColor: { control: 'color' },
+  },
+};
 
 //👇 Some function to demonstrate the behavior
-const someFunction = (someValue: string) => {
+const someFunction = (someValue: String) => {
   return `i am a ${someValue}`;
 };
 
-export const ExampleStory: Story<Button> = (args) => {
-  //👇 Destructure the label from the args object
-  const { label } = args;
-  
-  //👇 Assigns the function result to a variable and pass it as a prop into the component
-  const functionResult = someFunction(label);
-  return {
-    props: {
-      ...args,
-      label: functionResult,
-    },
-  };
-};
-ExampleStory.args = {
-  primary: true,
-  size: 'small',
-  label: 'button',
+export const ExampleStory = {
+  args: {
+    primary: true,
+    size: 'small',
+    label: 'button',
+  },
+  render: (args) => {
+    //👇 Destructure the label from the args object
+    const { label } = args;
+
+    //👇 Assigns the function result to a variable and pass it as a prop into the component
+    const functionResult = someFunction(label);
+    return {
+      props: {
+        ...args,
+        label: functionResult,
+      },
+    };
+  },
 };
 ```

--- a/docs/snippets/angular/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/angular/button-story-default-export-with-component.ts.mdx
@@ -1,12 +1,11 @@
 ```ts
 // Button.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-} as Meta;
+  //👇 Title is optional, you can omit it and Storybook automatically generates the title for the story
+  title: 'Components/Button',
+};
 ```

--- a/docs/snippets/angular/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/angular/button-story-default-export-with-component.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-rename-story.ts.mdx
+++ b/docs/snippets/angular/button-story-rename-story.ts.mdx
@@ -1,20 +1,20 @@
 ```ts
 // Button.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-} as Meta;
+};
 
-export const Primary = () => ({
-  props: {
-    label: 'Button',
-  },
-});
+export const Primary = {
+  render: () => ({
+    props: {
+      label: 'Button',
+      primary: true,
+    },
+  }),
+};
 
 Primary.storyName = 'I am the primary';
 ```

--- a/docs/snippets/angular/button-story-rename-story.ts.mdx
+++ b/docs/snippets/angular/button-story-rename-story.ts.mdx
@@ -8,6 +8,7 @@ export default {
 };
 
 export const Primary = {
+  name: 'I am the primary',
   render: () => ({
     props: {
       label: 'Button',
@@ -15,6 +16,4 @@ export const Primary = {
     },
   }),
 };
-
-Primary.storyName = 'I am the primary';
 ```

--- a/docs/snippets/angular/button-story-rename-story.ts.mdx
+++ b/docs/snippets/angular/button-story-rename-story.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-using-args.ts.mdx
+++ b/docs/snippets/angular/button-story-using-args.ts.mdx
@@ -1,20 +1,30 @@
 ```ts
 // Button.stories.ts
 
-import { Story } from '@storybook/angular/types-6-0';
+import Button from './button.component';
 
-//👇 We create a “template” of how args map to rendering
-const Template: Story<Button> = (args) => ({
-  props: args,
-});
+export default {
+  component: Button,
+};
 
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-Primary.args = { background: '#ff0', label: 'Button' };
+export const Primary = {
+  args: {
+    label: 'Button',
+    backgroundColor: '#ff0',
+  },
+};
 
-export const Secondary = Template.bind({});
-Secondary.args = { ...Primary.args, label: '😄👍😍💯' };
+export const Secondary = {
+  args: {
+    ...Primary.args,
+    label: '😄👍😍💯',
+  },
+};
 
-export const Tertiary = Template.bind({});
-Tertiary.args = { ...Primary.args, label: '📚📕📈🤓' };
+export const Tertiary = {
+  args: {
+    ...Primary.args,
+    label: '📚📕📈🤓',
+  },
+};
 ```

--- a/docs/snippets/angular/button-story-using-args.ts.mdx
+++ b/docs/snippets/angular/button-story-using-args.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/angular/button-story-with-addon-example.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/angular/button-story-with-addon-example.ts.mdx
@@ -1,12 +1,9 @@
 ```ts
 // Button.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific parameters for the story
   parameters: {
@@ -14,5 +11,11 @@ export default {
       data: 'this data is passed to the addon',
     },
   },
-} as Meta;
+};
+
+export const Basic = {
+  render: () => ({
+    template: `<app-button>hello</<app-button>`,
+  }),
+};
 ```

--- a/docs/snippets/angular/button-story-with-args.ts.mdx
+++ b/docs/snippets/angular/button-story-with-args.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 //Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-with-args.ts.mdx
+++ b/docs/snippets/angular/button-story-with-args.ts.mdx
@@ -1,25 +1,16 @@
 ```ts
 //Button.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-} as Meta;
+};
 
-//👇 We create a “template” of how args map to rendering
-const Template: Story<Button> = (args) => ({
-  props: args,
-});
-
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-
-Primary.args = {
-  primary: true,
-  label: 'Button',
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
 };
 ```

--- a/docs/snippets/angular/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/angular/button-story-with-blue-args.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/angular/button-story-with-blue-args.ts.mdx
@@ -1,12 +1,10 @@
 ```ts
 // Button.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Components/Button',
+  component: Button,
   //👇 Creates specific parameters for the story
   parameters: {
     backgrounds: {
@@ -17,5 +15,5 @@ export default {
       ],
     },
   },
-} as Meta;
+};
 ```

--- a/docs/snippets/angular/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/angular/button-story-with-emojis.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/angular/button-story-with-emojis.ts.mdx
@@ -1,33 +1,36 @@
 ```ts
 // Button.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-} as Meta;
+};
 
-export const Primary = () => ({
-  props: {
-    label: 'Button',
-    background: '#ff0',
-  },
-});
+export const Primary = {
+  render: () => ({
+    props: {
+      label: 'Button',
+      backgroundColor: '#ff0',
+    },
+  }),
+};
 
-export const Secondary = () => ({
-  props: {
-    label: '😄👍😍💯',
-    background: '#ff0',
-  },
-});
+export const Secondary = {
+  render: () => ({
+    props: {
+      label: '😄👍😍💯',
+      backgroundColor: '#ff0',
+    },
+  }),
+};
 
-export const Tertiary = () => ({
-  props: {
-    label: '📚📕📈🤓',
-    background: '#ff0',
-  },
-});
+export const Tertiary = {
+  render: () => ({
+    props: {
+      label: '📚📕📈🤓',
+      backgroundColor: '#ff0',
+    },
+  }),
+};
 ```

--- a/docs/snippets/angular/button-story-with-parameters.ts.mdx
+++ b/docs/snippets/angular/button-story-with-parameters.ts.mdx
@@ -1,12 +1,9 @@
 ```ts
 // Button.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
-  title: 'Button',
   component: Button,
   parameters: {
     backgrounds: {
@@ -16,5 +13,5 @@ export default {
       ],
     },
   },
-} as Meta;
+};
 ```

--- a/docs/snippets/angular/button-story.ts.mdx
+++ b/docs/snippets/angular/button-story.ts.mdx
@@ -1,18 +1,18 @@
 ```ts
 // Button.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
 import Button from './button.component';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-} as Meta;
+};
 
-export const Primary = () => ({
-  props: {
-    label: 'Button',
-  },
-});
+export const Primary = {
+  render: () => ({
+    props: {
+      label: 'Button',
+      primary: true,
+    },
+  }),
+};
 ```

--- a/docs/snippets/angular/button-story.ts.mdx
+++ b/docs/snippets/angular/button-story.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Button.stories.ts
 
-import Button from './button.component';
+import { Button } from './button.component';
 
 export default {
   component: Button,

--- a/docs/snippets/angular/checkbox-story-csf.ts.mdx
+++ b/docs/snippets/angular/checkbox-story-csf.ts.mdx
@@ -1,10 +1,9 @@
 ```ts
 // Checkbox.stories.ts
 
-import Checkbox from './Checkbox.component';
+import { Checkbox } from './Checkbox.component';
 
 export default {
-  title: 'MDX/Checkbox',
   component: Checkbox,
 };
 

--- a/docs/snippets/angular/checkbox-story-csf.ts.mdx
+++ b/docs/snippets/angular/checkbox-story-csf.ts.mdx
@@ -1,22 +1,22 @@
 ```ts
 // Checkbox.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
-
 import Checkbox from './Checkbox.component';
 
 export default {
   title: 'MDX/Checkbox',
   component: Checkbox,
-} as Meta;
+};
 
-export const allCheckboxes = () => ({
-    template:`
+export const allCheckboxes = () => {
+  render: () => ({
+    template: `
       <form>
         <Checkbox id="Unchecked" label="Unchecked" />
         <Checkbox id="Checked" label="Checked" checked />
         <Checkbox appearance="secondary" id="second" label="Secondary" checked />
       </form>
     `,
-});
+  });
+};
 ```

--- a/docs/snippets/angular/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/angular/component-story-custom-args-complex.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // YourComponent.stories.ts
 
-import YourComponent from './your.component';
+import { YourComponent } from './your-component.component';
 
 export default {
   component: YourComponent,

--- a/docs/snippets/angular/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/angular/component-story-custom-args-complex.ts.mdx
@@ -1,40 +1,39 @@
 ```ts
 // YourComponent.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
-
 import YourComponent from './your.component';
-
-// a function to apply some computations
-const someFunction = (valuePropertyA: string, valuePropertyB: string) => {
-  // makes some computations and returns something
-};
 
 export default {
   component: YourComponent,
-  title: 'A complex case with a function',
-  // creates specific argTypes with options
+  //👇 Creates specific argTypes with options
   argTypes: {
     propertyA: {
       options: ['Item One', 'Item Two', 'Item Three'],
-      control: { type: 'select' } // automatically inferred when 'options' is defined
+      control: { type: 'select' }, // automatically inferred when 'options' is defined
     },
     propertyB: {
-      options: ['Another Item One', 'Another Item Two', 'Another Item Three']
+      options: ['Another Item One', 'Another Item Two', 'Another Item Three'],
     },
   },
-} as Meta;
+};
 
-const Template: Story<YourComponent> = (args) => {
-  const { propertyA, propertyB } = args;
+//👇 Some function to demonstrate the behavior
+const someFunction = (valuePropertyA: String, valuePropertyB: String) => {
+  // Makes some computations and returns something
+};
 
-  const someFunctionResult = someFunction(propertyA, propertyB);
-  
-  return {
-    props: {
-      ...args,
-      someProperty: someFunctionResult,
-    },
-  };
+export const ExampleStory = {
+  args: { propertyA: 'Something', propertyB: 'Something else' },
+  render: (args) => {
+    const { propertyA, propertyB } = args;
+    //👇 Assigns the function result to a variable
+    const someFunctionResult = someFunction(propertyA, propertyB);
+    return {
+      props: {
+        ...args,
+        someProperty: someFunctionResult,
+      },
+    };
+  },
 };
 ```

--- a/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // MyComponent.stories.ts
 
-import MyComponent from './MyComponent.component';
+import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
@@ -7,7 +7,7 @@ export default {
   component: MyComponent,
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     props: {
       src: 'https://place-hold.it/350x150',

--- a/docs/snippets/angular/component-story-static-asset-with-import.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-with-import.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // MyComponent.stories.ts
 
-import MyComponent from './MyComponent.component';
+import { MyComponent } from './MyComponent.component';
 
 import imageFile from './static/image.png';
 

--- a/docs/snippets/angular/component-story-static-asset-with-import.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-with-import.ts.mdx
@@ -1,24 +1,25 @@
 ```ts
 // MyComponent.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
+import MyComponent from './MyComponent.component';
 
 import imageFile from './static/image.png';
 
 export default {
-  title: 'img',
-} as Meta;
+  component: MyComponent,
+};
 
 const image = {
   src: imageFile,
   alt: 'my image',
 };
 
-export const withAnImage = () => ({
-  template: `<img src="{{src}}" alt="{{alt}}" />`,
-  props: {
-    src: image.src,
-    alt: image.alt,
-  },
-});
+export const withAnImage = {
+  render: () => ({
+    props: {
+      src: image.src,
+      alt: image.alt,
+    },
+  }),
+};
 ```

--- a/docs/snippets/angular/component-story-static-asset-with-import.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-with-import.ts.mdx
@@ -14,7 +14,7 @@ const image = {
   alt: 'my image',
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     props: {
       src: image.src,

--- a/docs/snippets/angular/component-story-static-asset-without-import.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-without-import.ts.mdx
@@ -7,7 +7,7 @@ export default {
   component: MyComponent,
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     props: {
       src: '/image.png',

--- a/docs/snippets/angular/component-story-static-asset-without-import.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-without-import.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // MyComponent.stories.ts
 
-import MyComponent from './MyComponent.component';
+import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/angular/component-story-static-asset-without-import.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-without-import.ts.mdx
@@ -1,13 +1,18 @@
 ```ts
 // MyComponent.stories.ts
 
-import { Meta } from '@storybook/angular/types-6-0';
+import MyComponent from './MyComponent.component';
 
 export default {
-  title: 'img',
-} as Meta;
+  component: MyComponent,
+};
 
-export const withAnImage = () => ({
-  template: `<img src="/image.png" alt="my image"/>`
-});
+export const withAnImage = {
+  render: () => ({
+    props: {
+      src: '/image.png',
+      alt: 'my image',
+    },
+  }),
+};
 ```

--- a/docs/snippets/angular/document-screen-fetch.ts.mdx
+++ b/docs/snippets/angular/document-screen-fetch.ts.mdx
@@ -19,7 +19,7 @@ import { HttpClient } from '@angular/common/http';
     </div>
   `,
 })
-export default class DocumentScreen implements OnInit {
+export class DocumentScreen implements OnInit {
   user: any = { id: 0, name: 'Some User' };
 
   document: any = { id: 0, title: 'Some Title' };

--- a/docs/snippets/angular/documentscreen-story-msw-graphql-query.ts.mdx
+++ b/docs/snippets/angular/documentscreen-story-msw-graphql-query.ts.mdx
@@ -8,10 +8,10 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { graphql } from 'msw';
 
-import DocumentScreen from './YourPage.component';
-import DocumentList from './DocumentList.component';
-import DocumentHeader from './DocumentHeader.component';
-import PageLayout from './PageLayout.component';
+import { DocumentScreen } from './YourPage.component';
+import { DocumentList } from './DocumentList.component';
+import { DocumentHeader } from './DocumentHeader.component';
+import { PageLayout } from './PageLayout.component';
 
 import { MockGraphQLModule } from './mock-graphql.module';
 

--- a/docs/snippets/angular/documentscreen-story-msw-graphql-query.ts.mdx
+++ b/docs/snippets/angular/documentscreen-story-msw-graphql-query.ts.mdx
@@ -4,7 +4,7 @@
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 
-import { Story, Meta, moduleMetadata } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
 
 import { graphql } from 'msw';
 
@@ -23,8 +23,7 @@ export default {
       imports: [CommonModule, HttpClientModule, MockGraphQLModule],
     }),
   ],
-  title: 'Mock GraphQL query with Storybook and MSW',
-} as Meta;
+};
 
 //👇The mocked data that will be used in the story
 const TestData = {
@@ -75,32 +74,30 @@ const TestData = {
   ],
 };
 
-const PageTemplate: Story<DocumentScreen> = (args) => ({
-  props: args,
-});
-
-export const MockedSuccess = PageTemplate.bind({});
-MockedSuccess.parameters = {
-  msw: [
-    graphql.query('AllInfoQuery', (req, res, ctx) => {
-      return res(ctx.data(TestData));
-    }),
-  ],
+export const MockedSuccess = {
+  parameters: {
+    msw: [
+      graphql.query('AllInfoQuery', (req, res, ctx) => {
+        return res(ctx.data(TestData));
+      }),
+    ],
+  },
 };
 
-export const MockedError = PageTemplate.bind({});
-MockedError.parameters = {
-  msw: [
-    graphql.query('AllInfoQuery', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.errors([
-          {
-            message: 'Access denied',
-          },
-        ])
-      );
-    }),
-  ],
+export const MockedError = {
+  parameters: {
+    msw: [
+      graphql.query('AllInfoQuery', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.errors([
+            {
+              message: 'Access denied',
+            },
+          ])
+        );
+      }),
+    ],
+  },
 };
 ```

--- a/docs/snippets/angular/documentscreen-story-msw-rest-request.ts.mdx
+++ b/docs/snippets/angular/documentscreen-story-msw-rest-request.ts.mdx
@@ -4,7 +4,7 @@
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 
-import { Story, Meta, moduleMetadata } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
 
 import { rest } from 'msw';
 
@@ -21,8 +21,7 @@ export default {
       imports: [CommonModule, HttpClientModule],
     }),
   ],
-  title: 'Mock Rest request with Storybook and MSW',
-} as Meta;
+};
 
 //👇The mocked data that will be used in the story
 const TestData = {
@@ -73,25 +72,23 @@ const TestData = {
   ],
 };
 
-const PageTemplate: Story<DocumentScreen> = (args) => ({
-  props: args,
-});
-
-export const MockedSuccess = PageTemplate.bind({});
-MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
-      return res(ctx.json(TestData));
-    }),
-  ],
+export const MockedSuccess = {
+  parameters: {
+    msw: [
+      rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
+        return res(ctx.json(TestData));
+      }),
+    ],
+  },
 };
 
-export const MockedError = PageTemplate.bind({});
-MockedError.parameters = {
-  msw: [
-    rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
-      return res(ctx.delay(800), ctx.status(403));
-    }),
-  ],
+export const MockedError = {
+  parameters: {
+    msw: [
+      rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
+        return res(ctx.delay(800), ctx.status(403));
+      }),
+    ],
+  },
 };
 ```

--- a/docs/snippets/angular/documentscreen-story-msw-rest-request.ts.mdx
+++ b/docs/snippets/angular/documentscreen-story-msw-rest-request.ts.mdx
@@ -8,10 +8,10 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { rest } from 'msw';
 
-import DocumentScreen from './YourPage.component';
-import DocumentList from './DocumentList.component';
-import DocumentHeader from './DocumentHeader.component';
-import PageLayout from './PageLayout.component';
+import { DocumentScreen } from './YourPage.component';
+import { DocumentList } from './DocumentList.component';
+import { DocumentHeader } from './DocumentHeader.component';
+import { PageLayout } from './PageLayout.component';
 
 export default {
   component: DocumentScreen,

--- a/docs/snippets/angular/list-story-expanded.ts.mdx
+++ b/docs/snippets/angular/list-story-expanded.ts.mdx
@@ -1,9 +1,8 @@
 ```ts
 // List.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
-
 import { moduleMetadata } from '@storybook/angular';
+
 import { CommonModule } from '@angular/common';
 
 import List from './list.component';
@@ -11,36 +10,41 @@ import ListItem from './list-item.component';
 
 export default {
   component: List,
-  title: 'List',
   decorators: [
     moduleMetadata({
-      declarations: [List,ListItem],
+      declarations: [List, ListItem],
       imports: [CommonModule],
     }),
   ],
-} as Meta;
+};
 
-// Always an empty list, not super interesting
-export const Empty: Story<List> = (args: List) => ({
-  props: args,
-  template: `<app-list></<app-list>`,
-});
+export const Empty = {
+  render: (args) => ({
+    props: args,
+    template: '<app-list></app-list>',
+  }),
+};
 
-export const OneItem: Story<List> = (args) => ({
-  props: args,
-  template: `
-    <app-list>
-      <app-listitem></app-listitem>
-    </<app-list>`,
-});
+export const OneItem = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <app-list>
+        <app-listitem></app-listitem>
+      </app-list>`,
+  }),
+};
 
-export const ManyItems: Story<List> = (args) => ({
-  props: args,
-  template: `
-    <app-list>
-      <app-listitem></app-listitem>
-      <app-listitem></app-listitem>
-      <app-listitem></app-listitem>
-    </<app-list>`,
-});
+export const ManyItems = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <app-list>
+        <app-listitem></app-listitem>
+        <app-listitem></app-listitem>
+        <app-listitem></app-listitem>
+      </app-list>
+    `,
+  }),
+};
 ```

--- a/docs/snippets/angular/list-story-expanded.ts.mdx
+++ b/docs/snippets/angular/list-story-expanded.ts.mdx
@@ -5,8 +5,8 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import List from './list.component';
-import ListItem from './list-item.component';
+import { List } from './list.component';
+import { ListItem } from './list-item.component';
 
 export default {
   component: List,

--- a/docs/snippets/angular/list-story-expanded.ts.mdx
+++ b/docs/snippets/angular/list-story-expanded.ts.mdx
@@ -21,7 +21,7 @@ export default {
 export const Empty = {
   render: (args) => ({
     props: args,
-    template: '<app-list></app-list>',
+    template: '<list></list>',
   }),
 };
 
@@ -29,8 +29,8 @@ export const OneItem = {
   render: (args) => ({
     props: args,
     template: `
-      <app-list>
-        <app-listitem></app-listitem>
+      <list>
+        <list-item></app-list-item>
       </app-list>`,
   }),
 };
@@ -39,10 +39,10 @@ export const ManyItems = {
   render: (args) => ({
     props: args,
     template: `
-      <app-list>
-        <app-listitem></app-listitem>
-        <app-listitem></app-listitem>
-        <app-listitem></app-listitem>
+      <list>
+        <list-item></list-item>
+        <list-item></list-item>
+        <list-item></list-item>
       </app-list>
     `,
   }),

--- a/docs/snippets/angular/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/angular/list-story-reuse-data.ts.mdx
@@ -1,20 +1,40 @@
 ```ts
 // List.stories.ts
 
+import { moduleMetadata } from '@storybook/angular';
+
+import { CommonModule } from '@angular/common';
+
+import List from './list.component';
+import ListItem from './list-item.component';
+
 //👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
 
-export const ManyItems: Story<List> = (args) => ({
-  props: args,
-  template: `
-    <app-list>
-      <app-listitem [itemProperty]="Selected"></app-listitem>
-      <app-listitem [itemProperty]="Unselected"></app-listitem>
-      <app-listitem [itemProperty]="Unselected"></app-listitem>
-    </app-list>`,
-});
-ManyItems.args= {
-  Selected: Selected.args.itemProperty,
-  Unselected: Unselected.args.itemProperty,
+export default {
+  component: List,
+  decorators: [
+    moduleMetadata({
+      declarations: [List, ListItem],
+      imports: [CommonModule],
+    }),
+  ],
+};
+
+export const ManyItems = {
+  args: {
+    Selected: Selected.args.isSelected,
+    Unselected: Unselected.args.isSelected,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <app-list>
+        <app-listitem [isSelected]="Selected"></app-listitem>
+        <app-listitem [isSelected]="Unselected"></app-listitem>
+        <app-listitem [isSelected]="Unselected"></app-listitem>
+      </app-list>
+    `,
+  }),
 };
 ```

--- a/docs/snippets/angular/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/angular/list-story-reuse-data.ts.mdx
@@ -5,8 +5,8 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import List from './list.component';
-import ListItem from './list-item.component';
+import { List } from './list.component';
+import { ListItem } from './list-item.component';
 
 //👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';

--- a/docs/snippets/angular/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/angular/list-story-reuse-data.ts.mdx
@@ -29,10 +29,10 @@ export const ManyItems = {
   render: (args) => ({
     props: args,
     template: `
-      <app-list>
-        <app-listitem [isSelected]="Selected"></app-listitem>
-        <app-listitem [isSelected]="Unselected"></app-listitem>
-        <app-listitem [isSelected]="Unselected"></app-listitem>
+      <list>
+        <list-item [isSelected]="Selected"></list-item>
+        <list-item [isSelected]="Unselected"></list-item>
+        <list-item [isSelected]="Unselected"></list-item>
       </app-list>
     `,
   }),

--- a/docs/snippets/angular/list-story-starter.ts.mdx
+++ b/docs/snippets/angular/list-story-starter.ts.mdx
@@ -21,7 +21,7 @@ export default {
 export const Empty = {
   render: (args) => ({
     props: args,
-    template: '<app-list></app-list>',
+    template: '<list></list>',
   }),
 };
 ```

--- a/docs/snippets/angular/list-story-starter.ts.mdx
+++ b/docs/snippets/angular/list-story-starter.ts.mdx
@@ -5,7 +5,7 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import List from './list.component';
+import { List } from './list.component';
 
 export default {
   component: List,

--- a/docs/snippets/angular/list-story-starter.ts.mdx
+++ b/docs/snippets/angular/list-story-starter.ts.mdx
@@ -1,27 +1,27 @@
 ```ts
 // List.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
-
 import { moduleMetadata } from '@storybook/angular';
+
 import { CommonModule } from '@angular/common';
 
 import List from './list.component';
 
 export default {
-  title: 'List',
   component: List,
-   decorators: [
+  decorators: [
     moduleMetadata({
       declarations: [List],
       imports: [CommonModule],
     }),
   ],
-} as Meta;
+};
 
 // Always an empty list, not super interesting
-const Template: Story<List> = (args) => ({
-  props: args,
-  template: `<app-list></app-list>`,
-});
+export const Empty = {
+  render: (args) => ({
+    props: args,
+    template: '<app-list></app-list>',
+  }),
+};
 ```

--- a/docs/snippets/angular/list-story-template.ts.mdx
+++ b/docs/snippets/angular/list-story-template.ts.mdx
@@ -1,31 +1,48 @@
 ```ts
 // List.stories.ts
 
-import { Story } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
 
-import ListComponent from './List.component';
-import ListItemComponent from './ListItem.component';
+import { CommonModule } from '@angular/common';
+
+import ListItemComponent from './list-item.component';
+import ListComponent from './list.component';
 
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
-const ListTemplate: Story<ListComponent> = (args) => ({
-  moduleMetadata: {
-    declarations: [ListComponent, ListItemComponent],
-  },
-  props: args,
-  template: `
-    <list-component>
+export default {
+  component: ListComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [ListItemComponent],
+      imports: [CommonModule],
+    }),
+  ],
+};
+
+const ListTemplate = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <list>
         <div *ngFor="let item of items">
-            <listitem-component [item]="item"></listitem-component>
+          <list-item [item]="item"></list-item>
         </div>
-    </list-component>`,
-});
+      </list>
+    `,
+  }),
+};
 
-export const EmptyWithTemplate = ListTemplate.bind({});
-Empty.args = { items: [] };
+export const Empty = {
+  ...ListTemplate,
+  args: { items: [] },
+};
 
-
-export const OneItemWithTemplate = ListTemplate.bind({});
-OneItemWithTemplate.args = { items: [Unchecked.args.item] };
+export const OneItem = {
+  ...ListTemplate,
+  args: {
+    items: [{ ...Unchecked.args }],
+  },
+};
 ```

--- a/docs/snippets/angular/list-story-template.ts.mdx
+++ b/docs/snippets/angular/list-story-template.ts.mdx
@@ -5,8 +5,8 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import ListItemComponent from './list-item.component';
-import ListComponent from './list.component';
+import { ListItemComponent } from './list-item.component';
+import { ListComponent } from './list.component';
 
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';

--- a/docs/snippets/angular/list-story-template.ts.mdx
+++ b/docs/snippets/angular/list-story-template.ts.mdx
@@ -5,17 +5,17 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import { ListItemComponent } from './list-item.component';
-import { ListComponent } from './list.component';
+import { List } from './list.component';
+import { ListItem } from './list-item.component';
 
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
 export default {
-  component: ListComponent,
+  component: List,
   decorators: [
     moduleMetadata({
-      declarations: [ListItemComponent],
+      declarations: [ListItem],
       imports: [CommonModule],
     }),
   ],

--- a/docs/snippets/angular/list-story-unchecked.ts.mdx
+++ b/docs/snippets/angular/list-story-unchecked.ts.mdx
@@ -5,8 +5,8 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import ListItemComponent from './list-item.component';
-import ListComponent from './list.component';
+import { ListItemComponent } from './list-item.component';
+import { ListComponent } from './list.component';
 
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';

--- a/docs/snippets/angular/list-story-unchecked.ts.mdx
+++ b/docs/snippets/angular/list-story-unchecked.ts.mdx
@@ -5,17 +5,17 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import { ListItemComponent } from './list-item.component';
-import { ListComponent } from './list.component';
+import { List } from './list.component';
+import { ListItem } from './list-item.component';
 
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
 export default {
-  component: ListComponent,
+  component: List,
   decorators: [
     moduleMetadata({
-      declarations: [ListItemComponent],
+      declarations: [ListItem],
       imports: [CommonModule],
     }),
   ],

--- a/docs/snippets/angular/list-story-unchecked.ts.mdx
+++ b/docs/snippets/angular/list-story-unchecked.ts.mdx
@@ -1,27 +1,37 @@
 ```ts
 // List.stories.ts
 
-import { Story } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
 
-import ListComponent from './List.component';
-import ListItemComponent from './ListItem.component';
+import { CommonModule } from '@angular/common';
+
+import ListItemComponent from './list-item.component';
+import ListComponent from './list.component';
 
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
-export const OneItem: Story<ListComponent> = (args) => ({
-  moduleMetadata: {
-    declarations: [ListComponent, ListItemComponent],
-  },
-  props: args,
-  template: `
-    <list-component>
-        <listitem-component [item]="item"></listitem-component>
-    </list-component>
-   `,
-});
+export default {
+  component: ListComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [ListItemComponent],
+      imports: [CommonModule],
+    }),
+  ],
+};
 
-OneItem.args = {
-  ...Unchecked.args,
+export const OneItem = {
+  args: {
+    ...Unchecked.args,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <list>
+        <list-item [item]="item"></list-item>
+      </list>
+   `,
+  }),
 };
 ```

--- a/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
@@ -5,8 +5,8 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import ListItemComponent from './list-item.component';
-import ListComponent from './list.component';
+import { ListItemComponent } from './list-item.component';
+import { ListComponent } from './list.component';
 
 export default {
   component: ListComponent,

--- a/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
@@ -1,25 +1,31 @@
 ```ts
 // List.stories.ts
 
-import { Meta, moduleMetadata, Story } from '@storybook/angular';
-import { ListItemComponent } from './list-item.component';
-import { ListComponent } from './list.component';
+import { moduleMetadata } from '@storybook/angular';
+
+import { CommonModule } from '@angular/common';
+
+import ListItemComponent from './list-item.component';
+import ListComponent from './list.component';
 
 export default {
-  title: 'List',
   component: ListComponent,
   subcomponents: { ListItemComponent }, //👈 Adds the ListItem component as a subcomponent
-} as Meta;
+  decorators: [
+    moduleMetadata({
+      declarations: [ListItemComponent],
+      imports: [CommonModule],
+    }),
+  ],
+};
 
-const Template: Story<ListComponent> = (args) => ({
-  props: args,
-  moduleMetadata: {
-    declarations: [ListComponent, ListItemComponent],
-  },
-});
+export const Empty = {};
 
-export const OneItem = Template.bind({});
-OneItem.args = {
-  items: [ListItemComponent],
+export const OneItem = {
+  args: {},
+  render: (args) => ({
+    props: args,
+    template: `<list><list-item></list-item></list>`,
+  }),
 };
 ```

--- a/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/angular/list-story-with-subcomponents.ts.mdx
@@ -5,15 +5,15 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import { ListItemComponent } from './list-item.component';
-import { ListComponent } from './list.component';
+import { List } from './list.component';
+import { ListItem } from './list-item.component';
 
 export default {
-  component: ListComponent,
-  subcomponents: { ListItemComponent }, //👈 Adds the ListItem component as a subcomponent
+  component: List,
+  subcomponents: { ListItem }, //👈 Adds the ListItem component as a subcomponent
   decorators: [
     moduleMetadata({
-      declarations: [ListItemComponent],
+      declarations: [ListItem],
       imports: [CommonModule],
     }),
   ],

--- a/docs/snippets/angular/loader-story.ts.mdx
+++ b/docs/snippets/angular/loader-story.ts.mdx
@@ -1,37 +1,25 @@
 ```ts
 // TodoItem.stories.ts
 
-import { moduleMetadata, Story, Meta } from '@storybook/angular';
-
 import fetch from 'node-fetch';
-
-import { CommonModule } from '@angular/common';
 
 import TodoItem from './TodoItem';
 
 export default {
   component: TodoItem,
-  decorators: [
-    moduleMetadata({
-      declarations: [TodoItem],
-      imports: [CommonModule],
-    }),
-  ],
-  title: 'Examples/Loader',
-} as Meta;
+};
 
-export const Primary = (args, { loaded: { todo } }) => {
-  return {
+export const Primary = {
+  render: (args, { loaded: { todo } }) => ({
     props: {
       args,
       todo,
     },
-  };
-};
-
-Primary.loaders = [
-  async () => ({
-    todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
   }),
-];
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
 ```

--- a/docs/snippets/angular/loader-story.ts.mdx
+++ b/docs/snippets/angular/loader-story.ts.mdx
@@ -3,7 +3,7 @@
 
 import fetch from 'node-fetch';
 
-import TodoItem from './TodoItem';
+import { TodoItem } from './TodoItem';
 
 export default {
   component: TodoItem,

--- a/docs/snippets/angular/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/angular/my-component-story-basic-and-props.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // MyComponent.stories.ts
 
-import MyComponent from './MyComponent.component';
+import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/angular/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/angular/my-component-story-basic-and-props.ts.mdx
@@ -7,11 +7,12 @@ export default {
   component: MyComponent,
 };
 
-export const withAnImage = {
+export const Basic = {};
+
+export const WithProp = {
   render: () => ({
     props: {
-      src: 'https://place-hold.it/350x150',
-      alt: 'My CDN placeholder',
+      prop: 'value',
     },
   }),
 };

--- a/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
@@ -1,32 +1,32 @@
 ```ts
 // MyComponent.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import MyComponent from './MyComponent.component';
 
 export default {
-  title: 'Stories',
-  component: MyComponent, 
+  component: MyComponent,
   parameters: {
     //👇 The viewports object from the Essentials addon
     viewport: {
-      /👇 The viewports you want to use
+      //👇 The viewports you want to use
       viewports: INITIAL_VIEWPORTS,
 
       //👇 Your own default viewport
       defaultViewport: 'iphone6',
-    }
+    },
   },
-} as Meta;
+};
 
-export const myStory: Story<MyComponent> = () => ({
-  template: '<div></div>'
-});
-myStory.parameters = {
-  viewport: {
-    defaultViewport: 'iphonex'
-  }
+export const MyStory = {
+  render: () => ({
+    template: '<div></div>',
+  }),
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphonex',
+    },
+  },
 };
 ```

--- a/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
@@ -20,9 +20,6 @@ export default {
 };
 
 export const MyStory = {
-  render: () => ({
-    template: '<div></div>',
-  }),
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',

--- a/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
@@ -3,7 +3,7 @@
 
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
-import MyComponent from './MyComponent.component';
+import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/angular/my-component-story-use-globaltype-backwards-compat.ts.mdx
+++ b/docs/snippets/angular/my-component-story-use-globaltype-backwards-compat.ts.mdx
@@ -1,12 +1,10 @@
 ```ts
 // MyComponent.stories.ts
 
-export const StoryWithLocale = {
-  render: ({ globals: { locale } }) => {
-    const caption = getCaptionForLocale(locale);
-    return {
-      template: `<p>${caption}</p>`,
-    };
-  },
+export const StoryWithLocale = ({ globals: { locale } }) => {
+  const caption = getCaptionForLocale(locale);
+  return {
+    template: `<p>${caption}</p>`,
+  };
 };
 ```

--- a/docs/snippets/angular/my-component-story-use-globaltype-backwards-compat.ts.mdx
+++ b/docs/snippets/angular/my-component-story-use-globaltype-backwards-compat.ts.mdx
@@ -1,10 +1,12 @@
 ```ts
 // MyComponent.stories.ts
 
-export const StoryWithLocale = ({ globals: { locale } }) => {
-  const caption = getCaptionForLocale(locale);
-  return {
-    template: `<p>${caption}</p>`,
-  };
+export const StoryWithLocale = {
+  render: ({ globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return {
+      template: `<p>${caption}</p>`,
+    };
+  },
 };
 ```

--- a/docs/snippets/angular/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/angular/my-component-story-use-globaltype.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // MyComponent.stories.ts
 
-import MyComponent from './MyComponent.component';
+import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/angular/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/angular/my-component-story-use-globaltype.ts.mdx
@@ -1,6 +1,12 @@
 ```ts
 // MyComponent.stories.ts
 
+import MyComponent from './MyComponent.component';
+
+export default {
+  component: MyComponent,
+};
+
 const getCaptionForLocale = (locale) => {
   switch (locale) {
     case 'es':
@@ -16,10 +22,12 @@ const getCaptionForLocale = (locale) => {
   }
 };
 
-export const StoryWithLocale = (args, { globals: { locale } }) => {
-  const caption = getCaptionForLocale(locale);
-  return {
-    template: `<p>${caption}</p>`,
-  };
+export const StoryWithLocale = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return {
+      template: `<p>${caption}</p>`,
+    };
+  },
 };
 ```

--- a/docs/snippets/angular/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/angular/my-component-story-with-nonstory.ts.mdx
@@ -15,18 +15,14 @@ export const simpleData = { foo: 1, bar: 'baz' };
 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 
 export const SimpleStory = {
-  render: () => ({
-    props: {
-      data: simpleData,
-    },
-  }),
+  args: {
+    data: simpleData
+  },
 };
 
 export const ComplexStory = {
-  render: () => ({
-    props: {
-      data: complexData,
-    },
-  }),
+  args: {
+    data: complexData
+  },
 };
 ```

--- a/docs/snippets/angular/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/angular/my-component-story-with-nonstory.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // MyComponent.stories.ts
 
-import MyComponent from './MyComponent.component';
+import { MyComponent } from './MyComponent.component';
 
 import someData from './data.json';
 

--- a/docs/snippets/angular/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/angular/my-component-story-with-nonstory.ts.mdx
@@ -1,13 +1,13 @@
-```js
-// MyComponent.stories.js
+```ts
+// MyComponent.stories.ts
 
-import MyComponent from './MyComponent.vue';
+import MyComponent from './MyComponent.component';
 
 import someData from './data.json';
 
 export default {
   component: MyComponent,
-  includeStories: ['SimpleStory', 'ComplexStory'],
+  includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
   excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
 };
 
@@ -16,25 +16,17 @@ export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 
 export const SimpleStory = {
   render: () => ({
-    components: { MyComponent },
     props: {
-      data: {
-        default: () => simpleData,
-      },
+      data: simpleData,
     },
-    template: `<MyComponent :data="data"/>`,
   }),
 };
 
 export const ComplexStory = {
   render: () => ({
-    components: { MyComponent },
     props: {
-      data: {
-        default: () => complexData,
-      },
+      data: complexData,
     },
-    template: `<MyComponent :data="data"/>`,
   }),
 };
 ```

--- a/docs/snippets/angular/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/angular/my-component-with-env-variables.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // MyComponent.stories.ts
 
-import MyComponent from './mycomponent.component';
+import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/angular/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/angular/my-component-with-env-variables.ts.mdx
@@ -1,21 +1,15 @@
 ```ts
 // MyComponent.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
-
 import MyComponent from './mycomponent.component';
 
 export default {
   component: MyComponent,
-  title: 'A story using environment variables inside a .env file',
-} as Meta;
+};
 
-const Template: Story<MyComponent> = (args) => ({
-  props: args
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  propertyA: process.env.STORYBOOK_DATA_KEY
+export const ExampleStory = {
+  args: {
+    propertyA: process.env.STORYBOOK_DATA_KEY,
+  },
 };
 ```

--- a/docs/snippets/angular/page-story-slots.ts.mdx
+++ b/docs/snippets/angular/page-story-slots.ts.mdx
@@ -1,25 +1,22 @@
 ```ts
 // Page.stories.ts
 
-import { Meta, Story } from '@storybook/angular/types-6-0';
 import Page from './page.component';
 
 export default {
   component: Page,
-  title: 'Page',
-} as Meta;
-
-const Template: Story<Page> = (args) => ({
-  props: args,
-  template: `
-    <storybook-page>
-      <ng-container footer>${args.footer}</ng-container>
-    </storybook-page>`,
-});
-
-export const CustomFooter = Template.bind({});
-CustomFooter.args = {
-  footer: 'Built with Storybook',
 };
 
+export const CustomFooter = {
+  args: {
+    footer: 'Built with Storybook',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <storybook-page>
+        <ng-container footer>${args.footer}</ng-container>
+      </storybook-page>`,
+  }),
+};
 ```

--- a/docs/snippets/angular/page-story-slots.ts.mdx
+++ b/docs/snippets/angular/page-story-slots.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Page.stories.ts
 
-import Page from './page.component';
+import { Page } from './page.component';
 
 export default {
   component: Page,

--- a/docs/snippets/angular/page-story-with-args-composition.ts.mdx
+++ b/docs/snippets/angular/page-story-with-args-composition.ts.mdx
@@ -1,8 +1,7 @@
 ```ts
 // YourPage.stories.ts
 
-import { moduleMetadata } from '@storybook/angular'
-import { Story, Meta } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
@@ -18,24 +17,19 @@ import * as DocumentListStories from './DocumentList.stories';
 
 export default {
   component: DocumentScreen,
-  title: 'DocumentScreen',
   decorators: [
     moduleMetadata({
-      // imports components to allow component composition with Storybook
-      declarations: [DocumentList, DocumentHeader,PageLayout],
+      declarations: [DocumentList, DocumentHeader, PageLayout],
       imports: [CommonModule],
     }),
   ],
-} as Meta;
+};
 
-const Template: Story<DocumentScreen> = (args) => ({
-  props: args,
-});
-
-export const Simple = Template.bind({});
-Simple.args = {
-  user: PageLayoutStories.PageLayoutSimple.args.user,
-  document: DocumentHeaderStories.DocumentHeaderSimple.args.document,
-  subdocuments: DocumentListStories.DocumentListSimple.args.documents
+export const Simple = {
+  args: {
+    user: PageLayoutStories.Simple.args.user,
+    document: DocumentHeaderStories.Simple.args.document,
+    subdocuments: DocumentListStories.Simple.args.documents,
+  },
 };
 ```

--- a/docs/snippets/angular/page-story-with-args-composition.ts.mdx
+++ b/docs/snippets/angular/page-story-with-args-composition.ts.mdx
@@ -5,10 +5,10 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import DocumentScreen from './YourPage.component';
-import DocumentList from './DocumentList.component';
-import DocumentHeader from './DocumentHeader.component';
-import PageLayout from './PageLayout.component';
+import { DocumentScreen } from './YourPage.component';
+import { DocumentList } from './DocumentList.component';
+import { DocumentHeader } from './DocumentHeader.component';
+import { PageLayout } from './PageLayout.component';
 
 //👇 Imports the required stories
 import * as PageLayoutStories from './PageLayout.stories';

--- a/docs/snippets/angular/page-story.ts.mdx
+++ b/docs/snippets/angular/page-story.ts.mdx
@@ -1,19 +1,18 @@
 ```ts
 // Page.stories.ts
 
-import { Story, Meta } from '@storybook/angular/types-6-0';
-
 import { moduleMetadata } from '@storybook/angular';
+
 import { CommonModule } from '@angular/common';
 
 import Button from './button.component';
 import Header from './header.component';
 import Page from './page.component';
 
+//👇 Imports all Header stories
 import * as HeaderStories from './Header.stories';
 
 export default {
-  title: 'Page',
   component: Page,
   decorators: [
     moduleMetadata({
@@ -21,14 +20,11 @@ export default {
       imports: [CommonModule],
     }),
   ],
-} as Meta;
+};
 
-const Template: Story<Page> = (args) => ({
-  props: args,
-});
-
-export const LoggedIn = Template.bind({});
-LoggedIn.args = {
-  ...HeaderStories.LoggedIn.args,
+export const LoggedIn = {
+  args: {
+    ...HeaderStories.LoggedIn.args,
+  },
 };
 ```

--- a/docs/snippets/angular/page-story.ts.mdx
+++ b/docs/snippets/angular/page-story.ts.mdx
@@ -5,9 +5,9 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
 
-import Button from './button.component';
-import Header from './header.component';
-import Page from './page.component';
+import { Button } from './button.component';
+import { Header } from './header.component';
+import { Page } from './page.component';
 
 //👇 Imports all Header stories
 import * as HeaderStories from './Header.stories';

--- a/docs/snippets/angular/simple-page-implementation.ts.mdx
+++ b/docs/snippets/angular/simple-page-implementation.ts.mdx
@@ -12,7 +12,7 @@ import { Component, Input } from '@angular/core';
     </page-layout>
   `,
 })
-export default class DocumentScreen {
+export class DocumentScreen {
   @Input()
   user: any = { id: 0, name: 'Some User' };
 

--- a/docs/snippets/angular/table-story-fully-customize-controls.ts.mdx
+++ b/docs/snippets/angular/table-story-fully-customize-controls.ts.mdx
@@ -1,29 +1,35 @@
 ```ts
 // Table.stories.ts
 
-const TableStory: Story<TableComponent> = (args) => ({
-  props: args,
-  template: `
-    <table>
-      <tbody>
-        <tr *ngFor="let row of data; let i=index">
-          <td *ngFor="let col of row; let j=index">
-            {{data[i][j]}}
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    `,
-});
+import Table from './Table.component';
 
-export const Numeric = TableStory.bind({});
-Numeric.args = {
-  //👇 This arg is for the story component
-  data: [
-    [1, 2, 3],
-    [4, 5, 6],
-  ],
-  //👇 The remaining args get passed to the `Table` component
-  size: 'large',
+export default {
+  component: Table,
+};
+
+export const TableStory = {
+  args: {
+    //👇 This arg is for the story component
+    data: [
+      [1, 2, 3],
+      [4, 5, 6],
+    ],
+    //👇 The remaining args get passed to the `Table` component
+    size: 'large',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <table>
+        <tbody>
+          <tr *ngFor="let row of data; let i=index">
+            <td *ngFor="let col of row; let j=index">
+              {{data[i][j]}}
+            </td>
+          </tr>
+        </tbody>
+    </table>
+  `,
+  }),
 };
 ```

--- a/docs/snippets/angular/table-story-fully-customize-controls.ts.mdx
+++ b/docs/snippets/angular/table-story-fully-customize-controls.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // Table.stories.ts
 
-import Table from './Table.component';
+import { Table } from './Table.component';
 
 export default {
   component: Table,

--- a/docs/snippets/angular/your-component-with-decorator.ts.mdx
+++ b/docs/snippets/angular/your-component-with-decorator.ts.mdx
@@ -1,11 +1,12 @@
 ```ts
-// your-component.stories.ts
+// YourComponent.stories.ts
 
-import { Meta, componentWrapperDecorator } from '@storybook/angular';
+import { componentWrapperDecorator } from '@storybook/angular';
+
+import YourComponent from './your.component';
 
 export default {
-  title: 'YourComponent',
   component: YourComponent,
   decorators: [componentWrapperDecorator((story) => `<div style="margin: 3em">${story}</div>`)],
-} as Meta;
+};
 ```

--- a/docs/snippets/angular/your-component-with-decorator.ts.mdx
+++ b/docs/snippets/angular/your-component-with-decorator.ts.mdx
@@ -3,7 +3,7 @@
 
 import { componentWrapperDecorator } from '@storybook/angular';
 
-import YourComponent from './your.component';
+import { YourComponent } from './your.component';
 
 export default {
   component: YourComponent,

--- a/docs/snippets/angular/your-component.ts.mdx
+++ b/docs/snippets/angular/your-component.ts.mdx
@@ -1,23 +1,16 @@
 ```ts
 // YourComponent.stories.ts
 
-import { Meta, Story } from '@storybook/angular';
-
 import { YourComponent } from './your.component';
 
 //👇 This default export determines where your story goes in the story list
 export default {
-  title: 'YourComponent',
   component: YourComponent,
-} as Meta;
+};
 
-//👇 We create a “template” of how args map to rendering
-const Template: Story<YourComponent> = (args) => ({
-  props: args,
-});
-
-export const YourStory = Template.bind({});
-YourStory.args = {
-  /* 👇 The args you need here will depend on your component */
+export const FirstStory = {
+  args: {
+    //👇 The args you need here will depend on your component
+  },
 };
 ```

--- a/docs/snippets/common/addon-consume-globaltype.js.mdx
+++ b/docs/snippets/common/addon-consume-globaltype.js.mdx
@@ -1,20 +1,37 @@
 ```js
 // your-addon-register-file.js
 
+import React from 'react';
+
 import { useGlobals } from '@storybook/api';
+
 import { AddonPanel, Placeholder, Separator, Source, Spaced, Title } from '@storybook/components';
 
-const ThemePanel = props => {
+import { MyThemes } from '../my-theme-folder/my-theme-file';
+
+// Function to obtain the intended theme
+const getTheme = (themeName) => {
+  return MyThemes[themeName];
+};
+
+const ThemePanel = (props) => {
   const [{ theme: themeName }] = useGlobals();
-  const theme = getTheme(themeName);
+
+  const selectedTheme = getTheme(themeName);
 
   return (
     <AddonPanel {...props}>
-      {theme ? (
+      {selectedTheme ? (
         <Spaced row={3} outer={1}>
-          <Title>{theme.name}</Title>
+          <Title>{selectedTheme.name}</Title>
           <p>The full theme object</p>
-          <Source code={JSON.stringify(theme, null, 2)} language="js" copyable padded showLineNumbers />
+          <Source
+            code={JSON.stringify(selectedTheme, null, 2)}
+            language="js"
+            copyable
+            padded
+            showLineNumbers
+          />
         </Spaced>
       ) : (
         <Placeholder>No theme selected</Placeholder>

--- a/docs/snippets/common/args-usage-with-addons.js.mdx
+++ b/docs/snippets/common/args-usage-with-addons.js.mdx
@@ -9,7 +9,7 @@ const [args, updateArgs, resetArgs] = useArgs();
 updateArgs({ key: 'value' });
 
 // To reset one (or more) args:
-resetArgs(['key']);
+resetArgs((argNames: ['key']));
 
 // To reset all args
 resetArgs();

--- a/docs/snippets/common/badge-story-custom-argtypes.js.mdx
+++ b/docs/snippets/common/badge-story-custom-argtypes.js.mdx
@@ -1,6 +1,8 @@
 ```js
 // Badge.stories.js | Badge.stories.jsx  | Badge.stories.ts | Badge.stories.tsx
 
+import { Badge } from './Badge';
+
 export default {
   component: Badge,
   argTypes: {

--- a/docs/snippets/common/badge-story-custom-argtypes.js.mdx
+++ b/docs/snippets/common/badge-story-custom-argtypes.js.mdx
@@ -3,41 +3,34 @@
 
 export default {
   component: Badge,
-  title: 'CSF/Badge',
   argTypes: {
     status: {
       name: 'Badge Status',
       description: 'Available options available to the Badge',
-      options: [
-        'positive',
-        'negative',
-        'warning',
-        'error',
-        'neutral'
-      ],
+      options: ['positive', 'negative', 'warning', 'error', 'neutral'],
       table: {
         defaultValue: {
-          summary: 'positive'
+          summary: 'positive',
         },
         type: {
           summary: 'Shows options to the Badge',
-          detail: 'Listing of available options'
-        }
+          detail: 'Listing of available options',
+        },
       },
     },
     label: {
       name: 'Badge Content',
       description: 'Text shown by Badge',
       control: {
-        type: 'text'
+        type: 'text',
       },
       table: {
         type: {
           summary: 'The label contents',
-          detail: 'Text displayed by the Badge'
-        }
-      }
-    }
-  }
+          detail: 'Text displayed by the Badge',
+        },
+      },
+    },
+  },
 };
 ```

--- a/docs/snippets/common/button-group-story-subcomponents.js.mdx
+++ b/docs/snippets/common/button-group-story-subcomponents.js.mdx
@@ -4,7 +4,6 @@
 import { Button, ButtonGroup } from '../ButtonGroup';
 
 export default {
-  title: 'Path/to/ButtonGroup',
   component: ButtonGroup,
   subcomponents: { Button },
 };

--- a/docs/snippets/common/button-story-action-event-handle.js.mdx
+++ b/docs/snippets/common/button-story-action-event-handle.js.mdx
@@ -1,9 +1,10 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
+  component: Button,
   parameters: {
     actions: {
       handles: ['mouseover', 'click .btn'],

--- a/docs/snippets/common/button-story-action-event-handle.js.mdx
+++ b/docs/snippets/common/button-story-action-event-handle.js.mdx
@@ -1,8 +1,9 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 export default {
-  title: 'Button',
   parameters: {
     actions: {
       handles: ['mouseover', 'click .btn'],

--- a/docs/snippets/common/button-story-argtypes-with-categories.js.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-categories.js.mdx
@@ -1,40 +1,41 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 export default {
-  title: 'Button',
   component: Button,
   argTypes: {
     // Assigns the argTypes to the Colors category
     backgroundColor: {
       control: 'color',
       table: {
-        category: 'Colors'
-      }
+        category: 'Colors',
+      },
     },
     primary: {
       table: {
-        category: 'Colors'
-      }
+        category: 'Colors',
+      },
     },
     // Assigns the argType to the Text category
     label: {
       table: {
-        category: 'Text'
-      }
+        category: 'Text',
+      },
     },
     // Assigns the argType to the Events category
     onClick: {
       table: {
-        category: 'Events'
-      }
+        category: 'Events',
+      },
     },
     // Assigns the argType to the Sizes category
     size: {
       table: {
-        category: 'Sizes'
-      }
-    }
-  }
+        category: 'Sizes',
+      },
+    },
+  },
 };
 ```

--- a/docs/snippets/common/button-story-argtypes-with-categories.js.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-categories.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/button-story-argtypes-with-subcategories.js.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-subcategories.js.mdx
@@ -1,8 +1,9 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 export default {
-  title: 'Button',
   component: Button,
   argTypes: {
     // Assigns the argTypes to the Colors category
@@ -11,34 +12,34 @@ export default {
       table: {
         category: 'Colors',
         // Assigns the argTypes to a specific subcategory
-        subcategory: 'Button colors'
-      }
+        subcategory: 'Button colors',
+      },
     },
     primary: {
       table: {
         category: 'Colors',
-        subcategory: 'Button style'
-      }
+        subcategory: 'Button style',
+      },
     },
     label: {
       table: {
         category: 'Text',
-        subcategory: 'Button contents'
-      }
+        subcategory: 'Button contents',
+      },
     },
     // Assigns the argType to the Events category
     onClick: {
       table: {
         category: 'Events',
-        subcategory: 'Button Events'
-      }
+        subcategory: 'Button Events',
+      },
     },
     // Assigns the argType to the Sizes category
     size: {
       table: {
-        category: 'Sizes'
-      }
-    }
-  }
+        category: 'Sizes',
+      },
+    },
+  },
 };
 ```

--- a/docs/snippets/common/button-story-argtypes-with-subcategories.js.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-subcategories.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/button-story-controls-primary-variant.js.mdx
+++ b/docs/snippets/common/button-story-controls-primary-variant.js.mdx
@@ -1,8 +1,15 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-const Primary = Template.bind({});
-Primary.args = {
-   variant: 'primary',
+import Button from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Primary = {
+  args: {
+    variant: 'primary',
+  },
 };
 ```

--- a/docs/snippets/common/button-story-controls-primary-variant.js.mdx
+++ b/docs/snippets/common/button-story-controls-primary-variant.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/button-story-controls-radio-group.js.mdx
+++ b/docs/snippets/common/button-story-controls-radio-group.js.mdx
@@ -1,6 +1,8 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import { Button } from './Button';
+
 export default {
   component: Button,
   argTypes: {

--- a/docs/snippets/common/button-story-controls-radio-group.js.mdx
+++ b/docs/snippets/common/button-story-controls-radio-group.js.mdx
@@ -2,13 +2,12 @@
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
 export default {
-  title: 'Button',
   component: Button,
   argTypes: {
     variant: {
       options: ['primary', 'secondary'],
-      control: { type: 'radio' }
-    }
-  }
+      control: { type: 'radio' },
+    },
+  },
 };
 ```

--- a/docs/snippets/common/button-story-default-export.js.mdx
+++ b/docs/snippets/common/button-story-default-export.js.mdx
@@ -1,7 +1,10 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import { Button } from './Button';
+
 export default {
+  component: Button,
   title: 'Button',
 };
 ```

--- a/docs/snippets/common/button-story-disable-addon.js.mdx
+++ b/docs/snippets/common/button-story-disable-addon.js.mdx
@@ -1,8 +1,10 @@
 ```js
 // Button.stories.js |  Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import { Button } from './Button';
+
 export default {
-  title: 'Button',
+  component: Button,
   parameters: {
     myAddon: { disable: true }, // Disables the addon
   },

--- a/docs/snippets/common/button-story-disable-docspage-component.js.mdx
+++ b/docs/snippets/common/button-story-disable-docspage-component.js.mdx
@@ -4,15 +4,14 @@
 import { Button } from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-  parameters: { 
-    docs: { 
-      page: null 
-    } 
+  parameters: {
+    docs: {
+      page: null,
+    },
   },
 };
 ```

--- a/docs/snippets/common/button-story-docs-code-type.js.mdx
+++ b/docs/snippets/common/button-story-docs-code-type.js.mdx
@@ -1,8 +1,9 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 export default {
-  title: 'Button',
   component: Button,
   argTypes: {
     backgroundColor: { control: 'color' },
@@ -11,9 +12,9 @@ export default {
     docs: {
       source: {
         type: 'code',
-      }
-    }
-  }
+      },
+    },
+  },
 };
 
 // Remainder story implementation

--- a/docs/snippets/common/button-story-docs-code-type.js.mdx
+++ b/docs/snippets/common/button-story-docs-code-type.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/button-story-docspage-with-custom-component.js.mdx
+++ b/docs/snippets/common/button-story-docspage-with-custom-component.js.mdx
@@ -6,15 +6,14 @@ import { Button } from './Button';
 import ButtonDocumentationComponent from './CustomDocumentationComponent';
 
 export default {
-  title: 'Button',
   component: Button,
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-  parameters: { 
-    docs: { 
-      page: ButtonDocumentationComponent, 
-    } 
+  parameters: {
+    docs: {
+      page: ButtonDocumentationComponent,
+    },
   },
 };
 ```

--- a/docs/snippets/common/button-story-docspage-with-custom-component.js.mdx
+++ b/docs/snippets/common/button-story-docspage-with-custom-component.js.mdx
@@ -3,7 +3,7 @@
 
 import { Button } from './Button';
 
-import ButtonDocumentationComponent from './CustomDocumentationComponent';
+import { CustomDocumentationComponent } from './CustomDocumentationComponent';
 
 export default {
   component: Button,
@@ -12,7 +12,7 @@ export default {
   },
   parameters: {
     docs: {
-      page: ButtonDocumentationComponent,
+      page: CustomDocumentationComponent,
     },
   },
 };

--- a/docs/snippets/common/button-story-docspage-with-mdx.js.mdx
+++ b/docs/snippets/common/button-story-docspage-with-mdx.js.mdx
@@ -3,9 +3,10 @@
 
 import { Button } from './Button';
 
-import CustomMDXDocumentation from './Custom-MDX-Documentation.mdx' 
+import CustomMDXDocumentation from './Custom-MDX-Documentation.mdx';
 
 export default {
+  //👇 The title property is optional, if you don't include it within your story you'll have to adjust the story id in the custom page
   title: 'Example/Button',
   component: Button,
   argTypes: {
@@ -14,15 +15,23 @@ export default {
   parameters: {
     docs: {
       page: CustomMDXDocumentation,
-    }
+    },
   },
 };
 
-export const Primary = () => <Button backgroundColor="primary" />;
+export const Primary = {
+  render: () => <Button backgroundColor="primary" />,
+};
 
-export const Secondary = () => <Button backgroundColor="secondary" />;
+export const Secondary = {
+  render: () => <Button size="large" />,
+};
 
-export const Large = () => <Button size="large" />;
+export const Large =  = {
+  render: () => <Button size="large" />,
+};
 
-export const Small = () => <Button size="small" />;
+export const Small = {
+  render: () => <Button size="small" />,
+};
 ```

--- a/docs/snippets/common/button-story-docspage-with-mdx.js.mdx
+++ b/docs/snippets/common/button-story-docspage-with-mdx.js.mdx
@@ -20,18 +20,26 @@ export default {
 };
 
 export const Primary = {
-  render: () => <Button backgroundColor="primary" />,
+  args:{
+    backgroundColor: 'primary',
+  },
 };
 
 export const Secondary = {
-  render: () => <Button size="large" />,
+  args:{
+     backgroundColor: 'secondary',
+  },
 };
 
 export const Large =  = {
-  render: () => <Button size="large" />,
+  args:{
+    size:'large',
+  }
 };
 
 export const Small = {
-  render: () => <Button size="small" />,
+  args:{
+    size:'small',
+  },
 };
 ```

--- a/docs/snippets/common/button-story-grouped.js.mdx
+++ b/docs/snippets/common/button-story-grouped.js.mdx
@@ -1,7 +1,10 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import { Button } from './Button';
+
 export default {
+  component: Button,
   title: 'Design System/Atoms/Button',
 };
 ```

--- a/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx
+++ b/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx
+++ b/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx
@@ -1,9 +1,15 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const Large = Template.bind({});
+import Button from './Button';
 
-Large.parameters = {
-  controls: { hideNoControlsWarning: true },
+export default {
+  component: Button,
+};
+
+export const Large = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
 };
 ```

--- a/docs/snippets/common/button-story-hoisted.js.mdx
+++ b/docs/snippets/common/button-story-hoisted.js.mdx
@@ -4,10 +4,9 @@
 import { Button as ButtonComponent } from './Button';
 
 export default {
-  title: 'Design System/Atoms/Button',
   component: ButtonComponent,
 };
 
 // This is the only named export in the file, and it matches the component name
-export const Button = (args) => <ButtonComponent {...args} />;
+export const Button = {};
 ```

--- a/docs/snippets/common/button-story-hypothetical-example.js.mdx
+++ b/docs/snippets/common/button-story-hypothetical-example.js.mdx
@@ -4,14 +4,15 @@
 import { Button } from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
 };
 
-export const Sample = () => ({
-  template: '<button label=:label />',
-  data: {
-    label: 'hello button',
-  },
-});
+export const Sample = {
+  render: () => ({
+    template: '<button :label=label />',
+    data: {
+      label: 'hello button',
+    },
+  }),
+};
 ```

--- a/docs/snippets/common/button-story-matching-argtypes.js.mdx
+++ b/docs/snippets/common/button-story-matching-argtypes.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/button-story-matching-argtypes.js.mdx
+++ b/docs/snippets/common/button-story-matching-argtypes.js.mdx
@@ -1,8 +1,9 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 export default {
-  title: 'Button',
   component: Button,
   parameters: { actions: { argTypesRegex: '^on.*' } },
 };

--- a/docs/snippets/common/button-story-onclick-action-argtype.js.mdx
+++ b/docs/snippets/common/button-story-onclick-action-argtype.js.mdx
@@ -1,9 +1,10 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
+  component: Button,
   argTypes: { onClick: { action: 'clicked' } },
 };
 ```

--- a/docs/snippets/common/button-story-onclick-action-argtype.js.mdx
+++ b/docs/snippets/common/button-story-onclick-action-argtype.js.mdx
@@ -1,8 +1,9 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 export default {
-  title: 'Button',
   argTypes: { onClick: { action: 'clicked' } },
 };
 ```

--- a/docs/snippets/common/button-story-primary-composition.js.mdx
+++ b/docs/snippets/common/button-story-primary-composition.js.mdx
@@ -1,15 +1,23 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-const Primary = ButtonStory.bind({});
-Primary.args = {
-  primary: true,
-  label: 'Button',
-}
+import Button from './Button';
 
-const Secondary = ButtonStory.bind({});
-Secondary.args = {
-  ...Primary.args,
-  primary: false,
-}
+export default {
+  component: Button,
+};
+
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+const Secondary = {
+  args: {
+    ...Primary.args,
+    primary: false,
+  },
+};
 ```

--- a/docs/snippets/common/button-story-primary-composition.js.mdx
+++ b/docs/snippets/common/button-story-primary-composition.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/button-story-primary-long-name.js.mdx
+++ b/docs/snippets/common/button-story-primary-long-name.js.mdx
@@ -1,10 +1,16 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const PrimaryLongName = Template.bind({});
+import Button from './Button';
 
-PrimaryLongName.args = {
-  ...Primary.args,
-  label: 'Primary with a really long name',
-}
+export default {
+  component: Button,
+};
+
+export const PrimaryLongName = {
+  args: {
+    ...Primary.args,
+    label: 'Primary with a really long name',
+  },
+};
 ```

--- a/docs/snippets/common/button-story-primary-long-name.js.mdx
+++ b/docs/snippets/common/button-story-primary-long-name.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/button-story-remix-docspage.js.mdx
+++ b/docs/snippets/common/button-story-remix-docspage.js.mdx
@@ -16,7 +16,6 @@ import {
 import { Button } from './Button';
 
 export default {
-  title: 'Components/Button',
   component: Button,
   parameters: {
     docs: {

--- a/docs/snippets/common/button-story-with-parameters.js.mdx
+++ b/docs/snippets/common/button-story-with-parameters.js.mdx
@@ -1,6 +1,12 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import { Button } from './Button';
+
+export default {
+  component: Button,
+}
+
 export const Primary = Template.bind({});
 Primary.args ={
   primary: true,

--- a/docs/snippets/common/checkbox-story-csf.js.mdx
+++ b/docs/snippets/common/checkbox-story-csf.js.mdx
@@ -1,15 +1,15 @@
 ```js
-// Checkbox.stories.js | Checkbox.stories.jsx 
+// Checkbox.stories.js | Checkbox.stories.jsx
 
 import { Checkbox } from './Checkbox';
 
-export default { 
-  title: 'MDX/Checkbox',
+export default {
   component: Checkbox,
 };
 
-const Template = (args) => <Checkbox {...args} />
-
-export const Unchecked = Template.bind({});
-Unchecked.args = { label: 'Unchecked' };
+export const Unchecked = {
+  args: {
+    label: 'Unchecked',
+  },
+};
 ```

--- a/docs/snippets/common/checkbox-story-csf.js.mdx
+++ b/docs/snippets/common/checkbox-story-csf.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// Checkbox.stories.js | Checkbox.stories.jsx
+// Checkbox.stories.js | Checkbox.stories.jsx | Checkbox.stories.ts | Checkbox.stories.tsx
 
 import { Checkbox } from './Checkbox';
 

--- a/docs/snippets/common/checkbox-story-grouped.js.mdx
+++ b/docs/snippets/common/checkbox-story-grouped.js.mdx
@@ -1,7 +1,10 @@
 ```js
 // Checkbox.stories.js | Checkbox.stories.jsx | Checkbox.stories.ts | Checkbox.stories.tsx
 
+import { CheckBox } from './Checkbox';
+
 export default {
+  component: CheckBox,
   title: 'Design System/Atoms/Checkbox',
 };
 ```

--- a/docs/snippets/common/component-story-csf-argstable-customization.js.mdx
+++ b/docs/snippets/common/component-story-csf-argstable-customization.js.mdx
@@ -1,16 +1,17 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 export default {
-  title: 'Button',
   component: Button,
   argTypes: {
     label: {
       description: 'Overwritten description',
       table: {
-        type: { 
-          summary: 'Something short', 
-          detail: 'Something really really long' 
+        type: {
+          summary: 'Something short',
+          detail: 'Something really really long',
         },
       },
       control: {

--- a/docs/snippets/common/component-story-csf-argstable-customization.js.mdx
+++ b/docs/snippets/common/component-story-csf-argstable-customization.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/component-story-csf-description.js.mdx
+++ b/docs/snippets/common/component-story-csf-description.js.mdx
@@ -1,8 +1,10 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 export default {
-  title: 'CustomDescription',
+  component: Button,
   parameters: {
     docs: {
       description: {
@@ -12,11 +14,12 @@ export default {
   },
 };
 
-export const WithStoryDescription = Template.bind({});
-WithStoryDescription.parameters = {
-  docs: {
-    description: {
-      story: 'Some story **markdown**',
+export const WithStoryDescription = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Some story **markdown**',
+      },
     },
   },
 };

--- a/docs/snippets/common/component-story-csf-description.js.mdx
+++ b/docs/snippets/common/component-story-csf-description.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/component-story-custom-args-mapping.js.mdx
+++ b/docs/snippets/common/component-story-custom-args-mapping.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import { Button } from './button';
+import { Button } from './Button';
 import { ArrowUp, ArrowDown, ArrowLeft, ArrowRight } from './icons';
 
 const arrows = { ArrowUp, ArrowDown, ArrowLeft, ArrowRight };

--- a/docs/snippets/common/component-story-custom-args-mapping.js.mdx
+++ b/docs/snippets/common/component-story-custom-args-mapping.js.mdx
@@ -8,7 +8,6 @@ const arrows = { ArrowUp, ArrowDown, ArrowLeft, ArrowRight };
 
 export default {
   component: Button,
-  title: 'Button',
   argTypes: {
     arrow: {
       options: Object.keys(arrows), // An array of serializable values
@@ -21,8 +20,8 @@ export default {
           ArrowDown: 'Down',
           ArrowLeft: 'Left',
           ArrowRight: 'Right',
-        }
-      }
+        },
+      },
     },
   },
 };

--- a/docs/snippets/common/component-story-custom-params.js.mdx
+++ b/docs/snippets/common/component-story-custom-params.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.ts | Button.stories.jsx | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/component-story-custom-params.js.mdx
+++ b/docs/snippets/common/component-story-custom-params.js.mdx
@@ -1,18 +1,25 @@
 ```js
-// Button.stories.js | Button.stories.ts | Button.stories.jsx | Button.stories.tsx 
+// Button.stories.js | Button.stories.ts | Button.stories.jsx | Button.stories.tsx
 
-export const Primary = Template.bind({});
-Primary.args = {
-  primary: true,
-  label: 'Button',
+import Button from './Button';
+
+export default {
+  component: Button,
 };
-Primary.parameters = {
-  backgrounds: {
-    values: [
-      { name: 'red', value: '#f00' },
-      { name: 'green', value: '#0f0' },
-      { name: 'blue', value: '#00f' },
-    ],
+
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+  parameters: {
+    backgrounds: {
+      values: [
+        { name: 'red', value: '#f00' },
+        { name: 'green', value: '#0f0' },
+        { name: 'blue', value: '#00f' },
+      ],
+    },
   },
 };
 ```

--- a/docs/snippets/common/component-story-custom-source.js.mdx
+++ b/docs/snippets/common/component-story-custom-source.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from '.Button';
+import Button from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/component-story-custom-source.js.mdx
+++ b/docs/snippets/common/component-story-custom-source.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/component-story-custom-source.js.mdx
+++ b/docs/snippets/common/component-story-custom-source.js.mdx
@@ -1,12 +1,18 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const CustomSource = () => Template.bind({});
+import Button from '.Button';
 
-CustomSource.parameters = {
-  docs: {
-    source: {
-      code: 'Some custom string here',
+export default {
+  component: Button,
+};
+
+export const CustomSource = {
+  parameters: {
+    docs: {
+      source: {
+        code: 'Some custom string here',
+      },
     },
   },
 };

--- a/docs/snippets/common/component-story-disable-controls-alt.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-alt.js.mdx
@@ -1,16 +1,15 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
-import { YourComponent } from './your-component'
+import { YourComponent } from './YourComponent';
 
 export default {
   component: YourComponent,
-  title:'My Story',
-  argTypes:{
+  argTypes: {
     // foo is the property we want to remove from the UI
-    foo:{
-      control:false
-    }
-  }
+    foo: {
+      control: false,
+    },
+  },
 };
 ```

--- a/docs/snippets/common/component-story-disable-controls-regex.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-regex.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
-import YourComponent from './YourComponent';
+import { YourComponent } from './YourComponent';
 
 export default {
   component: YourComponent,

--- a/docs/snippets/common/component-story-disable-controls-regex.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-regex.js.mdx
@@ -1,15 +1,33 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
-ArrayInclude = Template.bind({})
-ArrayInclude.parameters = { controls: { include: ['foo', 'bar'] } };
+import YourComponent from './YourComponent';
 
-RegexInclude = Template.bind({})
-RegexInclude.parameters = { controls: { include: /^hello*/ } };
+export default {
+  component: YourComponent,
+};
 
-ArrayExclude = Template.bind({})
-ArrayExclude.parameters = { controls: { exclude: ['foo', 'bar'] } };
+export const ArrayInclude = {
+  parameters: {
+    controls: { include: ['foo', 'bar'] },
+  },
+};
 
-RegexExclude = Template.bind({})
-RegexExclude.parameters = { controls: { exclude: /^hello*/ } };
+export const RegexInclude = {
+  parameters: {
+    controls: { include: /^hello*/ },
+  },
+};
+
+export const ArrayExclude = {
+  parameters: {
+    controls: { exclude: ['foo', 'bar'] },
+  },
+};
+
+export const RegexExclude = {
+  parameters: {
+    controls: { exclude: /^hello*/ },
+  },
+};
 ```

--- a/docs/snippets/common/component-story-disable-controls.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls.js.mdx
@@ -1,18 +1,17 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
-import { YourComponent } from './your-component'
+import { YourComponent } from './YourComponent';
 
 export default {
   component: YourComponent,
-  title:'My Story',
-  argTypes:{
+  argTypes: {
     // foo is the property we want to remove from the UI
-    foo:{
-      table:{
-        disable:true
-      }
-    }
-  }
+    foo: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 ```

--- a/docs/snippets/common/component-story-sort-controls.js.mdx
+++ b/docs/snippets/common/component-story-sort-controls.js.mdx
@@ -1,10 +1,9 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx | YourComponent.stories.ts | YourComponent.stories.tsx
 
-import { YourComponent } from './your-component'
+import { YourComponent } from './your-component';
 
 export default {
-  title:'My Story',
   component: YourComponent,
   parameters: { controls: { sort: 'requiredFirst' } },
 };

--- a/docs/snippets/common/custom-docs-page.js-component.js.mdx
+++ b/docs/snippets/common/custom-docs-page.js-component.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-export default function CustomDocumentationComponent() {
+export function CustomDocumentationComponent() {
   return (
     <div>
       <h1>Replacing DocsPage with a custom component</h1>

--- a/docs/snippets/common/custom-docs-page.mdx.mdx
+++ b/docs/snippets/common/custom-docs-page.mdx.mdx
@@ -1,12 +1,11 @@
 ```md
-
 <!-- Custom-MDX-Documentation.mdx -->
 
 # Replacing DocsPage with custom `MDX` content
 
 This file is a documentation-only `MDX`file to customize Storybook's [DocsPage](https://storybook.js.org/docs/react/writing-docs/docs-page#replacing-docspage).
 
-It can be further expanded with your own code snippets and include specific information related to your stories. 
+It can be further expanded with your own code snippets and include specific information related to your stories.
 
 For example:
 
@@ -20,6 +19,10 @@ Button is the primary component. It has four possible states.
 - [Secondary](#secondary)
 - [Large](#large)
 - [Small](#small)
+
+## With the story title defined
+
+If you included the title in the story's default export, use this approach.
 
 ### Primary
 
@@ -36,4 +39,24 @@ Button is the primary component. It has four possible states.
 ### Small
 
 <Story id="example-button--small" />
+
+## Without the story title defined
+
+If you didn't include the title in the story's default export, use this approach.
+
+### Primary
+
+<Story id="your-directory-button--primary"/>
+
+### Secondary
+
+<Story id="your-directory-button--secondary"/>
+
+### Large
+
+<Story id="your-directory-button--large"/>
+
+### Small
+
+<Story id="your-directory-button--small" />
 ```

--- a/docs/snippets/common/foo-bar-baz-story.js.mdx
+++ b/docs/snippets/common/foo-bar-baz-story.js.mdx
@@ -1,7 +1,10 @@
 ```js
 // FooBar.stories.js | FooBar.stories.jsx | FooBar.stories.ts | FooBar.stories.tsx
 
+import { Foo } from './Foo';
+
 export default {
+  component:Foo,
   title: 'Foo/Bar',
 };
 

--- a/docs/snippets/common/foo-bar-baz-story.js.mdx
+++ b/docs/snippets/common/foo-bar-baz-story.js.mdx
@@ -5,5 +5,5 @@ export default {
   title: 'Foo/Bar',
 };
 
-export const Baz = BarStory.bind({});
+export const Baz = {};
 ```

--- a/docs/snippets/common/foo-bar-baz-story.js.mdx
+++ b/docs/snippets/common/foo-bar-baz-story.js.mdx
@@ -4,7 +4,7 @@
 import { Foo } from './Foo';
 
 export default {
-  component:Foo,
+  component: Foo,
   title: 'Foo/Bar',
 };
 

--- a/docs/snippets/common/gizmo-story-controls-customization.js.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.js.mdx
@@ -1,11 +1,12 @@
 ```js
 // Gizmo.stories.js | Gizmo.stories.jsx | Gizmo.stories.ts | Gizmo.stories.tsx
 
+import Gizmo from './Gizmo';
+
 export default {
-  title: 'Gizmo',
   component: Gizmo,
   argTypes: {
-    width: { 
+    width: {
       control: { type: 'range', min: 400, max: 1200, step: 50 },
     },
   },

--- a/docs/snippets/common/gizmo-story-controls-customization.js.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Gizmo.stories.js | Gizmo.stories.jsx | Gizmo.stories.ts | Gizmo.stories.tsx
 
-import Gizmo from './Gizmo';
+import { Gizmo } from './Gizmo';
 
 export default {
   component: Gizmo,

--- a/docs/snippets/common/my-component-story-mandatory-export.js.mdx
+++ b/docs/snippets/common/my-component-story-mandatory-export.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.story.js | MyComponent.story.jsx | MyComponent.story.ts | MyComponent.story.tsx
 
-import MyComponent from './MyComponent';
+import { MyComponent } from './MyComponent';
 
 export default {
   title: 'Path/To/MyComponent',

--- a/docs/snippets/common/my-component-story-with-storyname.js.mdx
+++ b/docs/snippets/common/my-component-story-with-storyname.js.mdx
@@ -1,9 +1,16 @@
 ```js
 // MyComponent.story.js | MyComponent.story.jsx | MyComponent.story.ts | MyComponent.story.tsx
 
-export const Simple = () => <MyComponent />;
+import MyComponent from './MyComponent';
+
+export default {
+  component: MyComponent,
+};
+
+export const Simple = {
+  decorators: [...],
+  parameters: {...},
+};
 
 Simple.storyName = 'So simple!';
-Simple.decorators = [ ... ];
-Simple.parameters = { ... };
 ```

--- a/docs/snippets/common/my-component-story-with-storyname.js.mdx
+++ b/docs/snippets/common/my-component-story-with-storyname.js.mdx
@@ -9,8 +9,7 @@ export default {
 
 export const Simple = {
   decorators: [...],
+  name:'So simple!',
   parameters: {...},
 };
-
-Simple.storyName = 'So simple!';
 ```

--- a/docs/snippets/common/my-component-story-with-storyname.js.mdx
+++ b/docs/snippets/common/my-component-story-with-storyname.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.story.js | MyComponent.story.jsx | MyComponent.story.ts | MyComponent.story.tsx
 
-import MyComponent from './MyComponent';
+import { MyComponent } from './MyComponent';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/common/my-component-story.js.mdx
+++ b/docs/snippets/common/my-component-story.js.mdx
@@ -4,8 +4,8 @@
 import { MyComponent } from './MyComponent';
 
 export default {
-  title: 'MyComponent',
   component: MyComponent,
 };
-// your templates and stories
+
+// Your stories
 ```

--- a/docs/snippets/common/other-foo-bar-story.js.mdx
+++ b/docs/snippets/common/other-foo-bar-story.js.mdx
@@ -6,6 +6,6 @@ export default {
   id: 'Foo/Bar', // Or 'foo-bar' if you prefer
 };
 
-export const Baz = () => BarStory.bind({});
+export const Baz = {};
 Baz.storyName = 'Moo';
 ```

--- a/docs/snippets/common/other-foo-bar-story.js.mdx
+++ b/docs/snippets/common/other-foo-bar-story.js.mdx
@@ -1,7 +1,10 @@
 ```js
 // FooBar.stories.js | FooBar.stories.jsx | FooBar.stories.ts | FooBar.stories.tsx
 
+import { Foo } from './Foo';
+
 export default {
+  component: Foo,
   title: 'OtherFoo/Bar',
   id: 'Foo/Bar', // Or 'foo-bar' if you prefer
 };

--- a/docs/snippets/common/other-foo-bar-story.js.mdx
+++ b/docs/snippets/common/other-foo-bar-story.js.mdx
@@ -9,6 +9,7 @@ export default {
   id: 'Foo/Bar', // Or 'foo-bar' if you prefer
 };
 
-export const Baz = {};
-Baz.storyName = 'Moo';
+export const Baz = {
+  name: 'Moo',
+};
 ```

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 // To apply a set of backgrounds to all stories of Button:
 export default {

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.js.mdx
@@ -1,9 +1,11 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from './Button';
+
 // To apply a set of backgrounds to all stories of Button:
 export default {
-  title: 'Button',
+  component: Button,
   parameters: {
     backgrounds: {
       default: 'twitter',

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
@@ -1,9 +1,11 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import Button from '.Button';
+
 // To apply a grid to all stories of Button:
 export default {
-  title: 'Button',
+  component: Button,
   parameters: {
     backgrounds: {
       grid: {

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from '.Button';
+import { Button } from './Button';
 
 // To apply a grid to all stories of Button:
 export default {

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.js.mdx
@@ -1,8 +1,15 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const Large = Template.bind({});
-Large.parameters = {
-  backgrounds: { disable: true }
+import Button from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Large = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
 };
 ```

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-grid.js.mdx
@@ -1,12 +1,19 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const Large = Template.bind({});
-Large.parameters = {
-  backgrounds: {
-    grid: {
-      disable: true,
-    }
-  }
+import Button from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Large = {
+  parameters: {
+    backgrounds: {
+      grid: {
+        disable: true,
+      },
+    },
+  },
 };
 ```

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-grid.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/storybook-addon-backgrounds-override-background-color.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-override-background-color.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx |  Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/storybook-addon-backgrounds-override-background-color.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-override-background-color.js.mdx
@@ -1,8 +1,15 @@
 ```js
 // Button.stories.js | Button.stories.jsx |  Button.stories.ts | Button.stories.tsx
 
-export const Large = Template.bind({});
-Large.parameters = {
-  backgrounds: { default: 'facebook' }
+import Button from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Large = {
+  parameters: {
+    backgrounds: { default: 'facebook' },
+  },
 };
 ```

--- a/docs/snippets/common/storybook-component-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-component-layout-param.js.mdx
@@ -4,11 +4,10 @@
 import Button from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
-   // Sets the layout parameter component wide. 
-   parameters:{
-    layout:'centered',
+  // Sets the layout parameter component wide.
+  parameters: {
+    layout: 'centered',
   },
 };
 ```

--- a/docs/snippets/common/storybook-component-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-component-layout-param.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/common/storybook-customize-argtypes.js.mdx
+++ b/docs/snippets/common/storybook-customize-argtypes.js.mdx
@@ -1,8 +1,9 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
+import { Button } from './Button';
+
 export default {
-  title: 'Button',
   component: Button,
   argTypes: {
     label: {

--- a/docs/snippets/common/storybook-preview-global-parameters.js.mdx
+++ b/docs/snippets/common/storybook-preview-global-parameters.js.mdx
@@ -4,9 +4,9 @@
 export const parameters = {
   backgrounds: {
     values: [
-        { name: 'red', value: '#f00', },
-        { name: 'green', value: '#0f0', },
+      { name: 'red', value: '#f00' },
+      { name: 'green', value: '#0f0' },
     ],
   },
-}
+};
 ```

--- a/docs/snippets/common/storybook-story-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-story-layout-param.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button':
+import { Button } from './Button':
 
 export default {
   component: Button,

--- a/docs/snippets/common/storybook-story-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-story-layout-param.js.mdx
@@ -1,9 +1,13 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import Button from './Button':
 
-export default WithLayout = {
+export default {
+  component: Button,
+}
+
+export const WithLayout = {
   parameters: {
     layout: 'centered',
   },

--- a/docs/snippets/common/storybook-story-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-story-layout-param.js.mdx
@@ -1,8 +1,11 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const WithLayout = Template.bind({});
-WithLayout.parameters = {
-  layout: 'centered',
+import Button from './Button';
+
+export default WithLayout = {
+  parameters: {
+    layout: 'centered',
+  },
 };
 ```

--- a/docs/snippets/react/app-story-with-mock.js.mdx
+++ b/docs/snippets/react/app-story-with-mock.js.mdx
@@ -6,27 +6,25 @@ import React from 'react';
 import App from './App';
 
 export default {
-  title: 'App',
   component: App,
 };
 
-const Template = (args) => <App {...args} />;
-
-export const Success = Template.bind({});
-Success.parameters = {
-  fetch: {
-    json: {
-      JavaScript: 3390991,
-      'C++': 44974,
-      TypeScript: 15530,
-      CoffeeScript: 12253,
-      Python: 9383,
-      C: 5341,
-      Shell: 5115,
-      HTML: 3420,
-      CSS: 3171,
-      Makefile: 189,
-    }
-  }
+export const Success = {
+  parameters: {
+    fetch: {
+      json: {
+        JavaScript: 3390991,
+        'C++': 44974,
+        TypeScript: 15530,
+        CoffeeScript: 12253,
+        Python: 9383,
+        C: 5341,
+        Shell: 5115,
+        HTML: 3420,
+        CSS: 3171,
+        Makefile: 189,
+      },
+    },
+  },
 };
 ```

--- a/docs/snippets/react/button-component-with-proptypes.js.mdx
+++ b/docs/snippets/react/button-component-with-proptypes.js.mdx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-export default function Button({ isDisabled, content }) {
+export function Button({ isDisabled, content }) {
   return (
     <button type="button" disabled={isDisabled}>
       {content}

--- a/docs/snippets/react/button-group-story.js.mdx
+++ b/docs/snippets/react/button-group-story.js.mdx
@@ -1,22 +1,19 @@
 ```js
 // ButtonGroup.stories.js | ButtonGroup.stories.jsx
 
-import React from 'react';
-
 import { ButtonGroup } from '../ButtonGroup';
 
 //👇 Imports the Button stories
 import * as ButtonStories from './Button.stories';
 
 export default {
-  title: 'ButtonGroup',
   component: ButtonGroup,
 };
-const Template = (args) => <ButtonGroup {...args} />;
 
-export const Pair = Template.bind({});
-Pair.args = {
-  buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
-  orientation: 'horizontal',
+export const Pair = {
+  args: {
+    buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
+    orientation: 'horizontal',
+  },
 };
 ```

--- a/docs/snippets/react/button-story-click-handler-args.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-args.js.mdx
@@ -1,9 +1,18 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const Text = ({ label, onClick }) => <Button label={label} onClick={onClick} />;
-Text.args = {
-  label: 'Hello',
-  onClick: action('clicked'),
+import React from 'react';
+
+import { action } from '@storybook/addon-actions';
+
+import { Button } from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Text = {
+  args: { label: 'Hello', onClick: action('clicked') },
+  render: ({ label, onClick }) => <Button label={label} onClick={onClick} />,
 };
 ```

--- a/docs/snippets/react/button-story-click-handler-simple-docs.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simple-docs.js.mdx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { action } from '@storybook/addon-actions';
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/react/button-story-click-handler-simple-docs.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simple-docs.js.mdx
@@ -1,5 +1,17 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const Text = ({ label, onClick }) => <Button label={label} onClick={onClick} />;
+import React from 'react';
+
+import { action } from '@storybook/addon-actions';
+
+import Button from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Text = {
+  render: ({ label, onClick }) => <Button label={label} onClick={onClick} />,
+};
 ```

--- a/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
@@ -3,7 +3,11 @@
 
 import Button from './Button';
 
-export default Text = {
+export default {
+  component: Button,
+}
+
+export const Text = {
   args: {...},
 };
 ```

--- a/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
@@ -1,5 +1,9 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const Text = (args) => <Button {...args} />;
+import Button from './Button';
+
+export default Text = {
+  args: {...},
+};
 ```

--- a/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/react/button-story-click-handler.js.mdx
+++ b/docs/snippets/react/button-story-click-handler.js.mdx
@@ -8,8 +8,10 @@ import { action } from '@storybook/addon-actions';
 import { Button } from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
 };
-export const Text = () => <Button label="Hello" onClick={action('clicked')} />;
+
+export const Text = {
+  render: () => <Button label="Hello" onClick={action('clicked')} />,
+};
 ```

--- a/docs/snippets/react/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.js.mdx
@@ -6,7 +6,6 @@ import React from 'react';
 import Button from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific argTypes
   argTypes: {

--- a/docs/snippets/react/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/react/button-story-component-decorator.js.mdx
+++ b/docs/snippets/react/button-story-component-decorator.js.mdx
@@ -6,7 +6,6 @@ import React from 'react';
 import { Button } from './Button';
 
 export default {
-  title: 'Components/Button',
   component: Button,
   decorators: [
     (Story) => (

--- a/docs/snippets/react/button-story-component-decorator.story-function-js.js.mdx
+++ b/docs/snippets/react/button-story-component-decorator.story-function-js.js.mdx
@@ -3,10 +3,9 @@
 
 import React from 'react';
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
   decorators: [
     (Story) => (

--- a/docs/snippets/react/button-story-decorator.js.mdx
+++ b/docs/snippets/react/button-story-decorator.js.mdx
@@ -1,6 +1,19 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const Primary = …
-Primary.decorators = [(Story) => <div style={{ margin: '3em' }}><Story/></div>];
+import Button from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Primary = {
+  decorators: [
+    (Story) => (
+      <div style={{ margin: '3em' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
 ```

--- a/docs/snippets/react/button-story-decorator.js.mdx
+++ b/docs/snippets/react/button-story-decorator.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/react/button-story-decorator.story-function.js.mdx
+++ b/docs/snippets/react/button-story-decorator.story-function.js.mdx
@@ -1,6 +1,13 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-export const Primary = …
-Primary.decorators = [(Story) => <div style={{ margin: '3em' }}>{Story()}</div>];
+import Button from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Primary = {
+  decorators: [(Story) => <div style={{ margin: '3em' }}>{Story()}</div>],
+};
 ```

--- a/docs/snippets/react/button-story-decorator.story-function.js.mdx
+++ b/docs/snippets/react/button-story-decorator.story-function.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js | Button.stories.jsx | Button.stories.ts | Button.stories.tsx
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/react/button-story-default-docs-code.js.mdx
+++ b/docs/snippets/react/button-story-default-docs-code.js.mdx
@@ -5,13 +5,7 @@ import React from 'react';
 
 import { Button } from './Button';
 
-//👇 Some function to demonstrate the behavior
-const someFunction = (someValue) => {
-  return `i am a ${someValue}`;
-};
-
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific argTypes
   argTypes: {
@@ -19,18 +13,25 @@ export default {
   },
 };
 
-export const ExampleStory = (args) => {
-  //👇 Destructure the label from the args object
-  const { label } = args;
-
-  //👇 Assigns the function result to a variable and pass it as a prop into the component
-  const functionResult = someFunction(label);
-  return <Button {...args} label={functionResult} />;
+//👇 Some function to demonstrate the behavior
+const someFunction = (someValue) => {
+  return `i am a ${someValue}`;
 };
 
-ExampleStory.args = {
-  primary: true,
-  size: 'small',
-  label: 'button',
+export const ExampleStory = {
+  args: {
+    primary: true,
+    size: 'small',
+    label: 'button',
+  },
+  render: (args) => {
+    //👇 Destructure the label from the args object
+    const { label } = args;
+
+    //👇 Assigns the function result to a variable and pass it as a prop into the component
+    const functionResult = someFunction(label);
+
+    return <Button {...args} label={functionResult} />;
+  },
 };
 ```

--- a/docs/snippets/react/button-story-default-export-with-component.js.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.js.mdx
@@ -6,7 +6,8 @@ import React from 'react';
 import { Button } from './Button';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-}
+  //👇 Title is optional, you can omit it and Storybook automatically generates the title for the story
+  title: 'Components/Button',
+};
 ```

--- a/docs/snippets/react/button-story-rename-story.js.mdx
+++ b/docs/snippets/react/button-story-rename-story.js.mdx
@@ -10,8 +10,7 @@ export default {
 };
 
 export const Primary = {
+  name: 'I am the primary',
   render: () => <Button primary label="Button" />,
 };
-
-Primary.storyName = 'I am the primary';
 ```

--- a/docs/snippets/react/button-story-rename-story.js.mdx
+++ b/docs/snippets/react/button-story-rename-story.js.mdx
@@ -5,7 +5,13 @@ import React from 'react';
 
 import { Button } from './Button';
 
-export const Primary = () => <Button primary label="Button"/>;
+export default {
+  component: Button,
+};
+
+export const Primary = {
+  render: () => <Button primary label="Button" />,
+};
 
 Primary.storyName = 'I am the primary';
 ```

--- a/docs/snippets/react/button-story-using-args.js.mdx
+++ b/docs/snippets/react/button-story-using-args.js.mdx
@@ -1,16 +1,30 @@
 ```js
 // Button.stories.js | Button.stories.jsx
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args) => <Button {...args} />;
+import { Button } from './Button';
 
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-Primary.args = { background: '#ff0', label: 'Button' };
+export default {
+  component: Button,
+};
 
-export const Secondary = Template.bind({});
-Secondary.args = { ...Primary.args, label: '😄👍😍💯' };
+export const Primary = {
+  args: {
+    backgroundColor: '#ff0',
+    label: 'Button',
+  },
+};
 
-export const Tertiary = Template.bind({});
-Tertiary.args = { ...Primary.args, label: '📚📕📈🤓' };
+export const Secondary = {
+  args: {
+    ...Primary.args,
+    label: '😄👍😍💯',
+  },
+};
+
+export const Tertiary = {
+  args: {
+    ...Primary.args,
+    label: '📚📕📈🤓',
+  },
+};
 ```

--- a/docs/snippets/react/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/react/button-story-with-addon-example.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
   component: Button,

--- a/docs/snippets/react/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/react/button-story-with-addon-example.js.mdx
@@ -6,7 +6,7 @@ import React from 'react';
 import Button from './Button';
 
 export default {
-  title: 'Button',
+  component: Button,
   //👇 Creates specific parameters for the story
   parameters: {
     myAddon: {
@@ -15,5 +15,7 @@ export default {
   },
 };
 
-export const Basic = () => <Button>hello</Button>;
+export const Basic = {
+  render: () => <Button>hello</Button>,
+};
 ```

--- a/docs/snippets/react/button-story-with-args.js.mdx
+++ b/docs/snippets/react/button-story-with-args.js.mdx
@@ -1,23 +1,16 @@
 ```js
 // Button.stories.js | Button.stories.jsx
 
-import React from 'react';
-
 import { Button } from './Button';
 
 export default {
   component: Button,
-  title: 'Components/Button',
 };
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args) => <Button {...args} />;
-
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-
-Primary.args = {
-  primary: true,
-  label: 'Button',
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
 };
 ```

--- a/docs/snippets/react/button-story-with-blue-args.js.mdx
+++ b/docs/snippets/react/button-story-with-blue-args.js.mdx
@@ -6,7 +6,6 @@ import React from 'react';
 import { Button } from './Button';
 
 export default {
-  title: 'Components/Button',
   component: Button,
   //👇 Creates specific parameters for the story
   parameters: {

--- a/docs/snippets/react/button-story-with-emojis.js.mdx
+++ b/docs/snippets/react/button-story-with-emojis.js.mdx
@@ -1,13 +1,22 @@
 ```ts
 // Button.stories.js | Button.stories.jsx
 
+import React from 'react';
+
 import { Button } from './Button';
 
 export default {
   component: Button,
-  title: 'Components/Button',
-}
-export const Primary = () => <Button background="#ff0" label="Button" />;
-export const Secondary = () => <Button background="#ff0" label="😄👍😍💯" />;
-export const Tertiary = () => <Button background="#ff0" label="📚📕📈🤓" />;
+};
+export const Primary = {
+  render: () => <Button backgroundColor="#ff0" label="Button" />,
+};
+
+export const Secondary = {
+  render: () => <Button backgroundColor="#ff0" label="😄👍😍💯" />,
+};
+
+export const Tertiary = {
+  render: () => <Button backgroundColor="#ff0" label="📚📕📈🤓" />,
+};
 ```

--- a/docs/snippets/react/button-story-with-parameters.js.mdx
+++ b/docs/snippets/react/button-story-with-parameters.js.mdx
@@ -3,10 +3,9 @@
 
 import React from 'react';
 
-import Button from './Button';
+import { Button } from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific parameters for the story
   parameters: {

--- a/docs/snippets/react/button-story-with-sample.js.mdx
+++ b/docs/snippets/react/button-story-with-sample.js.mdx
@@ -6,9 +6,10 @@ import React from 'react';
 import { Button } from './Button';
 
 export default {
-  title: 'Button',
   component: Button,
 };
 
-export const Sample = () => <Button label="hello button" />;
+export const Sample = {
+  render: () => <Button label="hello button" />,
+};
 ```

--- a/docs/snippets/react/button-story.js.mdx
+++ b/docs/snippets/react/button-story.js.mdx
@@ -7,8 +7,9 @@ import { Button } from './Button';
 
 export default {
   component: Button,
-  title: 'Components/Button',
-}
+};
 
-export const Primary = () => <Button primary>Button</Button>;
+export const Primary = {
+  render: () => <Button primary label="Button" />,
+};
 ```

--- a/docs/snippets/react/button-story.with-hooks.js.mdx
+++ b/docs/snippets/react/button-story.with-hooks.js.mdx
@@ -5,11 +5,15 @@ import React, { useState } from 'react';
 
 import { Button } from './Button';
 
+export default {
+  component: Button,
+};
+
 /*
-* Example Button story with React Hooks.
-* See note below related to this example.
-*/
-export const Primary = () => {
+ * Example Button story with React Hooks.
+ * See note below related to this example.
+ */
+const ButtonWithHooks = () => {
   // Sets the hooks for both the label and primary props
   const [value, setValue] = useState('Secondary');
   const [isPrimary, setIsPrimary] = useState(false);
@@ -22,5 +26,9 @@ export const Primary = () => {
     }
   };
   return <Button primary={isPrimary} onClick={handleOnChange} label={value} />;
+};
+
+export const Primary = {
+  render: () => <ButtonWithHooks />,
 };
 ```

--- a/docs/snippets/react/checkbox-story-csf.js.mdx
+++ b/docs/snippets/react/checkbox-story-csf.js.mdx
@@ -6,15 +6,16 @@ import React from 'react';
 import { Checkbox } from './Checkbox';
 
 export default {
-  title: 'MDX/Checkbox',
   component: Checkbox,
 };
 
-export const allCheckboxes = () => (
-  <form>
-    <Checkbox id="Unchecked" label="Unchecked" />
-    <Checkbox id="Checked" label="Checked" checked />
-    <Checkbox appearance="secondary" id="second" label="Secondary" checked />
-  </form>
-);
+export const allCheckboxes = {
+  render: () => (
+    <form>
+      <Checkbox id="Unchecked" label="Unchecked" />
+      <Checkbox id="Checked" label="Checked" checked />
+      <Checkbox appearance="secondary" id="second" label="Secondary" checked />
+    </form>
+  ),
+};
 ```

--- a/docs/snippets/react/component-story-custom-args-complex.js.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.js.mdx
@@ -5,19 +5,13 @@ import React from 'react';
 
 import { YourComponent } from './your-component';
 
-//👇 Some function to demonstrate the behavior
-const someFunction = (valuePropertyA, valuePropertyB) => {
-  // Makes some computations and returns something
-};
-
 export default {
   component: YourComponent,
-  title: 'A complex case with a function',
   //👇 Creates specific argTypes with options
   argTypes: {
     propertyA: {
       options: ['Item One', 'Item Two', 'Item Three'],
-      control: { type: 'select' } // Automatically inferred when 'options' is defined
+      control: { type: 'select' }, // Automatically inferred when 'options' is defined
     },
     propertyB: {
       options: ['Another Item One', 'Another Item Two', 'Another Item Three'],
@@ -25,10 +19,22 @@ export default {
   },
 };
 
-const Template = ({ propertyA, propertyB, ...rest }) => {
-  //👇 Assigns the function result to a variable
-  const someFunctionResult = someFunction(propertyA, propertyB);
+//👇 Some function to demonstrate the behavior
+const someFunction = (valuePropertyA, valuePropertyB) => {
+  // Makes some computations and returns something
+};
 
-  return <YourComponent someProperty={someFunctionResult} {...rest} />;
+export const ExampleStory = {
+  args: {
+    propertyA: 'Something',
+    propertyB: 'Something else',
+  },
+  render: (args) => {
+    const { propertyA, propertyB } = args;
+    //👇 Assigns the function result to a variable
+    const someFunctionResult = someFunction(propertyA, propertyB);
+
+    return <YourComponent {...args} someProperty={someFunctionResult} />;
+  },
 };
 ```

--- a/docs/snippets/react/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.js.mdx
@@ -7,7 +7,7 @@ export default {
   title: 'img',
 };
 
-export const withAnImage = () => (
-  <img src="https://place-hold.it/350x150" alt="My CDN placeholder" />
-);
+export const withAnImage = {
+  render: () => <img src="https://place-hold.it/350x150" alt="My CDN placeholder" />,
+};
 ```

--- a/docs/snippets/react/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.js.mdx
@@ -7,7 +7,7 @@ export default {
   title: 'img',
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => <img src="https://place-hold.it/350x150" alt="My CDN placeholder" />,
 };
 ```

--- a/docs/snippets/react/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-with-import.js.mdx
@@ -14,5 +14,7 @@ const image = {
   alt: 'my image',
 };
 
-export const withAnImage = () => <img src={image.src} alt={image.alt} />;
+export const withAnImage = {
+  render: () => <img src={image.src} alt={image.alt} />,
+};
 ```

--- a/docs/snippets/react/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-with-import.js.mdx
@@ -14,7 +14,7 @@ const image = {
   alt: 'my image',
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => <img src={image.src} alt={image.alt} />,
 };
 ```

--- a/docs/snippets/react/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-without-import.js.mdx
@@ -8,7 +8,7 @@ export default {
 };
 
 // Assume image.png is located in the "public" directory.
-export const withAnImage = {
+export const WithAnImage = {
   render: () => <img src="/image.png" alt="my image" />,
 };
 ```

--- a/docs/snippets/react/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-without-import.js.mdx
@@ -8,7 +8,7 @@ export default {
 };
 
 // Assume image.png is located in the "public" directory.
-export const withAnImage = () => (
-  <img src="/image.png" alt="my image" />
-);
+export const withAnImage = {
+  render: () => <img src="/image.png" alt="my image" />,
+};
 ```

--- a/docs/snippets/react/document-screen-fetch.js.mdx
+++ b/docs/snippets/react/document-screen-fetch.js.mdx
@@ -3,9 +3,9 @@
 
 import React, { useState, useEffect } from 'react';
 
-import PageLayout from './PageLayout';
-import DocumentHeader from './DocumentHeader';
-import DocumentList from './DocumentList';
+import { PageLayout } from './PageLayout';
+import { DocumentHeader } from './DocumentHeader';
+import { DocumentList } from './DocumentList';
 
 // Example hook to retrieve data from an external endpoint
 function useFetchData() {
@@ -34,7 +34,7 @@ function useFetchData() {
     data,
   };
 }
-function DocumentScreen() {
+export function DocumentScreen() {
   const { status, data } = useFetchData();
 
   const { user, document, subdocuments } = data;
@@ -52,6 +52,4 @@ function DocumentScreen() {
     </PageLayout>
   );
 }
-
-export default DocumentScreen;
 ```

--- a/docs/snippets/react/document-screen-with-graphql.js.mdx
+++ b/docs/snippets/react/document-screen-with-graphql.js.mdx
@@ -5,9 +5,9 @@ import React from 'react';
 
 import { useQuery, gql } from '@apollo/client';
 
-import PageLayout from './PageLayout';
-import DocumentHeader from './DocumentHeader';
-import DocumentList from './DocumentList';
+import { PageLayout } from './PageLayout';
+import { DocumentHeader } from './DocumentHeader';
+import { DocumentList } from './DocumentList';
 
 const AllInfoQuery = gql`
   query AllInfo {
@@ -38,7 +38,7 @@ function useFetchInfo() {
   return { loading, error, data };
 }
 
-function DocumentScreen() {
+export function DocumentScreen() {
   const { loading, error, data } = useFetchInfo();
 
   if (loading) {
@@ -56,5 +56,4 @@ function DocumentScreen() {
     </PageLayout>
   );
 }
-export default DocumentScreen;
 ```

--- a/docs/snippets/react/document-screen-with-graphql.js.mdx
+++ b/docs/snippets/react/document-screen-with-graphql.js.mdx
@@ -5,6 +5,10 @@ import React from 'react';
 
 import { useQuery, gql } from '@apollo/client';
 
+import PageLayout from './PageLayout';
+import DocumentHeader from './DocumentHeader';
+import DocumentList from './DocumentList';
+
 const AllInfoQuery = gql`
   query AllInfo {
     user {

--- a/docs/snippets/react/documentscreen-story-msw-graphql-query.js.mdx
+++ b/docs/snippets/react/documentscreen-story-msw-graphql-query.js.mdx
@@ -7,7 +7,7 @@ import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
 
 import { graphql } from 'msw';
 
-import DocumentScreen from './YourPage';
+import { DocumentScreen } from './YourPage';
 
 export default {
   component: DocumentScreen,

--- a/docs/snippets/react/documentscreen-story-msw-graphql-query.js.mdx
+++ b/docs/snippets/react/documentscreen-story-msw-graphql-query.js.mdx
@@ -7,11 +7,10 @@ import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
 
 import { graphql } from 'msw';
 
-import DocumentScreen from './DocumentScreen';
+import DocumentScreen from './YourPage';
 
 export default {
   component: DocumentScreen,
-  title: 'Mock GraphQL query with Storybook and MSW',
 };
 
 const mockedClient = new ApolloClient({
@@ -78,34 +77,40 @@ const TestData = {
   ],
 };
 
-const PageTemplate = () => (
-  <ApolloProvider client={mockedClient}>
-    <DocumentScreen />
-  </ApolloProvider>
-);
-
-export const MockedSuccess = PageTemplate.bind({});
-MockedSuccess.parameters = {
-  msw: [
-    graphql.query('AllInfoQuery', (req, res, ctx) => {
-      return res(ctx.data(TestData));
-    }),
-  ],
+export const MockedSuccess = {
+  parameters: {
+    msw: [
+      graphql.query('AllInfoQuery', (req, res, ctx) => {
+        return res(ctx.data(TestData));
+      }),
+    ],
+  },
+  render: () => (
+    <ApolloProvider client={mockedClient}>
+      <DocumentScreen />
+    </ApolloProvider>
+  ),
 };
 
-export const MockedError = PageTemplate.bind({});
-MockedError.parameters = {
-  msw: [
-    graphql.query('AllInfoQuery', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.errors([
-          {
-            message: 'Access denied',
-          },
-        ])
-      );
-    }),
-  ],
+export const MockedError = {
+  parameters: {
+    msw: [
+      graphql.query('AllInfoQuery', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.errors([
+            {
+              message: 'Access denied',
+            },
+          ])
+        );
+      }),
+    ],
+  },
+  render: () => (
+    <ApolloProvider client={mockedClient}>
+      <DocumentScreen />
+    </ApolloProvider>
+  ),
 };
 ```

--- a/docs/snippets/react/documentscreen-story-msw-rest-request.js.mdx
+++ b/docs/snippets/react/documentscreen-story-msw-rest-request.js.mdx
@@ -1,15 +1,12 @@
 ```js
 // YourPage.stories.js | YourPage.stories.jsx | YourPage.stories.ts | YourPage.stories.tsx
 
-import React from 'react';
-
 import { rest } from 'msw';
 
-import DocumentScreen from './DocumentScreen';
+import DocumentScreen from './YourPage';
 
 export default {
   component: DocumentScreen,
-  title: 'Mock Rest request with Storybook and MSW',
 };
 
 //👇The mocked data that will be used in the story
@@ -61,23 +58,23 @@ const TestData = {
   ],
 };
 
-const PageTemplate = () => <DocumentScreen />;
-
-export const MockedSuccess = PageTemplate.bind({});
-MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://your-restful-endpoint/', (_req, res, ctx) => {
-      return res(ctx.json(TestData));
-    }),
-  ],
+export const MockedSuccess = {
+  parameters: {
+    msw: [
+      rest.get('https://your-restful-endpoint/', (_req, res, ctx) => {
+        return res(ctx.json(TestData));
+      }),
+    ],
+  },
 };
 
-export const MockedError = PageTemplate.bind({});
-MockedError.parameters = {
-  msw: [
-    rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
-      return res(ctx.delay(800), ctx.status(403));
-    }),
-  ],
+export const MockedError = {
+  parameters: {
+    msw: [
+      rest.get('https://your-restful-endpoint/', (_req, res, ctx) => {
+        return res(ctx.delay(800), ctx.status(403));
+      }),
+    ],
+  },
 };
 ```

--- a/docs/snippets/react/documentscreen-story-msw-rest-request.js.mdx
+++ b/docs/snippets/react/documentscreen-story-msw-rest-request.js.mdx
@@ -3,7 +3,7 @@
 
 import { rest } from 'msw';
 
-import DocumentScreen from './YourPage';
+import { DocumentScreen } from './YourPage';
 
 export default {
   component: DocumentScreen,

--- a/docs/snippets/react/list-story-expanded.js.mdx
+++ b/docs/snippets/react/list-story-expanded.js.mdx
@@ -8,22 +8,27 @@ import ListItem from './ListItem';
 
 export default {
   component: List,
-  title: 'List',
 };
 
-export const Empty = (args) => <List {...args} />;
+export const Empty = {
+  render: (args) => <List {...args} />,
+};
 
-export const OneItem = (args) => (
-  <List {...args}>
-    <ListItem />
-  </List>
-);
+export const OneItem = {
+  render: (args) => (
+    <List {...args}>
+      <ListItem />
+    </List>
+  ),
+};
 
-export const ManyItems = (args) => (
-  <List {...args}>
-    <ListItem />
-    <ListItem />
-    <ListItem />
-  </List>
-);
+export const ManyItems = {
+  render: (args) => (
+    <List {...args}>
+      <ListItem />
+      <ListItem />
+      <ListItem />
+    </List>
+  ),
+};
 ```

--- a/docs/snippets/react/list-story-expanded.js.mdx
+++ b/docs/snippets/react/list-story-expanded.js.mdx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-import List from './List';
-import ListItem from './ListItem';
+import { List } from './List';
+import { ListItem } from './ListItem';
 
 export default {
   component: List,

--- a/docs/snippets/react/list-story-reuse-data.js.mdx
+++ b/docs/snippets/react/list-story-reuse-data.js.mdx
@@ -3,11 +3,15 @@
 
 import React from 'react';
 
-import List from './List';
-import ListItem from './ListItem';
+import { List } from './List';
+import { ListItem } from './ListItem';
 
 //👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
+
+export default {
+  component: List,
+};
 
 export const ManyItems = {
   render: (args) => (

--- a/docs/snippets/react/list-story-reuse-data.js.mdx
+++ b/docs/snippets/react/list-story-reuse-data.js.mdx
@@ -3,14 +3,19 @@
 
 import React from 'react';
 
+import List from './List';
+import ListItem from './ListItem';
+
 //👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
 
-export const ManyItems = (args) => (
-  <List {...args}>
-    <Selected {...Selected.args} />
-    <Unselected {...Unselected.args} />
-    <Unselected {...Unselected.args} />
-  </List>
-);
+export const ManyItems = {
+  render: (args) => (
+    <List {...args}>
+      <ListItem {...Selected.args} />
+      <ListItem {...Unselected.args} />
+      <ListItem {...Unselected.args} />
+    </List>
+  ),
+};
 ```

--- a/docs/snippets/react/list-story-starter.js.mdx
+++ b/docs/snippets/react/list-story-starter.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import List from './List';
+import { List } from './List';
 
 export default {
   component: List,

--- a/docs/snippets/react/list-story-starter.js.mdx
+++ b/docs/snippets/react/list-story-starter.js.mdx
@@ -7,9 +7,10 @@ import List from './List';
 
 export default {
   component: List,
-  title: 'List',
 };
 
 // Always an empty list, not super interesting
-const Template = (args) => <List {...args} />;
+export const Empty = {
+  render: (args) => <List {...args} />,
+};
 ```

--- a/docs/snippets/react/list-story-template.js.mdx
+++ b/docs/snippets/react/list-story-template.js.mdx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-import List from './List';
-import ListItem from './ListItem';
+import { List } from './List';
+import { ListItem } from './ListItem';
 
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';

--- a/docs/snippets/react/list-story-template.js.mdx
+++ b/docs/snippets/react/list-story-template.js.mdx
@@ -9,17 +9,34 @@ import ListItem from './ListItem';
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
-const ListTemplate = ({ items, ...args }) => (
-  <List>
-    {items.map((item) => (
-      <ListItem {...item} />
-    ))}
-  </List>
-);
+export default {
+  component: List,
+};
 
-export const Empty = ListTemplate.bind({});
-Empty.args = { items: [] };
+//👇 The ListTemplate construct will be spread to the existing stories.
+const ListTemplate = {
+  render: ({ items, ...args }) => {
+    return (
+      <List>
+        {items.map((item) => (
+          <ListItem {...item} />
+        ))}
+      </List>
+    );
+  },
+};
 
-export const OneItem = ListTemplate.bind({});
-OneItem.args = { items: [Unchecked.args] };
+export const Empty = {
+  ...ListTemplate,
+  args: {
+    items: [],
+  },
+};
+
+export const OneItem = {
+  ...ListTemplate,
+  args: {
+    items: [Unchecked.args],
+  },
+};
 ```

--- a/docs/snippets/react/list-story-unchecked.js.mdx
+++ b/docs/snippets/react/list-story-unchecked.js.mdx
@@ -3,10 +3,14 @@
 
 import React from 'react';
 
-import List from './List';
+import { List } from './List';
 
 //👇 Instead of importing ListItem, we import the stories
 import { Unchecked } from './ListItem.stories';
+
+export default {
+  component: List,
+};
 
 export const OneItem = (args) => (
   <List {...args}>

--- a/docs/snippets/react/list-story-with-subcomponents.js.mdx
+++ b/docs/snippets/react/list-story-with-subcomponents.js.mdx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-import List from './List';
-import ListItem from './ListItem';
+import { List } from './List';
+import { ListItem } from './ListItem';
 
 export default {
   component: List,

--- a/docs/snippets/react/list-story-with-subcomponents.js.mdx
+++ b/docs/snippets/react/list-story-with-subcomponents.js.mdx
@@ -9,14 +9,15 @@ import ListItem from './ListItem';
 export default {
   component: List,
   subcomponents: { ListItem }, //👈 Adds the ListItem component as a subcomponent
-  title: 'List',
 };
 
-export const Empty = (args) => <List {...args} />;
+export const Empty = {};
 
-export const OneItem = (args) => (
-  <List {...args}>
-    <ListItem />
-  </List>
-);
+export const OneItem = {
+  render: (args) => (
+    <List {...args}>
+      <ListItem />
+    </List>
+  ),
+};
 ```

--- a/docs/snippets/react/list-story-with-unchecked-children.js.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.js.mdx
@@ -3,11 +3,14 @@
 
 import React from 'react';
 
-import List from './List';
+import { List } from './List';
 
 //👇 Instead of importing ListItem, we import the stories
 import { Unchecked } from './ListItem.stories';
 
+export default {
+  component: List,
+};
 const Template = (args) => <List {...args} />;
 
 export const OneItem = Template.bind({});

--- a/docs/snippets/react/loader-story.js.mdx
+++ b/docs/snippets/react/loader-story.js.mdx
@@ -9,13 +9,16 @@ import { TodoItem } from './TodoItem';
 
 export default {
   component: TodoItem,
-  title: 'Examples/Loader',
 };
 
-export const Primary = (args, { loaded: { todo } }) => <TodoItem {...args} {...todo} />;
-Primary.loaders = [
-  async () => ({
-    todo: (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
-  }),
-];
+export const Primary = {
+  render: (args, { loaded: { todo } }) => {
+    return <TodoItem {...args} {...todo} />;
+  },
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
 ```

--- a/docs/snippets/react/mock-context-container-provider.js.mdx
+++ b/docs/snippets/react/mock-context-container-provider.js.mdx
@@ -4,9 +4,9 @@
 import React from 'react';
 
 import ProfilePageContext from './ProfilePageContext';
-import ProfilePageContainer from './ProfilePageContainer';
-import UserPostsContainer from './UserPostsContainer';
-import UserFriendsContainer from './UserFriendsContainer';
+import { ProfilePageContainer } from './ProfilePageContainer';
+import { UserPostsContainer } from './UserPostsContainer';
+import { UserFriendsContainer } from './UserFriendsContainer';
 
 //👇 Ensure that your context value remains referentially equal between each render.
 const context = {
@@ -14,13 +14,11 @@ const context = {
   UserFriendsContainer,
 };
 
-const AppProfilePage = () => {
+export const AppProfilePage = () => {
   return (
     <ProfilePageContext.Provider value={context}>
       <ProfilePageContainer />
     </ProfilePageContext.Provider>
   );
 };
-
-export default AppProfilePage;
 ```

--- a/docs/snippets/react/mock-context-container.js.mdx
+++ b/docs/snippets/react/mock-context-container.js.mdx
@@ -10,7 +10,7 @@ import UserPosts from './UserPosts';
 import { normal as UserFriendsNormal } from './UserFriends.stories';
 
 export default {
-  title: 'ProfilePage',
+  component: ProfilePage,
 };
 
 const ProfilePageProps = {
@@ -29,11 +29,11 @@ const context = {
   UserFriendsContainer: UserFriendsNormal,
 };
 
-export const normal = () => {
-  return (
+export const Normal = {
+  render: () => (
     <ProfilePageContext.Provider value={context}>
       <ProfilePage {...ProfilePageProps} />
     </ProfilePageContext.Provider>
-  );
+  ),
 };
 ```

--- a/docs/snippets/react/mock-context-container.js.mdx
+++ b/docs/snippets/react/mock-context-container.js.mdx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-import ProfilePage from './ProfilePage';
-import UserPosts from './UserPosts';
+import { ProfilePage } from './ProfilePage';
+import { UserPosts } from './UserPosts';
 
 //👇 Imports a specific story from a story file
 import { normal as UserFriendsNormal } from './UserFriends.stories';

--- a/docs/snippets/react/mock-context-in-use.js.mdx
+++ b/docs/snippets/react/mock-context-in-use.js.mdx
@@ -5,7 +5,7 @@ import { useContext } from 'react';
 
 import ProfilePageContext from './ProfilePageContext';
 
-const ProfilePage = ({ name, userId }) => {
+export const ProfilePage = ({ name, userId }) => {
   const { UserPostsContainer, UserFriendsContainer } = useContext(ProfilePageContext);
 
   return (
@@ -16,6 +16,4 @@ const ProfilePage = ({ name, userId }) => {
     </div>
   );
 };
-
-export default ProfilePage;
 ```

--- a/docs/snippets/react/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/react/my-component-story-basic-and-props.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import MyComponent from './MyComponent';
+import { MyComponent } from './MyComponent';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/react/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/react/my-component-story-basic-and-props.js.mdx
@@ -6,10 +6,12 @@ import React from 'react';
 import MyComponent from './MyComponent';
 
 export default {
-  title: 'Path/To/MyComponent',
   component: MyComponent,
 };
 
-export const Basic = () => <MyComponent />;
-export const WithProp = () => <MyComponent prop="value" />;
+export const Basic = {};
+
+export const WithProp = {
+  render: () => <MyComponent prop="value" />,
+};
 ```

--- a/docs/snippets/react/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.js.mdx
@@ -5,23 +5,27 @@ import React from 'react';
 
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
+import MyComponent from './MyComponent';
+
 export default {
-  title: 'Stories',
+  component: MyComponent,
   parameters: {
     //👇 The viewports object from the Essentials addon
     viewport: {
       //👇 The viewports you want to use
       viewports: INITIAL_VIEWPORTS,
       //👇 Your own default viewport
-      defaultViewport: 'iphone6'
+      defaultViewport: 'iphone6',
     },
   },
 };
 
-export const MyStory = () => <div />;
-MyStory.parameters = {
-  viewport: {
-    defaultViewport: 'iphonex'
+export const MyStory = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphonex',
+    },
   },
+  render: () => <div />,
 };
 ```

--- a/docs/snippets/react/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.js.mdx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
-import MyComponent from './MyComponent';
+import { MyComponent } from './MyComponent';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/react/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.js.mdx
@@ -26,6 +26,5 @@ export const MyStory = {
       defaultViewport: 'iphonex',
     },
   },
-  render: () => <div />,
 };
 ```

--- a/docs/snippets/react/my-component-story-use-globaltype-backwards-compat.js.mdx
+++ b/docs/snippets/react/my-component-story-use-globaltype-backwards-compat.js.mdx
@@ -1,10 +1,8 @@
 ```js
 // MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
-export const StoryWithLocale = {
-  render: ({ globals: { locale } }) => {
-    const caption = getCaptionForLocale(locale);
-    return <>{caption}</>;
-  },
+export const StoryWithLocale = ({ globals: { locale } }) => {
+  const caption = getCaptionForLocale(locale);
+  return <>{caption}</>;
 };
 ```

--- a/docs/snippets/react/my-component-story-use-globaltype-backwards-compat.js.mdx
+++ b/docs/snippets/react/my-component-story-use-globaltype-backwards-compat.js.mdx
@@ -1,8 +1,10 @@
 ```js
 // MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
-export const StoryWithLocale = ({ globals: { locale } }) => {
-  const caption = getCaptionForLocale(locale);
-  return <>{caption}</>;
+export const StoryWithLocale = {
+  render: ({ globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return <>{caption}</>;
+  },
 };
 ```

--- a/docs/snippets/react/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/react/my-component-story-use-globaltype.js.mdx
@@ -1,19 +1,33 @@
 ```js
 // MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
 
+import React from 'react';
+
+import MyComponent from './MyComponent';
+
+export default {
+  component: MyComponent,
+};
+
 const getCaptionForLocale = (locale) => {
-  switch(locale) {
-    case 'es': return 'Hola!';
-    case 'fr': return 'Bonjour!';
-    case 'kr': return '안녕하세요!';
-    case 'zh': return '你好!';
+  switch (locale) {
+    case 'es':
+      return 'Hola!';
+    case 'fr':
+      return 'Bonjour!';
+    case 'kr':
+      return '안녕하세요!';
+    case 'zh':
+      return '你好!';
     default:
       return 'Hello!';
   }
 };
 
-export const StoryWithLocale = (args, { globals: { locale } }) => {
-  const caption = getCaptionForLocale(locale);
-  return <>{caption}</>;
+export const StoryWithLocale = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return <>{caption}</>;
+  },
 };
 ```

--- a/docs/snippets/react/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/react/my-component-story-use-globaltype.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import MyComponent from './MyComponent';
+import { MyComponent } from './MyComponent';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/react/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/react/my-component-story-with-nonstory.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import MyComponent from './MyComponent';
+import { MyComponent } from './MyComponent';
 
 import someData from './data.json';
 

--- a/docs/snippets/react/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/react/my-component-story-with-nonstory.js.mdx
@@ -8,7 +8,6 @@ import MyComponent from './MyComponent';
 import someData from './data.json';
 
 export default {
-  title: 'MyComponent',
   component: MyComponent,
   includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
   excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
@@ -17,6 +16,11 @@ export default {
 export const simpleData = { foo: 1, bar: 'baz' };
 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 
-export const SimpleStory = () => <MyComponent data={simpleData} />;
-export const ComplexStory = () => <MyComponent data={complexData} />;
+export const SimpleStory = {
+  render: () => <MyComponent data={simpleData} />,
+};
+
+export const ComplexStory = {
+  render: () => <MyComponent data={complexData} />,
+};
 ```

--- a/docs/snippets/react/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.js.mdx
@@ -7,14 +7,11 @@ import MyComponent from './MyComponent';
 
 export default {
   component: MyComponent,
-  title: 'A story using environment variables inside a .env file',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const Default = Template.bind({});
-
-Default.args = {
-  propertyA: process.env.STORYBOOK_DATA_KEY,
+export const ExampleStory = {
+  args: {
+    propertyA: process.env.STORYBOOK_DATA_KEY,
+  },
 };
 ```

--- a/docs/snippets/react/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import MyComponent from './MyComponent';
+import { MyComponent } from './MyComponent';
 
 export default {
   component: MyComponent,

--- a/docs/snippets/react/page-story-slots.js.mdx
+++ b/docs/snippets/react/page-story-slots.js.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import Page from './Page';
+import { Page } from './Page';
 
 export default {
   component: Page,

--- a/docs/snippets/react/page-story-slots.js.mdx
+++ b/docs/snippets/react/page-story-slots.js.mdx
@@ -7,17 +7,16 @@ import Page from './Page';
 
 export default {
   component: Page,
-  title: 'Page',
 };
 
-const Template = (args) => (
-  <Page {...args}>
-    <footer>{args.footer}</footer>
-  </Page>
-);
-
-export const CustomFooter = Template.bind({});
-CustomFooter.args = {
-  footer: 'Built with Storybook',
+export const CustomFooter = {
+  args: {
+    footer: 'Built with Storybook',
+  },
+  render: (args) => (
+    <Page {...args}>
+      <footer>{args.footer}</footer>
+    </Page>
+  ),
 };
 ```

--- a/docs/snippets/react/page-story-with-args-composition.js.mdx
+++ b/docs/snippets/react/page-story-with-args-composition.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // YourPage.stories.js | YourPage.stories.jsx
 
-import DocumentScreen from './YourPage';
+import { DocumentScreen } from './YourPage';
 
 //👇 Imports the required stories
 import * as PageLayout from './PageLayout.stories';

--- a/docs/snippets/react/page-story-with-args-composition.js.mdx
+++ b/docs/snippets/react/page-story-with-args-composition.js.mdx
@@ -1,26 +1,22 @@
 ```js
 // YourPage.stories.js | YourPage.stories.jsx
 
-import React from 'react';
-
 import DocumentScreen from './YourPage';
 
 //👇 Imports the required stories
-import PageLayout from './PageLayout.stories';
-import DocumentHeader from './DocumentHeader.stories';
-import DocumentList from './DocumentList.stories';
+import * as PageLayout from './PageLayout.stories';
+import * as DocumentHeader from './DocumentHeader.stories';
+import * as DocumentList from './DocumentList.stories';
 
 export default {
   component: DocumentScreen,
-  title: 'DocumentScreen',
 };
 
-const Template = (args) => <DocumentScreen {...args} />;
-
-export const Simple = Template.bind({});
-Simple.args = {
-  user: PageLayout.Simple.args.user,
-  document: DocumentHeader.Simple.args.document,
-  subdocuments: DocumentList.Simple.args.documents,
+export const Simple = {
+  args: {
+    user: PageLayout.Simple.args.user,
+    document: DocumentHeader.Simple.args.document,
+    subdocuments: DocumentList.Simple.args.documents,
+  },
 };
 ```

--- a/docs/snippets/react/page-story.js.mdx
+++ b/docs/snippets/react/page-story.js.mdx
@@ -9,14 +9,12 @@ import { Page } from './Page';
 import * as HeaderStories from './Header.stories';
 
 export default {
-  title: 'Page',
   component: Page,
 };
 
-const Template = (args) => <Page {...args} />;
-
-export const LoggedIn = Template.bind({});
-LoggedIn.args = {
-  ...HeaderStories.LoggedIn.args,
+export const LoggedIn = {
+  args: {
+    ...HeaderStories.LoggedIn.args,
+  },
 };
 ```

--- a/docs/snippets/react/simple-page-implementation.js.mdx
+++ b/docs/snippets/react/simple-page-implementation.js.mdx
@@ -7,7 +7,7 @@ import PageLayout from './PageLayout';
 import DocumentHeader from './DocumentHeader';
 import DocumentList from './DocumentList';
 
-function DocumentScreen({ user, document, subdocuments }) {
+export default function DocumentScreen({ user, document, subdocuments }) {
   return (
     <PageLayout user={user}>
       <DocumentHeader document={document} />

--- a/docs/snippets/react/simple-page-implementation.js.mdx
+++ b/docs/snippets/react/simple-page-implementation.js.mdx
@@ -3,11 +3,11 @@
 
 import React from 'react';
 
-import PageLayout from './PageLayout';
-import DocumentHeader from './DocumentHeader';
-import DocumentList from './DocumentList';
+import { PageLayout } from './PageLayout';
+import { DocumentHeader } from './DocumentHeader';
+import { DocumentList } from './DocumentList';
 
-export default function DocumentScreen({ user, document, subdocuments }) {
+export function DocumentScreen({ user, document, subdocuments }) {
   return (
     <PageLayout user={user}>
       <DocumentHeader document={document} />

--- a/docs/snippets/react/table-story-fully-customize-controls.js.mdx
+++ b/docs/snippets/react/table-story-fully-customize-controls.js.mdx
@@ -1,18 +1,36 @@
 ```js
 // Table.stories.js | Table.stories.jsx
 
-const TableStory = ({ data, ...args }) => (
-  <Table {...args} >
-    {data.map(row => (<TR>{row.map(item => <TD>{item}</TD>}</TR>))}
-  </Table>
-)
+import React from 'react';
 
-export const Numeric = TableStory.bind({});
+import Table from './Table';
+import TD from './TableDataCell';
+import TR from './TableRow';
 
-Numeric.args = {
-  //👇 This arg is for the story component
-  data: [[1, 2, 3], [4, 5, 6]],
-  //👇 The remaining args get passed to the `Table` component
-  size: 'large',
-}
+export default {
+  component: Table,
+};
+
+export const TableStory = {
+  args: {
+    //👇 This arg is for the story component
+    data: [
+      [1, 2, 3],
+      [4, 5, 6],
+    ],
+    //👇 The remaining args get passed to the `Table` component
+    size: 'large',
+  },
+  render: ({ data, ...args }) => (
+    <Table {...args}>
+      {data.map((row) => (
+        <TR>
+          {row.map((item) => (
+            <TD>{item}</TD>
+          ))}
+        </TR>
+      ))}
+    </Table>
+  ),
+};
 ```

--- a/docs/snippets/react/table-story-fully-customize-controls.js.mdx
+++ b/docs/snippets/react/table-story-fully-customize-controls.js.mdx
@@ -3,9 +3,9 @@
 
 import React from 'react';
 
-import Table from './Table';
-import TD from './TableDataCell';
-import TR from './TableRow';
+import { Table } from './Table';
+import { TD } from './TableDataCell';
+import { TR } from './TableRow';
 
 export default {
   component: Table,

--- a/docs/snippets/react/your-component-with-decorator.js.mdx
+++ b/docs/snippets/react/your-component-with-decorator.js.mdx
@@ -1,14 +1,16 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx
 
+import YourComponent from './YourComponent';
+
 export default {
   component: YourComponent,
   decorators: [
     (Story) => (
       <div style={{ margin: '3em' }}>
-        <Story/>
+        <Story />
       </div>
     ),
   ],
-}
+};
 ```

--- a/docs/snippets/react/your-component-with-decorator.js.mdx
+++ b/docs/snippets/react/your-component-with-decorator.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx
 
-import YourComponent from './YourComponent';
+import { YourComponent } from './YourComponent';
 
 export default {
   component: YourComponent,

--- a/docs/snippets/react/your-component-with-decorator.story-function-js.js.mdx
+++ b/docs/snippets/react/your-component-with-decorator.story-function-js.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx
 
-import YourComponent from './YourComponent';
+import { YourComponent } from './YourComponent';
 
 // Replacing the <Story/> element with a Story function is also a good way of writing decorators.
 // Useful to prevent the full remount of the component's story.

--- a/docs/snippets/react/your-component-with-decorator.story-function-js.js.mdx
+++ b/docs/snippets/react/your-component-with-decorator.story-function-js.js.mdx
@@ -1,16 +1,12 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx
 
+import YourComponent from './YourComponent';
+
 // Replacing the <Story/> element with a Story function is also a good way of writing decorators.
 // Useful to prevent the full remount of the component's story.
 export default {
   component: YourComponent,
-  decorators: [
-    (Story) => (
-      <div style={{ margin: '3em' }}>
-        {Story()}
-      </div>
-    ),
-  ],
-}
+  decorators: [(Story) => <div style={{ margin: '3em' }}>{Story()}</div>],
+};
 ```

--- a/docs/snippets/react/your-component.js.mdx
+++ b/docs/snippets/react/your-component.js.mdx
@@ -1,22 +1,16 @@
 ```js
 // YourComponent.stories.js | YourComponent.stories.jsx
 
-import React from 'react';
-
 import { YourComponent } from './YourComponent';
 
 //👇 This default export determines where your story goes in the story list
 export default {
-  title: 'YourComponent',
   component: YourComponent,
 };
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args) => <YourComponent {...args} />;
-
-export const FirstStory = Template.bind({});
-
-FirstStory.args = {
-  /*👇 The args you need here will depend on your component */
+export const FirstStory = {
+  args: {
+    //👇 The args you need here will depend on your component
+  },
 };
 ```

--- a/docs/snippets/svelte/button-group-story.js.mdx
+++ b/docs/snippets/svelte/button-group-story.js.mdx
@@ -2,23 +2,22 @@
 // ButtonGroup.stories.js
 
 import ButtonGroup from '../ButtonGroup.svelte';
+
+//👇 Imports the Button stories
 import * as ButtonStories from './Button.stories';
 
 export default {
-  title: 'ButtonGroup',
   component: ButtonGroup,
-}
+};
 
-const Template = (args) => ({
-  props: args,
- });
-
-export const Pair = Template.bind({});
-Pair.args = {
-  buttons: [
-    { ...ButtonStories.Primary.args },
-    { ...ButtonStories.Secondary.args }
-  ],
-  orientation: 'horizontal',
+export const Pair = {
+  args: {
+    buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
+    orientation: 'horizontal',
+  },
+  render: (args) => ({
+    Component: ButtonGroup,
+    props: args,
+  }),
 };
 ```

--- a/docs/snippets/svelte/button-story-click-handler.js.mdx
+++ b/docs/snippets/svelte/button-story-click-handler.js.mdx
@@ -6,18 +6,18 @@ import Button from './Button.svelte';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Button',
   component: Button,
 };
 
-export const Text = () =>({
-  //👇 This is the same component as the one used in the default export and it's optional
-  Component: Button,
-  props:{
-    label: 'Hello',
-  },
-  on:{
-    onClick={action('clicked')}
-  }
-});
+export const Text = {
+  render: () => ({
+    Component: Button,
+    props: {
+      label: 'Hello',
+    },
+    on: {
+      click: action('clicked'),
+    },
+  }),
+};
 ```

--- a/docs/snippets/svelte/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/svelte/button-story-component-args-primary.js.mdx
@@ -4,7 +4,6 @@
 import Button from './Button.svelte';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific argTypes
   argTypes: {

--- a/docs/snippets/svelte/button-story-component-decorator.js.mdx
+++ b/docs/snippets/svelte/button-story-component-decorator.js.mdx
@@ -5,25 +5,24 @@ import Button from './Button.svelte';
 import MarginDecorator from './MarginDecorator.svelte';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-  decorators:  [() => MarginDecorator],
+  decorators: [() => MarginDecorator],
 };
 
-// Your templates and stories here. 
-// Don't forget to use the component you're testing and not the MarginDecorator component
+// Your stories here.
 
+// Don't forget to use the component you're testing and not the MarginDecorator component
 ```
 
 ```html
 <!-- MarginDecorator.svelte -->
 
 <div>
-  <slot/>
+  <slot />
 </div>
 
 <style>
-  div { 
+  div {
     margin: 3em;
   }
 </style>

--- a/docs/snippets/svelte/button-story-decorator.js.mdx
+++ b/docs/snippets/svelte/button-story-decorator.js.mdx
@@ -1,8 +1,17 @@
 ```js
 // Button.stories.js
 
+import Button from './Button.svelte';
 import MarginDecorator from './MarginDecorator.svelte';
 
-export const Primary = …
-Primary.decorators = [() => MarginDecorator]
+export default {
+  component: Button,
+};
+
+export const Primary = {
+  render: () => ({
+    component: Button,
+  }),
+  decorators: [() => MarginDecorator],
+};
 ```

--- a/docs/snippets/svelte/button-story-default-docs-code.js.mdx
+++ b/docs/snippets/svelte/button-story-default-docs-code.js.mdx
@@ -4,7 +4,6 @@
 import Button from './Button.svelte';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific argTypes
   argTypes: {
@@ -17,24 +16,25 @@ const someFunction = (someValue) => {
   return `i am a ${someValue}`;
 };
 
-export const ExampleStory = (args) => {
-  //👇 Destructure the label from the args object
-  const { label } = args;
+export const ExampleStory = {
+  args: {
+    primary: true,
+    size: 'small',
+    label: 'button',
+  },
+  render: (args) => {
+    //👇 Destructure the label from the args object
+    const { label } = args;
 
-  //👇 Assigns the function result to a variable and pass it as a prop into the component
-  const functionResult = someFunction(label);
-  return {
-    Component: Button,
-    props: {
-      ...args,
-      label: functionResult,
-    },
-  };
-};
-
-ExampleStory.args = {
-  primary: true,
-  size: 'small',
-  label: 'button',
+    //👇 Assigns the function result to a variable and pass it as a prop into the component
+    const functionResult = someFunction(label);
+    return {
+      Component: Button,
+      props: {
+        ...args,
+        label: functionResult,
+      },
+    };
+  },
 };
 ```

--- a/docs/snippets/svelte/button-story-default-export-with-component.js.mdx
+++ b/docs/snippets/svelte/button-story-default-export-with-component.js.mdx
@@ -4,7 +4,8 @@
 import Button from './Button.svelte';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-}
+  //👇 Title is optional, you can omit it and Storybook automatically generates the title for the story
+  title: 'Components/Button',
+};
 ```

--- a/docs/snippets/svelte/button-story-rename-story.js.mdx
+++ b/docs/snippets/svelte/button-story-rename-story.js.mdx
@@ -3,13 +3,19 @@
 
 import Button from './Button.svelte';
 
-export const Primary = () => ({
-  Component: Button,
-  props: {
-    primary: true,
-    label: 'Button',
-  },
-});
+export default {
+  component: Button,
+};
+
+export const Primary = ({
+  render: () => ({
+    Component: Button,
+    props: {
+      primary: true,
+      label: 'Button',
+    },
+  }),
+};
 
 Primary.storyName = 'I am the primary';
 ```

--- a/docs/snippets/svelte/button-story-rename-story.js.mdx
+++ b/docs/snippets/svelte/button-story-rename-story.js.mdx
@@ -8,6 +8,7 @@ export default {
 };
 
 export const Primary = ({
+  name: 'I am the primary',
   render: () => ({
     Component: Button,
     props: {
@@ -16,6 +17,4 @@ export const Primary = ({
     },
   }),
 };
-
-Primary.storyName = 'I am the primary';
 ```

--- a/docs/snippets/svelte/button-story-using-args.js.mdx
+++ b/docs/snippets/svelte/button-story-using-args.js.mdx
@@ -1,19 +1,42 @@
 ```js
 // Button.stories.js
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args) => ({
-  Component: Button,
-  props: args,
-});
+import Button from './Button.svelte';
 
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-Primary.args = { background: '#ff0', label: 'Button' };
+export default {
+  component: Button,
+};
 
-export const Secondary = Template.bind({});
-Secondary.args = { ...Primary.args, label: '😄👍😍💯' };
+export const Primary = {
+  args: {
+    backgroundColor: '#ff0',
+    label: 'Button',
+  },
+  render: (args) => ({
+    Component: Button,
+    props: args,
+  }),
+};
 
-export const Tertiary = Template.bind({});
-Tertiary.args = { ...Primary.args, label: '📚📕📈🤓' };
+export const Secondary = {
+  args: {
+    ...Primary.args,
+    label: '😄👍😍💯',
+  },
+  render: (args) => ({
+    Component: Button,
+    props: args,
+  }),
+};
+
+export const Tertiary = {
+  args: {
+    ...Primary.args,
+    label: '📚📕📈🤓',
+  },
+  render: (args) => ({
+    Component: Button,
+    props: args,
+  }),
+};
 ```

--- a/docs/snippets/svelte/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/svelte/button-story-with-addon-example.js.mdx
@@ -13,8 +13,10 @@ export default {
   },
 };
 
-export const Basic = (args) => ({
-  Component: Button,
-  props: args,
-});
+export const Basic = {
+  render: (args) => ({
+    Component: Button,
+    props: args,
+  }),
+};
 ```

--- a/docs/snippets/svelte/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/svelte/button-story-with-addon-example.js.mdx
@@ -4,7 +4,6 @@
 import Button from './Button.svelte';
 
 export default {
-  title: 'Button',
   //👇 Creates specific parameters for the story
   parameters: {
     myAddon: {

--- a/docs/snippets/svelte/button-story-with-args.js.mdx
+++ b/docs/snippets/svelte/button-story-with-args.js.mdx
@@ -4,16 +4,17 @@
 import Button from './Button.svelte';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-}
+};
 
-const Template = (args) => ({ Component: Button, props: args });
-
-export const Primary = Template.bind({});
-
-Primary.args = {
-  primary: true,
-  label: 'Button',
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+  render: (args) => ({
+    Component: Button,
+    props: args,
+  }),
 };
 ```

--- a/docs/snippets/svelte/button-story-with-blue-args.js.mdx
+++ b/docs/snippets/svelte/button-story-with-blue-args.js.mdx
@@ -4,17 +4,16 @@
 import Button from './Button.svelte';
 
 export default {
-  title: 'Components/Button',
   component: Button,
   //👇 Creates specific parameters for the story
   parameters: {
     backgrounds: {
       values: [
-        { name: 'red', value: '#f00', },
-        { name: 'green', value: '#0f0', },
-        { name: 'blue', value: '#00f', },
-      ]
-    }
-  }
-}
+        { name: 'red', value: '#f00' },
+        { name: 'green', value: '#0f0' },
+        { name: 'blue', value: '#00f' },
+      ],
+    },
+  },
+};
 ```

--- a/docs/snippets/svelte/button-story-with-emojis.js.mdx
+++ b/docs/snippets/svelte/button-story-with-emojis.js.mdx
@@ -5,30 +5,35 @@ import Button from './Button.svelte';
 
 export default {
   component: Button,
-  title:'Components/Button'
-}
+};
 
-export const Primary = () => ({
-  Component: Button,
-  props: {
-    background: '#ff0',
-    label: 'Button',
-  },
-});
+export const Primary = {
+  render: () => ({
+    Component: Button,
+    props: {
+      backgroundColor: '#ff0',
+      label: 'Button',
+    },
+  }),
+};
 
-export const Secondary = () => ({
-  Component: Button,
-  props: {
-    background: '#ff0',
-    label: '😄👍😍💯',
-  },
-});
+export const Secondary = {
+  render: () => ({
+    Component: Button,
+    props: {
+      backgroundColor: '#ff0',
+      label: '😄👍😍💯',
+    },
+  }),
+};
 
-export const Tertiary = () => ({
-  Component: Button,
-  props: {
-    background: '#ff0',
-    label: '📚📕📈🤓',
-  },
-});
+export const Tertiary = {
+  render: () => ({
+    Component: Button,
+    props: {
+      backgroundColor: '#ff0',
+      label: '📚📕📈🤓',
+    },
+  }),
+};
 ```

--- a/docs/snippets/svelte/button-story.js.mdx
+++ b/docs/snippets/svelte/button-story.js.mdx
@@ -4,15 +4,16 @@
 import Button from './Button.svelte';
 
 export default {
-  title: 'Components/Button',
   component: Button,
-}
+};
 
-export const Primary = () => ({
-  Component: Button,
-  props: {
-    primary: true,
-    label: 'Button',
-  },
-});
+export const Primary = {
+  render: () => ({
+    Component: Button,
+    props: {
+      primary: true,
+      label: 'Button',
+    },
+  }),
+};
 ```

--- a/docs/snippets/svelte/component-story-custom-args-complex.js.mdx
+++ b/docs/snippets/svelte/component-story-custom-args-complex.js.mdx
@@ -4,7 +4,6 @@
 import YourComponent from './YourComponent.svelte';
 
 export default {
-  title: 'A complex case with a function',
   component: YourComponent,
   //👇 Creates specific argTypes
   argTypes: {
@@ -23,17 +22,22 @@ const someFunction = (valuePropertyA, valuePropertyB) => {
   // Makes some computations and returns something
 };
 
-const Template = (args) => {
-  const { propertyA, propertyB } = args;
-  
-  //👇 Assigns the function result to a variable
-  const someFunctionResult = someFunction(propertyA, propertyB);
-  return {
-    Component: YourComponent,
-    props: {
-      ...args,
-      someProperty: someFunctionResult,
-    },
-  };
+export const ExampleStory = {
+  args: {
+    propertyA: 'Something',
+    propertyB: 'Something else',
+  },
+  render: (args) => {
+    const { propertyA, propertyB } = args;
+    //👇 Assigns the function result to a variable
+    const someFunctionResult = someFunction(propertyA, propertyB);
+    return {
+      Component: YourComponent,
+      props: {
+        ...args,
+        someProperty: someFunctionResult,
+      },
+    };
+  },
 };
 ```

--- a/docs/snippets/svelte/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-cdn.js.mdx
@@ -7,7 +7,7 @@ export default {
   component: MyComponent,
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     Component: MyComponent,
     props: {

--- a/docs/snippets/svelte/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-cdn.js.mdx
@@ -5,15 +5,15 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   component: MyComponent,
-  title: 'img',
 };
 
-// Assume image.png is located in the "public" directory.
-export const withAnImage = () => ({
-  Component: MyComponent,
-  props: {
-    src: 'https://place-hold.it/350x150',
-    alt: 'My CDN placeholder',
-  },
-});
+export const withAnImage = {
+  render: () => ({
+    Component: MyComponent,
+    props: {
+      src: 'https://place-hold.it/350x150',
+      alt: 'My CDN placeholder',
+    },
+  }),
+};
 ```

--- a/docs/snippets/svelte/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-with-import.js.mdx
@@ -7,18 +7,17 @@ import imageFile from './static/image.png';
 
 export default {
   component: MyComponent,
-  title: 'img',
 };
 
 const image = {
   src: imageFile,
-  alt: "my image",
+  alt: 'my image',
 };
 
-export const WithAnImage = () => ({
-  Component: MyComponent,
-  props: {
-    image: image
-  },
-});
+export const WithAnImage = {
+  render: () => ({
+    Component: MyComponent,
+    props: image,
+  }),
+};
 ```

--- a/docs/snippets/svelte/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-without-import.js.mdx
@@ -8,7 +8,7 @@ export default {
 };
 
 // Assume image.png is located in the "public" directory.
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     Component: MyComponent,
     props: {

--- a/docs/snippets/svelte/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-without-import.js.mdx
@@ -5,15 +5,16 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   component: MyComponent,
-  title: 'img',
 };
 
 // Assume image.png is located in the "public" directory.
-export const withAnImage = () => ({
-  Component: MyComponent,
-  props: {
-    src: '/image.png',
-    alt: 'my image',
-  },
-});
+export const withAnImage = {
+  render: () => ({
+    Component: MyComponent,
+    props: {
+      src: '/image.png',
+      alt: 'my image',
+    },
+  }),
+};
 ```

--- a/docs/snippets/svelte/component-story-static-asset-without-import.native-format.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-without-import.native-format.mdx
@@ -16,5 +16,5 @@
   <MyComponent src="/image2.png" alt="my image" />
 </Template>
 
-<Story name="withAnImage" />
+<Story name="WithAnImage" />
 ```

--- a/docs/snippets/svelte/documentscreen-story-msw-graphql-query.js.mdx
+++ b/docs/snippets/svelte/documentscreen-story-msw-graphql-query.js.mdx
@@ -3,13 +3,12 @@
 
 import { graphql } from 'msw';
 
-import DocumentScreen from './DocumentScreen.svelte';
+import DocumentScreen from './YourPage.svelte';
 import MockApolloWrapperClient from './MockApolloWrapperClient.svelte';
 
 export default {
   component: DocumentScreen,
   decorators: [() => MockGraphqlProvider],
-  title: 'Mock GraphQL query with Storybook and MSW',
 };
 
 //👇The mocked data that will be used in the story
@@ -61,32 +60,38 @@ const TestData = {
   ],
 };
 
-const PageTemplate = (args) => ({
-  Component: DocumentScreen,
-  props: args,
-});
-
-export const MockedSuccess = PageTemplate.bind({});
-MockedSuccess.parameters = {
-  msw: [
-    graphql.query('AllInfoQuery', (req, res, ctx) => {
-      return res(ctx.data(TestData));
-    }),
-  ],
+export const MockedSuccess = {
+  parameters: {
+    msw: [
+      graphql.query('AllInfoQuery', (req, res, ctx) => {
+        return res(ctx.data(TestData));
+      }),
+    ],
+  },
+  render: (args) => ({
+    Component: DocumentScreen,
+    props: args,
+  }),
 };
-export const MockedError = PageTemplate.bind({});
-MockedError.parameters = {
-  msw: [
-    graphql.query('AllInfoQuery', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.errors([
-          {
-            message: 'Access denied',
-          },
-        ])
-      );
-    }),
-  ],
+
+export const MockedError = {
+  parameters: {
+    msw: [
+      graphql.query('AllInfoQuery', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.errors([
+            {
+              message: 'Access denied',
+            },
+          ])
+        );
+      }),
+    ],
+  },
+  render: (args) => ({
+    Component: DocumentScreen,
+    props: args,
+  }),
 };
 ```

--- a/docs/snippets/svelte/documentscreen-story-msw-rest-request.js.mdx
+++ b/docs/snippets/svelte/documentscreen-story-msw-rest-request.js.mdx
@@ -1,12 +1,11 @@
 ```js
 // YourPage.stories.js
 
-import DocumentScreen from './DocumentScreen.svelte';
+import DocumentScreen from './YourPage.svelte';
 
 import { rest } from 'msw';
 export default {
   component: DocumentScreen,
-  title: 'Mock Rest request with Storybook and MSW',
 };
 
 //👇The mocked data that will be used in the story
@@ -58,26 +57,31 @@ const TestData = {
   ],
 };
 
-const PageTemplate = (args) => ({
-  Component: DocumentScreen,
-  props: args,
-});
-
-export const MockedSuccess = PageTemplate.bind({});
-MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
-      return res(ctx.json(TestData));
-    }),
-  ],
+export const MockedSuccess = {
+  parameters: {
+    msw: [
+      rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
+        return res(ctx.json(TestData));
+      }),
+    ],
+  },
+  render: (args) => ({
+    Component: DocumentScreen,
+    props: args,
+  }),
 };
 
-export const MockedError = PageTemplate.bind({});
-MockedError.parameters = {
-  msw: [
-    rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
-      return res(ctx.delay(800), ctx.status(403));
-    }),
-  ],
+export const MockedError = {
+  parameters: {
+    msw: [
+      rest.get('https://your-restful-endpoint', (_req, res, ctx) => {
+        return res(ctx.delay(800), ctx.status(403));
+      }),
+    ],
+  },
+  render: (args) => ({
+    Component: DocumentScreen,
+    props: args,
+  }),
 };
 ```

--- a/docs/snippets/svelte/documentscreen-story-msw-rest-request.js.mdx
+++ b/docs/snippets/svelte/documentscreen-story-msw-rest-request.js.mdx
@@ -4,6 +4,7 @@
 import DocumentScreen from './YourPage.svelte';
 
 import { rest } from 'msw';
+
 export default {
   component: DocumentScreen,
 };

--- a/docs/snippets/svelte/loader-story.js.mdx
+++ b/docs/snippets/svelte/loader-story.js.mdx
@@ -7,17 +7,20 @@ import TodoItem from './TodoItem.svelte';
 
 export default {
   component: TodoItem,
-  title: 'Examples/Loader',
 };
 
-export const Primary = (args, { loaded: { todo } }) => ({
-  Component: TodoItem,
-  props: { ...args, ...todo },
-});
-
-Primary.loaders = [
-  async () => ({
-    todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+export const Primary = {
+  render: (args, { loaded: { todo } }) => ({
+    component: TodoItem,
+    props: {
+      ...args,
+      todo,
+    },
   }),
-];
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
 ```

--- a/docs/snippets/svelte/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/svelte/my-component-story-basic-and-props.js.mdx
@@ -4,18 +4,21 @@
 import MyComponent from './MyComponent.svelte';
 
 export default {
-  title: 'Path/To/MyComponent',
   component: MyComponent,
 };
 
-export const Basic = () => ({
-  Component: MyComponent,
-});
+export const Basic = {
+  render: () => ({
+    Component: MyComponent,
+  }),
+};
 
-export const WithProp = () => ({
-  Component: MyComponent,
-  props:{
-    prop: 'value',
-  },
-});
+export const WithProp = {
+  render: () => ({
+    Component: MyComponent,
+    props: {
+      prop: 'value',
+    },
+  }),
+};
 ```

--- a/docs/snippets/svelte/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/svelte/my-component-story-configure-viewports.js.mdx
@@ -1,12 +1,11 @@
 ```js
 // MyComponent.stories.js
 
-import MyComponent from './MyComponent.svelte';
-
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
+import MyComponent from './MyComponent.svelte';
+
 export default {
-  title: 'Stories',
   component: MyComponent,
   parameters: {
     //👇 The viewports object from the Essentials addon
@@ -19,14 +18,14 @@ export default {
   },
 };
 
-export const MyStory = (args) => ({
-  Component: MyComponent,
-  props: args,
-});
-
-MyStory.parameters = {
-  viewport: {
-    defaultViewport: 'iphonex',
+export const MyStory = {
+  render: () => ({
+    Component: MyComponent,
+  }),
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphonex',
+    },
   },
 };
 ```

--- a/docs/snippets/svelte/my-component-story-use-globaltype-backwards-compat.js.mdx
+++ b/docs/snippets/svelte/my-component-story-use-globaltype-backwards-compat.js.mdx
@@ -1,15 +1,13 @@
 ```js
 // MyComponent.stories.js
 
-export const StoryWithLocale = {
-  render: ({ globals: { locale } }) => {
-    const caption = getCaptionForLocale(locale);
-    return {
-      component: MyComponent,
-      props: {
-        locale: caption,
-      },
-    };
-  },
+export const StoryWithLocale = ({ globals: { locale } }) => {
+  const caption = getCaptionForLocale(locale);
+  return {
+    component: SampleComponent,
+    props: {
+      locale: caption,
+    },
+  };
 };
 ```

--- a/docs/snippets/svelte/my-component-story-use-globaltype-backwards-compat.js.mdx
+++ b/docs/snippets/svelte/my-component-story-use-globaltype-backwards-compat.js.mdx
@@ -1,13 +1,15 @@
 ```js
 // MyComponent.stories.js
 
-export const StoryWithLocale = ({ globals: { locale } }) => {
-  const caption = getCaptionForLocale(locale);
-  return {
-    component: SampleComponent,
-    props: {
-      locale: caption,
-    },
-  };
+export const StoryWithLocale = {
+  render: ({ globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return {
+      component: MyComponent,
+      props: {
+        locale: caption,
+      },
+    };
+  },
 };
 ```

--- a/docs/snippets/svelte/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/svelte/my-component-story-use-globaltype.js.mdx
@@ -1,6 +1,12 @@
 ```js
 // MyComponent.stories.js
 
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+};
+
 const getCaptionForLocale = (locale) => {
   switch (locale) {
     case 'es':
@@ -16,13 +22,15 @@ const getCaptionForLocale = (locale) => {
   }
 };
 
-export const StoryWithLocale = (args, { globals: { locale } }) => {
-  const caption = getCaptionForLocale(locale);
-  return {
-    component: SampleComponent,
-    props: {
-      locale: caption,
-    },
-  };
+export const StoryWithLocale = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return {
+      component: MyComponent,
+      props: {
+        locale: caption,
+      },
+    };
+  },
 };
 ```

--- a/docs/snippets/svelte/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/svelte/my-component-story-with-nonstory.js.mdx
@@ -15,20 +15,22 @@ export const simpleData = { foo: 1, bar: 'baz' };
 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 
 export const SimpleStory = {
-  render: () => ({
+  args: {
+    data: simpleData,
+  },
+  render: (args) => ({
     Component: MyComponent,
-    props: {
-      data: simpleData,
-    },
+    props: args,
   }),
 };
 
 export const ComplexStory = {
-  render: () => ({
+  args: {
+    data: complexData,
+  },
+  render: (args) => ({
     Component: MyComponent,
-    props: {
-      data: complexData,
-    },
+    props: args,
   }),
 };
 ```

--- a/docs/snippets/svelte/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/svelte/my-component-story-with-nonstory.js.mdx
@@ -6,7 +6,6 @@ import MyComponent from './MyComponent.svelte';
 import someData from './data.json';
 
 export default {
-  title: 'MyComponent',
   component: MyComponent,
   includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
   excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
@@ -15,17 +14,21 @@ export default {
 export const simpleData = { foo: 1, bar: 'baz' };
 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 
-export const SimpleStory = () => ({
-  Component: MyComponent,
-  props: {
-    data: simpleData,
-  },
-});
+export const SimpleStory = {
+  render: () => ({
+    Component: MyComponent,
+    props: {
+      data: simpleData,
+    },
+  }),
+};
 
-export const ComplexStory = () => ({
-  Component: MyComponent,
-  props: {
-    data: complexData,
-  },
-});
+export const ComplexStory = {
+  render: () => ({
+    Component: MyComponent,
+    props: {
+      data: complexData,
+    },
+  }),
+};
 ```

--- a/docs/snippets/svelte/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/svelte/my-component-with-env-variables.js.mdx
@@ -5,17 +5,15 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   component: MyComponent,
-  title: 'A story using environment variables inside a .env file',
 };
 
-const Template = (args) => ({
-  Component: MyComponent,
-  props: args,
-});
-
-export const Default = Template.bind({});
-
-Default.args = {
-  propertyA: process.env.STORYBOOK_DATA_KEY,
+const Template = {
+  args: {
+    propertyA: process.env.STORYBOOK_DATA_KEY,
+  },
+  render: (args) => ({
+    Component: MyComponent,
+    props: args,
+  }),
 };
 ```

--- a/docs/snippets/svelte/page-story-with-args-composition.js.mdx
+++ b/docs/snippets/svelte/page-story-with-args-composition.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // YourPage.stories.js
 
-import DocumentScreen from './DocumentScreen.svelte';
+import DocumentScreen from './YourPage.svelte';
 
 //👇 Imports the required stories
 import * as PageLayoutStories from './PageLayout.stories';
@@ -10,18 +10,17 @@ import * as DocumentListStories from './DocumentList.stories';
 
 export default {
   component: DocumentScreen,
-  title: 'DocumentScreen',
 };
 
-const Template = (args) => ({
-  Component: DocumentScreen,
-  props: args,
-});
-
-export const SimplePage = Template.bind({});
-SimplePage.args = {
-  user: PageLayoutStories.Simple.args.user,
-  document: DocumentHeaderStories.Simple.args.document,
-  subdocuments: DocumentListStories.Simple.args.documents,
+export const Simple = {
+  args: {
+    user: PageLayoutStories.Simple.args.user,
+    document: DocumentHeaderStories.Simple.args.document,
+    subdocuments: DocumentListStories.Simple.args.documents,
+  },
+  render: (args) => ({
+    Components: DocumentScreen,
+    props: args,
+  }),
 };
 ```

--- a/docs/snippets/svelte/page-story.js.mdx
+++ b/docs/snippets/svelte/page-story.js.mdx
@@ -3,17 +3,20 @@
 
 import Page from './Page.svelte';
 
+//👇 Imports all Header stories
 import * as HeaderStories from './Header.stories';
 
 export default {
-  title: 'Page',
   component: Page,
 };
 
-const Template = (args) => ({ props: args });
-
-export const LoggedIn = Template.bind({});
-LoggedIn.args = {
-  ...HeaderStories.LoggedIn.args,
+export const LoggedIn = {
+  args: {
+    ...HeaderStories.LoggedIn.args,
+  },
+  render: (args) => ({
+    component: Page,
+    props: args,
+  }),
 };
 ```

--- a/docs/snippets/svelte/your-component.js.mdx
+++ b/docs/snippets/svelte/your-component.js.mdx
@@ -5,17 +5,16 @@ import YourComponent from './YourComponent.svelte';
 
 //👇This default export determines where your story goes in the story list
 export default {
-  title: 'YourComponent',
   component: YourComponent,
 };
 
-const Template = (args) => ({
-  props: args,
-});
-
-export const FirstStory = Template.bind({});
-
-FirstStory.args = {
-  /* The args you need here will depend on your component */
+export const FirstStory = {
+  args: {
+    //👇 The args you need here will depend on your component
+  },
+  render: (args) => ({
+    Component: YourComponent,
+    props: args,
+  }),
 };
 ```

--- a/docs/snippets/vue/app-story-with-mock.2.js.mdx
+++ b/docs/snippets/vue/app-story-with-mock.2.js.mdx
@@ -4,32 +4,30 @@
 import App from './App.vue';
 
 export default {
-  title: 'App',
-  component: App
+  component: App,
 };
 
-const Template = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
-  components: { App },
-  template: '<App v-bind="$props"/>',
-});
-
-export const Success = Template.bind({});
-
-Success.parameters = {
-  fetch: {
-    json: {
-      JavaScript: 3390991,
-      "C++": 44974,
-      TypeScript: 15530,
-      CoffeeScript: 12253,
-      Python: 9383,
-      C: 5341,
-      Shell: 5115,
-      HTML: 3420,
-      CSS: 3171,
-      Makefile: 189
-    }
-  }
+export const Success = {
+  parameters: {
+    fetch: {
+      json: {
+        JavaScript: 3390991,
+        'C++': 44974,
+        TypeScript: 15530,
+        CoffeeScript: 12253,
+        Python: 9383,
+        C: 5341,
+        Shell: 5115,
+        HTML: 3420,
+        CSS: 3171,
+        Makefile: 189,
+      },
+    },
+  },
+  render: (args) => ({
+    props: Object.keys(argTypes),
+    components: { App },
+    template: '<App v-bind="$props"/>',
+  }),
 };
 ```

--- a/docs/snippets/vue/app-story-with-mock.3.js.mdx
+++ b/docs/snippets/vue/app-story-with-mock.3.js.mdx
@@ -4,34 +4,32 @@
 import App from './App.vue';
 
 export default {
-  title: 'App',
-  component: App
+  component: App,
 };
 
-const Template = (args) => ({
-  components: { App },
-  setup() {
-    return { args };
-  }
-  template: '<App v-bind="args"/>',
-});
-
-export const Success = Template.bind({});
-
-Success.parameters = {
-  fetch: {
-    json: {
-      JavaScript: 3390991,
-      "C++": 44974,
-      TypeScript: 15530,
-      CoffeeScript: 12253,
-      Python: 9383,
-      C: 5341,
-      Shell: 5115,
-      HTML: 3420,
-      CSS: 3171,
-      Makefile: 189
-    }
-  }
+export const Success = {
+  parameters: {
+    fetch: {
+      json: {
+        JavaScript: 3390991,
+        'C++': 44974,
+        TypeScript: 15530,
+        CoffeeScript: 12253,
+        Python: 9383,
+        C: 5341,
+        Shell: 5115,
+        HTML: 3420,
+        CSS: 3171,
+        Makefile: 189,
+      },
+    },
+  },
+  render: (args) => ({
+    components: { App },
+    setup() {
+      return { args };
+    },
+    template: '<App v-bind="args" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/button-group-story.2.js.mdx
+++ b/docs/snippets/vue/button-group-story.2.js.mdx
@@ -4,22 +4,21 @@
 import ButtonGroup from './ButtonGroup.vue';
 
 //👇 Imports the Button stories
-import * as ButtonStories from './MyButton.stories';
+import * as ButtonStories from './Button.stories';
 
 export default {
   component: ButtonGroup,
-  title: 'ButtonGroup',
 };
 
-const Template = (args, { argTypes }) => ({
-  components: { ButtonGroup },
-  props: Object.keys(argTypes),
-  template: '<ButtonGroup v-bind="$props" />',
-});
-
-export const Pair = Template.bind({});
-Pair.args = {
-  buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
-  orientation: 'horizontal',
+export const Pair = {
+  args: {
+    buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
+    orientation: 'horizontal',
+  },
+  render: (args, { argTypes }) => ({
+    components: { ButtonGroup },
+    props: Object.keys(argTypes),
+    template: '<ButtonGroup v-bind="$props" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/button-group-story.3.js.mdx
+++ b/docs/snippets/vue/button-group-story.3.js.mdx
@@ -4,24 +4,23 @@
 import ButtonGroup from './ButtonGroup.vue';
 
 //👇 Imports the Button stories
-import * as ButtonStories from './MyButton.stories';
+import * as ButtonStories from './Button.stories';
 
 export default {
   component: ButtonGroup,
-  title: 'ButtonGroup',
 };
 
-const Template = (args) => ({
-  components: { ButtonGroup },
-  setup() {
-    return { args };
+export const Pair = {
+  args: {
+    buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
+    orientation: 'horizontal',
   },
-  template: '<ButtonGroup v-bind="args" />',
-});
-
-export const Pair = Template.bind({});
-Pair.args = {
-  buttons: [{ ...ButtonStories.Primary.args }, { ...ButtonStories.Secondary.args }],
-  orientation: 'horizontal',
+  render: (args) => ({
+    components: { ButtonGroup },
+    setup() {
+      return { args };
+    },
+    template: '<ButtonGroup v-bind="args" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/button-story-click-handler-args.2.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler-args.2.js.mdx
@@ -1,13 +1,23 @@
 ```js
 // Button.stories.js
 
-export const Text = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
-  components: { Button },
-  template: '<Button @onClick="onClick" :label="label" />'
-});
-Text.args = {
-  label: 'Hello',
-  onClick: action('clicked'),
+import Button from './Button.vue';
+
+import { action } from '@storybook/addon-actions';
+
+export default {
+  component: Button,
+};
+
+export const Text = {
+  args: {
+    label: 'Hello',
+    onClick: action('clicked'),
+  },
+  render: (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { Button },
+    template: '<Button @onClick="onClick" :label="label" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/button-story-click-handler-args.3.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler-args.3.js.mdx
@@ -1,17 +1,27 @@
 ```js
 // Button.stories.js
 
-export const Text = (args) => ({
-  components: { Button },
-  setup() {
-    return {
-      label: args.label,
-      onClick: action('clicked'),
-    };
+import Button from './Button.vue';
+
+import { action } from '@storybook/addon-actions';
+
+export default {
+  component: Button,
+};
+
+export const Text = {
+  args: {
+    label: 'Hello',
   },
-  template: '<Button @onClick="onClick" :label="label" />',
-});
-Text.args = {
-  label: 'Hello',
+  render: (args) => ({
+    components: { Button },
+    setup() {
+      return {
+        ...args,
+        onClick: action('clicked'),
+      };
+    },
+    template: '<Button @onClick="onClick" :label="label" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/button-story-click-handler-simple-docs.2.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler-simple-docs.2.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js
 
-import Button from './Button';
+import Button from './Button.vue';
 
 export default {
   component: Button,

--- a/docs/snippets/vue/button-story-click-handler-simple-docs.2.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler-simple-docs.2.js.mdx
@@ -1,9 +1,17 @@
 ```js
 // Button.stories.js
 
-export const Text  = (args, { argTypes }) => ({
-  components: { Button },
-  props: Object.keys(argTypes),
-  template: '<Button v-bind="$props" />',
-});
+import Button from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Text = {
+  render: (args, { argTypes }) => ({
+    components: { Button },
+    props: Object.keys(argTypes),
+    template: '<Button v-bind="$props" />',
+  }),
+};
 ```

--- a/docs/snippets/vue/button-story-click-handler-simple-docs.3.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler-simple-docs.3.js.mdx
@@ -1,14 +1,22 @@
 ```js
 // Button.stories.js
 
-export const Text = ({ label }) => ({
-  components: { Button },
-  setup() {
-    return {
-      label,
-      onClick: action('clicked'),
-    };
-  },
-  template: '<Button :label="label" @click="onClick" />',
-});
+import Button from './Button.vue';
+
+export default {
+  component: Button,
+};
+
+export const Text = {
+  render: ({ label }) => ({
+    components: { Button },
+    setup() {
+      return {
+        label,
+        onClick: action('clicked'),
+      };
+    },
+    template: '<Button :label="label" @click="onClick" />',
+  }),
+};
 ```

--- a/docs/snippets/vue/button-story-click-handler.2.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler.2.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js
 
-import Button from 'Button.vue';
+import Button from './Button.vue';
 
 import { action } from '@storybook/addon-actions';
 

--- a/docs/snippets/vue/button-story-click-handler.3.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler.3.js.mdx
@@ -1,22 +1,23 @@
 ```js
 // Button.stories.js
 
-import { action } from '@storybook/addon-actions';
-
 import Button from 'Button.vue';
+
+import { action } from '@storybook/addon-actions';
 
 export default {
   component: Button,
-  title: 'Button',
 };
 
-export const Text = () => ({
-  components: { Button },
-  template: '<Button label="Hello" @click="onClick" />',
-  setup(){
-    return {
-      onClick: action('clicked'),
-    };
-  },
-});
+export const Text = {
+  render: () => ({
+    components: { Button },
+    template: '<Button label="Hello" @click="onClick" />',
+    setup() {
+      return {
+        onClick: action('clicked'),
+      };
+    },
+  }),
+};
 ```

--- a/docs/snippets/vue/button-story-click-handler.3.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler.3.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // Button.stories.js
 
-import Button from 'Button.vue';
+import Button from './Button.vue';
 
 import { action } from '@storybook/addon-actions';
 

--- a/docs/snippets/vue/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/vue/button-story-component-args-primary.js.mdx
@@ -4,7 +4,6 @@
 import Button from './Button.vue';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific argTypes
   argTypes: {

--- a/docs/snippets/vue/button-story-component-decorator.js.mdx
+++ b/docs/snippets/vue/button-story-component-decorator.js.mdx
@@ -4,7 +4,6 @@
 import Button from './Button.vue';
 
 export default {
-  title: 'Components/Button',
   component: Button,
   decorators: [() => ({ template: '<div style="margin: 3em;"><story /></div>' })],
 };

--- a/docs/snippets/vue/button-story-decorator.js.mdx
+++ b/docs/snippets/vue/button-story-decorator.js.mdx
@@ -5,12 +5,13 @@ import Button from './Button.vue';
 
 export default {
   component: Button,
-  title: 'Components/Button',
 };
 
-export const Primary = () => ({
-  components: { Button },
-  template: '<Button primary label="Hello World" />',
-});
-Primary.decorators = [() => ({ template: '<div style="margin: 3em;"><story /></div>' })];
+export const Primary = {
+  render: () => ({
+    components: { Button },
+    template: '<Button primary label="Hello World" />',
+  }),
+  decorators: [() => ({ template: '<div style="margin: 3em;"><story /></div>' })],
+};
 ```

--- a/docs/snippets/vue/button-story-default-docs-code.3.js.mdx
+++ b/docs/snippets/vue/button-story-default-docs-code.3.js.mdx
@@ -4,7 +4,6 @@
 import Button from './Button.vue';
 
 export default {
-  title: 'Button',
   component: Button,
   //👇 Creates specific argTypes
   argTypes: {
@@ -17,27 +16,32 @@ const someFunction = (someValue) => {
   return `i am a ${someValue}`;
 };
 
-export const ExampleStory = (args) => {
-  //👇 Assigns the function result to a variable
-  const functionResult = someFunction(args.label);
-  return {
-    components: { Button },
-    setup() {
-      //👇 The args will now be passed down to the template
-      return {
-        args: {
-          ...args,
-          //👇 Replaces arg variable with the override (without the need of mutation)
-          label: functionResult,
-        },
-      };
-    },
-    template: '<Button v-bind="args" />',
-  };
-};
-ExampleStory.args = {
-  primary: true,
-  size: 'small',
-  label: 'button',
+export const ExampleStory = {
+  args: {
+    primary: true,
+    size: 'small',
+    label: 'button',
+  },
+  render: (args) => {
+    //👇 Destructure the label from the args object
+    const { label } = args;
+
+    //👇 Assigns the function result to a variable and pass it as a prop into the component
+    const functionResult = someFunction(label);
+    return {
+      components: { Button },
+      setup() {
+        //👇 The args will now be passed down to the template
+        return {
+          args: {
+            ...args,
+            //👇 Replaces arg variable with the override (without the need of mutation)
+            label: functionResult,
+          },
+        };
+      },
+      template: '<Button v-bind="args" />',
+    };
+  },
 };
 ```

--- a/docs/snippets/vue/button-story-default-export-with-component.js.mdx
+++ b/docs/snippets/vue/button-story-default-export-with-component.js.mdx
@@ -4,7 +4,8 @@
 import Button from './Button.vue';
 
 export default {
-  title: 'Components/Button',
   component: Button,
+  //👇 Title is optional, you can omit it and Storybook automatically generates the title for the story
+  title: 'Components/Button',
 };
 ```

--- a/docs/snippets/vue/button-story-rename-story.js.mdx
+++ b/docs/snippets/vue/button-story-rename-story.js.mdx
@@ -5,13 +5,14 @@ import Button from './Button.vue';
 
 export default {
   component: Button,
-  title: 'Components/Button',
 };
 
-export const Primary = () => ({
-  components: { Button },
-  template: '<Button primary label="Button" />',
-});
+export const Primary = {
+  render: () => ({
+    components: { Button },
+    template: '<Button primary label="Button" />',
+  }),
+};
 
 Primary.storyName = 'I am the primary';
 ```

--- a/docs/snippets/vue/button-story-rename-story.js.mdx
+++ b/docs/snippets/vue/button-story-rename-story.js.mdx
@@ -8,11 +8,10 @@ export default {
 };
 
 export const Primary = {
+  name: 'I am the primary',
   render: () => ({
     components: { Button },
     template: '<Button primary label="Button" />',
   }),
 };
-
-Primary.storyName = 'I am the primary';
 ```

--- a/docs/snippets/vue/button-story-using-args.2.js.mdx
+++ b/docs/snippets/vue/button-story-using-args.2.js.mdx
@@ -3,25 +3,43 @@
 
 import Button from './Button.vue';
 
-export default { 
+export default {
   component: Button,
-  title: 'Components/Button'
 };
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args, { argTypes }) => ({
-  components: { Button },
-  props: Object.keys(argTypes),
-  template: '<Button :background="background" :label="label" />',
-});
+export const Primary = {
+  args: {
+    backgroundColor: '#ff0',
+    label: 'Button',
+  },
+  render: (args, { argTypes }) => ({
+    components: { Button },
+    props: Object.keys(argTypes),
+    template: '<Button v-bind="$props" />',
+  }),
+};
 
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-Primary.args = { background: '#ff0', label: 'Button' };
+export const Secondary = {
+  args: {
+    ...Primary.args,
+    label: '😄👍😍💯',
+  },
+  render: (args, { argTypes }) => ({
+    components: { Button },
+    props: Object.keys(argTypes),
+    template: '<Button v-bind="$props" />',
+  }),
+};
 
-export const Secondary = Template.bind({});
-Secondary.args = { ...Primary.args, label: '😄👍😍💯' };
-
-export const Tertiary = Template.bind({});
-Tertiary.args = { ...Primary.args, label: '📚📕📈🤓' };
+export const Tertiary = {
+  args: {
+    ...Primary.args,
+    label: '📚📕📈🤓',
+  },
+  render: (args, { argTypes }) => ({
+    components: { Button },
+    props: Object.keys(argTypes),
+    template: '<Button v-bind="$props" />',
+  }),
+};
 ```

--- a/docs/snippets/vue/button-story-using-args.3.js.mdx
+++ b/docs/snippets/vue/button-story-using-args.3.js.mdx
@@ -5,25 +5,47 @@ import Button from './Button.vue';
 
 export default {
   component: Button,
-  title: 'Components/Button',
 };
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args) => ({
-  components: { Button },
-  setup() {
-    return { args };
+export const Primary = {
+  args: {
+    backgroundColor: '#ff0',
+    label: 'Button',
   },
-  template: '<Button v-bind="args" />',
-});
+  render: (args) => ({
+    components: { Button },
+    setup() {
+      return { args };
+    },
+    template: '<Button v-bind="args" />',
+  }),
+};
 
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-Primary.args = { background: '#ff0', label: 'Button' };
+export const Secondary = {
+  args: {
+    ...Primary.args,
+    label: '😄👍😍💯',
+  },
+  render: (args) => ({
+    components: { Button },
+    setup() {
+      return { args };
+    },
+    template: '<Button v-bind="args" />',
+  }),
+};
 
-export const Secondary = Template.bind({});
-Secondary.args = { ...Primary.args, label: '😄👍😍💯' };
-
-export const Tertiary = Template.bind({});
-Tertiary.args = { ...Primary.args, label: '📚📕📈🤓' };
+export const Tertiary = {
+  args: {
+    ...Primary.args,
+    label: '📚📕📈🤓',
+  },
+  render: (args) => ({
+    components: { Button },
+    setup() {
+      return { args };
+    },
+    template: '<Button v-bind="args" />',
+  }),
+};
 ```

--- a/docs/snippets/vue/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/vue/button-story-with-addon-example.js.mdx
@@ -13,8 +13,10 @@ export default {
   },
 };
 
-export const Primary = () => ({
-  components: { Button },
-  template: '<Button label="Hello" />',
-});
+export const Basic = {
+  render: () => ({
+    components: { Button },
+    template: '<Button label="Hello" />',
+  }),
+};
 ```

--- a/docs/snippets/vue/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/vue/button-story-with-addon-example.js.mdx
@@ -4,7 +4,6 @@
 import Button from './Button.vue';
 
 export default {
-  title: 'Button',
   //👇 Creates specific parameters for the story
   parameters: {
     myAddon: {

--- a/docs/snippets/vue/button-story-with-args.2.js.mdx
+++ b/docs/snippets/vue/button-story-with-args.2.js.mdx
@@ -5,22 +5,19 @@ import Button from './Button.vue';
 
 export default {
   component: Button,
-  title: 'Components/Button',
 };
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args, { argTypes }) => ({
-  components: { Button },
-  props: Object.keys(argTypes),
-  // Storybook provides all the args in a $props variable.
-  // Each arg is also available as their own name.
-  template: '<Button v-bind="$props" v-on="$props" />',
-});
-
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-Primary.args = {
-  primary: true,
-  label: 'Button',
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+  render: (args, { argTypes }) => ({
+    components: { Button },
+    props: Object.keys(argTypes),
+    // Storybook provides all the args in a $props variable.
+    // Each arg is also available as their own name.
+    template: '<Button v-bind="$props" v-on="$props" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/button-story-with-args.3.js.mdx
+++ b/docs/snippets/vue/button-story-with-args.3.js.mdx
@@ -5,23 +5,19 @@ import Button from './Button.vue';
 
 export default {
   component: Button,
-  title: 'Components/Button',
 };
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args) => ({
-  components: { Button },
-  setup() {
-    //👇 The args will now be passed down to the template
-    return { args };
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
   },
-  template: '<Button v-bind="args" />',
-});
-
-//👇 Each story then reuses that template
-export const Primary = Template.bind({});
-Primary.args = {
-  primary: true,
-  label: 'Button',
+  render: (args) => ({
+    components: { Button },
+    setup() {
+      return { args };
+    },
+    template: '<Button v-bind="args" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/button-story-with-blue-args.js.mdx
+++ b/docs/snippets/vue/button-story-with-blue-args.js.mdx
@@ -4,7 +4,6 @@
 import Button from './Button.vue';
 
 export default {
-  title: 'Components/Button',
   component: Button,
   //👇 Creates specific parameters for the story
   parameters: {

--- a/docs/snippets/vue/button-story-with-emojis.js.mdx
+++ b/docs/snippets/vue/button-story-with-emojis.js.mdx
@@ -5,19 +5,26 @@ import Button from './Button.vue';
 
 export default {
   component: Button,
-  title: 'Components/Button',
 };
 
-export const Primary = () => ({
-  components: { Button },
-  template: '<Button background="#ff0" label="Button" />',
-});
-export const Secondary = () => ({
-  components: { Button },
-  template: '<Button background="#ff0" label="😄👍😍💯" />',
-});
-export const Tertiary = () => ({
-  components: { Button },
-  template: '<Button background="#ff0" label="📚📕📈🤓" />',
-});
+export const Primary = {
+  render: () => ({
+    components: { Button },
+    template: '<Button backgroundColor="#ff0" label="Button" />',
+  }),
+};
+
+export const Secondary = {
+  render: () => ({
+    components: { Button },
+    template: '<Button backgroundColor="#ff0" label="😄👍😍💯" />',
+  }),
+};
+
+export const Tertiary = {
+  render: () => ({
+    components: { Button },
+    template: '<Button backgroundColor="#ff0" label="📚📕📈🤓" />',
+  }),
+};
 ```

--- a/docs/snippets/vue/button-story.js.mdx
+++ b/docs/snippets/vue/button-story.js.mdx
@@ -5,11 +5,12 @@ import Button from './Button.vue';
 
 export default {
   component: Button,
-  title: 'Components/Button',
 };
 
-export const Primary = () => ({
-  components: { Button },
-  template: '<Button primary label="Button" />',
-});
+export const Primary = {
+  render: () => ({
+    components: { Button },
+    template: '<Button primary label="Button" />',
+  }),
+};
 ```

--- a/docs/snippets/vue/checkbox-story-csf.js.mdx
+++ b/docs/snippets/vue/checkbox-story-csf.js.mdx
@@ -1,20 +1,21 @@
 ```js
 // Checkbox.stories.js
 
-import Checkbox from "./Checkbox.vue";
+import Checkbox from './Checkbox.vue';
 
 export default {
-  title: 'MDX/Checkbox',
   component: Checkbox,
 };
 
-export const allCheckboxes = () => ({
-  components: { Checkbox },
-  template: `
-    <form>
-      <Checkbox id="Unchecked" label="Unchecked"/>
-      <Checkbox id="Checked" label="Checked" checked />
-      <Checkbox appearance="secondary" id="second" label="Secondary" checked />
-    </form>`,
-});
+export const allCheckboxes = () => {
+  render: () => ({
+    components: { Checkbox },
+    template: `
+      <form>
+        <Checkbox id="Unchecked" label="Unchecked"/>
+        <Checkbox id="Checked" label="Checked" checked />
+        <Checkbox appearance="secondary" id="second" label="Secondary" checked />
+      </form>`,
+  });
+};
 ```

--- a/docs/snippets/vue/component-story-custom-args-complex.3.js.mdx
+++ b/docs/snippets/vue/component-story-custom-args-complex.3.js.mdx
@@ -4,13 +4,12 @@
 import YourComponent from './YourComponent.vue';
 
 export default {
-  title: 'A complex case with a function',
   component: YourComponent,
   //👇 Creates specific argTypes with options
   argTypes: {
     propertyA: {
       options: ['Item One', 'Item Two', 'Item Three'],
-      control: { type: 'select' } // automatically inferred when 'options' is defined
+      control: { type: 'select' }, // automatically inferred when 'options' is defined
     },
     propertyB: {
       options: ['Another Item One', 'Another Item Two', 'Another Item Three'],
@@ -23,22 +22,27 @@ const someFunction = (valuePropertyA, valuePropertyB) => {
   // Makes some computations and returns something
 };
 
-const Template = (args) => {
-  //👇 Assigns the function result to a variable
-  const functionResult = someFunction(args.propertyA, args.propertyB);
-  return {
-    components: { YourComponent },
-    setup() {
-      //👇 The args will now be passed down to the template
-      return {
-        args: {
+export const ExampleStory = {
+  args: {
+    propertyA: 'Something',
+    propertyB: 'Something else',
+  },
+  render: (args) => {
+    const { propertyA, propertyB } = args;
+    //👇 Assigns the function result to a variable
+    const functionResult = someFunction(propertyA, propertyB);
+    return {
+      components: { YourComponent },
+      setup() {
+        return {
           ...args,
           //👇 Replaces arg variable with the override (without the need of mutation)
           someProperty: functionResult,
-        },
-      };
-    },
-    template: '<YourComponent v-bind="args" />',
-  };
+        };
+      },
+      template:
+        '<YourComponent :propertyA="propertyA" :propertyB="propertyB" :someProperty="someProperty"/>',
+    };
+  },
 };
 ```

--- a/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
@@ -5,7 +5,7 @@ export default {
   title: 'img',
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     template: '<img src="https://place-hold.it/350x150" alt="My CDN placeholder"/>',
   }),

--- a/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
@@ -4,6 +4,7 @@
 export default {
   title: 'img',
 };
+
 export const withAnImage = {
   render: () => ({
     template: '<img src="https://place-hold.it/350x150" alt="My CDN placeholder"/>',

--- a/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
@@ -2,9 +2,11 @@
 // MyComponent.stories.js
 
 export default {
-  title: "img",
+  title: 'img',
 };
-export const withAnImage = () => ({
-  template: '<img src="https://place-hold.it/350x150" alt="My CDN placeholder"/>'
-});
+export const withAnImage = {
+  render: () => ({
+    template: '<img src="https://place-hold.it/350x150" alt="My CDN placeholder"/>',
+  }),
+};
 ```

--- a/docs/snippets/vue/component-story-static-asset-with-import.2.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.2.js.mdx
@@ -12,7 +12,7 @@ const image = {
   alt: 'my image',
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     props: {
       src: {

--- a/docs/snippets/vue/component-story-static-asset-with-import.2.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.2.js.mdx
@@ -4,23 +4,25 @@
 import imageFile from './static/image.png';
 
 export default {
-  title: 'img'
+  title: 'img',
 };
 
 const image = {
   src: imageFile,
-  alt: 'my image'
+  alt: 'my image',
 };
 
-export const withAnImage = () => ({
-  template: `<img :src="src" :alt="alt"/>`,
-  props: {
-    src: {
-      default: () => image.src,
+export const withAnImage = {
+  render: () => ({
+    props: {
+      src: {
+        default: () => image.src,
+      },
+      alt: {
+        default: () => image.alt,
+      },
     },
-    alt: {
-      default: () => image.alt,
-    }
-  }
-});
+    template: `<img :src="src" :alt="alt"/>`,
+  }),
+};
 ```

--- a/docs/snippets/vue/component-story-static-asset-with-import.3.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.3.js.mdx
@@ -12,7 +12,7 @@ const image = {
   alt: 'my image',
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     setup() {
       //👇 Returns the content of the image object create above.

--- a/docs/snippets/vue/component-story-static-asset-with-import.3.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.3.js.mdx
@@ -4,21 +4,21 @@
 import imageFile from './static/image.png';
 
 export default {
-  title: 'img'
+  title: 'img',
 };
 
 const image = {
   src: imageFile,
-  alt: 'my image'
+  alt: 'my image',
 };
 
-export const withAnImage = () => {
-  return {
+export const withAnImage = {
+  render: () => ({
     setup() {
-       //👇 Returns the content of the image object create above.
+      //👇 Returns the content of the image object create above.
       return { image };
     },
     template: `<img v-bind="image"/>`,
-  };
+  }),
 };
 ```

--- a/docs/snippets/vue/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-without-import.js.mdx
@@ -2,9 +2,11 @@
 // MyComponent.stories.js
 
 export default {
-  title: "img",
+  title: 'img',
 };
-export const withAnImage = () => ({
-  template: '<img src="image.png" alt="my image" />'
-});
+export const withAnImage = {
+  render: () => ({
+    template: '<img src="image.png" alt="my image" />',
+  }),
+};
 ```

--- a/docs/snippets/vue/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-without-import.js.mdx
@@ -5,7 +5,7 @@ export default {
   title: 'img',
 };
 
-export const withAnImage = {
+export const WithAnImage = {
   render: () => ({
     template: '<img src="image.png" alt="my image" />',
   }),

--- a/docs/snippets/vue/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-without-import.js.mdx
@@ -4,6 +4,7 @@
 export default {
   title: 'img',
 };
+
 export const withAnImage = {
   render: () => ({
     template: '<img src="image.png" alt="my image" />',

--- a/docs/snippets/vue/document-screen-with-graphql.3.js.mdx
+++ b/docs/snippets/vue/document-screen-with-graphql.3.js.mdx
@@ -15,8 +15,13 @@
 </template>
 
 <script>
+  import PageLayout from './PageLayout';
+  import DocumentHeader from './DocumentHeader';
+  import DocumentList from './DocumentList';
+
   import gql from 'graphql-tag';
   import { useQuery } from '@vue/apollo-composable';
+
   export default {
     name: 'DocumentScreen',
     setup() {

--- a/docs/snippets/vue/documentscreen-story-msw-graphql-query.3.js.mdx
+++ b/docs/snippets/vue/documentscreen-story-msw-graphql-query.3.js.mdx
@@ -1,14 +1,14 @@
 ```js
 // YourPage.stories.js
 
-import DocumentScreen from './DocumentScreen.vue';
+import DocumentScreen from './YourPage.vue';
+
 import WrapperComponent from './ApolloWrapperClient.vue';
 
 import { graphql } from 'msw';
 
 export default {
   component: DocumentScreen,
-  title: 'Mock GraphQL query with Storybook and MSW',
 };
 
 //👇The mocked data that will be used in the story
@@ -60,36 +60,44 @@ const TestData = {
   ],
 };
 
-const PageTemplate = (args) => ({
-  components: { DocumentScreen, WrapperComponent },
-  setup() {
-    return { args };
+export const MockedSuccess = {
+  parameters: {
+    msw: [
+      graphql.query('AllInfoQuery', (req, res, ctx) => {
+        return res(ctx.data(TestData));
+      }),
+    ],
   },
-  template: '<WrapperComponent><SampleGraphqlComponent v-bind="args"/></WrapperComponent>',
-});
-
-export const MockedSuccess = PageTemplate.bind({});
-MockedSuccess.parameters = {
-  msw: [
-    graphql.query('AllInfoQuery', (req, res, ctx) => {
-      return res(ctx.data(TestData));
-    }),
-  ],
+  render: (args) => ({
+    components: { DocumentScreen, WrapperComponent },
+    setup() {
+      return { args };
+    },
+    template: '<WrapperComponent><DocumentScreen v-bind="args"/></WrapperComponent>',
+  }),
 };
 
-export const MockedError = PageTemplate.bind({});
-MockedError.parameters = {
-  msw: [
-    graphql.query('AllInfoQuery', (req, res, ctx) => {
-      return res(
-        ctx.delay(800),
-        ctx.errors([
-          {
-            message: 'Access denied',
-          },
-        ])
-      );
-    }),
-  ],
+export const MockedError = {
+  parameters: {
+    msw: [
+      graphql.query('AllInfoQuery', (req, res, ctx) => {
+        return res(
+          ctx.delay(800),
+          ctx.errors([
+            {
+              message: 'Access denied',
+            },
+          ])
+        );
+      }),
+    ],
+  },
+  render: (args) => ({
+    components: { DocumentScreen, WrapperComponent },
+    setup() {
+      return { args };
+    },
+    template: '<WrapperComponent><DocumentScreen v-bind="args"/></WrapperComponent>',
+  }),
 };
 ```

--- a/docs/snippets/vue/documentscreen-story-msw-rest-request.3.js.mdx
+++ b/docs/snippets/vue/documentscreen-story-msw-rest-request.3.js.mdx
@@ -3,11 +3,10 @@
 
 import { rest } from 'msw';
 
-import DocumentScreen from './DocumentScreen.vue';
+import DocumentScreen from './YourPage.vue';
 
 export default {
   component: DocumentScreen,
-  title: 'Mock Rest request with Storybook and MSW',
 };
 
 //👇The mocked data that will be used in the story
@@ -59,29 +58,37 @@ const TestData = {
   ],
 };
 
-const PageTemplate = (args) => ({
-  components: { DocumentScreen },
-  setup() {
-    return { args };
+export const MockedSuccess = {
+  parameters: {
+    msw: [
+      rest.get('https://your-restful-endpoint/', (_req, res, ctx) => {
+        return res(ctx.json(TestData));
+      }),
+    ],
   },
-  template: '<DocumentScreen v-bind="args" />',
-});
-
-export const MockedSuccess = PageTemplate.bind({});
-MockedSuccess.parameters = {
-  msw: [
-    rest.get('https://your-restful-endpoint/', (_req, res, ctx) => {
-      return res(ctx.json(TestData));
-    }),
-  ],
+  render: (args) => ({
+    components: { DocumentScreen },
+    setup() {
+      return { args };
+    },
+    template: '<DocumentScreen v-bind="args" />',
+  }),
 };
 
-export const MockedError = PageTemplate.bind({});
-MockedError.parameters = {
-  msw: [
-    rest.get('https://your-restful-endpoint/', (_req, res, ctx) => {
-      return res(ctx.delay(800), ctx.status(403));
-    }),
-  ],
+export const MockedError = {
+  parameters: {
+    msw: [
+      rest.get('https://your-restful-endpoint/', (_req, res, ctx) => {
+        return res(ctx.delay(800), ctx.status(403));
+      }),
+    ],
+  },
+  render: (args) => ({
+    components: { DocumentScreen },
+    setup() {
+      return { args };
+    },
+    template: '<DocumentScreen v-bind="args" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/list-story-expanded.2.js.mdx
+++ b/docs/snippets/vue/list-story-expanded.2.js.mdx
@@ -6,30 +6,37 @@ import ListItem from './ListItem.vue';
 
 export default {
   component: List,
-  title: 'List',
 };
 
-export const Empty = (args, { argTypes }) => ({
-  components: { List },
-  props: Object.keys(argTypes),
-  template: '<list v-bind="$props"/>',
-});
+export const Empty = {
+  render: (args, { argTypes }) => ({
+    components: { List },
+    props: Object.keys(argTypes),
+    template: '<List v-bind="$props"/>',
+  }),
+};
 
-export const OneItem = (args, { argTypes }) => ({
-  components: { List, ListItem },
-  props: Object.keys(argTypes),
-  template: '<list v-bind="$props"><list-item/></list>',
-});
+export const OneItem = {
+  render: (args, { argTypes }) => ({
+    components: { List, ListItem },
+    props: Object.keys(argTypes),
+    template: `
+      <List v-bind="$props">
+        <list-item/>
+      </List>`,
+  }),
+};
 
-export const ManyItems = (args, { argTypes }) => ({
-  components: { List, ListItem },
-  props: Object.keys(argTypes),
-  template: `
-    <list v-bind="$props">
-      <list-item/>
-      <list-item/>
-      <list-item/>
-    </list>
-    `,
-});
+export const ManyItems = {
+  render: (args, { argTypes }) => ({
+    components: { List, ListItem },
+    props: Object.keys(argTypes),
+    template: `
+      <List v-bind="$props">
+        <list-item/>
+        <list-item/>
+        <list-item/>
+      </List>`,
+  }),
+};
 ```

--- a/docs/snippets/vue/list-story-expanded.3.js.mdx
+++ b/docs/snippets/vue/list-story-expanded.3.js.mdx
@@ -6,36 +6,43 @@ import ListItem from './ListItem.vue';
 
 export default {
   component: List,
-  title: 'List',
 };
 
-export const Empty = (args) => ({
-  components: { List },
-  setup() {
-    return { args };
-  },
-  template: '<list v-bind="args"/>',
-});
+export const Empty = {
+  render: (args) => ({
+    components: { List },
+    setup() {
+      return { args };
+    },
+    template: '<List v-bind="args">',
+  }),
+};
 
-export const OneItem = (args) => ({
-  components: { List, ListItem },
-  setup() {
-    return { args };
-  },
-  template: '<list v-bind="args"><list-item/></list>',
-});
+export const OneItem = {
+  render: (args) => ({
+    components: { List, ListItem },
+    setup() {
+      return { args };
+    },
+    template: `
+      <List v-bind="args">
+        <list-item/>
+      </List>`,
+  }),
+};
 
-export const ManyItems = (args) => ({
-  components: { List, ListItem },
-  setup() {
-    return { args };
-  },
-  template: `
-    <list v-bind="args">
-      <list-item/>
-      <list-item/>
-      <list-item/>
-    </list>
-    `,
-});
+export const ManyItems = {
+  render: (args) => ({
+    components: { List, ListItem },
+    setup() {
+      return { ...args };
+    },
+    template: `
+      <List v-bind="args">
+        <list-item/>
+        <list-item/>
+        <list-item/>
+      </List>`,
+  }),
+};
 ```

--- a/docs/snippets/vue/list-story-reuse-data.2.js.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.2.js.mdx
@@ -7,19 +7,20 @@ import ListItem from './ListItem.vue';
 //👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
 
-export const ManyItems = (args, { argTypes }) => ({
-  components: { List, ListItem },
-  props: Object.keys(argTypes),
-  template: `
-    <list v-bind="$props">
-      <list-item :itemProperty="Selected"/>
-      <list-item :itemProperty="Unselected"/>
-      <list-item :itemProperty="Unselected"/>
-    </list>
-    `,
-});
-ManyItems.args = {
-  Selected: Selected.args.itemProperty,
-  Unselected: Unselected.args.itemProperty,
+export const ManyItems = {
+  args: {
+    Selected: Selected.args.isSelected,
+    Unselected: Unselected.args.isSelected,
+  },
+  render: (args, { argTypes }) => ({
+    components: { List, ListItem },
+    props: Object.keys(argTypes),
+    template: `
+      <List v-bind="$props">
+        <list-item :isSelected="Selected"/>
+        <list-item :isSelected="Unselected"/>
+        <list-item :isSelected="Unselected"/>
+      </List>`,
+  }),
 };
 ```

--- a/docs/snippets/vue/list-story-reuse-data.2.js.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.2.js.mdx
@@ -7,6 +7,10 @@ import ListItem from './ListItem.vue';
 //👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
 
+export default {
+  component: List,
+};
+
 export const ManyItems = {
   args: {
     Selected: Selected.args.isSelected,

--- a/docs/snippets/vue/list-story-reuse-data.3.js.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.3.js.mdx
@@ -7,6 +7,10 @@ import ListItem from './ListItem.vue';
 //👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
 
+export default {
+  component: List,
+};
+
 export const ManyItems = {
   args: {
     Selected: Selected.args.isSelected,

--- a/docs/snippets/vue/list-story-reuse-data.3.js.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.3.js.mdx
@@ -7,21 +7,22 @@ import ListItem from './ListItem.vue';
 //👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
 
-export const ManyItems = (args) => ({
-  components: { List, ListItem },
-  setup() {
-    return { args };
+export const ManyItems = {
+  args: {
+    Selected: Selected.args.isSelected,
+    Unselected: Unselected.args.isSelected,
   },
-  template: `
-    <list v-bind="args">
-      <list-item :itemProperty="Selected"/>
-      <list-item :itemProperty="Unselected"/>
-      <list-item :itemProperty="Unselected"/>
-    </list>
-    `,
-});
-ManyItems.args = {
-  Selected: Selected.args.itemProperty,
-  Unselected: Unselected.args.itemProperty,
+  render: (args) => ({
+    components: { List, ListItem },
+    setup() {
+      return { ...args };
+    },
+    template: `
+      <List v-bind="args">
+        <list-item :isSelected="Selected"/>
+        <list-item :isSelected="Unselected"/>
+        <list-item :isSelected="Unselected"/>
+      </List>`,
+  }),
 };
 ```

--- a/docs/snippets/vue/list-story-starter.2.js.mdx
+++ b/docs/snippets/vue/list-story-starter.2.js.mdx
@@ -5,13 +5,14 @@ import List from './ListComponent.vue';
 
 export default {
   component: List,
-  title: 'List',
 };
 
 // Always an empty list, not super interesting
-const Template = (args, { argTypes }) => ({
-  components: { List },
-  props: Object.keys(argTypes),
-  template: '<list v-bind="$props"/>',
-});
+export const Empty = {
+  render: (args, { argTypes }) => ({
+    components: { List },
+    props: Object.keys(argTypes),
+    template: '<List v-bind="$props"/>',
+  }),
+};
 ```

--- a/docs/snippets/vue/list-story-starter.3.js.mdx
+++ b/docs/snippets/vue/list-story-starter.3.js.mdx
@@ -5,15 +5,16 @@ import List from './ListComponent.vue';
 
 export default {
   component: List,
-  title: 'List',
 };
 
 // Always an empty list, not super interesting
-const Template = (args) => ({
-  components: { List },
-  setup() {
-    return { args };
-  },
-  template: '<list v-bind="args"/>',
-});
+export const Empty = {
+  render: (args) => ({
+    components: { List },
+    setup() {
+      return { args };
+    },
+    template: '<List v-bind="args">',
+  }),
+};
 ```

--- a/docs/snippets/vue/list-story-template.2.js.mdx
+++ b/docs/snippets/vue/list-story-template.2.js.mdx
@@ -7,29 +7,34 @@ import ListItem from './ListItem.vue';
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
+//👇 The ListTemplate construct will be spread to the existing stories.
 const ListTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { List, ListItem },
   template: `
     <List v-bind="$props">
-        <div v-for="item in items" :key="item.title">
-            <ListItem :item="item" />
-        </div>
+      <div v-for="item in items" :key="item.title">
+        <ListItem :item="item" />
+      </div>
     </List>
     `,
 });
 
-export const Empty = ListTemplate.bind({});
-EmptyListTemplate.args = {
-  items: [],
+export const Empty = {
+  ...ListTemplate,
+  args: {
+    items: [],
+  },
 };
 
-export const OneItem = ListTemplate.bind({});
-OneItem.args = {
-  items: [
-    {
-      ...Unchecked.args,
-    },
-  ],
+export const OneItem = {
+  ...ListTemplate,
+  args: {
+    items: [
+      {
+        ...Unchecked.args,
+      },
+    ],
+  },
 };
 ```

--- a/docs/snippets/vue/list-story-template.2.js.mdx
+++ b/docs/snippets/vue/list-story-template.2.js.mdx
@@ -7,6 +7,10 @@ import ListItem from './ListItem.vue';
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
+export default {
+  component: List,
+};
+
 //👇 The ListTemplate construct will be spread to the existing stories.
 const ListTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),

--- a/docs/snippets/vue/list-story-template.3.js.mdx
+++ b/docs/snippets/vue/list-story-template.3.js.mdx
@@ -11,6 +11,7 @@ export default {
   component: List,
 };
 
+//👇 The ListTemplate construct will be spread to the existing stories.
 export const ListTemplate = {
   render: (args) => ({
     components: { List, ListItem },

--- a/docs/snippets/vue/list-story-template.3.js.mdx
+++ b/docs/snippets/vue/list-story-template.3.js.mdx
@@ -7,31 +7,45 @@ import ListItem from './ListItem.vue';
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
-const ListTemplate = (args) => ({
-  components: { List, ListItem },
-  setup() {
-    return { args };
-  },
-  template: `
-    <List v-bind="args">
-      <div v-for="item in items" :key="item.title">
-        <ListItem :item="item"/>
-      </div>
-    </List>
-    `,
-});
+export default {
+  component: List,
+};
 
+export const ListTemplate = {
+  render: (args) => ({
+    components: { List, ListItem },
+    setup() {
+      return { ...args };
+    },
+    template: `
+      <List v-bind="args">
+        <div v-for="item in items" :key="item.title">
+          <ListItem :item="item"/>
+        </div>
+      </List>
+    `,
+  }),
+};
+
+export const Empty = {
+  ...ListTemplate,
+  args: {
+    items: [],
+  },
+};
 export const Empty = ListTemplate.bind({});
 Empty.args = {
   items: [],
 };
 
-export const OneItem = ListTemplate.bind({});
-OneItem.args = {
-  items: [
-    {
-      ...Unchecked.args,
-    },
-  ],
+export const OneItem = {
+  ...ListTemplate,
+  args: {
+    items: [
+      {
+        ...Unchecked.args,
+      },
+    ],
+  },
 };
 ```

--- a/docs/snippets/vue/list-story-unchecked.2.js.mdx
+++ b/docs/snippets/vue/list-story-unchecked.2.js.mdx
@@ -7,12 +7,18 @@ import ListItem from './ListItem.vue';
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
-export const OneItem = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
-  components: { List, ListItem },
-  template: '<List v-bind="$props"><ListItem v-bind="$props"/></List>',
-});
-OneItem.args = {
-  ...Unchecked.args,
+export default {
+  component: List,
+};
+
+export const OneItem = {
+  args: {
+    ...Unchecked.args,
+  },
+  render: (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { List, ListItem },
+    template: '<List v-bind="$props"><ListItem v-bind="$props"/></List>',
+  }),
 };
 ```

--- a/docs/snippets/vue/list-story-unchecked.3.js.mdx
+++ b/docs/snippets/vue/list-story-unchecked.3.js.mdx
@@ -7,15 +7,21 @@ import ListItem from './ListItem.vue';
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
-export const OneItem = (args) => ({
-  components: { List, ListItem },
-  setup() {
-    //👇 The args will now be passed down to the template
-    return { args };
+export default {
+  component: List,
+};
+
+export const OneItem = {
+  args: {
+    ...Unchecked.args,
   },
-  template: '<List v-bind="args"><ListItem v-bind="args"/></List>',
-});
-OneItem.args = {
-  ...Unchecked.args,
+  render: (args) => ({
+    components: { List, ListItem },
+    setup() {
+      //👇 The args will now be passed down to the template
+      return { args };
+    },
+    template: '<List v-bind="args"><ListItem v-bind="args"/></List>',
+  }),
 };
 ```

--- a/docs/snippets/vue/list-story-with-sub-components.2.js.mdx
+++ b/docs/snippets/vue/list-story-with-sub-components.2.js.mdx
@@ -7,18 +7,21 @@ import ListItem from './ListItem.vue';
 export default {
   component: List,
   subcomponents: { ListItem }, //👈 Adds the ListItem component as a subcomponent
-  title: 'List',
 };
 
-export const Empty = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
-  components: { List },
-  template: '<List v-bind="$props"/>',
-});
+export const Empty = {
+  render: (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { List },
+    template: '<List v-bind="$props"/>',
+  }),
+};
 
-export const OneItem = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
-  components: { List, ListItem },
-  template: '<List v-bind="$props"><ListItem /></List>',
-});
+export const OneItem = {
+  render: (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { List, ListItem },
+    template: '<List v-bind="$props"><ListItem /></List>',
+  }),
+};
 ```

--- a/docs/snippets/vue/list-story-with-sub-components.3.js.mdx
+++ b/docs/snippets/vue/list-story-with-sub-components.3.js.mdx
@@ -7,24 +7,26 @@ import ListItem from './ListItem.vue';
 export default {
   component: List,
   subcomponents: { ListItem }, //👈 Adds the ListItem component as a subcomponent
-  title: 'List',
 };
 
-export const Empty = (args) => ({
-  components: { List },
-  setup() {
-    //👇 The args will now be passed down to the template
-    return { args };
-  }
-  template: '<List v-bind="args"/>',
-});
+export const Empty = {
+  render: (args) => ({
+    components: { Button },
+    setup() {
+      return { args };
+    },
+    template: '<List v-bind="args"/>',
+  }),
+};
 
-export const OneItem = (args) => ({
-  components: { List, ListItem },
-  setup() {
-    //👇 The args will now be passed down to the template
-    return { args };
-  }
-  template: '<List v-bind="args"><ListItem /></List>',
-});
+export const OneItem = {
+  render: (args) => ({
+    components: { List, ListItem },
+    setup() {
+      //👇 The args will now be passed down to the template
+      return { args };
+    },
+    template: '<List v-bind="args"><ListItem /></List>',
+  }),
+};
 ```

--- a/docs/snippets/vue/loader-story.3.js.mdx
+++ b/docs/snippets/vue/loader-story.3.js.mdx
@@ -7,22 +7,20 @@ import fetch from 'node-fetch';
 
 export default {
   component: TodoItem,
-  title: 'Examples/Loader',
 };
 
-export const Primary = (args, { loaded: { todo } }) => {
-  return {
+export const Primary = {
+  render: (args, { loaded: { todo } }) => ({
     components: { TodoItem },
     setup() {
       return { args, todo: todo };
     },
-    template: `<TodoItem :todo="todo"/>`,
-  };
-};
-
-Primary.loaders = [
-  async () => ({
-    todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    template: '<TodoItem :todo="todo" />',
   }),
-];
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
 ```

--- a/docs/snippets/vue/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/vue/my-component-story-basic-and-props.js.mdx
@@ -4,17 +4,20 @@
 import MyComponent from './MyComponent.vue';
 
 export default {
-  title: 'Path/To/MyComponent',
   component: MyComponent,
 };
 
-export const Basic = () => ({
-  components: { MyComponent },
-  template: '<MyComponent />',
-});
+export const Basic = {
+  render: () => ({
+    components: { MyComponent },
+    template: '<MyComponent />',
+  }),
+};
 
-export const WithProp = () => ({
-  components: { MyComponent },
-  template: '<MyComponent prop="value"/>',
-});
+export const WithProp = {
+  render: () => ({
+    components: { MyComponent },
+    template: '<MyComponent prop="value"/>',
+  }),
+};
 ```

--- a/docs/snippets/vue/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/vue/my-component-story-configure-viewports.js.mdx
@@ -3,8 +3,10 @@
 
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
+import MyComponent from './MyComponent.vue';
+
 export default {
-  title: 'Stories',
+  component: MyComponent,
   parameters: {
     //👇 The viewports object from the Essentials addon
     viewport: {
@@ -17,12 +19,15 @@ export default {
   },
 };
 
-export const myStory = () => ({
-  template: '<div />',
-});
-myStory.parameters = {
-  viewport: {
-    defaultViewport: 'iphonex',
+export const MyStory = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphonex',
+    },
   },
+  render: () => ({
+    components: { MyComponent },
+    template: '<div />',
+  }),
 };
 ```

--- a/docs/snippets/vue/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/vue/my-component-story-configure-viewports.js.mdx
@@ -27,7 +27,7 @@ export const MyStory = {
   },
   render: () => ({
     components: { MyComponent },
-    template: '<div />',
+    template: '<MyComponent />',
   }),
 };
 ```

--- a/docs/snippets/vue/my-component-story-use-globaltype-backwards-compat.js.mdx
+++ b/docs/snippets/vue/my-component-story-use-globaltype-backwards-compat.js.mdx
@@ -1,10 +1,12 @@
 ```js
 // MyComponent.stories.js
 
-export const StoryWithLocale = ({ globals: { locale } }) => {
-  const caption = getCaptionForLocale(locale);
-  return {
-    template: `<p>${caption}</p>`,
-  };
+export const StoryWithLocale = {
+  render: ({ globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return {
+      template: `<p>${caption}</p>`,
+    };
+  },
 };
 ```

--- a/docs/snippets/vue/my-component-story-use-globaltype-backwards-compat.js.mdx
+++ b/docs/snippets/vue/my-component-story-use-globaltype-backwards-compat.js.mdx
@@ -1,12 +1,10 @@
 ```js
 // MyComponent.stories.js
 
-export const StoryWithLocale = {
-  render: ({ globals: { locale } }) => {
-    const caption = getCaptionForLocale(locale);
-    return {
-      template: `<p>${caption}</p>`,
-    };
-  },
+export const StoryWithLocale = ({ globals: { locale } }) => {
+  const caption = getCaptionForLocale(locale);
+  return {
+    template: `<p>${caption}</p>`,
+  };
 };
 ```

--- a/docs/snippets/vue/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/vue/my-component-story-use-globaltype.js.mdx
@@ -1,6 +1,11 @@
 ```js
 // MyComponent.stories.js
 
+import MyComponent from './MyComponent.vue';
+
+export default {
+  component: MyComponent,
+};
 const getCaptionForLocale = (locale) => {
   switch (locale) {
     case 'es':
@@ -16,10 +21,12 @@ const getCaptionForLocale = (locale) => {
   }
 };
 
-export const StoryWithLocale = (args, { globals: { locale } }) => {
-  const caption = getCaptionForLocale(locale);
-  return {
-    template: `<p>${caption}</p>`,
-  };
+export const StoryWithLocale = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return {
+      template: `<p>${caption}</p>`,
+    };
+  },
 };
 ```

--- a/docs/snippets/vue/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/vue/my-component-story-use-globaltype.js.mdx
@@ -6,6 +6,7 @@ import MyComponent from './MyComponent.vue';
 export default {
   component: MyComponent,
 };
+
 const getCaptionForLocale = (locale) => {
   switch (locale) {
     case 'es':

--- a/docs/snippets/vue/my-component-story-with-nonstory.2.js.mdx
+++ b/docs/snippets/vue/my-component-story-with-nonstory.2.js.mdx
@@ -1,15 +1,13 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.jsx | MyComponent.stories.tsx
+// MyComponent.stories.js
 
-import React from 'react';
-
-import { MyComponent } from './MyComponent';
+import MyComponent from './MyComponent.vue';
 
 import someData from './data.json';
 
 export default {
   component: MyComponent,
-  includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
+  includeStories: ['SimpleStory', 'ComplexStory'],
   excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
 };
 
@@ -20,11 +18,21 @@ export const SimpleStory = {
   args: {
     data: simpleData,
   },
+  render: (args, { argTypes }) => ({
+    components: { MyComponent },
+    props: Object.keys(argTypes),
+    template: `<MyComponent v-bind="$props"/>`,
+  }),
 };
 
 export const ComplexStory = {
   args: {
     data: complexData,
   },
+  render: (args, { argTypes }) => ({
+    components: { MyComponent },
+    props: Object.keys(argTypes),
+    template: `<MyComponent v-bind="$props"/>`,
+  }),
 };
 ```

--- a/docs/snippets/vue/my-component-story-with-nonstory.3.js.mdx
+++ b/docs/snippets/vue/my-component-story-with-nonstory.3.js.mdx
@@ -15,26 +15,28 @@ export const simpleData = { foo: 1, bar: 'baz' };
 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 
 export const SimpleStory = {
-  render: () => ({
+  args: {
+    data: simpleData,
+  },
+  render: (args) => ({
     components: { MyComponent },
-    props: {
-      data: {
-        default: () => simpleData,
-      },
+    setup() {
+      return { args };
     },
-    template: `<MyComponent :data="data"/>`,
+    template: `<MyComponent v-bind="args"/>`,
   }),
 };
 
 export const ComplexStory = {
-  render: () => ({
+  args: {
+    data: complexData,
+  },
+  render: (args) => ({
     components: { MyComponent },
-    props: {
-      data: {
-        default: () => complexData,
-      },
+    setup() {
+      return { args };
     },
-    template: `<MyComponent :data="data"/>`,
+    template: `<MyComponent v-bind="args"/>`,
   }),
 };
 ```

--- a/docs/snippets/vue/my-component-with-env-variables.2.js.mdx
+++ b/docs/snippets/vue/my-component-with-env-variables.2.js.mdx
@@ -5,17 +5,16 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   component: MyComponent,
-  title: 'A story using environment variables inside a .env file',
 };
 
-const Template = (args, { argTypes }) => ({
-  components: { MyComponent },
-  props: Object.keys(argTypes),
-  template: '<MyComponent v-bind="$props"/>',
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  propertyA: process.env.STORYBOOK_DATA_KEY,
+export const ExampleStory = {
+  args: {
+    propertyA: process.env.STORYBOOK_DATA_KEY,
+  },
+  render: (args, { argTypes }) => ({
+    components: { MyComponent },
+    props: Object.keys(argTypes),
+    template: `<MyComponent v-bind="$props"/>`,
+  }),
 };
 ```

--- a/docs/snippets/vue/my-component-with-env-variables.3.js.mdx
+++ b/docs/snippets/vue/my-component-with-env-variables.3.js.mdx
@@ -5,19 +5,18 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   component: MyComponent,
-  title: 'A story using environment variables inside a .env file',
 };
 
-const Template = (args) => ({
-  components: { MyComponent },
-  setup() {
-    return { args };
+export const ExampleStory = {
+  args: {
+    propertyA: process.env.STORYBOOK_DATA_KEY,
   },
-  template: '<MyComponent v-bind="args"/>',
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  propertyA: process.env.STORYBOOK_DATA_KEY,
+  render: (args) => ({
+    components: { MyComponent },
+    setup() {
+      return { args };
+    },
+    template: `<MyComponent v-bind="args"/>`,
+  }),
 };
 ```

--- a/docs/snippets/vue/page-story-slots.2.js.mdx
+++ b/docs/snippets/vue/page-story-slots.2.js.mdx
@@ -5,21 +5,20 @@ import Page from './Page.vue';
 
 export default {
   component: Page,
-  title: 'Page',
 };
 
-const Template = (args, { argTypes }) => ({
-  components: { Page },
-  props: Object.keys(argTypes),
-  template: `
-    <page v-bind="$props">
-      <footer v-if="footer" v-slot=footer v-html="footer"/>
-    </page>
-  `,
-});
-
-export const CustomFooter = Template.bind({});
-CustomFooter.args = {
-  footer: '<a href="https://storybook.js.org/">Built with Storybook</a>',
+export const CustomFooter = {
+  args: {
+    footer: '<a href="https://storybook.js.org/">Built with Storybook</a>',
+  },
+  render: (args, { argTypes }) => ({
+    components: { Page },
+    props: Object.keys(argTypes),
+    template: `
+      <page v-bind="$props">
+        <footer v-if="footer" v-slot=footer v-html="footer"/>
+      </page>
+    `,
+  }),
 };
 ```

--- a/docs/snippets/vue/page-story-slots.3.js.mdx
+++ b/docs/snippets/vue/page-story-slots.3.js.mdx
@@ -5,23 +5,24 @@ import Page from './Page.vue';
 
 export default {
   component: Page,
-  title: 'Page',
 };
 
-const Template = (args, { argTypes }) => ({
-  components: { Page },
-  setup() {
-    return { args };
+export const CustomFooter = {
+  args: {
+    footer: '<a href="https://storybook.js.org/">Built with Storybook</a>',
   },
-  template: `
-    <page v-bind="args">
-      <footer v-if="footer" v-slot=footer v-html="footer"/>
-    </page>
-  `,
-});
-
-export const CustomFooter = Template.bind({});
-CustomFooter.args = {
-  footer: '<a href="https://storybook.js.org/">Built with Storybook</a>',
+  render: (args) => ({
+    components: { Page },
+    setup() {
+      return { args };
+    },
+    template: `
+      <page v-bind="args">
+        <template v-slot:footer>
+          <footer v-if="args.footer" v-html="args.footer" />
+        </template>
+      </page>    
+    `,
+  }),
 };
 ```

--- a/docs/snippets/vue/page-story-slots.mdx-3.mdx.mdx
+++ b/docs/snippets/vue/page-story-slots.mdx-3.mdx.mdx
@@ -5,20 +5,14 @@ import { Meta, Story } from '@storybook/addon-docs';
 
 import Page from './Page.vue';
 
-<Meta
-  title="Page"
-  component={Page}
-/>
+<Meta title="Page" component={Page} />
 
 export const Template = (args) => ({
   components: { Page },
   setup() {
     return { args };
   },
-  template: `
-    <page v-bind="args">
-      <footer v-if="footer" v-slot=footer v-html="footer"/>
-    </page>`,
+  template: `<page v-bind="args"> <template v-slot:footer> <footer v-if="args.footer" v-html="args.footer" /> </template> </page>`,
 });
 
 <Story

--- a/docs/snippets/vue/page-story-with-args-composition.2.js.mdx
+++ b/docs/snippets/vue/page-story-with-args-composition.2.js.mdx
@@ -10,19 +10,18 @@ import * as DocumentListStories from './DocumentList.stories';
 
 export default {
   component: DocumentScreen,
-  title: 'DocumentScreen',
 };
 
-const Template = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
-  components: { DocumentScreen },
-  template: '<DocumentScreen v-bind="$props"/>',
-});
-
-export const Simple = Template.bind({});
-Simple.args = {
-  user: PageLayoutStories.Simple.args.user,
-  document: DocumentHeaderStories.Simple.args.document,
-  subdocuments: DocumentListStories.Simple.args.documents,
+export const Simple = {
+  args: {
+    user: PageLayoutStories.Simple.args.user,
+    document: DocumentHeaderStories.Simple.args.document,
+    subdocuments: DocumentListStories.Simple.args.documents,
+  },
+  render: (args, { argTypes }) => ({
+    components: { DocumentScreen },
+    props: Object.keys(argTypes),
+    template: '<DocumentScreen v-bind="$props" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/page-story-with-args-composition.3.js.mdx
+++ b/docs/snippets/vue/page-story-with-args-composition.3.js.mdx
@@ -10,21 +10,20 @@ import * as DocumentListStories from './DocumentList.stories';
 
 export default {
   component: DocumentScreen,
-  title: 'DocumentScreen',
 };
 
-const Template = (args) => ({
-  components: { DocumentScreen },
-  setup() {
-    return { args };
+export const Simple = {
+  args: {
+    user: PageLayoutStories.Simple.args.user,
+    document: DocumentHeaderStories.Simple.args.document,
+    subdocuments: DocumentListStories.Simple.args.documents,
   },
-  template: '<DocumentScreen v-bind="args"/>',
-});
-
-export const Simple = Template.bind({});
-Simple.args = {
-  user: PageLayoutStories.Simple.args.user,
-  document: DocumentHeaderStories.Simple.args.document,
-  subdocuments: DocumentListStories.Simple.args.documents,
+  render: (args) => ({
+    components: { DocumentScreen },
+    setup() {
+      return { args };
+    },
+    template: '<DocumentScreen v-bind="args" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/page-story.2.js.mdx
+++ b/docs/snippets/vue/page-story.2.js.mdx
@@ -3,21 +3,21 @@
 
 import Page from './Page.vue';
 
+//👇 Imports all Header stories
 import * as HeaderStories from './Header.stories';
 
 export default {
   component: Page,
-  title: 'Page',
 };
 
-const Template = (args, { argTypes }) => ({
-  components: { Page },
-  props: Object.keys(argTypes),
-  template: '<page v-bind="$props" />',
-});
-
-export const LoggedIn = Template.bind({});
-LoggedIn.args = {
-  ...HeaderStories.LoggedIn.args,
+export const LoggedIn = {
+  args: {
+    ...HeaderStories.LoggedIn.args,
+  },
+  render: (args, { argTypes }) => ({
+    components: { Page },
+    props: Object.keys(argTypes),
+    template: '<page v-bind="$props" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/page-story.3.js.mdx
+++ b/docs/snippets/vue/page-story.3.js.mdx
@@ -3,23 +3,23 @@
 
 import Page from './Page.vue';
 
+//👇 Imports all Header stories
 import * as HeaderStories from './Header.stories';
 
 export default {
   component: Page,
-  title: 'Page',
 };
 
-const Template = (args) => ({
-  components: { Page },
-  setup() {
-    return { args };
+export const LoggedIn = {
+  args: {
+    ...HeaderStories.LoggedIn.args,
   },
-  template: '<page v-bind="args" />',
-});
-
-export const LoggedIn = Template.bind({});
-LoggedIn.args = {
-  ...HeaderStories.LoggedIn.args,
+  render: (args) => ({
+    components: { Page },
+    setup() {
+      return { args };
+    },
+    template: '<page v-bind="args" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/table-story-fully-customize-controls.2.js.mdx
+++ b/docs/snippets/vue/table-story-fully-customize-controls.2.js.mdx
@@ -1,27 +1,34 @@
 ```js
 // Table.stories.js
 
-const TableStory = (args, { argTypes }) => ({
-  components: { Table },
-  props: Object.keys(argTypes),
-  template: `
-    <Table v-bind="$props">
-      <tr v-for="(row, idx1) in data">
-        <td v-for="(col, idx2) in row">
-          {{ data[idx1][idx2] }}
-        </td>
-      </tr>
-    </Table>`,
-});
+import Table from './Table.vue';
 
-export const Numeric = TableStory.bind({});
-Numeric.args = {
-  //👇 This arg is for the story component
-  data: [
-    [1, 2, 3],
-    [4, 5, 6],
-  ],
-  //👇 The remaining args get passed to the `Table` component
-  size: 'large',
+export default {
+  component: Table,
+};
+
+export const TableStory = {
+  args: {
+    //👇 This arg is for the story component
+    data: [
+      [1, 2, 3],
+      [4, 5, 6],
+    ],
+    //👇 The remaining args get passed to the `Table` component
+    size: 'large',
+  },
+  render: (args, { argTypes }) => ({
+    components: { Table },
+    props: Object.keys(argTypes),
+    template: `
+      <Table v-bind="$props">
+        <tr v-for="(row, idx1) in data">
+          <td v-for="(col, idx2) in row">
+            {{ data[idx1][idx2] }}
+          </td>
+        </tr>
+    </Table>
+    `,
+  }),
 };
 ```

--- a/docs/snippets/vue/table-story-fully-customize-controls.3.js.mdx
+++ b/docs/snippets/vue/table-story-fully-customize-controls.3.js.mdx
@@ -1,30 +1,35 @@
 ```js
 // Table.stories.js
+import Table from './Table.vue';
 
-const TableStory = (args) => ({
-  components: { Table },
-  setup() {
-    return { args };
+export default {
+  component: Table,
+};
+
+export const TableStory = {
+  args: {
+    //👇 This arg is for the story component
+    data: [
+      [1, 2, 3],
+      [4, 5, 6],
+    ],
+    //👇 The remaining args get passed to the `Table` component
+    size: 'large',
   },
-  template: `
-    <Table v-bind="args">
-      <tr v-for="(row, idx1) in data">
-        <td v-for="(col, idx2) in row">
-          {{ data[idx1][idx2] }}
-        </td>
-      </tr>
-    </Table>
+  render: (args) => ({
+    components: { Table },
+    setup() {
+      return { args };
+    },
+    template: `
+      <Table v-bind="args">
+        <tr v-for="(row, idx1) in data">
+          <td v-for="(col, idx2) in row">
+            {{ data[idx1][idx2] }}
+          </td>
+        </tr>
+      </Table>
   `,
-});
-
-export const Numeric = TableStory.bind({});
-Numeric.args = {
-  //👇 This arg is for the story component
-  data: [
-    [1, 2, 3],
-    [4, 5, 6],
-  ],
-  //👇 The remaining args get passed to the `Table` component
-  size: 'large',
+  }),
 };
 ```

--- a/docs/snippets/vue/your-component-with-decorator.js.mdx
+++ b/docs/snippets/vue/your-component-with-decorator.js.mdx
@@ -1,6 +1,8 @@
 ```js
 // YourComponent.stories.js
 
+import YourComponent from './YourComponent.vue';
+
 export default {
   component: YourComponent,
   decorators: [() => ({ template: '<div style="margin: 3em;"><story/></div>' })],

--- a/docs/snippets/vue/your-component.2.js.mdx
+++ b/docs/snippets/vue/your-component.2.js.mdx
@@ -1,24 +1,21 @@
 ```js
 // YourComponent.stories.js
 
-import YourComponent  from './YourComponent.vue';
+import YourComponent from './YourComponent.vue';
 
 //👇 This default export determines where your story goes in the story list
 export default {
-  title: 'YourComponent',
   component: YourComponent,
 };
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args, { argTypes }) => ({
-  components: { YourComponent },
-  props: Object.keys(argTypes),
-  template: '<YourComponent v-bind="$props"/>',
-});
-
-export const FirstStory = Template.bind({});
-
-FirstStory.args = {
-  /* 👇 The args you need here will depend on your component */
+export const FirstStory = {
+  args: {
+    //👇 The args you need here will depend on your component
+  },
+  render: (args, { argTypes }) => ({
+    components: { Button },
+    props: Object.keys(argTypes),
+    template: '<Button v-bind="$props" />',
+  }),
 };
 ```

--- a/docs/snippets/vue/your-component.3.js.mdx
+++ b/docs/snippets/vue/your-component.3.js.mdx
@@ -1,27 +1,23 @@
 ```js
 // YourComponent.stories.js
 
-import YourComponent  from './YourComponent.vue';
+import YourComponent from './YourComponent.vue';
 
 //👇 This default export determines where your story goes in the story list
 export default {
-  title: 'YourComponent',
   component: YourComponent,
 };
 
-//👇 We create a “template” of how args map to rendering
-const Template = (args) => ({
-  components: { YourComponent },
-  setup() {
-    //👇 The args will now be passed down to the template
-    return { args };
+export const FirstStory = {
+  args: {
+    //👇 The args you need here will depend on your component
   },
-  template: '<YourComponent v-bind="args"/>',
-});
-
-export const FirstStory = Template.bind({});
-
-FirstStory.args = {
-  /* 👇 The args you need here will depend on your component */
+  render: (args) => ({
+    components: { YourComponent },
+    setup() {
+      return { args };
+    },
+    template: '<YourComponent v-bind="args" />',
+  }),
 };
 ```


### PR DESCRIPTION
With this pull request, the documentation's snippets are converted for CSF 3. 

Frameworks converted:
- React
- Vue
- Angular
- Svelte

What was done:
- The snippets in use were converted to CSF 3
- Polished some of the snippets as they are not entirely accurate.



@shilman is it required to get the patch label or we'll just leave it with the documentation.


Feel free to provide feedback