### PR TITLE
Vue: support @values in args table

### DIFF
--- a/addons/docs/src/frameworks/vue/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue/extractArgTypes.ts
@@ -20,11 +20,16 @@ function isEnum(propDef: PropDef, docgenInfo: DocgenInfo): false | PropDef {
   const matched = Array.isArray(values) && values.length && type.name !== 'enum';
 
   if (!matched) return false;
+
+  const enumString = values.join(', ');
+  let { summary } = propDef.type;
+  summary = summary ? `${summary}: ${enumString}` : enumString;
+
   Object.assign(propDef.type, {
     ...propDef.type,
     name: 'enum',
     value: values,
-    summary: `${propDef.type?.summary}: ${values.join(', ')}`,
+    summary,
   });
   return propDef;
 }

--- a/addons/docs/src/frameworks/vue/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue/extractArgTypes.ts
@@ -1,8 +1,57 @@
 import { StrictArgTypes } from '@storybook/csf';
-import { ArgTypesExtractor, hasDocgen, extractComponentProps } from '../../lib/docgen';
+import {
+  ArgTypesExtractor,
+  hasDocgen,
+  extractComponentProps,
+  DocgenInfo,
+  PropDef,
+} from '../../lib/docgen';
 import { convert } from '../../lib/convert';
 
 const SECTIONS = ['props', 'events', 'slots'];
+
+/**
+ * Check if "@values" tag is defined within docgenInfo.
+ * If true, then propDef is mutated.
+ */
+function isEnum(propDef: PropDef, docgenInfo: DocgenInfo): false | PropDef {
+  // cast as any, since "values" doesn't exist in DocgenInfo type
+  const { type, values } = docgenInfo as any;
+  const matched = Array.isArray(values) && values.length && type.name !== 'enum';
+
+  if (!matched) return false;
+  Object.assign(propDef.type, {
+    ...propDef.type,
+    name: 'enum',
+    value: values,
+    summary: `${propDef.type?.summary}: ${values.join(', ')}`,
+  });
+  return propDef;
+}
+
+/**
+ * @returns {Array} result
+ * @returns {PropDef} result.def - propDef
+ * @returns {boolean} result.isChanged - flag whether propDef is mutated or not.
+ *  this is needed to prevent sbType from performing convert(docgenInfo).
+ */
+function verifyPropDef(propDef: PropDef, docgenInfo: DocgenInfo): [PropDef, boolean] {
+  let def = propDef;
+  let isChanged = false;
+
+  // another callback can be added here.
+  // callback is mutually exclusive from each other.
+  const callbacks = [isEnum];
+  for (let i = 0, len = callbacks.length; i < len; i += 1) {
+    const matched = callbacks[i](propDef, docgenInfo);
+    if (matched) {
+      def = matched;
+      isChanged = true;
+    }
+  }
+
+  return [def, isChanged];
+}
 
 export const extractArgTypes: ArgTypesExtractor = (component) => {
   if (!hasDocgen(component)) {
@@ -12,8 +61,15 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
   SECTIONS.forEach((section) => {
     const props = extractComponentProps(component, section);
     props.forEach(({ propDef, docgenInfo, jsDocTags }) => {
-      const { name, type, description, defaultValue: defaultSummary, required } = propDef;
-      const sbType = section === 'props' ? convert(docgenInfo) : { name: 'void' };
+      const [result, isPropDefChanged] = verifyPropDef(propDef, docgenInfo);
+      const { name, type, description, defaultValue: defaultSummary, required } = result;
+
+      let sbType;
+      if (isPropDefChanged) {
+        sbType = type;
+      } else {
+        sbType = section === 'props' ? convert(docgenInfo) : { name: 'void' };
+      }
       results[name] = {
         name,
         description,

--- a/examples/vue-cli/src/button/Button.stories.ts
+++ b/examples/vue-cli/src/button/Button.stories.ts
@@ -1,6 +1,5 @@
 import { Meta, Story } from '@storybook/vue/types-6-0';
 import Button from './Button.vue';
-import { ButtonSizes } from './types';
 
 export default {
   title: 'Button',

--- a/examples/vue-cli/src/button/Button.stories.ts
+++ b/examples/vue-cli/src/button/Button.stories.ts
@@ -5,8 +5,10 @@ import { ButtonSizes } from './types';
 export default {
   title: 'Button',
   component: Button,
-  argTypes: {
-    size: { control: { type: 'select', options: ButtonSizes } },
+  parameters: {
+    controls: {
+      expanded: true,
+    },
   },
 } as Meta;
 

--- a/examples/vue-cli/src/button/Button.vue
+++ b/examples/vue-cli/src/button/Button.vue
@@ -18,6 +18,7 @@ import { ButtonSize } from './types';
 export default class Button extends Vue {
   /**
    * The size of the button
+   * @values default,small,big
    */
   @Prop({ type: String, default: 'default' }) readonly size!: ButtonSize;
 }


### PR DESCRIPTION
Issue: #13764 Addon-docs/Vue: Support @values in ArgsTable

## What I did
**Framework**
Vue

**Changes**
- `addon/docs`
    - Change how `ArgTypes` is returned from the `extractArgTypes: ArgTypesExtractor`
      - Mutate `propDef`, ensuring its type is converted to `enum` if `@values` tag is defined
      - Sync `sbType` with mutated `propDef.type`
      - Append corresponding enumerated values into the `propDef.type.summary`
- `examples/vue-cli`
    - Add example in `Button.vue`
    - Remove `argTypes.size` from Button's story, ensuring its size options are inferred from the generated docs, rather than being manually defined.

## How to test
```bash
cd examples/vue-cli
yarn storybook
```

Enums defined using `@values` tag will be shown under `Description` and available as either `radio` or `select` control in the `ArgsTable`.

![image](https://user-images.githubusercontent.com/20709202/132988640-27c3e6dd-9203-40f4-90da-97f3e3957dbe.png)
