### PR TITLE
Core: Ensure manager caching respects globals

### DIFF
--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -179,10 +179,8 @@ export default async (options: Options & Record<string, any>): Promise<Configura
         chunksSortMode: 'none' as any,
         alwaysWriteToDisk: true,
         inject: false,
-        templateParameters: (compilation, files, templateOptions) => ({
-          compilation,
-          files,
-          options: templateOptions,
+        template,
+        templateParameters: {
           version: packageJson.version,
           globals: {
             CONFIG_TYPE: configType,
@@ -198,7 +196,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
           },
           headHtmlSnippet,
           bodyHtmlSnippet,
-        }),
+        },
         minify: {
           collapseWhitespace: true,
           removeComments: true,
@@ -207,7 +205,6 @@ export default async (options: Options & Record<string, any>): Promise<Configura
           removeStyleLinkTypeAttributes: true,
           useShortDoctype: true,
         },
-        template,
       }),
       new DefinePlugin({
         ...stringifyProcessEnvs(envs),

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -177,10 +177,8 @@ export default async (options: Options & Record<string, any>): Promise<Configura
         chunksSortMode: 'none' as any,
         alwaysWriteToDisk: true,
         inject: false,
-        templateParameters: (compilation, files, templateOptions) => ({
-          compilation,
-          files,
-          options: templateOptions,
+        template,
+        templateParameters: {
           version: packageJson.version,
           globals: {
             CONFIG_TYPE: configType,
@@ -196,7 +194,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
           },
           headHtmlSnippet,
           bodyHtmlSnippet,
-        }),
+        },
         minify: {
           collapseWhitespace: true,
           removeComments: true,
@@ -205,7 +203,6 @@ export default async (options: Options & Record<string, any>): Promise<Configura
           removeStyleLinkTypeAttributes: true,
           useShortDoctype: true,
         },
-        template,
       }),
       new DefinePlugin({
         ...stringifyProcessEnvs(envs),

--- a/lib/core-common/src/templates/index.ejs
+++ b/lib/core-common/src/templates/index.ejs
@@ -2,16 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title><%= options.title || 'Storybook'%></title>
+    <title><%= htmlWebpackPlugin.options.title || 'Storybook'%></title>
 
-    <% if (files.favicon) { %>
-    <link rel="shortcut icon" href="<%= files.favicon%>" />
+    <% if (htmlWebpackPlugin.files.favicon) { %>
+    <link rel="shortcut icon" href="<%= htmlWebpackPlugin.files.favicon%>" />
     <% } %>
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <% if (typeof headHtmlSnippet !== 'undefined') { %> <%= headHtmlSnippet %> <% } %> <%
-    files.css.forEach(file => { %>
+    htmlWebpackPlugin.files.css.forEach(file => { %>
     <link href="<%= file %>" rel="stylesheet" />
     <% }); %>
 
@@ -23,25 +23,21 @@
     </style>
   </head>
   <body>
-    <% if (typeof bodyHtmlSnippet !== 'undefined') { %>
-      <%= bodyHtmlSnippet %>
-    <% } %>
+    <% if (typeof bodyHtmlSnippet !== 'undefined') { %> <%= bodyHtmlSnippet %> <% } %>
 
     <div id="root"></div>
     <div id="docs-root"></div>
 
     <% if (typeof globals !== 'undefined' && Object.keys(globals).length) { %>
-      <script>
-        <% for (var varName in globals) { %>
-            <% if (globals[varName] != undefined) { %>
-              window['<%=varName%>'] = <%= JSON.stringify(globals[varName]) %>;
-            <% } %>
-        <% } %>
-      </script>
-    <% } %>
-    
-    <% files.js.forEach(file => { %>
-      <script src="<%= file %>"></script>
+    <script>
+      <% for (var varName in globals) { %>
+          <% if (globals[varName] != undefined) { %>
+            window['<%=varName%>'] = <%= JSON.stringify(globals[varName]) %>;
+          <% } %>
+      <% } %>
+    </script>
+    <% } %> <% htmlWebpackPlugin.files.js.forEach(file => { %>
+    <script src="<%= file %>"></script>
     <% }); %>
   </body>
 </html>

--- a/lib/manager-webpack4/src/presets/manager-preset.ts
+++ b/lib/manager-webpack4/src/presets/manager-preset.ts
@@ -93,10 +93,8 @@ export async function managerWebpack(
         chunksSortMode: 'none' as any,
         alwaysWriteToDisk: true,
         inject: false,
-        templateParameters: (compilation, files, options) => ({
-          compilation,
-          files,
-          options,
+        template,
+        templateParameters: {
           version,
           globals: {
             CONFIG_TYPE: configType,
@@ -109,8 +107,7 @@ export async function managerWebpack(
             SERVER_CHANNEL_URL: serverChannelUrl,
           },
           headHtmlSnippet,
-        }),
-        template,
+        },
       }) as any) as WebpackPluginInstance,
       (new CaseSensitivePathsPlugin() as any) as WebpackPluginInstance,
       // graphql sources check process variable

--- a/lib/manager-webpack5/src/presets/manager-preset.ts
+++ b/lib/manager-webpack5/src/presets/manager-preset.ts
@@ -92,10 +92,8 @@ export async function managerWebpack(
         chunksSortMode: 'none' as any,
         alwaysWriteToDisk: true,
         inject: false,
-        templateParameters: (compilation, files, options) => ({
-          compilation,
-          files,
-          options,
+        template,
+        templateParameters: {
           version,
           globals: {
             CONFIG_TYPE: configType,
@@ -108,8 +106,7 @@ export async function managerWebpack(
             SERVER_CHANNEL_URL: serverChannelUrl,
           },
           headHtmlSnippet,
-        }),
-        template,
+        },
       }) as any) as WebpackPluginInstance,
       (new CaseSensitivePathsPlugin() as any) as WebpackPluginInstance,
       // graphql sources check process variable


### PR DESCRIPTION
Issue: #16647

The issue was that we use a serialized version of the webpack config as cache key, however the `templateParameters` option to `HtmlWebpackPlugin` was a **function** which when serialized, didn't include values for variables in scope -- i.e. it serialized as `"(...) => ({ features: features })"`, rather than `{ features: {X, Y, Z} }`.

## What I did

Luckily `HTMLWebpackPlugin` actually didn't require us to use a function, we could just use an object directly.

Some notes / caveats:

1. The function signature we were using was wrong (it had 4 arguments, not three), which in particular means the last argument `options` wasn't actually set to what we wanted, meaning `options.title` was never going to be set. So we might have fixed another bug here.

2. Some of the other globals perhaps will bust the cache frequently? In particular I am looking at `VERSIONCHECK` and `RELEASE_NODES_DATA`? OTOH it would just be a bug to not include the new values of these in the manager if they change. I'm not sure how commonly they change though. @ndelangen?

## How to test

1. Remove `--no-manager-cache` from `examples/react-ts/package.json`.
2. Run `yarn storybook`.
3. Change a feature
4. Run `yarn storybook`, check it has changed.

- [ ] Is this testable with Jest or Chromatic screenshots?

We don't seem to have any tests for this stuff :/ In particular I'm not sure how we would do an E2E here which is kinda what we need.