### PR TITLE
Angular: Fix for renamed method in angular 13.1

### DIFF
--- a/app/angular/src/server/angular-cli-webpack-13.x.x.js
+++ b/app/angular/src/server/angular-cli-webpack-13.x.x.js
@@ -5,6 +5,7 @@ const {
 const {
   getCommonConfig,
   getStylesConfig,
+  getDevServerConfig,
   getTypescriptWorkerPlugin,
 } = require('@angular-devkit/build-angular/src/webpack/configs');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
@@ -41,7 +42,11 @@ exports.getWebpackConfig = async (baseConfig, { builderOptions, builderContext }
       aot: false,
     },
     builderContext,
-    (wco) => [getCommonConfig(wco), getStylesConfig(wco), getTypescriptWorkerPlugin(wco)]
+    (wco) => [
+      getCommonConfig(wco),
+      getStylesConfig(wco),
+      getTypescriptWorkerPlugin ? getTypescriptWorkerPlugin(wco) : getDevServerConfig(wco),
+    ]
   );
 
   /**


### PR DESCRIPTION
Issue: #16977
Broken build when on Angular v. `13,1`

--> comment: [https://github.com/storybookjs/storybook/issues/16977#issuecomment-990965784](https://github.com/storybookjs/storybook/issues/16977#issuecomment-990965784)

Quoting comment:
_The problem is that in angular 13.1 the function `getTypescriptWorkerPlugin` changed names to `getDevServerConfig`
I was able to get it running by replacing all occurances of `getTypescriptWorkerPlugin`_

## What I did
Renamed the method to the new name -  it's a bit ugly because it's using a ternary to see if old one exists - if not use new one. More proper way would be to check Angular version from lock file I guess...

## How to test

Storybook for Angular `13.1` can now run without throwing the error `TypeError: getTypescriptWorkerPlugin is not a function`.

### Disclaimer
I am not sure if we would need to add an extra check of the Angular version that's actually installed..
