### PR TITLE
Upgrade boxen to 5.x

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -52,7 +52,7 @@
     "@storybook/core-common": "6.4.0-beta.1",
     "@storybook/node-logger": "6.4.0-beta.1",
     "@storybook/semver": "^7.3.2",
-    "boxen": "^4.2.0",
+    "boxen": "^5.1.2",
     "chalk": "^4.1.0",
     "commander": "^6.2.1",
     "core-js": "^3.8.2",

--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -54,7 +54,7 @@
     "@types/pretty-hrtime": "^1.0.0",
     "@types/webpack": "^4.41.26",
     "better-opn": "^2.1.1",
-    "boxen": "^4.2.0",
+    "boxen": "^5.1.2",
     "chalk": "^4.1.0",
     "cli-table3": "0.6.0",
     "commander": "^6.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7812,7 +7812,7 @@ __metadata:
     "@types/semver": ^7.3.4
     "@types/shelljs": ^0.8.7
     "@types/update-notifier": ^5.0.0
-    boxen: ^4.2.0
+    boxen: ^5.1.2
     chalk: ^4.1.0
     commander: ^6.2.1
     core-js: ^3.8.2
@@ -8065,7 +8065,7 @@ __metadata:
     "@types/serve-favicon": ^2.5.2
     "@types/webpack": ^4.41.26
     better-opn: ^2.1.1
-    boxen: ^4.2.0
+    boxen: ^5.1.2
     chalk: ^4.1.0
     cli-table3: 0.6.0
     commander: ^6.2.1
@@ -12927,6 +12927,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: 9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^2.2.1":
   version: 2.2.1
   resolution: "ansi-styles@npm:2.2.1"
@@ -14825,6 +14832,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"boxen@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "boxen@npm:5.1.2"
+  dependencies:
+    ansi-align: ^3.0.0
+    camelcase: ^6.2.0
+    chalk: ^4.1.0
+    cli-boxes: ^2.2.1
+    string-width: ^4.2.2
+    type-fest: ^0.20.2
+    widest-line: ^3.1.0
+    wrap-ansi: ^7.0.0
+  checksum: 71f31c2eb3dcacd5fce524ae509e0cc90421752e0bfbd0281fd3352871d106c462a0f810c85f2fdb02f3a9fab2d7a84e9718b4999384d651b76104ebe5d2c024
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -16653,7 +16676,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-boxes@npm:^2.2.0":
+"cli-boxes@npm:^2.2.0, cli-boxes@npm:^2.2.1":
   version: 2.2.1
   resolution: "cli-boxes@npm:2.2.1"
   checksum: 6111352edbb2f62dbc7bfd58f2d534de507afed7f189f13fa894ce5a48badd94b2aa502fda28f1d7dd5f1eb456e7d4033d09a76660013ef50c7f66e7a034f050
@@ -41480,6 +41503,17 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
+"string-width@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: ^8.0.0
+    is-fullwidth-code-point: ^3.0.0
+    strip-ansi: ^6.0.1
+  checksum: 1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
+  languageName: node
+  linkType: hard
+
 "string.prototype.matchall@npm:^4.0.0 || ^3.0.1, string.prototype.matchall@npm:^4.0.2":
   version: 4.0.4
   resolution: "string.prototype.matchall@npm:4.0.4"
@@ -41635,6 +41669,15 @@ resolve@1.19.0:
   dependencies:
     ansi-regex: ^4.1.0
   checksum: de4658c8a097ce3b15955bc6008f67c0790f85748bdc025b7bc8c52c7aee94bc4f9e50624516150ed173c3db72d851826cd57e7a85fe4e4bb6dbbebd5d297fdf
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+  checksum: 1ae5f212a126fe5b167707f716942490e3933085a5ff6c008ab97ab2f272c8025d3aa218b7bd6ab25729ca20cc81cddb252102f8751e13482a5199e873680952
   languageName: node
   linkType: hard
 
@@ -43573,6 +43616,13 @@ resolve@1.19.0:
   version: 0.18.1
   resolution: "type-fest@npm:0.18.1"
   checksum: 303f5ecf40d03e1d5b635ce7660de3b33c18ed8ebc65d64920c02974d9e684c72483c23f9084587e9dd6466a2ece1da42ddc95b412a461794dd30baca95e2bac
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.20.2":
+  version: 0.20.2
+  resolution: "type-fest@npm:0.20.2"
+  checksum: dea9df45ea1f0aaa4e2d3bed3f9a0bfe9e5b2592bddb92eb1bf06e50bcf98dbb78189668cd8bc31a0511d3fc25539b4cd5c704497e53e93e2d40ca764b10bfc3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue:

## What I did

`boxen` is upgraded from 4.x to 5.x.
The breaking change in this major version is dropping support for node <10, and storybook already requires node 10+.
This removes one path depending on outdated versions of `ansi-regex` that are vulnerable for ReDoS (the dependency tree of `npmlog` still includes it though).

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
