### PR TITLE
Core: Restore `queryparams` exports in `client-api`

### DIFF
--- a/lib/client-api/src/index.ts
+++ b/lib/client-api/src/index.ts
@@ -10,6 +10,8 @@ import {
 
 export * from './types';
 
+export * from './queryparams';
+
 // Typescript isn't happy that we are overwriting some types from store here
 // @ts-ignore
 export * from '@storybook/store';

--- a/lib/client-api/src/queryparams.ts
+++ b/lib/client-api/src/queryparams.ts
@@ -1,0 +1,18 @@
+import global from 'global';
+import { parse } from 'qs';
+
+const { document } = global;
+
+export const getQueryParams = () => {
+  // document.location is not defined in react-native
+  if (document && document.location && document.location.search) {
+    return parse(document.location.search, { ignoreQueryPrefix: true });
+  }
+  return {};
+};
+
+export const getQueryParam = (key: string) => {
+  const params = getQueryParams();
+
+  return params[key];
+};


### PR DESCRIPTION
Issue: #16411

## What I did

Restored the file `queryparams.ts` in `client-api`.

## How to test

Try it with knobs