### PR TITLE
CLI: Remove story format parameter

### DIFF
--- a/lib/cli/src/generate.ts
+++ b/lib/cli/src/generate.ts
@@ -25,7 +25,6 @@ program
   .option('-N --use-npm', 'Use npm to install deps')
   .option('-p --parser <babel | babylon | flow | ts | tsx>', 'jscodeshift parser')
   .option('-t --type <type>', 'Add Storybook for a specific project type')
-  .option('--story-format <csf | csf-ts | mdx >', 'Generate stories in a specified format')
   .option('-y --yes', 'Answer yes to all prompts')
   .option('-b --builder <builder>', 'Builder library')
   .option('-l --linkable', 'Prepare installation for link (contributor helper)')

--- a/lib/cli/src/generators/ANGULAR/index.ts
+++ b/lib/cli/src/generators/ANGULAR/index.ts
@@ -43,7 +43,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
     extraPackages: ['@compodoc/compodoc', '@angular/elements', '@webcomponents/custom-elements'],
     addScripts: false,
   });
-  copyTemplate(__dirname, options.storyFormat);
+  copyTemplate(__dirname);
 
   editAngularAppTsConfig();
   editStorybookTsConfig(path.resolve('./.storybook/tsconfig.json'));

--- a/lib/cli/src/generators/AURELIA/index.ts
+++ b/lib/cli/src/generators/AURELIA/index.ts
@@ -22,7 +22,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   baseGenerator(packageManager, npmOptions, options, 'aurelia', {
     extraPackages: ['aurelia'],
   });
-  copyTemplate(__dirname, options.storyFormat);
+  copyTemplate(__dirname);
 };
 
 export default generator;

--- a/lib/cli/src/generators/REACT_NATIVE/index.ts
+++ b/lib/cli/src/generators/REACT_NATIVE/index.ts
@@ -3,13 +3,11 @@ import shell from 'shelljs';
 import { getBabelDependencies, paddedLog, copyTemplate } from '../../helpers';
 import { JsPackageManager } from '../../js-package-manager';
 import { NpmOptions } from '../../NpmOptions';
-import { GeneratorOptions } from '../baseGenerator';
 
 const generator = async (
   packageManager: JsPackageManager,
   npmOptions: NpmOptions,
-  installServer: boolean,
-  options: GeneratorOptions
+  installServer: boolean
 ): Promise<void> => {
   // set correct project name on entry files if possible
   const dirname = shell.ls('-d', 'ios/*.xcodeproj').stdout;
@@ -69,7 +67,7 @@ const generator = async (
     });
   }
 
-  copyTemplate(__dirname, options.storyFormat);
+  copyTemplate(__dirname);
 };
 
 export default generator;

--- a/lib/cli/src/generators/SERVER/index.ts
+++ b/lib/cli/src/generators/SERVER/index.ts
@@ -6,7 +6,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
     extensions: ['json'],
   });
 
-  copyTemplate(__dirname, options.storyFormat);
+  copyTemplate(__dirname);
 };
 
 export default generator;

--- a/lib/cli/src/generators/baseGenerator.ts
+++ b/lib/cli/src/generators/baseGenerator.ts
@@ -1,13 +1,7 @@
 import fse from 'fs-extra';
 import { getStorybookBabelDependencies } from '@storybook/core-common';
 import { NpmOptions } from '../NpmOptions';
-import {
-  StoryFormat,
-  SupportedLanguage,
-  SupportedFrameworks,
-  Builder,
-  CoreBuilder,
-} from '../project_types';
+import { SupportedLanguage, SupportedFrameworks, Builder, CoreBuilder } from '../project_types';
 import { getBabelDependencies, copyComponents } from '../helpers';
 import { configure } from './configure';
 import { getPackageDetails, JsPackageManager } from '../js-package-manager';
@@ -15,7 +9,6 @@ import { generateStorybookBabelConfigInCWD } from '../babel-config';
 
 export type GeneratorOptions = {
   language: SupportedLanguage;
-  storyFormat: StoryFormat;
   builder: Builder;
   linkable: boolean;
 };

--- a/lib/cli/src/helpers.test.ts
+++ b/lib/cli/src/helpers.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import fse from 'fs-extra';
 
 import * as helpers from './helpers';
-import { StoryFormat, SupportedLanguage, SupportedFrameworks } from './project_types';
+import { SupportedLanguage, SupportedFrameworks } from './project_types';
 
 jest.mock('fs', () => ({
   existsSync: jest.fn(),
@@ -24,38 +24,7 @@ describe('Helpers', () => {
     jest.clearAllMocks();
   });
 
-  describe('copyTemplate', () => {
-    it(`should fall back to ${StoryFormat.CSF} 
-        in case ${StoryFormat.CSF_TYPESCRIPT} is not available`, () => {
-      const csfDirectory = `template-${StoryFormat.CSF}/`;
-      (fs.existsSync as jest.Mock).mockImplementation((filePath) => {
-        return filePath === csfDirectory;
-      });
-      helpers.copyTemplate('', StoryFormat.CSF_TYPESCRIPT);
-
-      const copySyncSpy = jest.spyOn(fse, 'copySync');
-      expect(copySyncSpy).toHaveBeenCalledWith(csfDirectory, expect.anything(), expect.anything());
-    });
-
-    it(`should use ${StoryFormat.CSF_TYPESCRIPT} if it is available`, () => {
-      const csfDirectory = `template-${StoryFormat.CSF_TYPESCRIPT}/`;
-      (fs.existsSync as jest.Mock).mockImplementation((filePath) => {
-        return filePath === csfDirectory;
-      });
-      helpers.copyTemplate('', StoryFormat.CSF_TYPESCRIPT);
-
-      const copySyncSpy = jest.spyOn(fse, 'copySync');
-      expect(copySyncSpy).toHaveBeenCalledWith(csfDirectory, expect.anything(), expect.anything());
-    });
-
-    it(`should throw an error for unsupported story format`, () => {
-      const storyFormat = 'non-existent-format' as StoryFormat;
-      const expectedMessage = `Unsupported story format: ${storyFormat}`;
-      expect(() => {
-        helpers.copyTemplate('', storyFormat);
-      }).toThrowError(expectedMessage);
-    });
-  });
+  describe('copyTemplate', () => {});
 
   it.each`
     language        | exists          | expected

--- a/lib/cli/src/helpers.test.ts
+++ b/lib/cli/src/helpers.test.ts
@@ -24,7 +24,28 @@ describe('Helpers', () => {
     jest.clearAllMocks();
   });
 
-  describe('copyTemplate', () => {});
+  describe('copyTemplate', () => {
+    it(`should copy template files when directory is present`, () => {
+      const csfDirectory = `template-csf/`;
+      (fs.existsSync as jest.Mock).mockImplementation((filePath) => {
+        return true;
+      });
+      helpers.copyTemplate('');
+
+      const copySyncSpy = jest.spyOn(fse, 'copySync');
+      expect(copySyncSpy).toHaveBeenCalledWith(csfDirectory, expect.anything(), expect.anything());
+    });
+
+    it(`should throw an error if template directory cannot be found`, () => {
+      (fs.existsSync as jest.Mock).mockImplementation((filePath) => {
+        return false;
+      });
+
+      expect(() => {
+        helpers.copyTemplate('');
+      }).toThrowError("Couldn't find template dir");
+    });
+  });
 
   it.each`
     language        | exists          | expected

--- a/lib/cli/src/helpers.ts
+++ b/lib/cli/src/helpers.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import { satisfies } from '@storybook/semver';
 import stripJsonComments from 'strip-json-comments';
 
-import { StoryFormat, SupportedFrameworks, SupportedLanguage } from './project_types';
+import { SupportedFrameworks, SupportedLanguage } from './project_types';
 import { JsPackageManager, PackageJson, PackageJsonWithDepsAndDevDeps } from './js-package-manager';
 
 const logger = console;
@@ -169,17 +169,11 @@ export function addToDevDependenciesIfNotPresent(
   }
 }
 
-export function copyTemplate(templateRoot: string, storyFormat: StoryFormat) {
-  const templateDir = path.resolve(templateRoot, `template-${storyFormat}/`);
+export function copyTemplate(templateRoot: string) {
+  const templateDir = path.resolve(templateRoot, `template-csf/`);
 
   if (!fs.existsSync(templateDir)) {
-    // Fallback to CSF plain first, in case format is typescript but template is not available.
-    if (storyFormat === StoryFormat.CSF_TYPESCRIPT) {
-      copyTemplate(templateRoot, StoryFormat.CSF);
-      return;
-    }
-
-    throw new Error(`Unsupported story format: ${storyFormat}`);
+    throw new Error(`Couldn't find template dir`);
   }
 
   fse.copySync(templateDir, '.', { overwrite: true });

--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -2,14 +2,7 @@ import { UpdateNotifier, Package } from 'update-notifier';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { detect, isStorybookInstalled, detectLanguage } from './detect';
-import {
-  installableProjectTypes,
-  ProjectType,
-  StoryFormat,
-  SupportedLanguage,
-  Builder,
-  CoreBuilder,
-} from './project_types';
+import { installableProjectTypes, ProjectType, Builder, CoreBuilder } from './project_types';
 import { commandLog, codeLog, paddedLog } from './helpers';
 import angularGenerator from './generators/ANGULAR';
 import aureliaGenerator from './generators/AURELIA';
@@ -33,7 +26,6 @@ import preactGenerator from './generators/PREACT';
 import svelteGenerator from './generators/SVELTE';
 import raxGenerator from './generators/RAX';
 import serverGenerator from './generators/SERVER';
-import { warn } from './warn';
 import { JsPackageManagerFactory, readPackageJson } from './js-package-manager';
 import { NpmOptions } from './NpmOptions';
 
@@ -45,7 +37,6 @@ type CommandOptions = {
   force?: any;
   html?: boolean;
   skipInstall?: boolean;
-  storyFormat?: StoryFormat;
   parser?: string;
   yes?: boolean;
   builder?: Builder;
@@ -62,14 +53,8 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
   };
 
   const language = detectLanguage();
-  const hasTSDependency = language === SupportedLanguage.TYPESCRIPT;
-
-  warn({ hasTSDependency });
-
-  const defaultStoryFormat = hasTSDependency ? StoryFormat.CSF_TYPESCRIPT : StoryFormat.CSF;
 
   const generatorOptions = {
-    storyFormat: options.storyFormat || defaultStoryFormat,
     language,
     builder: options.builder || CoreBuilder.Webpack4,
     linkable: !!options.linkable,
@@ -132,9 +117,7 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
               },
             ]) as Promise<{ server: boolean }>)
         )
-          .then(({ server }) =>
-            reactNativeGenerator(packageManager, npmOptions, server, generatorOptions)
-          )
+          .then(({ server }) => reactNativeGenerator(packageManager, npmOptions, server))
           .then(commandLog('Adding Storybook support to your "React Native" app'))
           .then(end)
           .then(() => {
@@ -343,16 +326,8 @@ export function initiate(options: CommandOptions, pkg: Package): Promise<void> {
   }
   done();
 
-  const cleanOptions = { ...options };
-  if (options.storyFormat === StoryFormat.MDX) {
-    logger.warn(
-      '   The MDX CLI template is deprecated. The JS and TS templates already include MDX examples!'
-    );
-    cleanOptions.storyFormat = undefined;
-  }
-
   return installStorybook(projectType, {
-    ...cleanOptions,
+    ...options,
     ...(isEsm ? { commonJs: true } : undefined),
   });
 }

--- a/lib/cli/src/project_types.ts
+++ b/lib/cli/src/project_types.ts
@@ -78,14 +78,6 @@ export const SUPPORTED_FRAMEWORKS: SupportedFrameworks[] = [
   'aurelia',
 ];
 
-export enum StoryFormat {
-  CSF = 'csf',
-  /** @deprecated only template-csf left for some frameworks */
-  CSF_TYPESCRIPT = 'csf-ts',
-  /** @deprecated only template-csf left for some frameworks */
-  MDX = 'mdx',
-}
-
 export enum CoreBuilder {
   Webpack4 = 'webpack4',
   Webpack5 = 'webpack5',


### PR DESCRIPTION
Issue: #15908

## What I did

Removed all traces of the story format parameter to the CLI. The `copyTemplate` helper is now hard-coded to use the `template-csf` directory and the `StoryFormat` enum removed from the codebase.

Stricly speaking, the complete removal of a parameter should be a BREAKING CHANGE, should I have approached this differently?

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

Existing unit tests are updated to reflect new behaviour

- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

I couldn't find any references in the documentation, feel free to point out if I've missed something.

Note: This PR obsoletes #15985 where the last comment was that it would be updated ASAP 28 days ago....