### PR TITLE
[documentation] Fix a library name mistake in documentation.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1500,7 +1500,7 @@ Solution:
 ```javascript
 getStorybookUI({
   ...
-  asyncStorage: require('@react-native-community/async-storage').default || require('react-native').AsyncStorage || null
+  asyncStorage: require('@react-native-async-storage/async-storage').default || require('react-native').AsyncStorage || null
 });
 ```
 


### PR DESCRIPTION
Issue: the documentation referenced `@react-native-community/async-storage` but the actual coordinates for the library are `@react-native-async-storage/async-storage`.

## What I did
I updated the docs accordingly.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
