### PR TITLE
UI: Improve WithTooltip contrast and positioning

### DIFF
--- a/addons/interactions/src/components/Subnav/Subnav.tsx
+++ b/addons/interactions/src/components/Subnav/Subnav.tsx
@@ -86,6 +86,21 @@ const JumpToEndButton = styled(StyledButton)({
   lineHeight: '12px',
 });
 
+const withTooltipModifiers = [
+  {
+    name: 'preventOverflow',
+    options: {
+      padding: 0,
+    },
+  },
+  {
+    name: 'offset',
+    options: {
+      offset: [0, -2],
+    },
+  },
+];
+
 export const Subnav: React.FC<SubnavProps> = ({
   isDisabled,
   hasNext,
@@ -112,13 +127,23 @@ export const Subnav: React.FC<SubnavProps> = ({
 
           <StyledSeparator />
 
-          <WithTooltip hasChrome={false} tooltip={<Note note="Go to start" />}>
+          <WithTooltip
+            modifiers={withTooltipModifiers}
+            hasChrome={false}
+            trigger={hasPrevious ? 'hover' : 'none'}
+            tooltip={<Note note="Go to start" />}
+          >
             <RewindButton containsIcon onClick={onStart} disabled={isDisabled || !hasPrevious}>
               <Icons icon="rewind" />
             </RewindButton>
           </WithTooltip>
 
-          <WithTooltip hasChrome={false} tooltip={<Note note="Go back" />}>
+          <WithTooltip
+            modifiers={withTooltipModifiers}
+            hasChrome={false}
+            trigger={hasPrevious ? 'hover' : 'none'}
+            tooltip={<Note note="Go back" />}
+          >
             <StyledIconButton
               containsIcon
               onClick={onPrevious}
@@ -128,13 +153,23 @@ export const Subnav: React.FC<SubnavProps> = ({
             </StyledIconButton>
           </WithTooltip>
 
-          <WithTooltip hasChrome={false} tooltip={<Note note="Go forward" />}>
+          <WithTooltip
+            modifiers={withTooltipModifiers}
+            hasChrome={false}
+            trigger={hasNext ? 'hover' : 'none'}
+            tooltip={<Note note="Go forward" />}
+          >
             <StyledIconButton containsIcon onClick={onNext} disabled={isDisabled || !hasNext}>
               <Icons icon="playnext" />
             </StyledIconButton>
           </WithTooltip>
 
-          <WithTooltip hasChrome={false} tooltip={<Note note="Go to end" />}>
+          <WithTooltip
+            modifiers={withTooltipModifiers}
+            trigger={hasNext ? 'hover' : 'none'}
+            hasChrome={false}
+            tooltip={<Note note="Go to end" />}
+          >
             <StyledIconButton containsIcon onClick={onEnd} disabled={isDisabled || !hasNext}>
               <Icons icon="fastforward" />
             </StyledIconButton>

--- a/lib/components/src/tooltip/TooltipNote.tsx
+++ b/lib/components/src/tooltip/TooltipNote.tsx
@@ -12,7 +12,7 @@ const Note = styled.div(({ theme }) => ({
   whiteSpace: 'nowrap',
   pointerEvents: 'none',
   zIndex: -1,
-  background: 'rgba(0, 0, 0, 0.4)',
+  background: theme.base === 'light' ? 'rgba(60, 60, 60, 0.9)' : 'rgba(20, 20, 20, 0.85)',
   margin: 6,
 }));
 


### PR DESCRIPTION
1. `WithTooltip` was showing too far away from the buttons in `Subnav`.
1. `TooltipNote` was hard to read when appearing over text.
1. `TooltipNote` was showing whether the the button was disabled or not.

I was contemplating adjusting the base offset in `WithTooltip`, but that would require adding specific offsets anywhere `WithTooltip` is used. We likely should do this at some point so `WithTooltip` has a good defaults. 

## What I did
1. I added some modifiers in `Subnav` to adjust the `WithTooltip` offset.
1. I improved the contrast of `TooltipNote` and in both light and dark themes.
1. I added a ternary operator to each button to prevent `TooltipNote` from showing when the button is disabled.

### Before
![](https://user-images.githubusercontent.com/1123119/139309536-bd5c715e-b951-4477-a68d-ac8d0e903fbc.png)
![](https://user-images.githubusercontent.com/1123119/139309477-09c4b7b4-ac45-421a-ab07-32ccf4802e72.png)

### After
![](https://user-images.githubusercontent.com/1123119/139309271-aeacca84-71fb-429a-9dc1-f15202e580d9.png)
![](https://user-images.githubusercontent.com/1123119/139309384-93769596-b69b-49a0-a082-e8b3401d7def.png)

## How to test
1. Open the Official Storybook using the link below.
1. Navigate to Interactions > Standard Email Success.
1. Open the addons panel: `a`.
1. Select the Interactions tab.
1. Hover over and click through the buttons in the Interactions panel's `Subnav`.

* [ ] Distance is closer
* [ ] Contrast is higher
* [ ] Tooltips no longer show when the button is disabled

<hr>

* [ ] Is this testable with Jest or Chromatic screenshots?
* [ ] Does this need a new example in the kitchen sink apps?
* [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200510412866230/1201289142784958) by [Unito](https://www.unito.io)
