### PR TITLE
UI: Fix ActionButton out of position in Safari

### DIFF
--- a/lib/components/src/ActionBar/ActionBar.tsx
+++ b/lib/components/src/ActionBar/ActionBar.tsx
@@ -14,6 +14,7 @@ const Container = styled.div<{}>(({ theme }) => ({
 
 export const ActionButton = styled.button<{ disabled: boolean }>(
   ({ theme }) => ({
+    margin: 0,
     border: '0 none',
     padding: '4px 10px',
     cursor: 'pointer',


### PR DESCRIPTION
Issue: #15974 

## What I did
As you can see on the issue, ActionButton is out of position in Safari. 
So I added 'margin: 0'.
## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
