### PR TITLE
Migrate from micromatch to picomatch

### DIFF
--- a/docs/configure/overview.md
+++ b/docs/configure/overview.md
@@ -46,7 +46,7 @@ By default, Storybook will load stories from your project based on a glob (patte
         └── Button.stories.js
 ```
 
-If you want to use a different naming convention, you can alter the glob, using the syntax supported by [micromatch](https://github.com/micromatch/micromatch#extended-globbing).
+If you want to use a different naming convention, you can alter the glob, using the syntax supported by [picomatch](https://github.com/micromatch/picomatch#globbing-features).
 
 For example if you wanted to pull both `.md` and `.js` files from the `my-project/src/components` directory, you could write:
 

--- a/lib/core-common/package.json
+++ b/lib/core-common/package.json
@@ -63,7 +63,6 @@
     "@babel/register": "^7.12.1",
     "@storybook/node-logger": "6.4.0-beta.22",
     "@storybook/semver": "^7.3.2",
-    "@types/micromatch": "^4.0.1",
     "@types/node": "^14.0.10",
     "@types/pretty-hrtime": "^1.0.0",
     "babel-loader": "^8.0.0",
@@ -81,7 +80,7 @@
     "interpret": "^2.2.0",
     "json5": "^2.1.3",
     "lazy-universal-dotenv": "^3.0.1",
-    "micromatch": "^4.0.2",
+    "picomatch": "^2.3.0",
     "pkg-dir": "^5.0.0",
     "pretty-hrtime": "^1.0.3",
     "resolve-from": "^5.0.0",
@@ -96,6 +95,7 @@
     "@types/compression": "^1.7.0",
     "@types/interpret": "^1.1.1",
     "@types/mock-fs": "^4.13.0",
+    "@types/picomatch": "^2.3.0",
     "mock-fs": "^4.13.0"
   },
   "peerDependencies": {

--- a/lib/core-common/src/utils/glob-to-regexp.ts
+++ b/lib/core-common/src/utils/glob-to-regexp.ts
@@ -1,4 +1,4 @@
-import { makeRe } from 'micromatch';
+import { makeRe } from 'picomatch';
 
 export function globToRegexp(glob: string) {
   const regex = makeRe(glob, {

--- a/lib/core-common/src/utils/normalize-stories.ts
+++ b/lib/core-common/src/utils/normalize-stories.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
-import { scan } from 'micromatch';
+import { scan } from 'picomatch';
 import slash from 'slash';
 
 import type { StoriesEntry, NormalizedStoriesSpecifier } from '../types';

--- a/lib/core-common/src/utils/to-importFn.ts
+++ b/lib/core-common/src/utils/to-importFn.ts
@@ -17,7 +17,7 @@ export function webpackIncludeRegexp(specifier: NormalizedStoriesSpecifier) {
     ? files
     : `${directoryWithoutLeadingDots}/${files}`;
   const webpackIncludeRegexpWithCaret = globToRegexp(webpackIncludeGlob);
-  // micromatch is creating an exact match, but we are only matching the end of the filename
+  // picomatch is creating an exact match, but we are only matching the end of the filename
   return new RegExp(webpackIncludeRegexpWithCaret.source.replace(/^\^/, ''));
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8044,9 +8044,9 @@ __metadata:
     "@storybook/semver": ^7.3.2
     "@types/compression": ^1.7.0
     "@types/interpret": ^1.1.1
-    "@types/micromatch": ^4.0.1
     "@types/mock-fs": ^4.13.0
     "@types/node": ^14.0.10
+    "@types/picomatch": ^2.3.0
     "@types/pretty-hrtime": ^1.0.0
     babel-loader: ^8.0.0
     babel-plugin-macros: ^3.0.1
@@ -8063,8 +8063,8 @@ __metadata:
     interpret: ^2.2.0
     json5: ^2.1.3
     lazy-universal-dotenv: ^3.0.1
-    micromatch: ^4.0.2
     mock-fs: ^4.13.0
+    picomatch: ^2.3.0
     pkg-dir: ^5.0.0
     pretty-hrtime: ^1.0.3
     resolve-from: ^5.0.0
@@ -9842,13 +9842,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/braces@npm:*":
-  version: 3.0.0
-  resolution: "@types/braces@npm:3.0.0"
-  checksum: 87f19190bb8ec194d2ae1e3960cedff2052a3e71fd311524a6adb49031708b7a1527e43d045eceaf7fb8cf0806e91b75e8536b4addd02971aa3c175144d87631
-  languageName: node
-  linkType: hard
-
 "@types/browserslist@npm:*":
   version: 4.8.0
   resolution: "@types/browserslist@npm:4.8.0"
@@ -10354,15 +10347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/micromatch@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@types/micromatch@npm:4.0.1"
-  dependencies:
-    "@types/braces": "*"
-  checksum: eab58130f915873015d6caa8b54212fefa0b1fc7fcd41dd5a271c7586a057cb82dae6f4713f8ecea89d364c91025011e81d69801f60e69070a84008ed9e480de
-  languageName: node
-  linkType: hard
-
 "@types/mime-types@npm:^2.1.0":
   version: 2.1.0
   resolution: "@types/mime-types@npm:2.1.0"
@@ -10494,6 +10478,13 @@ __metadata:
   version: 5.0.3
   resolution: "@types/parse5@npm:5.0.3"
   checksum: 7d7ebbcb704a0ef438aa0de43ea1fd9723dfa802b8fa459628ceaf063f092bd19791b2a2580265244898dcc9d40f7345588a76cf752847d29540539f802711ed
+  languageName: node
+  linkType: hard
+
+"@types/picomatch@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@types/picomatch@npm:2.3.0"
+  checksum: 529aca7f2397b920559c8b6314c5a543d8bc0e0b423edbba1c356ba4d1783325d712b1871991895eb80355422176e1714a097620afceaa05b160dbcf5890f577
   languageName: node
   linkType: hard
 
@@ -34593,7 +34584,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.2.3":
+"picomatch@npm:^2.2.3, picomatch@npm:^2.3.0":
   version: 2.3.0
   resolution: "picomatch@npm:2.3.0"
   checksum: a65bde78212368e16afb82429a0ea033d20a836270446acb53ec6e31d939bccf1213f788bc49361f7aff47b67c1fb74d898f99964f67f26ca07a3cd815ddbcbb


### PR DESCRIPTION
Issue: N/A

## What I did

The micromatch functions that were used are re-exports of the picomatch API (and they don't support braces, which are supported only by the main micromatch function and other functions based on top of it).

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
