### PR TITLE
StoryIndex: Detect added/moved directories and batch invalidations

### DIFF
--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -68,6 +68,7 @@
     "fs-extra": "^9.0.1",
     "globby": "^11.0.2",
     "ip": "^1.1.5",
+    "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",
     "pretty-hrtime": "^1.0.3",
     "prompts": "^2.4.0",

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -49,7 +49,7 @@ export async function useStoriesJson(
     if (started) return;
     started = true;
 
-    watchStorySpecifiers(normalizedStories, (specifier, path, removed) => {
+    watchStorySpecifiers(normalizedStories, { workingDir }, (specifier, path, removed) => {
       generator.invalidate(specifier, path, removed);
       invalidationEmitter.emit(INVALIDATE);
     });

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -7,11 +7,14 @@ import {
   NormalizedStoriesSpecifier,
   StorybookConfig,
 } from '@storybook/core-common';
+import debounce from 'lodash/debounce';
+
 import { StoryIndexGenerator } from './StoryIndexGenerator';
 import { watchStorySpecifiers } from './watch-story-specifiers';
 import { useEventsAsSSE } from './use-events-as-sse';
 
 const INVALIDATE = 'INVALIDATE';
+export const DEBOUNCE = 50;
 
 export async function extractStoriesJson(
   outputFile: string,
@@ -45,13 +48,16 @@ export async function useStoriesJson(
   // This is mainly for testing purposes.
   let started = false;
   const invalidationEmitter = new EventEmitter();
+  const maybeInvalidate = debounce(() => invalidationEmitter.emit(INVALIDATE), DEBOUNCE, {
+    leading: true,
+  });
   async function ensureStarted() {
     if (started) return;
     started = true;
 
     watchStorySpecifiers(normalizedStories, { workingDir }, (specifier, path, removed) => {
       generator.invalidate(specifier, path, removed);
-      invalidationEmitter.emit(INVALIDATE);
+      maybeInvalidate();
     });
 
     await generator.initialize();

--- a/lib/core-server/src/utils/watch-story-specifiers.test.ts
+++ b/lib/core-server/src/utils/watch-story-specifiers.test.ts
@@ -1,4 +1,5 @@
 import { normalizeStoriesEntry } from '@storybook/core-common';
+import path from 'path';
 import Watchpack from 'watchpack';
 
 import { watchStorySpecifiers } from './watch-story-specifiers';
@@ -6,9 +7,10 @@ import { watchStorySpecifiers } from './watch-story-specifiers';
 jest.mock('watchpack');
 
 describe('watchStorySpecifiers', () => {
+  const workingDir = path.join(__dirname, '__mockdata__');
   const options = {
-    configDir: '/path/to/project/.storybook',
-    workingDir: '/path/to/project',
+    configDir: path.join(workingDir, '.storybook'),
+    workingDir,
   };
 
   let close: () => void;
@@ -18,7 +20,7 @@ describe('watchStorySpecifiers', () => {
     const specifier = normalizeStoriesEntry('../src/**/*.stories.@(ts|js)', options);
 
     const onInvalidate = jest.fn();
-    close = watchStorySpecifiers([specifier], onInvalidate);
+    close = watchStorySpecifiers([specifier], { workingDir }, onInvalidate);
 
     expect(Watchpack).toHaveBeenCalledTimes(1);
     const watcher = Watchpack.mock.instances[0];
@@ -30,46 +32,64 @@ describe('watchStorySpecifiers', () => {
 
     // File changed, matching
     onInvalidate.mockClear();
-    onChange('src/button/Button.stories.ts', 1234);
-    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/button/Button.stories.ts`, false);
+    await onChange('src/nested/Button.stories.ts', 1234);
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button.stories.ts`, false);
 
     // File changed, NOT matching
     onInvalidate.mockClear();
-    onChange('src/button/Button.ts', 1234);
+    await onChange('src/nested/Button.ts', 1234);
     expect(onInvalidate).not.toHaveBeenCalled();
 
     // File removed, matching
     onInvalidate.mockClear();
-    onRemove('src/button/Button.stories.ts');
-    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/button/Button.stories.ts`, true);
+    await onRemove('src/nested/Button.stories.ts');
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button.stories.ts`, true);
 
     // File removed, NOT matching
     onInvalidate.mockClear();
-    onRemove('src/button/Button.ts');
+    await onRemove('src/nested/Button.ts');
     expect(onInvalidate).not.toHaveBeenCalled();
 
     // File moved out, matching
     onInvalidate.mockClear();
-    onChange('src/button/Button.stories.ts', null);
-    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/button/Button.stories.ts`, true);
+    await onChange('src/nested/Button.stories.ts', null);
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button.stories.ts`, true);
 
     // File renamed, matching
     onInvalidate.mockClear();
-    onChange('src/button/Button.stories.ts', null);
-    onChange('src/button/Button-2.stories.ts', 1234);
-    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/button/Button.stories.ts`, true);
-    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/button/Button-2.stories.ts`, false);
+    await onChange('src/nested/Button.stories.ts', null);
+    await onChange('src/nested/Button-2.stories.ts', 1234);
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button.stories.ts`, true);
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button-2.stories.ts`, false);
   });
 
-  it('watches single file globs', async () => {
-    const specifier = normalizeStoriesEntry('../src/button/Button.stories.mdx', options);
+  it('scans directories when they are added', async () => {
+    const specifier = normalizeStoriesEntry('../src/**/*.stories.@(ts|js)', options);
 
     const onInvalidate = jest.fn();
-    close = watchStorySpecifiers([specifier], onInvalidate);
+    close = watchStorySpecifiers([specifier], { workingDir }, onInvalidate);
 
     expect(Watchpack).toHaveBeenCalledTimes(1);
     const watcher = Watchpack.mock.instances[0];
-    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src/button'] });
+    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src'] });
+
+    expect(watcher.on).toHaveBeenCalledTimes(2);
+    const onChange = watcher.on.mock.calls[0][1];
+
+    onInvalidate.mockClear();
+    await onChange('src/nested', 1234);
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button.stories.ts`, false);
+  });
+
+  it('watches single file globs', async () => {
+    const specifier = normalizeStoriesEntry('../src/nested/Button.stories.mdx', options);
+
+    const onInvalidate = jest.fn();
+    close = watchStorySpecifiers([specifier], { workingDir }, onInvalidate);
+
+    expect(Watchpack).toHaveBeenCalledTimes(1);
+    const watcher = Watchpack.mock.instances[0];
+    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src/nested'] });
 
     expect(watcher.on).toHaveBeenCalledTimes(2);
     const onChange = watcher.on.mock.calls[0][1];
@@ -77,57 +97,57 @@ describe('watchStorySpecifiers', () => {
 
     // File changed, matching
     onInvalidate.mockClear();
-    onChange('src/button/Button.stories.mdx', 1234);
-    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/button/Button.stories.mdx`, false);
+    await onChange('src/nested/Button.stories.mdx', 1234);
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button.stories.mdx`, false);
 
     // File changed, NOT matching
     onInvalidate.mockClear();
-    onChange('src/button/Button.mdx', 1234);
+    await onChange('src/nested/Button.mdx', 1234);
     expect(onInvalidate).not.toHaveBeenCalled();
 
     // File removed, matching
     onInvalidate.mockClear();
-    onRemove('src/button/Button.stories.mdx');
-    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/button/Button.stories.mdx`, true);
+    await onRemove('src/nested/Button.stories.mdx');
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button.stories.mdx`, true);
 
     // File removed, NOT matching
     onInvalidate.mockClear();
-    onRemove('src/button/Button.mdx');
+    await onRemove('src/nested/Button.mdx');
     expect(onInvalidate).not.toHaveBeenCalled();
 
     // File moved out, matching
     onInvalidate.mockClear();
-    onChange('src/button/Button.stories.mdx', null);
-    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/button/Button.stories.mdx`, true);
+    await onChange('src/nested/Button.stories.mdx', null);
+    expect(onInvalidate).toHaveBeenCalledWith(specifier, `./src/nested/Button.stories.mdx`, true);
   });
 
-  it('multiplexes between two specifiers on the same directory', () => {
+  it('multiplexes between two specifiers on the same directory', async () => {
     const globSpecifier = normalizeStoriesEntry('../src/**/*.stories.@(ts|js)', options);
-    const fileSpecifier = normalizeStoriesEntry('../src/button/Button.stories.mdx', options);
+    const fileSpecifier = normalizeStoriesEntry('../src/nested/Button.stories.mdx', options);
 
     const onInvalidate = jest.fn();
-    close = watchStorySpecifiers([globSpecifier, fileSpecifier], onInvalidate);
+    close = watchStorySpecifiers([globSpecifier, fileSpecifier], { workingDir }, onInvalidate);
 
     expect(Watchpack).toHaveBeenCalledTimes(1);
     const watcher = Watchpack.mock.instances[0];
-    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src', './src/button'] });
+    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src', './src/nested'] });
 
     expect(watcher.on).toHaveBeenCalledTimes(2);
     const onChange = watcher.on.mock.calls[0][1];
 
     onInvalidate.mockClear();
-    onChange('src/button/Button.stories.ts', 1234);
+    await onChange('src/nested/Button.stories.ts', 1234);
     expect(onInvalidate).toHaveBeenCalledWith(
       globSpecifier,
-      `./src/button/Button.stories.ts`,
+      `./src/nested/Button.stories.ts`,
       false
     );
 
     onInvalidate.mockClear();
-    onChange('src/button/Button.stories.mdx', 1234);
+    await onChange('src/nested/Button.stories.mdx', 1234);
     expect(onInvalidate).toHaveBeenCalledWith(
       fileSpecifier,
-      `./src/button/Button.stories.mdx`,
+      `./src/nested/Button.stories.mdx`,
       false
     );
   });

--- a/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -61,7 +61,14 @@ export function watchStorySpecifiers(
           .map(async (specifier) => {
             // If `./path/to/dir` was added, check all files matching `./path/to/dir/**/*.stories.*`
             // (where the last bit depends on `files`).
-            const dirGlob = path.join(options.workingDir, importPath, '**', specifier.files);
+            const dirGlob = path.join(
+              options.workingDir,
+              importPath,
+              '**',
+              // files can be e.g. '**/foo/*/*.js' so we just want the last bit,
+              // because the directoru could already be within the files part (e.g. './x/foo/bar')
+              path.basename(specifier.files)
+            );
             const files = await glob(dirGlob);
             files.forEach((filePath) => {
               const fileImportPath = toImportPath(path.relative(options.workingDir, filePath));

--- a/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -1,9 +1,29 @@
 import Watchpack from 'watchpack';
+import fs from 'fs';
+import path from 'path';
+import glob from 'globby';
+
 import { NormalizedStoriesSpecifier } from '@storybook/core-common';
 import { Path } from '@storybook/store';
 
+const isDirectory = (directory: Path) => {
+  try {
+    return fs.lstatSync(directory).isDirectory();
+  } catch (err) {
+    return false;
+  }
+};
+
+// Watchpack (and path.relative) passes paths either with no leading './' - e.g. `src/Foo.stories.js`,
+// or with a leading `../` (etc), e.g. `../src/Foo.stories.js`.
+// We want to deal in importPaths relative to the working dir, so we normalize
+function toImportPath(relativePath: Path) {
+  return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+}
+
 export function watchStorySpecifiers(
   specifiers: NormalizedStoriesSpecifier[],
+  options: { workingDir: Path },
   onInvalidate: (specifier: NormalizedStoriesSpecifier, path: Path, removed: boolean) => void
 ) {
   // See https://www.npmjs.com/package/watchpack for full options.
@@ -17,19 +37,45 @@ export function watchStorySpecifiers(
     directories: specifiers.map((ns) => ns.directory),
   });
 
-  function onChangeOrRemove(watchpackPath: Path, removed: boolean) {
-    // Watchpack passes paths either with no leading './' - e.g. `src/Foo.stories.js`,
-    // or with a leading `../` (etc), e.g. `../src/Foo.stories.js`.
-    // We want to deal in importPaths relative to the working dir, or absolute paths.
-    const importPath = watchpackPath.startsWith('.') ? watchpackPath : `./${watchpackPath}`;
+  async function onChangeOrRemove(watchpackPath: Path, removed: boolean) {
+    const importPath = toImportPath(watchpackPath);
 
-    const specifier = specifiers.find((ns) => ns.importPathMatcher.exec(importPath));
-    if (specifier) {
-      onInvalidate(specifier, importPath, removed);
+    const matchingSpecifier = specifiers.find((ns) => ns.importPathMatcher.exec(importPath));
+    if (matchingSpecifier) {
+      onInvalidate(matchingSpecifier, importPath, removed);
+      return;
+    }
+
+    // When a directory is removed, watchpack will fire a removed event for each file also
+    // (so we don't need to do anything special).
+    // However, when a directory is added, it does not fire events for any files *within* the directory,
+    // so we need to scan within that directory for new files. It is tricky to use a glob for this,
+    // so we'll do something a bit more "dumb" for now
+    const absolutePath = path.join(options.workingDir, importPath);
+    if (!removed && isDirectory(absolutePath)) {
+      await Promise.all(
+        specifiers
+          // We only receive events for files (incl. directories) that are *within* a specifier,
+          // so will match one (or more) specifiers with this simple `startsWith`
+          .filter((specifier) => importPath.startsWith(specifier.directory))
+          .map(async (specifier) => {
+            // If `./path/to/dir` was added, check all files matching `./path/to/dir/**/*.stories.*`
+            // (where the last bit depends on `files`).
+            const dirGlob = path.join(options.workingDir, importPath, '**', specifier.files);
+            const files = await glob(dirGlob);
+            files.forEach((filePath) => {
+              const fileImportPath = toImportPath(path.relative(options.workingDir, filePath));
+
+              if (specifier.importPathMatcher.exec(fileImportPath)) {
+                onInvalidate(specifier, fileImportPath, removed);
+              }
+            });
+          })
+      );
     }
   }
 
-  wp.on('change', (path: Path, mtime: Date, explanation: string) => {
+  wp.on('change', async (filePath: Path, mtime: Date, explanation: string) => {
     // When a file is renamed (including being moved out of the watched dir)
     // we see first an event with explanation=rename and no mtime for the old name.
     // then an event with explanation=rename with an mtime for the new name.
@@ -37,10 +83,10 @@ export function watchStorySpecifiers(
     // but that seems dangerous (what if the contents changed?) and frankly not worth it
     // (at this stage at least)
     const removed = !mtime;
-    onChangeOrRemove(path, removed);
+    await onChangeOrRemove(filePath, removed);
   });
-  wp.on('remove', (path: Path, explanation: string) => {
-    onChangeOrRemove(path, true);
+  wp.on('remove', async (filePath: Path, explanation: string) => {
+    await onChangeOrRemove(filePath, true);
   });
 
   return () => wp.close();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8166,6 +8166,7 @@ __metadata:
     globby: ^11.0.2
     ip: ^1.1.5
     jest-specific-snapshot: ^4.0.0
+    lodash: ^4.17.20
     node-fetch: ^2.6.1
     pretty-hrtime: ^1.0.3
     prompts: ^2.4.0


### PR DESCRIPTION
Issue:#16295

## What I did

- Added some code to handle a directory added/moving as watchpack only gives us an event for the entire directory, not each file within it.

I use the files glob to scan the directory. This may be a mistake--perhaps I should just scan *all* files in the directory. What do you think? (this would be a rare event)

- Debounced the `INVALIDATE` event, so it fires at most twice, at least if watchpack events fire with no gap larger than 50ms.

## How to test

1. Run react TS
2. Move the `src/addon-docs` directory [optionally add some more files in there too].
3. Check the stories haven't been lost in the UI
4. Check the `INVALIDATE` event only fired twice and `stories.json` was only fetched 4 times (2x2[manager+preview]).

- [x] Is this testable with Jest or Chromatic screenshots?

Yes we have tests
