### PR TITLE
CLI: Improve build-storybooks script in the monorepo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
       - run:
           name: examples
           command: |
-            yarn build-storybooks
+            yarn build-storybooks --all
       - persist_to_workspace:
           root: .
           paths:

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -177,7 +177,7 @@ object ExamplesTemplate : Template({
                 rm -rf built-storybooks
                 mkdir -p built-storybooks
                 
-                yarn build-storybooks
+                yarn build-storybooks --all
             """.trimIndent()
             dockerImage = "buildkite/puppeteer"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux

--- a/CONTRIBUTING.old.md
+++ b/CONTRIBUTING.old.md
@@ -133,7 +133,7 @@ This should enable auto-fix for all source files, and give linting warnings and 
 
 First make sure the repo is bootstrapped.
 
-Then run `yarn build-storybooks`, this creates a static website from all examples.
+Then run `yarn build-storybooks --all`, this creates a static website from all examples.
 
 Then run `yarn serve-storybooks`, this will run the static site on the port cypress expects.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "built-storybooks"
-  command = "yarn bootstrap --core && yarn build-storybooks"
+  command = "yarn bootstrap --core && yarn build-storybooks --all"
 [build.environment]
   NODE_VERSION = "12"
   YARN_VERSION = "1.22.10"

--- a/scripts/build-storybooks.js
+++ b/scripts/build-storybooks.js
@@ -4,6 +4,7 @@ import { readdir as readdirRaw, writeFile as writeFileRaw, readFileSync, existsS
 import { join } from 'path';
 import program from 'commander';
 import prompts from 'prompts';
+import chalk from 'chalk';
 
 import { getDeployables } from './utils/list-examples';
 import { filterDataForCurrentCircleCINode } from './utils/concurrency';
@@ -163,6 +164,7 @@ const run = async () => {
       : allExamples.filter((example) => !example.includes('README'));
 
   if (examplesToSkip.length > 0) {
+    logger.log(`⏭  Will skip the following examples: ${chalk.yellow(examplesToSkip.join(', '))}`);
     examplesToBuild = examplesToBuild.filter((example) => !examplesToSkip.includes(example));
   }
 
@@ -191,7 +193,7 @@ const run = async () => {
   const deployables = filterDataForCurrentCircleCINode(list);
 
   if (deployables.length) {
-    logger.log(`🏗 Will build Storybook for: ${deployables.join(', ')}`);
+    logger.log(`🏗  Will build Storybook for: ${chalk.cyan(deployables.join(', '))}`);
     await handleExamples(deployables);
   }
 

--- a/scripts/build-storybooks.js
+++ b/scripts/build-storybooks.js
@@ -2,9 +2,23 @@ import { spawn } from 'child_process';
 import { promisify } from 'util';
 import { readdir as readdirRaw, writeFile as writeFileRaw, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import program from 'commander';
+import prompts from 'prompts';
 
 import { getDeployables } from './utils/list-examples';
 import { filterDataForCurrentCircleCINode } from './utils/concurrency';
+
+program
+  .option(
+    '--skip <value>',
+    'Skip an example, accepts multiple values like "--skip vue-kitchen-sink official-storybook"',
+    (value, previous) => previous.concat([value]),
+    []
+  )
+  .option('--all', `run e2e tests for every example`, false);
+program.parse(process.argv);
+
+const { all: shouldRunAllExamples, args: exampleArgs, skip: examplesToSkip } = program;
 
 const readdir = promisify(readdirRaw);
 const writeFile = promisify(writeFileRaw);
@@ -140,7 +154,40 @@ const handleExamples = async (deployables) => {
 };
 
 const run = async () => {
-  const list = getDeployables(await readdir(p(['examples'])), hasBuildScript);
+  const allExamples = await readdir(p(['examples']));
+
+  // if a specific example is passed, use it. Else use all
+  let examplesToBuild =
+    exampleArgs.length > 0
+      ? exampleArgs
+      : allExamples.filter((example) => !example.includes('README'));
+
+  if (examplesToSkip.length > 0) {
+    examplesToBuild = examplesToBuild.filter((example) => !examplesToSkip.includes(example));
+  }
+
+  if (!shouldRunAllExamples && exampleArgs.length === 0) {
+    const { selectedExamples } = await prompts([
+      {
+        type: 'autocompleteMultiselect',
+        message: 'Select the examples to build',
+        name: 'selectedExamples',
+        min: 1,
+        hint:
+          'You can also run directly with example name like `yarn build-storybooks official-example`, or `yarn build-storybooks --all` for all examples!',
+        choices: examplesToBuild.map((exampleName) => {
+          return {
+            value: exampleName,
+            title: exampleName,
+            selected: false,
+          };
+        }),
+      },
+    ]);
+    examplesToBuild = selectedExamples;
+  }
+
+  const list = getDeployables(examplesToBuild, hasBuildScript);
   const deployables = filterDataForCurrentCircleCINode(list);
 
   if (deployables.length) {


### PR DESCRIPTION
Issue: N/A

## What I did

Slight improvement in the `yarn build-storybooks` command to make it easier to run e2e tests in the examples in the monorepo.

`yarn build-storybooks` will now prompt the user with the list of examples to select:
![image](https://user-images.githubusercontent.com/1671563/138252810-9937e795-f972-4365-a5d1-a5f9f56e7b55.png)

`yarn build-storybooks <example-name>` will directly build only the example passed:
![image](https://user-images.githubusercontent.com/1671563/138253043-7aa02e5c-5ea8-4887-9d94-dd1eb6b251bd.png)

`yarn build-storybooks --all` (default in CI) will build all examples, but you can do `--skip <example-name>` to not build certain examples:
![image](https://user-images.githubusercontent.com/1671563/138252571-6de1fc44-77ae-489f-adfd-40664637c5dc.png)

`yarn build-storybooks --help` will display some helpful info:
![image](https://user-images.githubusercontent.com/1671563/138253403-94c2923c-1c87-4a3e-be99-4dee2516f993.png)


As a bonus, I added colors to the example names in the CLI to make things more 🌈 

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
