### PR TITLE
CLI: Add eslint-plugin-storybook to automigrate

### DIFF
--- a/lib/cli/src/automigrate/fixes/eslint-plugin.test.ts
+++ b/lib/cli/src/automigrate/fixes/eslint-plugin.test.ts
@@ -1,0 +1,151 @@
+/* eslint-disable no-underscore-dangle */
+import dedent from 'ts-dedent';
+import { JsPackageManager } from '../../js-package-manager';
+import { eslintPlugin } from './eslint-plugin';
+
+// eslint-disable-next-line global-require, jest/no-mocks-import
+jest.mock('fs-extra', () => require('../../../../../__mocks__/fs-extra'));
+
+const checkEslint = async ({
+  packageJson,
+  main = {},
+  hasEslint = true,
+  eslintExtension = 'js',
+}) => {
+  // eslint-disable-next-line global-require
+  require('fs-extra').__setMockFiles({
+    '.storybook/main.js': !main ? null : `module.exports = ${JSON.stringify(main)};`,
+    [`.eslintrc.${eslintExtension}`]: !hasEslint
+      ? null
+      : dedent(`
+      module.exports = {
+        extends: ['plugin:react/recommended', 'airbnb-typescript', 'plugin:prettier/recommended'],
+        parser: '@typescript-eslint/parser',
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+          ecmaVersion: 12,
+          sourceType: 'module',
+          project: 'tsconfig.eslint.json',
+        },
+        plugins: ['react', '@typescript-eslint'],
+        rules: {
+          'some/rule': 'warn',
+        },
+      }
+    `),
+  });
+  const packageManager = {
+    retrievePackageJson: () => ({ dependencies: {}, devDependencies: {}, ...packageJson }),
+  } as JsPackageManager;
+  return eslintPlugin.check({ packageManager });
+};
+
+describe('eslint-plugin fix', () => {
+  describe('should skip migration when', () => {
+    it('project does not have eslint installed', async () => {
+      const packageJson = { dependencies: {} };
+
+      await expect(
+        checkEslint({
+          packageJson,
+        })
+      ).resolves.toBeFalsy();
+    });
+
+    it('project already contains eslint-plugin-storybook dependency', async () => {
+      const packageJson = { dependencies: { 'eslint-plugin-storybook': '^0.0.0' } };
+
+      await expect(
+        checkEslint({
+          packageJson,
+        })
+      ).resolves.toBeFalsy();
+    });
+  });
+
+  describe('when project does not contain eslint-plugin-storybook but has eslint installed', () => {
+    const packageJson = { dependencies: { '@storybook/react': '^6.2.0', eslint: '^7.0.0' } };
+
+    describe('should no-op and warn when', () => {
+      it('main.js is not found', async () => {
+        const loggerSpy = jest.spyOn(console, 'warn').mockImplementationOnce(jest.fn);
+        const result = await checkEslint({
+          packageJson,
+          main: null,
+          hasEslint: false,
+        });
+
+        expect(loggerSpy).toHaveBeenCalledWith('Unable to find storybook main.js config');
+
+        await expect(result).toBeFalsy();
+      });
+
+      it('.eslintrc is not found', async () => {
+        const loggerSpy = jest.spyOn(console, 'warn').mockImplementationOnce(jest.fn);
+        const result = await checkEslint({
+          packageJson,
+          hasEslint: false,
+        });
+
+        expect(loggerSpy).toHaveBeenCalledWith('Unable to find .eslintrc config file');
+
+        await expect(result).toBeFalsy();
+      });
+    });
+
+    describe('should install eslint plugin', () => {
+      it('with globs defined in main.js', async () => {
+        await expect(
+          checkEslint({
+            packageJson,
+            main: {
+              stories: [
+                './stories/**/*.stories.@(js|ts|tsx)',
+                '../src/components/Accordion.stories.tsx',
+              ],
+            },
+          })
+        ).resolves.toMatchObject({
+          storiesGlobs: [
+            './stories/**/*.stories.@(js|ts|tsx)',
+            '../src/components/Accordion.stories.tsx',
+          ],
+        });
+      });
+
+      it('with composed globs from CSF3 configuration format', async () => {
+        await expect(
+          checkEslint({
+            packageJson,
+            main: {
+              stories: [
+                {
+                  dir: '../src/components',
+                },
+                {
+                  dir: '../src/pages',
+                },
+              ],
+            },
+          })
+        ).resolves.toMatchObject({
+          storiesGlobs: [
+            '../src/components/**/*.stories.@(js|ts|jsx|tsx)',
+            '../src/pages/**/*.stories.@(js|ts|jsx|tsx)',
+          ],
+        });
+      });
+
+      it('when .eslintrc is using unsupported extension', async () => {
+        await expect(
+          checkEslint({
+            packageJson,
+            eslintExtension: 'yml',
+          })
+        ).resolves.toMatchObject({ unsupportedExtension: 'yml' });
+      });
+    });
+  });
+});

--- a/lib/cli/src/automigrate/fixes/eslint-plugin.test.ts
+++ b/lib/cli/src/automigrate/fixes/eslint-plugin.test.ts
@@ -102,15 +102,18 @@ describe('eslint-plugin fix', () => {
             packageJson,
             main: {
               stories: [
-                './stories/**/*.stories.@(js|ts|tsx)',
+                // this is the path relative to .storybook
+                // or wherever the main.js file is
+                '../stories/**/*.stories.@(js|ts|tsx)',
                 '../src/components/Accordion.stories.tsx',
               ],
             },
           })
         ).resolves.toMatchObject({
           storiesGlobs: [
-            './stories/**/*.stories.@(js|ts|tsx)',
-            '../src/components/Accordion.stories.tsx',
+            // this should be the path based on main.js AND root directory
+            'stories/**/*.stories.@(js|ts|tsx)',
+            'src/components/Accordion.stories.tsx',
           ],
         });
       });
@@ -121,6 +124,8 @@ describe('eslint-plugin fix', () => {
             packageJson,
             main: {
               stories: [
+                // this is the path relative to .storybook
+                // or wherever the main.js file is
                 {
                   dir: '../src/components',
                 },
@@ -132,8 +137,9 @@ describe('eslint-plugin fix', () => {
           })
         ).resolves.toMatchObject({
           storiesGlobs: [
-            '../src/components/**/*.stories.@(js|ts|jsx|tsx)',
-            '../src/pages/**/*.stories.@(js|ts|jsx|tsx)',
+            // this should be the path based on main.js AND root directory
+            'src/components/**/*.stories.@(js|ts|jsx|tsx)',
+            'src/pages/**/*.stories.@(js|ts|jsx|tsx)',
           ],
         });
       });

--- a/lib/cli/src/automigrate/fixes/eslint-plugin.test.ts
+++ b/lib/cli/src/automigrate/fixes/eslint-plugin.test.ts
@@ -77,7 +77,7 @@ describe('eslint-plugin fix', () => {
           hasEslint: false,
         });
 
-        expect(loggerSpy).toHaveBeenCalledWith('Unable to find storybook main.js config');
+        expect(loggerSpy).toHaveBeenCalledWith('Unable to find storybook main.js config, skipping');
 
         await expect(result).toBeFalsy();
       });
@@ -89,7 +89,7 @@ describe('eslint-plugin fix', () => {
           hasEslint: false,
         });
 
-        expect(loggerSpy).toHaveBeenCalledWith('Unable to find .eslintrc config file');
+        expect(loggerSpy).toHaveBeenCalledWith('Unable to find .eslintrc config file, skipping');
 
         await expect(result).toBeFalsy();
       });

--- a/lib/cli/src/automigrate/fixes/eslint-plugin.test.ts
+++ b/lib/cli/src/automigrate/fixes/eslint-plugin.test.ts
@@ -96,51 +96,13 @@ describe('eslint-plugin fix', () => {
     });
 
     describe('should install eslint plugin', () => {
-      it('with globs defined in main.js', async () => {
+      it('when .eslintrc is using a supported extension', async () => {
         await expect(
           checkEslint({
             packageJson,
-            main: {
-              stories: [
-                // this is the path relative to .storybook
-                // or wherever the main.js file is
-                '../stories/**/*.stories.@(js|ts|tsx)',
-                '../src/components/Accordion.stories.tsx',
-              ],
-            },
           })
         ).resolves.toMatchObject({
-          storiesGlobs: [
-            // this should be the path based on main.js AND root directory
-            'stories/**/*.stories.@(js|ts|tsx)',
-            'src/components/Accordion.stories.tsx',
-          ],
-        });
-      });
-
-      it('with composed globs from CSF3 configuration format', async () => {
-        await expect(
-          checkEslint({
-            packageJson,
-            main: {
-              stories: [
-                // this is the path relative to .storybook
-                // or wherever the main.js file is
-                {
-                  dir: '../src/components',
-                },
-                {
-                  dir: '../src/pages',
-                },
-              ],
-            },
-          })
-        ).resolves.toMatchObject({
-          storiesGlobs: [
-            // this should be the path based on main.js AND root directory
-            'src/components/**/*.stories.@(js|ts|jsx|tsx)',
-            'src/pages/**/*.stories.@(js|ts|jsx|tsx)',
-          ],
+          unsupportedExtension: undefined,
         });
       });
 

--- a/lib/cli/src/automigrate/fixes/eslint-plugin.ts
+++ b/lib/cli/src/automigrate/fixes/eslint-plugin.ts
@@ -1,0 +1,141 @@
+import chalk from 'chalk';
+import dedent from 'ts-dedent';
+import { ConfigFile, readConfig, writeConfig } from '@storybook/csf-tools';
+
+import { findEslintFile, SUPPORTED_ESLINT_EXTENSIONS } from '../helpers/getEslintInfo';
+import { getStorybookInfo } from '../helpers/getStorybookInfo';
+
+import type { Fix } from '../types';
+
+const logger = console;
+
+interface EslintPluginRunOptions {
+  main: ConfigFile;
+  eslintFile: string;
+  storiesGlobs: string[];
+  unsupportedExtension?: string;
+}
+
+type StoriesConfig =
+  | string
+  | {
+      dir: string;
+    };
+
+/**
+ * Does the user not have eslint-plugin-storybook installed?
+ *
+ * If so:
+ * - Install it, and if possible configure it
+ */
+export const eslintPlugin: Fix<EslintPluginRunOptions> = {
+  id: 'eslintPlugin',
+
+  async check({ packageManager }) {
+    const packageJson = packageManager.retrievePackageJson();
+    const { dependencies, devDependencies } = packageJson;
+
+    const eslintPluginStorybook =
+      dependencies['eslint-plugin-storybook'] || devDependencies['eslint-plugin-storybook'];
+    const eslintDependency = dependencies.eslint || devDependencies.eslint;
+
+    if (eslintPluginStorybook || !eslintDependency) {
+      return null;
+    }
+
+    const config = getStorybookInfo(packageJson);
+
+    const { mainConfig } = config;
+    if (!mainConfig) {
+      logger.warn('Unable to find storybook main.js config');
+      return null;
+    }
+
+    let eslintFile;
+    let unsupportedExtension;
+    try {
+      eslintFile = findEslintFile();
+    } catch (err) {
+      unsupportedExtension = err.message;
+    }
+
+    if (!eslintFile && !unsupportedExtension) {
+      logger.warn('Unable to find .eslintrc config file');
+      return null;
+    }
+
+    const main = await readConfig(mainConfig);
+
+    const storiesGlobs: string[] = [];
+    if (!unsupportedExtension) {
+      const rawStoriesGlobs = main.getFieldValue(['stories']);
+      rawStoriesGlobs.forEach((glob: StoriesConfig) => {
+        if (typeof glob === 'string') {
+          if (!glob.endsWith('.mdx')) {
+            storiesGlobs.push(glob.replace(/(\|mdx)|(mdx\|)|(\|md)|(md\|)/g, ''));
+          }
+        } else {
+          // stories in CSF3 format. Users only specify the folder so we add a wildcard
+          storiesGlobs.push(`${glob.dir}/**/*.stories.@(js|ts|jsx|tsx)`);
+        }
+      });
+    }
+
+    return { eslintFile, main, storiesGlobs, unsupportedExtension };
+  },
+
+  prompt() {
+    return dedent`
+      We've detected you are not using our eslint-plugin.
+
+      In order to have the best experience with Storybook and follow best practices, we advise you to install eslint-plugin-storybook.
+
+      More info: ${chalk.yellow('https://github.com/storybookjs/eslint-plugin-storybook#readme')}
+    `;
+  },
+
+  async run({
+    result: { main, eslintFile, storiesGlobs, unsupportedExtension },
+    packageManager,
+    dryRun,
+  }) {
+    const deps = [`eslint-plugin-storybook`];
+
+    logger.info(`✅ Adding dependencies: ${deps}`);
+    if (!dryRun) packageManager.addDependencies({ installAsDevDependencies: true }, deps);
+
+    if (!dryRun && unsupportedExtension) {
+      logger.warn(
+        dedent(`
+            ⚠️ The plugin was successfuly installed but failed to configure.
+            
+            Found an .eslintrc config file with an unsupported automigration format: ${unsupportedExtension}.
+            Supported formats for automigration are: ${SUPPORTED_ESLINT_EXTENSIONS.join(', ')}.
+
+            Please refer to https://github.com/storybookjs/eslint-plugin-storybook#usage to finish setting up the plugin manually.
+        `)
+      );
+
+      return;
+    }
+
+    const eslint = await readConfig(eslintFile);
+    logger.info(`✅ Configuring eslint rules in ${eslint.fileName}`);
+
+    if (!dryRun) {
+      logger.info(`✅ Adding Storybook to plugin list`);
+      eslint.setFieldValue(['plugins'], [...eslint.getFieldValue(['plugins']), 'storybook']);
+
+      const storybookOverrides = {
+        files: storiesGlobs,
+        extends: ['plugin:storybook/recommended'],
+      };
+
+      logger.info(`✅ Adding overrides using stories defined in ${main.fileName}`);
+      const currentOverrides = eslint.getFieldValue(['overrides']) || [];
+
+      eslint.setFieldValue(['overrides'], [...currentOverrides, storybookOverrides]);
+      await writeConfig(eslint);
+    }
+  },
+};

--- a/lib/cli/src/automigrate/fixes/index.ts
+++ b/lib/cli/src/automigrate/fixes/index.ts
@@ -2,7 +2,8 @@ import { cra5 } from './cra5';
 import { webpack5 } from './webpack5';
 import { angular12 } from './angular12';
 import { mainjsFramework } from './mainjsFramework';
+import { eslintPlugin } from './eslint-plugin';
 import { Fix } from '../types';
 
 export * from '../types';
-export const fixes: Fix[] = [cra5, webpack5, angular12, mainjsFramework];
+export const fixes: Fix[] = [cra5, webpack5, angular12, mainjsFramework, eslintPlugin];

--- a/lib/cli/src/automigrate/helpers/getEslintInfo.ts
+++ b/lib/cli/src/automigrate/helpers/getEslintInfo.ts
@@ -1,0 +1,20 @@
+import fse from 'fs-extra';
+
+export const SUPPORTED_ESLINT_EXTENSIONS = ['js', 'cjs'];
+const UNSUPPORTED_ESLINT_EXTENSIONS = ['yaml', 'yml', 'json'];
+
+export const findEslintFile = () => {
+  const filePrefix = '.eslintrc';
+  const unsupportedExtension = UNSUPPORTED_ESLINT_EXTENSIONS.find((ext: string) =>
+    fse.existsSync(`${filePrefix}.${ext}`)
+  );
+
+  if (unsupportedExtension) {
+    throw new Error(unsupportedExtension);
+  }
+
+  const extension = SUPPORTED_ESLINT_EXTENSIONS.find((ext: string) =>
+    fse.existsSync(`${filePrefix}.${ext}`)
+  );
+  return extension ? `${filePrefix}.${extension}` : null;
+};


### PR DESCRIPTION
Issue: N/A

## What I did

This PR adds a new automigration step: eslint-plugin.

It will:
1 - Check if the user has `eslint` but does not have `eslint-plugin-storybook`
2 - If that is the case, it will check if the `.eslintrc` file of the user is supported (js or cjs)
3 - It will install the `eslint-plugin-storybook` dependency
4.1 - After that, if the eslintrc is **supported**, it will write the configuration in the eslint file.
4.2 If the eslintrc file is **unsupported** (json, yml, yaml), it will log a warning with instructions to install manually (but successfully install the dependency)

## What this depends on

The eslint plugin is not ready, so this should not be merged until it is published.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

1 -  go to examples/official-storybook
2 - add eslint in package.json
3 - add a .eslintrc.js file in examples/official-storybook:
```
module.exports = {
  extends: ['plugin:prettier/recommended'],
  plugins: ["react", "@typescript-eslint"],
  rules: {
    'some/rule': 'warn'
  }
};
```
4 - run `yarn build cli`
5 - run `../../lib/cli/bin/index.js automigrate`