### PR TITLE
Add core-js dependency in instrumenter

### DIFF
--- a/lib/instrumenter/package.json
+++ b/lib/instrumenter/package.json
@@ -43,6 +43,7 @@
     "@storybook/addons": "6.5.0-alpha.7",
     "@storybook/client-logger": "6.5.0-alpha.7",
     "@storybook/core-events": "6.5.0-alpha.7",
+    "core-js": "^3.8.2",
     "global": "^4.4.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10446,6 +10446,7 @@ __metadata:
     "@storybook/addons": 6.5.0-alpha.7
     "@storybook/client-logger": 6.5.0-alpha.7
     "@storybook/core-events": 6.5.0-alpha.7
+    core-js: ^3.8.2
     global: ^4.4.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Issue:

We are using [midgard-yarn-strict](https://github.com/VincentBailly/midgard-yarn-strict) package manager which ensures each package is a self contained unit and doesn’t have any phantom dependency which may be resolved by other packages or the parent due to package hoisting. When adding a dependency on storybook/testing-library we experienced following error on storybook build

```
| info => Manager built (49 s)
 |  | ERR! => Failed to build the preview
 |  | ERR! Module not found: Error: Can't resolve 'core-js/modules/es.object.to-string.js' in 'FILE_PATH\@storybook-instrumenter@6.4.0-rc.5-704a39f34529f4efe28e\node_modules\@storybook\instrumenter\dist\esm'
 |  | ERR! ModuleNotFoundError: Module not found: Error: Can't resolve 'core-js/modules/es.object.to-string.js' in 'FILE_PATH\@storybook-instrumenter@6.4.0-rc.5-704a39f34529f4efe28e\node_modules\@storybook\instrumenter\dist\esm'
 |  | ERR!     at FILE_PATH\webpack@4.46.0-ff2cd76973c1d47b60d8\node_modules\webpack\lib\Compilation.js:925:10
 |  | ERR!     at FILE_PATH\webpack@4.46.0-ff2cd76973c1d47b60d8\node_modules\webpack\lib\NormalModuleFactory.js:401:22
 |  | ERR!     at FILE_PATH\webpack@4.46.0-ff2cd76973c1d47b60d8\node_modules\webpack\lib\NormalModuleFactory.js:130:21
```

However, adding `core-js` as an extraDependency fixed the issue, so it seems we could resolve the problem on storybook level by adding `core-js` as dependency of the instrumenter.

## What I did

Add core-js as the dependency of instrumenter

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

