### PR TITLE
TS: Fix type for Refs so they can be disabled

### DIFF
--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -262,13 +262,7 @@ export type Preset =
  */
 export type Entry = string;
 
-type StorybookRefs = Record<
-  string,
-  {
-    title: string;
-    url: string;
-  }
->;
+type StorybookRefs = Record<string, { title: string; url: string } | { disable: boolean }>;
 
 /**
  * The interface for Storybook configuration in `main.ts` files.


### PR DESCRIPTION
Issue: -

## What I did

I wanted to disable `@storybook/design-system` autoref during a test, but discovered TS wouldn't let me. So I fixed the type.

Technically `disabled` is also supported but it's deprecated so I figured we shouldn't add TS support for it.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? no
- [x] Does this need a new example in the kitchen sink apps? maybe?
- [x] Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
