### PR TITLE
add ability to skip cypress tests based on framework

### DIFF
--- a/cypress/generated/addon-docs.spec.ts
+++ b/cypress/generated/addon-docs.spec.ts
@@ -1,30 +1,36 @@
+import { skipOn } from '@cypress/skip-test';
+
 describe('addon-action', () => {
-  before(() => {
+  beforeEach(() => {
     cy.visitStorybook();
+    cy.navigateToStory('example-button', 'primary');
+    cy.viewAddonTab('Docs');
   });
 
   it('should have docs tab', () => {
-    cy.navigateToStory('example-button', 'primary');
-    cy.viewAddonTab('Docs');
-
     // MDX rendering
     cy.getDocsElement().find('h1').should('contain.text', 'Button');
 
     // inline story rendering
     cy.getDocsElement().find('button').should('contain.text', 'Button');
+  });
 
-    cy.getDocsElement()
-      .find('.docblock-code-toggle')
-      .first()
-      .should('contain.text', 'Show code')
-      .click();
+  skipOn('vue3', () => {
+    it('should provide source snippet', () => {
+      cy.getDocsElement()
+        .find('.docblock-code-toggle')
+        .first()
+        .should('contain.text', 'Show code')
+        // use force click so cypress does not automatically scroll, making the source block visible on this step
+        .click({ force: true });
 
-    cy.getDocsElement()
-      .find('pre.prismjs')
-      .first()
-      .should(($div) => {
-        const text = $div.text();
-        expect(text).not.match(/^\(args\) => /);
-      });
+      cy.getDocsElement()
+        .find('pre.prismjs')
+        .first()
+        .should(($div) => {
+          const text = $div.text();
+          expect(text).not.match(/^\(args\) => /);
+        });
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -313,6 +313,7 @@
     }
   },
   "optionalDependencies": {
+    "@cypress/skip-test": "^2.6.1",
     "@cypress/webpack-preprocessor": "^5.7.0",
     "cypress": "6.8.0",
     "puppeteer": "^2.1.1",

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -56,7 +56,7 @@ const serveStorybook = async ({ cwd }: Options, port: string) => {
 const runCypress = async (location: string, name: string) => {
   const cypressCommand = openCypressInUIMode ? 'open' : 'run';
   await exec(
-    `yarn cypress ${cypressCommand} --config pageLoadTimeout=4000,execTimeout=4000,taskTimeout=4000,responseTimeout=4000,defaultCommandTimeout=4000,integrationFolder="cypress/generated",videosFolder="/tmp/cypress-record/${name}" --env location="${location}"`,
+    `CYPRESS_ENVIRONMENT=${name} yarn cypress ${cypressCommand} --config pageLoadTimeout=4000,execTimeout=4000,taskTimeout=4000,responseTimeout=4000,defaultCommandTimeout=4000,integrationFolder="cypress/generated",videosFolder="/tmp/cypress-record/${name}" --env location="${location}"`,
     { cwd: rootDir },
     {
       startMessage: `🤖 Running Cypress tests`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4068,6 +4068,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cypress/skip-test@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "@cypress/skip-test@npm:2.6.1"
+  checksum: 1d0d2cb4b3094c6dee2d2339b75d60f85e5fb17b4e281cbee854e6cd4a124fad61cc65db8335b9a169ccc24b490df5b29c3385f09fa590124dc4d5b57e110019
+  languageName: node
+  linkType: hard
+
 "@cypress/webpack-preprocessor@npm:^5.7.0":
   version: 5.7.0
   resolution: "@cypress/webpack-preprocessor@npm:5.7.0"
@@ -6835,18 +6842,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-a11y@6.4.0-beta.6, @storybook/addon-a11y@workspace:*, @storybook/addon-a11y@workspace:addons/a11y":
+"@storybook/addon-a11y@6.4.0-beta.7, @storybook/addon-a11y@workspace:*, @storybook/addon-a11y@workspace:addons/a11y":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-a11y@workspace:addons/a11y"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/channels": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/channels": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/theming": 6.4.0-beta.7
     "@testing-library/react": ^11.2.2
     "@types/webpack-env": ^1.16.0
     axe-core: ^4.2.0
@@ -6868,16 +6875,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-actions@6.4.0-beta.6, @storybook/addon-actions@workspace:*, @storybook/addon-actions@workspace:addons/actions":
+"@storybook/addon-actions@6.4.0-beta.7, @storybook/addon-actions@workspace:*, @storybook/addon-actions@workspace:addons/actions":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-actions@workspace:addons/actions"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/theming": 6.4.0-beta.7
     "@types/lodash": ^4.14.167
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -6902,17 +6909,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-backgrounds@6.4.0-beta.6, @storybook/addon-backgrounds@workspace:*, @storybook/addon-backgrounds@workspace:addons/backgrounds":
+"@storybook/addon-backgrounds@6.4.0-beta.7, @storybook/addon-backgrounds@workspace:*, @storybook/addon-backgrounds@workspace:addons/backgrounds":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-backgrounds@workspace:addons/backgrounds"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/theming": 6.4.0-beta.7
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -6931,18 +6938,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-controls@6.4.0-beta.6, @storybook/addon-controls@workspace:*, @storybook/addon-controls@workspace:addons/controls":
+"@storybook/addon-controls@6.4.0-beta.7, @storybook/addon-controls@workspace:*, @storybook/addon-controls@workspace:addons/controls":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-controls@workspace:addons/controls"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/store": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/store": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     core-js: ^3.8.2
     lodash: ^4.17.20
     ts-dedent: ^2.0.0
@@ -6957,7 +6964,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-docs@6.4.0-beta.6, @storybook/addon-docs@workspace:*, @storybook/addon-docs@workspace:addons/docs":
+"@storybook/addon-docs@6.4.0-beta.7, @storybook/addon-docs@workspace:*, @storybook/addon-docs@workspace:addons/docs":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-docs@workspace:addons/docs"
   dependencies:
@@ -6973,27 +6980,27 @@ __metadata:
     "@mdx-js/loader": ^1.6.22
     "@mdx-js/mdx": ^1.6.22
     "@mdx-js/react": ^1.6.22
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/angular": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/builder-webpack4": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/angular": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/builder-webpack4": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/csf-tools": 6.4.0-beta.6
-    "@storybook/html": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/postinstall": 6.4.0-beta.6
-    "@storybook/preview-web": 6.4.0-beta.6
-    "@storybook/react": 6.4.0-beta.6
-    "@storybook/source-loader": 6.4.0-beta.6
-    "@storybook/store": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
-    "@storybook/vue": 6.4.0-beta.6
-    "@storybook/web-components": 6.4.0-beta.6
+    "@storybook/csf-tools": 6.4.0-beta.7
+    "@storybook/html": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/postinstall": 6.4.0-beta.7
+    "@storybook/preview-web": 6.4.0-beta.7
+    "@storybook/react": 6.4.0-beta.7
+    "@storybook/source-loader": 6.4.0-beta.7
+    "@storybook/store": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
+    "@storybook/vue": 6.4.0-beta.7
+    "@storybook/web-components": 6.4.0-beta.7
     "@types/cross-spawn": ^6.0.2
     "@types/doctrine": ^0.0.3
     "@types/enzyme": ^3.10.8
@@ -7044,12 +7051,12 @@ __metadata:
     webpack: 4
     zone.js: ^0.11.3
   peerDependencies:
-    "@storybook/angular": 6.4.0-beta.6
-    "@storybook/html": 6.4.0-beta.6
-    "@storybook/react": 6.4.0-beta.6
-    "@storybook/vue": 6.4.0-beta.6
-    "@storybook/vue3": 6.4.0-beta.6
-    "@storybook/web-components": 6.4.0-beta.6
+    "@storybook/angular": 6.4.0-beta.7
+    "@storybook/html": 6.4.0-beta.7
+    "@storybook/react": 6.4.0-beta.7
+    "@storybook/vue": 6.4.0-beta.7
+    "@storybook/vue3": 6.4.0-beta.7
+    "@storybook/web-components": 6.4.0-beta.7
     lit: ^2.0.0-rc.1
     lit-html: ^1.4.1 || ^2.0.0-rc.3
     react: ^16.8.0 || ^17.0.0
@@ -7090,23 +7097,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-essentials@6.4.0-beta.6, @storybook/addon-essentials@workspace:*, @storybook/addon-essentials@workspace:addons/essentials":
+"@storybook/addon-essentials@6.4.0-beta.7, @storybook/addon-essentials@workspace:*, @storybook/addon-essentials@workspace:addons/essentials":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-essentials@workspace:addons/essentials"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/addon-measure": 6.4.0-beta.6
-    "@storybook/addon-outline": 6.4.0-beta.6
-    "@storybook/addon-toolbars": 6.4.0-beta.6
-    "@storybook/addon-viewport": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/vue": 6.4.0-beta.6
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/addon-measure": 6.4.0-beta.7
+    "@storybook/addon-outline": 6.4.0-beta.7
+    "@storybook/addon-toolbars": 6.4.0-beta.7
+    "@storybook/addon-viewport": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/vue": 6.4.0-beta.7
     "@types/jest": ^26.0.16
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -7114,8 +7121,8 @@ __metadata:
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
-    "@storybook/vue": 6.4.0-beta.6
-    "@storybook/web-components": 6.4.0-beta.6
+    "@storybook/vue": 6.4.0-beta.7
+    "@storybook/web-components": 6.4.0-beta.7
     babel-loader: ^8.0.0
     lit-html: ^1.4.1 || ^2.0.0-rc.3
     react: ^16.8.0 || ^17.0.0
@@ -7154,15 +7161,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-jest@6.4.0-beta.6, @storybook/addon-jest@workspace:*, @storybook/addon-jest@workspace:addons/jest":
+"@storybook/addon-jest@6.4.0-beta.7, @storybook/addon-jest@workspace:*, @storybook/addon-jest@workspace:addons/jest":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-jest@workspace:addons/jest"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -7180,15 +7187,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-links@6.4.0-beta.6, @storybook/addon-links@workspace:*, @storybook/addon-links@workspace:addons/links":
+"@storybook/addon-links@6.4.0-beta.7, @storybook/addon-links@workspace:*, @storybook/addon-links@workspace:addons/links":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-links@workspace:addons/links"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/router": 6.4.0-beta.6
+    "@storybook/router": 6.4.0-beta.7
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -7208,15 +7215,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-measure@6.4.0-beta.6, @storybook/addon-measure@workspace:*, @storybook/addon-measure@workspace:addons/measure":
+"@storybook/addon-measure@6.4.0-beta.7, @storybook/addon-measure@workspace:*, @storybook/addon-measure@workspace:addons/measure":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-measure@workspace:addons/measure"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -7232,15 +7239,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-outline@6.4.0-beta.6, @storybook/addon-outline@workspace:*, @storybook/addon-outline@workspace:addons/outline":
+"@storybook/addon-outline@6.4.0-beta.7, @storybook/addon-outline@workspace:*, @storybook/addon-outline@workspace:addons/outline":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-outline@workspace:addons/outline"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -7271,20 +7278,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-storyshots-puppeteer@6.4.0-beta.6, @storybook/addon-storyshots-puppeteer@workspace:*, @storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer":
+"@storybook/addon-storyshots-puppeteer@6.4.0-beta.7, @storybook/addon-storyshots-puppeteer@workspace:*, @storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": ^4.2.0
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/node-logger": 6.4.0-beta.6
+    "@storybook/node-logger": 6.4.0-beta.7
     "@types/jest-image-snapshot": ^4.1.3
     "@types/puppeteer": ^5.4.0
     core-js: ^3.8.2
     jest-image-snapshot: ^4.3.0
     regenerator-runtime: ^0.13.7
   peerDependencies:
-    "@storybook/addon-storyshots": 6.4.0-beta.6
+    "@storybook/addon-storyshots": 6.4.0-beta.7
     puppeteer: ^2.0.0 || ^3.0.0
   peerDependenciesMeta:
     puppeteer:
@@ -7292,24 +7299,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-storyshots@6.4.0-beta.6, @storybook/addon-storyshots@workspace:*, @storybook/addon-storyshots@workspace:addons/storyshots/storyshots-core":
+"@storybook/addon-storyshots@6.4.0-beta.7, @storybook/addon-storyshots@workspace:*, @storybook/addon-storyshots@workspace:addons/storyshots/storyshots-core":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-storyshots@workspace:addons/storyshots/storyshots-core"
   dependencies:
     "@angular/core": ^11.2.0
     "@angular/platform-browser-dynamic": ^11.2.0
     "@jest/transform": ^26.6.2
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/angular": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-client": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/angular": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-client": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/react": 6.4.0-beta.6
-    "@storybook/vue": 6.4.0-beta.6
-    "@storybook/vue3": 6.4.0-beta.6
+    "@storybook/react": 6.4.0-beta.7
+    "@storybook/vue": 6.4.0-beta.7
+    "@storybook/vue3": 6.4.0-beta.7
     "@types/glob": ^7.1.3
     "@types/jest": ^26.0.16
     "@types/jest-specific-snapshot": ^0.5.3
@@ -7383,17 +7390,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-storysource@6.4.0-beta.6, @storybook/addon-storysource@workspace:*, @storybook/addon-storysource@workspace:addons/storysource":
+"@storybook/addon-storysource@6.4.0-beta.7, @storybook/addon-storysource@workspace:*, @storybook/addon-storysource@workspace:addons/storysource":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-storysource@workspace:addons/storysource"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/router": 6.4.0-beta.6
-    "@storybook/source-loader": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/router": 6.4.0-beta.7
+    "@storybook/source-loader": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     "@types/react": ^16.14.2
     "@types/react-syntax-highlighter": ^11.0.5
     core-js: ^3.8.2
@@ -7414,14 +7421,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-toolbars@6.4.0-beta.6, @storybook/addon-toolbars@workspace:*, @storybook/addon-toolbars@workspace:addons/toolbars":
+"@storybook/addon-toolbars@6.4.0-beta.7, @storybook/addon-toolbars@workspace:*, @storybook/addon-toolbars@workspace:addons/toolbars":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-toolbars@workspace:addons/toolbars"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
   peerDependencies:
@@ -7435,16 +7442,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-viewport@6.4.0-beta.6, @storybook/addon-viewport@workspace:*, @storybook/addon-viewport@workspace:addons/viewport":
+"@storybook/addon-viewport@6.4.0-beta.7, @storybook/addon-viewport@workspace:*, @storybook/addon-viewport@workspace:addons/viewport":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-viewport@workspace:addons/viewport"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -7461,17 +7468,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addons@6.4.0-beta.6, @storybook/addons@workspace:*, @storybook/addons@workspace:lib/addons":
+"@storybook/addons@6.4.0-beta.7, @storybook/addons@workspace:*, @storybook/addons@workspace:lib/addons":
   version: 0.0.0-use.local
   resolution: "@storybook/addons@workspace:lib/addons"
   dependencies:
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/channels": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/channels": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/router": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/router": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     core-js: ^3.8.2
     global: ^4.4.0
     regenerator-runtime: ^0.13.7
@@ -7481,7 +7488,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/angular@6.4.0-beta.6, @storybook/angular@workspace:*, @storybook/angular@workspace:app/angular":
+"@storybook/angular@6.4.0-beta.7, @storybook/angular@workspace:*, @storybook/angular@workspace:app/angular":
   version: 0.0.0-use.local
   resolution: "@storybook/angular@workspace:app/angular"
   dependencies:
@@ -7497,14 +7504,14 @@ __metadata:
     "@angular/platform-browser": ^11.2.14
     "@angular/platform-browser-dynamic": ^11.2.14
     "@nrwl/workspace": ^11.6.3
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/store": 6.4.0-beta.7
     "@types/autoprefixer": ^9.7.2
     "@types/jest": ^26.0.16
     "@types/webpack-env": ^1.16.0
@@ -7563,18 +7570,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/api@6.4.0-beta.6, @storybook/api@workspace:*, @storybook/api@workspace:lib/api":
+"@storybook/api@6.4.0-beta.7, @storybook/api@workspace:*, @storybook/api@workspace:lib/api":
   version: 0.0.0-use.local
   resolution: "@storybook/api@workspace:lib/api"
   dependencies:
     "@reach/router": ^1.3.4
-    "@storybook/channels": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/channels": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/router": 6.4.0-beta.6
+    "@storybook/router": 6.4.0-beta.7
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/theming": 6.4.0-beta.7
     "@types/lodash": ^4.14.167
     "@types/reach__router": ^1.3.7
     "@types/semver": ^7.3.4
@@ -7597,7 +7604,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/builder-webpack4@6.4.0-beta.6, @storybook/builder-webpack4@workspace:lib/builder-webpack4":
+"@storybook/builder-webpack4@6.4.0-beta.7, @storybook/builder-webpack4@workspace:lib/builder-webpack4":
   version: 0.0.0-use.local
   resolution: "@storybook/builder-webpack4@workspace:lib/builder-webpack4"
   dependencies:
@@ -7622,22 +7629,22 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/channel-postmessage": 6.4.0-beta.6
-    "@storybook/channels": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/preview-web": 6.4.0-beta.6
-    "@storybook/router": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/channel-postmessage": 6.4.0-beta.7
+    "@storybook/channels": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/preview-web": 6.4.0-beta.7
+    "@storybook/router": 6.4.0-beta.7
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
-    "@storybook/ui": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
+    "@storybook/ui": 6.4.0-beta.7
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/node": ^14.0.10
     "@types/react-dev-utils": ^9.0.4
@@ -7686,7 +7693,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/builder-webpack5@6.4.0-beta.6, @storybook/builder-webpack5@workspace:lib/builder-webpack5":
+"@storybook/builder-webpack5@6.4.0-beta.7, @storybook/builder-webpack5@workspace:lib/builder-webpack5":
   version: 0.0.0-use.local
   resolution: "@storybook/builder-webpack5@workspace:lib/builder-webpack5"
   dependencies:
@@ -7710,21 +7717,21 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/channel-postmessage": 6.4.0-beta.6
-    "@storybook/channels": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/preview-web": 6.4.0-beta.6
-    "@storybook/router": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/channel-postmessage": 6.4.0-beta.7
+    "@storybook/channels": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/preview-web": 6.4.0-beta.7
+    "@storybook/router": 6.4.0-beta.7
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/node": ^14.0.10
     "@types/react-dev-utils": ^9.0.4
@@ -7761,13 +7768,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/channel-postmessage@6.4.0-beta.6, @storybook/channel-postmessage@workspace:*, @storybook/channel-postmessage@workspace:lib/channel-postmessage":
+"@storybook/channel-postmessage@6.4.0-beta.7, @storybook/channel-postmessage@workspace:*, @storybook/channel-postmessage@workspace:lib/channel-postmessage":
   version: 0.0.0-use.local
   resolution: "@storybook/channel-postmessage@workspace:lib/channel-postmessage"
   dependencies:
-    "@storybook/channels": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/channels": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
@@ -7779,14 +7786,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/channel-websocket@workspace:lib/channel-websocket"
   dependencies:
-    "@storybook/channels": 6.4.0-beta.6
+    "@storybook/channels": 6.4.0-beta.7
     core-js: ^3.8.2
     global: ^4.4.0
     telejson: ^5.3.2
   languageName: unknown
   linkType: soft
 
-"@storybook/channels@6.4.0-beta.6, @storybook/channels@workspace:*, @storybook/channels@workspace:lib/channels":
+"@storybook/channels@6.4.0-beta.7, @storybook/channels@workspace:*, @storybook/channels@workspace:lib/channels":
   version: 0.0.0-use.local
   resolution: "@storybook/channels@workspace:lib/channels"
   dependencies:
@@ -7796,17 +7803,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/cli@6.4.0-beta.6, @storybook/cli@workspace:*, @storybook/cli@workspace:lib/cli":
+"@storybook/cli@6.4.0-beta.7, @storybook/cli@workspace:*, @storybook/cli@workspace:lib/cli":
   version: 0.0.0-use.local
   resolution: "@storybook/cli@workspace:lib/cli"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/preset-env": ^7.12.11
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/codemod": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
-    "@storybook/csf-tools": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/codemod": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
+    "@storybook/csf-tools": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
     "@storybook/semver": ^7.3.2
     "@types/cross-spawn": ^6.0.2
     "@types/prompts": ^2.0.9
@@ -7843,17 +7850,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/client-api@6.4.0-beta.6, @storybook/client-api@workspace:*, @storybook/client-api@workspace:lib/client-api":
+"@storybook/client-api@6.4.0-beta.7, @storybook/client-api@workspace:*, @storybook/client-api@workspace:lib/client-api":
   version: 0.0.0-use.local
   resolution: "@storybook/client-api@workspace:lib/client-api"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/channel-postmessage": 6.4.0-beta.6
-    "@storybook/channels": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/channel-postmessage": 6.4.0-beta.7
+    "@storybook/channels": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -7872,7 +7879,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/client-logger@6.4.0-beta.6, @storybook/client-logger@workspace:*, @storybook/client-logger@workspace:lib/client-logger":
+"@storybook/client-logger@6.4.0-beta.7, @storybook/client-logger@workspace:*, @storybook/client-logger@workspace:lib/client-logger":
   version: 0.0.0-use.local
   resolution: "@storybook/client-logger@workspace:lib/client-logger"
   dependencies:
@@ -7881,15 +7888,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/codemod@6.4.0-beta.6, @storybook/codemod@workspace:*, @storybook/codemod@workspace:lib/codemod":
+"@storybook/codemod@6.4.0-beta.7, @storybook/codemod@workspace:*, @storybook/codemod@workspace:lib/codemod":
   version: 0.0.0-use.local
   resolution: "@storybook/codemod@workspace:lib/codemod"
   dependencies:
     "@babel/types": ^7.12.11
     "@mdx-js/mdx": ^1.6.22
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/csf-tools": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
+    "@storybook/csf-tools": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
     core-js: ^3.8.2
     cross-spawn: ^7.0.3
     globby: ^11.0.2
@@ -7903,14 +7910,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/components@6.4.0-beta.6, @storybook/components@workspace:*, @storybook/components@workspace:lib/components":
+"@storybook/components@6.4.0-beta.7, @storybook/components@workspace:*, @storybook/components@workspace:lib/components":
   version: 0.0.0-use.local
   resolution: "@storybook/components@workspace:lib/components"
   dependencies:
     "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.4.0-beta.6
+    "@storybook/client-logger": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/theming": 6.4.0-beta.7
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -7939,19 +7946,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-client@6.4.0-beta.6, @storybook/core-client@workspace:lib/core-client":
+"@storybook/core-client@6.4.0-beta.7, @storybook/core-client@workspace:lib/core-client":
   version: 0.0.0-use.local
   resolution: "@storybook/core-client@workspace:lib/core-client"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/channel-postmessage": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/channel-postmessage": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/preview-web": 6.4.0-beta.6
-    "@storybook/store": 6.4.0-beta.6
-    "@storybook/ui": 6.4.0-beta.6
+    "@storybook/preview-web": 6.4.0-beta.7
+    "@storybook/store": 6.4.0-beta.7
+    "@storybook/ui": 6.4.0-beta.7
     airbnb-js-shims: ^2.2.1
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
@@ -7972,7 +7979,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-common@6.4.0-beta.6, @storybook/core-common@workspace:lib/core-common":
+"@storybook/core-common@6.4.0-beta.7, @storybook/core-common@workspace:lib/core-common":
   version: 0.0.0-use.local
   resolution: "@storybook/core-common@workspace:lib/core-common"
   dependencies:
@@ -7997,7 +8004,7 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.4.0-beta.6
+    "@storybook/node-logger": 6.4.0-beta.7
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
     "@storybook/semver": ^7.3.2
     "@types/compression": ^1.7.0
@@ -8039,7 +8046,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-events@6.4.0-beta.6, @storybook/core-events@workspace:*, @storybook/core-events@workspace:lib/core-events":
+"@storybook/core-events@6.4.0-beta.7, @storybook/core-events@workspace:*, @storybook/core-events@workspace:lib/core-events":
   version: 0.0.0-use.local
   resolution: "@storybook/core-events@workspace:lib/core-events"
   dependencies:
@@ -8047,21 +8054,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-server@6.4.0-beta.6, @storybook/core-server@workspace:lib/core-server":
+"@storybook/core-server@6.4.0-beta.7, @storybook/core-server@workspace:lib/core-server":
   version: 0.0.0-use.local
   resolution: "@storybook/core-server@workspace:lib/core-server"
   dependencies:
     "@discoveryjs/json-ext": ^0.5.3
-    "@storybook/builder-webpack4": 6.4.0-beta.6
-    "@storybook/builder-webpack5": 6.4.0-beta.6
-    "@storybook/core-client": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/builder-webpack4": 6.4.0-beta.7
+    "@storybook/builder-webpack5": 6.4.0-beta.7
+    "@storybook/core-client": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/csf-tools": 6.4.0-beta.6
-    "@storybook/manager-webpack4": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
+    "@storybook/csf-tools": 6.4.0-beta.7
+    "@storybook/manager-webpack4": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
     "@types/compression": ^1.7.0
     "@types/ip": ^1.1.0
     "@types/node": ^14.0.10
@@ -8094,8 +8101,8 @@ __metadata:
     watchpack: ^2.2.0
     webpack: 4
   peerDependencies:
-    "@storybook/builder-webpack5": 6.4.0-beta.6
-    "@storybook/manager-webpack5": 6.4.0-beta.6
+    "@storybook/builder-webpack5": 6.4.0-beta.7
+    "@storybook/manager-webpack5": 6.4.0-beta.7
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -8108,14 +8115,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core@6.4.0-beta.6, @storybook/core@workspace:*, @storybook/core@workspace:lib/core":
+"@storybook/core@6.4.0-beta.7, @storybook/core@workspace:*, @storybook/core@workspace:lib/core":
   version: 0.0.0-use.local
   resolution: "@storybook/core@workspace:lib/core"
   dependencies:
-    "@storybook/core-client": 6.4.0-beta.6
-    "@storybook/core-server": 6.4.0-beta.6
+    "@storybook/core-client": 6.4.0-beta.7
+    "@storybook/core-server": 6.4.0-beta.7
   peerDependencies:
-    "@storybook/builder-webpack5": 6.4.0-beta.6
+    "@storybook/builder-webpack5": 6.4.0-beta.7
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
     webpack: "*"
@@ -8127,7 +8134,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf-tools@6.4.0-beta.6, @storybook/csf-tools@workspace:*, @storybook/csf-tools@workspace:lib/csf-tools":
+"@storybook/csf-tools@6.4.0-beta.7, @storybook/csf-tools@workspace:*, @storybook/csf-tools@workspace:lib/csf-tools":
   version: 0.0.0-use.local
   resolution: "@storybook/csf-tools@workspace:lib/csf-tools"
   dependencies:
@@ -8197,14 +8204,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/ember@6.4.0-beta.6, @storybook/ember@workspace:*, @storybook/ember@workspace:app/ember":
+"@storybook/ember@6.4.0-beta.7, @storybook/ember@workspace:*, @storybook/ember@workspace:app/ember":
   version: 0.0.0-use.local
   resolution: "@storybook/ember@workspace:app/ember"
   dependencies:
     "@ember/test-helpers": ^2.1.4
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
+    "@storybook/store": 6.4.0-beta.7
     core-js: ^3.8.2
     global: ^4.4.0
     react: 16.14.0
@@ -8237,10 +8244,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/example-react-ts-webpack4@workspace:examples/react-ts-webpack4"
   dependencies:
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-essentials": 6.4.0-beta.6
-    "@storybook/builder-webpack4": 6.4.0-beta.6
-    "@storybook/react": 6.4.0-beta.6
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-essentials": 6.4.0-beta.7
+    "@storybook/builder-webpack4": 6.4.0-beta.7
+    "@storybook/react": 6.4.0-beta.7
     "@types/react": ^16.14.2
     "@types/react-dom": ^16.9.10
     prop-types: 15.7.2
@@ -8258,12 +8265,12 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addon-essentials": 6.4.0-beta.6
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/addon-storysource": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/react": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/addon-essentials": 6.4.0-beta.7
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/addon-storysource": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/react": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     "@testing-library/dom": ^7.31.2
     "@testing-library/user-event": ^13.1.9
     "@types/babel__preset-env": ^7
@@ -8279,17 +8286,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/html@6.4.0-beta.6, @storybook/html@workspace:*, @storybook/html@workspace:app/html":
+"@storybook/html@6.4.0-beta.7, @storybook/html@workspace:*, @storybook/html@workspace:app/html":
   version: 0.0.0-use.local
   resolution: "@storybook/html@workspace:app/html"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/preview-web": 6.4.0-beta.6
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/preview-web": 6.4.0-beta.7
+    "@storybook/store": 6.4.0-beta.7
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -8336,19 +8343,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack4@6.4.0-beta.6, @storybook/manager-webpack4@workspace:lib/manager-webpack4":
+"@storybook/manager-webpack4@6.4.0-beta.7, @storybook/manager-webpack4@workspace:lib/manager-webpack4":
   version: 0.0.0-use.local
   resolution: "@storybook/manager-webpack4@workspace:lib/manager-webpack4"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/core-client": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
-    "@storybook/ui": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/core-client": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
+    "@storybook/ui": 6.4.0-beta.7
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/node": ^14.0.10
     "@types/terser-webpack-plugin": ^5.0.2
@@ -8396,12 +8403,12 @@ __metadata:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/core-client": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
-    "@storybook/ui": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/core-client": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
+    "@storybook/ui": 6.4.0-beta.7
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/node": ^14.0.10
     "@types/terser-webpack-plugin": ^5.0.2
@@ -8438,7 +8445,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/node-logger@6.4.0-beta.6, @storybook/node-logger@workspace:*, @storybook/node-logger@workspace:lib/node-logger":
+"@storybook/node-logger@6.4.0-beta.7, @storybook/node-logger@workspace:*, @storybook/node-logger@workspace:lib/node-logger":
   version: 0.0.0-use.local
   resolution: "@storybook/node-logger@workspace:lib/node-logger"
   dependencies:
@@ -8477,7 +8484,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/postinstall@6.4.0-beta.6, @storybook/postinstall@workspace:*, @storybook/postinstall@workspace:lib/postinstall":
+"@storybook/postinstall@6.4.0-beta.7, @storybook/postinstall@workspace:*, @storybook/postinstall@workspace:lib/postinstall":
   version: 0.0.0-use.local
   resolution: "@storybook/postinstall@workspace:lib/postinstall"
   dependencies:
@@ -8488,16 +8495,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/preact@6.4.0-beta.6, @storybook/preact@workspace:*, @storybook/preact@workspace:app/preact":
+"@storybook/preact@6.4.0-beta.7, @storybook/preact@workspace:*, @storybook/preact@workspace:app/preact":
   version: 0.0.0-use.local
   resolution: "@storybook/preact@workspace:app/preact"
   dependencies:
     "@babel/plugin-transform-react-jsx": ^7.12.12
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -8548,16 +8555,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/preview-web@6.4.0-beta.6, @storybook/preview-web@workspace:*, @storybook/preview-web@workspace:lib/preview-web":
+"@storybook/preview-web@6.4.0-beta.7, @storybook/preview-web@workspace:*, @storybook/preview-web@workspace:lib/preview-web":
   version: 0.0.0-use.local
   resolution: "@storybook/preview-web@workspace:lib/preview-web"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/channel-postmessage": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/channel-postmessage": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
@@ -8591,22 +8598,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react@6.4.0-beta.6, @storybook/react@workspace:*, @storybook/react@workspace:app/react":
+"@storybook/react@6.4.0-beta.7, @storybook/react@workspace:*, @storybook/react@workspace:app/react":
   version: 0.0.0-use.local
   resolution: "@storybook/react@workspace:app/react"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.1
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/node-logger": 6.4.0-beta.6
+    "@storybook/node-logger": 6.4.0-beta.7
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
     "@types/node": ^14.14.20
     "@types/prompts": ^2.0.9
     "@types/webpack-env": ^1.16.0
@@ -8661,6 +8668,7 @@ __metadata:
     "@babel/preset-typescript": ^7.12.7
     "@babel/runtime": ^7.12.5
     "@compodoc/compodoc": ^1.1.14
+    "@cypress/skip-test": ^2.6.1
     "@cypress/webpack-preprocessor": ^5.7.0
     "@emotion/snapshot-serializer": ^0.8.2
     "@nicolo-ribaudo/chokidar-2": ^2.1.8
@@ -8824,6 +8832,8 @@ __metadata:
   dependenciesMeta:
     "@compodoc/compodoc":
       built: false
+    "@cypress/skip-test":
+      optional: true
     "@cypress/webpack-preprocessor":
       optional: true
     core-js:
@@ -8860,12 +8870,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/router@6.4.0-beta.6, @storybook/router@workspace:*, @storybook/router@workspace:lib/router":
+"@storybook/router@6.4.0-beta.7, @storybook/router@workspace:*, @storybook/router@workspace:lib/router":
   version: 0.0.0-use.local
   resolution: "@storybook/router@workspace:lib/router"
   dependencies:
     "@reach/router": ^1.3.4
-    "@storybook/client-logger": 6.4.0-beta.6
+    "@storybook/client-logger": 6.4.0-beta.7
     "@types/reach__router": ^1.3.7
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -8892,19 +8902,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/server@6.4.0-beta.6, @storybook/server@workspace:*, @storybook/server@workspace:app/server":
+"@storybook/server@6.4.0-beta.7, @storybook/server@workspace:*, @storybook/server@workspace:app/server":
   version: 0.0.0-use.local
   resolution: "@storybook/server@workspace:app/server"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/preview-web": 6.4.0-beta.6
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/preview-web": 6.4.0-beta.7
+    "@storybook/store": 6.4.0-beta.7
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     fs-extra: ^9.0.1
@@ -8924,12 +8934,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/source-loader@6.4.0-beta.6, @storybook/source-loader@workspace:*, @storybook/source-loader@workspace:lib/source-loader":
+"@storybook/source-loader@6.4.0-beta.7, @storybook/source-loader@workspace:*, @storybook/source-loader@workspace:lib/source-loader":
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
     core-js: ^3.8.2
     estraverse: ^5.2.0
@@ -8944,13 +8954,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/store@6.4.0-beta.6, @storybook/store@workspace:*, @storybook/store@workspace:lib/store":
+"@storybook/store@6.4.0-beta.7, @storybook/store@workspace:*, @storybook/store@workspace:lib/store":
   version: 0.0.0-use.local
   resolution: "@storybook/store@workspace:lib/store"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -8965,15 +8975,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/svelte@6.4.0-beta.6, @storybook/svelte@workspace:*, @storybook/svelte@workspace:app/svelte":
+"@storybook/svelte@6.4.0-beta.7, @storybook/svelte@workspace:*, @storybook/svelte@workspace:app/svelte":
   version: 0.0.0-use.local
   resolution: "@storybook/svelte@workspace:app/svelte"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -8996,14 +9006,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/theming@6.4.0-beta.6, @storybook/theming@workspace:*, @storybook/theming@workspace:lib/theming":
+"@storybook/theming@6.4.0-beta.7, @storybook/theming@workspace:*, @storybook/theming@workspace:lib/theming":
   version: 0.0.0-use.local
   resolution: "@storybook/theming@workspace:lib/theming"
   dependencies:
     "@emotion/core": ^10.1.1
     "@emotion/is-prop-valid": ^0.8.6
     "@emotion/styled": ^10.0.27
-    "@storybook/client-logger": 6.4.0-beta.6
+    "@storybook/client-logger": 6.4.0-beta.7
     core-js: ^3.8.2
     deep-object-diff: ^1.1.0
     emotion-theming: ^10.0.27
@@ -9018,21 +9028,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/ui@6.4.0-beta.6, @storybook/ui@workspace:*, @storybook/ui@workspace:lib/ui":
+"@storybook/ui@6.4.0-beta.7, @storybook/ui@workspace:*, @storybook/ui@workspace:lib/ui":
   version: 0.0.0-use.local
   resolution: "@storybook/ui@workspace:lib/ui"
   dependencies:
     "@babel/core": ^7.12.10
     "@emotion/core": ^10.1.1
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/api": 6.4.0-beta.6
-    "@storybook/channels": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
-    "@storybook/router": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/api": 6.4.0-beta.7
+    "@storybook/channels": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
+    "@storybook/router": 6.4.0-beta.7
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/theming": 6.4.0-beta.7
     "@testing-library/react": ^11.2.2
     babel-loader: ^8.0.0
     chromatic: ^5.6.0
@@ -9064,15 +9074,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/vue3@6.4.0-beta.6, @storybook/vue3@workspace:app/vue3":
+"@storybook/vue3@6.4.0-beta.7, @storybook/vue3@workspace:app/vue3":
   version: 0.0.0-use.local
   resolution: "@storybook/vue3@workspace:app/vue3"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
     "@types/node": ^14.14.20
     "@types/webpack-env": ^1.16.0
     "@vue/compiler-sfc": ^3.0.0
@@ -9101,15 +9111,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/vue@6.4.0-beta.6, @storybook/vue@workspace:*, @storybook/vue@workspace:app/vue":
+"@storybook/vue@6.4.0-beta.7, @storybook/vue@workspace:*, @storybook/vue@workspace:app/vue":
   version: 0.0.0-use.local
   resolution: "@storybook/vue@workspace:app/vue"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/store": 6.4.0-beta.7
     "@types/node": ^14.14.20
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -9140,20 +9150,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/web-components@6.4.0-beta.6, @storybook/web-components@workspace:*, @storybook/web-components@workspace:app/web-components":
+"@storybook/web-components@6.4.0-beta.7, @storybook/web-components@workspace:*, @storybook/web-components@workspace:app/web-components":
   version: 0.0.0-use.local
   resolution: "@storybook/web-components@workspace:app/web-components"
   dependencies:
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
     "@babel/plugin-syntax-import-meta": ^7.10.4
     "@babel/preset-env": ^7.12.11
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-common": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-common": 6.4.0-beta.7
     "@storybook/csf": 0.0.2--canary.6aca495.0
-    "@storybook/preview-web": 6.4.0-beta.6
-    "@storybook/store": 6.4.0-beta.6
+    "@storybook/preview-web": 6.4.0-beta.7
+    "@storybook/store": 6.4.0-beta.7
     "@types/webpack-env": ^1.16.0
     babel-plugin-bundled-import-meta: ^0.3.1
     core-js: ^3.8.2
@@ -12803,18 +12813,18 @@ __metadata:
     "@angular/platform-browser-dynamic": ^11.2.14
     "@compodoc/compodoc": ^1.1.14
     "@ngrx/store": ^10.1.2
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/addon-jest": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/addon-storysource": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/angular": 6.4.0-beta.6
-    "@storybook/source-loader": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/addon-jest": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/addon-storysource": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/angular": 6.4.0-beta.7
+    "@storybook/source-loader": 6.4.0-beta.7
     "@types/core-js": ^2.5.4
     "@types/jest": ^26.0.16
     "@types/node": ^14.14.20
@@ -17909,20 +17919,20 @@ __metadata:
   resolution: "cra-kitchen-sink@workspace:examples/cra-kitchen-sink"
   dependencies:
     "@pmmmwh/react-refresh-webpack-plugin": ^0.4.3
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
     "@storybook/addon-ie11": 0.0.7--canary.5e87b64.0
-    "@storybook/addon-jest": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/builder-webpack4": 6.4.0-beta.6
-    "@storybook/client-logger": 6.4.0-beta.6
+    "@storybook/addon-jest": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/builder-webpack4": 6.4.0-beta.7
+    "@storybook/client-logger": 6.4.0-beta.7
     "@storybook/preset-create-react-app": ^3.1.6
-    "@storybook/react": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/react": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     global: ^4.4.0
     prop-types: ^15.7.2
     react: 16.14.0
@@ -17937,14 +17947,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cra-react15@workspace:examples/cra-react15"
   dependencies:
-    "@storybook/addon-actions": 6.4.0-beta.6
+    "@storybook/addon-actions": 6.4.0-beta.7
     "@storybook/addon-ie11": 0.0.7--canary.5e87b64.0
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/builder-webpack4": 6.4.0-beta.6
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/builder-webpack4": 6.4.0-beta.7
     "@storybook/preset-create-react-app": ^3.1.6
-    "@storybook/react": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/react": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     babel-core: 6
     babel-loader: ^8.0.0
     babel-runtime: 6
@@ -17961,12 +17971,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cra-ts-essentials@workspace:examples/cra-ts-essentials"
   dependencies:
-    "@storybook/addon-essentials": 6.4.0-beta.6
+    "@storybook/addon-essentials": 6.4.0-beta.7
     "@storybook/addon-ie11": 0.0.7--canary.5e87b64.0
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/builder-webpack4": 6.4.0-beta.6
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/builder-webpack4": 6.4.0-beta.7
     "@storybook/preset-create-react-app": ^3.1.6
-    "@storybook/react": 6.4.0-beta.6
+    "@storybook/react": 6.4.0-beta.7
     "@types/jest": ^26.0.16
     "@types/node": 14.14.20
     "@types/react": ^16.14.2
@@ -17984,15 +17994,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cra-ts-kitchen-sink@workspace:examples/cra-ts-kitchen-sink"
   dependencies:
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
     "@storybook/addon-ie11": 0.0.7--canary.5e87b64.0
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/builder-webpack4": 6.4.0-beta.6
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/builder-webpack4": 6.4.0-beta.7
     "@storybook/preset-create-react-app": ^3.1.6
-    "@storybook/react": 6.4.0-beta.6
+    "@storybook/react": 6.4.0-beta.7
     "@types/enzyme": ^3.10.8
     "@types/jest": 25.2.3
     "@types/node": 14.14.20
@@ -20551,18 +20561,18 @@ __metadata:
   dependencies:
     "@babel/core": ^7.12.10
     "@ember/optional-features": ^2.0.0
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addon-storysource": 6.4.0-beta.6
-    "@storybook/addon-viewport": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/ember": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addon-storysource": 6.4.0-beta.7
+    "@storybook/addon-viewport": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/ember": 6.4.0-beta.7
     "@storybook/ember-cli-storybook": ^0.2.1
-    "@storybook/source-loader": 6.4.0-beta.6
+    "@storybook/source-loader": 6.4.0-beta.7
     babel-loader: ^8.0.0
     broccoli-asset-rev: ^3.0.0
     cross-env: ^7.0.3
@@ -25269,23 +25279,23 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "html-kitchen-sink@workspace:examples/html-kitchen-sink"
   dependencies:
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/addon-jest": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/addon-jest": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
     "@storybook/addon-postcss": ^2.0.0
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/addon-storysource": 6.4.0-beta.6
-    "@storybook/addon-viewport": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/client-api": 6.4.0-beta.6
-    "@storybook/core": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
-    "@storybook/html": 6.4.0-beta.6
-    "@storybook/source-loader": 6.4.0-beta.6
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/addon-storysource": 6.4.0-beta.7
+    "@storybook/addon-viewport": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/client-api": 6.4.0-beta.7
+    "@storybook/core": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
+    "@storybook/html": 6.4.0-beta.7
+    "@storybook/source-loader": 6.4.0-beta.7
     autoprefixer: ^10.0.1
     eventemitter3: ^4.0.7
     format-json: ^1.0.3
@@ -33184,27 +33194,27 @@ fsevents@^1.2.7:
   dependencies:
     "@packtracker/webpack-plugin": ^2.3.0
     "@pmmmwh/react-refresh-webpack-plugin": ^0.4.3
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/addon-jest": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/addon-storyshots-puppeteer": 6.4.0-beta.6
-    "@storybook/addon-storysource": 6.4.0-beta.6
-    "@storybook/addon-toolbars": 6.4.0-beta.6
-    "@storybook/addon-viewport": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/cli": 6.4.0-beta.6
-    "@storybook/components": 6.4.0-beta.6
-    "@storybook/core-events": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/addon-jest": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/addon-storyshots-puppeteer": 6.4.0-beta.7
+    "@storybook/addon-storysource": 6.4.0-beta.7
+    "@storybook/addon-toolbars": 6.4.0-beta.7
+    "@storybook/addon-viewport": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/cli": 6.4.0-beta.7
+    "@storybook/components": 6.4.0-beta.7
+    "@storybook/core-events": 6.4.0-beta.7
     "@storybook/design-system": ^5.4.7
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/react": 6.4.0-beta.6
-    "@storybook/source-loader": 6.4.0-beta.6
-    "@storybook/theming": 6.4.0-beta.6
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/react": 6.4.0-beta.7
+    "@storybook/source-loader": 6.4.0-beta.7
+    "@storybook/theming": 6.4.0-beta.7
     "@testing-library/dom": ^7.31.2
     "@testing-library/user-event": ^13.1.9
     chromatic: ^5.6.0
@@ -36140,16 +36150,16 @@ fsevents@^1.2.7:
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-runtime": ^7.12.10
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/addon-storysource": 6.4.0-beta.6
-    "@storybook/addon-viewport": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/preact": 6.4.0-beta.6
-    "@storybook/source-loader": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/addon-storysource": 6.4.0-beta.7
+    "@storybook/addon-viewport": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/preact": 6.4.0-beta.7
+    "@storybook/source-loader": 6.4.0-beta.7
     "@types/prop-types": ^15.7.3
     "@types/react": ^17
     "@types/react-dom": ^17
@@ -39935,7 +39945,7 @@ resolve@1.19.0:
   version: 0.0.0-use.local
   resolution: "sb@workspace:lib/cli-sb"
   dependencies:
-    "@storybook/cli": 6.4.0-beta.6
+    "@storybook/cli": 6.4.0-beta.7
   bin:
     sb: ./index.js
   languageName: unknown
@@ -40262,13 +40272,13 @@ resolve@1.19.0:
   version: 0.0.0-use.local
   resolution: "server-kitchen-sink@workspace:examples/server-kitchen-sink"
   dependencies:
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/node-logger": 6.4.0-beta.6
-    "@storybook/server": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/node-logger": 6.4.0-beta.7
+    "@storybook/server": 6.4.0-beta.7
     concurrently: ^5.3.0
     cors: ^2.8.5
     express: ~4.17.1
@@ -41231,8 +41241,8 @@ resolve@1.19.0:
   version: 0.0.0-use.local
   resolution: "standalone-preview@workspace:examples/standalone-preview"
   dependencies:
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/react": 6.4.0-beta.6
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/react": 6.4.0-beta.7
     parcel: ^1.12.4
     react: 16.14.0
     react-dom: 16.14.0
@@ -41359,7 +41369,7 @@ resolve@1.19.0:
   version: 0.0.0-use.local
   resolution: "storybook@workspace:lib/cli-storybook"
   dependencies:
-    "@storybook/cli": 6.4.0-beta.6
+    "@storybook/cli": 6.4.0-beta.7
   bin:
     sb: ./index.js
     storybook: ./index.js
@@ -42087,18 +42097,18 @@ resolve@1.19.0:
   version: 0.0.0-use.local
   resolution: "svelte-example@workspace:examples/svelte-kitchen-sink"
   dependencies:
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/addon-storysource": 6.4.0-beta.6
-    "@storybook/addon-viewport": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/source-loader": 6.4.0-beta.6
-    "@storybook/svelte": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/addon-storysource": 6.4.0-beta.7
+    "@storybook/addon-viewport": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/source-loader": 6.4.0-beta.7
+    "@storybook/svelte": 6.4.0-beta.7
     global: ^4.4.0
     svelte-jester: 1.3.0
     svelte-preprocess: 4.6.8
@@ -44893,11 +44903,11 @@ resolve@1.19.0:
   resolution: "vue-3-cli-example@workspace:examples/vue-3-cli"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-essentials": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/vue3": 6.4.0-beta.6
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-essentials": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/vue3": 6.4.0-beta.7
     "@vue/cli-plugin-babel": ~4.5.0
     "@vue/cli-plugin-typescript": ~4.5.0
     "@vue/cli-service": ~4.5.0
@@ -44924,11 +44934,11 @@ resolve@1.19.0:
   version: 0.0.0-use.local
   resolution: "vue-cli-example@workspace:examples/vue-cli"
   dependencies:
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-essentials": 6.4.0-beta.6
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-essentials": 6.4.0-beta.7
     "@storybook/preset-scss": ^1.0.3
-    "@storybook/source-loader": 6.4.0-beta.6
-    "@storybook/vue": 6.4.0-beta.6
+    "@storybook/source-loader": 6.4.0-beta.7
+    "@storybook/vue": 6.4.0-beta.7
     "@vue/cli-plugin-babel": ~4.3.1
     "@vue/cli-plugin-typescript": ~4.3.1
     "@vue/cli-service": ~4.3.1
@@ -44980,18 +44990,18 @@ resolve@1.19.0:
   resolution: "vue-example@workspace:examples/vue-kitchen-sink"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addon-a11y": 6.4.0-beta.6
-    "@storybook/addon-actions": 6.4.0-beta.6
-    "@storybook/addon-backgrounds": 6.4.0-beta.6
-    "@storybook/addon-controls": 6.4.0-beta.6
-    "@storybook/addon-docs": 6.4.0-beta.6
-    "@storybook/addon-links": 6.4.0-beta.6
-    "@storybook/addon-storyshots": 6.4.0-beta.6
-    "@storybook/addon-storysource": 6.4.0-beta.6
-    "@storybook/addon-viewport": 6.4.0-beta.6
-    "@storybook/addons": 6.4.0-beta.6
-    "@storybook/source-loader": 6.4.0-beta.6
-    "@storybook/vue": 6.4.0-beta.6
+    "@storybook/addon-a11y": 6.4.0-beta.7
+    "@storybook/addon-actions": 6.4.0-beta.7
+    "@storybook/addon-backgrounds": 6.4.0-beta.7
+    "@storybook/addon-controls": 6.4.0-beta.7
+    "@storybook/addon-docs": 6.4.0-beta.7
+    "@storybook/addon-links": 6.4.0-beta.7
+    "@storybook/addon-storyshots": 6.4.0-beta.7
+    "@storybook/addon-storysource": 6.4.0-beta.7
+    "@storybook/addon-viewport": 6.4.0-beta.7
+    "@storybook/addons": 6.4.0-beta.7
+    "@storybook/source-loader": 6.4.0-beta.7
+    "@storybook/vue": 6.4.0-beta.7
     "@vue/babel-preset-jsx": ^1.2.4
     babel-loader: ^8.0.0
     cross-env: ^7.0.3


### PR DESCRIPTION
Issue: N/A

## What I did

This PR adds a way to skip certain specs based on frameworks, such as skipping dynamic rendering spec on `vue3`, which does not have dynamic rendering.

The command uses `name` which is defined in [here like this](https://github.com/storybookjs/storybook/blob/next/lib/cli/src/repro-generators/configs.ts#L35).

## How to test

- Clone the repo
- Install the deps
- Spin up verdaccio: `yarn local-registry --port 6000 --open --publish`
- On another terminal, run `yarn test:e2e-framework` and select vue3
- Select addon-docs spec
- It should skip vue3, but should run for other frameworks

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation? As a followup, we should have an "E2E testing" improvement story so we can iron out some frustrations when running stuff locally + add some guidance docs.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
