### PR TITLE
Core: Support v2 compatibility mode in story index

### DIFF
--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -44,6 +44,7 @@
     "@storybook/builder-webpack4": "6.4.0-beta.3",
     "@storybook/core-client": "6.4.0-beta.3",
     "@storybook/core-common": "6.4.0-beta.3",
+    "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/csf-tools": "6.4.0-beta.3",
     "@storybook/manager-webpack4": "6.4.0-beta.3",
     "@storybook/node-logger": "6.4.0-beta.3",

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -77,7 +77,8 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
     await extractStoriesJson(
       path.join(options.outputDir, 'stories.json'),
       stories,
-      options.configDir
+      options.configDir,
+      !features?.breakingChangesV7
     );
   }
 

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -78,7 +78,7 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
       path.join(options.outputDir, 'stories.json'),
       stories,
       options.configDir,
-      !features?.breakingChangesV7
+      !features?.breakingChangesV7 && !features?.storyStoreV7
     );
   }
 

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -5,9 +5,10 @@ import { StoryIndexGenerator } from './StoryIndexGenerator';
 export async function extractStoriesJson(
   outputFile: string,
   normalizedStories: NormalizedStoriesSpecifier[],
-  configDir: string
+  configDir: string,
+  v2compatibility: boolean
 ) {
-  const generator = new StoryIndexGenerator(normalizedStories, configDir);
+  const generator = new StoryIndexGenerator(normalizedStories, configDir, v2compatibility);
   await generator.initialize();
 
   const index = await generator.getIndex();
@@ -20,8 +21,14 @@ export async function useStoriesJson(router: any, options: Options) {
     workingDir: process.cwd(),
   });
 
+  const features = await options.presets.apply<{ breakingChangesV7?: boolean }>('features');
+
   router.use('/stories.json', async (_req: any, res: any) => {
-    const generator = new StoryIndexGenerator(normalized, options.configDir);
+    const generator = new StoryIndexGenerator(
+      normalized,
+      options.configDir,
+      !features?.breakingChangesV7
+    );
     await generator.initialize();
 
     try {

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -1,5 +1,10 @@
 import fs from 'fs-extra';
-import { Options, normalizeStories, NormalizedStoriesSpecifier } from '@storybook/core-common';
+import {
+  Options,
+  normalizeStories,
+  NormalizedStoriesSpecifier,
+  StorybookConfig,
+} from '@storybook/core-common';
 import { StoryIndexGenerator } from './StoryIndexGenerator';
 
 export async function extractStoriesJson(
@@ -21,13 +26,13 @@ export async function useStoriesJson(router: any, options: Options) {
     workingDir: process.cwd(),
   });
 
-  const features = await options.presets.apply<{ breakingChangesV7?: boolean }>('features');
+  const features = await options.presets.apply<StorybookConfig['features']>('features');
 
   router.use('/stories.json', async (_req: any, res: any) => {
     const generator = new StoryIndexGenerator(
       normalized,
       options.configDir,
-      !features?.breakingChangesV7
+      !features?.breakingChangesV7 && !features?.storyStoreV7
     );
     await generator.initialize();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8052,6 +8052,7 @@ __metadata:
     "@storybook/builder-webpack5": 6.4.0-beta.3
     "@storybook/core-client": 6.4.0-beta.3
     "@storybook/core-common": 6.4.0-beta.3
+    "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/csf-tools": 6.4.0-beta.3
     "@storybook/manager-webpack4": 6.4.0-beta.3
     "@storybook/node-logger": 6.4.0-beta.3


### PR DESCRIPTION
Issue: #16049 

## What I did

Serve a v2-compatible v3 `stories.json` unless `features.breakingChangesV7` or `features.storyStoreV7` is set.

This way:
- v6.4 storybooks will be compatible with older versions of storybook
- v7.0-mode storybooks will stay incompatible with older versions

## How to test

```sh
cd examples/react-ts
yarn build-storybook -o react-ts-70-compat
npx http-server react-ts-70-compat --cors
```

Then compose it into a storybook by adding the following to `.storybook/main.js`:

```
  refs: {
    first: {
      title: 'Composition test',
      url: 'http://localhost:8080',
    },
  },
```

You can do the same with:
- [ ] `features.storyStoreV7: false` 
- [ ] `features.breakingChangesV7: true` 

```