### PR TITLE
Core: Consolidate framework presets

### DIFF
--- a/app/angular/preset.js
+++ b/app/angular/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/ts3.9/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/ts3.9/server/preset');

--- a/app/angular/src/server/options.ts
+++ b/app/angular/src/server/options.ts
@@ -4,9 +4,5 @@ import { LoadOptions } from '@storybook/core-common';
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,
   framework: 'angular',
-  frameworkPresets: [
-    require.resolve('./framework-preset-angular'),
-    require.resolve('./framework-preset-angular-cli'),
-    require.resolve('./framework-preset-angular-ivy'),
-  ],
+  frameworkPresets: [require.resolve('./preset')],
 } as LoadOptions;

--- a/app/angular/src/server/preset.ts
+++ b/app/angular/src/server/preset.ts
@@ -1,0 +1,12 @@
+import type { StorybookConfig } from '@storybook/core-common';
+
+export const config: StorybookConfig['config'] = (entries = []) => [
+  ...entries,
+  require.resolve('../client/preview/config'),
+];
+
+export const addons: StorybookConfig['addons'] = [
+  require.resolve('./framework-preset-angular'),
+  require.resolve('./framework-preset-angular-cli'),
+  require.resolve('./framework-preset-angular-ivy'),
+];

--- a/app/ember/preset.js
+++ b/app/ember/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/framework-preset-babel-ember');

--- a/app/ember/src/server/framework-preset-babel-ember.ts
+++ b/app/ember/src/server/framework-preset-babel-ember.ts
@@ -1,5 +1,6 @@
 import { TransformOptions } from '@babel/core';
 import { precompile } from 'ember-source/dist/ember-template-compiler';
+import type { StorybookConfig } from '@storybook/core-common';
 
 let emberOptions: any;
 
@@ -45,3 +46,7 @@ export function babel(config: TransformOptions, options: any) {
     plugins: [].concat(babelConfigPlugins, extraPlugins),
   };
 }
+
+export const config: StorybookConfig['config'] = (entry = []) => {
+  return [...entry, require.resolve('../../esm/client/preview/config')];
+};

--- a/app/ember/src/server/framework-preset-babel-ember.ts
+++ b/app/ember/src/server/framework-preset-babel-ember.ts
@@ -1,6 +1,6 @@
 import { TransformOptions } from '@babel/core';
 import { precompile } from 'ember-source/dist/ember-template-compiler';
-import type { StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, StorybookConfig } from '@storybook/core-common';
 
 let emberOptions: any;
 
@@ -48,5 +48,5 @@ export function babel(config: TransformOptions, options: any) {
 }
 
 export const config: StorybookConfig['config'] = (entry = []) => {
-  return [...entry, require.resolve('../../esm/client/preview/config')];
+  return [...entry, findDistEsm(__dirname, 'client/preview/config')];
 };

--- a/app/html/preset.js
+++ b/app/html/preset.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/server/framework-preset-babel-html');
+module.exports = require('./dist/cjs/server/framework-preset-html');

--- a/app/html/preset.js
+++ b/app/html/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/framework-preset-babel-html');

--- a/app/html/src/server/framework-preset-html.ts
+++ b/app/html/src/server/framework-preset-html.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
-import { StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration) {
   config.module.rules.push({
@@ -12,5 +12,5 @@ export function webpack(config: Configuration) {
 }
 
 export const config: StorybookConfig['config'] = (entry = []) => {
-  return [...entry, require.resolve('../../esm/client/preview/config')];
+  return [...entry, findDistEsm(__dirname, 'client/preview/config')];
 };

--- a/app/html/src/server/framework-preset-html.ts
+++ b/app/html/src/server/framework-preset-html.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
+import { StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration) {
   config.module.rules.push({
@@ -9,3 +10,7 @@ export function webpack(config: Configuration) {
 
   return config;
 }
+
+export const config: StorybookConfig['config'] = (entry = []) => {
+  return [...entry, require.resolve('../../esm/client/preview/config')];
+};

--- a/app/preact/preset.js
+++ b/app/preact/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/framework-preset-babel-preact');

--- a/app/preact/src/server/framework-preset-preact.ts
+++ b/app/preact/src/server/framework-preset-preact.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { TransformOptions } from '@babel/core';
 import { Configuration } from 'webpack';
-import { StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, StorybookConfig } from '@storybook/core-common';
 
 export function babelDefault(config: TransformOptions) {
   return {
@@ -29,5 +29,5 @@ export function webpackFinal(config: Configuration) {
 }
 
 export const config: StorybookConfig['config'] = (entry = []) => {
-  return [...entry, require.resolve('../../esm/client/preview/config')];
+  return [...entry, findDistEsm(__dirname, 'client/preview/config')];
 };

--- a/app/preact/src/server/framework-preset-preact.ts
+++ b/app/preact/src/server/framework-preset-preact.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { TransformOptions } from '@babel/core';
 import { Configuration } from 'webpack';
+import { StorybookConfig } from '@storybook/core-common';
 
 export function babelDefault(config: TransformOptions) {
   return {
@@ -26,3 +27,7 @@ export function webpackFinal(config: Configuration) {
     },
   };
 }
+
+export const config: StorybookConfig['config'] = (entry = []) => {
+  return [...entry, require.resolve('../../esm/client/preview/config')];
+};

--- a/app/react/preset.js
+++ b/app/react/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/preset');

--- a/app/react/src/server/options.ts
+++ b/app/react/src/server/options.ts
@@ -4,9 +4,5 @@ import { LoadOptions } from '@storybook/core-common';
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,
   framework: 'react',
-  frameworkPresets: [
-    require.resolve('./framework-preset-react'),
-    require.resolve('./framework-preset-cra'),
-    require.resolve('./framework-preset-react-docgen'),
-  ],
+  frameworkPresets: [require.resolve('./preset')],
 } as LoadOptions;

--- a/app/react/src/server/preset.ts
+++ b/app/react/src/server/preset.ts
@@ -1,8 +1,8 @@
-import type { StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, StorybookConfig } from '@storybook/core-common';
 
 export const config: StorybookConfig['config'] = (entries = []) => [
   ...entries,
-  require.resolve('../../esm/client/preview/config'),
+  findDistEsm(__dirname, 'client/preview/config'),
 ];
 
 export const addons: StorybookConfig['addons'] = [

--- a/app/react/src/server/preset.ts
+++ b/app/react/src/server/preset.ts
@@ -1,0 +1,12 @@
+import type { StorybookConfig } from '@storybook/core-common';
+
+export const config: StorybookConfig['config'] = (entries = []) => [
+  ...entries,
+  require.resolve('../../esm/client/preview/config'),
+];
+
+export const addons: StorybookConfig['addons'] = [
+  require.resolve('./framework-preset-react'),
+  require.resolve('./framework-preset-cra'),
+  require.resolve('./framework-preset-react-docgen'),
+];

--- a/app/server/preset.js
+++ b/app/server/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/framework-preset-server');

--- a/app/server/src/server/framework-preset-server.ts
+++ b/app/server/src/server/framework-preset-server.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
 import path from 'path';
-import type { StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration) {
   config.module.rules.push({
@@ -20,5 +20,5 @@ export function webpack(config: Configuration) {
 }
 
 export const config: StorybookConfig['config'] = (entry = []) => {
-  return [...entry, require.resolve('../../esm/client/preview/config')];
+  return [...entry, findDistEsm(__dirname, 'client/preview/config')];
 };

--- a/app/server/src/server/framework-preset-server.ts
+++ b/app/server/src/server/framework-preset-server.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
 import path from 'path';
+import type { StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration) {
   config.module.rules.push({
@@ -17,3 +18,7 @@ export function webpack(config: Configuration) {
 
   return config;
 }
+
+export const config: StorybookConfig['config'] = (entry = []) => {
+  return [...entry, require.resolve('../../esm/client/preview/config')];
+};

--- a/app/svelte/preset.js
+++ b/app/svelte/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/framework-preset-svelte');

--- a/app/svelte/src/server/framework-preset-svelte.ts
+++ b/app/svelte/src/server/framework-preset-svelte.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
-import type { Options } from '@storybook/core-common';
+import type { Options, StorybookConfig } from '@storybook/core-common';
 
 export async function webpack(config: Configuration, options: Options): Promise<Configuration> {
   const { preprocess = undefined, loader = {} } = await options.presets.apply(
@@ -32,3 +32,7 @@ export async function webpack(config: Configuration, options: Options): Promise<
     },
   };
 }
+
+export const config: StorybookConfig['config'] = (entry = []) => {
+  return [...entry, require.resolve('../../esm/client/preview/config')];
+};

--- a/app/svelte/src/server/framework-preset-svelte.ts
+++ b/app/svelte/src/server/framework-preset-svelte.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
-import type { Options, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, Options, StorybookConfig } from '@storybook/core-common';
 
 export async function webpack(config: Configuration, options: Options): Promise<Configuration> {
   const { preprocess = undefined, loader = {} } = await options.presets.apply(
@@ -34,5 +34,5 @@ export async function webpack(config: Configuration, options: Options): Promise<
 }
 
 export const config: StorybookConfig['config'] = (entry = []) => {
-  return [...entry, require.resolve('../../esm/client/preview/config')];
+  return [...entry, findDistEsm(__dirname, 'client/preview/config')];
 };

--- a/app/vue/preset.js
+++ b/app/vue/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/framework-preset-babel-vue');

--- a/app/vue/src/server/framework-preset-vue.ts
+++ b/app/vue/src/server/framework-preset-vue.ts
@@ -2,7 +2,7 @@
 import VueLoaderPlugin from 'vue-loader/lib/plugin';
 import type { Configuration } from 'webpack';
 
-import type { Options, TypescriptConfig, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, Options, TypescriptConfig, StorybookConfig } from '@storybook/core-common';
 
 export async function webpack(config: Configuration, { presets }: Options) {
   const typescriptOptions = await presets.apply<TypescriptConfig>('typescript', {} as any);
@@ -45,5 +45,5 @@ export async function webpack(config: Configuration, { presets }: Options) {
 }
 
 export const config: StorybookConfig['config'] = (entry = []) => {
-  return [...entry, require.resolve('../../esm/client/preview/config')];
+  return [...entry, findDistEsm(__dirname, 'client/preview/config')];
 };

--- a/app/vue/src/server/framework-preset-vue.ts
+++ b/app/vue/src/server/framework-preset-vue.ts
@@ -2,7 +2,7 @@
 import VueLoaderPlugin from 'vue-loader/lib/plugin';
 import type { Configuration } from 'webpack';
 
-import type { Options, TypescriptConfig } from '@storybook/core-common';
+import type { Options, TypescriptConfig, StorybookConfig } from '@storybook/core-common';
 
 export async function webpack(config: Configuration, { presets }: Options) {
   const typescriptOptions = await presets.apply<TypescriptConfig>('typescript', {} as any);
@@ -43,3 +43,7 @@ export async function webpack(config: Configuration, { presets }: Options) {
 
   return config;
 }
+
+export const config: StorybookConfig['config'] = (entry = []) => {
+  return [...entry, require.resolve('../../esm/client/preview/config')];
+};

--- a/app/vue3/preset.js
+++ b/app/vue3/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/framework-preset-vue3');

--- a/app/vue3/src/server/framework-preset-vue3.ts
+++ b/app/vue3/src/server/framework-preset-vue3.ts
@@ -1,5 +1,6 @@
 import { VueLoaderPlugin } from 'vue-loader';
 import { Configuration, DefinePlugin } from 'webpack';
+import type { StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration): Configuration {
   return {
@@ -45,3 +46,7 @@ export function webpack(config: Configuration): Configuration {
     },
   };
 }
+
+export const config: StorybookConfig['config'] = (entry = []) => {
+  return [...entry, require.resolve('../../esm/client/preview/config')];
+};

--- a/app/vue3/src/server/framework-preset-vue3.ts
+++ b/app/vue3/src/server/framework-preset-vue3.ts
@@ -1,6 +1,6 @@
 import { VueLoaderPlugin } from 'vue-loader';
 import { Configuration, DefinePlugin } from 'webpack';
-import type { StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration): Configuration {
   return {
@@ -48,5 +48,5 @@ export function webpack(config: Configuration): Configuration {
 }
 
 export const config: StorybookConfig['config'] = (entry = []) => {
-  return [...entry, require.resolve('../../esm/client/preview/config')];
+  return [...entry, findDistEsm(__dirname, 'client/preview/config')];
 };

--- a/app/web-components/preset.js
+++ b/app/web-components/preset.js
@@ -1,7 +1,1 @@
-function config(entry = []) {
-  return [...entry, require.resolve('./dist/esm/client/preview/config')];
-}
-
-module.exports = {
-  config,
-};
+module.exports = require('./dist/cjs/server/framework-preset-web-components');

--- a/app/web-components/src/server/framework-preset-web-components.ts
+++ b/app/web-components/src/server/framework-preset-web-components.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
-import type { Options, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm, Options, StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration, options: Options) {
   const babelrcOptions = options.features?.babelModeV7 ? null : { babelrc: false };
@@ -41,5 +41,5 @@ export function webpack(config: Configuration, options: Options) {
 }
 
 export const config: StorybookConfig['config'] = (entry = []) => {
-  return [...entry, require.resolve('../../esm/client/preview/config')];
+  return [...entry, findDistEsm(__dirname, 'client/preview/config')];
 };

--- a/app/web-components/src/server/framework-preset-web-components.ts
+++ b/app/web-components/src/server/framework-preset-web-components.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Configuration } from 'webpack';
-import type { Options } from '@storybook/core-common';
+import type { Options, StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration, options: Options) {
   const babelrcOptions = options.features?.babelModeV7 ? null : { babelrc: false };
@@ -39,3 +39,7 @@ export function webpack(config: Configuration, options: Options) {
 
   return config;
 }
+
+export const config: StorybookConfig['config'] = (entry = []) => {
+  return [...entry, require.resolve('../../esm/client/preview/config')];
+};

--- a/examples/official-storybook/main.ts
+++ b/examples/official-storybook/main.ts
@@ -16,7 +16,6 @@ const config: StorybookConfig = {
     strictMode: true,
   },
   addons: [
-    '@storybook/react',
     {
       name: '@storybook/addon-docs',
       options: {

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -1,9 +1,13 @@
 import type { StorybookConfig } from '@storybook/react/types';
 
 const config: StorybookConfig = {
-  stories: [{ directory: '../src', titlePrefix: 'Demo' }],
+  stories: [
+    {
+      directory: '../src',
+      titlePrefix: 'Demo',
+    },
+  ],
   logLevel: 'debug',
-  framework: '@storybook/react',
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-storysource',
@@ -26,6 +30,6 @@ const config: StorybookConfig = {
     buildStoriesJson: true,
     babelModeV7: true,
   },
+  framework: '@storybook/react',
 };
-
 module.exports = config;

--- a/lib/cli/src/automigrate/fixes/index.ts
+++ b/lib/cli/src/automigrate/fixes/index.ts
@@ -1,7 +1,8 @@
 import { cra5 } from './cra5';
 import { webpack5 } from './webpack5';
 import { angular12 } from './angular12';
+import { mainjsFramework } from './mainjsFramework';
 import { Fix } from '../types';
 
 export * from '../types';
-export const fixes: Fix[] = [cra5, webpack5, angular12];
+export const fixes: Fix[] = [cra5, webpack5, angular12, mainjsFramework];

--- a/lib/cli/src/automigrate/fixes/mainjsFramework.ts
+++ b/lib/cli/src/automigrate/fixes/mainjsFramework.ts
@@ -51,7 +51,7 @@ export const mainjsFramework: Fix<MainjsFrameworkRunOptions> = {
       ${frameworkFormatted}
 
       More info: ${chalk.yellow(
-        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#webpack-5-manager-build'
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field'
       )}
     `;
   },

--- a/lib/cli/src/automigrate/fixes/mainjsFramework.ts
+++ b/lib/cli/src/automigrate/fixes/mainjsFramework.ts
@@ -20,18 +20,21 @@ export const mainjsFramework: Fix<MainjsFrameworkRunOptions> = {
   async check({ packageManager }) {
     const packageJson = packageManager.retrievePackageJson();
     const { mainConfig, framework, version: storybookVersion } = getStorybookInfo(packageJson);
-    const storybookCoerced = semver.coerce(storybookVersion).version;
+
+    const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
+    if (!storybookCoerced) {
+      logger.warn(dedent`
+        ❌ Unable to determine storybook version, skipping ${chalk.cyan('mainjsFramework')} fix.
+        🤔 Are you running automigrate from your project directory?
+      `);
+      return null;
+    }
 
     const main = await readConfig(mainConfig);
     const currentFramework = main.getFieldValue(['framework']);
     const features = main.getFieldValue(['features']);
 
     if (currentFramework) return null;
-
-    if (!storybookCoerced) {
-      logger.warn(`Unable to determine storybook version, skipping mainjsFramework fix.`);
-      return null;
-    }
 
     return features?.breakingChangesV7 ||
       features?.storyStoreV7 ||

--- a/lib/cli/src/automigrate/fixes/mainjsFramework.ts
+++ b/lib/cli/src/automigrate/fixes/mainjsFramework.ts
@@ -1,0 +1,66 @@
+import chalk from 'chalk';
+import dedent from 'ts-dedent';
+
+import semver from '@storybook/semver';
+import { ConfigFile, readConfig, writeConfig } from '@storybook/csf-tools';
+
+import { getStorybookInfo } from '../helpers/getStorybookInfo';
+import { Fix } from '../types';
+
+const logger = console;
+
+interface MainjsFrameworkRunOptions {
+  framework: string;
+  main: ConfigFile;
+}
+
+export const mainjsFramework: Fix<MainjsFrameworkRunOptions> = {
+  id: 'mainjsFramework',
+
+  async check({ packageManager }) {
+    const packageJson = packageManager.retrievePackageJson();
+    const { mainConfig, framework, version: storybookVersion } = getStorybookInfo(packageJson);
+    const storybookCoerced = semver.coerce(storybookVersion).version;
+
+    const main = await readConfig(mainConfig);
+    const currentFramework = main.getFieldValue(['framework']);
+    const features = main.getFieldValue(['features']);
+
+    if (currentFramework) return null;
+
+    if (!storybookCoerced) {
+      logger.warn(`Unable to determine storybook version, skipping mainjsFramework fix.`);
+      return null;
+    }
+
+    return features?.breakingChangesV7 ||
+      features?.storyStoreV7 ||
+      semver.gte(storybookCoerced, '7.0.0')
+      ? { main, framework: `@storybook/${framework}` }
+      : null;
+  },
+
+  prompt({ framework }) {
+    const frameworkFormatted = chalk.cyan(`framework: '${framework}'`);
+
+    return dedent`
+      We've detected that your main.js configuration file does not specify the
+      'framework' field, which is a requirement in SB7.0 and above. We can add one
+      for you automatically:
+
+      ${frameworkFormatted}
+
+      More info: ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#webpack-5-manager-build'
+      )}
+    `;
+  },
+
+  async run({ result: { main, framework }, dryRun }) {
+    logger.info(`✅ Setting 'framework' to '${framework}' in main.js`);
+    if (!dryRun) {
+      main.setFieldValue(['framework'], framework);
+      await writeConfig(main);
+    }
+  },
+};

--- a/lib/cli/src/automigrate/fixes/webpack5.ts
+++ b/lib/cli/src/automigrate/fixes/webpack5.ts
@@ -36,9 +36,12 @@ export const webpack5: Fix<Webpack5RunOptions> & CheckBuilder = {
   async checkWebpack5Builder(packageJson: PackageJsonWithDepsAndDevDeps) {
     const { mainConfig, version: storybookVersion } = getStorybookInfo(packageJson);
 
-    const storybookCoerced = semver.coerce(storybookVersion).version;
+    const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
     if (!storybookCoerced) {
-      logger.warn(`Unable to determine storybook version, skipping webpack5 fix.`);
+      logger.warn(dedent`
+        ❌ Unable to determine storybook version, skipping ${chalk.cyan('webpack5')} fix.
+        🤔 Are you running automigrate from your project directory?
+      `);
       return null;
     }
 

--- a/lib/core-common/src/index.ts
+++ b/lib/core-common/src/index.ts
@@ -26,5 +26,6 @@ export * from './utils/to-require-context';
 export * from './utils/normalize-stories';
 export * from './utils/to-importFn';
 export * from './utils/readTemplate';
+export * from './utils/findDistEsm';
 
 export * from './types';

--- a/lib/core-common/src/presets.ts
+++ b/lib/core-common/src/presets.ts
@@ -305,6 +305,10 @@ const getFrameworkPackage = (configDir: string) => {
   if (features.breakingChangesV7 && !frameworkPackage) {
     throw new Error(dedent`
       Expected 'framework' in your main.js, didn't find one.
+
+      You can fix this automatically by running:
+
+      npx sb@next automigrate
     
       More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field
     `);

--- a/lib/core-common/src/presets.ts
+++ b/lib/core-common/src/presets.ts
@@ -302,7 +302,7 @@ const getFrameworkPackage = (configDir: string) => {
   const main = serverRequire(resolve(configDir, 'main'));
   if (!main) return null;
   const { framework: frameworkPackage, features = {} } = main;
-  if ((features.storyStoreV7 || features.breakingChangesV7) && !frameworkPackage) {
+  if (features.breakingChangesV7 && !frameworkPackage) {
     throw new Error(dedent`
       Expected 'framework' in your main.js, didn't find one.
     

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -254,6 +254,12 @@ export type Preset =
     };
 
 /**
+ * An additional script that gets injected into the
+ * preview or the manager,
+ */
+export type Entry = string;
+
+/**
  * The interface for Storybook configuration in `main.ts` files.
  */
 export interface StorybookConfig {
@@ -328,4 +334,9 @@ export interface StorybookConfig {
     config: Configuration,
     options: Options
   ) => Configuration | Promise<Configuration>;
+
+  /**
+   * Add additional scripts to run in the preview a la `.storybook/preview.js`
+   */
+  config?: (entries: Entry[], options: Options) => Entry[];
 }

--- a/lib/core-common/src/utils/findDistEsm.ts
+++ b/lib/core-common/src/utils/findDistEsm.ts
@@ -1,0 +1,7 @@
+import path from 'path';
+import { sync as findUpSync } from 'find-up';
+
+export const findDistEsm = (cwd: string, relativePath: string) => {
+  const packageDir = path.dirname(findUpSync('package.json', { cwd }));
+  return path.join(packageDir, 'dist', 'esm', relativePath);
+};

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-dev
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-dev
@@ -10,6 +10,7 @@ Object {
     "ROOT/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-config-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-config-entry.js",
+    "ROOT/app/react/dist/esm/client/preview/config-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-config-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-config-entry.js",

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod
@@ -9,6 +9,7 @@ Object {
     "ROOT/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-config-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/react/config.js-generated-config-entry.js",
+    "ROOT/app/react/dist/esm/client/preview/config-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-config-entry.js",
     "ROOT/addons/backgrounds/dist/esm/preset/addDecorator.js-generated-config-entry.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
@@ -9,6 +9,7 @@ Object {
     "ROOT/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-config-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/html/config.js-generated-config-entry.js",
+    "ROOT/app/html/dist/esm/client/preview/config-generated-config-entry.js",
     "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-config-entry.js",
     "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-config-entry.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
@@ -8,6 +8,7 @@ Object {
     "ROOT/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-config-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/html/config.js-generated-config-entry.js",
+    "ROOT/app/html/dist/esm/client/preview/config-generated-config-entry.js",
     "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-config-entry.js",
     "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-config-entry.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
@@ -9,6 +9,7 @@ Object {
     "ROOT/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-config-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/vue3/config.js-generated-config-entry.js",
+    "ROOT/app/vue3/dist/esm/client/preview/config-generated-config-entry.js",
     "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-config-entry.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
@@ -8,6 +8,7 @@ Object {
     "ROOT/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-config-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/vue3/config.js-generated-config-entry.js",
+    "ROOT/app/vue3/dist/esm/client/preview/config-generated-config-entry.js",
     "ROOT/addons/links/dist/esm/preset/addDecorator.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addArgs.js-generated-config-entry.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
@@ -9,6 +9,7 @@ Object {
     "ROOT/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-config-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/web-components/config.js-generated-config-entry.js",
+    "ROOT/app/web-components/dist/esm/client/preview/config-generated-config-entry.js",
     "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-config-entry.js",
     "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-config-entry.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
@@ -8,6 +8,7 @@ Object {
     "ROOT/storybook-init-framework-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/common/config.js-generated-config-entry.js",
     "ROOT/addons/docs/dist/esm/frameworks/web-components/config.js-generated-config-entry.js",
+    "ROOT/app/web-components/dist/esm/client/preview/config-generated-config-entry.js",
     "ROOT/addons/a11y/dist/esm/a11yRunner.js-generated-config-entry.js",
     "ROOT/addons/a11y/dist/esm/a11yHighlight.js-generated-config-entry.js",
     "ROOT/addons/actions/dist/esm/preset/addDecorator.js-generated-config-entry.js",

--- a/lib/csf-tools/src/ConfigFile.test.ts
+++ b/lib/csf-tools/src/ConfigFile.test.ts
@@ -126,6 +126,21 @@ describe('ConfigFile', () => {
           )
         ).toEqual('webpack5');
       });
+      it('variable exports', () => {
+        expect(
+          getField(
+            ['stories'],
+            dedent`
+              import type { StorybookConfig } from '@storybook/react/types';
+
+              const config: StorybookConfig = {
+                stories: [{ directory: '../src', titlePrefix: 'Demo' }],
+              }
+              module.exports = config;
+            `
+          )
+        ).toEqual([{ directory: '../src', titlePrefix: 'Demo' }]);
+      });
     });
   });
 

--- a/lib/csf-tools/src/ConfigFile.ts
+++ b/lib/csf-tools/src/ConfigFile.ts
@@ -111,7 +111,7 @@ export class ConfigFile {
               }
             });
           } else {
-            logger.warn(`Unexpected ${node}`);
+            logger.warn(`Unexpected ${JSON.stringify(node)}`);
           }
         },
       },
@@ -126,9 +126,13 @@ export class ConfigFile {
               t.isIdentifier(left.property) &&
               left.property.name === 'exports'
             ) {
-              if (t.isObjectExpression(right)) {
-                self._exportsObject = right;
-                right.properties.forEach((p: t.ObjectProperty) => {
+              let exportObject = right;
+              if (t.isIdentifier(right)) {
+                exportObject = _findVarInitialization(right.name, parent as t.Program);
+              }
+              if (t.isObjectExpression(exportObject)) {
+                self._exportsObject = exportObject;
+                exportObject.properties.forEach((p: t.ObjectProperty) => {
                   const exportName = propKey(p);
                   if (exportName) {
                     let exportVal = p.value;
@@ -139,7 +143,7 @@ export class ConfigFile {
                   }
                 });
               } else {
-                logger.warn(`Unexpected ${node}`);
+                logger.warn(`Unexpected ${JSON.stringify(node)}`);
               }
             }
           }
@@ -205,7 +209,7 @@ export class ConfigFile {
       },
     });
     if (!valueNode) {
-      throw new Error(`Unexpected value ${value}`);
+      throw new Error(`Unexpected value ${JSON.stringify(value)}`);
     }
     this.setFieldNode(path, valueNode);
   }

--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -433,6 +433,10 @@ describe('PreviewWeb', () => {
           expect(preview.view.showErrorDisplay.mock.calls[0][0]).toMatchInlineSnapshot(`
             [Error:     Expected 'framework' in your main.js to export 'renderToDOM', but none found.
 
+                You can fix this automatically by running:
+
+                npx sb@next automigrate
+
                 More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field          ]
           `);
         } finally {

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -557,6 +557,10 @@ export class PreviewWeb<TFramework extends AnyFramework> {
         if (!this.renderToDOM) {
           throw new Error(dedent`
             Expected 'framework' in your main.js to export 'renderToDOM', but none found.
+
+            You can fix this automatically by running:
+
+            npx sb@next automigrate
         
             More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field          
           `);


### PR DESCRIPTION
Issue: #16394 

## What I did

There was a bug in the `main.js` `framework` addition #16393, which assumed that the new `@storybook/x/preset` added as part of the on-demand store also included the existing "framework presets".

This PR corrects that by fixing the presets:

- [x] Consolidated the storyStoreV7 presets with existing framework presets
- [x] Made storyStoreV7 backwards compatible if `breakingChangesV7` isn't set because framework presets include the new modifications
- [x] Fixed a bug in ConfigFile that's used to parse `main.js` (discovered in `react-ts`)
- [x] Created an automigration to add the `framework` field when it's needed

## How to test

- [ ] Run any of the examples with/without `breakingChangesV7`
- [ ] Run the automigrate tool on a project with `breakingChangesV7` and no `framework` set

```
/path/to/storybook/lib/cli/bin/index.js automigrate
```