### PR TITLE
CLI: Run automigrate at the end of `sb init`

### DIFF
--- a/lib/cli/src/automigrate/fixes/eslint-plugin.ts
+++ b/lib/cli/src/automigrate/fixes/eslint-plugin.ts
@@ -80,18 +80,14 @@ export const eslintPlugin: Fix<EslintPluginRunOptions> = {
     if (!dryRun) packageManager.addDependencies({ installAsDevDependencies: true }, deps);
 
     if (!dryRun && unsupportedExtension) {
-      logger.warn(
-        dedent(`
-            ⚠️ The plugin was successfuly installed but failed to configure.
-            
-            Found an .eslintrc config file with an unsupported automigration format: ${unsupportedExtension}.
-            Supported formats for automigration are: ${SUPPORTED_ESLINT_EXTENSIONS.join(', ')}.
+      throw new Error(dedent`
+          ⚠️ The plugin was successfuly installed but failed to configure.
+          
+          Found an .eslintrc config file with an unsupported automigration format: ${unsupportedExtension}.
+          Supported formats for automigration are: ${SUPPORTED_ESLINT_EXTENSIONS.join(', ')}.
 
-            Please refer to https://github.com/storybookjs/eslint-plugin-storybook#usage to finish setting up the plugin manually.
-        `)
-      );
-
-      return;
+          Please refer to https://github.com/storybookjs/eslint-plugin-storybook#usage to finish setting up the plugin manually.
+      `);
     }
 
     const eslint = await readConfig(eslintFile);

--- a/lib/cli/src/automigrate/index.ts
+++ b/lib/cli/src/automigrate/index.ts
@@ -41,8 +41,14 @@ export const automigrate = async ({ fixId, dryRun, yes }: FixOptions = {}) => {
             ]);
 
       if (runAnswer.fix) {
-        await f.run({ result, packageManager, dryRun });
-        logger.info(`✅ fixed ${chalk.cyan(f.id)}`);
+        try {
+          await f.run({ result, packageManager, dryRun });
+          logger.info(`✅ fixed ${chalk.cyan(f.id)}`);
+        } catch (error) {
+          logger.info(`❌ error in ${chalk.cyan(f.id)}:`);
+          logger.info(error.message);
+          logger.info();
+        }
       } else {
         logger.info(`Skipping the ${chalk.cyan(f.id)} fix.`);
         logger.info();

--- a/lib/cli/src/automigrate/index.ts
+++ b/lib/cli/src/automigrate/index.ts
@@ -14,7 +14,7 @@ interface FixOptions {
   dryRun?: boolean;
 }
 
-export const automigrate = async ({ fixId, dryRun, yes }: FixOptions) => {
+export const automigrate = async ({ fixId, dryRun, yes }: FixOptions = {}) => {
   const packageManager = JsPackageManagerFactory.getPackageManager();
   const filtered = fixId ? fixes.filter((f) => f.id === fixId) : fixes;
 

--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -296,7 +296,7 @@ export function initiate(options: CommandOptions, pkg: Package): Promise<void> {
   let projectType;
   const projectTypeProvided = options.type;
   const infoText = projectTypeProvided
-    ? 'Installing Storybook for user specified project type'
+    ? `Installing Storybook for user specified project type: ${projectTypeProvided}`
     : 'Detecting project type';
   const done = commandLog(infoText);
 
@@ -305,13 +305,13 @@ export function initiate(options: CommandOptions, pkg: Package): Promise<void> {
 
   try {
     if (projectTypeProvided) {
-      if (installableProjectTypes.includes(options.type)) {
+      if (installableProjectTypes.includes(projectTypeProvided)) {
         const storybookInstalled = isStorybookInstalled(packageJson, options.force);
         projectType = storybookInstalled
           ? ProjectType.ALREADY_HAS_STORYBOOK
-          : options.type.toUpperCase();
+          : projectTypeProvided.toUpperCase();
       } else {
-        done(`The provided project type was not recognized by Storybook.`);
+        done(`The provided project type was not recognized by Storybook: ${projectTypeProvided}`);
         logger.log(`\nThe project types currently supported by Storybook are:\n`);
         installableProjectTypes.sort().forEach((framework) => paddedLog(`- ${framework}`));
         logger.log();

--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -28,6 +28,7 @@ import raxGenerator from './generators/RAX';
 import serverGenerator from './generators/SERVER';
 import { JsPackageManagerFactory, readPackageJson } from './js-package-manager';
 import { NpmOptions } from './NpmOptions';
+import { automigrate } from './automigrate';
 
 const logger = console;
 
@@ -283,7 +284,7 @@ const projectTypeInquirer = async (options: { yes?: boolean }) => {
   return Promise.resolve();
 };
 
-export function initiate(options: CommandOptions, pkg: Package): Promise<void> {
+export async function initiate(options: CommandOptions, pkg: Package): Promise<void> {
   const welcomeMessage = 'sb init - the simplest way to add a Storybook to your project.';
   logger.log(chalk.inverse(`\n ${welcomeMessage} \n`));
 
@@ -326,8 +327,10 @@ export function initiate(options: CommandOptions, pkg: Package): Promise<void> {
   }
   done();
 
-  return installStorybook(projectType, {
+  await installStorybook(projectType, {
     ...options,
     ...(isEsm ? { commonJs: true } : undefined),
   });
+
+  return automigrate({ yes: true });
 }

--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -332,5 +332,5 @@ export async function initiate(options: CommandOptions, pkg: Package): Promise<v
     ...(isEsm ? { commonJs: true } : undefined),
   });
 
-  return automigrate({ yes: true });
+  return automigrate();
 }


### PR DESCRIPTION
Issue: #16439

## What I did

As title says

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation? Maybe?

1 - Generate a sample project without storybook
2 - `yarn build cli`
3 - `<path-to>/storybook/lib/cli/bin/index.js init`

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
