### PR TITLE
Addon-controls: Fix `{control: false}` handling

### DIFF
--- a/lib/store/src/normalizeInputTypes.test.ts
+++ b/lib/store/src/normalizeInputTypes.test.ts
@@ -41,6 +41,26 @@ describe('normalizeInputType', () => {
       defaultValue: 'defaultValue',
     });
   });
+
+  it('preserves disabled control via shortcut', () => {
+    expect(
+      normalizeInputType(
+        {
+          type: 'string',
+          control: false,
+          description: 'description',
+          defaultValue: 'defaultValue',
+        },
+        'arg'
+      )
+    ).toEqual({
+      name: 'arg',
+      type: { name: 'string' },
+      control: { disable: true },
+      description: 'description',
+      defaultValue: 'defaultValue',
+    });
+  });
 });
 
 describe('normalizeInputTypes', () => {

--- a/lib/store/src/normalizeInputTypes.ts
+++ b/lib/store/src/normalizeInputTypes.ts
@@ -22,7 +22,11 @@ export const normalizeInputType = (inputType: InputType, key: string): StrictInp
     ...rest,
   };
   if (type) normalized.type = normalizeType(type);
-  if (control) normalized.control = normalizeControl(control);
+  if (control) {
+    normalized.control = normalizeControl(control);
+  } else if (control === false) {
+    normalized.control = { disable: true };
+  }
   return normalized;
 };
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/16340

## What I did
I've figured out where we lose it, and, instead of losing, normalising to full version which worked before.

## How to test

I've added unit test. You can remove my changes and run unit test to make sure that it was lost before.
