### PR TITLE
CSF3: Fix story type back-compat

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -51,7 +51,7 @@
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/components": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/theming": "6.4.0-alpha.39",
     "axe-core": "^4.2.0",
     "core-js": "^3.8.2",

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -45,7 +45,7 @@
     "@storybook/api": "6.4.0-alpha.39",
     "@storybook/components": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/theming": "6.4.0-alpha.39",
     "core-js": "^3.8.2",
     "fast-deep-equal": "^3.1.3",

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -50,7 +50,7 @@
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/components": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/theming": "6.4.0-alpha.39",
     "core-js": "^3.8.2",
     "global": "^4.4.0",

--- a/addons/controls/package.json
+++ b/addons/controls/package.json
@@ -49,7 +49,7 @@
     "@storybook/api": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/components": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/node-logger": "6.4.0-alpha.39",
     "@storybook/store": "6.4.0-alpha.39",
     "@storybook/theming": "6.4.0-alpha.39",

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -71,7 +71,7 @@
     "@storybook/components": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/csf-tools": "6.4.0-alpha.39",
     "@storybook/node-logger": "6.4.0-alpha.39",
     "@storybook/postinstall": "6.4.0-alpha.39",

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -44,7 +44,7 @@
     "@storybook/addons": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/router": "6.4.0-alpha.39",
     "@types/qs": "^6.9.5",
     "core-js": "^3.8.2",

--- a/addons/measure/package.json
+++ b/addons/measure/package.json
@@ -49,7 +49,7 @@
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/components": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "core-js": "^3.8.2",
     "global": "^4.4.0"
   },

--- a/addons/outline/package.json
+++ b/addons/outline/package.json
@@ -52,7 +52,7 @@
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/components": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "core-js": "^3.8.2",
     "global": "^4.4.0",
     "regenerator-runtime": "^0.13.7",

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -50,7 +50,7 @@
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-client": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.16",
     "@types/jest-specific-snapshot": "^0.5.3",

--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/node-logger": "6.4.0-alpha.39",
     "@types/jest-image-snapshot": "^4.1.3",
     "core-js": "^3.8.2",
@@ -49,7 +49,7 @@
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@types/puppeteer": "^5.4.0"
   },
   "peerDependencies": {

--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -50,7 +50,7 @@
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/node-logger": "6.4.0-alpha.39",
     "@storybook/store": "6.4.0-alpha.39",
     "@types/webpack-env": "^1.16.0",

--- a/app/angular/src/client/preview/types-6-0.ts
+++ b/app/angular/src/client/preview/types-6-0.ts
@@ -3,7 +3,8 @@ import {
   Parameters as DefaultParameters,
   StoryContext as DefaultStoryContext,
   ComponentAnnotations,
-  StoryAnnotationsOrFn,
+  StoryAnnotations,
+  AnnotatedStoryFn,
 } from '@storybook/csf';
 
 import { StoryFnAngularReturnType } from './types';
@@ -23,11 +24,28 @@ export type AngularFramework = {
 export type Meta<TArgs = Args> = ComponentAnnotations<AngularFramework, TArgs>;
 
 /**
- * Story function that represents a component example.
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryAnnotationsOrFn<AngularFramework, TArgs>;
+export type StoryFn<TArgs = Args> = AnnotatedStoryFn<AngularFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type StoryObj<TArgs = Args> = StoryAnnotations<AngularFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv2 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ *
+ * NOTE that in Storybook 7.0, this type will be renamed to `StoryFn` and replaced by the current `StoryObj` type.
+ *
+ */
+export type Story<TArgs = Args> = StoryFn<TArgs>;
 
 export type Parameters = DefaultParameters & {
   /** Uses legacy angular rendering engine that use dynamic component */

--- a/app/angular/src/client/preview/types-7-0.ts
+++ b/app/angular/src/client/preview/types-7-0.ts
@@ -1,0 +1,14 @@
+import { Args } from '@storybook/csf';
+
+import type { StoryObj } from './types-6-0';
+
+export type { StoryFn, StoryObj, Meta } from './types-6-0';
+
+// NOTE these types are reversed from the way they are in types-6-0 and types-6-3
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<TArgs = Args> = StoryObj<TArgs>;

--- a/app/html/package.json
+++ b/app/html/package.json
@@ -49,7 +49,7 @@
     "@storybook/client-api": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/preview-web": "6.4.0-alpha.39",
     "@storybook/store": "6.4.0-alpha.39",
     "@types/webpack-env": "^1.16.0",

--- a/app/html/src/client/preview/types-6-0.ts
+++ b/app/html/src/client/preview/types-6-0.ts
@@ -1,4 +1,4 @@
-import { Args, ComponentAnnotations, StoryAnnotationsOrFn } from '@storybook/csf';
+import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
 
 import { StoryFnHtmlReturnType } from './types';
 
@@ -17,8 +17,25 @@ export type HtmlFramework = {
 export type Meta<TArgs = Args> = ComponentAnnotations<HtmlFramework, TArgs>;
 
 /**
- * Story function that represents a component example.
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryAnnotationsOrFn<HtmlFramework, TArgs>;
+export type StoryFn<TArgs = Args> = AnnotatedStoryFn<HtmlFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type StoryObj<TArgs = Args> = StoryAnnotations<HtmlFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv2 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ *
+ * NOTE that in Storybook 7.0, this type will be renamed to `StoryFn` and replaced by the current `StoryObj` type.
+ *
+ */
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/app/html/src/client/preview/types-7-0.ts
+++ b/app/html/src/client/preview/types-7-0.ts
@@ -1,0 +1,14 @@
+import { Args } from '@storybook/csf';
+
+import type { StoryObj } from './types-6-0';
+
+export type { StoryFn, StoryObj, Meta } from './types-6-0';
+
+// NOTE these types are reversed from the way they are in types-6-0 and types-6-3
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<TArgs = Args> = StoryObj<TArgs>;

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -49,7 +49,7 @@
     "@storybook/addons": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/store": "6.4.0-alpha.39",
     "@types/webpack-env": "^1.16.0",
     "core-js": "^3.8.2",

--- a/app/preact/src/client/preview/types-6-0.ts
+++ b/app/preact/src/client/preview/types-6-0.ts
@@ -1,5 +1,5 @@
 import { AnyComponent } from 'preact';
-import { Args, ComponentAnnotations, StoryAnnotationsOrFn } from '@storybook/csf';
+import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
 import { StoryFnPreactReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
@@ -17,8 +17,25 @@ export type PreactFramework = {
 export type Meta<TArgs = Args> = ComponentAnnotations<PreactFramework, TArgs>;
 
 /**
- * Story function that represents a component example.
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryAnnotationsOrFn<PreactFramework, TArgs>;
+export type StoryFn<TArgs = Args> = AnnotatedStoryFn<PreactFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type StoryObj<TArgs = Args> = StoryAnnotations<PreactFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv2 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ *
+ * NOTE that in Storybook 7.0, this type will be renamed to `StoryFn` and replaced by the current `StoryObj` type.
+ *
+ */
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/app/preact/src/client/preview/types-7-0.ts
+++ b/app/preact/src/client/preview/types-7-0.ts
@@ -1,0 +1,14 @@
+import { Args } from '@storybook/csf';
+
+import type { StoryObj } from './types-6-0';
+
+export type { StoryFn, StoryObj, Meta } from './types-6-0';
+
+// NOTE these types are reversed from the way they are in types-6-0 and types-6-3
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<TArgs = Args> = StoryObj<TArgs>;

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -52,7 +52,7 @@
     "@storybook/addons": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/node-logger": "6.4.0-alpha.39",
     "@storybook/react-docgen-typescript-plugin": "1.0.2-canary.253f8c1.0",
     "@storybook/semver": "^7.3.2",

--- a/app/react/src/client/preview/types-6-0.ts
+++ b/app/react/src/client/preview/types-6-0.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react';
-import { Args, ComponentAnnotations, StoryAnnotationsOrFn } from '@storybook/csf';
+import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
 import { StoryFnReactReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
@@ -17,8 +17,25 @@ export type ReactFramework = {
 export type Meta<TArgs = Args> = ComponentAnnotations<ReactFramework, TArgs>;
 
 /**
- * Story function that represents a component example.
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryAnnotationsOrFn<ReactFramework, TArgs>;
+export type StoryFn<TArgs = Args> = AnnotatedStoryFn<ReactFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type StoryObj<TArgs = Args> = StoryAnnotations<ReactFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv2 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ *
+ * NOTE that in Storybook 7.0, this type will be renamed to `StoryFn` and replaced by the current `StoryObj` type.
+ *
+ */
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/app/react/src/client/preview/types-6-3.ts
+++ b/app/react/src/client/preview/types-6-3.ts
@@ -1,5 +1,5 @@
 import { ComponentProps, JSXElementConstructor } from 'react';
-import type { Story, Meta } from './types-6-0';
+import type { StoryFn, StoryObj, Story, Meta } from './types-6-0';
 
 export * from './types-6-0';
 
@@ -15,11 +15,38 @@ export type ComponentMeta<
 > = Meta<ComponentProps<T>>;
 
 /**
- * For the common case where a story is a simple component that receives args as props:
+ * For the common case where a (CSFv2) story is a simple component that receives args as props:
  *
  * ```tsx
  * const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
  * ```
+ */
+export type ComponentStoryFn<
+  T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>
+> = StoryFn<ComponentProps<T>>;
+
+/**
+ * For the common case where a (CSFv3) story is a simple component that receives args as props:
+ *
+ * ```tsx
+ * const MyStory: ComponentStory<typeof Button> = {
+ *   args: { buttonArg1: 'val' },
+ * }
+ * ```
+ */
+export type ComponentStoryObj<
+  T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>
+> = StoryObj<ComponentProps<T>>;
+
+/**
+ * For the common case where a (CSFv2) story is a simple component that receives args as props:
+ *
+ * ```tsx
+ * const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
+ * ```
+ *
+ * NOTE: this is an alias for `ComponentStoryFn`.
+ * In Storybook v7, `ComponentStory` will alias `ComponentStoryObj`
  */
 export type ComponentStory<
   T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>

--- a/app/react/src/client/preview/types-7-0.ts
+++ b/app/react/src/client/preview/types-7-0.ts
@@ -1,0 +1,29 @@
+import { JSXElementConstructor } from 'react';
+import { Args } from '@storybook/csf';
+
+import type { StoryObj } from './types-6-0';
+import type { ComponentStoryObj } from './types-6-3';
+
+export type { StoryFn, StoryObj, Meta } from './types-6-0';
+export type { ComponentStoryFn, ComponentStoryObj, ComponentMeta } from './types-6-3';
+
+// NOTE these types are reversed from the way they are in types-6-0 and types-6-3
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<TArgs = Args> = StoryObj<TArgs>;
+
+/**
+ * For the common case where a (CSFv3) story is a simple component that receives args as props:
+ *
+ * ```tsx
+ * const MyStory: ComponentStory<typeof Button> = {
+ *   args: { buttonArg1: 'val' },
+ * }
+ * ```
+ */ export type ComponentStory<
+  T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>
+> = ComponentStoryObj<T>;

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -50,7 +50,7 @@
     "@storybook/client-api": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/node-logger": "6.4.0-alpha.39",
     "@storybook/preview-web": "6.4.0-alpha.39",
     "@storybook/store": "6.4.0-alpha.39",

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -48,7 +48,7 @@
     "@storybook/addons": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/store": "6.4.0-alpha.39",
     "core-js": "^3.8.2",
     "global": "^4.4.0",

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -48,7 +48,7 @@
     "@storybook/addons": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/store": "6.4.0-alpha.39",
     "@types/webpack-env": "^1.16.0",
     "core-js": "^3.8.2",

--- a/app/vue/src/client/preview/types-6-0.ts
+++ b/app/vue/src/client/preview/types-6-0.ts
@@ -1,5 +1,5 @@
 import { Component, AsyncComponent } from 'vue';
-import { Args, ComponentAnnotations, StoryAnnotationsOrFn } from '@storybook/csf';
+import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
 import { StoryFnVueReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
@@ -17,8 +17,25 @@ export type VueFramework = {
 export type Meta<TArgs = Args> = ComponentAnnotations<VueFramework, TArgs>;
 
 /**
- * Story function that represents a component example.
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryAnnotationsOrFn<VueFramework, TArgs>;
+export type StoryFn<TArgs = Args> = AnnotatedStoryFn<VueFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type StoryObj<TArgs = Args> = StoryAnnotations<VueFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv2 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ *
+ * NOTE that in Storybook 7.0, this type will be renamed to `StoryFn` and replaced by the current `StoryObj` type.
+ *
+ */
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/app/vue/src/client/preview/types-7-0.ts
+++ b/app/vue/src/client/preview/types-7-0.ts
@@ -1,0 +1,14 @@
+import { Args } from '@storybook/csf';
+
+import type { StoryObj } from './types-6-0';
+
+export type { StoryFn, StoryObj, Meta } from './types-6-0';
+
+// NOTE these types are reversed from the way they are in types-6-0 and types-6-3
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<TArgs = Args> = StoryObj<TArgs>;

--- a/app/vue3/package.json
+++ b/app/vue3/package.json
@@ -48,7 +48,7 @@
     "@storybook/addons": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/store": "6.4.0-alpha.39",
     "@types/webpack-env": "^1.16.0",
     "core-js": "^3.8.2",

--- a/app/vue3/src/client/preview/types-6-0.ts
+++ b/app/vue3/src/client/preview/types-6-0.ts
@@ -1,5 +1,5 @@
 import { ConcreteComponent } from 'vue';
-import { Args, ComponentAnnotations, StoryAnnotationsOrFn } from '@storybook/csf';
+import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
 import { StoryFnVueReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
@@ -17,8 +17,25 @@ export type VueFramework = {
 export type Meta<TArgs = Args> = ComponentAnnotations<VueFramework, TArgs>;
 
 /**
- * Story function that represents a component example.
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryAnnotationsOrFn<VueFramework, TArgs>;
+export type StoryFn<TArgs = Args> = AnnotatedStoryFn<VueFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type StoryObj<TArgs = Args> = StoryAnnotations<VueFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv2 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ *
+ * NOTE that in Storybook 7.0, this type will be renamed to `StoryFn` and replaced by the current `StoryObj` type.
+ *
+ */
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/app/vue3/src/client/preview/types-7-0.ts
+++ b/app/vue3/src/client/preview/types-7-0.ts
@@ -1,0 +1,14 @@
+import { Args } from '@storybook/csf';
+
+import type { StoryObj } from './types-6-0';
+
+export type { StoryFn, StoryObj, Meta } from './types-6-0';
+
+// NOTE these types are reversed from the way they are in types-6-0 and types-6-3
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<TArgs = Args> = StoryObj<TArgs>;

--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -54,7 +54,7 @@
     "@storybook/client-api": "6.4.0-alpha.39",
     "@storybook/core": "6.4.0-alpha.39",
     "@storybook/core-common": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/preview-web": "6.4.0-alpha.39",
     "@storybook/store": "6.4.0-alpha.39",
     "@types/webpack-env": "^1.16.0",

--- a/app/web-components/src/client/preview/types-6-0.ts
+++ b/app/web-components/src/client/preview/types-6-0.ts
@@ -1,4 +1,4 @@
-import { Args, ComponentAnnotations, StoryAnnotationsOrFn } from '@storybook/csf';
+import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
 import { StoryFnHtmlReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
@@ -16,8 +16,25 @@ export type WebComponentsFramework = {
 export type Meta<TArgs = Args> = ComponentAnnotations<WebComponentsFramework, TArgs>;
 
 /**
- * Story function that represents a component example.
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryAnnotationsOrFn<WebComponentsFramework, TArgs>;
+export type StoryFn<TArgs = Args> = AnnotatedStoryFn<WebComponentsFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type StoryObj<TArgs = Args> = StoryAnnotations<WebComponentsFramework, TArgs>;
+
+/**
+ * Story function that represents a CSFv2 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ *
+ * NOTE that in Storybook 7.0, this type will be renamed to `StoryFn` and replaced by the current `StoryObj` type.
+ *
+ */
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/app/web-components/src/client/preview/types-7-0.ts
+++ b/app/web-components/src/client/preview/types-7-0.ts
@@ -1,0 +1,14 @@
+import { Args } from '@storybook/csf';
+
+import type { StoryObj } from './types-6-0';
+
+export type { StoryFn, StoryObj, Meta } from './types-6-0';
+
+// NOTE these types are reversed from the way they are in types-6-0 and types-6-3
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<TArgs = Args> = StoryObj<TArgs>;

--- a/examples/react-ts/src/AccountForm.stories.tsx
+++ b/examples/react-ts/src/AccountForm.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { AccountForm } from './AccountForm';
@@ -16,7 +16,7 @@ export default {
 // export const Standard = (args: AccountFormProps) => <AccountForm {...args} />;
 // Standard.args = { passwordVerification: false };
 
-export const Standard: ComponentStory<typeof AccountForm> = {
+export const Standard: ComponentStoryObj<typeof AccountForm> = {
   // render: (args: AccountFormProps) => <AccountForm {...args} />,
   args: { passwordVerification: false },
 };
@@ -53,7 +53,7 @@ export const StandardFailHover = {
   },
 };
 
-export const Verification: ComponentStory<typeof AccountForm> = {
+export const Verification: ComponentStoryObj<typeof AccountForm> = {
   args: { passwordVerification: true },
 };
 

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -44,7 +44,7 @@
     "@storybook/channels": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/router": "6.4.0-alpha.39",
     "@storybook/theming": "6.4.0-alpha.39",
     "core-js": "^3.8.2",

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -42,7 +42,7 @@
     "@storybook/channels": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/router": "6.4.0-alpha.39",
     "@storybook/semver": "^7.3.2",
     "@storybook/theming": "6.4.0-alpha.39",

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -45,7 +45,7 @@
     "@storybook/channels": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/store": "6.4.0-alpha.39",
     "@types/qs": "^6.9.5",
     "@types/webpack-env": "^1.16.0",

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/types": "^7.12.11",
     "@mdx-js/mdx": "^1.6.22",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/csf-tools": "6.4.0-alpha.39",
     "@storybook/node-logger": "6.4.0-alpha.39",
     "core-js": "^3.8.2",

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@popperjs/core": "^2.6.0",
     "@storybook/client-logger": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/theming": "6.4.0-alpha.39",
     "@types/color-convert": "^2.0.0",
     "@types/overlayscrollbars": "^1.12.0",

--- a/lib/core-client/package.json
+++ b/lib/core-client/package.json
@@ -45,7 +45,7 @@
     "@storybook/client-api": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/preview-web": "6.4.0-alpha.39",
     "@storybook/store": "6.4.0-alpha.39",
     "@storybook/ui": "6.4.0-alpha.39",

--- a/lib/csf-tools/package.json
+++ b/lib/csf-tools/package.json
@@ -48,7 +48,7 @@
     "@babel/traverse": "^7.12.11",
     "@babel/types": "^7.12.11",
     "@mdx-js/mdx": "^1.6.22",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "core-js": "^3.8.2",
     "fs-extra": "^9.0.1",
     "global": "^4.4.0",

--- a/lib/preview-web/package.json
+++ b/lib/preview-web/package.json
@@ -44,7 +44,7 @@
     "@storybook/channel-postmessage": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/store": "6.4.0-alpha.39",
     "ansi-to-html": "^0.6.11",
     "core-js": "^3.8.2",

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@storybook/addons": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "global": "^4.4.0",

--- a/lib/store/package.json
+++ b/lib/store/package.json
@@ -43,7 +43,7 @@
     "@storybook/addons": "6.4.0-alpha.39",
     "@storybook/client-logger": "6.4.0-alpha.39",
     "@storybook/core-events": "6.4.0-alpha.39",
-    "@storybook/csf": "0.0.2--canary.68887a1.0",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "core-js": "^3.8.2",
     "fast-deep-equal": "^3.1.3",
     "global": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6843,7 +6843,7 @@ __metadata:
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/components": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/theming": 6.4.0-alpha.39
     "@testing-library/react": ^11.2.2
     "@types/webpack-env": ^1.16.0
@@ -6874,7 +6874,7 @@ __metadata:
     "@storybook/api": 6.4.0-alpha.39
     "@storybook/components": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/theming": 6.4.0-alpha.39
     "@types/lodash": ^4.14.167
     "@types/webpack-env": ^1.16.0
@@ -6909,7 +6909,7 @@ __metadata:
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/components": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/theming": 6.4.0-alpha.39
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -6937,7 +6937,7 @@ __metadata:
     "@storybook/api": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/components": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/node-logger": 6.4.0-alpha.39
     "@storybook/store": 6.4.0-alpha.39
     "@storybook/theming": 6.4.0-alpha.39
@@ -6980,7 +6980,7 @@ __metadata:
     "@storybook/components": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/csf-tools": 6.4.0-alpha.39
     "@storybook/html": 6.4.0-alpha.39
     "@storybook/node-logger": 6.4.0-alpha.39
@@ -7184,7 +7184,7 @@ __metadata:
     "@storybook/addons": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/router": 6.4.0-alpha.39
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
@@ -7214,7 +7214,7 @@ __metadata:
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/components": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -7238,7 +7238,7 @@ __metadata:
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/components": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -7273,7 +7273,7 @@ __metadata:
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": ^4.2.0
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/node-logger": 6.4.0-alpha.39
     "@types/jest-image-snapshot": ^4.1.3
     "@types/puppeteer": ^5.4.0
@@ -7303,7 +7303,7 @@ __metadata:
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-client": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/react": 6.4.0-alpha.39
     "@storybook/vue": 6.4.0-alpha.39
     "@storybook/vue3": 6.4.0-alpha.39
@@ -7466,7 +7466,7 @@ __metadata:
     "@storybook/channels": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/router": 6.4.0-alpha.39
     "@storybook/theming": 6.4.0-alpha.39
     core-js: ^3.8.2
@@ -7499,7 +7499,7 @@ __metadata:
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/node-logger": 6.4.0-alpha.39
     "@storybook/store": 6.4.0-alpha.39
     "@types/autoprefixer": ^9.7.2
@@ -7568,7 +7568,7 @@ __metadata:
     "@storybook/channels": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/router": 6.4.0-alpha.39
     "@storybook/semver": ^7.3.2
     "@storybook/theming": 6.4.0-alpha.39
@@ -7852,7 +7852,7 @@ __metadata:
     "@storybook/channels": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/store": 6.4.0-alpha.39
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
@@ -7888,7 +7888,7 @@ __metadata:
   dependencies:
     "@babel/types": ^7.12.11
     "@mdx-js/mdx": ^1.6.22
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/csf-tools": 6.4.0-alpha.39
     "@storybook/node-logger": 6.4.0-alpha.39
     core-js: ^3.8.2
@@ -7910,7 +7910,7 @@ __metadata:
   dependencies:
     "@popperjs/core": ^2.6.0
     "@storybook/client-logger": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/theming": 6.4.0-alpha.39
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
@@ -7949,7 +7949,7 @@ __metadata:
     "@storybook/client-api": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/preview-web": 6.4.0-alpha.39
     "@storybook/store": 6.4.0-alpha.39
     "@storybook/ui": 6.4.0-alpha.39
@@ -8136,7 +8136,7 @@ __metadata:
     "@babel/traverse": ^7.12.11
     "@babel/types": ^7.12.11
     "@mdx-js/mdx": ^1.6.22
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@types/fs-extra": ^9.0.6
     core-js: ^3.8.2
     fs-extra: ^9.0.1
@@ -8150,12 +8150,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf@npm:0.0.2--canary.68887a1.0":
-  version: 0.0.2--canary.68887a1.0
-  resolution: "@storybook/csf@npm:0.0.2--canary.68887a1.0"
+"@storybook/csf@npm:0.0.2--canary.6aca495.0":
+  version: 0.0.2--canary.6aca495.0
+  resolution: "@storybook/csf@npm:0.0.2--canary.6aca495.0"
   dependencies:
     lodash: ^4.17.15
-  checksum: 3235b52cd246a319b099e0e1022f0acd3ba3b402d4e0baf27b4c842980677fd49eb13cace3228392ca43156d4c704caee6bb554718bcadc0a45131bae9469b66
+  checksum: e3762b9c31f84ef96932502dabb0fba42b9a07993a79ef92ae4ec7897ca0086cba4f63e1bc479eac99628ed9383c39df0741e75471af3bd97ea6d62aca851f58
   languageName: node
   linkType: hard
 
@@ -8284,7 +8284,7 @@ __metadata:
     "@storybook/client-api": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/preview-web": 6.4.0-alpha.39
     "@storybook/store": 6.4.0-alpha.39
     "@types/webpack-env": ^1.16.0
@@ -8499,7 +8499,7 @@ __metadata:
     "@storybook/addons": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/store": 6.4.0-alpha.39
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -8559,7 +8559,7 @@ __metadata:
     "@storybook/channel-postmessage": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/store": 6.4.0-alpha.39
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
@@ -8605,7 +8605,7 @@ __metadata:
     "@storybook/client-api": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/node-logger": 6.4.0-alpha.39
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
     "@storybook/semver": ^7.3.2
@@ -8904,7 +8904,7 @@ __metadata:
     "@storybook/client-api": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/node-logger": 6.4.0-alpha.39
     "@storybook/preview-web": 6.4.0-alpha.39
     "@storybook/store": 6.4.0-alpha.39
@@ -8933,7 +8933,7 @@ __metadata:
   dependencies:
     "@storybook/addons": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     core-js: ^3.8.2
     estraverse: ^5.2.0
     global: ^4.4.0
@@ -8954,7 +8954,7 @@ __metadata:
     "@storybook/addons": 6.4.0-alpha.39
     "@storybook/client-logger": 6.4.0-alpha.39
     "@storybook/core-events": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -8974,7 +8974,7 @@ __metadata:
     "@storybook/addons": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/store": 6.4.0-alpha.39
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -9073,7 +9073,7 @@ __metadata:
     "@storybook/addons": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/store": 6.4.0-alpha.39
     "@types/node": ^14.14.20
     "@types/webpack-env": ^1.16.0
@@ -9110,7 +9110,7 @@ __metadata:
     "@storybook/addons": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/store": 6.4.0-alpha.39
     "@types/node": ^14.14.20
     "@types/webpack-env": ^1.16.0
@@ -9153,7 +9153,7 @@ __metadata:
     "@storybook/client-api": 6.4.0-alpha.39
     "@storybook/core": 6.4.0-alpha.39
     "@storybook/core-common": 6.4.0-alpha.39
-    "@storybook/csf": 0.0.2--canary.68887a1.0
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/preview-web": 6.4.0-alpha.39
     "@storybook/store": 6.4.0-alpha.39
     "@types/webpack-env": ^1.16.0


### PR DESCRIPTION
Issue: #16077

## What I did

- Made the exported types from `types-6-0` and `types-6-3` consistent with what they were in 6.3 (CSF v2)
- Added new exports `StoryObj` and `ComponentStoryObj` (CSF v3), duplicating `StoryFn` and `ComponentStoryFn` for the v2 types.
- Also exported everything from `types-7-0` and reversed the meaning of `[Component]Story` to be CSFv3.
