### PR TITLE
Addon-a11y: Export parameter types

### DIFF
--- a/addons/a11y/src/index.ts
+++ b/addons/a11y/src/index.ts
@@ -4,6 +4,7 @@ import dedent from 'ts-dedent';
 
 export { PARAM_KEY } from './constants';
 export * from './highlight';
+export * from './params';
 
 if (module && module.hot && module.hot.decline) {
   module.hot.decline();


### PR DESCRIPTION
## What I did

In order to match addon-a11y's options in our automated a11y testing suite, I'd like to use the same types.

Workaround:

```ts
import type {A11yParameters} from '@storybook/addon-a11y/dist/ts3.9/params';
```

Not sure my PR shows the correct way to do this, or if there are other existing workarounds – I'd appreciate some advice!

## How to test

Not sure!

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
