### PR TITLE
Core: Fix build-storybook sort bug in v6-mode

### DIFF
--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -101,6 +101,7 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
     await extractStoriesJson(path.join(options.outputDir, 'stories.json'), stories, {
       ...directories,
       storiesV2Compatibility: !features?.breakingChangesV7 && !features?.storyStoreV7,
+      storyStoreV7: features?.storyStoreV7,
     });
   }
 

--- a/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -15,6 +15,7 @@ const options = {
   configDir: path.join(__dirname, '__mockdata__'),
   workingDir: path.join(__dirname, '__mockdata__'),
   storiesV2Compatibility: false,
+  storyStoreV7: true,
 };
 
 describe('StoryIndexGenerator', () => {

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -18,7 +18,12 @@ export const DEBOUNCE = 100;
 export async function extractStoriesJson(
   outputFile: string,
   normalizedStories: NormalizedStoriesSpecifier[],
-  options: { configDir: string; workingDir: string; storiesV2Compatibility: boolean }
+  options: {
+    configDir: string;
+    workingDir: string;
+    storiesV2Compatibility: boolean;
+    storyStoreV7: boolean;
+  }
 ) {
   const generator = new StoryIndexGenerator(normalizedStories, options);
   await generator.initialize();
@@ -42,6 +47,7 @@ export async function useStoriesJson(
     configDir: options.configDir,
     workingDir,
     storiesV2Compatibility: !features?.breakingChangesV7 && !features?.storyStoreV7,
+    storyStoreV7: features?.storyStoreV7,
   });
 
   // Wait until someone actually requests `stories.json` before we start generating/watching.

--- a/lib/store/src/sortStories.ts
+++ b/lib/store/src/sortStories.ts
@@ -4,7 +4,7 @@ import { Comparator, StorySortParameter, StorySortParameterV7 } from '@storybook
 import { storySort } from './storySort';
 import { Story, StoryIndexEntry, Path, Parameters } from './types';
 
-export const sortStoriesV7 = (
+const sortStoriesCommon = (
   stories: StoryIndexEntry[],
   storySortParameter: StorySortParameterV7,
   fileNameOrder: Path[]
@@ -16,19 +16,7 @@ export const sortStoriesV7 = (
     } else {
       sortFn = storySort(storySortParameter);
     }
-    try {
-      stable.inplace(stories, sortFn);
-    } catch (err) {
-      throw new Error(dedent`
-        Error sorting stories with sort parameter ${storySortParameter}:
-
-        > ${err.message}
-        
-        Are you using a V6-style sort function in V7 mode?
-
-        More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#v7-style-story-sort
-      `);
-    }
+    stable.inplace(stories, sortFn);
   } else {
     stable.inplace(
       stories,
@@ -36,6 +24,26 @@ export const sortStoriesV7 = (
     );
   }
   return stories;
+};
+
+export const sortStoriesV7 = (
+  stories: StoryIndexEntry[],
+  storySortParameter: StorySortParameterV7,
+  fileNameOrder: Path[]
+) => {
+  try {
+    return sortStoriesCommon(stories, storySortParameter, fileNameOrder);
+  } catch (err) {
+    throw new Error(dedent`
+    Error sorting stories with sort parameter ${storySortParameter}:
+
+    > ${err.message}
+    
+    Are you using a V6-style sort function in V7 mode?
+
+    More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#v7-style-story-sort
+  `);
+  }
 };
 
 const toIndexEntry = (story: any): StoryIndexEntry => {
@@ -54,5 +62,5 @@ export const sortStoriesV6 = (
   }
 
   const storiesV7 = stories.map((s) => toIndexEntry(s[1]));
-  return sortStoriesV7(storiesV7, storySortParameter as StorySortParameterV7, fileNameOrder);
+  return sortStoriesCommon(storiesV7, storySortParameter as StorySortParameterV7, fileNameOrder);
 };


### PR DESCRIPTION
Issue: #16638

## What I did

- [x] Improve error message for bad sort function in v6
- [x] Skip sorting altogether when we're generating stories.json in v6-mode

## How to test

See `examples/react-ts` which has a few different sort functions in `preview.js`

Can add a unit test if you twist my arm 