### PR TITLE
Add qs as a dev dependency of the api package

### DIFF
--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -58,9 +58,11 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.167",
+    "@types/qs": "^6",
     "@types/semver": "^7.3.4",
     "flush-promises": "^1.0.2",
-    "preval.macro": "^5.0.0"
+    "preval.macro": "^5.0.0",
+    "qs": "^6.10.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7567,6 +7567,7 @@ __metadata:
     "@storybook/semver": ^7.3.2
     "@storybook/theming": 6.4.0-beta.22
     "@types/lodash": ^4.14.167
+    "@types/qs": ^6
     "@types/semver": ^7.3.4
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -7575,6 +7576,7 @@ __metadata:
     lodash: ^4.17.20
     memoizerific: ^1.11.3
     preval.macro: ^5.0.0
+    qs: ^6.10.1
     regenerator-runtime: ^0.13.7
     store2: ^2.12.0
     telejson: ^5.3.2
@@ -10609,6 +10611,13 @@ __metadata:
   version: 6.9.5
   resolution: "@types/qs@npm:6.9.5"
   checksum: 69ee832b3b30a1919892922877ae54d97622941e46874b1bedfe8fd44fb8972bce395814c9ccdab6016bb1f2f2d192eed0a4be21c0aba992509b06eb36951d18
+  languageName: node
+  linkType: hard
+
+"@types/qs@npm:^6":
+  version: 6.9.7
+  resolution: "@types/qs@npm:6.9.7"
+  checksum: 157eb05f4c75790b0ebdcf7b0547ff117feabc8cda03c3cac3d3ea82bb19a1912e76a411df3eb0bdd01026a9770f07bc0e7e3fbe39ebb31c1be4564c16be35f1
   languageName: node
   linkType: hard
 
@@ -37198,7 +37207,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.0":
+"qs@npm:^6.10.0, qs@npm:^6.10.1":
   version: 6.10.1
   resolution: "qs@npm:6.10.1"
   dependencies:


### PR DESCRIPTION
Issue:

## What I did

`qs` is used in the testsuite of the api package. #16440 removed `qs` from dependencies, but without adding it in devDependencies (the CI works thanks to the hoisting of `qs` from a transitive dependency).

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
