### PR TITLE
Core: Move the websocket channel to a specific path

### DIFF
--- a/lib/core-server/src/core-presets.test.ts
+++ b/lib/core-server/src/core-presets.test.ts
@@ -55,7 +55,7 @@ jest.mock('@storybook/store', () => {
 jest.mock('cpy', () => () => Promise.resolve());
 jest.mock('http', () => ({
   ...jest.requireActual('http'),
-  createServer: () => ({ listen: (_options, cb) => cb() }),
+  createServer: () => ({ listen: (_options, cb) => cb(), on: jest.fn() }),
 }));
 jest.mock('ws');
 jest.mock('@storybook/node-logger', () => ({

--- a/lib/core-server/src/utils/get-server-channel.ts
+++ b/lib/core-server/src/utils/get-server-channel.ts
@@ -7,7 +7,15 @@ export class ServerChannel {
   webSocketServer: WebSocketServer;
 
   constructor(server: Server) {
-    this.webSocketServer = new WebSocketServer({ server });
+    this.webSocketServer = new WebSocketServer({ noServer: true });
+
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url === '/server-channel') {
+        this.webSocketServer.handleUpgrade(request, socket, head, (ws) => {
+          this.webSocketServer.emit('connection', ws, request);
+        });
+      }
+    });
   }
 
   emit(type: string, args: any[] = []) {

--- a/lib/core-server/src/utils/get-server-channel.ts
+++ b/lib/core-server/src/utils/get-server-channel.ts
@@ -10,7 +10,7 @@ export class ServerChannel {
     this.webSocketServer = new WebSocketServer({ noServer: true });
 
     server.on('upgrade', (request, socket, head) => {
-      if (request.url === '/server-channel') {
+      if (request.url === '/storybook-server-channel') {
         this.webSocketServer.handleUpgrade(request, socket, head, (ws) => {
           this.webSocketServer.emit('connection', ws, request);
         });

--- a/lib/core-server/src/utils/server-address.ts
+++ b/lib/core-server/src/utils/server-address.ts
@@ -17,5 +17,5 @@ export const getServerPort = (port: number) =>
   });
 
 export const getServerChannelUrl = (port: number, { https }: { https?: boolean }) => {
-  return `${https ? 'wss' : 'ws'}://localhost:${port}/server-channel`;
+  return `${https ? 'wss' : 'ws'}://localhost:${port}/storybook-server-channel`;
 };

--- a/lib/core-server/src/utils/server-address.ts
+++ b/lib/core-server/src/utils/server-address.ts
@@ -17,5 +17,5 @@ export const getServerPort = (port: number) =>
   });
 
 export const getServerChannelUrl = (port: number, { https }: { https?: boolean }) => {
-  return `${https ? 'wss' : 'ws'}://localhost:${port}/`;
+  return `${https ? 'wss' : 'ws'}://localhost:${port}/server-channel`;
 };


### PR DESCRIPTION
Issue: https://github.com/eirslett/storybook-builder-vite/issues/139#issuecomment-965738316

SB's websocket was clashing with Vite's

## What I did

Move'd SB's WS to only connect on `/server-channel`. I could also make it like `/__storybook__server_channel_` or some such?

## How to test

Try `react-ts`, check HMR still works.

I tried it out with a Vite repro and it seemed to work.