### PR TITLE
Core: Fix Args combination to allow `undefined` overrides

### DIFF
--- a/lib/store/src/prepareStory.test.ts
+++ b/lib/store/src/prepareStory.test.ts
@@ -123,8 +123,17 @@ describe('prepareStory', () => {
         a: 'story',
         b: 'component',
         c: 'global',
-        nested: { z: 'story', y: 'component', x: 'global' },
+        nested: { z: 'story' },
       });
+    });
+
+    it('can be overriden by `undefined`', () => {
+      const { initialArgs } = prepareStory(
+        { id, name, args: { a: undefined } },
+        { id, title, args: { a: 'component' } },
+        { render }
+      );
+      expect(initialArgs).toEqual({ a: undefined });
     });
 
     it('sets a value even if metas do not have args', () => {

--- a/lib/store/src/prepareStory.ts
+++ b/lib/store/src/prepareStory.ts
@@ -92,11 +92,11 @@ export function prepareStory<TFramework extends AnyFramework>(
   parameters.__isArgsStory = passArgsFirst && render.length > 0;
 
   // Pull out args[X] into initialArgs for argTypes enhancers
-  const passedArgs: Args = combineParameters(
-    projectAnnotations.args,
-    componentAnnotations.args,
-    storyAnnotations.args
-  ) as Args;
+  const passedArgs: Args = {
+    ...projectAnnotations.args,
+    ...componentAnnotations.args,
+    ...storyAnnotations.args,
+  } as Args;
 
   const contextForEnhancers: StoryContextForEnhancers<TFramework> = {
     componentId: componentAnnotations.id,


### PR DESCRIPTION
Issue: #16384 

It is a breaking change to do otherwise.

## What I did

Reverted to the behaviour on `main`

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
