### PR TITLE
Fix `handle-release-branches` workflow

### DIFF
--- a/.github/workflows/handle-release-branches.yml
+++ b/.github/workflows/handle-release-branches.yml
@@ -40,7 +40,7 @@ jobs:
       - id: next-version
         uses: notiz-dev/github-action-json-property@release
         with:
-          path: ${{ github.workspace }}/next/docs/versions/next.json
+          path: ${{ github.workspace }}/next/package.json
           prop_path: version
 
       - run: |


### PR DESCRIPTION
- Grab "next" version from `/package.json` instead of `/docs/versions/next.json`