### PR TITLE
Angular: Fix incorrect log

### DIFF
--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -172,7 +172,7 @@ async function getLegacyDefaultBuildOptions(options: PresetOptions) {
       browserTarget.target
     );
 
-    logger.info(`=> Using angular project "${project}:${target}" for configuring Storybook`);
+    logger.info(`=> Using angular project "${browserTarget.project}:${browserTarget.target}" for configuring Storybook`);
     return { ...target.options };
   } catch (error) {
     logger.error(`=> Could not find angular project: ${error.message}`);


### PR DESCRIPTION
Issue: #16884

When starting angular I got this error
ERR! => Could not find angular project: Cannot convert object to primitive valueTypeError: Cannot convert object to primitive value
info => Fail to load angular-cli config. Using base config



## What I did
Origin is in framework-preset-angular-cli.ts l.175.


This line
logger.info(=> Using angular project "${project}:${target}" for configuring Storybook);
should be replaced by
logger.info(=> Using angular project "${project}:${browserTarget.target}" for configuring Storybook);

Because target is an object, it cannot be used in the logger

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
