### PR TITLE
webpack-manager: add ability to resolve js extensions in ts files

### DIFF
--- a/examples/cra-ts-kitchen-sink/src/components/List.stories.tsx
+++ b/examples/cra-ts-kitchen-sink/src/components/List.stories.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import { Meta } from '@storybook/react';
+import List from './List.js';
+import ListItem from './ListItem.js';
+
+export default {
+  title: 'Docgen/List',
+  component: List,
+  subcomponents: {
+    ListItem,
+  },
+} as Meta;
+
+export const SimpleList = () => {
+  return (
+    <List>
+      <ListItem>Hello World</ListItem>
+    </List>
+  );
+};
+
+export const WithMultiple = () => (
+  <List>
+    <ListItem>One</ListItem>
+    <ListItem>Two</ListItem>
+    <ListItem>Three</ListItem>
+  </List>
+);

--- a/examples/cra-ts-kitchen-sink/src/components/List.tsx
+++ b/examples/cra-ts-kitchen-sink/src/components/List.tsx
@@ -1,0 +1,7 @@
+import React, { FunctionComponent } from 'react';
+
+const List: FunctionComponent<unknown> = ({ children }) => {
+  return <ul>{children}</ul>;
+};
+
+export default List;

--- a/examples/cra-ts-kitchen-sink/src/components/ListItem.tsx
+++ b/examples/cra-ts-kitchen-sink/src/components/ListItem.tsx
@@ -1,0 +1,7 @@
+import React, { FunctionComponent } from 'react';
+
+const ListItem: FunctionComponent<unknown> = ({ children }) => {
+  return <li>{children}</li>;
+};
+
+export default ListItem;

--- a/lib/manager-webpack4/package.json
+++ b/lib/manager-webpack4/package.json
@@ -70,6 +70,7 @@
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
     "resolve-from": "^5.0.0",
+    "resolve-typescript-plugin": "^1.1.0",
     "style-loader": "^1.3.0",
     "telejson": "^5.3.2",
     "terser-webpack-plugin": "^4.2.3",

--- a/lib/manager-webpack4/src/presets/manager-preset.ts
+++ b/lib/manager-webpack4/src/presets/manager-preset.ts
@@ -7,6 +7,7 @@ import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
+import ResolveTypeScriptPlugin from 'resolve-typescript-plugin';
 
 import themingPaths from '@storybook/theming/paths';
 import uiPaths from '@storybook/ui/paths';
@@ -60,7 +61,6 @@ export async function managerWebpack(
     packageJson: { version },
   } = await readPackage({ cwd: __dirname });
 
-  // @ts-ignore
   // const { BundleAnalyzerPlugin } = await import('webpack-bundle-analyzer').catch(() => ({}));
 
   return {
@@ -166,6 +166,7 @@ export async function managerWebpack(
         ...uiPaths,
       },
       plugins: [
+        new ResolveTypeScriptPlugin(),
         // Transparently resolve packages via PnP when needed; noop otherwise
         PnpWebpackPlugin,
       ],

--- a/lib/manager-webpack5/package.json
+++ b/lib/manager-webpack5/package.json
@@ -68,6 +68,7 @@
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
     "resolve-from": "^5.0.0",
+    "resolve-typescript-plugin": "^1.1.0",
     "style-loader": "^2.0.0",
     "telejson": "^5.3.2",
     "terser-webpack-plugin": "^5.0.3",

--- a/lib/manager-webpack5/src/presets/manager-preset.ts
+++ b/lib/manager-webpack5/src/presets/manager-preset.ts
@@ -6,6 +6,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
+import ResolveTypeScriptPlugin from 'resolve-typescript-plugin';
 
 import themingPaths from '@storybook/theming/paths';
 import uiPaths from '@storybook/ui/paths';
@@ -60,7 +61,6 @@ export async function managerWebpack(
     packageJson: { version },
   } = await readPackage({ cwd: __dirname });
 
-  // @ts-ignore
   // const { BundleAnalyzerPlugin } = await import('webpack-bundle-analyzer').catch(() => ({}));
 
   return {
@@ -158,6 +158,7 @@ export async function managerWebpack(
       ],
     },
     resolve: {
+      plugins: [new ResolveTypeScriptPlugin()],
       extensions: ['.mjs', '.js', '.jsx', '.json', '.cjs', '.ts', '.tsx'],
       modules: ['node_modules'].concat(envs.NODE_PATH || []),
       mainFields: [modern ? 'sbmodern' : null, 'browser', 'module', 'main'].filter(Boolean),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8329,6 +8329,7 @@ __metadata:
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     resolve-from: ^5.0.0
+    resolve-typescript-plugin: ^1.1.0
     style-loader: ^1.3.0
     telejson: ^5.3.2
     terser-webpack-plugin: ^4.2.3
@@ -8382,6 +8383,7 @@ __metadata:
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     resolve-from: ^5.0.0
+    resolve-typescript-plugin: ^1.1.0
     style-loader: ^2.0.0
     telejson: ^5.3.2
     terser-webpack-plugin: ^5.0.3
@@ -39162,6 +39164,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"resolve-typescript-plugin@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "resolve-typescript-plugin@npm:1.1.0"
+  dependencies:
+    tslib: 2.3.0
+  peerDependencies:
+    webpack: ^5.0.0
+  checksum: 84d9a3b9f10b9d0f2a252b690108dd134c3a666a620e3ed3cc9079f9b1515b1d30426d076dd967d3edbb02c0746754fca65d78f7809878bef07b959939396828
+  languageName: node
+  linkType: hard
+
 "resolve-url-loader@npm:3.1.2, resolve-url-loader@npm:^3.1.2":
   version: 3.1.2
   resolution: "resolve-url-loader@npm:3.1.2"
@@ -43389,17 +43402,17 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.3.0, tslib@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "tslib@npm:2.3.0"
+  checksum: a845aed84e7e7dbb4c774582da60d7030ea39d67307250442d35c4c5dd77e4b44007098c37dd079e100029c76055f2a362734b8442ba828f8cc934f15ed9be61
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.10.0, tslib@npm:^1.8.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.2.0":
-  version: 2.3.0
-  resolution: "tslib@npm:2.3.0"
-  checksum: a845aed84e7e7dbb4c774582da60d7030ea39d67307250442d35c4c5dd77e4b44007098c37dd079e100029c76055f2a362734b8442ba828f8cc934f15ed9be61
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #15962

## What I did

add a Webpack plugin to resolve js extensions in ts files.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [x] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
