### PR TITLE
Core: Change CSF loading problems from warning to error

### DIFF
--- a/lib/core-client/src/preview/executeLoadable.ts
+++ b/lib/core-client/src/preview/executeLoadable.ts
@@ -31,7 +31,7 @@ export function executeLoadable(loadable: Loadable) {
         } catch (error) {
           const errorString =
             error.message && error.stack ? `${error.message}\n ${error.stack}` : error.toString();
-          logger.warn(`Unexpected error while loading ${filename}: ${errorString}`);
+          logger.error(`Unexpected error while loading ${filename}: ${errorString}`);
         }
       });
     });


### PR DESCRIPTION
Issue: #13366

## What I did

Changed `console.warn` to `console.error`.

## How to test

Put an error in a v6 CSF file (top-level).

![image](https://user-images.githubusercontent.com/132554/140688771-5ab4a4cf-4320-4d51-baf9-260e89d481a9.png)
