### PR TITLE
Fix require used in virtualModuleModernEntry template

### DIFF
--- a/lib/builder-webpack5/src/preview/virtualModuleModernEntry.js.handlebars
+++ b/lib/builder-webpack5/src/preview/virtualModuleModernEntry.js.handlebars
@@ -11,8 +11,8 @@ import { importFn } from './{{storiesFilename}}';
 
 const { SERVER_CHANNEL_URL } = global;
 
-const getProjectAnnotations = () =>
-  composeConfigs([{{#each configs}}require('{{this}}'),{{/each}}]);
+const getProjectAnnotations = async () =>
+  composeConfigs(await Promise.all([{{#each configs}}import('{{this}}'),{{/each}}]));
 
 const channel = createPostMessageChannel({ page: 'preview' });
 addons.setChannel(channel);


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/14877

When **package.json** contains `{ "type": "module" }`, the build fails with `Uncaught ReferenceError: require is not defined`.

## What I did

Used `async/await` to import all configuration files in bulk, maintaining the same functionality.

We'd still need to ensure that all the imported files have their extension specified (`.js`).
