### PR TITLE
Inherit anchor colour for a > code blocks

### DIFF
--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -102,6 +102,9 @@ export const A = styled(Link)<{}>(withReset, ({ theme }) => ({
     left: 0,
     bottom: 0,
   },
+  code: {
+    color: 'inherit',
+  },
 }));
 
 export const HR = styled.hr<{}>(({ theme }) => ({


### PR DESCRIPTION
Issue: When writing `.mdx` docs a `<code>` block inside an `<a>` has no highlighting to indicate it is a link.

## What I did

Inherit anchor colour to make it look like this:

![image](https://user-images.githubusercontent.com/5636273/141649041-baeab94a-75a5-40c5-b868-b924e997ad3b.png)

Rather than this:

![image](https://user-images.githubusercontent.com/5636273/141649023-a85bf991-eb60-4a2c-9312-5a1626b059e8.png)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? - Probably a visual diff test would do, not really familiar with where to put it though - is markdown output being visual diff tested elsewhere already, for example?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
