### PR TITLE
Interactions: Do not cleanup state when loading initial story

### DIFF
--- a/lib/instrumenter/src/instrumenter.test.ts
+++ b/lib/instrumenter/src/instrumenter.test.ts
@@ -317,6 +317,7 @@ describe('Instrumenter', () => {
   });
 
   it('clears state when switching stories', () => {
+    addons.getChannel().emit(SET_CURRENT_STORY); // initialization
     instrumenter.state = {
       'kind--story': {
         isDebugging: false,

--- a/lib/instrumenter/src/instrumenter.ts
+++ b/lib/instrumenter/src/instrumenter.ts
@@ -102,6 +102,8 @@ const getRetainedState = (state: State, isDebugging = false) => {
 export class Instrumenter {
   channel: Channel;
 
+  initialized = false;
+
   // State is tracked per story to deal with multiple stories on the same canvas (i.e. docs mode)
   state: Record<StoryId, State>;
 
@@ -144,8 +146,11 @@ export class Instrumenter {
       }
     });
 
-    // Trash non-retained state and clear the log when switching stories.
-    this.channel.on(SET_CURRENT_STORY, this.cleanup.bind(this));
+    // Trash non-retained state and clear the log when switching stories, but not on initial boot.
+    this.channel.on(SET_CURRENT_STORY, () => {
+      if (this.initialized) this.cleanup();
+      else this.initialized = true;
+    });
 
     const start = ({ storyId, playUntil }: { storyId: string; playUntil?: Call['id'] }) => {
       if (!this.getState(storyId).isDebugging) {


### PR DESCRIPTION
Issue: #16430 

## What I did

Prevent clearing the instrumenter state on the `SET_CURRENT_STORY` event caused by selection of the first story when navigating to `/` (opened on boot).

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? no
- [x] Does this need a new example in the kitchen sink apps? no
- [x] Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
