### PR TITLE
Core: Replace calls to `getElementById` by id check

### DIFF
--- a/addons/docs/src/frameworks/vue/prepareForInline.ts
+++ b/addons/docs/src/frameworks/vue/prepareForInline.ts
@@ -29,7 +29,7 @@ export const prepareForInline = (
       },
       render(h) {
         const children = this[COMPONENT] ? [h(this[COMPONENT])] : undefined;
-        return h('div', { attrs: { id: 'root' } }, children);
+        return h('div', children);
       },
     });
     return () => root.$destroy();

--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -401,6 +401,7 @@ describe('PreviewWeb', () => {
             initialArgs: { foo: 'a' },
             argTypes: { foo: { name: 'foo', type: { name: 'string' } } },
             args: { foo: 'a' },
+            viewMode: 'story',
           })
         );
       });
@@ -760,6 +761,7 @@ describe('PreviewWeb', () => {
         expect(componentOneExports.default.loaders[0]).toHaveBeenCalledWith(
           expect.objectContaining({
             args: { foo: 'a' },
+            viewMode: 'story',
           })
         );
 
@@ -773,6 +775,7 @@ describe('PreviewWeb', () => {
         expect(componentOneExports.default.loaders[0]).toHaveBeenCalledWith(
           expect.objectContaining({
             args: { foo: 'a', new: 'arg' },
+            viewMode: 'story',
           })
         );
 

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -609,7 +609,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
         await runPhase('loading', async () => {
           loadedContext = await applyLoaders({
             ...this.storyStore.getStoryContext(story),
-            viewMode: canvasElement === this.view.storyRoot() ? 'story' : 'docs',
+            viewMode: canvasElement?.id === this.view.storyRootId ? 'story' : 'docs',
           } as StoryContextForLoaders<TFramework>);
         });
         if (abortSignal.aborted) return;

--- a/lib/preview-web/src/WebView.ts
+++ b/lib/preview-web/src/WebView.ts
@@ -39,6 +39,10 @@ export class WebView {
 
   testing = false;
 
+  public readonly storyRootId = 'root';
+
+  public readonly docsRootId = 'docs-root';
+
   constructor() {
     // Special code for testing situations
     const { __SPECIAL_TEST_PARAMETER__ } = qs.parse(document.location.search, {
@@ -71,7 +75,7 @@ export class WebView {
   }
 
   storyRoot(): HTMLElement {
-    return document.getElementById('root');
+    return document.getElementById(this.storyRootId);
   }
 
   prepareForDocs() {
@@ -82,7 +86,7 @@ export class WebView {
   }
 
   docsRoot(): HTMLElement {
-    return document.getElementById('docs-root');
+    return document.getElementById(this.docsRootId);
   }
 
   applyLayout(layout: Layout = 'padded') {


### PR DESCRIPTION
Issue: #16862

## What I did

Use id check instead of checking the whole element to find if story should be in `story` or `docs` mode

This has 2 benefits:
 - avoid some calls to `document.getElementById`
 - fix weird behaviours with some frameworks (Vue + SFC for instance) where the `canvasElement` wasn't populated yet when the first check was done. Causing `viewMode` to be wrong when loaders are applied - This was the root cause of E2E tests failure for sfcVue

## How to test

- [ ] sfcVue e2e tests should be back to 🟢 
- [ ] Everything else on CI  should be still 🟢 
