### PR TITLE
Core: Fix module loading support

### DIFF
--- a/examples/web-components-kitchen-sink/src/stories/misc/script/script.stories.ts
+++ b/examples/web-components-kitchen-sink/src/stories/misc/script/script.stories.ts
@@ -12,3 +12,6 @@ export const inTemplate = () => html`
 `;
 
 export const inString = () => '<div>JS alert</div><script>alert("hello")</script>';
+
+export const typeModule = () =>
+  '<div>JS alert from module</div><script type="module">alert("hello from module"); export const a = 1;</script>';

--- a/lib/preview-web/src/simulate-pageload.test.ts
+++ b/lib/preview-web/src/simulate-pageload.test.ts
@@ -1,0 +1,44 @@
+import global from 'global';
+import { simulatePageLoad } from './simulate-pageload';
+
+const { document } = global;
+
+describe('simulatePageLoad', () => {
+  it('should add script with type module to scripts root', () => {
+    const container = document.createElement('div');
+    const script = document.createElement('script');
+    script.type = 'module';
+    container.appendChild(script);
+
+    simulatePageLoad(container);
+
+    expect(document.body.innerHTML).toEqual(
+      '<div id="scripts-root"><script type="module"></script></div>'
+    );
+  });
+
+  it('should add script with proper mime type to scripts root', () => {
+    const container = document.createElement('div');
+    const script = document.createElement('script');
+    script.type = 'application/javascript';
+    container.appendChild(script);
+
+    simulatePageLoad(container);
+
+    expect(document.body.innerHTML).toEqual(
+      '<div id="scripts-root"><script type="text/javascript"></script></div>'
+    );
+  });
+
+  it('should add script without type to scripts root', () => {
+    const container = document.createElement('div');
+    const script = document.createElement('script');
+    container.appendChild(script);
+
+    simulatePageLoad(container);
+
+    expect(document.body.innerHTML).toEqual(
+      '<div id="scripts-root"><script type="text/javascript"></script></div>'
+    );
+  });
+});

--- a/lib/preview-web/src/simulate-pageload.ts
+++ b/lib/preview-web/src/simulate-pageload.ts
@@ -20,6 +20,8 @@ const runScriptTypes = [
   'text/livescript',
   'text/x-ecmascript',
   'text/x-javascript',
+  // Support modern javascript
+  'module',
 ];
 
 const SCRIPT = 'script';
@@ -34,7 +36,7 @@ export function simulateDOMContentLoaded() {
 
 function insertScript($script: any, callback: any, $scriptRoot: any) {
   const scriptEl = document.createElement('script');
-  scriptEl.type = 'text/javascript';
+  scriptEl.type = $script.type === 'module' ? 'module' : 'text/javascript';
   if ($script.src) {
     scriptEl.onload = callback;
     scriptEl.onerror = callback;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/16257

## What I did
Added exception to allow loading of `<script type="module">`.
It was not possible as all types were overwritten to `text/javascript`. This prevented modern javascript from being loaded.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
