### PR TITLE
Core: Better story id generation, cope with unusual stories

### DIFF
--- a/lib/client-api/src/ClientApi.ts
+++ b/lib/client-api/src/ClientApi.ts
@@ -304,6 +304,7 @@ export class ClientApi<TFramework extends AnyFramework> {
     // We map these back to a simple default export, even though we have type guarantees at this point
     this.facade.csfExports[fileName] = { default: meta };
 
+    let counter = 0;
     api.add = (storyName: string, storyFn: StoryFn<TFramework>, parameters: Parameters = {}) => {
       hasAdded = true;
 
@@ -319,18 +320,20 @@ export class ClientApi<TFramework extends AnyFramework> {
 
       const { decorators, loaders, ...storyParameters } = parameters;
 
+      // eslint-disable-next-line no-underscore-dangle
+      const storyId = parameters.__id || toId(kind, storyName);
+
       const csfExports = this.facade.csfExports[fileName];
       // Whack a _ on the front incase it is "default"
-      csfExports[`_${sanitize(storyName)}`] = {
+      csfExports[`story${counter}`] = {
         name: storyName,
-        parameters: { fileName, ...storyParameters },
+        parameters: { fileName, __id: storyId, ...storyParameters },
         decorators,
         loaders,
         render: storyFn,
       };
+      counter += 1;
 
-      // eslint-disable-next-line no-underscore-dangle
-      const storyId = parameters.__id || toId(kind, storyName);
       this.facade.stories[storyId] = {
         id: storyId,
         title: csfExports.default.title,

--- a/lib/core-client/src/preview/start.test.ts
+++ b/lib/core-client/src/preview/start.test.ts
@@ -84,6 +84,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "Story One",
               "parameters": Object {
+                "__id": "component-a--story-one",
                 "__isArgsStory": false,
                 "fileName": "file1",
                 "framework": "test",
@@ -102,6 +103,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "Story Two",
               "parameters": Object {
+                "__id": "component-a--story-two",
                 "__isArgsStory": false,
                 "fileName": "file1",
                 "framework": "test",
@@ -120,6 +122,7 @@ describe('start', () => {
               "kind": "Component B",
               "name": "Story Three",
               "parameters": Object {
+                "__id": "component-b--story-three",
                 "__isArgsStory": false,
                 "fileName": "file2",
                 "framework": "test",
@@ -178,6 +181,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "Story One",
               "parameters": Object {
+                "__id": "component-a--story-one",
                 "__isArgsStory": false,
                 "docs": Object {},
                 "docsOnly": true,
@@ -206,6 +210,56 @@ describe('start', () => {
       await waitForRender();
 
       expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_RENDERED, 'component-a--default');
+    });
+
+    it('deals with stories with camel-cased names', async () => {
+      const render = jest.fn();
+
+      const { configure, clientApi } = start(render);
+
+      configure('test', () => {
+        clientApi
+          .storiesOf('Component A', { id: 'file1' } as NodeModule)
+          .add('storyOne', jest.fn());
+      });
+
+      await waitForRender();
+
+      expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_RENDERED, 'component-a--storyone');
+    });
+
+    it('deals with stories with spaces in the name', async () => {
+      const render = jest.fn();
+
+      const { configure, clientApi } = start(render);
+
+      configure('test', () => {
+        clientApi
+          .storiesOf('Component A', { id: 'file1' } as NodeModule)
+          .add('Story One', jest.fn());
+      });
+
+      await waitForRender();
+
+      expect(mockChannel.emit).toHaveBeenCalledWith(
+        Events.STORY_RENDERED,
+        'component-a--story-one'
+      );
+    });
+
+    // https://github.com/storybookjs/storybook/issues/16303
+    it('deals with stories with numeric names', async () => {
+      const render = jest.fn();
+
+      const { configure, clientApi } = start(render);
+
+      configure('test', () => {
+        clientApi.storiesOf('Component A', { id: 'file1' } as NodeModule).add('story0', jest.fn());
+      });
+
+      await waitForRender();
+
+      expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_RENDERED, 'component-a--story0');
     });
 
     it('deals with storiesOf from the same file twice', async () => {
@@ -368,6 +422,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "default",
               "parameters": Object {
+                "__id": "component-a--default",
                 "__isArgsStory": false,
                 "fileName": "file1",
                 "framework": "test",
@@ -386,6 +441,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "new",
               "parameters": Object {
+                "__id": "component-a--new",
                 "__isArgsStory": false,
                 "fileName": "file1",
                 "framework": "test",
@@ -442,6 +498,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "default",
               "parameters": Object {
+                "__id": "component-a--default",
                 "__isArgsStory": false,
                 "fileName": "file1",
                 "framework": "test",
@@ -460,6 +517,7 @@ describe('start', () => {
               "kind": "Component B",
               "name": "default",
               "parameters": Object {
+                "__id": "component-b--default",
                 "__isArgsStory": false,
                 "fileName": "file2",
                 "framework": "test",
@@ -496,6 +554,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "default",
               "parameters": Object {
+                "__id": "component-a--default",
                 "__isArgsStory": false,
                 "fileName": "file1",
                 "framework": "test",
@@ -920,6 +979,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "Story One",
               "parameters": Object {
+                "__id": "component-a--story-one",
                 "__isArgsStory": false,
                 "fileName": "file1",
                 "framework": "test",
@@ -938,6 +998,7 @@ describe('start', () => {
               "kind": "Component A",
               "name": "Story Two",
               "parameters": Object {
+                "__id": "component-a--story-two",
                 "__isArgsStory": false,
                 "fileName": "file1",
                 "framework": "test",
@@ -956,6 +1017,7 @@ describe('start', () => {
               "kind": "Component B",
               "name": "Story Three",
               "parameters": Object {
+                "__id": "component-b--story-three",
                 "__isArgsStory": false,
                 "fileName": "file2",
                 "framework": "test",

--- a/lib/store/src/normalizeStory.test.ts
+++ b/lib/store/src/normalizeStory.test.ts
@@ -12,6 +12,16 @@ describe('normalizeStory', () => {
         'component-id--name'
       );
     });
+
+    it('respects parameters.__id', () => {
+      expect(
+        normalizeStory(
+          'name',
+          { parameters: { __id: 'story-id' } },
+          { title: 'title', id: 'component-id' }
+        ).id
+      ).toEqual('story-id');
+    });
   });
 
   describe('name', () => {

--- a/lib/store/src/normalizeStory.ts
+++ b/lib/store/src/normalizeStory.ts
@@ -44,7 +44,6 @@ export function normalizeStory<TFramework extends AnyFramework>(
   }
 
   const exportName = storyNameFromExport(key);
-  const id = toId(meta.id || meta.title, exportName);
   const name =
     (typeof storyObject !== 'function' && storyObject.name) ||
     storyObject.storyName ||
@@ -57,6 +56,8 @@ export function normalizeStory<TFramework extends AnyFramework>(
   const loaders = [...(storyObject.loaders || []), ...(story?.loaders || [])];
   const { render, play } = storyObject;
 
+  // eslint-disable-next-line no-underscore-dangle
+  const id = parameters.__id || toId(meta.id || meta.title, exportName);
   return {
     id,
     name,


### PR DESCRIPTION
Issue: #16303 

## What I did

In v6 emulation mode, rather than setting the export name and "hoping" it'll get converted to the right id, let's just use the old `parameters.__id` format to enforce it.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
