### PR TITLE
CLI: Fix automigrate command for eslint with extends as string

### DIFF
--- a/lib/cli/src/automigrate/fixes/eslint-plugin.ts
+++ b/lib/cli/src/automigrate/fixes/eslint-plugin.ts
@@ -97,7 +97,7 @@ export const eslintPlugin: Fix<EslintPluginRunOptions> = {
       logger.info(`✅ Adding Storybook to extends list`);
       const extendsConfig = eslint.getFieldValue(['extends']) || [];
       const existingConfigValue =
-        typeof extendsConfig === 'string' ? [extendsConfig] : extendsConfig;
+        Array.isArray(extendsConfig) ? extendsConfig : [extendsConfig];
       eslint.setFieldValue(['extends'], [...existingConfigValue, 'plugin:storybook/recommended']);
 
       await writeConfig(eslint);

--- a/lib/cli/src/automigrate/fixes/eslint-plugin.ts
+++ b/lib/cli/src/automigrate/fixes/eslint-plugin.ts
@@ -96,7 +96,10 @@ export const eslintPlugin: Fix<EslintPluginRunOptions> = {
     if (!dryRun) {
       logger.info(`✅ Adding Storybook to extends list`);
       const extendsConfig = eslint.getFieldValue(['extends']) || [];
-      eslint.setFieldValue(['extends'], [...extendsConfig, 'plugin:storybook/recommended']);
+      const existingConfigValue =
+        typeof extendsConfig === 'string' ? [extendsConfig] : extendsConfig;
+      eslint.setFieldValue(['extends'], [...existingConfigValue, 'plugin:storybook/recommended']);
+
       await writeConfig(eslint);
     }
   },


### PR DESCRIPTION
Issue: #16686

## What I did
Add support for string type in eslintrc.extends

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

1 - yarn build cli
2 - go to examples/official-storybook
3 - add eslintrc.js with:
```
module.exports = {
  extends: 'something'
}
```
4 - add eslint as dummy dep in package.json (no need to install)
5 - run `../../lib/cli/bin/index.js automigrate` and type Y for eslint
6 - result should be:
```
module.exports = {
  extends: ['something', 'plugin:storybook/recommended]
}
```

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
