### PR TITLE
Addon-interactions: Add safety check on fileName parameter

### DIFF
--- a/addons/interactions/src/Panel.tsx
+++ b/addons/interactions/src/Panel.tsx
@@ -53,7 +53,8 @@ export const Panel: React.FC<PanelProps> = (props) => {
   });
 
   const { storyId } = useStorybookState();
-  const [fileName] = useParameter('fileName', '').split('/').slice(-1);
+  const storyFilePath = useParameter('fileName', '');
+  const [fileName] = storyFilePath.toString().split('/').slice(-1);
   const scrollToTarget = () => scrollTarget?.scrollIntoView({ behavior: 'smooth', block: 'end' });
 
   const isDebugging = log.some((item) => pendingStates.includes(item.state));


### PR DESCRIPTION
Issue: #16453

## What I did

This PR adds a safe check to make sure the `fileName` parameter is a string.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

## Additional context

Turns out the issue is in the metadata contained in `stories.json` v2, which had before `fileName` as a number and not a string.

V3(left) versus V2(right):
![image](https://user-images.githubusercontent.com/1671563/138495603-b78477ef-ce4f-4279-9f26-d8cd75e9b484.png)

I'm not sure what to make of this problem. Could mean that we need to do something extra/else to fix it properly? Seems like addon-interactions and the `sortStories` file are the only places where the fileName parameter is consumed.
