### PR TITLE
Addon-docs: Spread all the old docs context fields

### DIFF
--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -402,10 +402,16 @@ export class PreviewWeb<TFramework extends AnyFramework> {
     const Page: ComponentType = docs.page || NoDocs;
 
     const render = () => {
+      const fullDocsContext = {
+        ...docsContext,
+        // Put all the storyContext fields onto the docs context for back-compat
+        ...(!FEATURES.breakingChangesV7 && this.storyStore.getStoryContext(story)),
+      };
+
       // Use `componentId` as a key so that we force a re-render every time
       // we switch components
       const docsElement = (
-        <DocsContainer key={componentId} context={docsContext}>
+        <DocsContainer key={componentId} context={fullDocsContext}>
           <Page />
         </DocsContainer>
       );

--- a/lib/preview-web/src/types.ts
+++ b/lib/preview-web/src/types.ts
@@ -1,4 +1,13 @@
-import { StoryId, AnyFramework, ProjectAnnotations, StoryContextForLoaders } from '@storybook/csf';
+import {
+  StoryId,
+  StoryName,
+  AnyFramework,
+  ProjectAnnotations,
+  StoryContextForLoaders,
+  ComponentTitle,
+  Args,
+  Globals,
+} from '@storybook/csf';
 import { RenderContext, Story } from '@storybook/store';
 import { PreviewWeb } from './PreviewWeb';
 
@@ -9,9 +18,9 @@ export type WebProjectAnnotations<
 };
 
 export interface DocsContextProps<TFramework extends AnyFramework = AnyFramework> {
-  id: string;
-  title: string;
-  name: string;
+  id: StoryId;
+  title: ComponentTitle;
+  name: StoryName;
   storyById: (id: StoryId) => Story<TFramework>;
   componentStories: () => Story<TFramework>[];
   loadStory: (id: StoryId) => Promise<Story<TFramework>>;
@@ -25,4 +34,16 @@ export interface DocsContextProps<TFramework extends AnyFramework = AnyFramework
    */
   mdxStoryNameToKey?: Record<string, string>;
   mdxComponentAnnotations?: any;
+
+  // These keys are deprecated and will be removed in v7
+  /** @deprecated */
+  kind?: ComponentTitle;
+  /** @deprecated */
+  story?: StoryName;
+  /** @deprecated */
+  args?: Args;
+  /** @deprecated */
+  globals?: Globals;
+  /** @deprecated */
+  parameters?: Globals;
 }


### PR DESCRIPTION
Issue: #16243 

## What I did

Spread the full story context into docs context, in compat mode.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?

I didn't add a test. Should I?