### PR TITLE
Addon-docs: Add `extractSnippet` parameter

### DIFF
--- a/addons/docs/src/blocks/getSnippet.test.ts
+++ b/addons/docs/src/blocks/getSnippet.test.ts
@@ -1,0 +1,55 @@
+import { Story } from '@storybook/store';
+
+import { getSnippet } from './getSnippet';
+import { SourceType } from '../shared';
+
+const snippet = 'snippet';
+
+describe('addon-docs getSnippet', () => {
+  it('should return snippet when there is no story.', () => {
+    expect(getSnippet(snippet)).toBe(snippet);
+  });
+
+  it('should return user defined code when it exists.', () => {
+    const userDefinedCode = 'user-defined-code';
+    const story: Story<any> = ({
+      parameters: {
+        docs: {
+          source: {
+            code: userDefinedCode,
+          },
+        },
+      },
+    } as unknown) as Story<any>;
+    expect(getSnippet(snippet, story)).toBe(userDefinedCode);
+  });
+
+  describe('dynamic source type', () => {
+    it('should return snippet when transformSource does not exist.', () => {
+      const story: Story<any> = ({
+        parameters: {
+          docs: {
+            source: {
+              type: SourceType.DYNAMIC,
+            },
+          },
+        },
+      } as unknown) as Story<any>;
+      expect(getSnippet('', story)).toBe('');
+    });
+
+    it('should transform snippet when transformSource exists.', () => {
+      const story: Story<any> = ({
+        parameters: {
+          docs: {
+            transformSource: (val: string) => `${val}-transformed`,
+            source: {
+              type: SourceType.DYNAMIC,
+            },
+          },
+        },
+      } as unknown) as Story<any>;
+      expect(getSnippet(snippet, story)).toBe(`${snippet}-transformed`);
+    });
+  });
+});

--- a/addons/docs/src/blocks/getSnippet.ts
+++ b/addons/docs/src/blocks/getSnippet.ts
@@ -1,0 +1,34 @@
+import { Story } from '@storybook/store';
+import { SourceType } from '../shared';
+import { enhanceSource } from './enhanceSource';
+
+export const getSnippet = (snippet: string, story?: Story<any>): string => {
+  if (!story) {
+    return snippet;
+  }
+
+  const { parameters } = story;
+  // eslint-disable-next-line no-underscore-dangle
+  const isArgsStory = parameters.__isArgsStory;
+  const type = parameters.docs?.source?.type || SourceType.AUTO;
+
+  // if user has hard-coded the snippet, that takes precedence
+  const userCode = parameters.docs?.source?.code;
+  if (userCode !== undefined) {
+    return userCode;
+  }
+
+  // if user has explicitly set this as dynamic, use snippet
+  if (type === SourceType.DYNAMIC) {
+    return parameters.docs?.transformSource?.(snippet, story) || snippet;
+  }
+
+  // if this is an args story and there's a snippet
+  if (type === SourceType.AUTO && snippet && isArgsStory) {
+    return parameters.docs?.transformSource?.(snippet, story) || snippet;
+  }
+
+  // otherwise, use the source code logic
+  const enhanced = enhanceSource(story) || parameters;
+  return enhanced?.docs?.source?.code || '';
+};

--- a/addons/docs/src/frameworks/angular/config.ts
+++ b/addons/docs/src/frameworks/angular/config.ts
@@ -2,6 +2,7 @@ import { SourceType } from '../../shared';
 import { extractArgTypes, extractComponentDescription } from './compodoc';
 import { sourceDecorator } from './sourceDecorator';
 import { prepareForInline } from './prepareForInline';
+import { extractSnippet } from './extractSnippet';
 
 export const parameters = {
   docs: {
@@ -10,6 +11,7 @@ export const parameters = {
     prepareForInline,
     extractArgTypes,
     extractComponentDescription,
+    extractSnippet,
     source: {
       type: SourceType.DYNAMIC,
       language: 'html',

--- a/addons/docs/src/frameworks/angular/extractSnippet.ts
+++ b/addons/docs/src/frameworks/angular/extractSnippet.ts
@@ -1,0 +1,23 @@
+import { StoryContext, AngularFramework } from '@storybook/angular';
+import { BoundStory } from '@storybook/store';
+import { ArgsStoryFn } from '@storybook/csf';
+
+import { skipSourceRender, storyResultToSnippet } from './sourceDecorator';
+import { getSnippet } from '../../blocks/getSnippet';
+
+export const extractSnippet = async (
+  story: BoundStory<AngularFramework>,
+  context: StoryContext
+) => {
+  if (skipSourceRender(context)) {
+    return getSnippet('', story);
+  }
+
+  const storyResult = (context.originalStoryFn as ArgsStoryFn<AngularFramework>)(
+    context.args,
+    context
+  );
+
+  const storySnippet = await storyResultToSnippet(storyResult, context);
+  return getSnippet(storySnippet, story);
+};

--- a/addons/docs/src/frameworks/common/config.ts
+++ b/addons/docs/src/frameworks/common/config.ts
@@ -1,4 +1,5 @@
 import { enhanceArgTypes } from './enhanceArgTypes';
+import { extractSnippet } from './extractSnippet';
 
 export const parameters = {
   docs: {
@@ -6,6 +7,7 @@ export const parameters = {
     getContainer: async () => (await import('../../blocks')).DocsContainer,
     getPage: async () => (await import('../../blocks')).DocsPage,
     iframeHeight: 100,
+    extractSnippet,
   },
 };
 

--- a/addons/docs/src/frameworks/common/extractSnippet.ts
+++ b/addons/docs/src/frameworks/common/extractSnippet.ts
@@ -1,0 +1,7 @@
+import { Story } from '@storybook/store';
+
+import { getSnippet } from '../../blocks/getSnippet';
+
+export const extractSnippet = (story: Story<any>) => {
+  return getSnippet('', story);
+};

--- a/addons/docs/src/frameworks/html/config.ts
+++ b/addons/docs/src/frameworks/html/config.ts
@@ -1,6 +1,7 @@
 import { sourceDecorator } from './sourceDecorator';
 import { prepareForInline } from './prepareForInline';
 import { SourceType } from '../../shared';
+import { extractSnippet } from './extractSnippet';
 
 export const decorators = [sourceDecorator];
 
@@ -12,5 +13,6 @@ export const parameters = {
       type: SourceType.DYNAMIC,
       language: 'html',
     },
+    extractSnippet,
   },
 };

--- a/addons/docs/src/frameworks/html/extractSnippet.ts
+++ b/addons/docs/src/frameworks/html/extractSnippet.ts
@@ -1,0 +1,24 @@
+import { BoundStory } from '@storybook/store';
+import { ArgsStoryFn, StoryContext } from '@storybook/csf';
+import { HtmlFramework } from '@storybook/html';
+
+import { getSnippet } from '../../blocks/getSnippet';
+import { skipSourceRender, storyResultToSnippet } from './sourceDecorator';
+
+export const extractSnippet = (
+  story: BoundStory<HtmlFramework>,
+  context: StoryContext<HtmlFramework>
+) => {
+  if (skipSourceRender(context)) {
+    return getSnippet('', story);
+  }
+
+  const storyResult = (context.originalStoryFn as ArgsStoryFn<HtmlFramework>)(
+    context.args,
+    context
+  );
+
+  const storySnippet = storyResultToSnippet(storyResult, context);
+
+  return getSnippet(storySnippet, story);
+};

--- a/addons/docs/src/frameworks/html/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/html/sourceDecorator.ts
@@ -6,7 +6,7 @@ import { HtmlFramework } from '@storybook/html';
 
 import { SNIPPET_RENDERED, SourceType } from '../../shared';
 
-function skipSourceRender(context: StoryContext<HtmlFramework>) {
+export function skipSourceRender(context: StoryContext<HtmlFramework>) {
   const sourceParams = context?.parameters.docs?.source;
   const isArgsStory = context?.parameters.__isArgsStory;
 
@@ -32,6 +32,25 @@ function applyTransformSource(source: string, context: StoryContext<HtmlFramewor
   return transformSource(source, context);
 }
 
+export function storyResultToSnippet(
+  storyResult: HtmlFramework['storyResult'],
+  context: StoryContext<HtmlFramework>
+) {
+  let source;
+  if (typeof storyResult === 'string') {
+    source = storyResult;
+  }
+  // eslint-disable-next-line no-undef
+  else if (storyResult instanceof Element) {
+    source = storyResult.outerHTML;
+  }
+
+  if (source) {
+    return applyTransformSource(source, context);
+  }
+  return '';
+}
+
 export function sourceDecorator(
   storyFn: PartialStoryFn<HtmlFramework>,
   context: StoryContext<HtmlFramework>
@@ -42,15 +61,7 @@ export function sourceDecorator(
 
   let source: string;
   if (!skipSourceRender(context)) {
-    if (typeof story === 'string') {
-      source = story;
-    }
-    // eslint-disable-next-line no-undef
-    else if (story instanceof Element) {
-      source = story.outerHTML;
-    }
-
-    if (source) source = applyTransformSource(source, context);
+    source = storyResultToSnippet(story, context);
   }
   useEffect(() => {
     if (source) addons.getChannel().emit(SNIPPET_RENDERED, context.id, source);

--- a/addons/docs/src/frameworks/react/config.ts
+++ b/addons/docs/src/frameworks/react/config.ts
@@ -4,12 +4,14 @@ import { ReactFramework } from '@storybook/react';
 import { extractArgTypes } from './extractArgTypes';
 import { extractComponentDescription } from '../../lib/docgen';
 import { jsxDecorator } from './jsxDecorator';
+import { extractSnippet } from './extractSnippet';
 
 export const parameters = {
   docs: {
     inlineStories: true,
     // NOTE: that the result is a react element. Hooks support is provided by the outer code.
     prepareForInline: (storyFn: PartialStoryFn<ReactFramework>) => storyFn(),
+    extractSnippet,
     extractArgTypes,
     extractComponentDescription,
   },

--- a/addons/docs/src/frameworks/react/extractSnippet.ts
+++ b/addons/docs/src/frameworks/react/extractSnippet.ts
@@ -1,0 +1,20 @@
+import { ReactFramework } from '@storybook/react';
+
+import { BoundStory } from '@storybook/store';
+import { ArgsStoryFn, StoryContext } from '@storybook/csf';
+import { jsxToSnippet, skipJsxRender } from './jsxDecorator';
+import { getSnippet } from '../../blocks/getSnippet';
+
+export const extractSnippet = (
+  story: BoundStory<ReactFramework>,
+  context: StoryContext<ReactFramework>
+) => {
+  if (skipJsxRender(context)) {
+    return getSnippet('', story);
+  }
+
+  const jsx = (context.originalStoryFn as ArgsStoryFn<ReactFramework>)(context.args, context);
+
+  const storySnippet = jsxToSnippet(jsx, context);
+  return getSnippet(storySnippet, story);
+};

--- a/addons/docs/src/frameworks/svelte/config.ts
+++ b/addons/docs/src/frameworks/svelte/config.ts
@@ -2,6 +2,7 @@ import { extractArgTypes } from './extractArgTypes';
 import { extractComponentDescription } from './extractComponentDescription';
 import { prepareForInline } from './prepareForInline';
 import { sourceDecorator } from './sourceDecorator';
+import { extractSnippet } from './extractSnippet';
 
 export const parameters = {
   docs: {
@@ -9,6 +10,7 @@ export const parameters = {
     prepareForInline,
     extractArgTypes,
     extractComponentDescription,
+    extractSnippet,
   },
 };
 

--- a/addons/docs/src/frameworks/svelte/extractSnippet.ts
+++ b/addons/docs/src/frameworks/svelte/extractSnippet.ts
@@ -1,0 +1,17 @@
+import { BoundStory } from '@storybook/store';
+import { ArgsStoryFn, StoryContext } from '@storybook/csf';
+
+import { getSnippet } from '../../blocks/getSnippet';
+import { skipSourceRender, storyResultToSnippet } from './sourceDecorator';
+
+export const extractSnippet = (story: BoundStory, context: StoryContext) => {
+  if (skipSourceRender(context)) {
+    return getSnippet('', story);
+  }
+
+  const storyResult = (context.originalStoryFn as ArgsStoryFn)(context.args, context);
+
+  const storySnippet = storyResultToSnippet(storyResult, context);
+
+  return getSnippet(storySnippet, story);
+};

--- a/addons/docs/src/frameworks/svelte/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/svelte/sourceDecorator.ts
@@ -8,7 +8,7 @@ import { SourceType, SNIPPET_RENDERED } from '../../shared';
  *
  * @param context StoryContext
  */
-const skipSourceRender = (context: StoryContext<AnyFramework>) => {
+export const skipSourceRender = (context: StoryContext<AnyFramework>) => {
   const sourceParams = context?.parameters.docs?.source;
   const isArgsStory = context?.parameters.__isArgsStory;
 
@@ -139,6 +139,18 @@ function getWrapperProperties(component: any) {
   return { wrapper: true, slotProperty: slotProp?.name as string };
 }
 
+export const storyResultToSnippet = (storyResult: any, context: StoryContext<AnyFramework>) => {
+  const { parameters = {}, args = {} } = context || {};
+  let { Component: component = {} } = storyResult;
+
+  const { wrapper, slotProperty } = getWrapperProperties(component);
+  if (wrapper) {
+    component = parameters.component;
+  }
+
+  return generateSvelteSource(component, args, context?.argTypes, slotProperty);
+};
+
 /**
  * Svelte source decorator.
  * @param storyFn Fn
@@ -160,15 +172,7 @@ export const sourceDecorator = (storyFn: any, context: StoryContext<AnyFramework
     return story;
   }
 
-  const { parameters = {}, args = {} } = context || {};
-  let { Component: component = {} } = story;
-
-  const { wrapper, slotProperty } = getWrapperProperties(component);
-  if (wrapper) {
-    component = parameters.component;
-  }
-
-  source = generateSvelteSource(component, args, context?.argTypes, slotProperty);
+  source = storyResultToSnippet(story, context);
 
   return story;
 };

--- a/addons/docs/src/frameworks/vue/config.ts
+++ b/addons/docs/src/frameworks/vue/config.ts
@@ -2,6 +2,7 @@ import { extractArgTypes } from './extractArgTypes';
 import { extractComponentDescription } from '../../lib/docgen';
 import { prepareForInline } from './prepareForInline';
 import { sourceDecorator } from './sourceDecorator';
+import { extractSnippet } from './extractSnippet';
 
 export const parameters = {
   docs: {
@@ -9,6 +10,7 @@ export const parameters = {
     prepareForInline,
     extractArgTypes,
     extractComponentDescription,
+    extractSnippet,
   },
 };
 

--- a/addons/docs/src/frameworks/vue/extractSnippet.ts
+++ b/addons/docs/src/frameworks/vue/extractSnippet.ts
@@ -1,0 +1,35 @@
+import { BoundStory } from '@storybook/store';
+import { StoryContext } from '@storybook/csf';
+import Vue from 'vue';
+
+import { VueFramework } from '@storybook/vue';
+import { getSnippet } from '../../blocks/getSnippet';
+import { skipSourceRender, storyResultToSnippet } from './sourceDecorator';
+
+export const extractSnippet = async (
+  story: BoundStory<VueFramework>,
+  context: StoryContext<VueFramework>
+) => {
+  if (skipSourceRender(context)) {
+    return getSnippet('', story);
+  }
+
+  const storyResult = story.storyFn();
+
+  // Mounting vue component is a costly operation, but we need to do it to get the snippet.
+  // TODO: We should be able to get the snippet without mounting the component.
+  const vm = new Vue({
+    data() {
+      return {
+        STORYBOOK_VALUES: context.args,
+      };
+    },
+    render(h) {
+      return h(storyResult);
+    },
+  }).$mount();
+
+  const storySnippet = await storyResultToSnippet(storyResult, vm);
+
+  return getSnippet(storySnippet, story);
+};

--- a/addons/docs/src/frameworks/web-components/config.ts
+++ b/addons/docs/src/frameworks/web-components/config.ts
@@ -2,6 +2,7 @@ import { extractArgTypes, extractComponentDescription } from './custom-elements'
 import { sourceDecorator } from './sourceDecorator';
 import { prepareForInline } from './prepareForInline';
 import { SourceType } from '../../shared';
+import { extractSnippet } from './extractSnippet';
 
 export const decorators = [sourceDecorator];
 
@@ -9,6 +10,7 @@ export const parameters = {
   docs: {
     extractArgTypes,
     extractComponentDescription,
+    extractSnippet,
     inlineStories: true,
     prepareForInline,
     source: {

--- a/addons/docs/src/frameworks/web-components/extractSnippet.ts
+++ b/addons/docs/src/frameworks/web-components/extractSnippet.ts
@@ -1,0 +1,24 @@
+import { BoundStory } from '@storybook/store';
+import { ArgsStoryFn, StoryContext } from '@storybook/csf';
+import { WebComponentsFramework } from '@storybook/web-components';
+
+import { getSnippet } from '../../blocks/getSnippet';
+import { skipSourceRender, storyResultToSnippet } from './sourceDecorator';
+
+export const extractSnippet = (
+  story: BoundStory<WebComponentsFramework>,
+  context: StoryContext<WebComponentsFramework>
+) => {
+  if (skipSourceRender(context)) {
+    return getSnippet('', story);
+  }
+
+  const storyResult = (context.originalStoryFn as ArgsStoryFn<WebComponentsFramework>)(
+    context.args,
+    context
+  );
+
+  const storySnippet = storyResultToSnippet(storyResult, context);
+
+  return getSnippet(storySnippet, story);
+};

--- a/addons/docs/src/frameworks/web-components/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/web-components/sourceDecorator.ts
@@ -6,7 +6,7 @@ import { WebComponentsFramework } from '@storybook/web-components';
 
 import { SNIPPET_RENDERED, SourceType } from '../../shared';
 
-function skipSourceRender(context: StoryContext<WebComponentsFramework>) {
+export function skipSourceRender(context: StoryContext<WebComponentsFramework>) {
   const sourceParams = context?.parameters.docs?.source;
   const isArgsStory = context?.parameters.__isArgsStory;
 
@@ -29,6 +29,15 @@ function applyTransformSource(
   return transformSource(source, context);
 }
 
+export function storyResultToSnippet(
+  storyResult: WebComponentsFramework['storyResult'],
+  context: StoryContext<WebComponentsFramework>
+) {
+  const container = window.document.createElement('div');
+  render(storyResult, container);
+  return applyTransformSource(container.innerHTML.replace(/<!---->/g, ''), context);
+}
+
 export function sourceDecorator(
   storyFn: PartialStoryFn<WebComponentsFramework>,
   context: StoryContext<WebComponentsFramework>
@@ -42,9 +51,7 @@ export function sourceDecorator(
     if (source) addons.getChannel().emit(SNIPPET_RENDERED, context.id, source);
   });
   if (!skipSourceRender(context)) {
-    const container = window.document.createElement('div');
-    render(story, container);
-    source = applyTransformSource(container.innerHTML.replace(/<!---->/g, ''), context);
+    source = storyResultToSnippet(story, context);
   }
 
   return story;


### PR DESCRIPTION
Issue:

## What I did

I added `extractSnippet` function to docs addon, so other addons can get the snippet by calling `parameters.docs.extractSnippet`

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? (Mostly)
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
