### PR TITLE
POC of storyshots (v6) w/ story index

### DIFF
--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -51,6 +51,7 @@
     "@storybook/core-client": "6.4.0-beta.20",
     "@storybook/core-common": "6.4.0-beta.20",
     "@storybook/csf": "0.0.2--canary.87bc651.0",
+    "@storybook/store": "6.4.0-beta.20",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.16",
     "@types/jest-specific-snapshot": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7304,6 +7304,7 @@ __metadata:
     "@storybook/core-common": 6.4.0-beta.20
     "@storybook/csf": 0.0.2--canary.87bc651.0
     "@storybook/react": 6.4.0-beta.20
+    "@storybook/store": 6.4.0-beta.20
     "@storybook/vue": 6.4.0-beta.20
     "@storybook/vue3": 6.4.0-beta.20
     "@types/glob": ^7.1.3


### PR DESCRIPTION
Issue: #16048

## What I did

Initial proof of concept of using the story index to drive storyshots. The (storyshots) tests seem to be passing at least.

### Problems/Questions/TODOs:

1. For the v7 store we are going to need to generate the `storyIndex` in node, via reading main.js and calling `extractStoriesJson`. I guess this is OK?

2. With this approach there is no way to disable a test using `parameters.storyshots`. We can only make the test do nothing once we've run it (because the async part has to happen inside the test). Is this acceptable?


## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
