### PR TITLE
Draft: Update doc examples with new 6.3.x React types

### DIFF
--- a/docs/snippets/react/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.ts.mdx
@@ -3,12 +3,12 @@
 
 import React from 'react';
 
-import { Meta } from '@storybook/react';
+import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
 export default {
   title: 'Components/Button',
   component: Button,
-} as Meta;
+} as ComponentMeta<typeof Button>;
 ```


### PR DESCRIPTION
Issue:
n/a

## What I did
According to https://github.com/storybookjs/storybook/pull/15292, the types were updated; however, the docs still reflect the legacy 6.x types.

I'm opening a draft PR to see if this is something worth pursing. Happy to keep going (just did one button).

Thanks!

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

