### PR TITLE
Fix typo.

### DIFF
--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -136,7 +136,7 @@ Refine this pattern by introducing `args` for your component's stories. It reduc
 <!-- prettier-ignore-end -->
 
 <div class="aside">
-💡 <strong>Note:</strong> <code>Template.bind({})</code> is a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">standard JavaScript techique</a> for making a copy of a function. We copy the <code>Template</code> so each exported story can set its own properties on it.
+💡 <strong>Note:</strong> <code>Template.bind({})</code> is a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">standard JavaScript technique</a> for making a copy of a function. We copy the <code>Template</code> so each exported story can set its own properties on it.
 </div>
 
 By introducing args into your component's stories, you're not only reducing the amount of code you need to write, but you're also decreasing data duplication, as shown by spreading the `Primary` story's args into the other stories.


### PR DESCRIPTION
Issue:

## What I did

I corrected a typo on the [React Introduction documentation](https://storybook.js.org/docs/react/writing-stories/introduction).

Changed "techique" to "technique."

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
