### PR TITLE
feat: Add parameter to enable grid by default

### DIFF
--- a/addons/backgrounds/src/decorators/withGrid.ts
+++ b/addons/backgrounds/src/decorators/withGrid.ts
@@ -18,7 +18,9 @@ const deprecatedCellSizeWarning = deprecate(
 export const withGrid = (StoryFn: StoryFunction, context: StoryContext) => {
   const { globals, parameters } = context;
   const gridParameters = parameters[BACKGROUNDS_PARAM_KEY].grid;
-  const isActive = globals[BACKGROUNDS_PARAM_KEY]?.grid === true && gridParameters.disable !== true;
+  const isActive =
+    (globals[BACKGROUNDS_PARAM_KEY]?.grid === true || gridParameters?.isActive === true) &&
+    gridParameters.disable !== true;
   const { cellAmount, cellSize, opacity } = gridParameters;
   const isInDocs = context.viewMode === 'docs';
 

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
@@ -7,6 +7,7 @@ export default {
   parameters: {
     backgrounds: {
       grid: {
+        isActive: true, // whether the grid should be active by default
         cellSize: 20,
         opacity: 0.5,
         cellAmount: 5,

--- a/examples/official-storybook/stories/addon-backgrounds.stories.js
+++ b/examples/official-storybook/stories/addon-backgrounds.stories.js
@@ -101,6 +101,7 @@ GridCellProperties.args = {
 GridCellProperties.parameters = {
   backgrounds: {
     grid: {
+      isActive: true,
       cellSize: 10,
       cellAmount: 4,
       opacity: 0.2,


### PR DESCRIPTION
Issue: #7367

## What I did

Adds the `isActive` parameter to the `grid` section of the backgrounds
addon. It is `false` by default and may be set globally or per story.

Refs #7367

## How to test

One can add the following configuration to the `preview.js` or story parameters
```js
backgrounds: {
  grid: {
    isActive: true,
  },
},
```

This parameter has been set to true for the `GridCellProperties` story in the official-storybook example. As well as it has been added to the common snippets in the documentation.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
