### PR TITLE
Addon-links: Modernize to be compatible with v7 store

### DIFF
--- a/addons/links/src/preview.test.ts
+++ b/addons/links/src/preview.test.ts
@@ -1,39 +1,14 @@
 import { addons } from '@storybook/addons';
 import { SELECT_STORY } from '@storybook/core-events';
 
-import globalPkg from 'global';
 import { linkTo, hrefTo } from './preview';
-
-const { __STORYBOOK_STORY_STORE__ } = globalPkg;
 
 jest.mock('@storybook/addons');
 jest.mock('global', () => ({
   // @ts-ignore
   document: global.document,
-  __STORYBOOK_STORY_STORE__: {
-    getSelection: jest.fn(() => ({
-      storyId: 'name',
-      kind: 'kind',
-    })),
-    fromId: jest.fn(() => ({
-      story: 'name',
-      kind: 'kind',
-    })),
-  },
   // @ts-ignore
   window: global,
-  __STORYBOOK_CLIENT_API__: {
-    raw: jest.fn(() => [
-      {
-        story: 'name',
-        kind: 'kind',
-      },
-      {
-        story: 'namekind',
-        kind: 'kindname',
-      },
-    ]),
-  },
 }));
 
 const mockAddons = (addons as unknown) as jest.Mocked<typeof addons>;
@@ -45,82 +20,57 @@ describe('preview', () => {
   });
   beforeEach(channel.emit.mockReset);
   describe('linkTo()', () => {
-    it('should select the kind and story provided', () => {
-      const handler = linkTo('kind', 'name');
+    it('should select the title and name provided', () => {
+      const handler = linkTo('title', 'name');
       handler();
 
       expect(channel.emit).toHaveBeenCalledWith(SELECT_STORY, {
-        kind: 'kind',
+        kind: 'title',
         story: 'name',
       });
     });
 
-    it('should select the kind (only) provided', () => {
-      __STORYBOOK_STORY_STORE__.fromId.mockImplementation((): any => null);
-
-      const handler = linkTo('kind');
+    it('should select the title (only) provided', () => {
+      const handler = linkTo('title');
       handler();
 
       expect(channel.emit).toHaveBeenCalledWith(SELECT_STORY, {
-        kind: 'kind',
-        story: 'name',
+        kind: 'title',
       });
     });
 
     it('should select the story (only) provided', () => {
       // simulate a currently selected, but not found as ID
-      __STORYBOOK_STORY_STORE__.fromId.mockImplementation((input: any) =>
-        !input
-          ? {
-              kind: 'kind',
-              story: 'name',
-            }
-          : null
-      );
-
-      const handler = linkTo(undefined, 'kind');
+      const handler = linkTo(undefined, 'name');
       handler();
 
       expect(channel.emit).toHaveBeenCalledWith(SELECT_STORY, {
-        kind: 'kind',
         story: 'name',
       });
     });
 
     it('should select the id provided', () => {
-      __STORYBOOK_STORY_STORE__.fromId.mockImplementation((input: any) =>
-        input === 'kind--story'
-          ? {
-              story: 'name',
-              kind: 'kind',
-            }
-          : null
-      );
-
-      const handler = linkTo('kind--story');
+      const handler = linkTo('title--name');
       handler();
 
       expect(channel.emit).toHaveBeenCalledWith(SELECT_STORY, {
-        kind: 'kind',
-        story: 'name',
+        storyId: 'title--name',
       });
     });
 
     it('should handle functions returning strings', () => {
-      __STORYBOOK_STORY_STORE__.fromId.mockImplementation((input: any): any => null);
-
       const handler = linkTo(
         // @ts-expect-error
         (a, b) => a + b,
         (a, b) => b + a
       );
-      handler('kind', 'name');
+      handler('title', 'name');
 
       expect(channel.emit.mock.calls).toContainEqual([
         SELECT_STORY,
         {
-          kind: 'kindname',
-          story: 'namekind',
+          kind: 'titlename',
+          story: 'nametitle',
         },
       ]);
     });
@@ -128,8 +78,8 @@ describe('preview', () => {
 
   describe('hrefTo()', () => {
     it('should return promise resolved with story href', async () => {
-      const href = await hrefTo('kind', 'name');
-      expect(href).toContain('?id=kind--name');
+      const href = await hrefTo('title', 'name');
+      expect(href).toContain('?id=title--name');
     });
   });
 });

--- a/cypress/integration/addon-links.spec.ts
+++ b/cypress/integration/addon-links.spec.ts
@@ -1,0 +1,15 @@
+import { visit } from '../helper';
+
+describe('addon-links', () => {
+  before(() => {
+    visit('official-storybook?path=/story/addons-links-button--first');
+  });
+
+  it('should navigate on link', () => {
+    cy.getStoryElement().find('button').first().should('contain.text', 'Go to "Second"').click();
+    cy.url().should('include', 'path=/story/addons-links-button--second');
+
+    cy.getStoryElement().find('button').first().should('contain.text', 'Go to "First"').click();
+    cy.url().should('include', 'path=/story/addons-links-button--first');
+  });
+});

--- a/cypress/integration/addon-links.spec.ts
+++ b/cypress/integration/addon-links.spec.ts
@@ -6,19 +6,11 @@ describe('addon-links', () => {
   });
 
   it('should navigate on link', () => {
-    cy.getStoryElement()
-      .find('button')
-      .first()
-      .should('contain.text', 'Go to "Second"')
-      .click({ force: true });
+    cy.getStoryElement().find('button').should('contain.text', 'Go to "Second"').click();
 
     cy.url().should('include', 'path=/story/addons-links-button--second');
 
-    cy.getStoryElement()
-      .find('button')
-      .first()
-      .should('contain.text', 'Go to "First"')
-      .click({ force: true });
+    cy.getStoryElement().find('button').should('contain.text', 'Go to "First"').click();
 
     cy.url().should('include', 'path=/story/addons-links-button--first');
   });

--- a/cypress/integration/addon-links.spec.ts
+++ b/cypress/integration/addon-links.spec.ts
@@ -6,10 +6,20 @@ describe('addon-links', () => {
   });
 
   it('should navigate on link', () => {
-    cy.getStoryElement().find('button').first().should('contain.text', 'Go to "Second"').click();
+    cy.getStoryElement()
+      .find('button')
+      .first()
+      .should('contain.text', 'Go to "Second"')
+      .click({ force: true });
+
     cy.url().should('include', 'path=/story/addons-links-button--second');
 
-    cy.getStoryElement().find('button').first().should('contain.text', 'Go to "First"').click();
+    cy.getStoryElement()
+      .find('button')
+      .first()
+      .should('contain.text', 'Go to "First"')
+      .click({ force: true });
+
     cy.url().should('include', 'path=/story/addons-links-button--first');
   });
 });

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -273,7 +273,7 @@ export const init: ModuleFn = ({
 
       navigate('/');
     },
-    selectStory: (kindOrId, story = undefined, options = {}) => {
+    selectStory: (kindOrId = undefined, story = undefined, options = {}) => {
       const { ref, viewMode: viewModeFromArgs } = options;
       const {
         viewMode: viewModeFromState = 'story',
@@ -284,8 +284,10 @@ export const init: ModuleFn = ({
 
       const hash = ref ? refs[ref].stories : storiesHash;
 
+      const kindSlug = storyId?.split('--', 2)[0];
+
       if (!story) {
-        const s = hash[kindOrId] || hash[sanitize(kindOrId)];
+        const s = kindOrId ? hash[kindOrId] || hash[sanitize(kindOrId)] : hash[kindSlug];
         // eslint-disable-next-line no-nested-ternary
         const id = s ? (s.children ? s.children[0] : s.id) : kindOrId;
         let viewMode =
@@ -305,8 +307,7 @@ export const init: ModuleFn = ({
         navigate(p);
       } else if (!kindOrId) {
         // This is a slugified version of the kind, but that's OK, our toId function is idempotent
-        const kind = storyId.split('--', 2)[0];
-        const id = toId(kind, story);
+        const id = toId(kindSlug, story);
 
         api.selectStory(id, undefined, options);
       } else {

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -470,18 +470,20 @@ export const init: ModuleFn = ({
       function handler({
         kind,
         story,
+        storyId,
         ...rest
       }: {
         kind: string;
         story: string;
+        storyId: string;
         viewMode: ViewMode;
       }) {
         const { ref } = getEventMetadata(this, fullAPI);
 
         if (!ref) {
-          fullAPI.selectStory(kind, story, rest);
+          fullAPI.selectStory(storyId || kind, story, rest);
         } else {
-          fullAPI.selectStory(kind, story, { ...rest, ref: ref.id });
+          fullAPI.selectStory(storyId || kind, story, { ...rest, ref: ref.id });
         }
       }
     );

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -834,6 +834,24 @@ describe('stories API', () => {
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
 
+    it('allows navigating to the first story of the current kind if passed nothing', () => {
+      const navigate = jest.fn();
+      const store = createMockStore();
+
+      const {
+        api: { selectStory, setStories },
+        state,
+      } = initStories({ store, navigate, provider });
+      store.setState({
+        ...state,
+        storyId: 'a--2',
+      });
+      setStories(storiesHash);
+
+      selectStory();
+      expect(navigate).toHaveBeenCalledWith('/story/a--1');
+    });
+
     describe('component permalinks', () => {
       it('allows navigating to kind/storyname (legacy api)', () => {
         const navigate = jest.fn();


### PR DESCRIPTION
Issue: #16050

## What I did

- Refactored Links to be much simpler. It more or less just emits what the user gives it without checking the store.
- Slightly expanded the stories API on the manager to allow more flexible `SELECT_STORY` event to allow the above.

## NOTES

- I guess the changed `SELECT_STORY` event could be considered a breaking change. The old event still works, it is just the links addon will emit some more versions of it. I don't think it's a problem, unless we expect people to be listening to the events emitted by the links addon?

- Also there is slightly funky part -- if you call `linkTo(title, null)` with a title that contains a `--`, it will think it is a story id, and try to navigate to that. It's not actually a problem because the manager API it ends up calling mushes the `storyId` and `title`/`kind` back together anyway, but it could lead to bugs in the future. It is just a lot better not checking if things are story ids in the store on the preview side.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
Yes tests exist

- [x] Does this need a new example in the kitchen sink apps?
There are examples in official SB
