### PR TITLE
Core: Persist globals to variable on parent window, then restore on init

### DIFF
--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -170,10 +170,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
   }
 
   async setGlobalsAndRenderSelection() {
-    const { globals } = this.urlStore.selectionSpecifier || {};
-    if (globals) {
-      this.storyStore.globals.updateFromPersisted(globals);
-    }
+    this.storyStore.globals.updateFromPersisted(this.urlStore.selectionSpecifier?.globals);
     this.channel.emit(Events.SET_GLOBALS, {
       globals: this.storyStore.globals.get() || {},
       globalTypes: this.storyStore.projectAnnotations.globalTypes || {},
@@ -604,6 +601,9 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       // If we still haven't completed, reload the page (iframe) to ensure we have a clean slate
       // for the next render. Since the reload can take a brief moment to happen, we want to stop
       // further rendering by awaiting a never-resolving promise (which is destroyed on reload).
+      // We persist the current globals to a variable on the parent window (manager), so they can be
+      // restored after reloading.
+      this.storyStore.globals.persist();
       global.window.location.reload();
       await new Promise(() => {});
     };


### PR DESCRIPTION
Issue: #16383

## What I did

Before reloading the preview iframe, persist the current `globals` to a global variable on `window.parent` (the manager) if possible. Then restore globals from there on reinitialization after the reload.

Alternative solution: https://github.com/storybookjs/storybook/pull/16469

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? no
- [x] Does this need a new example in the kitchen sink apps? no
- [x] Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
