### PR TITLE
Angular: Add back-compat method to find options (styles) in angular.json

### DIFF
--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -133,7 +133,7 @@ async function getBuilderOptions(
 
 /**
  * Get options from legacy way
- * /!\ This is only for backward compatibility and wild be removed on Storybook 7.0
+ * /!\ This is only for backward compatibility and would be removed on Storybook 7.0
  * only work for angular.json with [defaultProject].build or "storybook.build" config
  */
 async function getLegacyDefaultBuildOptions(options: PresetOptions) {
@@ -142,8 +142,8 @@ async function getLegacyDefaultBuildOptions(options: PresetOptions) {
     return {};
   }
 
-  logger.info(`=> TODO ~ legacy way to get default options`);
-  logger.info(`=> TODO ~ Add deprecation warning and ex for builder use ? `);
+  // TODO ~ legacy way to get default options
+  // TODO ~ Add deprecation warning and ex for builder use ? `);
   const dirToSearch = process.cwd();
 
   // Read angular workspace
@@ -159,9 +159,6 @@ async function getLegacyDefaultBuildOptions(options: PresetOptions) {
   }
 
   // Find angular project target
-  let project: workspaces.ProjectDefinition;
-  let target: workspaces.TargetDefinition;
-  let confName: string;
   try {
     const browserTarget = {
       configuration: undefined,
@@ -169,26 +166,17 @@ async function getLegacyDefaultBuildOptions(options: PresetOptions) {
       target: 'build',
     } as Target;
 
-    const fondProject = findAngularProjectTarget(
+    const { target, project } = findAngularProjectTarget(
       workspaceConfig,
       browserTarget.project,
       browserTarget.target
     );
-    project = fondProject.project;
-    target = fondProject.target;
 
-    logger.info(
-      `=> Using angular project "${browserTarget.project}:${browserTarget.target}${
-        confName ? `:${confName}` : ''
-      }" for configuring Storybook`
-    );
+    logger.info(`=> Using angular project "${project}:${target}" for configuring Storybook`);
+    return { ...target.options };
   } catch (error) {
     logger.error(`=> Could not find angular project: ${error.message}`);
     logger.info(`=> Fail to load angular-cli config. Using base config`);
     return {};
   }
-
-  const projectBuildOptions = { ...target.options };
-
-  return projectBuildOptions;
 }

--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -1,15 +1,20 @@
 import webpack from 'webpack';
 import { logger } from '@storybook/node-logger';
-import { targetFromTargetString, BuilderContext } from '@angular-devkit/architect';
+import { targetFromTargetString, BuilderContext, Target } from '@angular-devkit/architect';
 import { sync as findUpSync } from 'find-up';
 import semver from '@storybook/semver';
 
-import { logging, JsonObject } from '@angular-devkit/core';
+import { logging, JsonObject, workspaces } from '@angular-devkit/core';
 import { moduleIsAvailable } from './utils/module-is-available';
 import { getWebpackConfig as getWebpackConfig12_2_x } from './angular-cli-webpack-12.2.x';
 import { getWebpackConfig as getWebpackConfig13_x_x } from './angular-cli-webpack-13.x.x';
 import { getWebpackConfig as getWebpackConfigOlder } from './angular-cli-webpack-older';
 import { PresetOptions } from './options';
+import {
+  getDefaultProjectName,
+  findAngularProjectTarget,
+  readAngularWorkspaceConfig,
+} from './angular-read-workspace';
 
 export async function webpackFinal(baseConfig: webpack.Configuration, options: PresetOptions) {
   if (!moduleIsAvailable('@angular-devkit/build-angular')) {
@@ -36,6 +41,7 @@ export async function webpackFinal(baseConfig: webpack.Configuration, options: P
       getWebpackConfig: async (_baseConfig, _options) => {
         const builderContext = getBuilderContext(_options);
         const builderOptions = await getBuilderOptions(_options, builderContext);
+        const legacyDefaultOptions = await getLegacyDefaultBuildOptions(_options);
 
         return getWebpackConfig13_x_x(_baseConfig, {
           builderOptions,
@@ -123,4 +129,66 @@ async function getBuilderOptions(
   logger.info(`=> Using angular project with "tsConfig:${builderOptions.tsConfig}"`);
 
   return builderOptions;
+}
+
+/**
+ * Get options from legacy way
+ * /!\ This is only for backward compatibility and wild be removed on Storybook 7.0
+ * only work for angular.json with [defaultProject].build or "storybook.build" config
+ */
+async function getLegacyDefaultBuildOptions(options: PresetOptions) {
+  if (options.angularBrowserTarget !== undefined) {
+    // Not use legacy way with builder (`angularBrowserTarget` is defined or null with builder and undefined without)
+    return {};
+  }
+
+  logger.info(`=> TODO ~ legacy way to get default options`);
+  logger.info(`=> TODO ~ Add deprecation warning and ex for builder use ? `);
+  const dirToSearch = process.cwd();
+
+  // Read angular workspace
+  let workspaceConfig;
+  try {
+    workspaceConfig = await readAngularWorkspaceConfig(dirToSearch);
+  } catch (error) {
+    logger.error(
+      `=> Could not find angular workspace config (angular.json) on this path "${dirToSearch}"`
+    );
+    logger.info(`=> Fail to load angular-cli config. Using base config`);
+    return {};
+  }
+
+  // Find angular project target
+  let project: workspaces.ProjectDefinition;
+  let target: workspaces.TargetDefinition;
+  let confName: string;
+  try {
+    const browserTarget = {
+      configuration: undefined,
+      project: getDefaultProjectName(workspaceConfig),
+      target: 'build',
+    } as Target;
+
+    const fondProject = findAngularProjectTarget(
+      workspaceConfig,
+      browserTarget.project,
+      browserTarget.target
+    );
+    project = fondProject.project;
+    target = fondProject.target;
+
+    logger.info(
+      `=> Using angular project "${browserTarget.project}:${browserTarget.target}${
+        confName ? `:${confName}` : ''
+      }" for configuring Storybook`
+    );
+  } catch (error) {
+    logger.error(`=> Could not find angular project: ${error.message}`);
+    logger.info(`=> Fail to load angular-cli config. Using base config`);
+    return {};
+  }
+
+  const projectBuildOptions = { ...target.options };
+
+  return projectBuildOptions;
 }

--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -4,7 +4,7 @@ import { targetFromTargetString, BuilderContext, Target } from '@angular-devkit/
 import { sync as findUpSync } from 'find-up';
 import semver from '@storybook/semver';
 
-import { logging, JsonObject, workspaces } from '@angular-devkit/core';
+import { logging, JsonObject } from '@angular-devkit/core';
 import { moduleIsAvailable } from './utils/module-is-available';
 import { getWebpackConfig as getWebpackConfig12_2_x } from './angular-cli-webpack-12.2.x';
 import { getWebpackConfig as getWebpackConfig13_x_x } from './angular-cli-webpack-13.x.x';

--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -44,7 +44,7 @@ export async function webpackFinal(baseConfig: webpack.Configuration, options: P
         const legacyDefaultOptions = await getLegacyDefaultBuildOptions(_options);
 
         return getWebpackConfig13_x_x(_baseConfig, {
-          builderOptions,
+          builderOptions: { ...builderOptions, ...legacyDefaultOptions },
           builderContext,
         });
       },


### PR DESCRIPTION
TODO

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
