### PR TITLE
Fix docs: debug webpack command example

### DIFF
--- a/docs/configure/webpack.md
+++ b/docs/configure/webpack.md
@@ -40,10 +40,14 @@ You can import `.json` files and have them expanded to a JavaScript object:
 
 <!-- prettier-ignore-end -->
 
-If you want to know the exact details of the webpack config, the best way is to run:
+If you want to know the exact details of the webpack config, the best way is to run either of the following:
 
 ```shell
-yarn storybook --debug-webpack
+yarn start-storybook --debug-webpack
+```
+
+```shell
+yarn build-storybook --debug-webpack
 ```
 
 ### Extending Storybook’s webpack config


### PR DESCRIPTION
Issue:
The command shown in the docs didn't work:

package.json
```json
"scripts": {
	"debug": "storybook --debug-webpack"
}
```

terminal:
```
$ npm run debug

sh: storybook: command not found
```

## What I did

Update the docs to suggest either `build-storybook` or `start-storybook` when using the webpack debug flag.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
