### PR TITLE
Core: Bust the prebuilt manager cache if user has set `features`

### DIFF
--- a/lib/manager-webpack4/src/utils/prebuilt-manager.ts
+++ b/lib/manager-webpack4/src/utils/prebuilt-manager.ts
@@ -34,8 +34,8 @@ export const getPrebuiltDir = async (options: Options): Promise<string | false> 
   const mainConfigFile = getInterpretedFile(path.resolve(configDir, 'main'));
   if (!mainConfigFile) return false;
 
-  const { addons, refs, managerBabel, managerWebpack } = serverRequire(mainConfigFile);
-  if (!addons || refs || managerBabel || managerWebpack) return false;
+  const { addons, refs, managerBabel, managerWebpack, features } = serverRequire(mainConfigFile);
+  if (!addons || refs || managerBabel || managerWebpack || features) return false;
   if (DEFAULT_ADDONS.some((addon) => !addons.includes(addon))) return false;
   if (addons.some((addon: string) => !IGNORED_ADDONS.includes(addon))) return false;
 

--- a/lib/manager-webpack5/src/utils/prebuilt-manager.ts
+++ b/lib/manager-webpack5/src/utils/prebuilt-manager.ts
@@ -34,8 +34,8 @@ export const getPrebuiltDir = async (options: Options): Promise<string | false> 
   const mainConfigFile = getInterpretedFile(path.resolve(configDir, 'main'));
   if (!mainConfigFile) return false;
 
-  const { addons, refs, managerBabel, managerWebpack } = serverRequire(mainConfigFile);
-  if (!addons || refs || managerBabel || managerWebpack) return false;
+  const { addons, refs, managerBabel, managerWebpack, features } = serverRequire(mainConfigFile);
+  if (!addons || refs || managerBabel || managerWebpack || features) return false;
   if (DEFAULT_ADDONS.some((addon) => !addons.includes(addon))) return false;
   if (addons.some((addon: string) => !IGNORED_ADDONS.includes(addon))) return false;
 


### PR DESCRIPTION
Issue: #16647 

## What I did

Don't use the prebuilt manager if the user has set `features`

## How to test

Not sure?