### PR TITLE
UI: Fix links that have no onClick handler

### DIFF
--- a/lib/components/src/typography/link/link.tsx
+++ b/lib/components/src/typography/link/link.tsx
@@ -191,22 +191,24 @@ export const Link: FunctionComponent<LinkProps & AProps> = ({
   containsIcon,
   className,
   ...rest
-}) => {
-  return (
-    <A {...rest} onClick={cancel ? (e) => cancelled(e, onClick) : onClick} className={className}>
-      <LinkInner withArrow={withArrow} containsIcon={containsIcon}>
-        {children}
-        {withArrow && <Icons icon="arrowright" />}
-      </LinkInner>
-    </A>
-  );
-};
+}) => (
+  <A
+    {...rest}
+    onClick={onClick && cancel ? (e) => cancelled(e, onClick) : onClick}
+    className={className}
+  >
+    <LinkInner withArrow={withArrow} containsIcon={containsIcon}>
+      {children}
+      {withArrow && <Icons icon="arrowright" />}
+    </LinkInner>
+  </A>
+);
 
 Link.defaultProps = {
   cancel: true,
   className: undefined,
   style: undefined,
-  onClick: () => {},
+  onClick: undefined,
   withArrow: false,
   containsIcon: false,
 };


### PR DESCRIPTION
Issue: -

## What I did

Made sure the `Link` component will not set an `onClick` property if we're not passing one, because it'll break any links that have no `onClick` handler but rather an `href`.

I noticed this was broken because the link you see when there's no interactions on a story wasn't working.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? no
- [x] Does this need a new example in the kitchen sink apps? no
- [x] Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
