### PR TITLE
Update storybook-main-add-sass-config.js.mdx

### DIFF
--- a/docs/snippets/common/storybook-main-add-sass-config.js.mdx
+++ b/docs/snippets/common/storybook-main-add-sass-config.js.mdx
@@ -5,7 +5,7 @@ const path = require('path');
 
 // Export a function. Accept the base config as the only param.
 module.exports = {
-  webpackFinal: async (config, { configType }) => {
+  webpackFinal: (config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
     // You can change the configuration based on that.
     // 'PRODUCTION' is used when building the static version of storybook.


### PR DESCRIPTION
Issue: If I pass an `async` function to `webpackFinal`, my build breaks even though I am not modifying the `config` object.

## What I did

Removed the `async` modifier.

## How to test

- [ NO ] Is this testable with Jest or Chromatic screenshots?
- [ NO ] Does this need a new example in the kitchen sink apps?
- [ NO ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
