### PR TITLE
Fix converting enum type for number literal

### DIFF
--- a/addons/docs/src/lib/convert/convert.test.ts
+++ b/addons/docs/src/lib/convert/convert.test.ts
@@ -603,9 +603,9 @@ describe('storybook type system', () => {
           "oneOfNumber": {
             "name": "enum",
             "value": [
-              "1",
-              "2",
-              "3"
+              1,
+              2,
+              3
             ]
           },
           "oneOfString": {

--- a/addons/docs/src/lib/convert/proptypes/convert.ts
+++ b/addons/docs/src/lib/convert/proptypes/convert.ts
@@ -2,7 +2,7 @@
 import mapValues from 'lodash/mapValues';
 import { SBType } from '@storybook/csf';
 import { PTType } from './types';
-import { trimQuotes } from '../utils';
+import { QUOTE_REGEX, trimQuotes } from '../utils';
 
 const SIGNATURE_REGEXP = /^\(.*\) => /;
 
@@ -13,7 +13,14 @@ export const convert = (type: PTType): SBType | any => {
 
   switch (name) {
     case 'enum': {
-      const values = computed ? value : value.map((v: PTType) => trimQuotes(v.value));
+      const values = computed
+        ? value
+        : value.map((v: PTType) => {
+            if (QUOTE_REGEX.test(v.value)) {
+              return trimQuotes(v.value);
+            }
+            return Number(v.value);
+          });
       return { ...base, name, value: values };
     }
     case 'string':

--- a/addons/docs/src/lib/convert/utils.ts
+++ b/addons/docs/src/lib/convert/utils.ts
@@ -1,2 +1,2 @@
-const QUOTE_REGEX = /^['"]|['"]$/g;
+export const QUOTE_REGEX = /^['"]|['"]$/g;
 export const trimQuotes = (str: string) => str.replace(QUOTE_REGEX, '');


### PR DESCRIPTION
Issue:

When selecting auto-generated control for number literals enum, it gives string type instead of number type
![image](https://user-images.githubusercontent.com/12604726/147811047-356be5f5-2bc6-4ce3-9b13-bc085cced038.png)

## What I did
While converting enum, there are two types: string and number.

Both string literals and number literals' values are string type.
We should cast the type of number literal values to fix this issue.
Then, how can we distinguish string literal and number literal? : The value of string literals has double quotes(") but value of number literals doesn't. (e.g. string -> value: ['"string1"', '"string2"'], number -> value: ['1', '2'])

Converting logic already has trimming double quotes from string literal. I just added converting the type of value into number type when the value does not have double quotes. 

I also update the test file for the `convert` method.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
