### PR TITLE
Remove IE 11 from ES6 modules transpilation targets

### DIFF
--- a/lib/core-common/src/utils/es6Transpiler.ts
+++ b/lib/core-common/src/utils/es6Transpiler.ts
@@ -50,7 +50,7 @@ export const es6Transpiler: () => RuleSetRule = () => {
                 shippedProposals: true,
                 modules: false,
                 loose: true,
-                targets: 'defaults',
+                targets: 'defaults, not ie 11',
               },
             ],
             require.resolve('@babel/preset-react'),

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-dev
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-dev
@@ -174,7 +174,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod
@@ -174,7 +174,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-dev
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-dev
@@ -175,7 +175,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-prod
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-prod
@@ -175,7 +175,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev
@@ -173,7 +173,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod
@@ -172,7 +172,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_manager-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_manager-dev
@@ -176,7 +176,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_manager-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_manager-prod
@@ -176,7 +176,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev
@@ -174,7 +174,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod
@@ -173,7 +173,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-dev
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-dev
@@ -176,7 +176,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-prod
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-prod
@@ -176,7 +176,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev
@@ -174,7 +174,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod
@@ -173,7 +173,7 @@ Object {
                     "loose": true,
                     "modules": false,
                     "shippedProposals": true,
-                    "targets": "defaults",
+                    "targets": "defaults, not ie 11",
                   },
                 ],
                 "NODE_MODULES/@babel/preset-react/lib/index.js",


### PR DESCRIPTION
Issue: #16820 

## What I did

Remove `ie 11` from `es6Transpiler` targets.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

To fix weird behavior described at #16820 , I've tested many approaches in my local environment (technically modifying codes in `node_modules`). I've not yet created useful repro to validate this solution.

Clearly, this bug is caused when `babel-loader` tries to parse `prettier/standalone.js` in `es6Transpiler` processing. And `prettier/standalone.js` is truly valid JS file. So, the problem is the incompatibility between `prettier/standalone.js` and the babel config written in `es6Transpiler`.

I've tested some patterns of `targets` in `@babel/preset-env` options. Currently `es6Transpiler` uses `defaults` targets. If I remove only `ie 11`, errors went away. So I conclude targeting `ie 11` is not compatible with `prettier/standalone.js`. 

cc/ @shilman 


