### PR TITLE
Chore: (Docs) Adjust snippets arg types

### DIFF
--- a/docs/snippets/angular/my-component-play-function-alt-queries.mdx.mdx
+++ b/docs/snippets/angular/my-component-play-function-alt-queries.mdx.mdx
@@ -7,15 +7,14 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
-<!-- 👇 Marking the onButtonClick with this configuration will log the event in the Actions panel -->
-
-<Meta title="QueryMethods" component={MyComponent} argTypes={{ onButtonClick: { action: true }}/>
+<Meta title="QueryMethods" component={MyComponent}/>
 
 <!-- The play function interacts with the component and looks for the button. -->
 
 <Story
   name="ExampleWithRole"
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button', { name: / button label/i }));
   }} />
 

--- a/docs/snippets/angular/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-alt-queries.ts.mdx
@@ -7,15 +7,11 @@ import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,
-  // 👇 Marking the onButtonClick with this configuration will log the event in the Actions panel
-  argTypes: {
-    onButtonClick: { action: true },
-  },
 };
 
 export const ExampleWithRole = {
   play: async () => {
-    // The play function interacts with the component and looks for the button.
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button', { name: / button label/i }));
   },
 };

--- a/docs/snippets/angular/my-component-play-function-waitfor.mdx.mdx
+++ b/docs/snippets/angular/my-component-play-function-waitfor.mdx.mdx
@@ -7,9 +7,7 @@ import { screen, fireEvent, userEvent, waitFor } from '@storybook/testing-librar
 
 import { MyComponent } from './MyComponent.component';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel -->
-
-<Meta title="WithAsync" component={MyComponent} argTypes={{ onSubmit: { action: true }}/>
+<Meta title="WithAsync" component={MyComponent}/>
 
 <!-- The delay option sets the amount of milliseconds between characters being typed-->
 
@@ -24,7 +22,7 @@ import { MyComponent } from './MyComponent.component';
     await userEvent.type(emailInput, 'WrongInput', {
       delay: 100,
     });
-
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/angular/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-waitfor.ts.mdx
@@ -7,8 +7,6 @@ import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const ExampleAsyncStory = {
@@ -20,7 +18,7 @@ export const ExampleAsyncStory = {
     await userEvent.type(emailInput, 'WrongInput', {
       delay: 100,
     });
-
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
 
     await userEvent.click(Submit);

--- a/docs/snippets/angular/my-component-play-function-with-clickevent.mdx.mdx
+++ b/docs/snippets/angular/my-component-play-function-with-clickevent.mdx.mdx
@@ -7,19 +7,20 @@ import { fireEvent, screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
-<!-- 👇 Marking the onClick with this configuration will log the event in the Actions panel -->
 
-<Meta title="ClickExamples" component={MyComponent} argTypes={{ onClick: { action: true }}/>
+<Meta title="ClickExamples" component={MyComponent} />
 
 <Story
   name="ClickExample"
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   }} />
 
 <Story
   name="FireEventExample"
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(screen.getByTestId('data-testid'));
   }} />
 ```

--- a/docs/snippets/angular/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-with-clickevent.ts.mdx
@@ -7,18 +7,18 @@ import { MyComponent } from './MyComponent.component';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onClick with this configuration will log the event in the Actions panel
-  argTypes: { onClick: { action: true } },
 };
 
 export const ClickExample = {
   play: async () => {
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   },
 };
 
 export const FireEventExample = {
   play: async () => {
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(screen.getByTestId('data-testid'));
   },
 };

--- a/docs/snippets/angular/register-component-with-play-function.mdx.mdx
+++ b/docs/snippets/angular/register-component-with-play-function.mdx.mdx
@@ -7,9 +7,7 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { RegistrationForm } from './RegistrationForm.component';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel -->
-
-<Meta title="RegistrationForm" component={RegistrationForm} argTypes={{ onSubmit: { action: true }} />
+<Meta title="RegistrationForm" component={RegistrationForm} />
 
 <Story
   name="FilledForm"
@@ -30,7 +28,7 @@ import { RegistrationForm } from './RegistrationForm.component';
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
     await fireEvent.click(submitButton);

--- a/docs/snippets/angular/register-component-with-play-function.mdx.mdx
+++ b/docs/snippets/angular/register-component-with-play-function.mdx.mdx
@@ -31,7 +31,7 @@ import { RegistrationForm } from './RegistrationForm.component';
     // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
-    await fireEvent.click(submitButton);
+    await userEvent.click(submitButton);
   }}
 />
 ```

--- a/docs/snippets/angular/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/angular/register-component-with-play-function.ts.mdx
@@ -30,7 +30,7 @@ export const FilledForm = {
     // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
-    await fireEvent.click(submitButton);
+    await userEvent.click(submitButton);
   },
 };
 ```

--- a/docs/snippets/angular/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/angular/register-component-with-play-function.ts.mdx
@@ -7,8 +7,6 @@ import { RegistrationForm } from './RegistrationForm.component';
 
 export default {
   component: RegistrationForm,
-  //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const FilledForm = {
@@ -29,7 +27,7 @@ export const FilledForm = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
     await fireEvent.click(submitButton);

--- a/docs/snippets/common/login-form-with-play-function.js.mdx
+++ b/docs/snippets/common/login-form-with-play-function.js.mdx
@@ -7,8 +7,6 @@ import { LoginForm } from './LoginForm';
 
 export default {
   component: LoginForm,
-   //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const Example = {
@@ -22,6 +20,7 @@ export const Example = {
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password'{
       delay: 100,
     });
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
   },
 };

--- a/docs/snippets/common/login-form-with-play-function.mdx.mdx
+++ b/docs/snippets/common/login-form-with-play-function.mdx.mdx
@@ -7,9 +7,7 @@ import { userEvent, within } from '@storybook/testing-library';
 
 import { LoginForm } from './LoginForm';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel -->
-
-<Meta title="Form" component={LoginForm} argTypes={{ onSubmit: { action: true }}/>
+<Meta title="Form" component={LoginForm} />
 
 <!--👇 Queries the DOM and looks for the root element of the component and assigns it for a performance boost -->
 
@@ -24,6 +22,8 @@ import { LoginForm } from './LoginForm';
     await userEvent.type(screen.getByTestId('password'), 'a-random-password', {
       delay: 100,
     });
+    
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 }} />
 ```

--- a/docs/snippets/react/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/react/my-component-play-function-alt-queries.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
+// MyComponent.stories.js|jsx|ts|tsx
 
 import { screen, userEvent } from '@storybook/testing-library';
 

--- a/docs/snippets/react/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/react/my-component-play-function-alt-queries.js.mdx
@@ -7,15 +7,13 @@ import { MyComponent } from './MyComponent.js';
 
 export default {
   component: MyComponent,
-  // 👇 Marking the onButtonClick with this configuration will log the event in the Actions panel
-  argTypes: {
-    onButtonClick: { action: true },
-  },
 };
 
 export const ExampleWithRole = {
   play: async () => {
     // The play function interacts with the component and looks for the button.
+    
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button', { name: / button label/i }));
   },
 };

--- a/docs/snippets/react/my-component-play-function-alt-queries.mdx.mdx
+++ b/docs/snippets/react/my-component-play-function-alt-queries.mdx.mdx
@@ -7,15 +7,15 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.js';
 
-<!-- 👇 Marking the onButtonClick with this configuration will log the event in the Actions panel -->
-
-<Meta title="QueryMethods" component={MyComponent} argTypes={{ onButtonClick: { action: true }}/>
+<Meta title="QueryMethods" component={MyComponent} />
 
 <!-- The play function interacts with the component and looks for the button. -->
 
 <Story
   name="ExampleWithRole"
   play={async () => {
+    
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button', { name: / button label/i }));
   }} />
 

--- a/docs/snippets/react/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
+// MyComponent.stories.js|jsx|ts|tsx
 
 import { screen, userEvent } from '@storybook/testing-library';
 

--- a/docs/snippets/react/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/react/my-component-play-function-waitfor.js.mdx
@@ -7,8 +7,6 @@ import { MyComponent } from './MyComponent.js';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const ExampleAsyncStory = {
@@ -20,7 +18,8 @@ export const ExampleAsyncStory = {
     await userEvent.type(Input, 'WrongInput', {
       delay: 100,
     });
-    
+
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/react/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/react/my-component-play-function-waitfor.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
+// MyComponent.stories.js|jsx|ts|tsx
 
 import { screen, userEvent, waitFor } from '@storybook/testing-library';
 

--- a/docs/snippets/react/my-component-play-function-waitfor.mdx.mdx
+++ b/docs/snippets/react/my-component-play-function-waitfor.mdx.mdx
@@ -8,9 +8,8 @@ import { screen, userEvent, waitFor } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.js';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel -->
 
-<Meta title="WithAsync" component={MyComponent} argTypes={{ onSubmit: { action: true }}/>
+<Meta title="WithAsync" component={MyComponent}/>
 
 <!-- The delay option sets the amount of milliseconds between characters being typed-->
 
@@ -22,7 +21,8 @@ import { MyComponent } from './MyComponent.js';
     await userEvent.type(Input, 'WrongInput', {
       delay: 100,
     });
-
+    
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);
     

--- a/docs/snippets/react/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/react/my-component-play-function-with-clickevent.js.mdx
@@ -7,18 +7,18 @@ import { MyComponent } from './MyComponent.js';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onClick with this configuration will log the event in the Actions panel
-  argTypes: { onClick: { action: true } },
 };
 
 export const ClickExample = {
   play: async () => {
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   },
 };
 
 export const FireEventExample = {
   play: async () => {
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(screen.getByTestId('data-testid'));
   },
 };

--- a/docs/snippets/react/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/react/my-component-play-function-with-clickevent.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// MyComponent.stories.js | MyComponent.stories.jsx | MyComponent.stories.ts | MyComponent.stories.tsx
+// MyComponent.stories.js|jsx|ts|tsx
 
 import { fireEvent, screen, userEvent } from '@storybook/testing-library';
 

--- a/docs/snippets/react/my-component-play-function-with-clickevent.mdx.mdx
+++ b/docs/snippets/react/my-component-play-function-with-clickevent.mdx.mdx
@@ -7,19 +7,19 @@ import { fireEvent, screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.js';
 
-<!-- 👇 Marking the onClick with this configuration will log the event in the Actions panel -->
-
-<Meta title="ClickExamples" component={MyComponent} argTypes={{ onClick: { action: true }}/>
+<Meta title="ClickExamples" component={MyComponent} />
 
 <Story
   name="ClickExample"
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   }} />
 
 <Story
   name="FireEventExample"
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(screen.getByTestId('data-testid'));
   }} />
 ```

--- a/docs/snippets/react/register-component-with-play-function.js.mdx
+++ b/docs/snippets/react/register-component-with-play-function.js.mdx
@@ -7,8 +7,6 @@ import { RegistrationForm } from './RegistrationForm.js';
 
 export default {
   component: RegistrationForm,
-  //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const FilledForm = {
@@ -29,7 +27,8 @@ export const FilledForm = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-
+    
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);
   },

--- a/docs/snippets/react/register-component-with-play-function.mdx.mdx
+++ b/docs/snippets/react/register-component-with-play-function.mdx.mdx
@@ -7,9 +7,8 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { RegistrationForm } from './RegistrationForm.js';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel -->
 
-<Meta title="RegistrationForm" component={RegistrationForm} argTypes={{ onSubmit: { action: true }}/>
+<Meta title="RegistrationForm" component={RegistrationForm}/>
 
 <Story
   name="FilledForm"
@@ -30,6 +29,7 @@ import { RegistrationForm } from './RegistrationForm.js';
       delay: 100,
     });
 
+    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);
   }} />

--- a/docs/snippets/svelte/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-alt-queries.js.mdx
@@ -7,15 +7,13 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onButtonClick with this configuration will log the event in the Actions panel
-  argTypes: {
-    onButtonClick: { action: true },
-  },
 };
 
 export const ExampleWithRole = {
   play: async () => {
     // The play function interacts with the component and looks for the button.
+
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button', { name: / button label/i }));
   },
   render: () => ({

--- a/docs/snippets/svelte/my-component-play-function-alt-queries.mdx.mdx
+++ b/docs/snippets/svelte/my-component-play-function-alt-queries.mdx.mdx
@@ -7,15 +7,15 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
-<!-- 👇 Marking the onButtonClick with this configuration will log the event in the Actions panel -->
 
-<Meta title="QueryMethods" component={MyComponent} argTypes={{ onButtonClick: { action: true }}/>
+<Meta title="QueryMethods" component={MyComponent}/>
 
 <!-- The play function interacts with the component and looks for the button. -->
 
 <Story
   name="ExampleWithRole"
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button', { name: / button label/i }));
   }}
   render={()=>({

--- a/docs/snippets/svelte/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-waitfor.js.mdx
@@ -7,8 +7,6 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const ExampleAsyncStory = {
@@ -22,6 +20,7 @@ export const ExampleAsyncStory = {
       delay: 100,
     });
 
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/svelte/my-component-play-function-waitfor.mdx.mdx
+++ b/docs/snippets/svelte/my-component-play-function-waitfor.mdx.mdx
@@ -7,9 +7,8 @@ import { screen, userEvent, waitFor } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel-->
 
-<Meta title="WithAsync" component={MyComponent} argTypes={{ onSubmit: { action: true }}/>
+<Meta title="WithAsync" component={MyComponent}/>
 
 <Story
   name="ExampleAsyncStory"
@@ -18,7 +17,8 @@ import MyComponent from './MyComponent.svelte';
     await userEvent.type(Input, 'WrongInput', {
       delay: 100,
     });
-
+    
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);
     

--- a/docs/snippets/svelte/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-with-clickevent.js.mdx
@@ -7,12 +7,11 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   component: MyComponent,
-   //👇 Marking the onClick with this configuration will log the event in the Actions panel
-  argTypes: { onClick: { action: true } },
 };
 
 export const ClickExample = {
   play: async () => {
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   },
   render: () => ({
@@ -22,6 +21,7 @@ export const ClickExample = {
 
 export const FireEventExample = {
   play: async () => {
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(screen.getByTestId('data-testid'));
   },
   render: () => ({

--- a/docs/snippets/svelte/my-component-play-function-with-clickevent.mdx.mdx
+++ b/docs/snippets/svelte/my-component-play-function-with-clickevent.mdx.mdx
@@ -7,13 +7,12 @@ import { fireEvent, screen, userEvent } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
-<!-- 👇 Marking the onClick with this configuration will log the event in the Actions panel -->
-
-<Meta title="ClickExamples" component={MyComponent} argTypes={{ onClick: { action: true }}/>
+<Meta title="ClickExamples" component={MyComponent} />
 
 <Story 
   name="ClickExample" 
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   }}
   render={() => ({
@@ -23,6 +22,7 @@ import MyComponent from './MyComponent.svelte';
 <Story 
   name="FireEventExample" 
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(screen.getByTestId('data-testid'));
   }}
   render={() => ({

--- a/docs/snippets/svelte/my-component-play-function-with-delay.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-with-delay.js.mdx
@@ -9,10 +9,9 @@ export default {
   component: MyComponent,
 };
 
-export const CombinedStories = {
-  ...FirstStory,
+export const DelayedStory = {
   play: async () => {
-    // The delay option set the ammount of milliseconds between characters being typed
+     // The delay option set the ammount of milliseconds between characters being typed
     await userEvent.type(screen.getByTestId('example-element'), 'random string', {
       delay: 100,
     });

--- a/docs/snippets/svelte/register-component-with-play-function.js.mdx
+++ b/docs/snippets/svelte/register-component-with-play-function.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // RegistrationForm.stories.js
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { screen, userEvent } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.svelte';
 
@@ -32,7 +32,7 @@ export const FilledForm = {
 
     const submitButton = screen.getByRole('button');
 
-    await fireEvent.click(submitButton);
+    await userEvent.click(submitButton);
   },
   render: () => ({
     Component: MyComponent,

--- a/docs/snippets/svelte/register-component-with-play-function.js.mdx
+++ b/docs/snippets/svelte/register-component-with-play-function.js.mdx
@@ -7,8 +7,6 @@ import RegistrationForm from './RegistrationForm.svelte';
 
 export default {
   component: RegistrationForm,
-  //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const FilledForm = {
@@ -29,6 +27,8 @@ export const FilledForm = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
+
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
 
     const submitButton = screen.getByRole('button');
 

--- a/docs/snippets/svelte/register-component-with-play-function.mdx.mdx
+++ b/docs/snippets/svelte/register-component-with-play-function.mdx.mdx
@@ -7,9 +7,7 @@ import { fireEvent, screen, userEvent } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.svelte';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel-->
-
-<Meta title="RegistrationForm" component={RegistrationForm} argTypes={{ onSubmit: { action: true }}/>
+<Meta title="RegistrationForm" component={RegistrationForm}/>
 
 <Story
   name="FilledForm"
@@ -31,6 +29,7 @@ import RegistrationForm from './RegistrationForm.svelte';
       delay: 100,
     });
 
+    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
     await fireEvent.click(submitButton);

--- a/docs/snippets/svelte/register-component-with-play-function.mdx.mdx
+++ b/docs/snippets/svelte/register-component-with-play-function.mdx.mdx
@@ -3,7 +3,7 @@
 
 import { Meta, Story } from '@storybook/addon-docs';
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { screen, userEvent } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.svelte';
 
@@ -32,7 +32,7 @@ import RegistrationForm from './RegistrationForm.svelte';
     // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
-    await fireEvent.click(submitButton);
+    await userEvent.click(submitButton);
   }}
   render={() => ({
     Component: RegistrationForm,

--- a/docs/snippets/vue/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-alt-queries.js.mdx
@@ -7,13 +7,13 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onButtonClick with this configuration will log the event in the Actions panel
-  argTypes: { onButtonClick: { action: true } },
 };
 
 export const ExampleWithRole = {
   play: async () => {
     // The play function interacts with the component and looks for the button.
+
+    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   },
   render: () => ({

--- a/docs/snippets/vue/my-component-play-function-alt-queries.mdx.mdx
+++ b/docs/snippets/vue/my-component-play-function-alt-queries.mdx.mdx
@@ -7,13 +7,12 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
-<!-- 👇 Marking the onButtonClick with this configuration will log the event in the Actions panel -->
-
-<Meta title="QueryMethods" component={MyComponent} argTypes={{ onButtonClick: { action: true }}/>
+<Meta title="QueryMethods" component={MyComponent}/>
 
 <Story 
   name="ExampleWithRole"
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   }}
   render={() => ({

--- a/docs/snippets/vue/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-waitfor.js.mdx
@@ -7,8 +7,6 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const ExampleAsyncStory = {
@@ -21,6 +19,8 @@ export const ExampleAsyncStory = {
     await userEvent.type(exampleElement, 'WrongInput', {
       delay: 100,
     });
+
+    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
 
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);

--- a/docs/snippets/vue/my-component-play-function-waitfor.mdx.mdx
+++ b/docs/snippets/vue/my-component-play-function-waitfor.mdx.mdx
@@ -7,9 +7,7 @@ import { screen, userEvent, waitFor } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel-->
-
-<Meta title="WithAsync" component={MyComponent} argTypes={{ onSubmit: { action: true }}/>
+<Meta title="WithAsync" component={MyComponent}/>
 
 <Story
   name="ExampleAsyncStory"
@@ -19,6 +17,7 @@ import MyComponent from './MyComponent.vue';
       delay: 100,
     });
 
+    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = screen.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/vue/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-with-clickevent.js.mdx
@@ -7,12 +7,11 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   component: MyComponent,
-  //👇 Marking the onButtonClick with this configuration will log the event in the Actions panel
-  argTypes: { onButtonClick: { action: true } },
 };
 
 export const ClickExample = {
   play: async () => {
+    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   },
   render: () => ({
@@ -23,6 +22,7 @@ export const ClickExample = {
 
 export const FireEventExample = {
   play: async () => {
+    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(screen.getByTestId('data-testid'));
   },
   render: () => ({

--- a/docs/snippets/vue/my-component-play-function-with-clickevent.mdx.mdx
+++ b/docs/snippets/vue/my-component-play-function-with-clickevent.mdx.mdx
@@ -7,13 +7,13 @@ import { fireEvent,screen, userEvent } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
-<!-- 👇 Marking the onClick with this configuration will log the event in the Actions panel -->
 
-<Meta title="ClickExamples" component={MyComponent} argTypes={{ onClick: { action: true }}/>
+<Meta title="ClickExamples" component={MyComponent}/>
 
 <Story 
   name="ClickExample"
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(screen.getByRole('button'));
   }}
   render={()=>({
@@ -24,6 +24,7 @@ import MyComponent from './MyComponent.vue';
 <Story 
   name="FireEventExample" 
   play={async () => {
+    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(screen.getByTestId('data-testid'));
   }}
   render={()=> ({

--- a/docs/snippets/vue/register-component-with-play-function.js.mdx
+++ b/docs/snippets/vue/register-component-with-play-function.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // RegistrationForm.stories.js
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { screen, userEvent } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.vue';
 
@@ -30,7 +30,7 @@ export const FilledForm = {
     // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
-    await fireEvent.click(submitButton);
+    await userEvent.click(submitButton);
     
   },
   render: () => ({

--- a/docs/snippets/vue/register-component-with-play-function.js.mdx
+++ b/docs/snippets/vue/register-component-with-play-function.js.mdx
@@ -7,8 +7,6 @@ import RegistrationForm from './RegistrationForm.vue';
 
 export default {
   component: RegistrationForm,
-  //👇 Marking the onSubmit with this configuration will log the event in the Actions panel
-  argTypes: { onSubmit: { action: true } },
 };
 
 export const FilledForm = {
@@ -29,6 +27,7 @@ export const FilledForm = {
       delay: 100,
     });
 
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
     await fireEvent.click(submitButton);

--- a/docs/snippets/vue/register-component-with-play-function.mdx.mdx
+++ b/docs/snippets/vue/register-component-with-play-function.mdx.mdx
@@ -7,9 +7,9 @@ import { fireEvent, screen, userEvent } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.vue';
 
-<!-- 👇 Marking the onSubmit with this configuration will log the event in the Actions panel-->
 
-<Meta title="RegistrationForm" component={RegistrationForm} argTypes={{ onSubmit: { action: true }}/>
+
+<Meta title="RegistrationForm" component={RegistrationForm} />
 
 <Story
   name="FilledForm"
@@ -30,6 +30,7 @@ import RegistrationForm from './RegistrationForm.vue';
       delay: 100,
     });
 
+    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
     await fireEvent.click(submitButton);

--- a/docs/snippets/vue/register-component-with-play-function.mdx.mdx
+++ b/docs/snippets/vue/register-component-with-play-function.mdx.mdx
@@ -3,7 +3,7 @@
 
 import { Meta, Story } from '@storybook/addon-docs';
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { screen, userEvent } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.vue';
 
@@ -33,7 +33,7 @@ import RegistrationForm from './RegistrationForm.vue';
     // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = screen.getByRole('button');
 
-    await fireEvent.click(submitButton);
+    await userEvent.click(submitButton);
   }}
   render={() => ({
     components: { RegistrationForm },


### PR DESCRIPTION
With this pull request, the documentation's snippets are adjusted for clarity in terms of usage with the addon-interactions and the argtypes required for logging.

This follows up a conversation that I had with @yannbf !

