### PR TITLE
CLI: Show framework name in startup banner

### DIFF
--- a/lib/core-server/src/build-dev.ts
+++ b/lib/core-server/src/build-dev.ts
@@ -25,7 +25,7 @@ import { getManagerBuilder } from './utils/get-manager-builder';
 
 export async function buildDevStandalone(options: CLIOptions & LoadOptions & BuilderOptions) {
   const { packageJson, versionUpdates, releaseNotes } = options;
-  const { version } = packageJson;
+  const { version, name = '' } = packageJson;
 
   // updateInfo and releaseNotesData are cached, so this is typically pretty fast
   const [port, versionCheck, releaseNotesData] = await Promise.all([
@@ -110,9 +110,14 @@ export async function buildDevStandalone(options: CLIOptions & LoadOptions & Bui
     return;
   }
 
+  // Get package name and capitalize it e.g. @storybook/react -> React
+  const packageName = name.split('@storybook/').length > 0 ? name.split('@storybook/')[1] : name;
+  const frameworkName = packageName.charAt(0).toUpperCase() + packageName.slice(1);
+
   outputStartupInformation({
     updateInfo: versionCheck,
     version,
+    name: frameworkName,
     address,
     networkAddress,
     managerTotalTime,

--- a/lib/core-server/src/utils/output-startup-information.ts
+++ b/lib/core-server/src/utils/output-startup-information.ts
@@ -10,6 +10,7 @@ import { createUpdateMessage } from './update-check';
 export function outputStartupInformation(options: {
   updateInfo: VersionCheck;
   version: string;
+  name: string;
   address: string;
   networkAddress: string;
   managerTotalTime?: [number, number];
@@ -18,6 +19,7 @@ export function outputStartupInformation(options: {
   const {
     updateInfo,
     version,
+    name,
     address,
     networkAddress,
     managerTotalTime,
@@ -67,7 +69,7 @@ export function outputStartupInformation(options: {
   console.log(
     boxen(
       dedent`
-          ${colors.green(`Storybook ${chalk.bold(version)} started`)}
+          ${colors.green(`Storybook ${chalk.bold(version)} for ${chalk.bold(name)} started`)}
           ${chalk.gray(timeStatement)}
 
           ${serveMessage.toString()}${updateMessage ? `\n\n${updateMessage}` : ''}


### PR DESCRIPTION
Issue: #15951 

## What I did

The name of the framework is an important information that can be missed by other logs, so it's nice to have it in the last log from Storybook.

Here's how it looks like:

![image](https://user-images.githubusercontent.com/1671563/131867726-35ab395e-c924-4bf8-bbd7-918763f7888f.png)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
