### PR TITLE
CLI: Fix CRA version detection crash

### DIFF
--- a/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -25,7 +25,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   const craVersion = semver.coerce(
     packageManager.retrievePackageJson().dependencies['react-scripts']
   )?.version;
-  const isCra5 = semver.gte(craVersion, '5.0.0');
+  const isCra5 = craVersion && semver.gte(craVersion, '5.0.0');
   const updatedOptions = isCra5 ? { ...options, builder: CoreBuilder.Webpack5 } : options;
   // `@storybook/preset-create-react-app` has `@storybook/node-logger` as peerDep
   const extraPackages = ['@storybook/node-logger'];


### PR DESCRIPTION
Issue: #16306 

## What I did

When the user specifies `--type react_scripts` or runs `sb init` in a monorepo where we cannot find the `react-scripts` package version, `sb init` crashes.

This workaround assumes that we are on CRA4 for now, since that is the latest stable version. It will need to be updated at some point after CRA5 is released.

In addition to this change, I have taken the further action of updating the dist tags for `@storybook/preset-create-react-app`:
- `latest` = `3.2.0`
- `next` = `4.0.0`

This will also need to be updated as soon as CRA5 is released. @tmeasday should I just go ahead and point the CLI to `next` if the app is CRA5?

## How to test

```
mkdir foo && cd foo
npm init
/path/to/storybook/lib/cli/bin/index.js init --type react_scripts
```