### PR TITLE
CLI: Fix sb link to yarn3 repos

### DIFF
--- a/lib/cli/src/link.ts
+++ b/lib/cli/src/link.ts
@@ -38,8 +38,8 @@ export const link = async ({ target, local }: LinkOptions) => {
     stdio: 'pipe',
   }).stdout.toString();
 
-  if (!version.startsWith('2.')) {
-    logger.warn(`🚨 Expected yarn 2 in ${reproDir}!`);
+  if (!/^[23]\./.test(version)) {
+    logger.warn(`🚨 Expected yarn 2 or 3 in ${reproDir}!`);
     logger.warn('');
     logger.warn('Please set it up with `yarn set version berry`,');
     logger.warn(`then link '${reproDir}' with the '--local' flag.`);


### PR DESCRIPTION
Issue: N/A

## What I did

Relax constraints on `sb link` to include `yarn3` repos

Self-merging @gaetanmaisse 

## How to test

```
lib/cli/bin/index.js repro ../storybook-repros/foo -t react
lib/cli/bin/index.js link ../storybook-repros
```

Before this change, it will fail. After, it will succeed.
