### PR TITLE
Core: Add IS_STORYBOOK global variable

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -349,4 +349,4 @@ Applying this small change will enable you to add syntax highlight for SCSS or a
 
 ### How can my code detect if it is running in Storybook?
 
-You can do this by checking for the `IS_STORYBOOK` global variable, which will equal `true` when running in Storybook.
+You can do this by checking for the `IS_STORYBOOK` global variable, which will equal `true` when running in Storybook. The environment variable `process.env.STORYBOOK` is also set to `true`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -349,29 +349,4 @@ Applying this small change will enable you to add syntax highlight for SCSS or a
 
 ### How can my code detect if it is running in Storybook?
 
-You can do this by checking the value of `process.env.STORYBOOK`, which will
-equal `'true'` when running in Storybook. Be careful — `process` may be
-undefined when your code runs outside of Storybook.
-
-```javascript
-export function isRunningInStorybook() {
-  try {
-    if (process.env.STORYBOOK) return true;
-  } catch {
-    // A ReferenceError will be thrown if process is undefined
-  }
-
-  return false;
-}
-```
-
-This works because Babel replaces `process.env.STORYBOOK` with the value of the
-`STORYBOOK` environment variable. Because this is done through a Babel plugin,
-the following will **NOT** work:
-
-```javascript
-export function isRunningInStorybook() {
-  return typeof process?.env?.STORYBOOK !== 'undefined';
-  // ReferenceError: process is not defined
-}
-```
+You can do this by checking for the `IS_STORYBOOK` global variable, which will equal `true` when running in Storybook.

--- a/lib/core-client/src/preview/start.test.ts
+++ b/lib/core-client/src/preview/start.test.ts
@@ -1,3 +1,4 @@
+/* global window */
 import Events from '@storybook/core-events';
 
 import {
@@ -357,6 +358,8 @@ describe('start', () => {
         }),
         undefined
       );
+
+      expect((window as any).IS_STORYBOOK).toBe(true);
     });
 
     it('supports forceRerender()', async () => {

--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -34,6 +34,11 @@ export function start<TFramework extends AnyFramework>(
     render?: ArgsStoryFn<TFramework>;
   } = {}
 ) {
+  if (globalWindow) {
+    // To enable user code to detect if it is running in Storybook
+    globalWindow.IS_STORYBOOK = true;
+  }
+
   if (FEATURES?.storyStoreV7) {
     return {
       forceReRender: removedApi('forceReRender'),


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/16485.

## What I did

Added a global variable to the preview window to enable user code to detect if it is running in Storybook. This was suggested in the discussion on https://github.com/storybookjs/storybook/pull/16379.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps? **NO**
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
