### PR TITLE
[addon-a11y] Fix name of configuration key in README

### DIFF
--- a/addons/a11y/README.md
+++ b/addons/a11y/README.md
@@ -94,7 +94,7 @@ Tip: clearly explain in a comment why a rule was overridden, it’ll help you an
 ```js
 MyStory.parameters = {
   a11y: {
-    options: {
+    config: {
       rules: [
         {
           // Allow `autocomplete="nope"` on form elements,


### PR DESCRIPTION
I mixed up `options.rules` and `config.rules` when I first wrote this. The recommended way to override rules is to use `config.rules`, as it allows more granularity (`options.rules` only allows disabling/enabling rules).