### PR TITLE
Core: Ensure that `context.args` is always set

### DIFF
--- a/lib/store/src/prepareStory.test.ts
+++ b/lib/store/src/prepareStory.test.ts
@@ -527,6 +527,49 @@ describe('prepareStory', () => {
         expect.objectContaining({ argsByTarget: { [NO_TARGET_NAME]: { a: 1 }, foo: { b: 2 } } })
       );
     });
+
+    it('always sets args, even when all are targetted', () => {
+      const renderMock = jest.fn();
+      const firstStory = prepareStory(
+        {
+          id,
+          name,
+          args: { b: 2 },
+          argTypes: { b: { name: 'b', target: 'foo' } },
+        },
+        { id, title },
+        { render: renderMock }
+      );
+
+      firstStory.unboundStoryFn({
+        args: firstStory.initialArgs,
+        hooks: new HooksContext(),
+        ...firstStory,
+      } as any);
+      expect(renderMock).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ argsByTarget: { foo: { b: 2 } } })
+      );
+    });
+
+    it('always sets args, even when none are set for the story', () => {
+      const renderMock = jest.fn();
+      const firstStory = prepareStory(
+        {
+          id,
+          name,
+        },
+        { id, title },
+        { render: renderMock }
+      );
+
+      firstStory.unboundStoryFn({
+        args: firstStory.initialArgs,
+        hooks: new HooksContext(),
+        ...firstStory,
+      } as any);
+      expect(renderMock).toHaveBeenCalledWith({}, expect.objectContaining({ argsByTarget: {} }));
+    });
   });
 });
 

--- a/lib/store/src/prepareStory.ts
+++ b/lib/store/src/prepareStory.ts
@@ -187,7 +187,7 @@ export function prepareStory<TFramework extends AnyFramework>(
         ...context,
         allArgs: context.args,
         argsByTarget,
-        args: argsByTarget[NO_TARGET_NAME],
+        args: argsByTarget[NO_TARGET_NAME] || {},
       };
     }
 


### PR DESCRIPTION
Issue: #16743 

## What I did

Ensure we don't filter all args down to nothing.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
Yes see tests
