### PR TITLE
Add missing peer dependencies

### DIFF
--- a/lib/store/package.json
+++ b/lib/store/package.json
@@ -56,6 +56,10 @@
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"
   },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9253,6 +9253,9 @@ __metadata:
     synchronous-promise: ^2.0.15
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Issue: related to https://github.com/storybookjs/storybook/issues/14838

## What I did

Fixed these [implicit transitive peer dependency](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0) warnings:

```
➤ YN0002: │ @storybook/store@npm:6.4.0-beta.23 doesn't provide react (p19f07), requested by @storybook/addons
➤ YN0002: │ @storybook/store@npm:6.4.0-beta.23 doesn't provide react-dom (p54b7a), requested by @storybook/addons
```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
