### PR TITLE
Add puppeteer 5.2.1 to dependencies for flex gap

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@storybook/addon-storyshots": "6.4.0-beta.22",
-    "puppeteer": "^2.0.0 || ^3.0.0"
+    "puppeteer": "^2.0.0 || ^3.0.0 || ^5.2.1"
   },
   "peerDependenciesMeta": {
     "puppeteer": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7254,7 +7254,7 @@ __metadata:
     regenerator-runtime: ^0.13.7
   peerDependencies:
     "@storybook/addon-storyshots": 6.4.0-beta.22
-    puppeteer: ^2.0.0 || ^3.0.0
+    puppeteer: ^2.0.0 || ^3.0.0 || ^5.2.1
   peerDependenciesMeta:
     puppeteer:
       optional: true


### PR DESCRIPTION
puppeteer 2 and 3 do not support flex gap. I have gotten storyshots puppeteer to work with flex gap by forcing 5.2.1. I would recommend the maintainers update the dependencies to support the lts of puppeteer.

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
