### PR TITLE
Addon-a11y: Fix to use `loadStory` over deprecated `fromId`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,6 +9,7 @@
     - [Behavioral differences](#behavioral-differences)
     - [Using the v7 store](#using-the-v7-store)
     - [V7-style story sort](#v7-style-story-sort)
+    - [Store API changes for addon authors](#store-api-changes-for-addon-authors)
   - [Babel mode v7](#babel-mode-v7)
   - [Loader behavior with args changes](#loader-behavior-with-args-changes)
   - [Angular component parameter removed](#angular-component-parameter-removed)
@@ -331,6 +332,14 @@ function storySort(a, b) {
     : a.id.localeCompare(b.id, undefined, { numeric: true });
 },
 ```
+
+#### Store API changes for addon authors
+
+The Story Store in v7 mode is async, so syncronous story loading APIs no longer work. In particular:
+
+ - `store.fromId()` has been replaced by `store.loadStory()`, which is async (i.e. returns a `Promise` you will need to await).
+ - `store.raw()/store.extract()` and friends that list all stories require a prior call to `store.cacheAllCSFFiles()` (which is async). This will load all stories, and isn't generally a good idea in an addon, as it will force the whole store to load.
+
 
 ### Babel mode v7
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@
     - [Behavioral differences](#behavioral-differences)
     - [Using the v7 store](#using-the-v7-store)
     - [V7-style story sort](#v7-style-story-sort)
-    - [Store API changes for addon authors](#store-api-changes-for-addon-authors)
+    - [V7 Store API changes for addon authors](#v7-store-api-changes-for-addon-authors)
   - [Babel mode v7](#babel-mode-v7)
   - [Loader behavior with args changes](#loader-behavior-with-args-changes)
   - [Angular component parameter removed](#angular-component-parameter-removed)
@@ -333,13 +333,12 @@ function storySort(a, b) {
 },
 ```
 
-#### Store API changes for addon authors
+#### V7 Store API changes for addon authors
 
 The Story Store in v7 mode is async, so syncronous story loading APIs no longer work. In particular:
 
- - `store.fromId()` has been replaced by `store.loadStory()`, which is async (i.e. returns a `Promise` you will need to await).
- - `store.raw()/store.extract()` and friends that list all stories require a prior call to `store.cacheAllCSFFiles()` (which is async). This will load all stories, and isn't generally a good idea in an addon, as it will force the whole store to load.
-
+- `store.fromId()` has been replaced by `store.loadStory()`, which is async (i.e. returns a `Promise` you will need to await).
+- `store.raw()/store.extract()` and friends that list all stories require a prior call to `store.cacheAllCSFFiles()` (which is async). This will load all stories, and isn't generally a good idea in an addon, as it will force the whole store to load.
 
 ### Babel mode v7
 

--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -68,7 +68,7 @@ const run = async (storyId: string) => {
 
 /** Returns story parameters or default ones. */
 const getParams = async (storyId: string): Promise<A11yParameters> => {
-  const { parameters } = (await globalWindow.__STORYBOOK_STORY_STORE__.loadStory({})) || {};
+  const { parameters } = (await globalWindow.__STORYBOOK_STORY_STORE__.loadStory({ storyId })) || {};
   return (
     parameters.a11y || {
       config: {},

--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -68,8 +68,7 @@ const run = async (storyId: string) => {
 
 /** Returns story parameters or default ones. */
 const getParams = async (storyId: string): Promise<A11yParameters> => {
-  const { parameters } =
-    (await globalWindow.__STORYBOOK_STORY_STORE__.loadStory({ storyId })) || {};
+  const { parameters } = (await globalWindow.__STORYBOOK_STORY_STORE__.loadStory({})) || {};
   return (
     parameters.a11y || {
       config: {},

--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -25,17 +25,17 @@ const getElement = () => {
  * Handle A11yContext events.
  * Because the event are sent without manual check, we split calls
  */
-const handleRequest = (storyId: string) => {
-  const { manual } = getParams(storyId);
+const handleRequest = async (storyId: string) => {
+  const { manual } = await getParams(storyId);
   if (!manual) {
-    run(storyId);
+    await run(storyId);
   }
 };
 
 const run = async (storyId: string) => {
   activeStoryId = storyId;
   try {
-    const input = getParams(storyId);
+    const input = await getParams(storyId);
 
     if (!active) {
       active = true;
@@ -67,8 +67,9 @@ const run = async (storyId: string) => {
 };
 
 /** Returns story parameters or default ones. */
-const getParams = (storyId: string): A11yParameters => {
-  const { parameters } = globalWindow.__STORYBOOK_STORY_STORE__.fromId(storyId) || {};
+const getParams = async (storyId: string): Promise<A11yParameters> => {
+  const { parameters } =
+    (await globalWindow.__STORYBOOK_STORY_STORE__.loadStory({ storyId })) || {};
   return (
     parameters.a11y || {
       config: {},

--- a/examples/official-storybook/main.ts
+++ b/examples/official-storybook/main.ts
@@ -31,6 +31,7 @@ const config: StorybookConfig = {
     '@storybook/addon-storysource',
     '@storybook/addon-links',
     '@storybook/addon-jest',
+    '@storybook/addon-a11y',
   ],
   core: {
     builder: 'webpack4',

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
     '@storybook/addon-essentials',
     '@storybook/addon-storysource',
     '@storybook/addon-storyshots',
+    '@storybook/addon-a11y',
   ],
   typescript: {
     check: true,


### PR DESCRIPTION
Issue: #16353 

## What I did

Use async `loadStory()`, rather than deprecated `fromId()`

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?

We could add an e2e test?

- [x] Does this need a new example in the kitchen sink apps?

I restored `addon-a11y` to a couple of examples
