### PR TITLE
Core: Add `framework` field support to main.js

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,7 @@
     - [String literal titles](#string-literal-titles)
   - [Story Store v7](#story-store-v7)
     - [Behavioral differences](#behavioral-differences)
+    - [Main.js framework field](#mainjs-framework-field)
     - [Using the v7 store](#using-the-v7-store)
     - [V7-style story sort](#v7-style-story-sort)
   - [Babel mode v7](#babel-mode-v7)
@@ -281,6 +282,21 @@ The key behavioral differences of the v7 store are:
 - A new event `STORY_PREPARED` is emitted when a story is rendered for the first time, which contains metadata about the story, such as `parameters`.
 - All "entire" store APIs such as `extract()` need to be proceeded by an async call to `loadAllCSFFiles()` which fetches all CSF files and processes them.
 
+#### Main.js framework field
+
+In earlier versions of Storybook, each framework package (e.g. `@storybook/react`) provided its own `start-storybook` and `build-storybook` binaries, which automatically filled in various settings.
+
+In 7.0, we're moving towards a model where the user specifies their framework in `main.js`.
+
+```js
+module.exports = {
+  // ... your existing config
+  framework: '@storybook/react', // OR whatever framework you're using
+};
+```
+
+Each framework must export a `renderToDOM` function and `parameters.framework`. We'll be adding more documentation for framework authors in a future release.
+
 #### Using the v7 store
 
 To activate the v7 mode set the feature flag in your `.storybook/main.js` config:
@@ -288,6 +304,7 @@ To activate the v7 mode set the feature flag in your `.storybook/main.js` config
 ```js
 module.exports = {
   // ... your existing config
+  framework: '@storybook/react', // OR whatever framework you're using
   features: {
     storyStoreV7: true,
   },

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -3,8 +3,8 @@ import type { StorybookConfig } from '@storybook/react/types';
 const config: StorybookConfig = {
   stories: [{ directory: '../src', titlePrefix: 'Demo' }],
   logLevel: 'debug',
+  framework: '@storybook/react',
   addons: [
-    '@storybook/react',
     '@storybook/addon-essentials',
     '@storybook/addon-storysource',
     '@storybook/addon-storyshots',

--- a/lib/cli/src/generators/baseGenerator.ts
+++ b/lib/cli/src/generators/baseGenerator.ts
@@ -96,9 +96,10 @@ export async function baseGenerator(
 
   const packageJson = packageManager.retrievePackageJson();
   const installedDependencies = new Set(Object.keys(packageJson.dependencies));
+  const frameworkPackage = `@storybook/${framework}`;
 
   const packages = [
-    `@storybook/${framework}`,
+    frameworkPackage,
     ...addonPackages,
     ...extraPackages,
     ...extraAddons,
@@ -122,6 +123,7 @@ export async function baseGenerator(
         }
       : extraMain;
   configure(framework, {
+    framework: frameworkPackage,
     addons: [...addons, ...stripVersions(extraAddons)],
     extensions,
     commonJs: options.commonJs,

--- a/lib/core-common/src/presets.test.ts
+++ b/lib/core-common/src/presets.test.ts
@@ -412,6 +412,7 @@ describe('resolveAddonName', () => {
 });
 
 describe('loadPreset', () => {
+  mockPreset('@storybook/react', {});
   mockPreset('@storybook/preset-typescript', {});
   mockPreset('@storybook/addon-docs/preset', {});
   mockPreset('@storybook/addon-actions/register', {});
@@ -421,6 +422,54 @@ describe('loadPreset', () => {
   mockPreset('@storybook/addon-notes/register-panel', {});
 
   const { loadPreset } = jest.requireActual('./presets');
+
+  it('should prepend framework field to list of presets', () => {
+    const loaded = loadPreset(
+      {
+        name: '',
+        type: 'managerEntries',
+        framework: '@storybook/react',
+        presets: ['@storybook/preset-typescript'],
+        addons: ['@storybook/addon-docs'],
+      },
+      0,
+      {}
+    );
+    expect(loaded).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "name": "@storybook/react",
+          "options": Object {},
+          "preset": Object {},
+        },
+        Object {
+          "name": "@storybook/preset-typescript",
+          "options": Object {},
+          "preset": Object {},
+        },
+        Object {
+          "name": "@storybook/addon-docs/preset",
+          "options": Object {},
+          "preset": Object {},
+        },
+        Object {
+          "name": Object {
+            "addons": Array [
+              "@storybook/addon-docs",
+            ],
+            "framework": "@storybook/react",
+            "name": "",
+            "presets": Array [
+              "@storybook/preset-typescript",
+            ],
+            "type": "managerEntries",
+          },
+          "options": Object {},
+          "preset": Object {},
+        },
+      ]
+    `);
+  });
 
   it('should resolve all addons & presets in correct order', () => {
     const loaded = loadPreset(

--- a/lib/core-common/src/presets.ts
+++ b/lib/core-common/src/presets.ts
@@ -304,8 +304,6 @@ export function loadAllPresets(
     }
 ) {
   const { corePresets = [], frameworkPresets = [], overridePresets = [], ...restOptions } = options;
-  // const main = serverRequire(resolve(options.configDir, 'main'));
-  // const framework = main?.framework ? [require.resolve(main.framework)] : frameworkPresets;
 
   const presetsConfig: PresetConfig[] = [
     ...corePresets,

--- a/lib/core-common/src/presets.ts
+++ b/lib/core-common/src/presets.ts
@@ -302,28 +302,9 @@ const getFrameworkPackage = (configDir: string) => {
   const main = serverRequire(resolve(configDir, 'main'));
   if (!main) return null;
   const { framework: frameworkPackage, features = {} } = main;
-  const frameworkErrors = [];
-  if (!(features.storyStoreV7 || features.breakingChangesV7) && !frameworkPackage) {
-    frameworkErrors.push(`Expected 'framework' in your main.js, didn't find one.`);
-  }
-  if (frameworkPackage) {
-    const framework = serverRequire(require.resolve(frameworkPackage));
-    if (!framework) {
-      frameworkErrors.push(`Unable to import '${frameworkPackage}' specified in main.js`);
-    } else {
-      if (!framework.renderToDOM) {
-        frameworkErrors.push(`Framework '${frameworkPackage}' does not provide 'renderToDOM'`);
-      }
-      if (!framework.parameters?.framework) {
-        frameworkErrors.push(
-          `Framework '${frameworkPackage}' does not provide 'parameters.framework'`
-        );
-      }
-    }
-  }
-  if (frameworkErrors.length) {
+  if ((features.storyStoreV7 || features.breakingChangesV7) && !frameworkPackage) {
     throw new Error(dedent`
-      ${frameworkErrors.join('\n')}
+      Expected 'framework' in your main.js, didn't find one.
     
       More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field
     `);

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -246,6 +246,13 @@ export type NormalizedStoriesSpecifier = Required<StoriesSpecifier> & {
   importPathMatcher: RegExp;
 };
 
+export type Preset =
+  | string
+  | {
+      name: string;
+      options?: any;
+    };
+
 /**
  * The interface for Storybook configuration in `main.ts` files.
  */
@@ -255,13 +262,7 @@ export interface StorybookConfig {
    *
    * @example `['@storybook/addon-essentials']` or `[{ name: '@storybook/addon-essentials', options: { backgrounds: false } }]`
    */
-  addons?: Array<
-    | string
-    | {
-        name: string;
-        options?: any;
-      }
-  >;
+  addons?: Preset[];
   core?: CoreConfig;
   logLevel?: string;
   features?: {
@@ -302,16 +303,24 @@ export interface StorybookConfig {
      */
     babelModeV7?: boolean;
   };
+
   /**
    * Tells Storybook where to find stories.
    *
    * @example `['./src/*.stories.@(j|t)sx?']`
    */
   stories: StoriesEntry[];
+
+  /**
+   * Framework, e.g. '@storybook/react', required in v7
+   */
+  framework?: Preset;
+
   /**
    * Controls how Storybook handles TypeScript files.
    */
   typescript?: Partial<TypescriptOptions>;
+
   /**
    * Modify or return a custom Webpack config.
    */

--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -421,6 +421,25 @@ describe('PreviewWeb', () => {
         expect(preview.view.showErrorDisplay).toHaveBeenCalledWith(error);
       });
 
+      it('renders helpful message if renderToDOM is undefined', async () => {
+        const originalRenderToDOM = projectAnnotations.renderToDOM;
+        try {
+          projectAnnotations.renderToDOM = undefined;
+
+          document.location.search = '?id=component-one--a';
+          const preview = await createAndRenderPreview();
+
+          expect(preview.view.showErrorDisplay).toHaveBeenCalled();
+          expect(preview.view.showErrorDisplay.mock.calls[0][0]).toMatchInlineSnapshot(`
+            [Error:     Expected 'framework' in your main.js to export 'renderToDOM', but none found.
+
+                More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field          ]
+          `);
+        } finally {
+          projectAnnotations.renderToDOM = originalRenderToDOM;
+        }
+      });
+
       it('renders exception if the play function throws', async () => {
         const error = new Error('error');
         componentOneExports.a.play.mockImplementationOnce(() => {

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -548,6 +548,13 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       };
 
       try {
+        if (!this.renderToDOM) {
+          throw new Error(dedent`
+            Expected 'framework' in your main.js to export 'renderToDOM', but none found.
+        
+            More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field          
+          `);
+        }
         await runPhase('rendering', () => this.renderToDOM(renderContext, element));
         if (ctrl.signal.aborted) return;
 


### PR DESCRIPTION
Issue: #16296 

## What I did

- [x] Add framework support to preset loader
- [x] Add `framework: x` to CLI for forward-compatibility
- [x] Add error handling (when you don't provide it, or when there's bad exports)
- [x] Add documentation
- [ ] Local framework definition?

## How to test

- [ ] See attached tests
- [ ] See updated `react-ts` example