### PR TITLE
Addon-actions: Omit sending window object thru the channel

### DIFF
--- a/addons/actions/src/preview/action.ts
+++ b/addons/actions/src/preview/action.ts
@@ -5,16 +5,16 @@ import { ActionDisplay, ActionOptions, HandlerFunction } from '../models';
 import { config } from './configureActions';
 
 type SyntheticEvent = any; // import('react').SyntheticEvent;
-const protoWithName = (obj: unknown, name: string): Function | null => {
+const findProto = (obj: unknown, callback: (proto: any) => boolean): Function | null => {
   const proto = Object.getPrototypeOf(obj);
-  if (!proto || proto.constructor.name === name) return proto;
-  return protoWithName(proto, name);
+  if (!proto || callback(proto)) return proto;
+  return findProto(proto, callback);
 };
 const isReactSyntheticEvent = (e: unknown): e is SyntheticEvent =>
   Boolean(
     typeof e === 'object' &&
       e &&
-      protoWithName(e, 'SyntheticEvent') &&
+      findProto(e, (proto) => /^Synthetic(?:Base)?Event$/.test(proto.constructor.name)) &&
       typeof (e as SyntheticEvent).persist === 'function'
   );
 const serializeArg = <T>(a: T) => {

--- a/addons/actions/src/preview/action.ts
+++ b/addons/actions/src/preview/action.ts
@@ -4,6 +4,40 @@ import { EVENT_ID } from '../constants';
 import { ActionDisplay, ActionOptions, HandlerFunction } from '../models';
 import { config } from './configureActions';
 
+type SyntheticEvent = any; // import('react').SyntheticEvent;
+const protoWithName = (obj: unknown, name: string): Function | null => {
+  const proto = Object.getPrototypeOf(obj);
+  if (!proto || proto.constructor.name === name) return proto;
+  return protoWithName(proto, name);
+};
+const isReactSyntheticEvent = (e: unknown): e is SyntheticEvent =>
+  Boolean(
+    typeof e === 'object' &&
+      e &&
+      protoWithName(e, 'SyntheticEvent') &&
+      typeof (e as SyntheticEvent).persist === 'function'
+  );
+const serializeArg = <T>(a: T) => {
+  if (isReactSyntheticEvent(a)) {
+    const e: SyntheticEvent = Object.create(
+      a.constructor.prototype,
+      Object.getOwnPropertyDescriptors(a)
+    );
+    e.persist();
+    const viewDescriptor = Object.getOwnPropertyDescriptor(e, 'view');
+    // dont send the entire window object over.
+    const view: unknown = viewDescriptor?.value;
+    if (typeof view === 'object' && view?.constructor.name === 'Window') {
+      Object.defineProperty(e, 'view', {
+        ...viewDescriptor,
+        value: Object.create(view.constructor.prototype),
+      });
+    }
+    return e;
+  }
+  return a;
+};
+
 export function action(name: string, options: ActionOptions = {}): HandlerFunction {
   const actionOptions = {
     ...config,
@@ -14,7 +48,8 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
     const channel = addons.getChannel();
     const id = uuidv4();
     const minDepth = 5; // anything less is really just storybook internals
-    const normalizedArgs = args.length > 1 ? args : args[0];
+    const serializedArgs = args.map(serializeArg);
+    const normalizedArgs = args.length > 1 ? serializedArgs : serializedArgs[0];
 
     const actionDisplayToEmit: ActionDisplay = {
       id,


### PR DESCRIPTION
Issue: #6471

## What I did

I detect a react synthetic event, perform a shallow clone, mark the clone with `persist()` and, if the event has a `view` property which is an instance of `Window`, also perform a shallow clone on that object, so that the entire window object is not passed through the channel (which would cause it to be fully cloned every time with the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? Maybe?
- [ ] Does this need a new example in the kitchen sink apps? No
- [ ] Does this need an update to the documentation? No

> If your answer is yes to any of these, please make sure to include it in your PR.

* Let me know if this approach is suitable. I'm not sure how to approach testing this; I verified it by making sure things still worked in the demo storybook (the one started with `yarn start`).

Everything continues to work, the UI is much more responsive (since it's not cloning the entire window on every action), and you can see that the "Window" entry for `view` is not expandable.
<img width="949" alt="Screen Shot 2021-10-28 at 4 28 58 PM" src="https://user-images.githubusercontent.com/760204/139350867-de28f95f-d993-4b00-b599-1c741b77dc06.png">

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
