### PR TITLE
Core: Ensure we don't reset `WebPreview` if calling `start()` in v7 mode

### DIFF
--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -46,6 +46,7 @@ export function start<TFramework extends AnyFramework>(
         clearDecorators: removedApi('clientApi.clearDecorators'),
         setAddon: removedApi('clientApi.setAddon'),
         getStorybook: removedApi('clientApi.getStorybook'),
+        storiesOf: removedApi('clientApi.storiesOf'),
       },
     };
   }

--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -34,7 +34,7 @@ export function start<TFramework extends AnyFramework>(
     render?: ArgsStoryFn<TFramework>;
   } = {}
 ) {
-  if (FEATURES.storyStoreV7) {
+  if (FEATURES?.storyStoreV7) {
     return {
       forceReRender: removedApi('forceReRender'),
       getStorybook: removedApi('getStorybook'),

--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -38,7 +38,6 @@ export function start<TFramework extends AnyFramework>(
     return {
       forceReRender: removedApi('forceReRender'),
       getStorybook: removedApi('getStorybook'),
-      raw: removedApi('raw'),
       configure: removedApi('configure'),
       clientApi: {
         addDecorator: removedApi('clientApi.addDecorator'),
@@ -48,6 +47,7 @@ export function start<TFramework extends AnyFramework>(
         setAddon: removedApi('clientApi.setAddon'),
         getStorybook: removedApi('clientApi.getStorybook'),
         storiesOf: removedApi('clientApi.storiesOf'),
+        raw: removedApi('raw'),
       },
     };
   }

--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -44,6 +44,7 @@ export function start<TFramework extends AnyFramework>(
         addDecorator: removedApi('clientApi.addDecorator'),
         addParameters: removedApi('clientApi.addParameters'),
         clearDecorators: removedApi('clientApi.clearDecorators'),
+        addLoader: removedApi('clientApi.addLoader'),
         setAddon: removedApi('clientApi.setAddon'),
         getStorybook: removedApi('clientApi.getStorybook'),
         storiesOf: removedApi('clientApi.storiesOf'),

--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -11,7 +11,7 @@ import { Path } from '@storybook/store';
 import { Loadable } from './types';
 import { executeLoadableForChanges } from './executeLoadable';
 
-const { window: globalWindow } = global;
+const { window: globalWindow, FEATURES } = global;
 
 const configureDeprecationWarning = deprecate(
   () => {},
@@ -19,6 +19,10 @@ const configureDeprecationWarning = deprecate(
 Please use the \`stories\` field of \`main.js\` to load stories.
 Read more at https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-configure`
 );
+
+const removedApi = (name: string) => () => {
+  throw new Error(`@storybook/client-api:${name} was removed in storyStoreV7.`);
+};
 
 export function start<TFramework extends AnyFramework>(
   renderToDOM: WebProjectAnnotations<TFramework>['renderToDOM'],
@@ -30,6 +34,22 @@ export function start<TFramework extends AnyFramework>(
     render?: ArgsStoryFn<TFramework>;
   } = {}
 ) {
+  if (FEATURES.storyStoreV7) {
+    return {
+      forceReRender: removedApi('forceReRender'),
+      getStorybook: removedApi('getStorybook'),
+      raw: removedApi('raw'),
+      configure: removedApi('configure'),
+      clientApi: {
+        addDecorator: removedApi('clientApi.addDecorator'),
+        addParameters: removedApi('clientApi.addParameters'),
+        clearDecorators: removedApi('clientApi.clearDecorators'),
+        setAddon: removedApi('clientApi.setAddon'),
+        getStorybook: removedApi('clientApi.getStorybook'),
+      },
+    };
+  }
+
   const channel = createChannel({ page: 'preview' });
   addons.setChannel(channel);
 


### PR DESCRIPTION
Issue: #16455

The problem was that when you import from `@storybook/angular` it calls `start()` (as do all other frameworks), which created an old, non-v7 `StoryStore` and assigned it to `__STORYBOOK_STORY_STORE__`, then awaited a `configure()` call (that never came....)

## What I did

- Ensure `start()` is a no-op in v7 mode
- Return an API that throws errors

## Questions

Should we make some of that API work (i.e. `api.raw()` etc?)

## How to test

See example in issue.