### PR TITLE
Addon-docs/Angular: Fix missing condition in compodoc resolveTypealias

### DIFF
--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -217,7 +217,7 @@ const extractDefaultValue = (property: Property) => {
 
 const resolveTypealias = (compodocType: string): string => {
   const compodocJson = getCompodocJson();
-  const typeAlias = compodocJson?.miscellaneous.typealiases.find((x) => x.name === compodocType);
+  const typeAlias = compodocJson?.miscellaneous?.typealiases?.find((x) => x.name === compodocType);
   return typeAlias ? resolveTypealias(typeAlias.rawtype) : compodocType;
 };
 


### PR DESCRIPTION
## What I did

When Storybook, using Compodoc, does not found the type alias from an external lib, the app breaks completely.

For example: when using @ngx-formly/core, FormlyFieldConfig is not recognized and the app breaks, because typealias is already undefined in miscellaneous

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
