### PR TITLE
Addon-docs/HTML: Fix source snippetization for DOM elements

### DIFF
--- a/addons/docs/src/frameworks/html/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/html/sourceDecorator.ts
@@ -41,8 +41,16 @@ export function sourceDecorator(
     : storyFn();
 
   let source: string;
-  if (typeof story === 'string' && !skipSourceRender(context)) {
-    source = applyTransformSource(story, context);
+  if (!skipSourceRender(context)) {
+    if (typeof story === 'string') {
+      source = story;
+    }
+    // eslint-disable-next-line no-undef
+    else if (story instanceof Element) {
+      source = story.outerHTML;
+    }
+
+    if (source) source = applyTransformSource(source, context);
   }
   useEffect(() => {
     if (source) addons.getChannel().emit(SNIPPET_RENDERED, context.id, source);


### PR DESCRIPTION
Issue: N/A

## What I did

HTML DOM elements were not getting properly snippetized, which was causing our CI to fail (`sb repro -t html`)

## How to test

See `html-kitchen-sink` DocsPage for `Demo` before & after this change
