### PR TITLE
Fix preact install instructions

### DIFF
--- a/docs/get-started/installation-problems/preact.mdx
+++ b/docs/get-started/installation-problems/preact.mdx
@@ -1,2 +1,2 @@
-- You can also setup Storybook manually through the Storybook CLI. Add the `--type mithril` flag when you initialize Storybook in your project.
+- You can also setup Storybook manually through the Storybook CLI. Add the `--type preact` flag when you initialize Storybook in your project.
 - If there's an installation problem, check the [README for the Preact framework](../../app/preact/README.md).


### PR DESCRIPTION
Issue:
preact  install instruction says that one should add `--type mithril` as arguments to `sb init` instead of `--type preact`
## What I did
Updated documentation for `sb init` preact projects
## How to test

No way to automatically test this I suppose(?). So test by reading the install instructions for preact on https://storybook.js.org/docs/preact/get-started/install (maybe there's a staging that presents this file in the same way?)



