### PR TITLE
Core: Fix breaking change in process/browser

### DIFF
--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -214,7 +214,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
         ...stringifyProcessEnvs(envs),
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       }),
-      new ProvidePlugin({ process: 'process/browser' }),
+      new ProvidePlugin({ process: 'process/browser.js' }),
       isProd ? null : new WatchMissingNodeModulesPlugin(nodeModulesPaths),
       isProd ? null : new HotModuleReplacementPlugin(),
       new CaseSensitivePathsPlugin(),


### PR DESCRIPTION
Issue:

## What I did

Trying to build the latest SB 6.4 gives me the following error

```
ModuleNotFoundError: Module not found: Error: Can't resolve 'process/browser' in '/home/sebdev20/Documents/git/Flint2/node_modules/uvu/node_modules/kleur'

Did you mean 'browser.js'?

BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').

The extension in the request is mandatory for it to be fully specified.
```

Changing the line to `browser.js` fixes the issue. 

I'm not sure which breaking change causes this exactly of if there is a better fix for this issue, but it seems to have affected [other people](https://github.com/remarkjs/remark/discussions/903) as well in different projects

I did notice that the `package.json` for `process/browser` has the following alias in it
```
"browser": "./browser.js",
```

So it seems that this is meant to be aliased in the `package.json` and specifying `process/browser.js` is just by-passing the `package.json` alias and going straight to the file 🤔