### PR TITLE
Storybook Vue2 template "npx sb init" doesn't work by VueLoader in framework-preset-vue.ts

### DIFF
--- a/app/vue/src/server/framework-preset-vue.ts
+++ b/app/vue/src/server/framework-preset-vue.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import VueLoaderPlugin from 'vue-loader/lib/plugin';
+import { VueLoaderPlugin } from 'vue-loader/lib/plugin';
 import type { Configuration } from 'webpack';
 
 import type { Options, TypescriptConfig } from '@storybook/core-common';

--- a/app/vue/src/server/framework-preset-vue.ts
+++ b/app/vue/src/server/framework-preset-vue.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { VueLoaderPlugin } from 'vue-loader/lib/plugin';
+import { VueLoaderPlugin } from 'vue-loader';
 import type { Configuration } from 'webpack';
 
 import type { Options, TypescriptConfig } from '@storybook/core-common';


### PR DESCRIPTION
We come from here: 
https://github.com/storybookjs/storybook/issues/15964

Follow this documentation and stack error:
https://vue-loader.vuejs.org/migrating.html#notable-breaking-changes

Issue:
We Can't load a Vue framework in storybook because VueLoader doesn't work.

I don't know how check this code but in the documentation URL of vue-loader is the new modification.