### PR TITLE
bug: provide args values from url to control

### DIFF
--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -529,6 +529,17 @@ export class PreviewWeb<TFramework extends AnyFramework> {
         unboundStoryFn,
       };
 
+      // Populate args from url to ArgsTable controls.
+      if (initial) {
+        const { args, storySpecifier } = this.urlStore.selectionSpecifier;
+        if (Object.keys(args).length > 0) {
+          this.channel.emit(Events.STORY_ARGS_UPDATED, {
+            storyId: storySpecifier,
+            updatedArgs: args,
+          });
+        }
+      }
+
       try {
         if (!this.renderToDOM) {
           throw new Error(dedent`


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/15278

## What I did
I passed values from URL to ArgsTable by emitting `storyArgsUpdated` with URL args state, which is not populated on the initial render.

## How to test

Go to the issue and try to reproduce it with these changes.

If a unit test is necessary for this fix, let me know how to write it.

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?
