### PR TITLE
chore(docs): Correct a small oversight

### DIFF
--- a/docs/workflows/storybook-composition.md
+++ b/docs/workflows/storybook-composition.md
@@ -10,7 +10,7 @@ You can compose any Storybook [published online](./publish-storybook.md) or runn
 
 ## Compose published Storybooks
 
-In your [`storybook/main.js`](../configure/overview.md#configure-story-rendering) file add a `refs` field with information about the reference Storybook. Pass in a URL to a statically built Storybook.
+In your [`.storybook/main.js`](../configure/overview.md#configure-story-rendering) file add a `refs` field with information about the reference Storybook. Pass in a URL to a statically built Storybook.
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
Issue:

The docs talk about updating your `storybook/main.js` file, but it's
actually `.storybook/main.js`.

## What I did

Add a single `.` to make it `.storybook/main.js`.

## How to test

Read the documentation 😉 

- [X] Is this testable with Jest or Chromatic screenshots?
  - Yes, but .. should one?
- [ ] Does this need a new example in the kitchen sink apps? 
- [X] Does this need an update to the documentation?
  - This *is* an update to the documentation 😀 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
