### PR TITLE
Angular: Fix support for non-roman alphabets in story titles

### DIFF
--- a/app/angular/src/client/preview/angular-beta/AbstractRenderer.ts
+++ b/app/angular/src/client/preview/angular-beta/AbstractRenderer.ts
@@ -108,7 +108,7 @@ export abstract class AbstractRenderer {
     parameters: Parameters;
     targetDOMNode: HTMLElement;
   }) {
-    const targetSelector = `${this.storyId}`;
+    const targetSelector = `${this.generateTargetSelectorFromStoryId()}`;
 
     const newStoryProps$ = new BehaviorSubject<ICollection>(storyFnAngular.props);
     const moduleMetadata = getStorybookModuleMetadata(
@@ -142,6 +142,26 @@ export abstract class AbstractRenderer {
       parameters.bootstrapModuleOptions ?? undefined
     );
     await this.afterFullRender();
+  }
+
+  /**
+   * Only ASCII alphanumerics can be used as HTML tag name.
+   * https://html.spec.whatwg.org/#elements-2
+   *
+   * Therefore, stories break when non-ASCII alphanumerics are included in target selector.
+   * https://github.com/storybookjs/storybook/issues/15147
+   *
+   * This method returns storyId when it doesn't contain any non-ASCII alphanumerics.
+   * Otherwise, it generates a valid HTML tag name from storyId by removing non-ASCII alphanumerics from storyId, prefixing "sb-", and suffixing "-component"
+   * @protected
+   * @memberof AbstractRenderer
+   */
+  protected generateTargetSelectorFromStoryId() {
+    const invalidHtmlTag = /[^A-Za-z0-9-]/g;
+    const storyIdIsInvalidHtmlTagName = invalidHtmlTag.test(this.storyId);
+    return storyIdIsInvalidHtmlTagName
+      ? `sb-${this.storyId.replace(invalidHtmlTag, '')}-component`
+      : this.storyId;
   }
 
   protected initAngularRootElement(targetDOMNode: HTMLElement, targetSelector: string) {

--- a/app/angular/src/client/preview/angular-beta/RendererFactory.test.ts
+++ b/app/angular/src/client/preview/angular-beta/RendererFactory.test.ts
@@ -239,6 +239,49 @@ describe('RendererFactory', () => {
 
       expect(countDestroy).toEqual(1);
     });
+
+    describe('when story id contains non-Ascii characters', () => {
+      it('should render my-story for story template', async () => {
+        const render = await rendererFactory.getRendererInstance(
+          'my-ストーリー',
+          rootTargetDOMNode
+        );
+        await render.render({
+          storyFnAngular: {
+            template: '🦊',
+            props: {},
+          },
+          forced: false,
+          parameters: {},
+          targetDOMNode: rootTargetDOMNode,
+        });
+
+        expect(document.body.getElementsByTagName('sb-my--component')[0].innerHTML).toBe('🦊');
+      });
+
+      it('should render my-story for story component', async () => {
+        @Component({ selector: 'foo', template: '🦊' })
+        class FooComponent {}
+
+        const render = await rendererFactory.getRendererInstance(
+          'my-ストーリー',
+          rootTargetDOMNode
+        );
+        await render.render({
+          storyFnAngular: {
+            props: {},
+          },
+          forced: false,
+          parameters: {},
+          component: FooComponent,
+          targetDOMNode: rootTargetDOMNode,
+        });
+
+        expect(document.body.getElementsByTagName('sb-my--component')[0].innerHTML).toBe(
+          '<foo>🦊</foo><!--container-->'
+        );
+      });
+    });
   });
 
   describe('DocsRenderer', () => {


### PR DESCRIPTION
Issue: #15147

## What I did
@storybook/angular uses story id as HTML tag. So using non-ascii characters in story title generates invalid HTML tag. I added a new method to create a valid HTML tag from story id. This method returns storyId when it doesn't contain any non-ASCII alphanumerics. Otherwise, it generates an HTML tag from storyId by removing non-ASCII alphanumerics from storyId, prefixing "sb-", and suffixing "-component"

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

My answer is no to all of these questions.  I added tests in `app/angular/src/client/preview/angular-beta/RendererFactory.test.ts` to test having non-ascii characters in story id  doesn't break stories now. 