### PR TITLE
CSF: Add error handling for CSF story index generation

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -223,9 +223,9 @@ export default {
   title: foo('bar'),
 };
 
-// ❌ template literals 6.3 OK / 7.0 OK
+// ❌ template literals 6.3 OK / 7.0 KO
 export default {
-  title: foo('bar'),
+  title: `${bar}`,
 };
 ```
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,8 @@
 
 - [From version 6.3.x to 6.4.0](#from-version-63x-to-640)
   - [CSF3 enabled](#csf3-enabled)
+    - [Optional titles](#optional-titles)
+    - [String literal titles](#string-literal-titles)
   - [Story Store v7](#story-store-v7)
     - [Behavioral differences](#behavioral-differences)
     - [Using the v7 store](#using-the-v7-store)
@@ -177,6 +179,56 @@
 
 SB6.3 introduced a feature flag, `features.previewCsfV3`, to opt-in to experimental [CSF3 syntax support](https://storybook.js.org/blog/component-story-format-3-0/). In SB6.4, CSF3 is supported regardless of `previewCsfV3`'s value. This should be a fully backwards-compatible change. The `previewCsfV3` flag has been deprecated and will be removed in SB7.0.
 
+#### Optional titles
+
+In SB6.3 and earlier, component titles were required in CSF default exports. Starting in 6.4, they are optional.
+If you don't specify a component file, it will be inferred from the file's location on disk.
+
+Consider a project configuration `/path/to/project/.storybook/main.js` containing:
+
+```js
+module.exports = { stories: ['../src/**/*.stories.*'] };
+```
+
+And te file `/path/to/project/src/components/Button.stories.tsx` containing the default export:
+
+```js
+import { Button } from './Button';
+export default { component: Button };
+// named exports...
+```
+
+The inferred title of this file will be `components/Button` based on the stories glob in the configuration file.
+We will provide more documentation soon on how to configure this.
+
+#### String literal titles
+
+Starting in 6.4 CSF component [titles are optional](#optional-titles). However, if you do specify titles, title handing is becoming more strict in V7 and are limited to string literals.
+
+Earlier versions of Storybook supported story titles that are dynamic Javascript expressions
+
+```js
+// ✅ string literals 6.3 OK / 7.0 OK
+export default {
+  title: 'Components/Atoms/Button',
+};
+
+// ✅ undefined 6.3 KO / 7.0 OK
+export default {
+  component: Button,
+};
+
+// ❌ expressions: 6.3 OK / 7.0 KO
+export default {
+  title: foo('bar'),
+};
+
+// ❌ template literals 6.3 OK / 7.0 OK
+export default {
+  title: foo('bar'),
+};
+```
+
 ### Story Store v7
 
 SB6.4 introduces an opt-in feature flag, `features.storyStoreV7`, which loads stories in an "on demand" way (that is when rendered), rather than up front when the Storybook is booted. This way of operating will become the default in 7.0 and will likely be switched to opt-out in that version.
@@ -194,7 +246,7 @@ However, the `autoTitle` feature is supported.
 
 The key behavioral differences of the v7 store are:
 
-- `SET_STORIES` is not emitted on boot up. Instead the manager loads the story index independenly.
+- `SET_STORIES` is not emitted on boot up. Instead the manager loads the story index independently.
 - A new event `STORY_PREPARED` is emitted when a story is rendered for the first time, which contains metadata about the story, such as `parameters`.
 - All "entire" store APIs such as `extract()` need to be proceeded by an async call to `loadAllCSFFiles()` which fetches all CSF files and processes them.
 

--- a/lib/codemod/src/transforms/csf-2-to-3.ts
+++ b/lib/codemod/src/transforms/csf-2-to-3.ts
@@ -4,6 +4,8 @@ import * as t from '@babel/types';
 import { CsfFile, formatCsf, loadCsf } from '@storybook/csf-tools';
 import { jscodeshiftToPrettierParser } from '../lib/utils';
 
+const logger = console;
+
 const _rename = (annotation: string) => {
   return annotation === 'storyName' ? 'name' : annotation;
 };
@@ -87,7 +89,14 @@ const isSimpleCSFStory = (init: t.Expression, annotations: t.ObjectProperty[]) =
   annotations.length === 0 && t.isArrowFunctionExpression(init) && init.params.length === 0;
 
 function transform({ source }: { source: string }, api: any, options: { parser?: string }) {
-  const csf = loadCsf(source, { defaultTitle: 'FIXME' }).parse();
+  const csf = loadCsf(source, { defaultTitle: 'FIXME' });
+
+  try {
+    csf.parse();
+  } catch (err) {
+    logger.log(`Error ${err}, skipping`);
+    return source;
+  }
 
   const objectExports: Record<string, t.Statement> = {};
   Object.entries(csf._storyExports).forEach(([key, decl]) => {

--- a/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -109,7 +109,6 @@ export class StoryIndexGenerator {
       entry[absolutePath] = fileStories;
     } catch (err) {
       logger.warn(`🚨 Extraction error on ${relativePath}: ${err}`);
-      logger.warn(`🚨 ${err.stack}`);
       throw err;
     }
   }

--- a/lib/csf-tools/src/CsfFile.test.ts
+++ b/lib/csf-tools/src/CsfFile.test.ts
@@ -9,7 +9,7 @@ expect.addSnapshotSerializer({
   test: (val) => typeof val !== 'string',
 });
 
-const parse = async (code: string, includeParameters?: boolean) => {
+const parse = (code: string, includeParameters?: boolean) => {
   const { stories, meta } = loadCsf(code, { defaultTitle: 'Default Title' }).parse();
   const filtered = includeParameters
     ? stories
@@ -19,9 +19,9 @@ const parse = async (code: string, includeParameters?: boolean) => {
 
 describe('CsfFile', () => {
   describe('basic', () => {
-    it('args stories', async () => {
+    it('args stories', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           export const A = () => {};
@@ -46,9 +46,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('underscores', async () => {
+    it('underscores', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           export const __Basic__ = () => {};
@@ -67,9 +67,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('exclude stories', async () => {
+    it('exclude stories', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar', excludeStories: ['B', 'C'] };
           export const A = () => {};
@@ -89,9 +89,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('include stories', async () => {
+    it('include stories', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar', includeStories: /^Include.*/ };
           export const SomeHelper = () => {};
@@ -108,9 +108,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('storyName annotation', async () => {
+    it('storyName annotation', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           export const A = () => {};
@@ -126,23 +126,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('no meta', async () => {
+    it('no title', () => {
       expect(
-        await parse(
-          dedent`
-          export const A = () => {};
-          export const B = () => {};
-      `
-        )
-      ).toMatchInlineSnapshot(`
-        meta: !<tag:yaml.org,2002:js/undefined> ''
-        stories: []
-      `);
-    });
-
-    it('no title', async () => {
-      expect(
-        await parse(
+        parse(
           dedent`
           export default { component: 'foo' }
           export const A = () => {};
@@ -161,9 +147,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('typescript', async () => {
+    it('typescript', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           import { Meta, Story } from '@storybook/react';
           type PropTypes = {};
@@ -183,9 +169,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('template bind', async () => {
+    it('template bind', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           const Template = (args) => { };
@@ -206,9 +192,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('meta variable', async () => {
+    it('meta variable', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           const meta = { title: 'foo/bar' };
           export default meta;
@@ -228,9 +214,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('docs-only story', async () => {
+    it('docs-only story', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           export const __page = () => {};
@@ -249,6 +235,82 @@ describe('CsfFile', () => {
               __id: foo-bar--page
               docsOnly: true
       `);
+    });
+
+    it('title variable', () => {
+      expect(
+        parse(
+          dedent`
+            const title = 'foo/bar';
+            export default { title };
+            export const A = () => {};
+            export const B = (args) => {};
+        `,
+          true
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+            parameters:
+              __isArgsStory: false
+              __id: foo-bar--a
+          - id: foo-bar--b
+            name: B
+            parameters:
+              __isArgsStory: true
+              __id: foo-bar--b
+      `);
+    });
+  });
+
+  describe('error handling', () => {
+    it('no meta', () => {
+      expect(() =>
+        parse(
+          dedent`
+          export const A = () => {};
+          export const B = () => {};
+      `
+        )
+      ).toThrow('CSF: missing default export');
+    });
+    it('no metadata', () => {
+      expect(() =>
+        parse(
+          dedent`
+          export default { foo: '5' };
+          export const A = () => {};
+          export const B = () => {};
+      `
+        )
+      ).toThrow('CSF: missing title/component');
+    });
+    it('dynamic titles', () => {
+      expect(() =>
+        parse(
+          dedent`
+            export default { title: 'foo' + 'bar' };
+            export const A = () => {};
+        `,
+          true
+        )
+      ).toThrow('CSF: unexpected dynamic title');
+    });
+    it('storiesOf calls', () => {
+      expect(() =>
+        parse(
+          dedent`
+            import { storiesOf } from '@storybook/react';
+            export default { title: 'foo/bar' };
+            export const A = () => {};
+            storiesOf('foo').add('bar', () => <baz />);
+        `,
+          true
+        )
+      ).toThrow('CSF: unexpected storiesOf call');
     });
   });
 
@@ -296,9 +358,9 @@ describe('CsfFile', () => {
   });
 
   describe('CSF3', () => {
-    it('Object export with no-args render', async () => {
+    it('Object export with no-args render', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           export const A = {
@@ -319,9 +381,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('Object export with args render', async () => {
+    it('Object export with args render', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           export const A = {
@@ -342,9 +404,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('Object export with default render', async () => {
+    it('Object export with default render', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           export const A = {}
@@ -363,9 +425,9 @@ describe('CsfFile', () => {
       `);
     });
 
-    it('Object export with name', async () => {
+    it('Object export with name', () => {
       expect(
-        await parse(
+        parse(
           dedent`
           export default { title: 'foo/bar' };
           export const A = {

--- a/lib/csf-tools/src/CsfFile.ts
+++ b/lib/csf-tools/src/CsfFile.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import fs from 'fs-extra';
+import dedent from 'ts-dedent';
 import * as t from '@babel/types';
 import generate from '@babel/generator';
 import traverse from '@babel/traverse';
@@ -35,12 +36,6 @@ function parseIncludeExclude(prop: t.Node) {
   throw new Error(`Unknown include/exclude: ${prop}`);
 }
 
-const parseTitle = (value: any) => {
-  if (t.isStringLiteral(value)) return value.value;
-  logger.warn(`Unexpected meta.title: ${JSON.stringify(value)}`);
-  return undefined;
-};
-
 const findVarInitialization = (identifier: string, program: t.Program) => {
   let init: t.Expression = null;
   let declarations: t.VariableDeclarator[] = null;
@@ -67,6 +62,11 @@ const findVarInitialization = (identifier: string, program: t.Program) => {
     );
   });
   return init;
+};
+
+const formatLocation = (node: t.Node, fileName?: string) => {
+  const { line, column } = node.loc.start;
+  return `${fileName || ''} (line ${line}, col ${column})`.trim();
 };
 
 const isArgsStory = (init: t.Expression, parent: t.Node, csf: CsfFile) => {
@@ -102,11 +102,14 @@ const isArgsStory = (init: t.Expression, parent: t.Node, csf: CsfFile) => {
 
 export interface CsfOptions {
   defaultTitle: string;
+  fileName?: string;
 }
 export class CsfFile {
   _ast: t.File;
 
   _defaultTitle: string;
+
+  _fileName: string;
 
   _meta?: Meta;
 
@@ -120,19 +123,32 @@ export class CsfFile {
 
   _templates: Record<string, t.Expression> = {};
 
-  constructor(ast: t.File, { defaultTitle }: CsfOptions) {
+  constructor(ast: t.File, { defaultTitle, fileName }: CsfOptions) {
     this._ast = ast;
     this._defaultTitle = defaultTitle;
+    this._fileName = fileName;
   }
 
-  _parseMeta(declaration: t.ObjectExpression) {
+  _parseTitle(value: t.Node) {
+    const node = t.isIdentifier(value)
+      ? findVarInitialization(value.name, this._ast.program)
+      : value;
+    if (t.isStringLiteral(node)) return node.value;
+    throw new Error(dedent`
+      CSF: unexpected dynamic title ${formatLocation(node, this._fileName)}
+
+      More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#string-literal-titles
+    `);
+  }
+
+  _parseMeta(declaration: t.ObjectExpression, program: t.Program) {
     const meta: Meta = {};
     declaration.properties.forEach((p: t.ObjectProperty) => {
       if (t.isIdentifier(p.key)) {
         this._metaAnnotations[p.key.name] = p.value;
 
         if (p.key.name === 'title') {
-          meta.title = parseTitle(p.value);
+          meta.title = this._parseTitle(p.value);
         } else if (['includeStories', 'excludeStories'].includes(p.key.name)) {
           // @ts-ignore
           meta[p.key.name] = parseIncludeExclude(p.value);
@@ -171,8 +187,8 @@ export class CsfFile {
             }
           }
 
-          if (!self._meta && metaNode) {
-            self._parseMeta(metaNode);
+          if (!self._meta && metaNode && t.isProgram(parent)) {
+            self._parseMeta(metaNode, parent);
           }
         },
       },
@@ -263,36 +279,57 @@ export class CsfFile {
           }
         },
       },
+      CallExpression: {
+        enter({ node }) {
+          const { callee } = node;
+          if (t.isIdentifier(callee) && callee.name === 'storiesOf') {
+            throw new Error(dedent`
+              CSF: unexpected storiesOf call ${formatLocation(node, self._fileName)}
+
+              More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#story-store-v7
+            `);
+          }
+        },
+      },
     });
 
-    // default export can come at any point in the file, so we do this post processing last
-    if (self._meta?.title || self._meta?.component) {
-      const entries = Object.entries(self._stories);
-      self._meta.title = self._meta.title || this._defaultTitle;
-      self._stories = entries.reduce((acc, [key, story]) => {
-        if (isExportStory(key, self._meta)) {
-          const id = toId(self._meta.title, storyNameFromExport(key));
-          const parameters: Record<string, any> = { ...story.parameters, __id: id };
-          if (entries.length === 1 && key === '__page') {
-            parameters.docsOnly = true;
-          }
-          acc[key] = { ...story, id, parameters };
-        }
-        return acc;
-      }, {} as Record<string, Story>);
+    if (!self._meta) {
+      throw new Error(dedent`
+        CSF: missing default export ${formatLocation(self._ast, self._fileName)}
 
-      Object.keys(self._storyExports).forEach((key) => {
-        if (!isExportStory(key, self._meta)) {
-          delete self._storyExports[key];
-          delete self._storyAnnotations[key];
-        }
-      });
-    } else {
-      // no meta = no stories
-      self._stories = {};
-      self._storyExports = {};
-      self._storyAnnotations = {};
+        More info: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+      `);
     }
+
+    if (!self._meta.title && !self._meta.component) {
+      throw new Error(dedent`
+        CSF: missing title/component ${formatLocation(self._ast, self._fileName)}
+
+        More info: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+      `);
+    }
+
+    // default export can come at any point in the file, so we do this post processing last
+    const entries = Object.entries(self._stories);
+    self._meta.title = self._meta.title || this._defaultTitle;
+    self._stories = entries.reduce((acc, [key, story]) => {
+      if (isExportStory(key, self._meta)) {
+        const id = toId(self._meta.title, storyNameFromExport(key));
+        const parameters: Record<string, any> = { ...story.parameters, __id: id };
+        if (entries.length === 1 && key === '__page') {
+          parameters.docsOnly = true;
+        }
+        acc[key] = { ...story, id, parameters };
+      }
+      return acc;
+    }, {} as Record<string, Story>);
+
+    Object.keys(self._storyExports).forEach((key) => {
+      if (!isExportStory(key, self._meta)) {
+        delete self._storyExports[key];
+        delete self._storyAnnotations[key];
+      }
+    });
 
     return self;
   }
@@ -318,9 +355,11 @@ export const formatCsf = (csf: CsfFile) => {
 
 export const readCsf = async (fileName: string, options: CsfOptions) => {
   const code = (await fs.readFile(fileName, 'utf-8')).toString();
-  return loadCsf(code, options);
+  return loadCsf(code, { ...options, fileName });
 };
 
-export const writeCsf = async (fileName: string, csf: CsfFile) => {
+export const writeCsf = async (csf: CsfFile, fileName?: string) => {
+  const fname = fileName || csf._fileName;
+  if (!fname) throw new Error('Please specify a fileName for writeCsf');
   await fs.writeFile(fileName, await formatCsf(csf));
 };

--- a/lib/csf-tools/src/index.ts
+++ b/lib/csf-tools/src/index.ts
@@ -9,7 +9,7 @@ export const readCsfOrMdx = async (fileName: string, options: CsfOptions) => {
   if (fileName.endsWith('.mdx')) {
     code = await mdx(code, { compilers: [createCompiler({})] });
   }
-  return loadCsf(code, options);
+  return loadCsf(code, { ...options, fileName });
 };
 
 export * from './CsfFile';


### PR DESCRIPTION
Issue: #16221 

## What I did

Add error handling for:
- [x] dynamic titles
- [x] storiesOf calls
- [x] missing default exports
- [x] default exports missing title & component

Also:
- [x] Added test cases
- [x] Don't log the full stack in story index generation to reduce noise

Add migrations for dynamic titles & title inference

## How to test

Add `features.buildStoriesJson` to `official-storybook` 