### PR TITLE
Core: Add feature flag to disable legacy hierarchy separator warning

### DIFF
--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -31,6 +31,7 @@ const config: StorybookConfig = {
     storyStoreV7: !global.navigator?.userAgent?.match?.('jsdom'),
     buildStoriesJson: true,
     babelModeV7: true,
+    warnOnLegacyHierarchySeparator: false,
   },
   framework: '@storybook/react',
 };

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -3,6 +3,7 @@ import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 import mapValues from 'lodash/mapValues';
 import countBy from 'lodash/countBy';
+import global from 'global';
 import {
   StoryId,
   ComponentTitle,
@@ -18,6 +19,8 @@ import { combineParameters } from '../index';
 import merge from './merge';
 import { Provider } from '../modules/provider';
 import { ViewMode } from '../modules/addons';
+
+const { FEATURES } = global;
 
 export type { StoryId };
 
@@ -207,7 +210,7 @@ export const transformStoriesRawToStoriesHash = (
     }
 
     const setShowRoots = typeof showRoots !== 'undefined';
-    if (usesOldHierarchySeparator && !setShowRoots) {
+    if (usesOldHierarchySeparator && !setShowRoots && FEATURES?.warnOnLegacyHierarchySeparator) {
       warnChangedDefaultHierarchySeparators();
     }
 

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -366,6 +366,12 @@ export interface StorybookConfig {
      * Filter args with a "target" on the type from the render function (EXPERIMENTAL)
      */
     argTypeTargetsV7?: boolean;
+
+    /**
+     * Warn when there is a pre-6.0 hierarchy separator ('.' / '|') in the story title.
+     * Will be removed in 7.0.
+     */
+    warnOnLegacyHierarchySeparator?: boolean;
   };
 
   /**

--- a/lib/core-server/src/presets/common-preset.ts
+++ b/lib/core-server/src/presets/common-preset.ts
@@ -65,4 +65,5 @@ export const features = async (existing: Record<string, boolean>) => ({
   ...existing,
   postcss: true,
   emotionAlias: true,
+  warnOnLegacyHierarchySeparator: true,
 });


### PR DESCRIPTION
Issue: #16845 

## What I did

Add a feature flag to disable a warning (that will be removed in 7.0)

self-merging @yannbf 

## How to test

Add a . or | to a title in `examples/react-ts`