### PR TITLE
fix: correct story name override hint

### DIFF
--- a/docs/writing-stories/naming-components-and-hierarchy.md
+++ b/docs/writing-stories/naming-components-and-hierarchy.md
@@ -70,7 +70,7 @@ This will then be visually presented in the sidebar like this:
 
 ![Stories hierarchy with single story hoisting](./naming-hierarchy-single-story-hoisting.png)
 
-Because story exports are automatically "start cased" (`myStory` becomes `"My Story"`), your component name should match that. Alternatively you can override the story name using `myStory.name = '...'` to match the component name.
+Because story exports are automatically "start cased" (`myStory` becomes `"My Story"`), your component name should match that. Alternatively you can override the story name using `myStory.storyName = '...'` to match the component name.
 
 ## Sorting stories
 


### PR DESCRIPTION
Issue: `storyName` should be used to override a story's name. The `name` property is readonly and trying to override it fails.

## What I did
Simply changed `name` to `storyName`

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
