### PR TITLE
CSFFile: Handle re-exported stories

### DIFF
--- a/lib/csf-tools/src/CsfFile.test.ts
+++ b/lib/csf-tools/src/CsfFile.test.ts
@@ -285,6 +285,26 @@ describe('CsfFile', () => {
               __id: foo-bar--b
       `);
     });
+
+    it('re-exported stories', () => {
+      expect(
+        parse(
+          dedent`
+          export default { title: 'foo/bar' };
+          export { default as A } from './A';
+          export { B } from './B';
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+          - id: foo-bar--b
+            name: B
+      `);
+    });
   });
 
   describe('error handling', () => {

--- a/lib/csf-tools/src/CsfFile.ts
+++ b/lib/csf-tools/src/CsfFile.ts
@@ -234,6 +234,15 @@ export class CsfFile {
                 };
               }
             });
+          } else if (node.specifiers.length > 0) {
+            // export { X as Y }
+            node.specifiers.forEach((specifier) => {
+              if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
+                const { name: exportName } = specifier.exported;
+                self._storyAnnotations[exportName] = {};
+                self._stories[exportName] = { id: 'FIXME', name: exportName, parameters: {} };
+              }
+            });
           }
         },
       },


### PR DESCRIPTION
Issue: #16598 

## What I did

Users are breaking up their files into individual stories and then re-exporting those files from a central `.stories.js` file, which is a reasonable pattern.

I've extended CSFFile to handle this case. However it doesn't analyze the content of the story file that's being re-exported. For now this means if you want to rename the story using `storyName`, you'll need to do this in the parent file.

## How to test

See attached tests