### PR TITLE
FIX #12705 fix infinite loading state when no storyfiles

### DIFF
--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -136,16 +136,17 @@ export default async (options: Options & Record<string, any>): Promise<Configura
       );
       entries.push(`${configFilename}-generated-config-entry.js`);
     });
-    if (stories.length > 0) {
-      const storyTemplate = await readTemplate(
-        path.join(__dirname, 'virtualModuleStory.template.js')
+    const storyTemplate = await readTemplate(
+      path.join(__dirname, 'virtualModuleStory.template.js')
+    );
+    const storiesFilename = path.resolve(path.join(workingDir, `generated-stories-entry.js`));
+    virtualModuleMapping[storiesFilename] = interpolate(storyTemplate, { frameworkImportPath })
+      // Make sure we also replace quotes for this one
+      .replace(
+        "'{{stories}}'",
+        stories.length > 0 ? stories.map(toRequireContextString).join(',') : ''
       );
-      const storiesFilename = path.resolve(path.join(workingDir, `generated-stories-entry.js`));
-      virtualModuleMapping[storiesFilename] = interpolate(storyTemplate, { frameworkImportPath })
-        // Make sure we also replace quotes for this one
-        .replace("'{{stories}}'", stories.map(toRequireContextString).join(','));
-      entries.push(storiesFilename);
-    }
+    entries.push(storiesFilename);
   }
 
   const shouldCheckTs = useBaseTsSupport(framework) && typescriptOptions.check;

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -135,16 +135,17 @@ export default async (options: Options & Record<string, any>): Promise<Configura
       );
       entries.push(`${configFilename}-generated-config-entry.js`);
     });
-    if (stories.length > 0) {
-      const storyTemplate = await readTemplate(
-        path.join(__dirname, 'virtualModuleStory.template.js')
+    const storyTemplate = await readTemplate(
+      path.join(__dirname, 'virtualModuleStory.template.js')
+    );
+    const storiesFilename = path.resolve(path.join(workingDir, `generated-stories-entry.js`));
+    virtualModuleMapping[storiesFilename] = interpolate(storyTemplate, { frameworkImportPath })
+      // Make sure we also replace quotes for this one
+      .replace(
+        "'{{stories}}'",
+        stories.length > 0 ? stories.map(toRequireContextString).join(',') : ''
       );
-      const storiesFilename = path.resolve(path.join(workingDir, `generated-stories-entry.js`));
-      virtualModuleMapping[storiesFilename] = interpolate(storyTemplate, { frameworkImportPath })
-        // Make sure we also replace quotes for this one
-        .replace("'{{stories}}'", stories.map(toRequireContextString).join(','));
-      entries.push(storiesFilename);
-    }
+    entries.push(storiesFilename);
   }
 
   const shouldCheckTs = useBaseTsSupport(framework) && typescriptOptions.check;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12705

## What I did

when there are 0 storyfiles, still create an entrypoint, to prevent a infinite loading state

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?