### PR TITLE
Core: Save and restore globals on preview init using the channel

### DIFF
--- a/lib/api/src/modules/globals.ts
+++ b/lib/api/src/modules/globals.ts
@@ -77,7 +77,7 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
         logger.warn('received globals from a non-local ref. This is not currently supported.');
       }
 
-      if (currentGlobals) {
+      if (currentGlobals && !deepEqual(globals, currentGlobals)) {
         api.updateGlobals(currentGlobals);
       }
     });

--- a/lib/api/src/modules/globals.ts
+++ b/lib/api/src/modules/globals.ts
@@ -54,14 +54,11 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
   };
 
   const initModule = () => {
-    let storedGlobals: Globals;
-
     fullAPI.on(GLOBALS_UPDATED, function handleGlobalsUpdated({ globals }: { globals: Globals }) {
       const { ref } = getEventMetadata(this, fullAPI);
 
       if (!ref) {
         updateGlobals(globals);
-        storedGlobals = globals;
       } else {
         logger.warn(
           'received a GLOBALS_UPDATED from a non-local ref. This is not currently supported.'
@@ -72,6 +69,7 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
     // Emitted by the preview on initialization
     fullAPI.on(SET_GLOBALS, function handleSetStories({ globals, globalTypes }: SetGlobalsPayload) {
       const { ref } = getEventMetadata(this, fullAPI);
+      const currentGlobals = store.getState()?.globals;
 
       if (!ref) {
         store.setState({ globals, globalTypes });
@@ -79,8 +77,8 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
         logger.warn('received globals from a non-local ref. This is not currently supported.');
       }
 
-      if (storedGlobals) {
-        api.updateGlobals(storedGlobals);
+      if (currentGlobals) {
+        api.updateGlobals(currentGlobals);
       }
     });
   };

--- a/lib/api/src/modules/globals.ts
+++ b/lib/api/src/modules/globals.ts
@@ -54,17 +54,22 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
   };
 
   const initModule = () => {
+    let storedGlobals: Globals;
+
     fullAPI.on(GLOBALS_UPDATED, function handleGlobalsUpdated({ globals }: { globals: Globals }) {
       const { ref } = getEventMetadata(this, fullAPI);
 
       if (!ref) {
         updateGlobals(globals);
+        storedGlobals = globals;
       } else {
         logger.warn(
           'received a GLOBALS_UPDATED from a non-local ref. This is not currently supported.'
         );
       }
     });
+
+    // Emitted by the preview on initialization
     fullAPI.on(SET_GLOBALS, function handleSetStories({ globals, globalTypes }: SetGlobalsPayload) {
       const { ref } = getEventMetadata(this, fullAPI);
 
@@ -72,6 +77,10 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
         store.setState({ globals, globalTypes });
       } else if (Object.keys(globals).length > 0) {
         logger.warn('received globals from a non-local ref. This is not currently supported.');
+      }
+
+      if (storedGlobals) {
+        api.updateGlobals(storedGlobals);
       }
     });
   };

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -4,6 +4,7 @@ import {
   STORY_ARGS_UPDATED,
   SET_CURRENT_STORY,
   GLOBALS_UPDATED,
+  UPDATE_QUERY_PARAMS,
 } from '@storybook/core-events';
 import { queryFromLocation, buildArgsParam, NavigateOptions } from '@storybook/router';
 import { toId, sanitize } from '@storybook/csf';
@@ -164,7 +165,10 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
         }, queryParams),
       };
       const equal = deepEqual(customQueryParams, update);
-      if (!equal) store.setState({ customQueryParams: update });
+      if (!equal) {
+        store.setState({ customQueryParams: update });
+        fullAPI.emit(UPDATE_QUERY_PARAMS, update);
+      }
     },
     navigateUrl(url, options) {
       navigate(url, { ...options, plain: true });

--- a/lib/api/src/modules/url.ts
+++ b/lib/api/src/modules/url.ts
@@ -164,8 +164,7 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
           return acc;
         }, queryParams),
       };
-      const equal = deepEqual(customQueryParams, update);
-      if (!equal) {
+      if (!deepEqual(customQueryParams, update)) {
         store.setState({ customQueryParams: update });
         fullAPI.emit(UPDATE_QUERY_PARAMS, update);
       }

--- a/lib/api/src/tests/url.test.js
+++ b/lib/api/src/tests/url.test.js
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import { SET_CURRENT_STORY, GLOBALS_UPDATED } from '@storybook/core-events';
+import { SET_CURRENT_STORY, GLOBALS_UPDATED, UPDATE_QUERY_PARAMS } from '@storybook/core-events';
 
 import { init as initURL } from '../modules/url';
 
@@ -147,11 +147,18 @@ describe('queryParams', () => {
       },
       getState: () => state,
     };
-    const { api } = initURL({ state: { location: { search: '' } }, navigate: jest.fn(), store });
+    const fullAPI = { emit: jest.fn() };
+    const { api } = initURL({
+      state: { location: { search: '' } },
+      navigate: jest.fn(),
+      store,
+      fullAPI,
+    });
 
     api.setQueryParams({ foo: 'bar' });
 
     expect(api.getQueryParam('foo')).toEqual('bar');
+    expect(fullAPI.emit).toHaveBeenCalledWith(UPDATE_QUERY_PARAMS, { foo: 'bar' });
   });
 });
 

--- a/lib/core-events/src/index.ts
+++ b/lib/core-events/src/index.ts
@@ -48,6 +48,7 @@ enum events {
   SHARED_STATE_CHANGED = 'sharedStateChanged',
   SHARED_STATE_SET = 'sharedStateSet',
   NAVIGATE_URL = 'navigateUrl',
+  UPDATE_QUERY_PARAMS = 'updateQueryParams',
 }
 
 // Enables: `import Events from ...`
@@ -87,6 +88,7 @@ export const {
   SHARED_STATE_CHANGED,
   SHARED_STATE_SET,
   NAVIGATE_URL,
+  UPDATE_QUERY_PARAMS,
 } = events;
 
 // Used to break out of the current render without showing a redbox

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -164,6 +164,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       this.indexClient.addEventListener(INVALIDATE, this.onStoryIndexChanged.bind(this));
 
     this.channel.on(Events.SET_CURRENT_STORY, this.onSetCurrentStory.bind(this));
+    this.channel.on(Events.UPDATE_QUERY_PARAMS, this.onUpdateQueryParams.bind(this));
     this.channel.on(Events.UPDATE_GLOBALS, this.onUpdateGlobals.bind(this));
     this.channel.on(Events.UPDATE_STORY_ARGS, this.onUpdateArgs.bind(this));
     this.channel.on(Events.RESET_STORY_ARGS, this.onResetArgs.bind(this));
@@ -219,6 +220,10 @@ export class PreviewWeb<TFramework extends AnyFramework> {
     this.urlStore.setSelection(selection);
     this.channel.emit(Events.CURRENT_STORY_WAS_SET, this.urlStore.selection);
     this.renderSelection();
+  }
+
+  onUpdateQueryParams(queryParams: any) {
+    this.urlStore.setQueryParams(queryParams);
   }
 
   onUpdateGlobals({ globals }: { globals: Globals }) {


### PR DESCRIPTION
Issue: #16383

## What I did

We now send an `UPDATE_QUERY_PARAMS` event to the preview each time the queryParams change in the manager, allowing the preview to update its own URL accordingly. This will ensure that at least for serializable args/globals, the iframe URL is set correctly when it reloads, and will therefore initialize with the proper args/globals.

This actually also fixes an existing issue with args/globals getting lost when you manually refresh the iframe (right click, reload frame).

For insecure args/globals, we listen for the `SET_GLOBALS` event emitted by the preview on initialization, and respond by sending the current globals from the manager back to the preview.

This supersedes https://github.com/storybookjs/storybook/pull/16468

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? no
- [x] Does this need a new example in the kitchen sink apps? no
- [x] Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
