### PR TITLE
Core: Don't log a console error when the story is missing

### DIFF
--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -729,7 +729,6 @@ export class PreviewWeb<TFramework extends AnyFramework> {
   }
 
   renderMissingStory() {
-    logger.error(`No story selected`);
     this.view.showNoPreview();
     this.channel.emit(Events.STORY_MISSING);
   }


### PR DESCRIPTION
It doesn't really add anything and it trips up tools like storyshots.

@yannbf I wasn't actually able to reproduce this problem in Storyshots in any of the internal projects however.