### PR TITLE
Build: Tighten github action unit test triggers

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -12,7 +12,6 @@ jobs:
     name: Core Unit Tests node-${{ matrix.node_version }}, ${{ matrix.os }}
     if: |
       ${{ github.event.label.name == 'ci:matrix' || 
-      contains(github.event.pull_request.labels.*.name, 'ci:matrix') ||
       github.event.type == 'push'}}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Issue: N/A

## What I did

Github unit tests incorrectly running on each PR, so trying to fix that by removing one of the closes

Self-merging @IanVS 

## How to test

- [ ] Does a new PR run the GH unit tests after this is merged?