### PR TITLE
CLI: Don't upgrade preset-create-react-app if react-scripts < 5

### DIFF
--- a/lib/cli/src/upgrade.test.ts
+++ b/lib/cli/src/upgrade.test.ts
@@ -1,4 +1,4 @@
-import { getStorybookVersion, isCorePackage } from './upgrade';
+import { addExtraFlags, getStorybookVersion, isCorePackage } from './upgrade';
 
 describe.each([
   ['│ │ │ ├── @babel/code-frame@7.10.3 deduped', null],
@@ -34,5 +34,41 @@ describe.each([
   // eslint-disable-next-line jest/valid-title
   it(input, () => {
     expect(isCorePackage(input)).toEqual(output);
+  });
+});
+
+describe('extra flags', () => {
+  const extraFlags = {
+    'react-scripts@<5': ['--foo'],
+  };
+  const devDependencies = {};
+  it('package matches constraints', () => {
+    expect(
+      addExtraFlags(extraFlags, [], { dependencies: { 'react-scripts': '4' }, devDependencies })
+    ).toEqual(['--foo']);
+  });
+  it('package prerelease matches constraints', () => {
+    expect(
+      addExtraFlags(extraFlags, [], {
+        dependencies: { 'react-scripts': '4.0.0-alpha.0' },
+        devDependencies,
+      })
+    ).toEqual(['--foo']);
+  });
+  it('package not matches constraints', () => {
+    expect(
+      addExtraFlags(extraFlags, [], {
+        dependencies: { 'react-scripts': '5.0.0-alpha.0' },
+        devDependencies,
+      })
+    ).toEqual([]);
+  });
+  it('no package not matches constraints', () => {
+    expect(
+      addExtraFlags(extraFlags, [], {
+        dependencies: {},
+        devDependencies,
+      })
+    ).toEqual([]);
   });
 });

--- a/lib/cli/src/upgrade.ts
+++ b/lib/cli/src/upgrade.ts
@@ -1,7 +1,11 @@
 import { sync as spawnSync } from 'cross-spawn';
 import semver from '@storybook/semver';
 import { logger } from '@storybook/node-logger';
-import { JsPackageManagerFactory } from './js-package-manager';
+import {
+  getPackageDetails,
+  JsPackageManagerFactory,
+  PackageJsonWithDepsAndDevDeps,
+} from './js-package-manager';
 import { commandLog } from './helpers';
 
 type Package = {
@@ -91,16 +95,43 @@ export const checkVersionConsistency = () => {
   });
 };
 
+type ExtraFlags = Record<string, string[]>;
+const EXTRA_FLAGS: ExtraFlags = {
+  'react-scripts@<5': ['--reject', '/preset-create-react-app/'],
+};
+
+export const addExtraFlags = (
+  extraFlags: ExtraFlags,
+  flags: string[],
+  { dependencies, devDependencies }: PackageJsonWithDepsAndDevDeps
+) => {
+  return Object.entries(extraFlags).reduce(
+    (acc, entry) => {
+      const [pattern, extra] = entry;
+      const [pkg, specifier] = getPackageDetails(pattern);
+      const pkgVersion = dependencies[pkg] || devDependencies[pkg];
+
+      if (pkgVersion && semver.satisfies(semver.coerce(pkgVersion), specifier)) {
+        return [...acc, ...extra];
+      }
+
+      return acc;
+    },
+    [...flags]
+  );
+};
+
 type Options = { prerelease: boolean; skipCheck: boolean; useNpm: boolean; dryRun: boolean };
 export const upgrade = async ({ prerelease, skipCheck, useNpm, dryRun }: Options) => {
   const packageManager = JsPackageManagerFactory.getPackageManager(useNpm);
 
   commandLog(`Checking for latest versions of '@storybook/*' packages`);
 
-  const flags = [];
+  let flags = [];
   if (!dryRun) flags.push('--upgrade');
   flags.push('--target');
   flags.push(prerelease ? 'greatest' : 'latest');
+  flags = addExtraFlags(EXTRA_FLAGS, flags, packageManager.retrievePackageJson());
   const check = spawnSync('npx', ['npm-check-updates', '/storybook/', ...flags], {
     stdio: 'pipe',
   }).output.toString();


### PR DESCRIPTION
Issue: #16253

## What I did

Fix broken CRA4 upgrade

Self-merging @tmeasday 

## How to test

- [ ] See attached tests
- [ ] Run `upgrade` in a CRA4 project
