### PR TITLE
Angular: Fix getComponentInputsOutputs for multiple decorators

### DIFF
--- a/app/angular/src/client/preview/angular-beta/utils/NgComponentAnalyzer.test.ts
+++ b/app/angular/src/client/preview/angular-beta/utils/NgComponentAnalyzer.test.ts
@@ -4,6 +4,7 @@ import {
   ComponentFactoryResolver,
   Directive,
   EventEmitter,
+  HostBinding,
   Injectable,
   Input,
   Output,
@@ -102,6 +103,36 @@ describe('getComponentInputsOutputs', () => {
     const fooComponentFactory = resolveComponentFactory(FooComponent);
 
     const { inputs, outputs } = getComponentInputsOutputs(FooComponent);
+
+    expect(sortByPropName(inputs)).toEqual(sortByPropName(fooComponentFactory.inputs));
+    expect(sortByPropName(outputs)).toEqual(sortByPropName(fooComponentFactory.outputs));
+  });
+
+  it('should return I/O in the presence of multiple decorators', () => {
+    @Component({
+      template: '',
+    })
+    class FooComponent {
+      @Input()
+      @HostBinding('class.preceeding-first')
+      public inputPreceedingHostBinding: string;
+
+      @HostBinding('class.following-binding')
+      @Input()
+      public inputFollowingHostBinding: string;
+    }
+
+    const fooComponentFactory = resolveComponentFactory(FooComponent);
+
+    const { inputs, outputs } = getComponentInputsOutputs(FooComponent);
+
+    expect({ inputs, outputs }).toEqual({
+      inputs: [
+        { propName: 'inputPreceedingHostBinding', templateName: 'inputPreceedingHostBinding' },
+        { propName: 'inputFollowingHostBinding', templateName: 'inputFollowingHostBinding' },
+      ],
+      outputs: [],
+    });
 
     expect(sortByPropName(inputs)).toEqual(sortByPropName(fooComponentFactory.inputs));
     expect(sortByPropName(outputs)).toEqual(sortByPropName(fooComponentFactory.outputs));

--- a/app/angular/src/client/preview/angular-beta/utils/NgComponentAnalyzer.ts
+++ b/app/angular/src/client/preview/angular-beta/utils/NgComponentAnalyzer.ts
@@ -41,7 +41,8 @@ export const getComponentInputsOutputs = (component: any): ComponentInputsOutput
 
   // Browses component properties to extract I/O
   // Filters properties that have the same name as the one present in the @Component property
-  return Object.entries(componentPropsMetadata).reduce((previousValue, [propertyName, [value]]) => {
+  return Object.entries(componentPropsMetadata).reduce((previousValue, [propertyName, values]) => {
+    const value = values.find((v) => v instanceof Input || v instanceof Output);
     if (value instanceof Input) {
       const inputToAdd = {
         propName: propertyName,


### PR DESCRIPTION
…han one decorator

Issue:

The Angular addon for storybook was not able to see components inputs that were declared with both HostBinding and Input decorators (in that order), as in the following example:

```typescript
@Component({
  template: '',
})
class FooComponent {
  @HostBinding('class.example')
  @Input()
  public example: string;
}

```

## What I did

Altered getComponentInputsOutputs to search the whole decorator array for an Input or Output, instead of just the first element.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

I've added a test case that failed with the old implementation.