### PR TITLE
Addon-docs: Fix centered layout on DocsPage

### DIFF
--- a/addons/docs/src/blocks/DocsStory.tsx
+++ b/addons/docs/src/blocks/DocsStory.tsx
@@ -41,7 +41,7 @@ export const DocsStory: FunctionComponent<DocsStoryProps> = ({
       {subheading && <Subheading>{subheading}</Subheading>}
       {description && <Description markdown={description} />}
       <Canvas withToolbar={withToolbar}>
-        <Story id={id} />
+        <Story id={id} parameters={parameters} />
       </Canvas>
     </Anchor>
   );

--- a/examples/official-storybook/stories/core/layout.stories.js
+++ b/examples/official-storybook/stories/core/layout.stories.js
@@ -7,6 +7,9 @@ const Box = ({ children, display = 'block', width, height }) => (
 
 export default {
   title: 'Core/Layout',
+  parameters: {
+    layout: 'centered',
+  },
 };
 
 export const Default = () => <Box>padded by default</Box>;
@@ -37,6 +40,9 @@ CenteredWide.parameters = { layout: 'centered' };
 
 export const None = () => <Box>none</Box>;
 None.parameters = { layout: 'none' };
+
+export const Inherited = () => <Box>none</Box>;
+Inherited.parameters = {};
 
 export const Invalid = () => <Box>invalid layout value</Box>;
 Invalid.parameters = { layout: '!invalid!' };


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12935

## What I did

I passed down the parameters of the story to the Story component, so it gets the layout correctly

## How to test

- this story in the official storybook should display properly now:
`?path=/docs/core-layout--fullscreen-inline`
