### PR TITLE
UI: Only push the view back to Story if the viewMode is settings

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -293,9 +293,9 @@ export const init: ModuleFn = ({
             ? s.parameters.viewMode
             : viewModeFromState;
 
-        // If the viewMode is settings, we should go back to the 'story' view
-        // when navigating to another story.
-        if (viewMode === 'settings') {
+        // Some viewModes are not story-specific, and we should reset viewMode
+        //  to 'story' if one of those is active when navigating to another story
+        if (['settings', 'about', 'release'].includes(viewMode)) {
           viewMode = 'story';
         }
 

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -293,10 +293,9 @@ export const init: ModuleFn = ({
             ? s.parameters.viewMode
             : viewModeFromState;
 
-        // In some cases, the viewMode could be something other than docs/story
-        // ('settings', for example) and therefore we should make sure we go back
-        // to the 'story' viewMode when navigating away from those pages.
-        if (!viewMode.match(/docs|story/)) {
+        // If the viewMode is settings, we should go back to the 'story' view
+        // when navigating to another story.
+        if (viewMode === 'settings') {
           viewMode = 'story';
         }
 


### PR DESCRIPTION
Issue: #16518

Without this change, custom tabs are reset when switching stories, and they cannot be linked to.

it might be preferable to make this a list of tabs-that-should-be-reset, that can be added to when adding a tab via the api, but that's up to yourselves. i'm just a rabbit