### PR TITLE
Interactions: Fix panel tab icon/count

### DIFF
--- a/addons/interactions/src/Panel.tsx
+++ b/addons/interactions/src/Panel.tsx
@@ -19,7 +19,6 @@ interface AddonPanelProps {
 
 interface InteractionsPanelProps {
   active: boolean;
-  showTabIcon?: boolean;
   interactions: (Call & { state?: CallStates })[];
   isDisabled?: boolean;
   hasPrevious?: boolean;
@@ -47,7 +46,6 @@ const TabIcon = styled(StatusIcon)({
 
 export const AddonPanelPure: React.FC<InteractionsPanelProps> = React.memo(
   ({
-    showTabIcon,
     interactions,
     isDisabled,
     hasPrevious,
@@ -68,9 +66,9 @@ export const AddonPanelPure: React.FC<InteractionsPanelProps> = React.memo(
   }) => {
     return (
       <AddonPanel {...panelProps}>
-        {showTabIcon &&
+        {interactions.length > 0 &&
           ReactDOM.createPortal(
-            <TabIcon status={hasException ? CallStates.ERROR : CallStates.ACTIVE} />,
+            hasException ? <TabIcon status={CallStates.ERROR} /> : ` (${interactions.length})`,
             global.document.getElementById('tabbutton-interactions')
           )}
         {isDebuggingEnabled && interactions.length > 0 && (
@@ -165,8 +163,6 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
     ? hasActive || isLocked || (isPlaying && !isDebugging)
     : true;
 
-  const showTabIcon = isDebugging || (!isPlaying && hasException);
-
   const onStart = React.useCallback(() => emit(EVENTS.START, { storyId }), [storyId]);
   const onPrevious = React.useCallback(() => emit(EVENTS.BACK, { storyId }), [storyId]);
   const onNext = React.useCallback(() => emit(EVENTS.NEXT, { storyId }), [storyId]);
@@ -178,7 +174,6 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
 
   return (
     <AddonPanelPure
-      showTabIcon={showTabIcon}
       interactions={interactions}
       isDisabled={isDisabled}
       hasPrevious={hasPrevious}

--- a/addons/interactions/src/Panel.tsx
+++ b/addons/interactions/src/Panel.tsx
@@ -44,6 +44,11 @@ const TabIcon = styled(StatusIcon)({
   marginLeft: 5,
 });
 
+const TabStatus = ({ children }: { children: React.ReactChild }) => {
+  const container = global.document.getElementById('tabbutton-interactions');
+  return container && ReactDOM.createPortal(children, container);
+};
+
 export const AddonPanelPure: React.FC<InteractionsPanelProps> = React.memo(
   ({
     interactions,
@@ -63,57 +68,50 @@ export const AddonPanelPure: React.FC<InteractionsPanelProps> = React.memo(
     endRef,
     isDebuggingEnabled,
     ...panelProps
-  }) => {
-    return (
-      <AddonPanel {...panelProps}>
-        {interactions.length > 0 &&
-          ReactDOM.createPortal(
-            hasException ? <TabIcon status={CallStates.ERROR} /> : ` (${interactions.length})`,
-            global.document.getElementById('tabbutton-interactions')
-          )}
-        {isDebuggingEnabled && interactions.length > 0 && (
-          <Subnav
-            isDisabled={isDisabled}
-            hasPrevious={hasPrevious}
-            hasNext={hasNext}
-            storyFileName={fileName}
-            status={
-              // eslint-disable-next-line no-nested-ternary
-              isPlaying ? CallStates.ACTIVE : hasException ? CallStates.ERROR : CallStates.DONE
-            }
-            onStart={onStart}
-            onPrevious={onPrevious}
-            onNext={onNext}
-            onEnd={onEnd}
-            onScrollToEnd={onScrollToEnd}
-          />
-        )}
-        {interactions.map((call) => (
-          <Interaction
-            key={call.id}
-            call={call}
-            callsById={calls}
-            isDebuggingEnabled={isDebuggingEnabled}
-            isDisabled={isDisabled}
-            onClick={() => onInteractionClick(call.id)}
-          />
-        ))}
-        <div ref={endRef} />
-        {!isPlaying && interactions.length === 0 && (
-          <Placeholder>
-            No interactions found
-            <Link
-              href="https://storybook.js.org/docs/react/essentials/interactions"
-              target="_blank"
-              withArrow
-            >
-              Learn how to add interactions to your story
-            </Link>
-          </Placeholder>
-        )}
-      </AddonPanel>
-    );
-  }
+  }) => (
+    <AddonPanel {...panelProps}>
+      {isDebuggingEnabled && interactions.length > 0 && (
+        <Subnav
+          isDisabled={isDisabled}
+          hasPrevious={hasPrevious}
+          hasNext={hasNext}
+          storyFileName={fileName}
+          status={
+            // eslint-disable-next-line no-nested-ternary
+            isPlaying ? CallStates.ACTIVE : hasException ? CallStates.ERROR : CallStates.DONE
+          }
+          onStart={onStart}
+          onPrevious={onPrevious}
+          onNext={onNext}
+          onEnd={onEnd}
+          onScrollToEnd={onScrollToEnd}
+        />
+      )}
+      {interactions.map((call) => (
+        <Interaction
+          key={call.id}
+          call={call}
+          callsById={calls}
+          isDebuggingEnabled={isDebuggingEnabled}
+          isDisabled={isDisabled}
+          onClick={() => onInteractionClick(call.id)}
+        />
+      ))}
+      <div ref={endRef} />
+      {!isPlaying && interactions.length === 0 && (
+        <Placeholder>
+          No interactions found
+          <Link
+            href="https://storybook.js.org/docs/react/essentials/interactions"
+            target="_blank"
+            withArrow
+          >
+            Learn how to add interactions to your story
+          </Link>
+        </Placeholder>
+      )}
+    </AddonPanel>
+  )
 );
 
 export const Panel: React.FC<AddonPanelProps> = (props) => {
@@ -154,6 +152,7 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
 
   const isDebuggingEnabled = FEATURES.interactionsDebugger === true;
 
+  const showStatus = log.length > 0 && !isPlaying;
   const isDebugging = log.some((item) => pendingStates.includes(item.state));
   const hasPrevious = log.some((item) => completedStates.includes(item.state));
   const hasNext = log.some((item) => item.state === CallStates.WAITING);
@@ -173,24 +172,30 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
   );
 
   return (
-    <AddonPanelPure
-      interactions={interactions}
-      isDisabled={isDisabled}
-      hasPrevious={hasPrevious}
-      hasNext={hasNext}
-      fileName={fileName}
-      hasException={hasException}
-      isPlaying={isPlaying}
-      calls={calls.current}
-      endRef={endRef}
-      isDebuggingEnabled={isDebuggingEnabled}
-      onStart={onStart}
-      onPrevious={onPrevious}
-      onNext={onNext}
-      onEnd={onEnd}
-      onInteractionClick={onInteractionClick}
-      onScrollToEnd={scrollTarget && scrollToTarget}
-      {...props}
-    />
+    <React.Fragment key="interactions">
+      <TabStatus>
+        {showStatus &&
+          (hasException ? <TabIcon status={CallStates.ERROR} /> : ` (${interactions.length})`)}
+      </TabStatus>
+      <AddonPanelPure
+        interactions={interactions}
+        isDisabled={isDisabled}
+        hasPrevious={hasPrevious}
+        hasNext={hasNext}
+        fileName={fileName}
+        hasException={hasException}
+        isPlaying={isPlaying}
+        calls={calls.current}
+        endRef={endRef}
+        isDebuggingEnabled={isDebuggingEnabled}
+        onStart={onStart}
+        onPrevious={onPrevious}
+        onNext={onNext}
+        onEnd={onEnd}
+        onInteractionClick={onInteractionClick}
+        onScrollToEnd={scrollTarget && scrollToTarget}
+        {...props}
+      />
+    </React.Fragment>
   );
 };

--- a/addons/interactions/src/components/StatusIcon/StatusIcon.tsx
+++ b/addons/interactions/src/components/StatusIcon/StatusIcon.tsx
@@ -31,12 +31,19 @@ const StyledStatusIcon = styled(Icons)<StatusIconProps>(({ theme, status }) => {
   };
 });
 
-export const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
+export const StatusIcon: React.FC<StatusIconProps> = ({ status, className }) => {
   const icon = {
     [CallStates.DONE]: 'check',
     [CallStates.ERROR]: 'stopalt',
     [CallStates.ACTIVE]: 'play',
     [CallStates.WAITING]: 'circle',
   }[status] as IconsProps['icon'];
-  return <StyledStatusIcon data-testid={`icon-${status}`} status={status} icon={icon} />;
+  return (
+    <StyledStatusIcon
+      data-testid={`icon-${status}`}
+      status={status}
+      icon={icon}
+      className={className}
+    />
+  );
 };


### PR DESCRIPTION
Issue: #16359

## What I did

I made the panel tag show the number of interactions if there are any (regardless of whether the play function is running). If there's an error it will show the square error icon instead of the count. I also fixed the spacing on the error icon.

This deviates from what Michael suggested in the ticket because I felt the play icon looks really out of place when it's not actually playing at that time, and I thing the count is relevant info to see at a glance.

<img width="392" alt="Screenshot 2021-11-03 at 17 36 48" src="https://user-images.githubusercontent.com/321738/140103487-dba3fa53-728a-4c03-8788-a16f53ecfe2c.png"> <img width="453" alt="Screenshot 2021-11-03 at 17 36 38" src="https://user-images.githubusercontent.com/321738/140103509-8a3843e9-320f-4cb3-aa7c-7cd52c937323.png">


## How to test

- [x] Is this testable with Jest or Chromatic screenshots? no
- [x] Does this need a new example in the kitchen sink apps? no
- [x] Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
