### PR TITLE
Addon-docs: Fix `useStories` to correctly respond to change in `storyId`

### DIFF
--- a/addons/docs/src/blocks/Source.tsx
+++ b/addons/docs/src/blocks/Source.tsx
@@ -109,7 +109,7 @@ export const getSourceProps = (
   const targetIds = multiProps.ids || [targetId];
 
   const stories = useStories(targetIds, docsContext);
-  if (!stories) {
+  if (!stories.every(Boolean)) {
     return { error: SourceError.SOURCE_UNAVAILABLE, state: SourceState.NONE };
   }
 
@@ -117,13 +117,13 @@ export const getSourceProps = (
     source = targetIds
       .map((storyId, idx) => {
         const storySource = getStorySource(storyId, sourceContext);
-        const storyObj = stories[idx];
+        const storyObj = stories[idx] as Story;
         return getSnippet(storySource, storyObj);
       })
       .join('\n\n');
   }
 
-  const state = getSourceState(stories);
+  const state = getSourceState(stories as Story[]);
 
   const { docs: docsParameters = {} } = parameters;
   const { source: sourceParameters = {} } = docsParameters;

--- a/addons/docs/src/blocks/useStory.ts
+++ b/addons/docs/src/blocks/useStory.ts
@@ -4,7 +4,7 @@ import { Story } from '@storybook/store';
 
 import { DocsContextProps } from './DocsContext';
 
-export function useStory<TFramework extends AnyFramework>(
+export function useStory<TFramework extends AnyFramework = AnyFramework>(
   storyId: StoryId,
   context: DocsContextProps<TFramework>
 ): Story<TFramework> | void {
@@ -12,19 +12,20 @@ export function useStory<TFramework extends AnyFramework>(
   return stories && stories[0];
 }
 
-export function useStories<TFramework extends AnyFramework>(
+export function useStories<TFramework extends AnyFramework = AnyFramework>(
   storyIds: StoryId[],
   context: DocsContextProps<TFramework>
-): Story<TFramework>[] | void {
-  const [stories, setStories] = useState(null);
+): (Story<TFramework> | void)[] {
+  const [storiesById, setStories] = useState({} as Record<StoryId, Story<TFramework>>);
 
   useEffect(() => {
-    Promise.all(storyIds.map((storyId) => context.loadStory(storyId))).then((loadedStories) => {
-      if (!stories) {
-        setStories(loadedStories);
-      }
-    });
-  });
+    Promise.all(
+      storyIds.map(async (storyId) => {
+        const story = await context.loadStory(storyId);
+        setStories((current) => ({ ...current, [storyId]: story }));
+      })
+    );
+  }, storyIds);
 
-  return stories;
+  return storyIds.map((storyId) => storiesById[storyId]);
 }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/16045

## What I did

Change `useStory` to respond to changes in `storyIds`.

We could also do something like:

```js
useEffect(async () => {
  setStories(undefined);
 
  // This code similar to what you had before
  const stories = await Promise.all(storyIds.map(...))
}, storyIds);
```

If you want the return type of `useStories` to still be `Story[] | void`.
