### PR TITLE
Core: Handle missing websocket in production build

### DIFF
--- a/lib/addons/src/index.ts
+++ b/lib/addons/src/index.ts
@@ -92,6 +92,8 @@ export class AddonStore {
 
   hasChannel = (): boolean => !!this.channel;
 
+  hasServerChannel = (): boolean => !!this.serverChannel;
+
   setChannel = (channel: Channel): void => {
     this.channel = channel;
     this.resolve();

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -514,7 +514,7 @@ export const init: ModuleFn = ({
     );
 
     if (FEATURES?.storyStoreV7) {
-      provider.serverChannel.on(STORY_INDEX_INVALIDATED, () => fullAPI.fetchStoryList());
+      provider.serverChannel?.on(STORY_INDEX_INVALIDATED, () => fullAPI.fetchStoryList());
       await fullAPI.fetchStoryList();
     }
   };

--- a/lib/builder-webpack4/src/preview/virtualModuleModernEntry.js.handlebars
+++ b/lib/builder-webpack4/src/preview/virtualModuleModernEntry.js.handlebars
@@ -17,15 +17,17 @@ const getProjectAnnotations = () =>
 const channel = createPostMessageChannel({ page: 'preview' });
 addons.setChannel(channel);
 
-const serverChannel = createWebSocketChannel({ url: SERVER_CHANNEL_URL, });
-addons.setServerChannel(serverChannel);
+if (SERVER_CHANNEL_URL) {
+  const serverChannel = createWebSocketChannel({ url: SERVER_CHANNEL_URL, });
+  addons.setServerChannel(serverChannel);
+  window.__STORYBOOK_SERVER_CHANNEL__ = serverChannel;
+}
 
 const preview = new PreviewWeb();
 
 window.__STORYBOOK_PREVIEW__ = preview;
 window.__STORYBOOK_STORY_STORE__ = preview.storyStore;
 window.__STORYBOOK_ADDONS_CHANNEL__ = channel;
-window.__STORYBOOK_SERVER_CHANNEL__ = serverChannel;
 window.__STORYBOOK_CLIENT_API__ = new ClientApi({ storyStore: preview.storyStore });
 
 preview.initialize({ importFn, getProjectAnnotations });

--- a/lib/builder-webpack5/src/preview/virtualModuleModernEntry.js.handlebars
+++ b/lib/builder-webpack5/src/preview/virtualModuleModernEntry.js.handlebars
@@ -17,15 +17,17 @@ const getProjectAnnotations = () =>
 const channel = createPostMessageChannel({ page: 'preview' });
 addons.setChannel(channel);
 
-const serverChannel = createWebSocketChannel({ url: SERVER_CHANNEL_URL, });
-addons.setServerChannel(serverChannel);
+if (SERVER_CHANNEL_URL) {
+  const serverChannel = createWebSocketChannel({ url: SERVER_CHANNEL_URL, });
+  addons.setServerChannel(serverChannel);
+  window.__STORYBOOK_SERVER_CHANNEL__ = serverChannel;
+}
 
 const preview = new PreviewWeb();
 
 window.__STORYBOOK_PREVIEW__ = preview;
 window.__STORYBOOK_STORY_STORE__ = preview.storyStore;
 window.__STORYBOOK_ADDONS_CHANNEL__ = channel;
-window.__STORYBOOK_SERVER_CHANNEL__ = serverChannel;
 window.__STORYBOOK_CLIENT_API__ = new ClientApi({ storyStore: preview.storyStore });
 
 preview.initialize({ importFn, getProjectAnnotations });

--- a/lib/core-client/src/manager/provider.ts
+++ b/lib/core-client/src/manager/provider.ts
@@ -25,7 +25,7 @@ export default class ReactProvider extends Provider {
     this.addons = addons;
     this.channel = channel;
 
-    if (FEATURES?.storyStoreV7) {
+    if (FEATURES?.storyStoreV7 && SERVER_CHANNEL_URL) {
       const serverChannel = createWebSocketChannel({ url: SERVER_CHANNEL_URL });
       this.serverChannel = serverChannel;
       addons.setServerChannel(this.serverChannel);

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -92,7 +92,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
 
   constructor() {
     this.channel = addons.getChannel();
-    if (FEATURES?.storyStoreV7) {
+    if (FEATURES?.storyStoreV7 && addons.hasServerChannel()) {
       this.serverChannel = addons.getServerChannel();
     }
     this.view = new WebView();


### PR DESCRIPTION
Issue: #16585

## What I did

Don't setup the server channel or listen to events in prod mode (if the URL isn't set).

## How to test

Check `react-ts` build. We should probably have an E2E test for this project?