### PR TITLE
Core: Be explicit about `viewMode` to fix Vue issue

### DIFF
--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -147,6 +147,7 @@ const Story: FunctionComponent<StoryProps> = (props) => {
         story,
         renderContext,
         element: storyRef.current as HTMLElement,
+        viewMode: 'docs',
       });
       setShowLoader(false);
     }

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -562,7 +562,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       showException: (err: Error) => this.renderException(id, err),
     };
 
-    return this.renderStoryToElement({ story, renderContext, element });
+    return this.renderStoryToElement({ story, renderContext, element, viewMode: 'story' });
   }
 
   // Render a story into a given element and watch for the events that would trigger us
@@ -571,6 +571,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
     story,
     renderContext: renderContextWithoutStoryContext,
     element: canvasElement,
+    viewMode,
   }: {
     story: Story<TFramework>;
     renderContext: Omit<
@@ -578,6 +579,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       'storyContext' | 'storyFn' | 'unboundStoryFn' | 'forceRemount'
     >;
     element: HTMLElement;
+    viewMode: ViewMode;
   }): StoryCleanupFn {
     const { id, applyLoaders, unboundStoryFn, playFunction } = story;
 
@@ -609,7 +611,7 @@ export class PreviewWeb<TFramework extends AnyFramework> {
         await runPhase('loading', async () => {
           loadedContext = await applyLoaders({
             ...this.storyStore.getStoryContext(story),
-            viewMode: canvasElement === this.view.storyRoot() ? 'story' : 'docs',
+            viewMode,
           } as StoryContextForLoaders<TFramework>);
         });
         if (abortSignal.aborted) return;


### PR DESCRIPTION
Issue: #16862 

## What I did

Explicitly pass `viewMode` into `renderStoryToElement`, instead of trying to infer it from the `canvasElement`.

Vue is doing whacky (?) things and re-creating the `#root` element, but in any case, it is better to just be explicit I think.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?

Try changing globals in the `vue-cli` example. Also the E2E tests
