### PR TITLE
Core: Add `core.channelOptions` to main.js config

### DIFF
--- a/addons/actions/ADVANCED.md
+++ b/addons/actions/ADVANCED.md
@@ -60,7 +60,7 @@ To apply the configuration globally use the `configureActions` function in your 
 import { configureActions } from '@storybook/addon-actions';
 
 configureActions({
-  depth: 100,
+  maxDepth: 100,
   // Limit the number of items logged into the actions panel
   limit: 20,
 });
@@ -70,7 +70,7 @@ To apply the configuration per action use:
 
 ```js
 action('my-action', {
-  depth: 5,
+  maxDepth: 5,
 });
 ```
 
@@ -78,6 +78,6 @@ action('my-action', {
 
 | Name                 | Type    | Description                                                                         | Default |
 | -------------------- | ------- | ----------------------------------------------------------------------------------- | ------- |
-| `depth`              | Number  | Configures the transferred depth of any logged objects.                             | `10`    |
+| `maxDepth`           | Number  | Configures the transferred depth of any logged objects.                             | `10`    |
 | `clearOnStoryChange` | Boolean | Flag whether to clear the action logger when switching away from the current story. | `true`  |
 | `limit`              | Number  | Limits the number of items logged in the action logger                              | `50`    |

--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -55,6 +55,7 @@
     "prop-types": "^15.7.2",
     "react-inspector": "^5.1.0",
     "regenerator-runtime": "^0.13.7",
+    "telejson": "^5.3.2",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2",
     "uuid-browser": "^3.1.0"

--- a/addons/actions/src/models/ActionOptions.ts
+++ b/addons/actions/src/models/ActionOptions.ts
@@ -1,6 +1,9 @@
-export interface ActionOptions {
-  depth?: number;
-  clearOnStoryChange?: boolean;
-  limit?: number;
-  allowFunction?: boolean;
+import type { Options as TelejsonOptions } from 'telejson';
+
+interface Options {
+  depth: number; // backards compatibility, remove in 7.0
+  clearOnStoryChange: boolean;
+  limit: number;
 }
+
+export type ActionOptions = Partial<Options> & Partial<TelejsonOptions>;

--- a/addons/actions/src/preview/action.ts
+++ b/addons/actions/src/preview/action.ts
@@ -22,7 +22,7 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
       data: { name, args: normalizedArgs },
       options: {
         ...actionOptions,
-        depth: minDepth + (actionOptions.depth || 3),
+        maxDepth: minDepth + (actionOptions.depth || 3),
         allowFunction: actionOptions.allowFunction || false,
       },
     };

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -18,6 +18,7 @@ const config: StorybookConfig = {
   },
   core: {
     builder: 'webpack4',
+    channelOptions: { allowFunction: false, maxDepth: 10 },
   },
   features: {
     postcss: false,

--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -25,6 +25,7 @@ import {
   normalizeStories,
   loadPreviewOrConfigFile,
   readTemplate,
+  CoreConfig,
 } from '@storybook/core-common';
 import { createBabelLoader } from './babel-loader-preview';
 
@@ -74,6 +75,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
   const bodyHtmlSnippet = await presets.apply('previewBody');
   const template = await presets.apply<string>('previewMainTemplate');
   const envs = await presets.apply<Record<string, string>>('env');
+  const coreOptions = await presets.apply<CoreConfig>('core');
 
   const babelLoader = createBabelLoader(babelOptions, framework);
   const isProd = configType === 'PRODUCTION';
@@ -183,6 +185,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
             CONFIG_TYPE: configType,
             LOGLEVEL: logLevel,
             FRAMEWORK_OPTIONS: frameworkOptions,
+            CHANNEL_OPTIONS: coreOptions.channelOptions,
             FEATURES: features,
             STORIES: stories.map((specifier) => ({
               ...specifier,

--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -185,7 +185,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
             CONFIG_TYPE: configType,
             LOGLEVEL: logLevel,
             FRAMEWORK_OPTIONS: frameworkOptions,
-            CHANNEL_OPTIONS: coreOptions.channelOptions,
+            CHANNEL_OPTIONS: coreOptions?.channelOptions,
             FEATURES: features,
             STORIES: stories.map((specifier) => ({
               ...specifier,

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -184,7 +184,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
             CONFIG_TYPE: configType,
             LOGLEVEL: logLevel,
             FRAMEWORK_OPTIONS: frameworkOptions,
-            CHANNEL_OPTIONS: coreOptions.channelOptions,
+            CHANNEL_OPTIONS: coreOptions?.channelOptions,
             FEATURES: features,
             STORIES: stories.map((specifier) => ({
               ...specifier,

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -21,6 +21,7 @@ import {
   normalizeStories,
   readTemplate,
   loadPreviewOrConfigFile,
+  CoreConfig,
 } from '@storybook/core-common';
 import { createBabelLoader } from './babel-loader-preview';
 
@@ -69,6 +70,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
   const headHtmlSnippet = await presets.apply('previewHead');
   const bodyHtmlSnippet = await presets.apply('previewBody');
   const template = await presets.apply<string>('previewMainTemplate');
+  const coreOptions = await presets.apply<CoreConfig>('core');
 
   const babelLoader = createBabelLoader(babelOptions, framework);
   const isProd = configType === 'PRODUCTION';
@@ -182,6 +184,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
             CONFIG_TYPE: configType,
             LOGLEVEL: logLevel,
             FRAMEWORK_OPTIONS: frameworkOptions,
+            CHANNEL_OPTIONS: coreOptions.channelOptions,
             FEATURES: features,
             STORIES: stories.map((specifier) => ({
               ...specifier,

--- a/lib/channel-postmessage/src/index.ts
+++ b/lib/channel-postmessage/src/index.ts
@@ -58,18 +58,40 @@ export class PostmsgTransport {
    * @param event
    */
   send(event: ChannelEvent, options?: any): Promise<any> {
-    let depth = 25;
-    let allowFunction = true;
-    let target;
+    const {
+      target,
 
-    if (options && typeof options.allowFunction === 'boolean') {
-      allowFunction = options.allowFunction;
-    }
+      // telejson options
+      allowRegExp,
+      allowFunction,
+      allowSymbol,
+      allowDate,
+      allowUndefined,
+      allowClass,
+      maxDepth,
+      space,
+      lazyEval,
+    } = options || {};
+
+    const c = Object.fromEntries(
+      Object.entries({
+        allowRegExp,
+        allowFunction,
+        allowSymbol,
+        allowDate,
+        allowUndefined,
+        allowClass,
+        maxDepth,
+        space,
+        lazyEval,
+      }).filter(([k, v]) => typeof v !== 'undefined')
+    );
+
+    const stringifyOptions = { ...(global.CHANNEL_OPTIONS || {}), ...c };
+
+    // backwards compat: convert depth to maxDepth
     if (options && Number.isInteger(options.depth)) {
-      depth = options.depth;
-    }
-    if (options && typeof options.target === 'string') {
-      target = options.target;
+      stringifyOptions.maxDepth = options.depth;
     }
 
     const frames = this.getFrames(target);
@@ -82,7 +104,7 @@ export class PostmsgTransport {
         event,
         refId: query.refId,
       },
-      { maxDepth: depth, allowFunction }
+      stringifyOptions
     );
 
     if (!frames.length) {

--- a/lib/channel-postmessage/src/index.ts
+++ b/lib/channel-postmessage/src/index.ts
@@ -63,12 +63,12 @@ export class PostmsgTransport {
 
       // telejson options
       allowRegExp,
-      allowFunction,
+      allowFunction = true,
       allowSymbol,
       allowDate,
       allowUndefined,
       allowClass,
-      maxDepth,
+      maxDepth = 25,
       space,
       lazyEval,
     } = options || {};

--- a/lib/core-common/package.json
+++ b/lib/core-common/package.json
@@ -86,6 +86,7 @@
     "pretty-hrtime": "^1.0.3",
     "resolve-from": "^5.0.0",
     "slash": "^3.0.0",
+    "telejson": "^5.3.2",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2",
     "webpack": "4"

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -24,7 +24,7 @@ export interface TypescriptConfig {
 export interface CoreConfig {
   builder: 'webpack4' | 'webpack5';
   disableWebpackDefaults?: boolean;
-  channelOptions?: TelejsonOptions;
+  channelOptions?: Partial<TelejsonOptions>;
 }
 
 export interface Presets {

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -1,4 +1,5 @@
 import type ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+import type { Options as TelejsonOptions } from 'telejson';
 import type { PluginOptions } from '@storybook/react-docgen-typescript-plugin';
 import { Configuration, Stats } from 'webpack';
 import { TransformOptions } from '@babel/core';
@@ -23,6 +24,7 @@ export interface TypescriptConfig {
 export interface CoreConfig {
   builder: 'webpack4' | 'webpack5';
   disableWebpackDefaults?: boolean;
+  channelOptions?: TelejsonOptions;
 }
 
 export interface Presets {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "target": "es5",
     "types": ["jest"],
-    "lib": ["es2017", "dom"]
+    "lib": ["es2019", "dom"]
   },
   "exclude": [
     "**/dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8166,6 +8166,7 @@ __metadata:
     pretty-hrtime: ^1.0.3
     resolve-from: ^5.0.0
     slash: ^3.0.0
+    telejson: ^5.3.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
     webpack: 4

--- a/yarn.lock
+++ b/yarn.lock
@@ -6921,6 +6921,7 @@ __metadata:
     prop-types: ^15.7.2
     react-inspector: ^5.1.0
     regenerator-runtime: ^0.13.7
+    telejson: ^5.3.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
     uuid-browser: ^3.1.0


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12364

giving users the ability to optimize the channel default options for security of performance reasons


## What I did

- allow users to define custom config for the storybook channel.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [x] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?
