### PR TITLE
Addon-docs: Ensure we don't clobber multiple source container state updates

### DIFF
--- a/addons/docs/src/blocks/SourceContainer.tsx
+++ b/addons/docs/src/blocks/SourceContainer.tsx
@@ -21,11 +21,14 @@ export const SourceContainer: FC<{}> = ({ children }) => {
   useEffect(() => {
     const handleSnippetRendered = (id: StoryId, newItem: SourceItem) => {
       if (newItem !== sources[id]) {
-        const newSources = { ...sources, [id]: newItem };
+        setSources((current) => {
+          const newSources = { ...current, [id]: newItem };
 
-        if (!deepEqual(sources, newSources)) {
-          setSources(newSources);
-        }
+          if (!deepEqual(current, newSources)) {
+            return newSources;
+          }
+          return current;
+        });
       }
     };
 


### PR DESCRIPTION
Issue: As reported by @shilman 

http://localhost:9011/?path=/docs/addons-docs-props--arg-types in Official Storybook

## What I did

Ensure we don't clobber state if multiple events are received before a re-render finishes

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?

I'm not sure if we have the ability to test this outside of e2e?
