### PR TITLE
Core: Align storyIndex generated by the server and client

### DIFF
--- a/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -6,21 +6,14 @@ import {
   autoTitleFromSpecifier,
   sortStoriesV7,
   Path,
-  Parameters,
   StoryIndex,
-  StoryIndexEntry,
+  V2CompatIndexEntry,
   StoryId,
 } from '@storybook/store';
 import { NormalizedStoriesSpecifier } from '@storybook/core-common';
 import { logger } from '@storybook/node-logger';
 import { readCsfOrMdx, getStorySortParameter } from '@storybook/csf-tools';
 import { ComponentTitle } from '@storybook/csf';
-
-interface V2CompatIndexEntry extends StoryIndexEntry {
-  kind: StoryIndexEntry['title'];
-  story: StoryIndexEntry['name'];
-  parameters: Parameters;
-}
 
 function sortExtractedStories(
   stories: StoryIndex['stories'],

--- a/lib/store/src/StoryStore.test.ts
+++ b/lib/store/src/StoryStore.test.ts
@@ -1,10 +1,11 @@
 import { AnyFramework, ProjectAnnotations } from '@storybook/csf';
-import { HooksContext } from '../../addons/dist/ts3.9/hooks';
+import global from 'global';
 
 import { prepareStory } from './prepareStory';
 import { processCSFFile } from './processCSFFile';
 import { StoryStore } from './StoryStore';
 import { StoryIndex } from './types';
+import { HooksContext } from './hooks';
 
 // Spy on prepareStory/processCSFFile
 jest.mock('./prepareStory', () => ({
@@ -789,50 +790,99 @@ describe('StoryStore', () => {
   });
 
   describe('getStoriesJsonData', () => {
-    it('maps stories list to payload correctly', async () => {
-      const store = new StoryStore();
-      store.initialize({ getStoryIndex, importFn, projectAnnotations, cache: false });
-      await store.cacheAllCSFFiles(false);
+    describe('in back-compat mode', () => {
+      beforeEach(() => {
+        global.FEATURES.breakingChangesV7 = false;
+      });
+      afterEach(() => {
+        global.FEATURES.breakingChangesV7 = true;
+      });
+      it('maps stories list to payload correctly', async () => {
+        const store = new StoryStore();
+        store.initialize({ getStoryIndex, importFn, projectAnnotations, cache: false });
+        await store.cacheAllCSFFiles(false);
 
-      expect(store.getStoriesJsonData()).toMatchInlineSnapshot(`
-        Object {
-          "globalParameters": Object {},
-          "kindParameters": Object {
-            "Component One": Object {},
-            "Component Two": Object {},
-          },
-          "stories": Object {
-            "component-one--a": Object {
-              "id": "component-one--a",
-              "kind": "Component One",
-              "name": "A",
-              "parameters": Object {
-                "__isArgsStory": false,
+        expect(store.getStoriesJsonData()).toMatchInlineSnapshot(`
+          Object {
+            "stories": Object {
+              "component-one--a": Object {
+                "id": "component-one--a",
+                "importPath": "./src/ComponentOne.stories.js",
+                "kind": "Component One",
+                "name": "A",
+                "parameters": Object {
+                  "__id": "component-one--a",
+                  "__isArgsStory": false,
+                  "fileName": "./src/ComponentOne.stories.js",
+                },
+                "story": "A",
+                "title": "Component One",
               },
-              "story": "A",
-            },
-            "component-one--b": Object {
-              "id": "component-one--b",
-              "kind": "Component One",
-              "name": "B",
-              "parameters": Object {
-                "__isArgsStory": false,
+              "component-one--b": Object {
+                "id": "component-one--b",
+                "importPath": "./src/ComponentOne.stories.js",
+                "kind": "Component One",
+                "name": "B",
+                "parameters": Object {
+                  "__id": "component-one--b",
+                  "__isArgsStory": false,
+                  "fileName": "./src/ComponentOne.stories.js",
+                },
+                "story": "B",
+                "title": "Component One",
               },
-              "story": "B",
-            },
-            "component-two--c": Object {
-              "id": "component-two--c",
-              "kind": "Component Two",
-              "name": "C",
-              "parameters": Object {
-                "__isArgsStory": false,
+              "component-two--c": Object {
+                "id": "component-two--c",
+                "importPath": "./src/ComponentTwo.stories.js",
+                "kind": "Component Two",
+                "name": "C",
+                "parameters": Object {
+                  "__id": "component-two--c",
+                  "__isArgsStory": false,
+                  "fileName": "./src/ComponentTwo.stories.js",
+                },
+                "story": "C",
+                "title": "Component Two",
               },
-              "story": "C",
             },
-          },
-          "v": 2,
-        }
-      `);
+            "v": 3,
+          }
+        `);
+      });
+    });
+
+    describe('in non-back-compat mode', () => {
+      it('maps stories list to payload correctly', async () => {
+        const store = new StoryStore();
+        store.initialize({ getStoryIndex, importFn, projectAnnotations, cache: false });
+        await store.cacheAllCSFFiles(false);
+
+        expect(store.getStoriesJsonData()).toMatchInlineSnapshot(`
+          Object {
+            "stories": Object {
+              "component-one--a": Object {
+                "id": "component-one--a",
+                "importPath": "./src/ComponentOne.stories.js",
+                "name": "A",
+                "title": "Component One",
+              },
+              "component-one--b": Object {
+                "id": "component-one--b",
+                "importPath": "./src/ComponentOne.stories.js",
+                "name": "B",
+                "title": "Component One",
+              },
+              "component-two--c": Object {
+                "id": "component-two--c",
+                "importPath": "./src/ComponentTwo.stories.js",
+                "name": "C",
+                "title": "Component Two",
+              },
+            },
+            "v": 3,
+          }
+        `);
+      });
     });
   });
 });

--- a/lib/store/src/types.ts
+++ b/lib/store/src/types.ts
@@ -90,6 +90,12 @@ export interface StoryIndexEntry {
   importPath: Path;
 }
 
+export interface V2CompatIndexEntry extends StoryIndexEntry {
+  kind: StoryIndexEntry['title'];
+  story: StoryIndexEntry['name'];
+  parameters: Parameters;
+}
+
 export interface StoryIndex {
   v: number;
   stories: Record<StoryId, StoryIndexEntry>;

--- a/lib/ui/src/FakeProvider.tsx
+++ b/lib/ui/src/FakeProvider.tsx
@@ -15,6 +15,7 @@ export class FakeProvider extends Provider {
       off: () => {},
       emit: () => {},
       addListener: () => {},
+      removeListener: () => {},
     };
   }
 


### PR DESCRIPTION
Issue: #16307 

## What I did

Return data from `store.getStoriesJsonData` that is consistent with what would be generated if `buildStoriesJson` was being used.

In particular if you are running in `storyStoreV7`, actually build a `stories.json` that doesn't break your SB.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
