### PR TITLE
Core: Restore `stringifyEnvs` utility used by Vite builder

### DIFF
--- a/lib/core-common/src/utils/envs.ts
+++ b/lib/core-common/src/utils/envs.ts
@@ -42,6 +42,12 @@ export function loadEnvs(
   };
 }
 
+export const stringifyEnvs = (raw: Record<string, string>): Record<string, string> =>
+  Object.entries(raw).reduce<Record<string, string>>((acc, [key, value]) => {
+    acc[key] = JSON.stringify(value);
+    return acc;
+  }, {});
+
 export const stringifyProcessEnvs = (raw: Record<string, string>): Record<string, string> => {
   const envs = Object.entries(raw).reduce<Record<string, string>>(
     (acc, [key, value]) => {


### PR DESCRIPTION
Issue: N/A

## What I did

Unintentionally introduced a breaking change in #16725 as noted in https://github.com/eirslett/storybook-builder-vite/issues/159. Adding `stringifyEnvs` back to fix.

self-merging @tmeasday @joshwooding

## How to test

N/A
