### PR TITLE
Core: Fix `process.env` stringification

### DIFF
--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -1,5 +1,11 @@
 import path from 'path';
-import { Configuration, DefinePlugin, HotModuleReplacementPlugin, ProgressPlugin } from 'webpack';
+import {
+  Configuration,
+  DefinePlugin,
+  HotModuleReplacementPlugin,
+  ProgressPlugin,
+  ProvidePlugin,
+} from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import WatchMissingNodeModulesPlugin from 'react-dev-utils/WatchMissingNodeModulesPlugin';
@@ -208,6 +214,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
         ...stringifyProcessEnvs(envs),
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       }),
+      new ProvidePlugin({ process: 'process/browser' }),
       isProd ? null : new WatchMissingNodeModulesPlugin(nodeModulesPaths),
       isProd ? null : new HotModuleReplacementPlugin(),
       new CaseSensitivePathsPlugin(),

--- a/lib/core-common/src/utils/envs.ts
+++ b/lib/core-common/src/utils/envs.ts
@@ -42,12 +42,6 @@ export function loadEnvs(
   };
 }
 
-export const stringifyEnvs = (raw: Record<string, string>): Record<string, string> =>
-  Object.entries(raw).reduce<Record<string, string>>((acc, [key, value]) => {
-    acc[key] = JSON.stringify(value);
-    return acc;
-  }, {});
-
 export const stringifyProcessEnvs = (raw: Record<string, string>): Record<string, string> => {
   const envs = Object.entries(raw).reduce<Record<string, string>>(
     (acc, [key, value]) => {
@@ -61,6 +55,6 @@ export const stringifyProcessEnvs = (raw: Record<string, string>): Record<string
   );
   // support destructuring like
   // const { foo } = process.env;
-  envs['process.env'] = JSON.stringify(stringifyEnvs(raw));
+  envs['process.env'] = JSON.stringify(raw);
   return envs;
 };


### PR DESCRIPTION
Issue: #16381 #16067

## What I did

- [x] Remove one layer of `process.env` stringification
- [x] Make `process` available for NextJS compat

self-merging @tmeasday 

## How to test

Create a `.env` file or run with `STORYBOOK_X` environment vars & console.log(process.env) & console.log(process) in a story
