### PR TITLE
Pin the version of `history` for `react-router-dom` compat

### DIFF
--- a/lib/router/package.json
+++ b/lib/router/package.json
@@ -44,7 +44,7 @@
     "core-js": "^3.8.2",
     "fast-deep-equal": "^3.1.3",
     "global": "^4.4.0",
-    "history": "^5.0.1",
+    "history": "5.0.0",
     "lodash": "^4.17.20",
     "memoizerific": "^1.11.3",
     "qs": "^6.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8980,7 +8980,7 @@ __metadata:
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    history: ^5.0.1
+    history: 5.0.0
     lodash: ^4.17.20
     memoizerific: ^1.11.3
     qs: ^6.10.0
@@ -25304,12 +25304,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"history@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "history@npm:5.0.1"
+"history@npm:5.0.0":
+  version: 5.0.0
+  resolution: "history@npm:5.0.0"
   dependencies:
     "@babel/runtime": ^7.7.6
-  checksum: a36e20f3513acf5c3bd2c0edd5790cbf8ef6befb754595a7c99ee70b07afd6eef07396ec2f90f50e0602b580e4fbe6fe5950e812e4bb08fa541e296f9434a566
+  checksum: 6e1a0880c1d67a9040117e5b426e71bc35642488485354d378cb635f194c2177979558b6fb537972840c6993d92c1ae971ab6c33bf77be1b1f135349ea65cde0
   languageName: node
   linkType: hard
 
@@ -37887,25 +37887,25 @@ fsevents@^1.2.7:
   linkType: hard
 
 "react-router-dom@npm:^6.0.0-beta.8":
-  version: 6.0.0-beta.7
-  resolution: "react-router-dom@npm:6.0.0-beta.7"
+  version: 6.0.0-beta.8
+  resolution: "react-router-dom@npm:6.0.0-beta.8"
   dependencies:
-    react-router: 6.0.0-beta.7
+    react-router: 6.0.0-beta.8
   peerDependencies:
     history: ">=5"
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: baf821316e5b1bb6f82f986e2a603123e5300264a036ea9ddeef4687c77daa4dd8a1fade4f890b6b1e5241745bc98791107cf8193596473e42be873ae6674dcc
+  checksum: 6f1a49ff010fb1c59cec67d035b47accbcf764f0d1c5b6e7f011d91f794bdcdc2156430030da5f8a038390a4b37e38a764b2854d84d30a612c39aab4a0c8c024
   languageName: node
   linkType: hard
 
-"react-router@npm:6.0.0-beta.7, react-router@npm:^6.0.0-beta.8":
-  version: 6.0.0-beta.7
-  resolution: "react-router@npm:6.0.0-beta.7"
+"react-router@npm:6.0.0-beta.8, react-router@npm:^6.0.0-beta.8":
+  version: 6.0.0-beta.8
+  resolution: "react-router@npm:6.0.0-beta.8"
   peerDependencies:
     history: ">=5"
     react: ">=16.8"
-  checksum: f28071978b9329d3c3c998dd86a2e2ef59bfded6fa62976705959ffbfe6e0cb2b739f8dc364cd0deac69968444a3218c3cd94f48a4ed7753db91967321eeb9f1
+  checksum: af2ac31557915cf35417413b3b2cc27efeaf889d16aad48cd964414637fcb387f710969c4d6b30ff1b46b1df98b3b2f81a0e1854a0f4d73b551d832b40a4317a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

Issue: https://github.com/storybookjs/storybook/issues/16552

## What I did

fixate the version of the `history` package so it's the version that still included the `State` export.