### PR TITLE
Fix `useEffect` in docs and `SourceContainer`

### DIFF
--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -159,6 +159,8 @@ export const StoryTable: FC<
       }
     }
     const story = useStory(storyId, context);
+    // eslint-disable-next-line prefer-const
+    let [args, updateArgs, resetArgs] = useArgs(storyId, context);
     if (!story) {
       return <div>Loading...</div>;
     }
@@ -167,8 +169,6 @@ export const StoryTable: FC<
 
     const mainLabel = getComponentName(component) || 'Story';
 
-    // eslint-disable-next-line prefer-const
-    let [args, updateArgs, resetArgs] = useArgs(storyId, context);
     let tabs = { [mainLabel]: { rows: argTypes, args, updateArgs, resetArgs } } as Record<
       string,
       PureArgsTableProps

--- a/addons/docs/src/blocks/SourceContainer.tsx
+++ b/addons/docs/src/blocks/SourceContainer.tsx
@@ -18,24 +18,18 @@ export const SourceContainer: FC<{}> = ({ children }) => {
   const [sources, setSources] = useState<StorySources>({});
   const channel = addons.getChannel();
 
-  const sourcesRef = React.useRef<StorySources>();
-  const handleSnippetRendered = (id: StoryId, newItem: SourceItem) => {
-    if (newItem !== sources[id]) {
-      const newSources = { ...sourcesRef.current, [id]: newItem };
-      sourcesRef.current = newSources;
-    }
-  };
-
-  // Bind this early (instead of inside `useEffect`), because the `SNIPPET_RENDERED` event
-  // is triggered *during* the rendering process, not after. We have to use the ref
-  // to ensure we don't end up calling setState outside the effect though.
-  channel.on(SNIPPET_RENDERED, handleSnippetRendered);
-
   useEffect(() => {
-    const current = sourcesRef.current || {};
-    if (!deepEqual(sources, current)) {
-      setSources(current);
-    }
+    const handleSnippetRendered = (id: StoryId, newItem: SourceItem) => {
+      if (newItem !== sources[id]) {
+        const newSources = { ...sources, [id]: newItem };
+
+        if (!deepEqual(sources, newSources)) {
+          setSources(newSources);
+        }
+      }
+    };
+
+    channel.on(SNIPPET_RENDERED, handleSnippetRendered);
 
     return () => channel.off(SNIPPET_RENDERED, handleSnippetRendered);
   });

--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -6,6 +6,7 @@ import React, {
   useContext,
   useRef,
   useEffect,
+  useMemo,
 } from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { resetComponents, Story as PureStory } from '@storybook/components';
@@ -104,6 +105,15 @@ const Story: FunctionComponent<StoryProps> = (props) => {
   const context = useContext(DocsContext);
   const ref = useRef();
   const story = useStory(getStoryId(props, context), context);
+
+  // Ensure we wait until this story is properly rendered in the docs context.
+  // The purpose of this is to ensure that that the `DOCS_RENDERED` event isn't emitted
+  // until all stories on the page have rendered.
+  const { id: storyId, registerRenderingStory } = context;
+  const storyRendered = useMemo(registerRenderingStory, [storyId]);
+  useEffect(() => {
+    if (story) storyRendered();
+  }, [story]);
 
   useEffect(() => {
     let cleanup: () => void;

--- a/addons/docs/src/frameworks/angular/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/angular/sourceDecorator.ts
@@ -1,4 +1,4 @@
-import { addons } from '@storybook/addons';
+import { addons, useEffect } from '@storybook/addons';
 import { PartialStoryFn } from '@storybook/csf';
 import { StoryContext, AngularFramework } from '@storybook/angular';
 import { computesTemplateSourceFromComponent } from '@storybook/angular/renderer';
@@ -44,20 +44,21 @@ export const sourceDecorator = (
 
   const { component, argTypes } = context;
 
+  let toEmit: string;
+  useEffect(() => {
+    if (toEmit) channel.emit(SNIPPET_RENDERED, context.id, prettyUp(template));
+  });
+
   if (component && !userDefinedTemplate) {
     const source = computesTemplateSourceFromComponent(component, props, argTypes);
 
     // We might have a story with a Directive or Service defined as the component
     // In these cases there might exist a template, even if we aren't able to create source from component
     if (source || template) {
-      channel.emit(SNIPPET_RENDERED, context.id, prettyUp(source || template));
+      toEmit = prettyUp(source || template);
     }
-    return story;
-  }
-
-  if (template) {
-    channel.emit(SNIPPET_RENDERED, context.id, prettyUp(template));
-    return story;
+  } else if (template) {
+    toEmit = prettyUp(template);
   }
 
   return story;

--- a/addons/docs/src/frameworks/html/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/html/sourceDecorator.ts
@@ -1,5 +1,5 @@
 /* global window */
-import { addons } from '@storybook/addons';
+import { addons, useEffect } from '@storybook/addons';
 import { ArgsStoryFn, PartialStoryFn, StoryContext } from '@storybook/csf';
 import dedent from 'ts-dedent';
 import { HtmlFramework } from '@storybook/html';
@@ -40,11 +40,13 @@ export function sourceDecorator(
     ? (context.originalStoryFn as ArgsStoryFn<HtmlFramework>)(context.args, context)
     : storyFn();
 
+  let source: string;
   if (typeof story === 'string' && !skipSourceRender(context)) {
-    const source = applyTransformSource(story, context);
-
-    addons.getChannel().emit(SNIPPET_RENDERED, context.id, source);
+    source = applyTransformSource(story, context);
   }
+  useEffect(() => {
+    if (source) addons.getChannel().emit(SNIPPET_RENDERED, context.id, source);
+  });
 
   return story;
 }

--- a/addons/docs/src/frameworks/react/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/react/jsxDecorator.tsx
@@ -175,10 +175,12 @@ export const jsxDecorator = (
   storyFn: PartialStoryFn<ReactFramework>,
   context: StoryContext<ReactFramework>
 ) => {
+  const channel = addons.getChannel();
   const skip = skipJsxRender(context);
   const story = storyFn();
 
   let jsx = '';
+
   useEffect(() => {
     if (!skip) channel.emit(SNIPPET_RENDERED, (context || {}).id, jsx);
   });
@@ -188,8 +190,6 @@ export const jsxDecorator = (
   if (skip) {
     return story;
   }
-
-  const channel = addons.getChannel();
 
   const options = {
     ...defaultOpts,

--- a/addons/docs/src/frameworks/svelte/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/svelte/sourceDecorator.ts
@@ -145,6 +145,7 @@ function getWrapperProperties(component: any) {
  * @param context  StoryContext
  */
 export const sourceDecorator = (storyFn: any, context: StoryContext<AnyFramework>) => {
+  const channel = addons.getChannel();
   const skip = skipSourceRender(context);
   const story = storyFn();
 
@@ -158,8 +159,6 @@ export const sourceDecorator = (storyFn: any, context: StoryContext<AnyFramework
   if (skip) {
     return story;
   }
-
-  const channel = addons.getChannel();
 
   const { parameters = {}, args = {} } = context || {};
   let { Component: component = {} } = story;

--- a/addons/docs/src/frameworks/svelte/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/svelte/sourceDecorator.ts
@@ -1,4 +1,4 @@
-import { addons } from '@storybook/addons';
+import { addons, useEffect } from '@storybook/addons';
 import { ArgTypes, Args, StoryContext, AnyFramework } from '@storybook/csf';
 
 import { SourceType, SNIPPET_RENDERED } from '../../shared';
@@ -145,9 +145,17 @@ function getWrapperProperties(component: any) {
  * @param context  StoryContext
  */
 export const sourceDecorator = (storyFn: any, context: StoryContext<AnyFramework>) => {
+  const skip = skipSourceRender(context);
   const story = storyFn();
 
-  if (skipSourceRender(context)) {
+  let source: string;
+  useEffect(() => {
+    if (!skip && source) {
+      channel.emit(SNIPPET_RENDERED, (context || {}).id, source);
+    }
+  });
+
+  if (skip) {
     return story;
   }
 
@@ -161,11 +169,7 @@ export const sourceDecorator = (storyFn: any, context: StoryContext<AnyFramework
     component = parameters.component;
   }
 
-  const source = generateSvelteSource(component, args, context?.argTypes, slotProperty);
-
-  if (source) {
-    channel.emit(SNIPPET_RENDERED, (context || {}).id, source);
-  }
+  source = generateSvelteSource(component, args, context?.argTypes, slotProperty);
 
   return story;
 };

--- a/addons/docs/src/frameworks/web-components/sourceDecorator.test.ts
+++ b/addons/docs/src/frameworks/web-components/sourceDecorator.test.ts
@@ -1,16 +1,19 @@
 import { html } from 'lit-html';
 import { styleMap } from 'lit-html/directives/style-map';
-import { addons, StoryContext } from '@storybook/addons';
+import { addons, StoryContext, useEffect } from '@storybook/addons';
 import { sourceDecorator } from './sourceDecorator';
 import { SNIPPET_RENDERED } from '../../shared';
 
 jest.mock('@storybook/addons');
 const mockedAddons = addons as jest.Mocked<typeof addons>;
+const mockedUseEffect = useEffect as jest.Mocked<typeof useEffect>;
 
 expect.addSnapshotSerializer({
   print: (val: any) => val,
   test: (val) => typeof val === 'string',
 });
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
 
 const makeContext = (name: string, parameters: any, args: any, extra?: object): StoryContext => ({
   id: `lit-test--${name}`,
@@ -27,15 +30,17 @@ describe('sourceDecorator', () => {
   let mockChannel: { on: jest.Mock; emit?: jest.Mock };
   beforeEach(() => {
     mockedAddons.getChannel.mockReset();
+    mockedUseEffect.mockImplementation((cb) => setTimeout(cb, 0));
 
     mockChannel = { on: jest.fn(), emit: jest.fn() };
     mockedAddons.getChannel.mockReturnValue(mockChannel as any);
   });
 
-  it('should render dynamically for args stories', () => {
+  it('should render dynamically for args stories', async () => {
     const storyFn = (args: any) => html`<div>args story</div>`;
     const context = makeContext('args', { __isArgsStory: true }, {});
     sourceDecorator(storyFn, context);
+    await tick();
     expect(mockChannel.emit).toHaveBeenCalledWith(
       SNIPPET_RENDERED,
       'lit-test--args',
@@ -43,14 +48,15 @@ describe('sourceDecorator', () => {
     );
   });
 
-  it('should skip dynamic rendering for no-args stories', () => {
+  it('should skip dynamic rendering for no-args stories', async () => {
     const storyFn = () => html`<div>classic story</div>`;
     const context = makeContext('classic', {}, {});
     sourceDecorator(storyFn, context);
+    await tick();
     expect(mockChannel.emit).not.toHaveBeenCalled();
   });
 
-  it('should use the originalStoryFn if excludeDecorators is set', () => {
+  it('should use the originalStoryFn if excludeDecorators is set', async () => {
     const storyFn = (args: any) => html`<div>args story</div>`;
     const decoratedStoryFn = (args: any) => html`
       <div style=${styleMap({ padding: `${25}px`, border: '3px solid red' })}>${storyFn(args)}</div>
@@ -69,6 +75,7 @@ describe('sourceDecorator', () => {
       { originalStoryFn: storyFn }
     );
     sourceDecorator(decoratedStoryFn, context);
+    await tick();
     expect(mockChannel.emit).toHaveBeenCalledWith(
       SNIPPET_RENDERED,
       'lit-test--args',
@@ -76,12 +83,13 @@ describe('sourceDecorator', () => {
     );
   });
 
-  it('allows the snippet output to be modified by transformSource', () => {
+  it('allows the snippet output to be modified by transformSource', async () => {
     const storyFn = (args: any) => html`<div>args story</div>`;
     const transformSource = (dom: string) => `<p>${dom}</p>`;
     const docs = { transformSource };
     const context = makeContext('args', { __isArgsStory: true, docs }, {});
     sourceDecorator(storyFn, context);
+    await tick();
     expect(mockChannel.emit).toHaveBeenCalledWith(
       SNIPPET_RENDERED,
       'lit-test--args',

--- a/addons/docs/src/frameworks/web-components/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/web-components/sourceDecorator.ts
@@ -1,7 +1,7 @@
 /* global window */
 import { render } from 'lit-html';
 import { ArgsStoryFn, PartialStoryFn, StoryContext } from '@storybook/csf';
-import { addons } from '@storybook/addons';
+import { addons, useEffect } from '@storybook/addons';
 import { WebComponentsFramework } from '@storybook/web-components';
 
 import { SNIPPET_RENDERED, SourceType } from '../../shared';
@@ -37,11 +37,14 @@ export function sourceDecorator(
     ? (context.originalStoryFn as ArgsStoryFn<WebComponentsFramework>)(context.args, context)
     : storyFn();
 
+  let source: string;
+  useEffect(() => {
+    if (source) addons.getChannel().emit(SNIPPET_RENDERED, context.id, source);
+  });
   if (!skipSourceRender(context)) {
     const container = window.document.createElement('div');
     render(story, container);
-    const source = applyTransformSource(container.innerHTML.replace(/<!---->/g, ''), context);
-    if (source) addons.getChannel().emit(SNIPPET_RENDERED, context.id, source);
+    source = applyTransformSource(container.innerHTML.replace(/<!---->/g, ''), context);
   }
 
   return story;

--- a/lib/preview-web/src/types.ts
+++ b/lib/preview-web/src/types.ts
@@ -17,6 +17,7 @@ export interface DocsContextProps<TFramework extends AnyFramework = AnyFramework
   loadStory: (id: StoryId) => Promise<Story<TFramework>>;
   renderStoryToElement: PreviewWeb<TFramework>['renderStoryToElement'];
   getStoryContext: (story: Story<TFramework>) => StoryContextForLoaders<TFramework>;
+  registerRenderingStory: () => (v: void) => void;
 
   /**
    * mdxStoryNameToKey is an MDX-compiler-generated mapping of an MDX story's


### PR DESCRIPTION
Issue:

1. `SourceContainer` wasn't working because of ordering issues -- solution => `useEffect`
2. `useEffect` wasn't working in docs, we need to track rendering stories in the docs context.

Both issues were due to the `<Story/>` element rendering async -- meaning the story is not rendered immediately the first time the component is rendered.