### PR TITLE
Show "Loading..." while switching between async stories

### DIFF
--- a/lib/core-common/src/templates/base-preview-body.html
+++ b/lib/core-common/src/templates/base-preview-body.html
@@ -1,3 +1,5 @@
+<div class="sb-preparing sb-wrapper">Loading...</div>
+
 <div class="sb-nopreview sb-wrapper">
   <div class="sb-nopreview_main">
     <h1 class="sb-nopreview_heading sb-heading">No Preview</h1>
@@ -6,7 +8,9 @@
       <li>Please check the Storybook config.</li>
       <li>Try reloading the page.</li>
     </ul>
-    <p>If the problem persists, check the browser console, or the terminal you've run Storybook from.</p>
+    <p>
+      If the problem persists, check the browser console, or the terminal you've run Storybook from.
+    </p>
   </div>
 </div>
 

--- a/lib/core-common/src/templates/base-preview-head.html
+++ b/lib/core-common/src/templates/base-preview-head.html
@@ -1,7 +1,9 @@
-<base target="_parent">
+<base target="_parent" />
 
 <style>
-  :not(.sb-show-main) > .sb-main,
+  :not(.sb-show-main) > #root,
+  :not(.sb-show-main) > #docs-root,
+  :not(.sb-show-preparing) > .sb-preparing,
   :not(.sb-show-nopreview) > .sb-nopreview,
   :not(.sb-show-errordisplay) > .sb-errordisplay {
     display: none;
@@ -50,7 +52,8 @@
     left: 0;
     right: 0;
     padding: 20px;
-    font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular", "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: 'Nunito Sans', -apple-system, '.SFNSText-Regular', 'San Francisco',
+      BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     overflow: auto;
   }
@@ -73,7 +76,7 @@
     margin: auto;
     padding: 30px;
     border-radius: 10px;
-    background: rgba(0,0,0,0.03);
+    background: rgba(0, 0, 0, 0.03);
   }
 
   .sb-nopreview_heading {
@@ -91,7 +94,8 @@
     padding: 10px;
     background: #000;
     color: #eee;
-    font-family: "Operator Mono", "Fira Code Retina", "Fira Code", "FiraCode-Retina", "Andale Mono", "Lucida Console", Consolas, Monaco, monospace;
+    font-family: 'Operator Mono', 'Fira Code Retina', 'Fira Code', 'FiraCode-Retina', 'Andale Mono',
+      'Lucida Console', Consolas, Monaco, monospace;
   }
 
   .sb-errordisplay pre {

--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -1222,6 +1222,19 @@ describe('PreviewWeb', () => {
         );
       });
 
+      it('renders preparing state', async () => {
+        document.location.search = '?id=component-one--a';
+        const preview = await createAndRenderPreview();
+
+        emitter.emit(Events.SET_CURRENT_STORY, {
+          storyId: 'component-one--b',
+          viewMode: 'story',
+        });
+        await waitForSetCurrentStory();
+
+        expect(preview.view.showPreparing).toHaveBeenCalled();
+      });
+
       it('emits STORY_CHANGED', async () => {
         document.location.search = '?id=component-one--a';
         await createAndRenderPreview();

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -342,6 +342,12 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       selection: { storyId },
     } = this.urlStore;
 
+    const storyIdChanged = this.previousSelection?.storyId !== storyId;
+    const viewModeChanged = this.previousSelection?.viewMode !== selection.viewMode;
+
+    // Show a spinner while we load the next story
+    if (selection.viewMode !== 'docs' || viewModeChanged) this.view.showPreparing();
+
     let story;
     try {
       story = await this.storyStore.loadStory({ storyId });
@@ -351,9 +357,6 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       await this.renderMissingStory(storyId);
       return;
     }
-
-    const storyIdChanged = this.previousSelection?.storyId !== storyId;
-    const viewModeChanged = this.previousSelection?.viewMode !== selection.viewMode;
 
     const implementationChanged =
       !storyIdChanged && this.previousStory && story !== this.previousStory;

--- a/lib/preview-web/src/WebView.ts
+++ b/lib/preview-web/src/WebView.ts
@@ -15,6 +15,7 @@ const layoutClassMap = {
 type Layout = keyof typeof layoutClassMap | 'none';
 
 const classes = {
+  PREPARING: 'sb-show-preparing',
   MAIN: 'sb-show-main',
   NOPREVIEW: 'sb-show-nopreview',
   ERROR: 'sb-show-errordisplay',
@@ -84,6 +85,7 @@ export class WebView {
 
     document.body.classList.remove(classes.MAIN);
     document.body.classList.remove(classes.NOPREVIEW);
+    document.body.classList.remove(classes.PREPARING);
 
     document.body.classList.add(classes.ERROR);
   }
@@ -91,6 +93,7 @@ export class WebView {
   showNoPreview() {
     document.body.classList.remove(classes.MAIN);
     document.body.classList.remove(classes.ERROR);
+    document.body.classList.remove(classes.PREPARING);
 
     document.body.classList.add(classes.NOPREVIEW);
 
@@ -99,9 +102,18 @@ export class WebView {
     this.docsRoot()?.setAttribute('hidden', 'true');
   }
 
+  showPreparing() {
+    document.body.classList.remove(classes.MAIN);
+    document.body.classList.remove(classes.ERROR);
+    document.body.classList.remove(classes.NOPREVIEW);
+
+    document.body.classList.add(classes.PREPARING);
+  }
+
   showMain() {
     document.body.classList.remove(classes.NOPREVIEW);
     document.body.classList.remove(classes.ERROR);
+    document.body.classList.remove(classes.PREPARING);
 
     document.body.classList.add(classes.MAIN);
   }


### PR DESCRIPTION
Issue: #16051

## What I did

Added a new state to the template, `"preparing"`.

I followed the same patterns as for the remaining states (`"error"`, `"nopreview"`), which might be worth tweaking also @MichaelArestad 

## How to test

- Switch stories for different components in a SB (it will flash up).
- Apply the `sb-show-preparing` state to the `body` in the preview iframe:
<img width="578" alt="image" src="https://user-images.githubusercontent.com/132554/139630165-1237dddc-77cb-4906-981c-51588a58e101.png">

I am not sure of a better way to see it.

## How to develop it

1. Run `yarn build --watch core -common`
2. Edit the two files `lib/core-common/src/templates/base-preview-body.html` and `lib/core-common/src/templates/base-preview-head.html`
3. Every time you make changes, restart `yarn storybook` in `examples/react-ts` (sorry I am not sure of a better way to do this, I know it is atrocious!)