### PR TITLE
Include require statement in code snippet

### DIFF
--- a/docs/configure/webpack.md
+++ b/docs/configure/webpack.md
@@ -133,7 +133,7 @@ When you start your Storybook, you'll see an improvement in loading times. Read 
 When working with TypeScript projects, the default Webpack configuration may fail to resolve module aliases defined in your [`tsconfig` file](https://www.typescriptlang.org/tsconfig). To work around this issue you may use [`tsconfig-paths-webpack-plugin`](https://github.com/dividab/tsconfig-paths-webpack-plugin#tsconfig-paths-webpack-plugin) while [extending Storybook's Webpack config](#extending-storybooks-webpack-config) like:
 
 <!-- prettier-ignore-start -->
-
+<!-- code snippet below should include require statement: const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin'); -->
 <CodeSnippets
   paths={[
     'common/storybook-main-ts-module-resolution.js.mdx',


### PR DESCRIPTION
I couldn't find the code file (common/storybook-main-ts-module-resolution.js.mdx) to make the change, but you also need **const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');** in main.js.  Obvious, perhaps, but it could save someone a step if they miss it (like I did :-) )

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
