### PR TITLE
Core: Infer docs only stories

### DIFF
--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 import mapValues from 'lodash/mapValues';
+import countBy from 'lodash/countBy';
 import {
   StoryId,
   ComponentTitle,
@@ -173,12 +174,14 @@ export const transformStoryIndexToStoriesHash = (
   index: StoryIndex,
   { provider }: { provider: Provider }
 ): StoriesHash => {
+  const countByTitle = countBy(Object.values(index.stories), 'title');
   const input = Object.entries(index.stories).reduce((acc, [id, { title, name, importPath }]) => {
+    const docsOnly = name === 'Page' && countByTitle[title] === 1;
     acc[id] = {
       id,
       kind: title,
       name,
-      parameters: { fileName: importPath, options: {} },
+      parameters: { fileName: importPath, options: {}, docsOnly },
     };
     return acc;
   }, {} as StoriesRaw);

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -914,6 +914,59 @@ describe('stories API', () => {
       });
       expect(storedStoriesHash['component-a--story-1'].args).toBeUndefined();
     });
+
+    it('infers docs only if there is only one story and it has the name "Page"', async () => {
+      mockStories.mockReset().mockReturnValue({
+        'component-a--page': {
+          title: 'Component A',
+          name: 'Page', // Called "Page" but not only story
+          importPath: './path/to/component-a.ts',
+        },
+        'component-a--story-2': {
+          title: 'Component A',
+          name: 'Story 2',
+          importPath: './path/to/component-a.ts',
+        },
+        'component-b--page': {
+          title: 'Component B',
+          name: 'Page', // Page and only story
+          importPath: './path/to/component-b.ts',
+        },
+        'component-c--story-4': {
+          title: 'Component c',
+          name: 'Story 4', // Only story but not page
+          importPath: './path/to/component-c.ts',
+        },
+      });
+
+      const navigate = jest.fn();
+      const store = createMockStore();
+      const fullAPI = Object.assign(new EventEmitter(), {
+        setStories: jest.fn(),
+      });
+
+      const { api, init } = initStories({ store, navigate, provider, fullAPI });
+      Object.assign(fullAPI, api);
+
+      await init();
+
+      const { storiesHash: storedStoriesHash } = store.getState();
+
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(storedStoriesHash)).toEqual([
+        'component-a',
+        'component-a--page',
+        'component-a--story-2',
+        'component-b',
+        'component-b--page',
+        'component-c',
+        'component-c--story-4',
+      ]);
+      expect(storedStoriesHash['component-a--page'].parameters.docsOnly).toBe(false);
+      expect(storedStoriesHash['component-a--story-2'].parameters.docsOnly).toBe(false);
+      expect(storedStoriesHash['component-b--page'].parameters.docsOnly).toBe(true);
+      expect(storedStoriesHash['component-c--story-4'].parameters.docsOnly).toBe(false);
+    });
   });
 
   describe('STORY_PREPARED', () => {

--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -452,6 +452,19 @@ describe('PreviewWeb', () => {
         expect(preview.view.prepareForDocs).toHaveBeenCalled();
       });
 
+      it('emits STORY_PREPARED', async () => {
+        document.location.search = '?id=component-one--a&viewMode=docs';
+        await new PreviewWeb({ importFn, fetchStoryIndex }).initialize({ getProjectAnnotations });
+
+        expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_PREPARED, {
+          id: 'component-one--a',
+          parameters: { __isArgsStory: false, docs: { container: expect.any(Function) } },
+          initialArgs: { foo: 'a' },
+          argTypes: { foo: { name: 'foo', type: { name: 'string' } } },
+          args: { foo: 'a' },
+        });
+      });
+
       it('render the docs container with the correct context', async () => {
         document.location.search = '?id=component-one--a&viewMode=docs';
 

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -307,6 +307,17 @@ export class PreviewWeb<TFramework extends AnyFramework> {
     this.previousSelection = selection;
     this.previousStory = story;
 
+    const { parameters, initialArgs, argTypes, args } = this.storyStore.getStoryContext(story);
+    if (FEATURES?.storyStoreV7) {
+      this.channel.emit(Events.STORY_PREPARED, {
+        id: story.id,
+        parameters,
+        initialArgs,
+        argTypes,
+        args,
+      });
+    }
+
     if (selection.viewMode === 'docs' || story.parameters.docsOnly) {
       await this.renderDocs({ story });
     } else {
@@ -415,17 +426,6 @@ export class PreviewWeb<TFramework extends AnyFramework> {
     let renderContext: RenderContext<TFramework>;
     const initialRender = async () => {
       const storyContext = this.storyStore.getStoryContext(story);
-
-      const { parameters, initialArgs, argTypes, args } = storyContext;
-      if (FEATURES?.storyStoreV7) {
-        this.channel.emit(Events.STORY_PREPARED, {
-          id,
-          parameters,
-          initialArgs,
-          argTypes,
-          args,
-        });
-      }
 
       const viewMode = element === this.view.storyRoot() ? 'story' : 'docs';
       const loadedContext = await applyLoaders({


### PR DESCRIPTION
Issue: #16056

## What I did

- Emit `STORY_PREPARED` in both modes. Note this doesn't affect the rendering of the sidebar however (I guess it must cached the "docs-only-ness" of stories.
- In the manager side, infer if a story is `docsOnly` if it it the only story for it's component and has the name `"Page"`.


## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

Yes, tests exist
