### PR TITLE
CLI: Fix open storybook in default browser

### DIFF
--- a/lib/core-client/src/typings.d.ts
+++ b/lib/core-client/src/typings.d.ts
@@ -6,6 +6,8 @@ declare module 'pnp-webpack-plugin';
 declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
+declare module 'open';
+declare module 'x-default-browser';
 declare module '@storybook/ui';
 
 declare module 'file-system-cache' {

--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -71,6 +71,7 @@
     "ip": "^1.1.5",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",
+    "open": "^8.4.0",
     "pretty-hrtime": "^1.0.3",
     "prompts": "^2.4.0",
     "regenerator-runtime": "^0.13.7",
@@ -81,7 +82,8 @@
     "util-deprecate": "^1.0.2",
     "watchpack": "^2.2.0",
     "webpack": "4",
-    "ws": "^8.2.3"
+    "ws": "^8.2.3",
+    "x-default-browser": "^0.4.0"
   },
   "devDependencies": {
     "@storybook/builder-webpack5": "6.4.0-rc.11",

--- a/lib/core-server/src/utils/open-in-browser.ts
+++ b/lib/core-server/src/utils/open-in-browser.ts
@@ -1,15 +1,45 @@
 import { logger } from '@storybook/node-logger';
-import open from 'better-opn';
+import betterOpn from 'better-opn'; // betterOpn alias used because also loading open
+import open from 'open';
+import getDefaultBrowser from 'x-default-browser';
 import dedent from 'ts-dedent';
 
 export function openInBrowser(address: string) {
-  try {
-    open(address);
-  } catch (error) {
-    logger.error(dedent`
-      Could not open ${address} inside a browser. If you're running this command inside a
-      docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
-      browser by default.
-    `);
-  }
+  const defaultBrowserCallback = async (err: any, res: any) => {
+    if (res.isFirefox) {
+      // Handle firefox cross-browser using open's system-specific binary utility.
+      // See https://github.com/sindresorhus/open#openapps for more information.
+      try {
+        await open(address, {
+          app: {
+            name: 'firefox',
+          },
+        });
+      } catch (error) {
+        logger.error(dedent`
+          Could not open ${address} inside a browser. If you're running this command inside a
+          docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
+          browser by default.
+        `);
+      }
+    } else {
+      if (res.isSafari) {
+        // If Safari, set BROWSER env variable to leverage better-opn built-in override.
+        // See https://github.com/michaellzc/better-opn#usage for more information.
+        process.env.BROWSER = 'safari';
+      }
+
+      try {
+        betterOpn(address);
+      } catch (error) {
+        logger.error(dedent`
+          Could not open ${address} inside a browser. If you're running this command inside a
+          docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
+          browser by default.
+        `);
+      }
+    }
+  };
+
+  getDefaultBrowser(defaultBrowserCallback);
 }

--- a/lib/core-server/src/utils/open-in-browser.ts
+++ b/lib/core-server/src/utils/open-in-browser.ts
@@ -5,41 +5,21 @@ import getDefaultBrowser from 'x-default-browser';
 import dedent from 'ts-dedent';
 
 export function openInBrowser(address: string) {
-  const defaultBrowserCallback = async (err: any, res: any) => {
-    if (res.isFirefox) {
-      // Handle firefox cross-browser using open's system-specific binary utility.
-      // See https://github.com/sindresorhus/open#openapps for more information.
-      try {
-        await open(address, {
-          app: {
-            name: 'firefox',
-          },
-        });
-      } catch (error) {
-        logger.error(dedent`
-          Could not open ${address} inside a browser. If you're running this command inside a
-          docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
-          browser by default.
-        `);
-      }
-    } else {
-      if (res.isSafari) {
-        // If Safari, set BROWSER env variable to leverage better-opn built-in override.
-        // See https://github.com/michaellzc/better-opn#usage for more information.
-        process.env.BROWSER = 'safari';
-      }
-
-      try {
+  getDefaultBrowser(async (err: any, res: any) => {
+    try {
+      if (res.isChrome || res.isChromium) {
+        // We use betterOpn for Chrome because it is better at handling which chrome tab
+        // or window the preview loads in.
         betterOpn(address);
-      } catch (error) {
-        logger.error(dedent`
-          Could not open ${address} inside a browser. If you're running this command inside a
-          docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
-          browser by default.
-        `);
+      } else {
+        await open(address);
       }
+    } catch (error) {
+      logger.error(dedent`
+        Could not open ${address} inside a browser. If you're running this command inside a
+        docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
+        browser by default.
+      `);
     }
-  };
-
-  getDefaultBrowser(defaultBrowserCallback);
+  });
 }

--- a/lib/core-server/typings.d.ts
+++ b/lib/core-server/typings.d.ts
@@ -6,6 +6,8 @@ declare module 'pnp-webpack-plugin';
 declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
+declare module 'open';
+declare module 'x-default-browser';
 declare module '@storybook/ui';
 declare module '@discoveryjs/json-ext';
 declare module 'watchpack';

--- a/lib/manager-webpack4/typings.d.ts
+++ b/lib/manager-webpack4/typings.d.ts
@@ -6,6 +6,8 @@ declare module 'pnp-webpack-plugin';
 declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
+declare module 'open';
+declare module 'x-default-browser';
 declare module '@storybook/ui';
 
 declare module 'file-system-cache' {

--- a/lib/manager-webpack5/typings.d.ts
+++ b/lib/manager-webpack5/typings.d.ts
@@ -5,6 +5,8 @@ declare module 'lazy-universal-dotenv';
 declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
+declare module 'open';
+declare module 'x-default-browser';
 declare module '@storybook/ui';
 
 declare module 'file-system-cache' {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8269,6 +8269,7 @@ __metadata:
     jest-specific-snapshot: ^4.0.0
     lodash: ^4.17.20
     node-fetch: ^2.6.1
+    open: ^8.4.0
     pretty-hrtime: ^1.0.3
     prompts: ^2.4.0
     regenerator-runtime: ^0.13.7
@@ -8280,6 +8281,7 @@ __metadata:
     watchpack: ^2.2.0
     webpack: 4
     ws: ^8.2.3
+    x-default-browser: ^0.4.0
   peerDependencies:
     "@storybook/builder-webpack5": 6.4.0-rc.11
     "@storybook/manager-webpack5": 6.4.0-rc.11
@@ -15036,6 +15038,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"big-integer@npm:^1.6.7":
+  version: 1.6.51
+  resolution: "big-integer@npm:1.6.51"
+  checksum: c8139662d57f8833a44802f4b65be911679c569535ea73c5cfd3c1c8994eaead1b84b6f63e1db63833e4d4cacb6b6a9e5522178113dfdc8e4c81ed8436f1e8cc
+  languageName: node
+  linkType: hard
+
 "big.js@npm:^3.1.3":
   version: 3.2.0
   resolution: "big.js@npm:3.2.0"
@@ -15254,6 +15263,15 @@ __metadata:
     widest-line: ^3.1.0
     wrap-ansi: ^7.0.0
   checksum: 71f31c2eb3dcacd5fce524ae509e0cc90421752e0bfbd0281fd3352871d106c462a0f810c85f2fdb02f3a9fab2d7a84e9718b4999384d651b76104ebe5d2c024
+  languageName: node
+  linkType: hard
+
+"bplist-parser@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "bplist-parser@npm:0.1.1"
+  dependencies:
+    big-integer: ^1.6.7
+  checksum: cd50206f956e74f6e46cb5ed14be5eb00b2e14676ea3dd36703470715177a2770fc22032eca63a36adb3b56a1e51138a95bb0fc6849a78c21e92caeedf219ea7
   languageName: node
   linkType: hard
 
@@ -19591,6 +19609,19 @@ __metadata:
   version: 4.2.2
   resolution: "deepmerge@npm:4.2.2"
   checksum: d6136eee869057fea7a829aa2d10073ed49db5216e42a77cc737dd385334aab9b68dae22020a00c24c073d5f79cbbdd3f11b8d4fc87700d112ddaa0e1f968ef2
+  languageName: node
+  linkType: hard
+
+"default-browser-id@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "default-browser-id@npm:1.0.4"
+  dependencies:
+    bplist-parser: ^0.1.0
+    meow: ^3.1.0
+    untildify: ^2.0.0
+  bin:
+    default-browser-id: cli.js
+  checksum: a00a2ab66beab70490b4d76258a1f2eadfadca6414bf67ab78aa25b33dc3de0c4c813bb8f204271aa7a08281c39474487db0229e325112456464fb97a0522a8a
   languageName: node
   linkType: hard
 
@@ -31727,7 +31758,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"meow@npm:^3.3.0":
+"meow@npm:^3.1.0, meow@npm:^3.3.0":
   version: 3.7.0
   resolution: "meow@npm:3.7.0"
   dependencies:
@@ -33663,6 +33694,17 @@ fsevents@^1.2.7:
     is-docker: ^2.0.0
     is-wsl: ^2.1.1
   checksum: 77573a6a68f7364f3a19a4c80492712720746b63680ee304555112605ead196afe91052bd3c3d165efdf4e9d04d255e87de0d0a77acec11ef47fd5261251813f
+  languageName: node
+  linkType: hard
+
+"open@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "open@npm:8.4.0"
+  dependencies:
+    define-lazy-prop: ^2.0.0
+    is-docker: ^2.1.1
+    is-wsl: ^2.2.0
+  checksum: 585596580226cbeb7262f36b5acc7eed05211dc26980020a2527f829336b8b07fd79cdc4240f4d995b5615f635e0a59ebb0261c4419fef91edd5d4604c463f18
   languageName: node
   linkType: hard
 
@@ -44665,7 +44707,7 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"untildify@npm:^2.1.0":
+"untildify@npm:^2.0.0, untildify@npm:^2.1.0":
   version: 2.1.0
   resolution: "untildify@npm:2.1.0"
   dependencies:
@@ -47089,6 +47131,20 @@ resolve@1.19.0:
     utf-8-validate:
       optional: true
   checksum: 5ef0f81cc5b8776fb5dd5504c83b4f49be5aa610f9319ff774158bba7db495127e69763d73085288223061e7a5d104d022e2e264346b36b046322f50057e7945
+  languageName: node
+  linkType: hard
+
+"x-default-browser@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "x-default-browser@npm:0.4.0"
+  dependencies:
+    default-browser-id: ^1.0.4
+  dependenciesMeta:
+    default-browser-id:
+      optional: true
+  bin:
+    x-default-browser: bin/x-default-browser.js
+  checksum: a19e42ffeab19560ea05a423561f5b3b82bb3a5878dc932cfd0847fadc5890b8b685d6b39e2356c8304b3943f5a7120ba4b233365d686ff8f9bf2499ce11f052
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #15316 

## What I did
Updated `open-in-browser.ts` to find the user's default browser, and attempt to honor that default browser (when default is Firefox or Safari) instead of automatically opening in a Chromium-based browser.  
- Included 2 new npm packages:
  - `x-default-browser` to detect the user's system default browser
  - `open` to handle cross-platform versions of Firefox

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
