### PR TITLE
Fix code snippet missing a chevron.

### DIFF
--- a/docs/snippets/react/checkbox-story-starter-example.mdx.mdx
+++ b/docs/snippets/react/checkbox-story-starter-example.mdx.mdx
@@ -11,7 +11,7 @@ import { Checkbox } from './Checkbox';
 
 With `MDX`, we can define a story for `Checkbox` right in the middle of our Markdown documentation.
 
-Canvas>
+<Canvas>
   <Story name="all checkboxes">
     <form>
       <Checkbox id="Unchecked" label="Unchecked" />


### PR DESCRIPTION
Issue: Code Snippet had malformed MDX 

## What I did
Updated and added the missing chevron.
## How to test
- View the snippet 
