### PR TITLE
Core: Fix multiple invalidations

### DIFF
--- a/lib/core-server/src/utils/stories-json.test.ts
+++ b/lib/core-server/src/utils/stories-json.test.ts
@@ -156,6 +156,30 @@ describe('useStoriesJson', () => {
       const onChange = watcher.on.mock.calls[0][1];
 
       onChange('src/nested/Button.stories.ts');
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(write).toHaveBeenCalledWith('event:INVALIDATE\ndata:\n\n');
+    });
+
+    it('only sends one invalidation when multiple event listeners are listening', async () => {
+      await useStoriesJson(router, options, options.configDir);
+
+      expect(use).toHaveBeenCalledTimes(1);
+      const route = use.mock.calls[0][1];
+
+      await route(request, response);
+      await route(request, { ...response, write: jest.fn() });
+
+      expect(write).not.toHaveBeenCalled();
+
+      expect(Watchpack).toHaveBeenCalledTimes(1);
+      const watcher = Watchpack.mock.instances[0];
+      expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src'] });
+
+      expect(watcher.on).toHaveBeenCalledTimes(2);
+      const onChange = watcher.on.mock.calls[0][1];
+
+      onChange('src/nested/Button.stories.ts');
+      expect(write).toHaveBeenCalledTimes(1);
       expect(write).toHaveBeenCalledWith('event:INVALIDATE\ndata:\n\n');
     });
   });

--- a/lib/core-server/src/utils/stories-json.test.ts
+++ b/lib/core-server/src/utils/stories-json.test.ts
@@ -166,8 +166,11 @@ describe('useStoriesJson', () => {
       expect(use).toHaveBeenCalledTimes(1);
       const route = use.mock.calls[0][1];
 
-      await route(request, response);
-      await route(request, { ...response, write: jest.fn() });
+      // Don't wait for the first request here before starting the second
+      await Promise.all([
+        route(request, response),
+        route(request, { ...response, write: jest.fn() }),
+      ]);
 
       expect(write).not.toHaveBeenCalled();
 

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -47,6 +47,7 @@ export async function useStoriesJson(
   const invalidationEmitter = new EventEmitter();
   async function ensureStarted() {
     if (started) return;
+    started = true;
 
     watchStorySpecifiers(normalizedStories, (specifier, path, removed) => {
       generator.invalidate(specifier, path, removed);
@@ -54,7 +55,6 @@ export async function useStoriesJson(
     });
 
     await generator.initialize();
-    started = true;
   }
 
   const eventsAsSSE = useEventsAsSSE(invalidationEmitter, [INVALIDATE]);


### PR DESCRIPTION
Issue: #16267

## What I did

Fix some egregious bugs in our `watchpack` handler => `INVALIDATE` event code that led to (many many) invalidations being emitted on file rename.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
Yes I have tests

## Follow on

Note that after this change, we still emit **two** `INVALIDATE` events whenever a rename happens, which leads to both the manager + preview doing **two** fetches for the new `stories.json`, with some associated weirdness (for instance, for some reason we end up emitting **three** `STORY_UNCHANGED` events, rather than two, not sure why).

However, at least in `react-ts` I can't actually detect any obvious user-visible artifacts from all that so this "issue" appears solved. 

Ideally we would only emit one[1] `INVALIDATE` for a single file rename, or even for more complex things like a whole directory worth of files being added or removed. In order to do that we'd need to add some debouncing somewhere. The options are:

1. In `watchpack`. It has an [`aggregateTimeout` option](https://www.npmjs.com/package/watchpack), but in my experiments, the info it gives you on that callback isn't detailed enough to invalidate efficiently.

2. In our `watch-story-specifiers` function (in node).

3. On the client side code, so we still emit a bunch of `INVALIDATE`s, but we only re-fetch on a debounced schedule.

I'm inclined to go with 2, but I can see the argument for 3. 

I also don't know about the priority of this (renaming or moving files around is sort of a rare(r) occurrence).

[1] Alternatively, in order to maximize responsiveness, we might want to include a leading event (i.e. emit `INVALIDATE` once ASAP, then wait for events to settle, and emit a second `INVALIDATE` at the end) on the debounce, which would mean for the case of a rename, we'd end up emitting two `INVALIDATE`s, unless we try and special case it somehow.