### PR TITLE
UI: Update sidebar hover color to be a refreshing transparent blue

### DIFF
--- a/addons/interactions/src/components/Interaction/Interaction.tsx
+++ b/addons/interactions/src/components/Interaction/Interaction.tsx
@@ -40,14 +40,14 @@ const RowLabel = styled('button', { shouldForwardProp: (prop) => !['call'].inclu
   textAlign: 'start',
   cursor: disabled || call.state === CallStates.ERROR ? 'default' : 'pointer',
   '&:hover': {
-    background: theme.base === 'dark' ? transparentize(0.9, theme.color.secondary) : '#F3FAFF',
+    background: theme.background.hoverable,
   },
   '&:focus-visible': {
     outline: 0,
     boxShadow: `inset 3px 0 0 0 ${
       call.state === CallStates.ERROR ? theme.color.warning : theme.color.secondary
     }`,
-    background: call.state === CallStates.ERROR ? 'transparent' : '#F3FAFF',
+    background: call.state === CallStates.ERROR ? 'transparent' : theme.background.hoverable,
   },
   '& > div': {
     opacity: call.state === CallStates.WAITING ? 0.5 : 1,

--- a/addons/interactions/src/components/Subnav/Subnav.tsx
+++ b/addons/interactions/src/components/Subnav/Subnav.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Button, Icons, Separator, P, TooltipNote, WithTooltip, Bar } from '@storybook/components';
 import { Call, CallStates } from '@storybook/instrumenter';
 import { styled } from '@storybook/theming';
-import { transparentize } from 'polished';
 
 import { StatusBadge } from '../StatusBadge/StatusBadge';
 
@@ -52,7 +51,7 @@ export const StyledIconButton = styled(StyledButton)(({ theme }) => ({
   margin: '0 3px',
   '&:not(:disabled)': {
     '&:hover,&:focus-visible': {
-      background: transparentize(0.9, theme.color.secondary),
+      background: theme.background.hoverable,
     },
   },
 }));

--- a/lib/theming/src/base.ts
+++ b/lib/theming/src/base.ts
@@ -1,3 +1,5 @@
+import { transparentize } from 'polished';
+
 export const color = {
   // Official color palette
   primary: '#FF4785', // coral
@@ -42,7 +44,7 @@ export const background = {
   bar: '#FFFFFF',
   content: color.lightest,
   gridCellSize: 10,
-  hoverable: 'rgba(0,0,0,.05)', // hover state for items in a list
+  hoverable: transparentize(0.93, color.secondary), // hover state for items in a list
 
   // Notification, error, and warning backgrounds
   positive: '#E1FFD4',

--- a/lib/theming/src/convert.ts
+++ b/lib/theming/src/convert.ts
@@ -109,9 +109,7 @@ export const convert = (inherit: ThemeVars = themes[getPreferredColorScheme()]):
       bar: barBg,
       content: appContentBg,
       gridCellSize: gridCellSize || background.gridCellSize,
-      hoverable:
-        base === 'light' ? 'rgba(0,0,0,.05)' : 'rgba(250,250,252,.1)' || background.hoverable,
-
+      hoverable: background.hoverable,
       positive: background.positive,
       negative: background.negative,
       warning: background.warning,

--- a/lib/ui/src/components/sidebar/SearchResults.tsx
+++ b/lib/ui/src/components/sidebar/SearchResults.tsx
@@ -9,7 +9,6 @@ import React, {
   useEffect,
 } from 'react';
 import { ControllerStateAndHelpers } from 'downshift';
-import { transparentize } from 'polished';
 
 import { ComponentNode, DocumentNode, Path, RootNode, StoryNode } from './TreeNode';
 import {
@@ -37,7 +36,7 @@ const ResultRow = styled.li<{ isHighlighted: boolean }>(({ theme, isHighlighted 
   display: 'block',
   margin: 0,
   padding: 0,
-  background: isHighlighted ? transparentize(0.9, theme.color.secondary) : 'transparent',
+  background: isHighlighted ? theme.background.hoverable : 'transparent',
   cursor: 'pointer',
   'a:hover, button:hover': {
     background: 'transparent',


### PR DESCRIPTION
## What I did

In a discussion with @dom, we decided to update the sidebar item hover color to the same blue we used as a hover state in the Interactions addon. I updated `theme.background.hoverable` to use a transparent blue that place really nicely in both light and dark contexts.

## How to test

1. Open up the Official Storybook linked below.
2. Navigate to UI > Sidebar > Sidebar > Simple
3. Try out the new hover color
4. Switch to the dark theme and make sure it works there

Other places to test:

 - [ ] The Storybook search results
 - [ ] The accessibility addon uses this color, but doesn't have stories for its own components.
 - [ ] Addons > Interactions > Interaction
 - [ ] Addons > Interactions > Subnav (the buttons)
 - [ ] Jest > open a story > open the Tests panel

## Before
![image](https://user-images.githubusercontent.com/1123119/137985097-4cfb0487-f05a-4509-93f4-712a3df1ace2.png)
![image](https://user-images.githubusercontent.com/1123119/137985139-1f1eefd3-ec77-4e70-b4c0-cae28eca4675.png)
![image](https://user-images.githubusercontent.com/1123119/137985356-2c47d385-cc01-4ab7-8365-0c41f76e44ec.png)
![image](https://user-images.githubusercontent.com/1123119/137985390-7dd21d54-db31-4e1a-b7f6-80c1b8364700.png)


## After
![image](https://user-images.githubusercontent.com/1123119/137984543-2646e118-1ba3-43cd-821b-4c794b81dce9.png)
![image](https://user-images.githubusercontent.com/1123119/137984659-b7b8db2f-0ce7-4a27-bb6f-a28566a10533.png)
![image](https://user-images.githubusercontent.com/1123119/137984945-383b0f78-d9ee-4221-b19f-bfb1a57d7db6.png)
![image](https://user-images.githubusercontent.com/1123119/137984888-3eb9e8c3-bae0-4f42-914f-449da76cce47.png)

