### PR TITLE
CLI: Force `sb upgrade` to use latest version of `npm-check-updates`

### DIFF
--- a/lib/cli/src/upgrade.ts
+++ b/lib/cli/src/upgrade.ts
@@ -138,7 +138,7 @@ export const upgrade = async ({ prerelease, skipCheck, useNpm, dryRun, yes }: Up
   let flags = [];
   if (!dryRun) flags.push('--upgrade');
   flags.push('--target');
-  flags.push(prerelease ? 'greatest' : 'latest');
+  flags.push(prerelease ? '--greatest' : '--latest');
   flags = addExtraFlags(EXTRA_FLAGS, flags, packageManager.retrievePackageJson());
   const check = spawnSync('npx', ['npm-check-updates', '/storybook/', ...flags], {
     stdio: 'pipe',

--- a/lib/cli/src/upgrade.ts
+++ b/lib/cli/src/upgrade.ts
@@ -138,9 +138,9 @@ export const upgrade = async ({ prerelease, skipCheck, useNpm, dryRun, yes }: Up
   let flags = [];
   if (!dryRun) flags.push('--upgrade');
   flags.push('--target');
-  flags.push(prerelease ? '--greatest' : '--latest');
+  flags.push(prerelease ? 'greatest' : 'latest');
   flags = addExtraFlags(EXTRA_FLAGS, flags, packageManager.retrievePackageJson());
-  const check = spawnSync('npx', ['npm-check-updates', '/storybook/', ...flags], {
+  const check = spawnSync('npx', ['npm-check-updates@latest', '/storybook/', ...flags], {
     stdio: 'pipe',
   }).output.toString();
   logger.info(check);


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/16335

## What I did
Npx doesn't necessarily download the latest version, so this change adds `@latest` when npm-check-updates is run, to ensure it's working as intended


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

Run `sb upgrade --prerelease`

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
