### PR TITLE
Interactions: Use Icon button and add disabled state to IconButton

### DIFF
--- a/addons/interactions/src/components/Subnav/Subnav.tsx
+++ b/addons/interactions/src/components/Subnav/Subnav.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Button, Icons, Separator, P, TooltipNote, WithTooltip, Bar } from '@storybook/components';
+import {
+  Button,
+  IconButton,
+  Icons,
+  Separator,
+  P,
+  TooltipNote,
+  WithTooltip,
+  Bar,
+} from '@storybook/components';
 import { Call, CallStates } from '@storybook/instrumenter';
 import { styled } from '@storybook/theming';
 
@@ -46,14 +55,9 @@ const Note = styled(TooltipNote)(({ theme }) => ({
   fontFamily: theme.typography.fonts.base,
 }));
 
-export const StyledIconButton = styled(StyledButton)(({ theme }) => ({
+export const StyledIconButton = styled(IconButton)(({ theme }) => ({
   color: theme.color.mediumdark,
   margin: '0 3px',
-  '&:not(:disabled)': {
-    '&:hover,&:focus-visible': {
-      background: theme.background.hoverable,
-    },
-  },
 }));
 
 const StyledSeparator = styled(Separator)({
@@ -133,7 +137,7 @@ export const Subnav: React.FC<SubnavProps> = ({
             trigger={hasPrevious ? 'hover' : 'none'}
             tooltip={<Note note="Go to start" />}
           >
-            <RewindButton containsIcon onClick={onStart} disabled={isDisabled || !hasPrevious}>
+            <RewindButton onClick={onStart} disabled={isDisabled || !hasPrevious}>
               <Icons icon="rewind" />
             </RewindButton>
           </WithTooltip>
@@ -144,11 +148,7 @@ export const Subnav: React.FC<SubnavProps> = ({
             trigger={hasPrevious ? 'hover' : 'none'}
             tooltip={<Note note="Go back" />}
           >
-            <StyledIconButton
-              containsIcon
-              onClick={onPrevious}
-              disabled={isDisabled || !hasPrevious}
-            >
+            <StyledIconButton onClick={onPrevious} disabled={isDisabled || !hasPrevious}>
               <Icons icon="playback" />
             </StyledIconButton>
           </WithTooltip>
@@ -159,7 +159,7 @@ export const Subnav: React.FC<SubnavProps> = ({
             trigger={hasNext ? 'hover' : 'none'}
             tooltip={<Note note="Go forward" />}
           >
-            <StyledIconButton containsIcon onClick={onNext} disabled={isDisabled || !hasNext}>
+            <StyledIconButton onClick={onNext} disabled={isDisabled || !hasNext}>
               <Icons icon="playnext" />
             </StyledIconButton>
           </WithTooltip>
@@ -170,7 +170,7 @@ export const Subnav: React.FC<SubnavProps> = ({
             hasChrome={false}
             tooltip={<Note note="Go to end" />}
           >
-            <StyledIconButton containsIcon onClick={onEnd} disabled={isDisabled || !hasNext}>
+            <StyledIconButton onClick={onEnd} disabled={isDisabled || !hasNext}>
               <Icons icon="fastforward" />
             </StyledIconButton>
           </WithTooltip>

--- a/lib/components/src/bar/button.stories.tsx
+++ b/lib/components/src/bar/button.stories.tsx
@@ -21,6 +21,12 @@ export const Active = () => (
   </IconButton>
 );
 
+export const Disabled = () => (
+  <IconButton disabled>
+    <Icons icon="beaker" />
+  </IconButton>
+);
+
 export const WithText = () => (
   <IconButton>
     <Icons icon="circlehollow" />
@@ -30,6 +36,13 @@ export const WithText = () => (
 
 export const WithTextActive = () => (
   <IconButton active>
+    <Icons icon="circlehollow" />
+    &nbsp;Howdy!
+  </IconButton>
+);
+
+export const WithTextDisabled = () => (
+  <IconButton disabled>
     <Icons icon="circlehollow" />
     &nbsp;Howdy!
   </IconButton>

--- a/lib/components/src/bar/button.tsx
+++ b/lib/components/src/bar/button.tsx
@@ -6,10 +6,12 @@ import { auto } from '@popperjs/core';
 interface ButtonProps
   extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   href?: void;
+  disabled?: boolean;
 }
 interface LinkProps
   extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
   href: string;
+  disabled?: boolean;
 }
 
 const ButtonOrLink = ({ children, ...restProps }: ButtonProps | LinkProps) =>
@@ -74,10 +76,11 @@ TabButton.displayName = 'TabButton';
 
 export interface IconButtonProps {
   active?: boolean;
+  disabled?: boolean;
 }
 
 export const IconButton = styled(ButtonOrLink, { shouldForwardProp: isPropValid })<IconButtonProps>(
-  ({ theme }) => ({
+  ({ disabled, theme }) => ({
     alignItems: 'center',
     background: 'transparent',
     border: 'none',
@@ -92,16 +95,6 @@ export const IconButton = styled(ButtonOrLink, { shouldForwardProp: isPropValid 
     marginTop: 6,
     padding: '8px 7px',
 
-    '&:hover, &:focus-visible': {
-      background: transparentize(0.88, theme.color.secondary),
-      color: theme.color.secondary,
-    },
-    '&:focus-visible': {
-      outline: auto, // Ensures links have the same focus style
-    },
-    '&:focus:not(:focus-visible)': {
-      outline: 'none',
-    },
     '& > svg': {
       width: 14,
     },
@@ -112,6 +105,24 @@ export const IconButton = styled(ButtonOrLink, { shouldForwardProp: isPropValid 
           backgroundColor: theme.background.hoverable,
           color: theme.color.secondary,
         }
-      : {}
+      : {},
+  ({ disabled, theme }) =>
+    disabled
+      ? {
+          opacity: 0.5,
+          cursor: 'not-allowed',
+        }
+      : {
+          '&:hover, &:focus-visible': {
+            background: transparentize(0.88, theme.color.secondary),
+            color: theme.color.secondary,
+          },
+          '&:focus-visible': {
+            outline: auto, // Ensures links have the same focus style
+          },
+          '&:focus:not(:focus-visible)': {
+            outline: 'none',
+          },
+        }
 );
 IconButton.displayName = 'IconButton';

--- a/lib/components/src/bar/button.tsx
+++ b/lib/components/src/bar/button.tsx
@@ -1,17 +1,15 @@
 import React, { AnchorHTMLAttributes, ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
 import { styled, isPropValid } from '@storybook/theming';
-import { darken, transparentize } from 'polished';
+import { transparentize } from 'polished';
 import { auto } from '@popperjs/core';
 
 interface ButtonProps
   extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   href?: void;
-  disabled?: boolean;
 }
 interface LinkProps
   extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
   href: string;
-  disabled?: boolean;
 }
 
 const ButtonOrLink = ({ children, ...restProps }: ButtonProps | LinkProps) =>
@@ -80,7 +78,7 @@ export interface IconButtonProps {
 }
 
 export const IconButton = styled(ButtonOrLink, { shouldForwardProp: isPropValid })<IconButtonProps>(
-  ({ disabled, theme }) => ({
+  () => ({
     alignItems: 'center',
     background: 'transparent',
     border: 'none',


### PR DESCRIPTION
The Interactions Subnav used its own set of buttons. Recently, I updated the `IconButton` component. This change simply switches to use the IconButton component for consistentcy. I also added a disabled state to `IconButton`.

### Before
![image](https://user-images.githubusercontent.com/1123119/140423290-94f437c9-f283-4a75-b280-48a51fb06780.png)
![image](https://user-images.githubusercontent.com/1123119/140423239-bc0a1499-3d2a-4bff-b06e-f2781050cecc.png)

### After
![image](https://user-images.githubusercontent.com/1123119/140423106-b2fd2371-dbc3-4304-b6a6-c85eabf8769c.png)
![image](https://user-images.githubusercontent.com/1123119/140423183-94ea5850-4b3b-4bd2-aebb-df71e304a619.png)

## How to test
1. Open up the Official Storybook linked below
1. Navigate to a story with Interactions: Interactions > Account Form > Standard Email Success
1. Use both keyboard and mouse to test out the new button implementations
1. Take a look at the IconButton stories

<hr>

* [ ] Is this testable with Jest or Chromatic screenshots?
* [ ] Does this need a new example in the kitchen sink apps?
* [ ] Does this need an update to the documentation?

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200510412866230/1201327415756945) by [Unito](https://www.unito.io)
