### PR TITLE
UI: Fix brand logo layout shift

### DIFF
--- a/lib/ui/src/components/sidebar/Heading.tsx
+++ b/lib/ui/src/components/sidebar/Heading.tsx
@@ -34,6 +34,7 @@ const HeadingWrapper = styled.div({
   alignItems: 'center',
   justifyContent: 'space-between',
   position: 'relative',
+  minHeight: 28,
 });
 
 const SkipToCanvasLink = styled(Button)(({ theme }) => ({


### PR DESCRIPTION
issue: 


https://user-images.githubusercontent.com/3140656/138656554-91aa44a8-7ba0-4f70-ad69-d064aa69d084.mp4


## What I did

Add a min height property to sidebar header. 28px is the height of the menu icon button.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

Chromatic: https://61765b77578f7c004a3621ca-lysmbbsgwj.chromatic.com/

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
