### PR TITLE
Add require line for TsconfigPathsPlugin

### DIFF
--- a/docs/snippets/common/storybook-main-ts-module-resolution.js.mdx
+++ b/docs/snippets/common/storybook-main-ts-module-resolution.js.mdx
@@ -1,6 +1,8 @@
 ```js
 // .storybook/main.js
 
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
 module.exports = {
   webpackFinal: async (config) => {
     config.resolve.plugins = [


### PR DESCRIPTION
you also need const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin'); in main.js. Obvious, perhaps, but it could save someone a step if they miss it (like I did :-) )

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
