### PR TITLE
Add comments to sb init stories template

### DIFF
--- a/lib/cli/src/frameworks/angular/Button.stories.ts
+++ b/lib/cli/src/frameworks/angular/Button.stories.ts
@@ -2,19 +2,23 @@
 import { Story, Meta } from '@storybook/angular/types-6-0';
 import Button from './button.component';
 
+// More on default export: https://storybook.js.org/docs/angular/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
   component: Button,
+  // More on argTypes: https://storybook.js.org/docs/angular/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
   },
 } as Meta;
 
+// More on component templates: https://storybook.js.org/docs/angular/writing-stories/introduction#using-args
 const Template: Story<Button> = (args: Button) => ({
   props: args,
 });
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/angular/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/angular/Page.stories.ts
+++ b/lib/cli/src/frameworks/angular/Page.stories.ts
@@ -24,6 +24,7 @@ const Template: Story<Page> = (args: Page) => ({
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/angular/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/ember/1-Button.stories.js
+++ b/lib/cli/src/frameworks/ember/1-Button.stories.js
@@ -2,19 +2,23 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 
+// More on default export: https://storybook.js.org/docs/ember/writing-stories/introduction#default-export
 export default {
   title: 'Button',
+  // More on argTypes: https://storybook.js.org/docs/ember/api/argtypes
   argTypes: {
     children: { control: 'text' },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/ember/writing-stories/introduction#using-args
 const Template = (args) => ({
   template: hbs`<button {{action onClick}}>{{children}}</button>`,
   context: args,
 });
 
 export const Text = Template.bind({});
+// More on args: https://storybook.js.org/docs/ember/writing-stories/args
 Text.args = {
   children: 'Button',
   onClick: action('onClick'),

--- a/lib/cli/src/frameworks/html/js/Button.stories.js
+++ b/lib/cli/src/frameworks/html/js/Button.stories.js
@@ -1,18 +1,22 @@
 import { createButton } from './Button';
 
+// More on default export: https://storybook.js.org/docs/html/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
+  // More on argTypes: https://storybook.js.org/docs/html/api/argtypes
   argTypes: {
-    label: { control: 'text' },
-    primary: { control: 'boolean' },
     backgroundColor: { control: 'color' },
-    size: {
-      control: { type: 'select', options: ['small', 'medium', 'large'] },
-    },
+    label: { control: 'text' },
     onClick: { action: 'onClick' },
+    primary: { control: 'boolean' },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/html/writing-stories/introduction#using-args
 const Template = ({ label, ...args }) => {
   // You can either use a function to create DOM elements or use a plain html string!
   // return `<div>${label}</div>`;
@@ -20,6 +24,7 @@ const Template = ({ label, ...args }) => {
 };
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/html/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/html/js/Page.stories.js
+++ b/lib/cli/src/frameworks/html/js/Page.stories.js
@@ -14,6 +14,7 @@ const Template = (args) => createPage(args);
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/html/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/html/ts/Button.stories.ts
+++ b/lib/cli/src/frameworks/html/ts/Button.stories.ts
@@ -1,19 +1,23 @@
 import { Story, Meta } from '@storybook/html';
 import { createButton, ButtonProps } from './Button';
 
+// More on default export: https://storybook.js.org/docs/html/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
+  // More on argTypes: https://storybook.js.org/docs/html/api/argtypes
   argTypes: {
-    label: { control: 'text' },
-    primary: { control: 'boolean' },
     backgroundColor: { control: 'color' },
-    size: {
-      control: { type: 'select', options: ['small', 'medium', 'large'] },
-    },
+    label: { control: 'text' },
     onClick: { action: 'onClick' },
+    primary: { control: 'boolean' },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
   },
 } as Meta;
 
+// More on component templates: https://storybook.js.org/docs/html/writing-stories/introduction#using-args
 const Template: Story<ButtonProps> = (args) => {
   // You can either use a function to create DOM elements or use a plain html string!
   // return `<div>${label}</div>`;
@@ -21,6 +25,7 @@ const Template: Story<ButtonProps> = (args) => {
 };
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/html/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/html/ts/Page.stories.ts
+++ b/lib/cli/src/frameworks/html/ts/Page.stories.ts
@@ -16,6 +16,7 @@ const Template: Story<HeaderProps> = (args) => createPage(args);
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/html/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/marko/1-Button.stories.js
+++ b/lib/cli/src/frameworks/marko/1-Button.stories.js
@@ -1,19 +1,23 @@
 import { action } from '@storybook/addon-actions';
 import Button from './Button.marko';
 
+// More on default export: https://storybook.js.org/docs/marko/writing-stories/introduction#default-export
 export default {
   title: 'Button',
+  // More on argTypes: https://storybook.js.org/docs/marko/api/argtypes
   argTypes: {
     children: { control: 'text' },
   },
 };
 
-const ButtonStory = (args) => ({
+// More on component templates: https://storybook.js.org/docs/marko/writing-stories/introduction#using-args
+const Template = (args) => ({
   component: Button,
   input: args,
 });
 
-export const Text = ButtonStory.bind({});
+export const Text = Template.bind({});
+// More on args: https://storybook.js.org/docs/marko/writing-stories/args
 Text.args = {
   children: 'Button',
   onClick: action('onClick'),

--- a/lib/cli/src/frameworks/mithril/Button.stories.js
+++ b/lib/cli/src/frameworks/mithril/Button.stories.js
@@ -2,20 +2,24 @@ import m from 'mithril';
 
 import { Button } from './Button';
 
+// More on default export: https://storybook.js.org/docs/mithril/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
   component: Button,
+  // More on argTypes: https://storybook.js.org/docs/mithril/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
     onClick: { action: 'onClick' },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/mithril/writing-stories/introduction#using-args
 const Template = ({ children, ...args }) => ({
   view: () => m(Button, args, children),
 });
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/mithril/writing-stories/args
 Primary.args = {
   primary: true,
   children: 'Button',

--- a/lib/cli/src/frameworks/mithril/Page.stories.js
+++ b/lib/cli/src/frameworks/mithril/Page.stories.js
@@ -14,6 +14,7 @@ const Template = ({ children, ...args }) => ({
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/mithril/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/preact/Button.stories.jsx
+++ b/lib/cli/src/frameworks/preact/Button.stories.jsx
@@ -2,18 +2,22 @@
 import { h } from 'preact';
 import { Button } from './Button';
 
+// More on default export: https://storybook.js.org/docs/preact/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
   component: Button,
+  // More on argTypes: https://storybook.js.org/docs/preact/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
     onClick: { action: 'onClick' },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/preact/writing-stories/introduction#using-args
 const Template = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/preact/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/preact/Page.stories.jsx
+++ b/lib/cli/src/frameworks/preact/Page.stories.jsx
@@ -13,6 +13,7 @@ const Template = (args) => <Page {...args} />;
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/preact/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/rax/Button.stories.js
+++ b/lib/cli/src/frameworks/rax/Button.stories.js
@@ -2,17 +2,21 @@ import { createElement } from 'rax';
 
 import { Button } from './Button';
 
+// More on default export: https://storybook.js.org/docs/rax/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
+  // More on argTypes: https://storybook.js.org/docs/rax/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
     onClick: { action: 'onClick' },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/rax/writing-stories/introduction#using-args
 const Template = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/rax/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/rax/Page.stories.js
+++ b/lib/cli/src/frameworks/rax/Page.stories.js
@@ -11,6 +11,7 @@ const Template = (args) => <Page {...args} />;
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/rax/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/react/js/Button.stories.jsx
+++ b/lib/cli/src/frameworks/react/js/Button.stories.jsx
@@ -2,17 +2,21 @@ import React from 'react';
 
 import { Button } from './Button';
 
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
   component: Button,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/react/js/Page.stories.jsx
+++ b/lib/cli/src/frameworks/react/js/Page.stories.jsx
@@ -12,6 +12,7 @@ const Template = (args) => <Page {...args} />;
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/react/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/react/ts/Button.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Button.stories.tsx
@@ -3,17 +3,21 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
   component: Button,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
   },
 } as ComponentMeta<typeof Button>;
 
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/react/ts/Page.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Page.stories.tsx
@@ -13,6 +13,7 @@ const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/react/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/riot/1-Button.stories.js
+++ b/lib/cli/src/frameworks/riot/1-Button.stories.js
@@ -6,16 +6,20 @@ import { action } from '@storybook/addon-actions';
 import MyButtonRaw from 'raw-loader!./MyButton.tag';
 import './MyButton.tag';
 
+// More on default export: https://storybook.js.org/docs/riot/writing-stories/introduction#default-export
 export default {
   title: 'Button',
+  // More on argTypes: https://storybook.js.org/docs/riot/api/argtypes
   argTypes: {
     content: { control: 'text' },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/riot/writing-stories/introduction#using-args
 const Template = (args) => mount('my-button', args);
 
 export const Text = Template.bind({});
+// More on args: https://storybook.js.org/docs/riot/writing-stories/args
 Text.args = {
   content: 'Button',
   onClick: action('onClick'),

--- a/lib/cli/src/frameworks/svelte/Button.stories.svelte
+++ b/lib/cli/src/frameworks/svelte/Button.stories.svelte
@@ -3,24 +3,29 @@
   import Button from "./Button.svelte";
 </script>
 
+<!-- More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export -->
+<!-- More on argTypes: https://storybook.js.org/docs/svelte/api/argtypes -->
 <Meta
   title="Example/Button"
   component={Button}
   argTypes={{
-    label: { control: "text" },
-    primary: { control: "boolean" },
     backgroundColor: { control: "color" },
-    size: {
-      control: { type: "select", options: ["small", "medium", "large"] },
-    },
+    label: { control: "text" },
     onClick: { action: "onClick" },
+    primary: { control: "boolean" },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
   }}
 />
 
+<!-- More on component templates: https://storybook.js.org/docs/svelte/writing-stories/introduction#using-args -->
 <Template let:args>
   <Button {...args} on:click={args.onClick} />
 </Template>
 
+<!-- More on args: https://storybook.js.org/docs/svelte/writing-stories/args -->
 <Story
   name="Primary"
   args={{

--- a/lib/cli/src/frameworks/vue/Button.stories.js
+++ b/lib/cli/src/frameworks/vue/Button.stories.js
@@ -1,14 +1,20 @@
 import MyButton from './Button.vue';
 
+// More on default export: https://storybook.js.org/docs/vue/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
   component: MyButton,
+  // More on argTypes: https://storybook.js.org/docs/vue/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
-    size: { control: { type: 'select', options: ['small', 'medium', 'large'] } },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/vue/writing-stories/introduction#using-args
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { MyButton },
@@ -16,6 +22,7 @@ const Template = (args, { argTypes }) => ({
 });
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/vue/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/vue/Page.stories.js
+++ b/lib/cli/src/frameworks/vue/Page.stories.js
@@ -15,6 +15,7 @@ const Template = (args, { argTypes }) => ({
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/vue/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/vue3/Button.stories.js
+++ b/lib/cli/src/frameworks/vue3/Button.stories.js
@@ -1,15 +1,21 @@
 import MyButton from './Button.vue';
 
+// More on default export: https://storybook.js.org/docs/vue/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
   component: MyButton,
+  // More on argTypes: https://storybook.js.org/docs/vue/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
-    size: { control: { type: 'select', options: ['small', 'medium', 'large'] } },
     onClick: {},
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/vue/writing-stories/introduction#using-args
 const Template = (args) => ({
   // Components used in your story `template` are defined in the `components` object
   components: { MyButton },
@@ -22,6 +28,7 @@ const Template = (args) => ({
 });
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/vue/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/vue3/Page.stories.js
+++ b/lib/cli/src/frameworks/vue3/Page.stories.js
@@ -20,6 +20,7 @@ const Template = (args) => ({
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/vue/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/web-components/js/Button.stories.js
+++ b/lib/cli/src/frameworks/web-components/js/Button.stories.js
@@ -1,16 +1,24 @@
 import { Button } from './Button';
 
+// More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
+  // More on argTypes: https://storybook.js.org/docs/web-components/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
     onClick: { action: 'onClick' },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
   },
 };
 
+// More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 const Template = (args) => Button(args);
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/web-components/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/web-components/js/Page.stories.js
+++ b/lib/cli/src/frameworks/web-components/js/Page.stories.js
@@ -9,6 +9,7 @@ const Template = (args) => Page(args);
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/web-components/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 

--- a/lib/cli/src/frameworks/web-components/ts/Button.stories.ts
+++ b/lib/cli/src/frameworks/web-components/ts/Button.stories.ts
@@ -1,17 +1,25 @@
 import { Story, Meta } from '@storybook/web-components';
 import { Button, ButtonProps } from './Button';
 
+// More on default export: https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 export default {
   title: 'Example/Button',
+  // More on argTypes: https://storybook.js.org/docs/web-components/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
     onClick: { action: 'onClick' },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
   },
 } as Meta;
 
+// More on component templates: https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 const Template: Story<Partial<ButtonProps>> = (args) => Button(args);
 
 export const Primary = Template.bind({});
+// More on args: https://storybook.js.org/docs/web-components/writing-stories/args
 Primary.args = {
   primary: true,
   label: 'Button',

--- a/lib/cli/src/frameworks/web-components/ts/Page.stories.ts
+++ b/lib/cli/src/frameworks/web-components/ts/Page.stories.ts
@@ -10,6 +10,7 @@ const Template: Story<Partial<PageProps>> = (args) => Page(args);
 
 export const LoggedIn = Template.bind({});
 LoggedIn.args = {
+  // More on composing args: https://storybook.js.org/docs/web-components/writing-stories/args#args-composition
   ...HeaderStories.LoggedIn.args,
 };
 


### PR DESCRIPTION
## What I did

- Add helpful comments to particular parts of the template files used to generate stories with `npx sb init`
- Only done for frameworks that display in the framework switcher
- URLs in comments are framework-specific
- Other minor tweaks
    - Fix (and alpha-order) argTypes definitions
    - Use "Template" name/concept consistently

~Submitting a draft PR to start the conversation on whether this is a good idea and if this is the right execution. If we come to an agreement on that, I'll propagate this pattern throughout other template files.~ _Done._

## How to test

_Not sure how to test `sb init`, but I don't think these changes would require testing anyway_

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
