### PR TITLE
Addon-a11y: Fix type of context passed to `axe.run`

### DIFF
--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -18,7 +18,7 @@ let activeStoryId: string | undefined;
 
 const getElement = () => {
   const storyRoot = document.getElementById('story-root');
-  return storyRoot ? storyRoot.children : document.getElementById('root');
+  return storyRoot ? storyRoot.childNodes : document.getElementById('root');
 };
 
 /**


### PR DESCRIPTION
## What I did

According to [axe's API reference](https://www.deque.com/axe/core-documentation/api-documentation/#context-parameter), the context passed to `axe.run` can be a `NodeList`, but the addon-a11y is passing an `HTMLCollection`.


![Screen Shot 2021-09-22 at 10 49 02 AM](https://user-images.githubusercontent.com/85783/134395422-eb93064c-945a-4ddb-b276-09fd14deb88e.png)

This PR ensures we're passing a NodeList and shouldn't impact functionality.

Related: https://github.com/dequelabs/axe-core/pull/3161

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
