### PR TITLE
UI: Remove `nopreview` and show redbox for any story error

### DIFF
--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -255,11 +255,23 @@ export class PreviewWeb<TFramework extends AnyFramework> {
 
     if (!storyId) {
       if (storySpecifier === '*') {
-        this.renderMissingStory();
+        this.renderStoryLoadingException(
+          storySpecifier,
+          new Error(dedent`
+            Couldn't find any stories in your Storybook.
+            - Please check your stories field of your main.js config.
+            - Also check the browser console and terminal for error messages.
+          `)
+        );
       } else {
         this.renderStoryLoadingException(
           storySpecifier,
-          new Error(`Couldn't find story matching ${storySpecifier}.`)
+          new Error(dedent`
+            Couldn't find story matching '${storySpecifier}'.
+            - Are you sure a story with that id exists?
+            - Please check your stories field of your main.js config.
+            - Also check the browser console and terminal for error messages.
+          `)
         );
       }
 

--- a/lib/preview-web/src/WebView.ts
+++ b/lib/preview-web/src/WebView.ts
@@ -79,8 +79,16 @@ export class WebView {
   }
 
   showErrorDisplay({ message = '', stack = '' }) {
-    document.getElementById('error-message').innerHTML = ansiConverter.toHtml(message);
-    document.getElementById('error-stack').innerHTML = ansiConverter.toHtml(stack);
+    let header = message;
+    let detail = stack;
+    const parts = message.split('\n');
+    if (parts.length > 1) {
+      [header] = parts;
+      detail = parts.slice(1).join('\n');
+    }
+
+    document.getElementById('error-message').innerHTML = ansiConverter.toHtml(header);
+    document.getElementById('error-stack').innerHTML = ansiConverter.toHtml(detail);
 
     document.body.classList.remove(classes.MAIN);
     document.body.classList.remove(classes.NOPREVIEW);

--- a/lib/store/src/StoryIndexStore.test.ts
+++ b/lib/store/src/StoryIndexStore.test.ts
@@ -146,7 +146,7 @@ describe('StoryIndexStore', () => {
     it('throws when the story does not', async () => {
       const store = new StoryIndexStore(storyIndex);
 
-      expect(() => store.storyIdToEntry('random')).toThrow(/Didn't find 'random'/);
+      expect(() => store.storyIdToEntry('random')).toThrow(/Couldn't find story matching 'random'/);
     });
   });
 });

--- a/lib/store/src/StoryIndexStore.ts
+++ b/lib/store/src/StoryIndexStore.ts
@@ -1,3 +1,4 @@
+import dedent from 'ts-dedent';
 import { Channel } from '@storybook/addons';
 import { StoryId } from '@storybook/csf';
 
@@ -40,7 +41,11 @@ export class StoryIndexStore {
   storyIdToEntry(storyId: StoryId): StoryIndexEntry {
     const storyEntry = this.stories[storyId];
     if (!storyEntry) {
-      throw new Error(`Didn't find '${storyId}' in story index (\`stories.json\`)`);
+      throw new Error(dedent`Couldn't find story matching '${storyId}' after HMR.
+      - Did you remove it from your CSF file?
+      - Are you sure a story with that id exists?
+      - Please check your stories field of your main.js config.
+      - Also check the browser console and terminal for error messages.`);
     }
 
     return storyEntry;


### PR DESCRIPTION
## What I did

Some errors don't have a meaningful stack trace -- for those we include some debugging instructions in the error message. 

This has the side effect of fixing the flaky chromatic snapshot.

Here is the full set of errors a user can see (would be great to figure out how to get stories for these):

### Empty storybook

<img width="1370" alt="Pasted Graphic 4" src="https://user-images.githubusercontent.com/132554/141446484-5aa66059-d49d-439f-9db2-2a2ff31a98ff.png">

### Missing story id on startup

<img width="1370" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/132554/141446383-24e0f8fb-b02c-4d41-827b-a3ae3626cb6e.png">

### Story removed (missing story id after HMR)
<img width="1370" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/132554/141446536-02a981cd-e4c7-41b1-bb5c-4a48361c9b62.png">

### CSF file throws error (but valid enough to allow you to select the story)

<img width="1370" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/132554/141446596-a6b36418-ae24-44d9-83fb-53ad406b4083.png">

### Direct access to iframe without selection

<img width="1370" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/132554/141449235-7ce053ae-8393-418c-b9b9-34c929de3ea8.png">


