### PR TITLE
Core: Fix auto-title in webpack5

### DIFF
--- a/lib/builder-webpack5/package.json
+++ b/lib/builder-webpack5/package.json
@@ -86,6 +86,7 @@
     "glob": "^7.1.6",
     "glob-promise": "^3.4.0",
     "html-webpack-plugin": "^5.0.0",
+    "path-browserify": "^1.0.1",
     "react-dev-utils": "^11.0.4",
     "stable": "^0.1.8",
     "style-loader": "^2.0.0",

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -241,7 +241,9 @@ export default async (options: Options & Record<string, any>): Promise<Configura
         react: path.dirname(require.resolve('react/package.json')),
         'react-dom': path.dirname(require.resolve('react-dom/package.json')),
       },
-      fallback: { path: false },
+      fallback: {
+        path: require.resolve('path-browserify'),
+      },
     },
     optimization: {
       splitChunks: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7889,6 +7889,7 @@ __metadata:
     glob: ^7.1.6
     glob-promise: ^3.4.0
     html-webpack-plugin: ^5.0.0
+    path-browserify: ^1.0.1
     react-dev-utils: ^11.0.4
     stable: ^0.1.8
     style-loader: ^2.0.0


### PR DESCRIPTION
Issue: #16891 #16903

## What I did

Webpack5 no longer includes `path` polyfills by default, so we need to add it by hand.

self-merging @tmeasday 

## How to test

I did `sb link` the repro from #16891 and it failed before the change & worked after