### PR TITLE
Core: Ensure we have a full story index before caching

### DIFF
--- a/lib/store/src/StoryStore.test.ts
+++ b/lib/store/src/StoryStore.test.ts
@@ -281,7 +281,7 @@ describe('StoryStore', () => {
       const store = new StoryStore();
       store.setProjectAnnotations(projectAnnotations);
       store.initialize({ storyIndex, importFn, cache: false });
-      await store.cacheAllCSFFiles(false);
+      await store.cacheAllCSFFiles();
 
       await store.loadStory({ storyId: 'component-one--a' });
       expect(importFn).toHaveBeenCalledWith(storyIndex.stories['component-one--a'].importPath);
@@ -940,6 +940,22 @@ describe('StoryStore', () => {
             "v": 3,
           }
         `);
+      });
+    });
+  });
+
+  describe('cacheAllCsfFiles', () => {
+    describe('if the store is not yet initialized', () => {
+      it('waits for initialization', async () => {
+        const store = new StoryStore();
+
+        importFn.mockClear();
+        const cachePromise = store.cacheAllCSFFiles();
+
+        store.setProjectAnnotations(projectAnnotations);
+        store.initialize({ storyIndex, importFn, cache: false });
+
+        await expect(cachePromise).resolves.toEqual(undefined);
       });
     });
   });

--- a/lib/store/src/StoryStore.ts
+++ b/lib/store/src/StoryStore.ts
@@ -81,7 +81,7 @@ export class StoryStore<TFramework extends AnyFramework> {
 
   prepareStoryWithCache: typeof prepareStory;
 
-  initializationPromise: Promise<void>;
+  initializationPromise: SynchronousPromise<void>;
 
   resolveInitializationPromise: () => void;
 
@@ -175,9 +175,11 @@ export class StoryStore<TFramework extends AnyFramework> {
   }
 
   cacheAllCSFFiles(): PromiseLike<void> {
-    return this.loadAllCSFFiles().then((csfFiles) => {
-      this.cachedCSFFiles = csfFiles;
-    });
+    return this.initializationPromise.then(() =>
+      this.loadAllCSFFiles().then((csfFiles) => {
+        this.cachedCSFFiles = csfFiles;
+      })
+    );
   }
 
   // Load the CSF file for a story and prepare the story from it and the project annotations.


### PR DESCRIPTION
See https://github.com/storybookjs/storybook/issues/16877#issuecomment-987571692

## What I did

Ensure we wait on the index before trying to cache.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

Yes see unit test