### PR TITLE
Invoke `play()` with context, ignore `IgnoredException` and chain argsEnhancers

### DIFF
--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -34,6 +34,7 @@ import {
   StoreSelectionSpecifier,
   StoreSelection,
   StorySpecifier,
+  PlayContext,
 } from './types';
 import { combineArgs, mapArgsToTypes, validateOptions } from './args';
 import { HooksContext } from './hooks';
@@ -571,9 +572,9 @@ export default class StoryStore {
       originalArgs
     );
 
-    const runPlayFunction = async () => {
-      const { play } = combinedParameters as { play?: () => any };
-      return play ? play() : undefined;
+    const runPlayFunction = async (context: PlayContext) => {
+      const { play } = combinedParameters as { play?: StoreItem['runPlayFunction'] };
+      return play ? play(context) : undefined;
     };
 
     _stories[id] = {

--- a/lib/client-api/src/story_store.ts
+++ b/lib/client-api/src/story_store.ts
@@ -554,20 +554,21 @@ export default class StoryStore {
       argTypeDefaultValueWarning();
     }
 
-    const initialArgsBeforeEnhancers = { ...defaultArgs, ...passedArgs };
+    const originalArgs = { ...defaultArgs, ...passedArgs };
     const initialArgs = this._argsEnhancers.reduce(
       (accumulatedArgs: Args, enhancer) => ({
         ...accumulatedArgs,
         ...enhancer({
           ...identification,
           parameters: combinedParameters,
-          args: initialArgsBeforeEnhancers,
+          args: accumulatedArgs,
           argTypes,
           globals: {},
+          originalArgs,
           originalStoryFn: getOriginal(),
         }),
       }),
-      initialArgsBeforeEnhancers
+      originalArgs
     );
 
     const runPlayFunction = async () => {

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -54,12 +54,16 @@ export type AddStoryArgs = StoryIdentifier & {
   loaders?: LoaderFunction[];
 };
 
+export type PlayContext = StoryContext & {
+  canvasId: string;
+};
+
 export type StoreItem = StoryIdentifier & {
   parameters: Parameters;
   getDecorated: () => StoryFn<any>;
   getOriginal: () => StoryFn<any>;
   applyLoaders: () => Promise<StoryContext>;
-  runPlayFunction: () => Promise<any>;
+  runPlayFunction: (context: PlayContext) => Promise<any>;
   storyFn: StoryFn<any>;
   unboundStoryFn: StoryFn<any>;
   hooks: HooksContext;

--- a/lib/core-client/src/preview/StoryRenderer.test.ts
+++ b/lib/core-client/src/preview/StoryRenderer.test.ts
@@ -11,6 +11,7 @@ import {
   STORY_CHANGED,
   STORY_UNCHANGED,
   STORY_RENDERED,
+  IGNORED_EXCEPTION,
 } from '@storybook/core-events';
 import { toId } from '@storybook/csf';
 import {
@@ -291,6 +292,23 @@ describe('core.preview.StoryRenderer', () => {
 
       expect(renderer.showErrorDisplay).toHaveBeenCalledWith(err);
       expect(onStoryThrewException).toHaveBeenCalledWith(err);
+    });
+
+    it('ignores exception if the render function throws IGNORED_EXCEPTION', async () => {
+      const { render, channel, storyStore, renderer } = prepareRenderer();
+
+      const onStoryThrewException = jest.fn();
+      channel.on(STORY_THREW_EXCEPTION, onStoryThrewException);
+
+      render.mockImplementation(() => {
+        throw IGNORED_EXCEPTION;
+      });
+
+      addAndSelectStory(storyStore, 'a', '1');
+      await renderer.renderCurrentStory(false);
+
+      expect(renderer.showErrorDisplay).not.toHaveBeenCalled();
+      expect(onStoryThrewException).not.toHaveBeenCalled();
     });
 
     it('renders an error if the story is missing', async () => {

--- a/lib/core-client/src/preview/StoryRenderer.tsx
+++ b/lib/core-client/src/preview/StoryRenderer.tsx
@@ -327,9 +327,11 @@ export class StoryRenderer {
   }
 
   // renderException is used if we fail to render the story and it is uncaught by the app layer
-  renderException(err: Error) {
+  renderException(err: Error | typeof Events.IGNORED_EXCEPTION) {
+    if (err === Events.IGNORED_EXCEPTION) return;
+
     this.channel.emit(Events.STORY_THREW_EXCEPTION, err);
-    this.showErrorDisplay(err);
+    this.showErrorDisplay(err as Error);
 
     // Log the stack to the console. So, user could check the source code.
     logger.error(err);

--- a/lib/core-client/src/preview/StoryRenderer.tsx
+++ b/lib/core-client/src/preview/StoryRenderer.tsx
@@ -282,7 +282,9 @@ export class StoryRenderer {
         const storyFn = () => unboundStoryFn(storyContext);
         await this.render({ ...context, storyContext, storyFn });
         if (FEATURES.previewCsfV3 && !forceRender) {
-          await runPlayFunction();
+          const canvasId =
+            storyContext.viewMode === 'docs' ? `story--${storyContext.storyId}` : 'root';
+          await runPlayFunction({ ...storyContext, canvasId });
         }
         this.channel.emit(Events.STORY_RENDERED, id);
       } catch (err) {

--- a/lib/core-events/src/index.ts
+++ b/lib/core-events/src/index.ts
@@ -39,8 +39,12 @@ enum events {
   NAVIGATE_URL = 'navigateUrl',
 }
 
+const symbols = {
+  IGNORED_EXCEPTION: Symbol('IgnoredException'),
+};
+
 // Enables: `import Events from ...`
-export default events;
+export default { ...events, ...symbols };
 
 // Enables: `import * as Events from ...` or `import { CHANNEL_CREATED } as Events from ...`
 // This is the preferred method
@@ -72,3 +76,5 @@ export const {
   SHARED_STATE_SET,
   NAVIGATE_URL,
 } = events;
+
+export const { IGNORED_EXCEPTION } = symbols;


### PR DESCRIPTION
Issue: -

## What I did

- Invoke any `play` functions with the `StoryContext` including `canvasId`, so element selectors (e.g. `canvas.getByText()`) can be limited to a container node (typically `#root`). Using `screen.*` is discouraged.
- When the story throws a `Symbol('IgnoredException')`, this will be caught and silently ignored, under the assumption that this error is handled elsewhere and/or used only for control flow.
- Changed `argsEnhancers` to receive `args` as they were returned by any previous enhancer, so that one enhancer can chain on another. I've added `originalArgs` to provide access to the original not-yet-enhanced args. Technically this is a breaking change, but since argsEnhancers was only recently introduced, it's unlikely any other addons are using it yet, let alone be affected by this change. A consequence of this change is that the order in which addons are specified in `main.js` is now relevant (i.e. `addon-test` will always have to be specified *after* addon-actions (or addon-essentials)).

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? no
- [ ] Does this need a new example in the kitchen sink apps? no
- [ ] Does this need an update to the documentation? maybe

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
