### PR TITLE
Core: Fix issue with more complex `stories` paths.

### DIFF
--- a/lib/core-common/src/utils/to-importFn.ts
+++ b/lib/core-common/src/utils/to-importFn.ts
@@ -8,18 +8,20 @@ export function toImportFnPart(entry: NormalizedStoriesEntry) {
 
   const webpackIncludeRegex = new RegExp(regex.source.substring(1));
 
-  // NOTE: `base` looks like './src' but `path`, (and what micromatch expects)
-  // is something that starts with `src/`. So to strip off base from path, we
-  // need to drop `base.length - 1` chars.
   return dedent`
       async (path) => {
-        if (!${regex}.exec(path)) {
+        const pathBase = path.substring(0, ${base.length + 1});
+        if (pathBase !== '${base}/') {
           return;
         }
-        const remainder = path.substring(${base.length - 1});
+
+        const pathRemainder = path.substring(${base.length + 1});
+        if (!${regex}.exec(pathRemainder)) {
+          return;
+        }
         return import(
           /* webpackInclude: ${webpackIncludeRegex} */
-          '${base}/' + remainder
+          '${base}/' + pathRemainder
         );
       }
 

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -41,7 +41,7 @@ async function extractStories(storiesGlobs: string[], configDir: string) {
           stories[id] = {
             title: csf.meta.title,
             name,
-            importPath: relativePath,
+            importPath: relativePath[0] === '.' ? relativePath : `./${relativePath}`,
           };
         });
       } catch (err) {


### PR DESCRIPTION
Issue: #16069

Do a much better and more sensible job of checking if a regexp is going to match

## What I did

Improved `to-importFn` logic although it is still imperfect. Hopefully it'll tide us over for now.

## How to test

Check `react-ts` for now.
