### PR TITLE
Angular: Fix zonejs imports in framework preset

### DIFF
--- a/app/angular/src/client/preview/config.ts
+++ b/app/angular/src/client/preview/config.ts
@@ -1,3 +1,5 @@
+import './globals';
+
 export { render, renderToDOM } from './render';
 export { decorateStory } from './decorateStory';
 


### PR DESCRIPTION
Issue: #16499 

## What I did

The angular preset was not importing the zone.js polyfill, so only files that used the `moduleMetadata` decorator were getting it loaded properly

self-merging @tmeasday 

## How to test

See repro steps in the issue:
- [ ] Delete the legacy stories from `examples/angular-cli`
- [ ] Add `storyStoreV7` flag to `main.js`