### PR TITLE
Addon-docs: Always render the `children` of the `Canvas` component

### DIFF
--- a/addons/docs/src/blocks/Canvas.tsx
+++ b/addons/docs/src/blocks/Canvas.tsx
@@ -70,9 +70,14 @@ export const Canvas: FC<CanvasProps> = (props) => {
   const sourceContext = useContext(SourceContext);
   const { isLoading, previewProps } = getPreviewProps(props, docsContext, sourceContext);
   const { children } = props;
-  return isLoading ? null : (
+  return (
     <MDXProvider components={resetComponents}>
-      <PurePreview {...previewProps}>{children}</PurePreview>
+      {/* We use `isLoading` as a key here to make a new instance of the PurePreview when we have
+          the proper set of props for the Preview. Otherwise, the preview will store an incorrect
+          value for the sourceState into its internal state. */}
+      <PurePreview key={isLoading.toString()} {...previewProps}>
+        {children}
+      </PurePreview>
     </MDXProvider>
   );
 };

--- a/cypress/generated/addon-docs.spec.ts
+++ b/cypress/generated/addon-docs.spec.ts
@@ -20,7 +20,7 @@ describe('addon-action', () => {
       .click();
 
     cy.getDocsElement()
-      .find('code.language-jsx')
+      .find('pre.prismjs')
       .first()
       .should(($div) => {
         const text = $div.text();

--- a/cypress/generated/addon-docs.spec.ts
+++ b/cypress/generated/addon-docs.spec.ts
@@ -12,5 +12,19 @@ describe('addon-action', () => {
 
     // inline story rendering
     cy.getDocsElement().find('button').should('contain.text', 'Button');
+
+    cy.getDocsElement()
+      .find('.docblock-code-toggle')
+      .first()
+      .should('contain.text', 'Show code')
+      .click();
+
+    cy.getDocsElement()
+      .find('code.language-jsx')
+      .first()
+      .should(($div) => {
+        const text = $div.text();
+        expect(text).not.match(/^\(args\) => /);
+      });
   });
 });


### PR DESCRIPTION
Issue: #16162

## What I did

Use a different technique to avoid "fixing" a value for `sourceState` of the `Preview` component.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?

@shilman is going to add an E2E test for this 🙏 
