### PR TITLE
Core: Fix channel options so that they are merged in correct order

### DIFF
--- a/lib/channel-postmessage/src/index.ts
+++ b/lib/channel-postmessage/src/index.ts
@@ -19,6 +19,8 @@ interface BufferedEvent {
 
 export const KEY = 'storybook-channel';
 
+const defaultEventOptions = { allowFunction: true, maxDepth: 25 };
+
 // TODO: we should export a method for opening child windows here and keep track of em.
 // that way we can send postMessage to child windows as well, not just iframe
 // https://stackoverflow.com/questions/6340160/how-to-get-the-references-of-all-already-opened-child-windows
@@ -73,7 +75,7 @@ export class PostmsgTransport {
       lazyEval,
     } = options || {};
 
-    const c = Object.fromEntries(
+    const eventOptions = Object.fromEntries(
       Object.entries({
         allowRegExp,
         allowFunction,
@@ -88,9 +90,9 @@ export class PostmsgTransport {
     );
 
     const stringifyOptions = {
-      ...{ allowFunction: true, maxDepth: 25 },
+      ...defaultEventOptions,
       ...(global.CHANNEL_OPTIONS || {}),
-      ...c,
+      ...eventOptions,
     };
 
     // backwards compat: convert depth to maxDepth

--- a/lib/channel-postmessage/src/index.ts
+++ b/lib/channel-postmessage/src/index.ts
@@ -63,12 +63,12 @@ export class PostmsgTransport {
 
       // telejson options
       allowRegExp,
-      allowFunction = true,
+      allowFunction,
       allowSymbol,
       allowDate,
       allowUndefined,
       allowClass,
-      maxDepth = 25,
+      maxDepth,
       space,
       lazyEval,
     } = options || {};
@@ -87,7 +87,11 @@ export class PostmsgTransport {
       }).filter(([k, v]) => typeof v !== 'undefined')
     );
 
-    const stringifyOptions = { ...(global.CHANNEL_OPTIONS || {}), ...c };
+    const stringifyOptions = {
+      ...{ allowFunction: true, maxDepth: 25 },
+      ...(global.CHANNEL_OPTIONS || {}),
+      ...c,
+    };
 
     // backwards compat: convert depth to maxDepth
     if (options && Number.isInteger(options.depth)) {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/12364

## What I did

The options were merged incorrectly, making the default be preserved over the configured options by the user.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?
