### PR TITLE
Button story with args snippets for html framework

### DIFF
--- a/docs/get-started/whats-a-story.md
+++ b/docs/get-started/whats-a-story.md
@@ -56,6 +56,7 @@ The above story definition can be further improved to take advantage of [Storybo
     'svelte/button-story-with-args.native-format.mdx',
     'svelte/button-story-with-args.mdx.mdx',
     'html/button-story-with-args.js.mdx',
+    'html/button-story-with-args.ts.mdx',
   ]}
 />
 

--- a/docs/get-started/whats-a-story.md
+++ b/docs/get-started/whats-a-story.md
@@ -55,6 +55,7 @@ The above story definition can be further improved to take advantage of [Storybo
     'svelte/button-story-with-args.js.mdx',
     'svelte/button-story-with-args.native-format.mdx',
     'svelte/button-story-with-args.mdx.mdx',
+    'html/button-story-with-args.js.mdx',
   ]}
 />
 

--- a/docs/snippets/html/button-story-with-args.js.mdx
+++ b/docs/snippets/html/button-story-with-args.js.mdx
@@ -1,0 +1,27 @@
+```js
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Button',
+};
+
+//👇 We create a “template” of how args map to rendering
+const Template = (args) => {
+  const btn = document.createElement('button');
+  btn.innerText = args.label;
+
+  const mode = args.primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  btn.className = ['storybook-button', 'storybook-button--medium', mode].join(' ');
+
+  return btn;
+};
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});
+Primary.args = {
+  primary: true,
+  label: 'Button',
+};
+```

--- a/docs/snippets/html/button-story-with-args.ts.mdx
+++ b/docs/snippets/html/button-story-with-args.ts.mdx
@@ -1,0 +1,29 @@
+```ts
+import { Meta, StoryFn } from '@storybook/html';
+
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Button',
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: StoryFn = (args): HTMLButtonElement => {
+  const btn = document.createElement('button');
+  btn.innerText = args.label;
+
+  const mode = args.primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  btn.className = ['storybook-button', 'storybook-button--medium', mode].join(' ');
+
+  return btn;
+};
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});
+Primary.args = {
+  primary: true,
+  label: 'Button',
+};
+```


### PR DESCRIPTION
## What I did
I've add `button-story-with-args` code snippets to `what-a-story.md` documentation for `html` framework. Code snippets contain javascript and typescript versions of `button-story-with-args` snippet.

## How to test
It's possible to test by using [frontpage repo ](https://github.com/storybookjs/frontpage) with a link to docs in current branch. 
1. Follow the instructions from [preview your work documentation](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) to start frontpage server
2. Open in browser http://localhost:8000/docs/html/get-started/whats-a-story to see how code snippets will be displayed on a webpage
