### PR TITLE
Addon-docs: Fix transclusion crash on webpack rules without test field

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -65,7 +65,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}) {
   let rules = module.rules || [];
   if (transcludeMarkdown) {
     rules = [
-      ...rules.filter((rule: any) => rule.test.toString() !== '/\\.md$/'),
+      ...rules.filter((rule: any) => rule.test?.toString() !== '/\\.md$/'),
       {
         test: /\.md$/,
         use: [


### PR DESCRIPTION
Issue: N/A

#11334 followup

## What I did

Guard against empty `rule.test`

self-merging @tmeasday 

## How to test

N/A
