### PR TITLE
Interactions: Unlock controls when play function is finished

### DIFF
--- a/lib/instrumenter/src/instrumenter.ts
+++ b/lib/instrumenter/src/instrumenter.ts
@@ -138,6 +138,7 @@ export class Instrumenter {
       }
       if (newPhase === 'played') {
         this.setState(storyId, {
+          isLocked: false,
           isPlaying: false,
           isDebugging: false,
           forwardedException: undefined,
@@ -489,7 +490,7 @@ export class Instrumenter {
   update(call: Call) {
     clearTimeout(this.getState(call.storyId).syncTimeout);
     this.channel.emit(EVENTS.CALL, call);
-    this.setState(call.storyId, ({ calls, isLocked }) => {
+    this.setState(call.storyId, ({ calls }) => {
       // Omit earlier calls for the same ID, which may have been superceded by a later invocation.
       // This typically happens when calls are part of a callback which runs multiple times.
       const callsById = calls


### PR DESCRIPTION
Issue: -

## What I did

This unlocks the controls when you reach the end while debugging.

Before:

https://user-images.githubusercontent.com/321738/143415517-92c2e452-f0b9-4261-9bd9-2c4928616c3d.mov

After: 

https://user-images.githubusercontent.com/321738/143415545-d88b9150-d1eb-43c7-a7b0-f5ceed898931.mov


## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [x] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
