### PR TITLE
CLI: Add webpack5 builder to CRA5 `sb init`

### DIFF
--- a/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -32,7 +32,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   if (isCra5) extraPackages.push('webpack');
 
   // preset v3 is compat with older versions of CRA, otherwise let version float
-  const extraAddons = [`@storybook/preset-create-react-app${isCra5 ? '' : '@3'}`];
+  const extraAddons = [`@storybook/preset-create-react-app${isCra5 ? '' : ''}`];
 
   await baseGenerator(packageManager, npmOptions, updatedOptions, 'react', {
     extraAddons,

--- a/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -1,7 +1,9 @@
 import path from 'path';
 import fs from 'fs';
+import semver from '@storybook/semver';
 
 import { baseGenerator, Generator } from '../baseGenerator';
+import { CoreBuilder } from '../../project_types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
   const extraMain = options.linkable
@@ -20,10 +22,18 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
       }
     : {};
 
-  await baseGenerator(packageManager, npmOptions, options, 'react', {
+  const craVersion = semver.coerce(
+    packageManager.retrievePackageJson().dependencies['react-scripts']
+  )?.version;
+  const isWebpack5 = semver.gte(craVersion, '5.0.0');
+  const updatedOptions = isWebpack5 ? { ...options, builder: CoreBuilder.Webpack5 } : options;
+  const extraPackages = ['@storybook/node-logger'];
+  if (isWebpack5) extraPackages.push('webpack');
+
+  await baseGenerator(packageManager, npmOptions, updatedOptions, 'react', {
     extraAddons: ['@storybook/preset-create-react-app'],
     // `@storybook/preset-create-react-app` has `@storybook/node-logger` as peerDep
-    extraPackages: ['@storybook/node-logger'],
+    extraPackages,
     staticDir: fs.existsSync(path.resolve('./public')) ? 'public' : undefined,
     addBabel: false,
     addESLint: true,

--- a/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -27,12 +27,15 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   )?.version;
   const isCra5 = semver.gte(craVersion, '5.0.0');
   const updatedOptions = isCra5 ? { ...options, builder: CoreBuilder.Webpack5 } : options;
+  // `@storybook/preset-create-react-app` has `@storybook/node-logger` as peerDep
   const extraPackages = ['@storybook/node-logger'];
   if (isCra5) extraPackages.push('webpack');
 
+  // preset v3 is compat with older versions of CRA, otherwise let version float
+  const extraAddons = [`@storybook/preset-create-react-app${isCra5 ? '' : '@3'}`];
+
   await baseGenerator(packageManager, npmOptions, updatedOptions, 'react', {
-    extraAddons: ['@storybook/preset-create-react-app'],
-    // `@storybook/preset-create-react-app` has `@storybook/node-logger` as peerDep
+    extraAddons,
     extraPackages,
     staticDir: fs.existsSync(path.resolve('./public')) ? 'public' : undefined,
     addBabel: false,

--- a/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -32,7 +32,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   if (isCra5) extraPackages.push('webpack');
 
   // preset v3 is compat with older versions of CRA, otherwise let version float
-  const extraAddons = [`@storybook/preset-create-react-app${isCra5 ? '' : ''}`];
+  const extraAddons = [`@storybook/preset-create-react-app${isCra5 ? '' : '@3'}`];
 
   await baseGenerator(packageManager, npmOptions, updatedOptions, 'react', {
     extraAddons,

--- a/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -25,10 +25,10 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   const craVersion = semver.coerce(
     packageManager.retrievePackageJson().dependencies['react-scripts']
   )?.version;
-  const isWebpack5 = semver.gte(craVersion, '5.0.0');
-  const updatedOptions = isWebpack5 ? { ...options, builder: CoreBuilder.Webpack5 } : options;
+  const isCra5 = semver.gte(craVersion, '5.0.0');
+  const updatedOptions = isCra5 ? { ...options, builder: CoreBuilder.Webpack5 } : options;
   const extraPackages = ['@storybook/node-logger'];
-  if (isWebpack5) extraPackages.push('webpack');
+  if (isCra5) extraPackages.push('webpack');
 
   await baseGenerator(packageManager, npmOptions, updatedOptions, 'react', {
     extraAddons: ['@storybook/preset-create-react-app'],

--- a/lib/cli/src/generators/baseGenerator.ts
+++ b/lib/cli/src/generators/baseGenerator.ts
@@ -63,6 +63,8 @@ const builderDependencies = (builder: Builder) => {
   }
 };
 
+const stripVersions = (addons: string[]) => addons.map((addon) => getPackageDetails(addon)[0]);
+
 export async function baseGenerator(
   packageManager: JsPackageManager,
   npmOptions: NpmOptions,
@@ -127,7 +129,7 @@ export async function baseGenerator(
         }
       : extraMain;
   configure(framework, {
-    addons: [...addons, ...extraAddons],
+    addons: [...addons, ...stripVersions(extraAddons)],
     extensions,
     commonJs: options.commonJs,
     ...mainOptions,


### PR DESCRIPTION
Issue: #16150

## What I did

- [x] Install webpack5 builder on fresh CRA projects
- [x] Version `@storybook/preset-create-react-app` based on CRA version?

## How to test

```sh
yarn create react-app --scripts-version=@next --template=cra-template@next cra-sb-fresh
cd cra-sb-fresh
/path/to/storybook/lib/cli/bin/index.js init
```
