### PR TITLE
Core: Fix debug output on webpack failures

### DIFF
--- a/lib/core-server/src/build-dev.ts
+++ b/lib/core-server/src/build-dev.ts
@@ -99,11 +99,11 @@ export async function buildDevStandalone(options: CLIOptions & LoadOptions & Bui
   if (options.smokeTest) {
     // @ts-ignore
     const managerWarnings = (managerStats && managerStats.toJson().warnings) || [];
-    if (managerWarnings.length > 0) logger.warn(`manager: ${managerWarnings}`);
+    if (managerWarnings.length > 0) logger.warn(`manager: ${JSON.stringify(managerWarnings, null, 2)}`);
     // I'm a little reticent to import webpack types in this file :shrug:
     // @ts-ignore
     const previewWarnings = (previewStats && previewStats.toJson().warnings) || [];
-    if (previewWarnings.length > 0) logger.warn(`preview: ${previewWarnings}`);
+    if (previewWarnings.length > 0) logger.warn(`preview: ${JSON.stringify(previewWarnings, null, 2)}`);
     process.exit(
       managerWarnings.length > 0 || (previewWarnings.length > 0 && !options.ignorePreview) ? 1 : 0
     );


### PR DESCRIPTION
@shilman - re: [our conversations](https://github.com/redwoodjs/redwood/pull/3515#issuecomment-984942484) over @ redwood.js

> the debug output needs to be fixed

This PR is meant to address fixing the debug output.

Issue:

Manager and preview warnings currently print `[object Object]`.

e.g.
```sh
...
WARN preview: [object Object]
...
```

## What I did

Make sure to `JSON.stringify` logged debug output when running  using the `--ci --smoke-test` [CLI options](https://storybook.js.org/docs/react/api/cli-options)

This change now results in warning output such as:

```sh
...
WARN preview: [
WARN   {
WARN     "message": "DefinePlugin\nConflicting values for 'process.env'",
WARN     "details": "'{NODE_ENV: \"development\", NODE_PATH: [], STORYBOOK: \"true\", PUBLIC_URL: \".\"}' !== '\"MISSING_ENV_VAR\"'",
WARN     "stack": "Error: DefinePlugin\nConflicting values for 'process.env'\n    at /workspace/rw-test-app/node_modules/webpack/lib/DefinePlugin.js:573:24\n    at Array.forEach (<anonymous>)\n    at walkDefinitionsForValues (/workspace/rw-test-app/node_modules/webpack/lib/DefinePlugin.js:564:31)\n    at /workspace/rw-test-app/node_modules/webpack/lib/DefinePlugin.js:591:5\n    at Hook.eval [as call] (eval at create (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:291:1)\n    at Hook.CALL_DELEGATE [as _call] (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/Hook.js:14:14)\n    at Compiler.newCompilation (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/Compiler.js:1053:26)\n    at /workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/Compiler.js:1097:29\n    at Hook.eval [as callAsync] (eval at create (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:40:1)\n    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/Hook.js:18:14)\n    at Compiler.compile (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/Compiler.js:1092:28)\n    at /workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/Watching.js:200:19\n    at _next0 (eval at create (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)\n    at eval (eval at create (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:40:1)\n    at watchRunHook (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack-virtual-modules/lib/index.js:236:13)\n    at Hook.eval [as callAsync] (eval at create (/workspace/rw-test-app/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:34:1)"
WARN   }
WARN ]
...
```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
