### PR TITLE
Default sb init in ESM projects to use cjs

### DIFF
--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -206,7 +206,10 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
           .then(end);
 
       case ProjectType.WEB_COMPONENTS:
-        return webComponentsGenerator(packageManager, npmOptions, generatorOptions)
+        return webComponentsGenerator(packageManager, npmOptions, {
+          ...generatorOptions,
+          commonJs: true,
+        })
           .then(commandLog('Adding Storybook support to your "web components" app'))
           .then(end);
 

--- a/lib/cli/src/js-package-manager/PackageJson.ts
+++ b/lib/cli/src/js-package-manager/PackageJson.ts
@@ -4,6 +4,7 @@ export type PackageJson = {
   peerDependencies?: Record<string, string>;
   scripts?: Record<string, string>;
   eslintConfig?: any;
+  type?: 'module';
 };
 
 export type PackageJsonWithDepsAndDevDeps = PackageJson &


### PR DESCRIPTION
Discovered the following issue (_edit: also reported here: #16181_):

1. Start a new project with [lit-element-starter-js](https://github.com/lit/lit-element-starter-js)
1. Run `npx sb init`
1. Run `npm run storybook`
1. Receive the following error:
   ```bash
   ERR! Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: <path-to-project>/.storybook/main.js
   ERR! require() of ES modules is not supported.
   ERR! require() of <path-to-project>/.storybook/main.js from <path-to-project>/node_modules/@storybook/core-common/dist/cjs/utils/interpret-require.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
   ERR! Instead rename main.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from <path-to-project>/package.json.
   ERR!
   ERR!     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1089:13)
   ERR!     at Module.load (internal/modules/cjs/loader.js:937:32)
   ERR!     at Function.Module._load (internal/modules/cjs/loader.js:778:12)
   ERR!     at Module.require (internal/modules/cjs/loader.js:961:19)
   ERR!     at require (internal/modules/cjs/helpers.js:92:18)
   ERR!     at interopRequireDefault (<path-to-project>/node_modules/@storybook/core-common/dist/cjs/utils/interpret-require.js:64:16)
   ERR!     at serverRequire (<path-to-project>/node_modules/@storybook/core-common/dist/cjs/utils/interpret-require.js:101:10)
   ERR!     at getPreviewBuilder (<path-to-project>/node_modules/@storybook/core-server/dist/cjs/utils/get-preview-builder.js:25:55)
   ERR!     at buildDevStandalone (<path-to-project>/node_modules/@storybook/core-server/dist/cjs/build-dev.js:99:71)
   ERR!     at async buildDev (<path-to-project>/node_modules/@storybook/core-server/dist/cjs/build-dev.js:154:5)
   ```
1. Following those directions corrected the issue, so this PR is an attempt to do that automatically

## What I did

1. Attempt to default to `commonJs: true` when ran in an ESM project (e.g. `"type": "module"`)

_Submitting a draft PR because I'm only ~80% sure this is the way to do that, or that it should be done in the first place)._

## How to test

_No idea how to test `sb init`_

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
