### PR TITLE
Addon-docs: Fix args passing for inline rendering (e.g. for vue)

### DIFF
--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -85,6 +85,7 @@ export const getStoryProps = <TFramework extends AnyFramework>(
       ...context.getStoryContext(story),
       loaded: {},
     });
+
   return {
     inline: storyIsInline,
     id: story.id,
@@ -92,7 +93,7 @@ export const getStoryProps = <TFramework extends AnyFramework>(
     title: storyName,
     ...(storyIsInline && {
       parameters,
-      storyFn: () => prepareForInline(boundStoryFn, story),
+      storyFn: () => prepareForInline(boundStoryFn, context.getStoryContext(story)),
     }),
   };
 };


### PR DESCRIPTION
Issue: #16223 

## What I did

Pass the full context including `args` to the inline rendering function, which was missing in the old code.

Self-merging @tmeasday 

## How to test

- [x] This should fix the broken e2e test in CI
