### PR TITLE
Args: Re-render the whole container when args or globals change

### DIFF
--- a/examples/react-ts/main.ts
+++ b/examples/react-ts/main.ts
@@ -21,7 +21,7 @@ const config: StorybookConfig = {
   },
   features: {
     postcss: false,
-    modernInlineRender: true,
+    // modernInlineRender: true,
     storyStoreV7: true,
     buildStoriesJson: true,
     babelModeV7: true,

--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -578,6 +578,21 @@ describe('PreviewWeb', () => {
 
       expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_RENDERED, 'component-one--a');
     });
+
+    describe('in docs mode', () => {
+      it('re-renders the docs container', async () => {
+        document.location.search = '?id=component-one--a&viewMode=docs';
+
+        await new PreviewWeb({ importFn, fetchStoryIndex }).initialize({ getProjectAnnotations });
+        await waitForRender();
+
+        mockChannel.emit.mockClear();
+        emitter.emit(Events.UPDATE_GLOBALS, { globals: { foo: 'bar' } });
+        await waitForRender();
+
+        expect(ReactDOM.render).toHaveBeenCalledTimes(2);
+      });
+    });
   });
 
   describe('onUpdateArgs', () => {
@@ -806,6 +821,24 @@ describe('PreviewWeb', () => {
 
         // Now let the runPlayFunction call resolve
         openGate();
+      });
+    });
+
+    describe('in docs mode', () => {
+      it('re-renders the docs container', async () => {
+        document.location.search = '?id=component-one--a&viewMode=docs';
+
+        await new PreviewWeb({ importFn, fetchStoryIndex }).initialize({ getProjectAnnotations });
+        await waitForRender();
+
+        mockChannel.emit.mockClear();
+        emitter.emit(Events.UPDATE_STORY_ARGS, {
+          storyId: 'component-one--a',
+          updatedArgs: { new: 'arg' },
+        });
+        await waitForRender();
+
+        expect(ReactDOM.render).toHaveBeenCalledTimes(2);
       });
     });
   });

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -319,7 +319,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
     }
 
     if (selection.viewMode === 'docs' || story.parameters.docsOnly) {
-      await this.renderDocs({ story });
+      this.previousCleanup = await this.renderDocs({ story });
     } else {
       this.previousCleanup = this.renderStory({ story });
     }
@@ -368,18 +368,43 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       docs.container || (({ children }: { children: Element }) => <>{children}</>);
     const Page: ComponentType = docs.page || NoDocs;
 
-    // Use `componentId` as a key so that we force a re-render every time
-    // we switch components
-    const docsElement = (
-      <DocsContainer key={componentId} context={docsContext}>
-        <Page />
-      </DocsContainer>
-    );
+    const render = () => {
+      // Use `componentId` as a key so that we force a re-render every time
+      // we switch components
+      const docsElement = (
+        <DocsContainer key={componentId} context={docsContext}>
+          <Page />
+        </DocsContainer>
+      );
 
-    ReactDOM.render(docsElement, element, async () => {
-      await Promise.all(renderingStoryPromises);
-      this.channel.emit(Events.DOCS_RENDERED, id);
-    });
+      ReactDOM.render(docsElement, element, async () => {
+        await Promise.all(renderingStoryPromises);
+        this.channel.emit(Events.DOCS_RENDERED, id);
+      });
+    };
+
+    // Initially render right away
+    render();
+
+    // Listen to events and re-render
+    // NOTE: we aren't checking to see the story args are targetted at the "right" story.
+    // This is because we may render >1 story on the page and there is no easy way to keep track
+    // of which ones were rendered by the docs page.
+    // However, in `modernInlineRender`, the individual stories track their own events as they
+    // each call `renderStoryToElement` below.
+    if (!global?.FEATURES?.modernInlineRender) {
+      this.channel.on(Events.UPDATE_GLOBALS, render);
+      this.channel.on(Events.UPDATE_STORY_ARGS, render);
+      this.channel.on(Events.RESET_STORY_ARGS, render);
+    }
+
+    return () => {
+      if (!global?.FEATURES?.modernInlineRender) {
+        this.channel.off(Events.UPDATE_GLOBALS, render);
+        this.channel.off(Events.UPDATE_STORY_ARGS, render);
+        this.channel.off(Events.RESET_STORY_ARGS, render);
+      }
+    };
   }
 
   renderStory({ story }: { story: Story<TFramework> }) {
@@ -563,7 +588,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       ReactDOM.unmountComponentAtNode(this.view.docsRoot());
     }
 
-    if (previousViewMode === 'story') {
+    if (previousViewMode) {
       this.previousCleanup();
     }
   }


### PR DESCRIPTION
Issue: #16154

## What I did

Update `PreviewWeb` to re-render the docs container on args/globals changes (in v6 inline mode).

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

Yes, added tests
