### PR TITLE
CLI: Improve `sb repro` directory prompt

### DIFF
--- a/lib/cli/src/repro.ts
+++ b/lib/cli/src/repro.ts
@@ -118,11 +118,13 @@ export const repro = async ({
       type: 'text',
       message: 'Enter the output directory',
       name: 'directory',
+      initial: selectedConfig.name,
+      validate: (directoryName) =>
+        fs.existsSync(directoryName)
+          ? `${directoryName} already exists. Please choose another name.`
+          : true,
     });
     selectedDirectory = directory;
-    if (fs.existsSync(selectedDirectory)) {
-      throw new Error(`🚨 Repro: ${selectedDirectory} already exists`);
-    }
   }
 
   try {


### PR DESCRIPTION
Issue: N/A

## What I did

The repro command will set the template of choice as default directory name, so you can just press enter:
![image](https://user-images.githubusercontent.com/1671563/144237167-a971c005-afaf-4cd9-856b-b36e17b1b161.png)

If you set a directory name manually and that directory exists, rather than failing the entire command, it will show a validation message until you type a directory that wouldn't clash:
![image](https://user-images.githubusercontent.com/1671563/144237172-83ec822f-c0c9-4175-bf58-084b7fa832f1.png)


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
