### PR TITLE
Avoid referencing internal Emotion packages in built types

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -104,7 +104,7 @@
   "devDependencies": {
     "@angular/core": "^11.2.14",
     "@babel/core": "^7.12.10",
-    "@emotion/core": "^10.1.1",
+    "@emotion/core": "^10.3.1",
     "@emotion/styled": "^10.0.27",
     "@storybook/angular": "6.5.0-alpha.3",
     "@storybook/html": "6.5.0-alpha.3",

--- a/lib/theming/package.json
+++ b/lib/theming/package.json
@@ -40,7 +40,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
-    "@emotion/core": "^10.1.1",
+    "@emotion/core": "^10.3.1",
     "@emotion/is-prop-valid": "^0.8.6",
     "@emotion/styled": "^10.0.27",
     "@storybook/client-logger": "6.5.0-alpha.3",

--- a/lib/theming/src/animation.ts
+++ b/lib/theming/src/animation.ts
@@ -1,10 +1,10 @@
-import { css, keyframes } from '@emotion/core';
+import { css, keyframes, Keyframes, SerializedStyles } from '@emotion/core';
 
 export const easing = {
   rubber: 'cubic-bezier(0.175, 0.885, 0.335, 1.05)',
 };
 
-const rotate360 = keyframes`
+const rotate360: Keyframes = keyframes`
 	from {
 		transform: rotate(0deg);
 	}
@@ -13,32 +13,32 @@ const rotate360 = keyframes`
 	}
 `;
 
-const glow = keyframes`
+const glow: Keyframes = keyframes`
   0%, 100% { opacity: 1; }
   50% { opacity: .4; }
 `;
 
-const float = keyframes`
+const float: Keyframes = keyframes`
   0% { transform: translateY(1px); }
   25% { transform: translateY(0px); }
   50% { transform: translateY(-3px); }
   100% { transform: translateY(1px); }
 `;
 
-const jiggle = keyframes`
+const jiggle: Keyframes = keyframes`
   0%, 100% { transform:translate3d(0,0,0); }
   12.5%, 62.5% { transform:translate3d(-4px,0,0); }
   37.5%, 87.5% {  transform: translate3d(4px,0,0);  }
 `;
 
-const inlineGlow = css`
+const inlineGlow: SerializedStyles = css`
   animation: ${glow} 1.5s ease-in-out infinite;
   color: transparent;
   cursor: progress;
 `;
 
 // hover & active state for links and buttons
-const hoverable = css`
+const hoverable: SerializedStyles = css`
   transition: all 150ms ease-out;
   transform: translate3d(0, 0, 0);
 

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -40,7 +40,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
-    "@emotion/core": "^10.1.1",
+    "@emotion/core": "^10.3.1",
     "@storybook/addons": "6.5.0-alpha.3",
     "@storybook/api": "6.5.0-alpha.3",
     "@storybook/channels": "6.5.0-alpha.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4262,6 +4262,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/core@npm:^10.3.1":
+  version: 10.3.1
+  resolution: "@emotion/core@npm:10.3.1"
+  dependencies:
+    "@babel/runtime": ^7.5.5
+    "@emotion/cache": ^10.0.27
+    "@emotion/css": ^10.0.27
+    "@emotion/serialize": ^0.11.15
+    "@emotion/sheet": 0.9.4
+    "@emotion/utils": 0.11.3
+  peerDependencies:
+    react: ">=16.3.0"
+  checksum: 99b27ffa33408e3987f0d77e1f18a6145c0c11fa0c8991adf09e5dba0451fcfb45288132b8caf2a038695fa081c593bfaab82e01f64fee86ddbb2bd3c5a41ed7
+  languageName: node
+  linkType: hard
+
 "@emotion/css@npm:^10.0.27":
   version: 10.0.27
   resolution: "@emotion/css@npm:10.0.27"
@@ -7802,7 +7818,7 @@ __metadata:
     "@babel/parser": ^7.12.11
     "@babel/plugin-transform-react-jsx": ^7.12.12
     "@babel/preset-env": ^7.12.11
-    "@emotion/core": ^10.1.1
+    "@emotion/core": ^10.3.1
     "@emotion/styled": ^10.0.27
     "@jest/transform": ^26.6.2
     "@mdx-js/loader": ^1.6.22
@@ -10076,7 +10092,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/theming@workspace:lib/theming"
   dependencies:
-    "@emotion/core": ^10.1.1
+    "@emotion/core": ^10.3.1
     "@emotion/is-prop-valid": ^0.8.6
     "@emotion/styled": ^10.0.27
     "@storybook/client-logger": 6.5.0-alpha.3
@@ -10122,7 +10138,7 @@ __metadata:
   resolution: "@storybook/ui@workspace:lib/ui"
   dependencies:
     "@babel/core": ^7.12.10
-    "@emotion/core": ^10.1.1
+    "@emotion/core": ^10.3.1
     "@storybook/addons": 6.5.0-alpha.3
     "@storybook/api": 6.5.0-alpha.3
     "@storybook/channels": 6.5.0-alpha.3


### PR DESCRIPTION
Issue: N/A

## What I did

Errors I'm trying to fix when using Yarn PnP:
```
../../.yarn/__virtual__/@storybook-theming-virtual-8ade4919eb/0/cache/@storybook-theming-npm-6.4.7-455113f13a-4e2300146b.zip/node_modules/@storybook/theming/dist/ts3.9/animation.d.ts:5:23 - error TS2307: Cannot find module '@emotion/serialize' or its corresponding type declarations.

5     rotate360: import("@emotion/serialize").Keyframes;
                        ~~~~~~~~~~~~~~~~~~~~

../../.yarn/__virtual__/@storybook-theming-virtual-8ade4919eb/0/cache/@storybook-theming-npm-6.4.7-455113f13a-4e2300146b.zip/node_modules/@storybook/theming/dist/ts3.9/animation.d.ts:6:18 - error TS2307: Cannot find module '@emotion/serialize' or its corresponding type declarations.

6     glow: import("@emotion/serialize").Keyframes;
                   ~~~~~~~~~~~~~~~~~~~~

../../.yarn/__virtual__/@storybook-theming-virtual-8ade4919eb/0/cache/@storybook-theming-npm-6.4.7-455113f13a-4e2300146b.zip/node_modules/@storybook/theming/dist/ts3.9/animation.d.ts:7:19 - error TS2307: Cannot find module '@emotion/serialize' or its corresponding type declarations.

7     float: import("@emotion/serialize").Keyframes;
                    ~~~~~~~~~~~~~~~~~~~~

../../.yarn/__virtual__/@storybook-theming-virtual-8ade4919eb/0/cache/@storybook-theming-npm-6.4.7-455113f13a-4e2300146b.zip/node_modules/@storybook/theming/dist/ts3.9/animation.d.ts:8:20 - error TS2307: Cannot find module '@emotion/serialize' or its corresponding type declarations.

8     jiggle: import("@emotion/serialize").Keyframes;
                     ~~~~~~~~~~~~~~~~~~~~

../../.yarn/__virtual__/@storybook-theming-virtual-8ade4919eb/0/cache/@storybook-theming-npm-6.4.7-455113f13a-4e2300146b.zip/node_modules/@storybook/theming/dist/ts3.9/animation.d.ts:9:24 - error TS2307: Cannot find module '@emotion/utils' or its corresponding type declarations.

9     inlineGlow: import("@emotion/utils").SerializedStyles;
                         ~~~~~~~~~~~~~~~~

../../.yarn/__virtual__/@storybook-theming-virtual-8ade4919eb/0/cache/@storybook-theming-npm-6.4.7-455113f13a-4e2300146b.zip/node_modules/@storybook/theming/dist/ts3.9/animation.d.ts:10:23 - error TS2307: Cannot find module '@emotion/utils' or its corresponding type declarations.

10     hoverable: import("@emotion/utils").SerializedStyles;
                         ~~~~~~~~~~~~~~~~


Found 6 errors.
```

This happens because `lib/theming/src/animation.d.ts` ends up referencing these packages like this:

```
export declare const easing: {
    rubber: string;
};
export declare const animation: {
    rotate360: import("@emotion/serialize").Keyframes;
    glow: import("@emotion/serialize").Keyframes;
    float: import("@emotion/serialize").Keyframes;
    jiggle: import("@emotion/serialize").Keyframes;
    inlineGlow: import("@emotion/utils").SerializedStyles;
    hoverable: import("@emotion/utils").SerializedStyles;
};

```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
