### PR TITLE
Core: Remove unused and occluded types

### DIFF
--- a/lib/client-api/src/index.ts
+++ b/lib/client-api/src/index.ts
@@ -12,8 +12,6 @@ export * from './types';
 
 export * from './queryparams';
 
-// Typescript isn't happy that we are overwriting some types from store here
-// @ts-ignore
 export * from '@storybook/store';
 
 export {

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -14,7 +14,7 @@ import {
   StoryContext,
 } from '@storybook/addons';
 import { AnyFramework, StoryIdentifier, ProjectAnnotations } from '@storybook/csf';
-import { StoryStore, HooksContext } from '@storybook/store';
+import { StoryStore, HooksContext, RenderContext } from '@storybook/store';
 
 export type {
   SBType,
@@ -116,3 +116,5 @@ export interface GetStorybookKind {
   fileName: string;
   stories: GetStorybookStory[];
 }
+
+export type RenderContextWithoutStoryContext = Omit<RenderContext, 'storyContext'>;

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -44,7 +44,7 @@ export interface StoryMetadata {
 export type ArgTypesEnhancer = (context: StoryContext) => ArgTypes;
 export type ArgsEnhancer = (context: StoryContext) => Args;
 
-export type StorySpecifier = StoryId | { name: StoryName; kind: StoryKind } | '*';
+type StorySpecifier = StoryId | { name: StoryName; kind: StoryKind } | '*';
 
 export interface StoreSelectionSpecifier {
   storySpecifier: StorySpecifier;
@@ -116,17 +116,3 @@ export interface GetStorybookKind {
   fileName: string;
   stories: GetStorybookStory[];
 }
-
-// This really belongs in lib/core, but that depends on lib/ui which (dev) depends on app/react
-// which needs this type. So we put it here to avoid the circular dependency problem.
-export type RenderContextWithoutStoryContext = StoreItem & {
-  forceRender: boolean;
-
-  showMain: () => void;
-  showError: (error: { title: string; description: string }) => void;
-  showException: (err: Error) => void;
-};
-
-export type RenderContext = RenderContextWithoutStoryContext & {
-  storyContext: StoryContext;
-};


### PR DESCRIPTION
Issue: #16839 

## What I did

Removed two types that weren't exported (as they were overwritten by the `export * from '@storybook/store'`) and weren't used internally.

## How to test

I think if it builds it is OK :)