### PR TITLE
Core: Update behavior around missing stories to be more clear

### DIFF
--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -240,12 +240,12 @@ describe('PreviewWeb', () => {
     });
 
     describe('if the story specified does not exist', () => {
-      it('renders missing', async () => {
+      it('renders a loading error', async () => {
         document.location.search = '?id=random';
 
         const preview = await createAndRenderPreview();
 
-        expect(preview.view.showNoPreview).toHaveBeenCalled();
+        expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_MISSING, 'random');
       });
 
@@ -254,7 +254,7 @@ describe('PreviewWeb', () => {
 
         const preview = await createAndRenderPreview();
 
-        expect(preview.view.showNoPreview).toHaveBeenCalled();
+        expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_MISSING, 'component-one--d');
 
         mockChannel.emit.mockClear();
@@ -298,7 +298,7 @@ describe('PreviewWeb', () => {
 
           const preview = await createAndRenderPreview();
 
-          expect(preview.view.showNoPreview).toHaveBeenCalled();
+          expect(preview.view.showErrorDisplay).toHaveBeenCalled();
           expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_MISSING, 'component-one--d');
 
           emitter.emit(Events.SET_CURRENT_STORY, {
@@ -343,7 +343,7 @@ describe('PreviewWeb', () => {
       const preview = await createAndRenderPreview();
 
       expect(preview.view.showNoPreview).toHaveBeenCalled();
-      expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_MISSING, undefined);
+      expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_MISSING);
     });
 
     describe('in story viewMode', () => {
@@ -1147,7 +1147,7 @@ describe('PreviewWeb', () => {
       });
     });
 
-    it('renders missing if the story specified does not exist', async () => {
+    it('renders loading error if the story specified does not exist', async () => {
       document.location.search = '?id=component-one--a';
       const preview = await createAndRenderPreview();
 
@@ -1158,7 +1158,7 @@ describe('PreviewWeb', () => {
       await waitForSetCurrentStory();
 
       await waitForEvents([Events.STORY_MISSING]);
-      expect(preview.view.showNoPreview).toHaveBeenCalled();
+      expect(preview.view.showErrorDisplay).toHaveBeenCalled();
       expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_MISSING, 'random');
     });
 
@@ -2406,7 +2406,7 @@ describe('PreviewWeb', () => {
         },
       };
 
-      it('renders story missing', async () => {
+      it('renders loading error', async () => {
         document.location.search = '?id=component-one--a';
         const preview = await createAndRenderPreview();
 
@@ -2414,7 +2414,7 @@ describe('PreviewWeb', () => {
         preview.onStoriesChanged({ importFn: newImportFn, storyIndex: newStoryIndex });
         await waitForEvents([Events.STORY_MISSING]);
 
-        expect(preview.view.showNoPreview).toHaveBeenCalled();
+        expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(mockChannel.emit).toHaveBeenCalledWith(Events.STORY_MISSING, 'component-one--a');
       });
 


### PR DESCRIPTION
Issue: #16605 

## What I did

Only use `renderMissing` if there is really no selection or stories in the storybook at all. If the user has tried to pick a story, use `renderStoryLoadingException`, which redboxes the error, but still emits `STORY_MISSING`.

## Screenshots

Empty SB, no selection:
<img width="1580" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/132554/140457483-7d565d59-d1ff-4c04-a142-7be5dbb2f7f8.png">

Empty storybook w/ selection:
<img width="1580" alt="Pasted Graphic 5" src="https://user-images.githubusercontent.com/132554/140457462-bd4558cd-5a0d-4bc6-9dc9-d367f27ebc63.png">

Full storybook selected missing story:
<img width="1580" alt="Pasted Graphic 7" src="https://user-images.githubusercontent.com/132554/140457527-87876aa9-a868-494b-b684-92d1ae824a55.png">

Full storybook selected story that gets deleted on HMR:
<img width="1580" alt="Pasted Graphic 8" src="https://user-images.githubusercontent.com/132554/140457579-53e86c4c-eef8-4395-a544-6c0e0dbe66fb.png">

Full storybook no selection (iframe no id):
<img width="1580" alt="Pasted Graphic 9" src="https://user-images.githubusercontent.com/132554/140457606-3f57fa15-ec8e-41b8-a484-ae9b4485a568.png">

## How to test

See scenarios above.