### PR TITLE
Chore: (Docs)Fixes the addon snippet for the toolbars

### DIFF
--- a/docs/snippets/common/addon-consume-globaltype.js.mdx
+++ b/docs/snippets/common/addon-consume-globaltype.js.mdx
@@ -1,20 +1,37 @@
 ```js
 // your-addon-register-file.js
 
+import React from 'react';
+
 import { useGlobals } from '@storybook/api';
+
 import { AddonPanel, Placeholder, Separator, Source, Spaced, Title } from '@storybook/components';
 
-const ThemePanel = props => {
+import { MyThemes } from '../my-theme-folder/my-theme-file';
+
+// Function to obtain the intended theme
+const getTheme = (themeName) => {
+  return MyThemes[themeName];
+};
+
+const ThemePanel = (props) => {
   const [{ theme: themeName }] = useGlobals();
-  const theme = getTheme(themeName);
+
+  const selectedTheme = getTheme(themeName);
 
   return (
     <AddonPanel {...props}>
-      {theme ? (
+      {selectedTheme ? (
         <Spaced row={3} outer={1}>
-          <Title>{theme.name}</Title>
+          <Title>{selectedTheme.name}</Title>
           <p>The full theme object</p>
-          <Source code={JSON.stringify(theme, null, 2)} language="js" copyable padded showLineNumbers />
+          <Source
+            code={JSON.stringify(selectedTheme, null, 2)}
+            language="js"
+            copyable
+            padded
+            showLineNumbers
+          />
         </Spaced>
       ) : (
         <Placeholder>No theme selected</Placeholder>


### PR DESCRIPTION
With this small pull request the snippet used in this [section](https://storybook.js.org/docs/react/essentials/toolbars-and-globals#consuming-globals-from-within-an-addon) of the documentation is updated to prevent issues when using it.

Closes #15947


What was done:
- The snippet was updated to actually work. It was missing an import and updated the destructuring to avoid issues.