### PR TITLE
StoryIndex: Skip files with no default export

### DIFF
--- a/lib/client-api/src/StoryStoreFacade.ts
+++ b/lib/client-api/src/StoryStoreFacade.ts
@@ -22,6 +22,7 @@ import {
   sortStoriesV6,
   StoryIndexEntry,
 } from '@storybook/store';
+import { logger } from '@storybook/client-logger';
 
 const { STORIES = [] } = global;
 
@@ -156,11 +157,12 @@ export class StoryStoreFacade<TFramework extends AnyFramework> {
         }))
       );
     if (!title) {
-      throw new Error(
+      logger.info(
         `Unexpected default export without title in '${fileName}': ${JSON.stringify(
           fileExports.default
         )}`
       );
+      return;
     }
 
     this.csfExports[fileName] = {

--- a/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -167,7 +167,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([specifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(readCsfOrMdxMock).toHaveBeenCalledTimes(5);
+        expect(readCsfOrMdxMock).toHaveBeenCalledTimes(6);
 
         readCsfOrMdxMock.mockClear();
         await generator.getIndex();
@@ -204,7 +204,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([specifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(readCsfOrMdxMock).toHaveBeenCalledTimes(5);
+        expect(readCsfOrMdxMock).toHaveBeenCalledTimes(6);
 
         generator.invalidate(specifier, './src/B.stories.ts', false);
 
@@ -244,7 +244,7 @@ describe('StoryIndexGenerator', () => {
           const generator = new StoryIndexGenerator([specifier], options);
           await generator.initialize();
           await generator.getIndex();
-          expect(readCsfOrMdxMock).toHaveBeenCalledTimes(5);
+          expect(readCsfOrMdxMock).toHaveBeenCalledTimes(6);
 
           generator.invalidate(specifier, './src/B.stories.ts', true);
 
@@ -283,7 +283,7 @@ describe('StoryIndexGenerator', () => {
           const generator = new StoryIndexGenerator([specifier], options);
           await generator.initialize();
           await generator.getIndex();
-          expect(readCsfOrMdxMock).toHaveBeenCalledTimes(5);
+          expect(readCsfOrMdxMock).toHaveBeenCalledTimes(6);
 
           generator.invalidate(specifier, './src/B.stories.ts', true);
 

--- a/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -13,7 +13,7 @@ import {
 } from '@storybook/store';
 import { NormalizedStoriesSpecifier } from '@storybook/core-common';
 import { logger } from '@storybook/node-logger';
-import { readCsfOrMdx, getStorySortParameter } from '@storybook/csf-tools';
+import { readCsfOrMdx, getStorySortParameter, NoMetaError } from '@storybook/csf-tools';
 import { ComponentTitle } from '@storybook/csf';
 
 function sortExtractedStories(
@@ -99,10 +99,9 @@ export class StoryIndexGenerator {
 
   async extractStories(specifier: NormalizedStoriesSpecifier, absolutePath: Path) {
     const relativePath = path.relative(this.options.workingDir, absolutePath);
+    const fileStories = {} as StoryIndex['stories'];
+    const entry = this.storyIndexEntries.get(specifier);
     try {
-      const entry = this.storyIndexEntries.get(specifier);
-      const fileStories = {} as StoryIndex['stories'];
-
       const importPath = slash(relativePath[0] === '.' ? relativePath : `./${relativePath}`);
       const defaultTitle = autoTitleFromSpecifier(importPath, specifier);
       const csf = (await readCsfOrMdx(absolutePath, { defaultTitle })).parse();
@@ -114,13 +113,16 @@ export class StoryIndexGenerator {
           importPath,
         };
       });
-
-      entry[absolutePath] = fileStories;
-      return fileStories;
     } catch (err) {
-      logger.warn(`🚨 Extraction error on ${relativePath}: ${err}`);
-      throw err;
+      if (err.name === 'NoMetaError') {
+        logger.info(`💡 Skipping ${relativePath}: ${err}`);
+      } else {
+        logger.warn(`🚨 Extraction error on ${relativePath}: ${err}`);
+        throw err;
+      }
     }
+    entry[absolutePath] = fileStories;
+    return fileStories;
   }
 
   async sortStories(storiesList: StoryIndex['stories'][]) {

--- a/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -13,7 +13,7 @@ import {
 } from '@storybook/store';
 import { NormalizedStoriesSpecifier } from '@storybook/core-common';
 import { logger } from '@storybook/node-logger';
-import { readCsfOrMdx, getStorySortParameter, NoMetaError } from '@storybook/csf-tools';
+import { readCsfOrMdx, getStorySortParameter } from '@storybook/csf-tools';
 import { ComponentTitle } from '@storybook/csf';
 
 function sortExtractedStories(

--- a/lib/core-server/src/utils/__mockdata__/src/NoMeta.stories.ts
+++ b/lib/core-server/src/utils/__mockdata__/src/NoMeta.stories.ts
@@ -1,0 +1,3 @@
+// no default export
+// e.g. https://github.com/storybookjs/storybook/issues/16421
+export const StoryOne = {};

--- a/lib/csf-tools/src/CsfFile.ts
+++ b/lib/csf-tools/src/CsfFile.ts
@@ -104,6 +104,17 @@ export interface CsfOptions {
   defaultTitle: string;
   fileName?: string;
 }
+
+export class NoMetaError extends Error {
+  constructor(ast: t.Node, fileName?: string) {
+    super(dedent`
+      CSF: missing default export ${formatLocation(ast, fileName)}
+
+      More info: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+    `);
+    this.name = this.constructor.name;
+  }
+}
 export class CsfFile {
   _ast: t.File;
 
@@ -291,11 +302,7 @@ export class CsfFile {
     });
 
     if (!self._meta) {
-      throw new Error(dedent`
-        CSF: missing default export ${formatLocation(self._ast, self._fileName)}
-
-        More info: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
-      `);
+      throw new NoMetaError(self._ast, self._fileName);
     }
 
     if (!self._meta.title && !self._meta.component) {


### PR DESCRIPTION
Issue: #16421 

## What I did

The way our StoryIndex handles CSF with no default export is inconsistent with the old `loadCsf` code, which simply skipped files with no default export and this is built into our recipes (e.g. CSF+MDX). For now, let's make it consistent.

- [x] Skip CSF files with no default export & show a warning 
- [x] Update tests

## How to test

See attached
