### PR TITLE
Core: Fix packageName check in build-dev

### DIFF
--- a/lib/core-server/src/build-dev.ts
+++ b/lib/core-server/src/build-dev.ts
@@ -112,7 +112,7 @@ export async function buildDevStandalone(options: CLIOptions & LoadOptions & Bui
   }
 
   // Get package name and capitalize it e.g. @storybook/react -> React
-  const packageName = name.split('@storybook/').length > 0 ? name.split('@storybook/')[1] : name;
+  const packageName = name.split('@storybook/').length > 1 ? name.split('@storybook/')[1] : name;
   const frameworkName = packageName.charAt(0).toUpperCase() + packageName.slice(1);
 
   outputStartupInformation({


### PR DESCRIPTION
The current check breaks for non-storybook packages.

`Array.split` always returns 1 items at minimum, so with a `> 0` check in there it always executed the "if" part, breaking on the `.split()[1]` after.

## What I did

Change to a `> 1` check to allow accessing the 2nd item in the Array.

## How to test

I guess there is no non-storybook packaged framework included in the kitchen sink or other tests, otherwise this would have failed already.

At minimum, all existing test should still pass with this change.
