### PR TITLE
docs: fix incorrect Vue v-slot usage

### DIFF
--- a/docs/snippets/vue/page-story-slots.2.js.mdx
+++ b/docs/snippets/vue/page-story-slots.2.js.mdx
@@ -17,7 +17,9 @@ const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
     <page v-bind="$props">
-      <footer v-if="footer" v-slot=footer v-html="footer"/>
+      <template v-slot:footer>
+        <footer v-if="footer" v-html="footer"/>
+      </template>
     </page>
   `,
 });

--- a/docs/snippets/vue/page-story-slots.mdx-2.mdx.mdx
+++ b/docs/snippets/vue/page-story-slots.mdx-2.mdx.mdx
@@ -12,7 +12,9 @@ export const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
     <page v-bind="$props">
-      <footer v-if="footer" v-slot=footer v-html="footer"/>
+      <template v-slot:footer>
+        <footer v-if="footer" v-html="footer"/>
+      </template>
     </page>
   `,
 });


### PR DESCRIPTION
Issue:

Documentation contains incorrect example of Vue `v-slot` usage.

## What I did

Replaced incorrect usage of Vue [v-slot](https://vuejs.org/v2/guide/components-slots.html).

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
