### PR TITLE
Remove react and react-dom from Svelte and Vue3 package.json

### DIFF
--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -52,8 +52,6 @@
     "@storybook/store": "6.4.0-rc.11",
     "core-js": "^3.8.2",
     "global": "^4.4.0",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
     "sveltedoc-parser": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9253,8 +9253,6 @@ __metadata:
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
-    react: 16.14.0
-    react-dom: 16.14.0
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     svelte: ^3.31.2


### PR DESCRIPTION
Issue:

`react` and `react-dom` were present in the `package.json` dependencies section.

## What I did

Removed them :P 

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
