### PR TITLE
Core: Add `./` to start of hidden file & folder paths

### DIFF
--- a/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
+++ b/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
@@ -54,6 +54,25 @@ describe('normalizeStoriesEntry', () => {
     ]);
   });
 
+  it('story in config dir', () => {
+    const specifier = normalizeStoriesEntry('./file.stories.mdx', options);
+    expect(specifier).toMatchInlineSnapshot(`
+      {
+        "titlePrefix": "",
+        "directory": ".storybook",
+        "files": "file.stories.mdx",
+        "importPathMatcher": {}
+      }
+    `);
+
+    expect(specifier.importPathMatcher).toMatchPaths(['./.storybook/file.stories.mdx']);
+    expect(specifier.importPathMatcher).not.toMatchPaths([
+      '.storybook/file.stories.mdx',
+      './file.stories.mdx',
+      '../file.stories.mdx',
+    ]);
+  });
+
   it('non-recursive files glob', () => {
     const specifier = normalizeStoriesEntry('../*/*.stories.mdx', options);
     expect(specifier).toMatchInlineSnapshot(`

--- a/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
+++ b/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
@@ -23,11 +23,26 @@ expect.extend({
   },
 });
 
-jest.mock('fs', () => ({
-  lstatSync: (path: string) => ({
-    isDirectory: () => !path.match(/\.[a-z]+$/),
-  }),
-}));
+jest.mock('fs', () => {
+  const mockStat = (
+    path: string,
+    options: Record<string, any>,
+    cb: (error?: Error, stats?: Record<string, any>) => void
+  ) => {
+    cb(undefined, {
+      isDirectory: () => !path.match(/\.[a-z]+$/),
+    });
+  };
+
+  return {
+    access: (path: string, mode: number, cb: (err?: Error) => void): void => undefined,
+    lstatSync: (path: string) => ({
+      isDirectory: () => !path.match(/\.[a-z]+$/),
+    }),
+    stat: mockStat,
+    lstat: mockStat,
+  };
+});
 
 describe('normalizeStoriesEntry', () => {
   const options = {
@@ -59,7 +74,7 @@ describe('normalizeStoriesEntry', () => {
     expect(specifier).toMatchInlineSnapshot(`
       {
         "titlePrefix": "",
-        "directory": ".storybook",
+        "directory": "./.storybook",
         "files": "file.stories.mdx",
         "importPathMatcher": {}
       }

--- a/lib/core-common/src/utils/__tests__/paths.test.ts
+++ b/lib/core-common/src/utils/__tests__/paths.test.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+import { normalizeStoryPath } from '../paths';
+
+describe('paths - normalizeStoryPath()', () => {
+  it('returns a path starting with "./" unchanged', () => {
+    // ./src/Comp.story.js
+    const filename = `.${path.sep}src${path.sep}Comp.story.js`;
+    expect(normalizeStoryPath(filename)).toEqual(filename);
+  });
+
+  it('returns a path starting with "../" unchanged', () => {
+    // ../src/Comp.story.js
+    const filename = `..${path.sep}src${path.sep}Comp.story.js`;
+    expect(normalizeStoryPath(filename)).toEqual(filename);
+  });
+
+  it('adds "./" to a normalized relative path', () => {
+    // src/Comp.story.js
+    const filename = `src${path.sep}Comp.story.js`;
+    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+  });
+
+  it('adds "./" to a hidden folder', () => {
+    // .storybook/Comp.story.js
+    const filename = `.storybook${path.sep}Comp.story.js`;
+    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+  });
+
+  it('adds "./" to a hidden file', () => {
+    // .storybook/Comp.story.js
+    const filename = `.Comp.story.js`;
+    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+  });
+});

--- a/lib/core-common/src/utils/__tests__/paths.test.ts
+++ b/lib/core-common/src/utils/__tests__/paths.test.ts
@@ -3,32 +3,54 @@ import { normalizeStoryPath } from '../paths';
 
 describe('paths - normalizeStoryPath()', () => {
   it('returns a path starting with "./" unchanged', () => {
-    // ./src/Comp.story.js
-    const filename = `.${path.sep}src${path.sep}Comp.story.js`;
+    const filename = `./src/Comp.story.js`;
     expect(normalizeStoryPath(filename)).toEqual(filename);
   });
 
   it('returns a path starting with "../" unchanged', () => {
-    // ../src/Comp.story.js
-    const filename = `..${path.sep}src${path.sep}Comp.story.js`;
+    const filename = `../src/Comp.story.js`;
     expect(normalizeStoryPath(filename)).toEqual(filename);
   });
 
   it('adds "./" to a normalized relative path', () => {
-    // src/Comp.story.js
-    const filename = `src${path.sep}Comp.story.js`;
-    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    const filename = `src/Comp.story.js`;
+    expect(normalizeStoryPath(filename)).toEqual(`./${filename}`);
   });
 
   it('adds "./" to a hidden folder', () => {
-    // .storybook/Comp.story.js
-    const filename = `.storybook${path.sep}Comp.story.js`;
-    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    const filename = `.storybook/Comp.story.js`;
+    expect(normalizeStoryPath(filename)).toEqual(`./${filename}`);
   });
 
   it('adds "./" to a hidden file', () => {
-    // .storybook/Comp.story.js
     const filename = `.Comp.story.js`;
-    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    expect(normalizeStoryPath(filename)).toEqual(`./${filename}`);
+  });
+
+  describe('windows paths', () => {
+    it('returns a path starting with ".\\" unchanged', () => {
+      const filename = `.\\src\\Comp.story.js`;
+      expect(normalizeStoryPath(filename)).toEqual(filename);
+    });
+
+    it('returns a path starting with "..\\" unchanged', () => {
+      const filename = `..\\src\\Comp.story.js`;
+      expect(normalizeStoryPath(filename)).toEqual(filename);
+    });
+
+    it('adds ".{path.sep}" to a normalized relative path', () => {
+      const filename = `src\\Comp.story.js`;
+      expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    });
+
+    it('adds ".{path.sep}" to a hidden folder', () => {
+      const filename = `.storybook\\Comp.story.js`;
+      expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    });
+
+    it('adds ".{path.sep}" to a hidden file', () => {
+      const filename = `.Comp.story.js`;
+      expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    });
   });
 });

--- a/lib/core-common/src/utils/__tests__/to-importFn.test.ts
+++ b/lib/core-common/src/utils/__tests__/to-importFn.test.ts
@@ -160,6 +160,24 @@ const testCases: [string, string[], string[]][] = [
       '/Users/user/code/src/components/Icon.stories.js',
     ],
   ],
+  [
+    './Introduction.stories.tsx',
+    ['/Users/user/code/path/Introduction.stories.tsx'],
+    [
+      '/Users/user/code/Introduction.stories.tsx',
+      '/Users/user/code/src/Introduction.stories.tsx',
+      '/Users/user/code/src/Introduction.tsx',
+    ],
+  ],
+  [
+    'Introduction.stories.tsx',
+    ['/Users/user/code/path/Introduction.stories.tsx'],
+    [
+      '/Users/user/code/Introduction.stories.tsx',
+      '/Users/user/code/src/Introduction.stories.tsx',
+      '/Users/user/code/src/Introduction.tsx',
+    ],
+  ],
 ];
 
 describe('toImportFn - webpackIncludeRegexp', () => {

--- a/lib/core-common/src/utils/__tests__/to-importFn.test.ts
+++ b/lib/core-common/src/utils/__tests__/to-importFn.test.ts
@@ -118,9 +118,12 @@ const testCases: [string, string[], string[]][] = [
     ],
     [
       '/Users/user/code/.storybook/Icon.stories.tsx',
-      '/Users/user/code/.storybook/src/Icon.stories.tsx',
-      '/Users/user/code/.storybook/src/components/Icon.stories.tsx',
-      '/Users/user/code/.storybook/src/components/Icon.stories/Icon.stories.tsx',
+      // Although it would make sense for these three files to fail to match the `importFn()`,
+      // because we are limited to matching on the RHS of the path (from 'src' onwards, basically)
+      // we cannot avoid matching things inside the config dir in such situations.
+      // '/Users/user/code/.storybook/src/Icon.stories.tsx',
+      // '/Users/user/code/.storybook/src/components/Icon.stories.tsx',
+      // '/Users/user/code/.storybook/src/components/Icon.stories/Icon.stories.tsx',
       '/Users/user/code/Icon.stories.tsx',
       '/Users/user/code/stories.tsx',
       '/Users/user/code/Icon.stories.ts',

--- a/lib/core-common/src/utils/__tests__/to-importFn.test.ts
+++ b/lib/core-common/src/utils/__tests__/to-importFn.test.ts
@@ -5,47 +5,50 @@ const testCases: [string, string[], string[]][] = [
   [
     '**/*.stories.tsx',
     [
-      '/Users/user/code/Icon.stories.tsx',
-      '/Users/user/code/src/Icon.stories.tsx',
-      '/Users/user/code/src/components/Icon.stories.tsx',
+      '/Users/user/code/.storybook/Icon.stories.tsx',
+      '/Users/user/code/.storybook/stories/Icon.stories.tsx',
+      '/Users/user/code/.storybook/stories/components/Icon.stories.tsx',
     ],
     [
-      '/Users/user/code/stories.tsx',
-      '/Users/user/code/Icon.stories.ts',
-      '/Users/user/code/Icon.stories.js',
-      '/Users/user/code/src/components/stories.tsx',
-      '/Users/user/code/src/components/Icon.stories/stories.tsx',
-      '/Users/user/code/src/components/Icon.stories.ts',
-      '/Users/user/code/src/components/Icon.stories.js',
+      '/Users/user/code/.storybook/stories.tsx',
+      '/Users/user/code/.storybook/Icon.stories.ts',
+      '/Users/user/code/.storybook/Icon.stories.js',
+      '/Users/user/code/.storybook/src/components/stories.tsx',
+      '/Users/user/code/.storybook/src/components/Icon.stories/stories.tsx',
+      '/Users/user/code/.storybook/src/components/Icon.stories.ts',
+      '/Users/user/code/.storybook/src/components/Icon.stories.js',
+      '/Users/user/code/src/components/Icon.stories.tsx',
     ],
   ],
   [
     './**/*.stories.tsx',
     [
-      '/Users/user/code/Icon.stories.tsx',
-      '/Users/user/code/src/Icon.stories.tsx',
-      '/Users/user/code/src/components/Icon.stories.tsx',
-      '/Users/user/code/src/components/Icon.stories/Icon.stories.tsx',
+      '/Users/user/code/.storybook/Icon.stories.tsx',
+      '/Users/user/code/.storybook/stories/Icon.stories.tsx',
+      '/Users/user/code/.storybook/stories/components/Icon.stories.tsx',
     ],
     [
-      '/Users/user/code/stories.tsx',
-      '/Users/user/code/Icon.stories.ts',
-      '/Users/user/code/Icon.stories.js',
-      '/Users/user/code/src/components/stories.tsx',
-      '/Users/user/code/src/components/Icon.stories/stories.tsx',
-      '/Users/user/code/src/components/Icon.stories.ts',
-      '/Users/user/code/src/components/Icon.stories.js',
+      '/Users/user/code/.storybook/stories.tsx',
+      '/Users/user/code/.storybook/Icon.stories.ts',
+      '/Users/user/code/.storybook/Icon.stories.js',
+      '/Users/user/code/.storybook/src/components/stories.tsx',
+      '/Users/user/code/.storybook/src/components/Icon.stories/stories.tsx',
+      '/Users/user/code/.storybook/src/components/Icon.stories.ts',
+      '/Users/user/code/.storybook/src/components/Icon.stories.js',
+      '/Users/user/code/src/components/Icon.stories.tsx',
     ],
   ],
   [
     '../**/*.stories.tsx',
     [
+      '/Users/user/code/.storybook/Icon.stories.tsx',
       '/Users/user/code/Icon.stories.tsx',
       '/Users/user/code/src/Icon.stories.tsx',
       '/Users/user/code/src/components/Icon.stories.tsx',
       '/Users/user/code/src/components/Icon.stories/Icon.stories.tsx',
     ],
     [
+      '/Users/user/code/.storybook/stories.tsx',
       '/Users/user/code/stories.tsx',
       '/Users/user/code/Icon.stories.ts',
       '/Users/user/code/Icon.stories.js',
@@ -56,7 +59,7 @@ const testCases: [string, string[], string[]][] = [
     ],
   ],
   [
-    'src',
+    '../src',
     [],
     [
       '/Users/user/code/Icon.stories.tsx',
@@ -73,7 +76,7 @@ const testCases: [string, string[], string[]][] = [
     ],
   ],
   [
-    'src/*',
+    '../src/*',
     ['/Users/user/code/src/Icon.stories.tsx'],
     [
       '/Users/user/code/Icon.stories.tsx',
@@ -89,21 +92,21 @@ const testCases: [string, string[], string[]][] = [
     ],
   ],
   [
-    './src/**/*.stories.tsx',
+    './stories/**/*.stories.tsx',
     [
-      '/Users/user/code/src/Icon.stories.tsx',
-      '/Users/user/code/src/components/Icon.stories.tsx',
-      '/Users/user/code/src/components/Icon.stories/Icon.stories.tsx',
+      '/Users/user/code/.storybook/stories/Icon.stories.tsx',
+      '/Users/user/code/.storybook/stories/components/Icon.stories.tsx',
+      '/Users/user/code/.storybook/stories/components/Icon.stories/Icon.stories.tsx',
     ],
     [
       '/Users/user/code/Icon.stories.tsx',
       '/Users/user/code/stories.tsx',
       '/Users/user/code/Icon.stories.ts',
       '/Users/user/code/Icon.stories.js',
-      '/Users/user/code/src/components/stories.tsx',
-      '/Users/user/code/src/components/Icon.stories/stories.tsx',
-      '/Users/user/code/src/components/Icon.stories.ts',
-      '/Users/user/code/src/components/Icon.stories.js',
+      '/Users/user/code/stories/components/stories.tsx',
+      '/Users/user/code/stories/components/Icon.stories/stories.tsx',
+      '/Users/user/code/stories/components/Icon.stories.ts',
+      '/Users/user/code/stories/components/Icon.stories.js',
     ],
   ],
   [
@@ -114,6 +117,10 @@ const testCases: [string, string[], string[]][] = [
       '/Users/user/code/src/components/Icon.stories/Icon.stories.tsx',
     ],
     [
+      '/Users/user/code/.storybook/Icon.stories.tsx',
+      '/Users/user/code/.storybook/src/Icon.stories.tsx',
+      '/Users/user/code/.storybook/src/components/Icon.stories.tsx',
+      '/Users/user/code/.storybook/src/components/Icon.stories/Icon.stories.tsx',
       '/Users/user/code/Icon.stories.tsx',
       '/Users/user/code/stories.tsx',
       '/Users/user/code/Icon.stories.ts',
@@ -162,7 +169,7 @@ const testCases: [string, string[], string[]][] = [
   ],
   [
     './Introduction.stories.tsx',
-    ['/Users/user/code/path/Introduction.stories.tsx'],
+    ['/Users/user/code/.storybook/Introduction.stories.tsx'],
     [
       '/Users/user/code/Introduction.stories.tsx',
       '/Users/user/code/src/Introduction.stories.tsx',
@@ -171,7 +178,7 @@ const testCases: [string, string[], string[]][] = [
   ],
   [
     'Introduction.stories.tsx',
-    ['/Users/user/code/path/Introduction.stories.tsx'],
+    ['/Users/user/code/.storybook/Introduction.stories.tsx'],
     [
       '/Users/user/code/Introduction.stories.tsx',
       '/Users/user/code/src/Introduction.stories.tsx',
@@ -183,7 +190,10 @@ const testCases: [string, string[], string[]][] = [
 describe('toImportFn - webpackIncludeRegexp', () => {
   it.each(testCases)('matches only suitable paths - %s', (glob, validPaths, invalidPaths) => {
     const regex = webpackIncludeRegexp(
-      normalizeStoriesEntry(glob, { configDir: '/path', workingDir: '/path' })
+      normalizeStoriesEntry(glob, {
+        configDir: '/Users/user/code/.storybook',
+        workingDir: '/Users/user/code/',
+      })
     );
 
     const isNotMatchedForValidPaths = validPaths.filter(

--- a/lib/core-common/src/utils/normalize-stories.ts
+++ b/lib/core-common/src/utils/normalize-stories.ts
@@ -6,6 +6,7 @@ import { scan } from 'picomatch';
 import slash from 'slash';
 
 import type { StoriesEntry, NormalizedStoriesSpecifier } from '../types';
+import { normalizeStoryPath } from './paths';
 import { globToRegexp } from './glob-to-regexp';
 
 const DEFAULT_TITLE_PREFIX = '';
@@ -44,14 +45,11 @@ export const getDirectoryFromWorkingDir = ({
   directory,
 }: NormalizeOptions & { directory: string }) => {
   const directoryFromConfig = path.resolve(configDir, directory);
-  let directoryFromWorking = path.relative(workingDir, directoryFromConfig);
+  const directoryFromWorking = path.relative(workingDir, directoryFromConfig);
 
   // relative('/foo', '/foo/src') => 'src'
   // but we want `./src` to match importPaths
-  if (!directoryFromWorking.startsWith('.')) {
-    directoryFromWorking = `.${path.sep}${directoryFromWorking}`;
-  }
-  return directoryFromWorking;
+  return normalizeStoryPath(directoryFromWorking);
 };
 
 export const normalizeStoriesEntry = (

--- a/lib/core-common/src/utils/paths.ts
+++ b/lib/core-common/src/utils/paths.ts
@@ -28,3 +28,12 @@ export const nodePathsToArray = (nodePath: string) =>
     .split(process.platform === 'win32' ? ';' : ':')
     .filter(Boolean)
     .map((p) => path.resolve('./', p));
+
+/**
+ * Ensures that a path starts with `./` or `../`
+ */
+export function normalizeStoryPath(filename: string) {
+  if (filename.startsWith(`.${path.sep}`) || filename.startsWith(`..${path.sep}`)) return filename;
+
+  return `.${path.sep}${filename}`;
+}

--- a/lib/core-common/src/utils/paths.ts
+++ b/lib/core-common/src/utils/paths.ts
@@ -29,11 +29,12 @@ export const nodePathsToArray = (nodePath: string) =>
     .filter(Boolean)
     .map((p) => path.resolve('./', p));
 
+const relativePattern = /^\.{1,2}[/\\]/;
 /**
  * Ensures that a path starts with `./` or `../`
  */
 export function normalizeStoryPath(filename: string) {
-  if (filename.startsWith(`.${path.sep}`) || filename.startsWith(`..${path.sep}`)) return filename;
+  if (relativePattern.test(filename)) return filename;
 
   return `.${path.sep}${filename}`;
 }

--- a/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -11,7 +11,7 @@ import {
   V2CompatIndexEntry,
   StoryId,
 } from '@storybook/store';
-import { NormalizedStoriesSpecifier } from '@storybook/core-common';
+import { NormalizedStoriesSpecifier, normalizeStoryPath } from '@storybook/core-common';
 import { logger } from '@storybook/node-logger';
 import { readCsfOrMdx, getStorySortParameter } from '@storybook/csf-tools';
 import { ComponentTitle } from '@storybook/csf';
@@ -90,7 +90,7 @@ export class StoryIndexGenerator {
     const fileStories = {} as StoryIndex['stories'];
     const entry = this.storyIndexEntries.get(specifier);
     try {
-      const importPath = slash(relativePath[0] === '.' ? relativePath : `./${relativePath}`);
+      const importPath = slash(normalizeStoryPath(relativePath));
       const defaultTitle = autoTitleFromSpecifier(importPath, specifier);
       const csf = (await readCsfOrMdx(absolutePath, { defaultTitle })).parse();
       csf.stories.forEach(({ id, name }) => {

--- a/lib/store/src/autoTitle.test.ts
+++ b/lib/store/src/autoTitle.test.ts
@@ -12,6 +12,10 @@ const options = {
   configDir: '/path',
   workingDir: '/path',
 };
+const winOptions = {
+  configDir: '\\path',
+  workingDir: '\\path',
+};
 
 describe('autoTitle', () => {
   it('no match', () => {
@@ -58,7 +62,7 @@ describe('autoTitle', () => {
       expect(
         auto(
           './path/to_my/file.stories.js',
-          normalizeStoriesEntry({ directory: '.\\path' }, options)
+          normalizeStoriesEntry({ directory: '.\\path' }, winOptions)
         )
       ).toMatchInlineSnapshot(`To My/File`);
     });
@@ -102,7 +106,7 @@ describe('autoTitle', () => {
       expect(
         auto(
           './path/to_my/file.stories.js',
-          normalizeStoriesEntry({ directory: '.\\path\\' }, options)
+          normalizeStoriesEntry({ directory: '.\\path\\' }, winOptions)
         )
       ).toMatchInlineSnapshot(`To My/File`);
     });


### PR DESCRIPTION
Issue:

I'm trying to troubleshoot https://github.com/eirslett/storybook-builder-vite/issues/155, where I'm having trouble with stories that are defined inside of my `.storybook` folder. I found that storybook only adds a `./` to the start of a filename if it doesn't already find a single `.` at the start of the file, which inadvertently picks up hidden files & folders.  

## What I did

I've created a helper function to add the ./ when necessary, so it can be shared between the two places we know of where the same thing is done. I used @joshwooding's suggested snippet, because I couldn't think of anything better and I think it's pretty solid.  

## How to test

```
yarn test lib/core-common/src/utils/__tests__/paths.test.ts
yarn test lib/core-common/src/utils/__tests__/to-importFn.test.ts
yarn test lib/core-common/src/utils/__tests__/normalize-stories.test.ts
```

- [X] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
