### PR TITLE
Addons: Add webpack-env as dependency

### DIFF
--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -47,6 +47,7 @@
     "@storybook/csf": "0.0.2--canary.6aca495.0",
     "@storybook/router": "6.4.0-beta.7",
     "@storybook/theming": "6.4.0-beta.7",
+    "@types/webpack-env": "^1.16.0",
     "core-js": "^3.8.2",
     "global": "^4.4.0",
     "regenerator-runtime": "^0.13.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7479,6 +7479,7 @@ __metadata:
     "@storybook/csf": 0.0.2--canary.6aca495.0
     "@storybook/router": 6.4.0-beta.7
     "@storybook/theming": 6.4.0-beta.7
+    "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
     regenerator-runtime: ^0.13.7


### PR DESCRIPTION
## What I did
For packages who consume `@storybook/addons` to properly build using tools like`tsc`, the webpack-env type should be available otherwise errors like this can happen: 

![image](https://user-images.githubusercontent.com/1671563/136805349-f817530a-5920-4b0c-b318-0a6009688af0.png)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
