### PR TITLE
Angular: Fix preset for storyStoreV7

### DIFF
--- a/app/angular/preset.js
+++ b/app/angular/preset.js
@@ -1,5 +1,5 @@
 function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
+  return [...entry, require.resolve('./dist/ts3.9/client/preview/config')];
 }
 
 module.exports = {


### PR DESCRIPTION
Issue: #16365 

## What I did

Import the angular preset from the correct build location

self-merging @tmeasday 

## How to test

Add to an angular project's `.storybook/main.js`:

```
module.exports = {
  addons: [
    '@storybook/angular',
  ],
  features: {
    storyStoreV7: true,
  },
}
```