### PR TITLE
Improve inline/iframe rendering documentation

### DIFF
--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -174,7 +174,7 @@ But using an iframe has disadvantages. For example, you have to set the height o
 
 Therefore, we recommend inline rendering where possible. It's the default mode for all the frameworks in which [we support it](../api/frameworks-feature-support.md). The one exception is Angular, where it's opt-in.
 
-To toggle the between the two settings, set the `docs.inlineStories` parameter in `.storybook/preview.js`:
+To toggle the between the two settings, set `docs.inlineStories` in `.storybook/preview.js`. Like most [parameters](../writing-stories/parameters.md), you can also toggle at the component or story level:
 
 ```js
 export const parameters = {

--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -208,7 +208,3 @@ Here’s an example of how to render Vue stories inline. The following docs conf
 With this function, anyone using the docs addon for [@storybook/vue](https://github.com/storybookjs/storybook/tree/master/app/vue) can make their stories render inline, either globally with the inlineStories docs parameter, or on a per-story-basis using the inline prop on the `<Story>` doc block.
 
 If you come up with an elegant and flexible implementation for the `prepareForInline` function for your framework, let us know. We'd love to make it the default configuration to make inline stories more accessible for a larger variety of frameworks!
-
-```
-
-```

--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -168,7 +168,7 @@ Unless you use a custom [webpack configuration](../configure/webpack.md#extendin
 
 DocsPage displays all the stories of a component on one page. You have the option of rendering those stories inline or in an iframe.
 
-The iframe creates a clean separation between your code and Storybook’s UI, which is useful if your stories are rendering correctly in the Canvas but not on the docs page.
+The iframe creates a clean separation between your code and Storybook’s UI, which is useful if your stories are rendering correctly in the Canvas but not on the docs page, for instance with fixed positioned components like modals.
 
 But using an iframe has disadvantages. For example, you have to set the height of iframe stories explicitly, or you’ll see a scroll bar. Having more than a few iframe stories on a page can lead to performance issues. And certain dev tools might not work right.
 

--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -91,7 +91,7 @@ For example, with Angular start by adding a `babel.config.js` file at the root o
 ```js
 // babel.config.js
 
-module.exports = function(api) {
+module.exports = function (api) {
   process.env.NODE_ENV === 'development' ? api.cache(false) : api.cache(true);
   const presets = [
     [
@@ -124,8 +124,8 @@ Then, update your `tsconfig.json` to include the following:
   },
 }
 ```
-Finally write your custom React component and and update the `docs.page` [parameter](../writing-stories/parameters.md) to render the custom documentation.
 
+Finally write your custom React component and and update the `docs.page` [parameter](../writing-stories/parameters.md) to render the custom documentation.
 
 <!-- prettier-ignore-start -->
 
@@ -168,11 +168,26 @@ Unless you use a custom [webpack configuration](../configure/webpack.md#extendin
 
 DocsPage displays all the stories of a component on one page. You have the option of rendering those stories inline or in an iframe.
 
-By default, we render React and Vue stories inline. Stories from other supported frameworks will render in an `<iframe>` by default.
+The iframe creates a clean separation between your code and Storybook’s UI, which is useful if your stories are rendering correctly in the Canvas but not on the docs page.
 
-The iframe creates a clean separation between your code and Storybook’s UI. But using an iframe has disadvantages. For example, you have to set the height of iframe stories explicitly, or you’ll see a scroll bar. And certain dev tools might not work right.
+But using an iframe has disadvantages. For example, you have to set the height of iframe stories explicitly, or you’ll see a scroll bar. Having more than a few iframe stories on a page can lead to performance issues. And certain dev tools might not work right.
 
-Render your framework’s stories inline using two docs configuration options in tandem, `inlineStories` and `prepareForInline`.
+Therefore, we recommend inline rendering where possible. It's the default mode for all the frameworks in which [we support it](../api/frameworks-feature-support.md). The one exception is Angular, where it's opt-in.
+
+To toggle the between the two settings, set the `docs.inlineStories` parameter in `.storybook/preview.js`:
+
+```js
+export const parameters = {
+  docs: {
+    // opt-out of inline rendering
+    inlineStories: false,
+  },
+};
+```
+
+### Custom inline rendering
+
+If your framework doesn't [support inline rendering](../api/frameworks-feature-support.md), you also need to provide a `prepareForInline` function in addition to the `inlineStories` parameter.
 
 Setting `inlineStories` to `true` tells Storybook to stop putting your stories in an iframe. The `prepareForInline` accepts a function that transforms story content from your given framework to something React can render (Storybook’s UI is built in React).
 
@@ -193,3 +208,7 @@ Here’s an example of how to render Vue stories inline. The following docs conf
 With this function, anyone using the docs addon for [@storybook/vue](https://github.com/storybookjs/storybook/tree/master/app/vue) can make their stories render inline, either globally with the inlineStories docs parameter, or on a per-story-basis using the inline prop on the `<Story>` doc block.
 
 If you come up with an elegant and flexible implementation for the `prepareForInline` function for your framework, let us know. We'd love to make it the default configuration to make inline stories more accessible for a larger variety of frameworks!
+
+```
+
+```


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Clarify how to opt-in to inline rendering in Angular
- [x] Separate out the custom `prepareForInline` docs, which are advanced usage

Self-merging @jonniebigodes 

## How to test

N/A