### PR TITLE
Better scope sample page component styles

### DIFF
--- a/lib/cli/src/frameworks/common/page.css
+++ b/lib/cli/src/frameworks/common/page.css
@@ -8,7 +8,7 @@ section {
   color: #333;
 }
 
-h2 {
+section h2 {
   font-weight: 900;
   font-size: 32px;
   line-height: 1;
@@ -17,25 +17,25 @@ h2 {
   vertical-align: top;
 }
 
-p {
+section p {
   margin: 1em 0;
 }
 
-a {
+section a {
   text-decoration: none;
   color: #1ea7fd;
 }
 
-ul {
+section ul {
   padding-left: 30px;
   margin: 1em 0;
 }
 
-li {
+section li {
   margin-bottom: 8px;
 }
 
-.tip {
+section .tip {
   display: inline-block;
   border-radius: 1em;
   font-size: 11px;
@@ -48,14 +48,14 @@ li {
   vertical-align: top;
 }
 
-.tip-wrapper {
+section .tip-wrapper {
   font-size: 13px;
   line-height: 20px;
   margin-top: 40px;
   margin-bottom: 40px;
 }
 
-.tip-wrapper svg {
+section .tip-wrapper svg {
   display: inline-block;
   height: 12px;
   width: 12px;
@@ -64,6 +64,6 @@ li {
   margin-top: 3px;
 }
 
-.tip-wrapper svg path {
+section .tip-wrapper svg path {
   fill: #1ea7fd;
 }


### PR DESCRIPTION
## What I did

- Prepend each selector in the `page.css` template file with "section ", to scope the styles to the component
    - You can see how the unscoped styles were affecting Docs-page elements in the Before/After
    - I scoped the styles in a way that didn't require changes to the Page component templates themselves; scoping with a class name would be better practice, though

### Before

![DocsH2_before](https://user-images.githubusercontent.com/486540/135169326-78d3eab5-e35a-463e-af0a-49653cc3d688.png)

### After

![DocsH2_after](https://user-images.githubusercontent.com/486540/135169339-69544f20-9927-4c4d-984e-93af14c8d684.png)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
