### PR TITLE
Fix rename of "sb fix" into "sb automigrate"

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -190,7 +190,7 @@ Storybook 6.3 supports CRA5 out of the box when you install it fresh. However, i
 upgrade the configuration. You can do this automatically by running:
 
 ```
-npx sb@next fix
+npx sb@next automigrate
 ```
 
 Or you can do the following steps manually to force Storybook to use webpack 5 for building your project:

--- a/lib/cli/src/automigrate/index.ts
+++ b/lib/cli/src/automigrate/index.ts
@@ -46,7 +46,7 @@ export const automigrate = async ({ fixId, dryRun, yes }: FixOptions) => {
       } else {
         logger.info(`Skipping the ${chalk.cyan(f.id)} fix.`);
         logger.info();
-        logger.info(`If you change your mind, run '${chalk.cyan('npx sb@next fix')}'`);
+        logger.info(`If you change your mind, run '${chalk.cyan('npx sb@next automigrate')}'`);
       }
     }
   }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/16617

## What I did

Fixed a wrong CLI command, that is mentioned in `MIGRATION.md`.

## How to test

Open `MIGRATION.md#from-version-63x-to-640`.