### PR TITLE
Core: Continue running `play` function on rerender (e.g. on args/globals change)

### DIFF
--- a/addons/interactions/src/components/AccountForm/addon-interactions.stories.tsx
+++ b/addons/interactions/src/components/AccountForm/addon-interactions.stories.tsx
@@ -62,15 +62,11 @@ export const StandardEmailFailed: CSF3Story = {
   ...Standard,
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.type(canvas.getByTestId('email'), 'me');
-    await userEvent.type(canvas.getByTestId('password1'), 'helloyou');
+    await userEvent.type(canvas.getByTestId('email'), 'gert@chromatic');
+    await userEvent.type(canvas.getByTestId('password1'), 'supersecret');
     await userEvent.click(canvas.getByRole('button', { name: /create account/i }));
 
-    await canvas.findByText(
-      'Please enter a correctly formatted email address',
-      {},
-      { timeout: 2000 }
-    );
+    await canvas.findByText('Please enter a correctly formatted email address');
     expect(args.onSubmit).not.toHaveBeenCalled();
   },
 };

--- a/addons/interactions/src/components/AccountForm/addon-interactions.stories.tsx
+++ b/addons/interactions/src/components/AccountForm/addon-interactions.stories.tsx
@@ -8,7 +8,11 @@ import { AccountForm } from './AccountForm';
 export default {
   title: 'Addons/Interactions/AccountForm',
   component: AccountForm,
-  parameters: { layout: 'centered', theme: 'light' },
+  parameters: {
+    layout: 'centered',
+    theme: 'light',
+    options: { selectedPanel: 'storybook/interactions/panel' },
+  },
   argTypes: {
     onSubmit: { action: true },
   },

--- a/lib/api/src/modules/globals.ts
+++ b/lib/api/src/modules/globals.ts
@@ -77,7 +77,12 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
         logger.warn('received globals from a non-local ref. This is not currently supported.');
       }
 
-      if (currentGlobals && !deepEqual(globals, currentGlobals)) {
+      if (
+        currentGlobals &&
+        Object.keys(currentGlobals).length !== 0 &&
+        !deepEqual(globals, currentGlobals)
+      ) {
+        console.log('foo', { globals, currentGlobals });
         api.updateGlobals(currentGlobals);
       }
     });

--- a/lib/api/src/modules/globals.ts
+++ b/lib/api/src/modules/globals.ts
@@ -82,7 +82,6 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
         Object.keys(currentGlobals).length !== 0 &&
         !deepEqual(globals, currentGlobals)
       ) {
-        console.log('foo', { globals, currentGlobals });
         api.updateGlobals(currentGlobals);
       }
     });

--- a/lib/instrumenter/src/instrumenter.test.ts
+++ b/lib/instrumenter/src/instrumenter.test.ts
@@ -286,7 +286,7 @@ describe('Instrumenter', () => {
       },
     });
     expect(fn()).toEqual(new Error('Boom!'));
-    expect(() => setRenderPhase('completed')).toThrow(new Error('Boom!'));
+    expect(() => setRenderPhase('played')).toThrow(new Error('Boom!'));
   });
 
   it('forwards nested exceptions', () => {
@@ -297,7 +297,7 @@ describe('Instrumenter', () => {
       },
     });
     expect(fn1(fn2())).toEqual(new Error('Boom!'));
-    expect(() => setRenderPhase('completed')).toThrow(new Error('Boom!'));
+    expect(() => setRenderPhase('played')).toThrow(new Error('Boom!'));
   });
 
   it("re-throws anything that isn't an error", () => {

--- a/lib/instrumenter/src/instrumenter.ts
+++ b/lib/instrumenter/src/instrumenter.ts
@@ -31,7 +31,7 @@ export interface Options {
 }
 
 export interface State {
-  renderPhase: 'loading' | 'rendering' | 'playing' | 'completed' | 'aborted';
+  renderPhase: 'loading' | 'rendering' | 'playing' | 'played' | 'completed' | 'aborted' | 'errored';
   isDebugging: boolean;
   cursor: number;
   calls: Call[];
@@ -139,7 +139,7 @@ export class Instrumenter {
       if (newPhase === 'playing') {
         resetState({ storyId, isDebugging });
       }
-      if (newPhase === 'completed') {
+      if (newPhase === 'played') {
         this.setState(storyId, { isDebugging: false, forwardedException: undefined });
         // Rethrow any unhandled forwarded exception so it doesn't go unnoticed.
         if (forwardedException) throw forwardedException;
@@ -430,7 +430,7 @@ export class Instrumenter {
         throw forwardedException;
       }
 
-      if (renderPhase === 'completed' && !call.retain) {
+      if (renderPhase === 'played' && !call.retain) {
         throw alreadyCompletedException;
       }
 

--- a/lib/instrumenter/src/instrumenter.ts
+++ b/lib/instrumenter/src/instrumenter.ts
@@ -361,8 +361,9 @@ export class Instrumenter {
   }
 
   invoke(fn: Function, call: Call, options: Options) {
-    const { abortSignal } = global.window.__STORYBOOK_PREVIEW__ || {};
-    if (abortSignal && abortSignal.aborted) throw IGNORED_EXCEPTION;
+    // TODO this doesnt work because the abortSignal we have here is the newly created one
+    // const { abortSignal } = global.window.__STORYBOOK_PREVIEW__ || {};
+    // if (abortSignal && abortSignal.aborted) throw IGNORED_EXCEPTION;
 
     const { parentCall, callRefsByResult, forwardedException, renderPhase } = this.getState(
       call.storyId

--- a/lib/instrumenter/src/instrumenter.ts
+++ b/lib/instrumenter/src/instrumenter.ts
@@ -361,6 +361,9 @@ export class Instrumenter {
   }
 
   invoke(fn: Function, call: Call, options: Options) {
+    const { abortSignal } = global.window.__STORYBOOK_PREVIEW__ || {};
+    if (abortSignal && abortSignal.aborted) throw IGNORED_EXCEPTION;
+
     const { parentCall, callRefsByResult, forwardedException, renderPhase } = this.getState(
       call.storyId
     );

--- a/lib/instrumenter/src/instrumenter.ts
+++ b/lib/instrumenter/src/instrumenter.ts
@@ -175,7 +175,6 @@ export class Instrumenter {
       });
 
       // Force remount may trigger a page reload if the play function can't be aborted.
-      // global.window.location.reload();
       this.channel.emit(FORCE_REMOUNT, { storyId, isDebugging: true });
     };
 

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -38,7 +38,7 @@ function focusInInput(event: Event) {
   return /input|textarea/i.test(target.tagName) || target.getAttribute('contenteditable') !== null;
 }
 
-function createController() {
+function createController(): AbortController {
   if (AbortController) return new AbortController();
   // Polyfill for IE11
   return {
@@ -46,7 +46,7 @@ function createController() {
     abort() {
       this.signal.aborted = true;
     },
-  };
+  } as AbortController;
 }
 
 export type RenderPhase = 'loading' | 'rendering' | 'playing' | 'completed' | 'aborted' | 'errored';
@@ -74,6 +74,8 @@ export class PreviewWeb<TFramework extends AnyFramework> {
   previousStory: Story<TFramework>;
 
   previousCleanup: StoryCleanupFn;
+
+  abortSignal: AbortSignal;
 
   constructor() {
     this.channel = addons.getChannel();
@@ -514,6 +516,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       if (ctrl) ctrl.abort();
       ctrl = createController();
       controller = ctrl;
+      this.abortSignal = controller.signal;
 
       const runPhase = async (phaseName: RenderPhase, phaseFn: () => MaybePromise<void>) => {
         phase = phaseName;

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -84,6 +84,8 @@ export class PreviewWeb<TFramework extends AnyFramework> {
 
   abortSignal: AbortSignal;
 
+  disableKeyListeners: boolean;
+
   constructor() {
     this.channel = addons.getChannel();
     if (FEATURES?.storyStoreV7) {
@@ -240,7 +242,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
   }
 
   onKeydown(event: KeyboardEvent) {
-    if (!focusInInput(event)) {
+    if (!this.disableKeyListeners && !focusInInput(event)) {
       // We have to pick off the keys of the event that we need on the other side
       const { altKey, ctrlKey, metaKey, shiftKey, key, code, keyCode } = event;
       this.channel.emit(Events.PREVIEW_KEYDOWN, {
@@ -566,8 +568,10 @@ export class PreviewWeb<TFramework extends AnyFramework> {
         if (ctrl.signal.aborted) return;
 
         if (forceRemount && playFunction) {
+          this.disableKeyListeners = true;
           await runPhase('playing', () => playFunction(renderContext.storyContext));
           await runPhase('played');
+          this.disableKeyListeners = false;
           if (ctrl.signal.aborted) return;
         }
 

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "@testing-library/dom": "^7.29.4",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.2",
-    "@testing-library/user-event": "^12.6.0",
+    "@testing-library/user-event": "^13.2.1",
     "@types/detect-port": "^1.3.0",
     "@types/doctrine": "^0.0.3",
     "@types/enzyme": "^3.10.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8830,7 +8830,7 @@ __metadata:
     "@testing-library/dom": ^7.29.4
     "@testing-library/jest-dom": ^5.11.9
     "@testing-library/react": ^11.2.2
-    "@testing-library/user-event": ^12.6.0
+    "@testing-library/user-event": ^13.2.1
     "@types/detect-port": ^1.3.0
     "@types/doctrine": ^0.0.3
     "@types/enzyme": ^3.10.8
@@ -9706,17 +9706,6 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: e38e05ed0c70d2edae6c5bbeed796c8c6674312e8ee45614fb26b4121add1c4ee623bf179bf31319fe2a934f6e23f5ad75d78d2ff81c4514cabfe6f68fc63c7a
-  languageName: node
-  linkType: hard
-
-"@testing-library/user-event@npm:^12.6.0":
-  version: 12.7.3
-  resolution: "@testing-library/user-event@npm:12.7.3"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-  peerDependencies:
-    "@testing-library/dom": ">=7.21.4"
-  checksum: e4c176bd40ac7ad564c8f215245f30f93a395d9f96207bdf29bf9ed2dfdc81226059dd182509695cbf27f49e87a46adcdae40a87d330cc4b96998cd33a5e8bd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #16431

## What I did

- Don't abort the AbortController on rerender, but only on remount or when switching stories.
- Introduced a new `played` phase which is entered after the `play` function is done, but only for the render cycle where `playing` originally started. The instrumenter now uses this instead of the `completed` event, because `completed` is also emitted on a subsequent rerender where the play function is skipped and therefore jumps immediately to `completed`, even though the original play function might still be running
- Fix update to empty globals object on manager init
- Disabled keyboard event listeners while the play function is running, to avoid interference with `userEvent.type()`.

Note that for now, the abortSignal isn't actually considered by the instrumenter, meaning it'll fall back to reloading the iframe when remounting or switching stories while the play function is running.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? no
- [x] Does this need a new example in the kitchen sink apps? no
- [x] Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
