### PR TITLE
Core: Fix `./stories.json` requests in manager for relative paths

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -351,7 +351,7 @@ export const init: ModuleFn = ({
     },
     fetchStoryList: async () => {
       // This needs some fleshing out as part of the stories list server project
-      const result = await global.fetch('/stories.json');
+      const result = await global.fetch('./stories.json');
       const storyIndex = (await result.json()) as StoryIndex;
 
       // We can only do this if the stories.json is a proper storyIndex


### PR DESCRIPTION
Issue: v7 store didn't work if hosted on a path - https://next--storybookjs.netlify.app/react-ts/