### PR TITLE
CLI: Use correct link for static dir migration docs

### DIFF
--- a/lib/core-server/src/cli/utils.ts
+++ b/lib/core-server/src/cli/utils.ts
@@ -36,7 +36,7 @@ const warnStaticDirDeprecated = warnDeprecatedFlag(
   `
     --static-dir CLI flag is deprecated, see:
 
-    https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-static-dir-flag
+    https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag
   `
 );
 


### PR DESCRIPTION
Issue: N/A

## What I did

When running Storybook and getting the deprecation warning, the link displayed in the CLI is wrong.
This PR fixes that!

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
