### PR TITLE
CLI: Fix broken link in react native template

### DIFF
--- a/lib/cli/src/generators/REACT_NATIVE/template-csf/storybook/index.js
+++ b/lib/cli/src/generators/REACT_NATIVE/template-csf/storybook/index.js
@@ -14,7 +14,7 @@ configure(() => {
   require('./stories');
 }, module);
 
-// Refer to https://github.com/storybookjs/storybook/tree/master/app/react-native#start-command-parameters
+// Refer to https://github.com/storybookjs/react-native/tree/master/app/react-native#getstorybookui-options
 // To find allowed options for getStorybookUI
 const StorybookUIRoot = getStorybookUI({});
 


### PR DESCRIPTION
Issue: Link in react native template is broken

## What I did

Changed it to new react-native repo

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
