### PR TITLE
Add FAQ entry about process.env.STORYBOOK

### DIFF
--- a/docs/workflows/faq.md
+++ b/docs/workflows/faq.md
@@ -342,3 +342,32 @@ Out of the box, Storybook provides syntax highlighting for a set of languages (e
 </div>
 
 Applying this small change will enable you to add syntax highlight for SCSS or any other language available.
+
+### How can my code detect if it is running in Storybook?
+
+You can do this by checking the value of `process.env.STORYBOOK`, which will
+equal `'true'` when running in Storybook. Be careful — `process` may be
+undefined when your code runs outside of Storybook.
+
+```javascript
+export function isRunningInStorybook() {
+  try {
+    if (process.env.STORYBOOK) return true;
+  } catch {
+    // A ReferenceError will be thrown if process is undefined
+  }
+
+  return false;
+}
+```
+
+This works because Babel replaces `process.env.STORYBOOK` with the value of the
+`STORYBOOK` environment variable. Because this is done through a Babel plugin,
+the following will **NOT** work:
+
+```javascript
+export function isRunningInStorybook(): boolean {
+  return typeof process?.env?.STORYBOOK !== 'undefined';
+  // ReferenceError: process is not defined
+}
+```

--- a/docs/workflows/faq.md
+++ b/docs/workflows/faq.md
@@ -366,7 +366,7 @@ This works because Babel replaces `process.env.STORYBOOK` with the value of the
 the following will **NOT** work:
 
 ```javascript
-export function isRunningInStorybook(): boolean {
+export function isRunningInStorybook() {
   return typeof process?.env?.STORYBOOK !== 'undefined';
   // ReferenceError: process is not defined
 }


### PR DESCRIPTION
Closes #16343. 

Pinging @jonniebigodes as requested.

## What I did

This adds a FAQ entry titled "How can my code detect if it is running in Storybook?". The solution of checking `process.env.STORYBOOK` was recommended by @shilman.

## How to test

- [ NO ] Is this testable with Jest or Chromatic screenshots?
- [ NO ] Does this need a new example in the kitchen sink apps?
- [ N/A ] Does this need an update to the documentation?

## Alternative Proposal

In my opinion, this method for checking if the code is running in Storybook is not ideal because it is so error prone. A user who doesn't know about babel-plugin-transform-inline-environment-variables is likely to be very confused that `process.env.STORYBOOK === 'true'` while `process?.env?.STORYBOOK` is undefined at best.

I think a boolean global variable would be a safer way to solve this problem. Then you could do:

```js
export function isRunningInStorybook() {
  return !!window.__STORYBOOK
}
```
