### PR TITLE
Controls: Hide color control format toggle when no value

### DIFF
--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -358,7 +358,7 @@ export const ColorControl: FC<ColorProps> = ({
         onFocus={(e: FocusEvent<HTMLInputElement>) => e.target.select()}
         placeholder="Choose color..."
       />
-      <ToggleIcon icon="markup" onClick={cycleColorSpace} />
+      {value ? <ToggleIcon icon="markup" onClick={cycleColorSpace} /> : null}
     </Wrapper>
   );
 };


### PR DESCRIPTION
## What I did

I noticed that clicking on the format (color space) toggle of the Color control when there's no value caused strange issues. This PR prevents the toggle from rendering unless there's a value, to avoid that problematic state.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
