### PR TITLE
Core: Add feature flag to stop storybook from aliasing emotion

### DIFF
--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -238,7 +238,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
       modules: ['node_modules'].concat(envs.NODE_PATH || []),
       mainFields: [modern ? 'sbmodern' : null, 'browser', 'module', 'main'].filter(Boolean),
       alias: {
-        ...(features.emotionAlias ? themingPaths : {}),
+        ...(features?.emotionAlias ? themingPaths : {}),
         ...storybookPaths,
         react: path.dirname(require.resolve('react/package.json')),
         'react-dom': path.dirname(require.resolve('react-dom/package.json')),

--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -238,7 +238,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
       modules: ['node_modules'].concat(envs.NODE_PATH || []),
       mainFields: [modern ? 'sbmodern' : null, 'browser', 'module', 'main'].filter(Boolean),
       alias: {
-        ...themingPaths,
+        ...(features.emotionAlias ? themingPaths : {}),
         ...storybookPaths,
         react: path.dirname(require.resolve('react/package.json')),
         'react-dom': path.dirname(require.resolve('react-dom/package.json')),

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -232,8 +232,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
       modules: ['node_modules'].concat(envs.NODE_PATH || []),
       mainFields: [modern ? 'sbmodern' : null, 'browser', 'module', 'main'].filter(Boolean),
       alias: {
-        ...themingPaths,
-        ...storybookPaths,
+        ...(features.emotionAlias ? themingPaths : {}),
         react: path.dirname(require.resolve('react/package.json')),
         'react-dom': path.dirname(require.resolve('react-dom/package.json')),
       },

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -232,7 +232,8 @@ export default async (options: Options & Record<string, any>): Promise<Configura
       modules: ['node_modules'].concat(envs.NODE_PATH || []),
       mainFields: [modern ? 'sbmodern' : null, 'browser', 'module', 'main'].filter(Boolean),
       alias: {
-        ...(features.emotionAlias ? themingPaths : {}),
+        ...(features?.emotionAlias ? themingPaths : {}),
+        ...storybookPaths,
         react: path.dirname(require.resolve('react/package.json')),
         'react-dom': path.dirname(require.resolve('react-dom/package.json')),
       },

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -295,6 +295,10 @@ export interface StorybookConfig {
      * Allows to disable deprecated implicit PostCSS loader.
      */
     postcss?: boolean;
+    /**
+     * Allows to disable deprecated implicit PostCSS loader.
+     */
+    emotionAlias?: boolean;
 
     /**
      * Build stories.json automatically on start/build

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -295,6 +295,7 @@ export interface StorybookConfig {
      * Allows to disable deprecated implicit PostCSS loader.
      */
     postcss?: boolean;
+
     /**
      * Allows to disable deprecated implicit PostCSS loader.
      */

--- a/lib/core-server/src/presets/common-preset.ts
+++ b/lib/core-server/src/presets/common-preset.ts
@@ -64,4 +64,5 @@ export const typescript = () => ({
 export const features = async (existing: Record<string, boolean>) => ({
   ...existing,
   postcss: true,
+  emotionAlias: true,
 });


### PR DESCRIPTION
Issue: #16099 

## What I did

Allow users to disable the default behavior of storybook of creating a webpack alias for emotion packages.

User can now configure this behavior by setting `emotionAlias: false` in `main.js` like so:

```ts
const config: StorybookConfig = {
  features: {
    emotionAlias: false,
  },
};
