### PR TITLE
bug: do not stuck if story name starts with "settings"

### DIFF
--- a/lib/ui/src/app.tsx
+++ b/lib/ui/src/app.tsx
@@ -48,7 +48,7 @@ const App = React.memo<AppProps>(
             key: 'settings',
             render: () => <SettingsPages />,
             route: (({ children }) => (
-              <Route path="/settings" startsWith>
+              <Route path="/settings/" startsWith>
                 {children}
               </Route>
             )) as FunctionComponent,


### PR DESCRIPTION
Issue: #14718

## What I did
I added a trailing slash to avoid conflicts with stories that contain "settings" in their name.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
