### PR TITLE
Gotcha about chromatic publish not working

### DIFF
--- a/docs/writing-tests/visual-testing.md
+++ b/docs/writing-tests/visual-testing.md
@@ -40,7 +40,6 @@ npx chromatic --project-token <your-project-token>
  
 </div>
 
-
 ```shell
 Build 1 published.
 

--- a/docs/writing-tests/visual-testing.md
+++ b/docs/writing-tests/visual-testing.md
@@ -40,6 +40,13 @@ npx chromatic --project-token <your-project-token>
  
 </div>
 
+<div class="aside">
+ 
+ GOTCHA: If you're project has less than 2 commits chromatic publishing will fail while `Retrieving git information` add another commit and try again.
+ 
+</div>
+
+
 ```shell
 Build 1 published.
 

--- a/docs/writing-tests/visual-testing.md
+++ b/docs/writing-tests/visual-testing.md
@@ -40,18 +40,16 @@ npx chromatic --project-token <your-project-token>
  
 </div>
 
-<div class="aside">
- 
- GOTCHA: If you're project has less than 2 commits chromatic publishing will fail while `Retrieving git information` add another commit and try again.
- 
-</div>
-
 
 ```shell
 Build 1 published.
 
 View it online at https://www.chromatic.com/build?appId=...&number=1.
 ```
+
+<div class="aside">
+💡 Before running Chromatic's CLI ensure you have at least two commits added to the repository to prevent build failures, as Chromatic relies on a full Git history graph to establish the baselines. Read more about baselines in Chromatic's <a href="https://www.chromatic.com/docs/branching-and-baselines"> documentation</a>
+</div>
 
 When Chromatic finishes, it should have successfully deployed your Storybook and established the baselines (i.e., starting point) for all your component's stories. Additionally, providing you with a link to the published Storybook that you can share with your team to gather feedback.
 


### PR DESCRIPTION
New repos with less than 2 commits will fail due to the shallow clone test `Found only one commit
This typically means you've checked out a shallow copy of the Git repository,`

Issue:

## What I did

My chat from the chromatic intercom that pointed this out and helped me resolve the issue.

cli issue trying to install chromatic while following the storybook testing tutorial
taskbox git:(master) npx chromatic --project-token=40bc0fc490f8
Chromatic CLI v6.3.3
https://www.chromatic.com/docs/cli
✔ Authenticated with Chromatic
→ Using project token '********90f8'
✖ Retrieving git information
→ Refer to your CI provider's documentation for details.
Collect Storybook metadata
Build Storybook
Publish your built Storybook
Verify your Storybook
Test your stories
✖ Failed to retrieve git information
✖ Found only one commit
This typically means you've checked out a shallow copy of the Git repository, which some CI systems do by default.
In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
Refer to your CI provider's documentation for details.
→ View the full stacktrace below
If you need help, please chat with us at https://www.chromatic.com/docs/cli for the fastest response.
You can also email the team at support@chromatic.com if chat is not an option.
Please provide us with the above CLI output and the following info:
{
"timestamp": "2022-01-03T01:55:06.683Z",
"sessionId": "5b14b470-bc2b-4aa7-904b-6143d02a71cf",
"nodePlatform": "darwin",
"nodeVersion": "14.18.1",
"packageName": "chromatic",
"packageVersion": "6.3.3",
"flags": {
"projectToken": [
"40bc0fc490f8"
],
"appCode": [],
"outputDir": [],
"storybookBuildDir": [],
"untraced": [],
"externals": [],
"interactive": true
},
"buildScript": "build-storybook -s public",
"errorType": "Error",
"errorMessage": "✖ Failed to retrieve git information"
}
Error: ✖ Failed to retrieve git information
✖ Found only one commit
This typically means you've checked out a shallow copy of the Git repository, which some CI systems do by default.
In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
Refer to your CI provider's documentation for details.
at /Users/cabbiepete/development/taskbox/node_modules/chromatic/bin/main.cjs:95:1602
at processTicksAndRejections (internal/process/task_queues.js:95:5)
at async wt.steps (/Users/cabbiepete/development/taskbox/node_modules/chromatic/bin/main.cjs:95:1089)
at async e.exports.task (/Users/cabbiepete/development/taskbox/node_modules/chromatic/bin/main.cjs:70:11136)
Operator profile
Thanks we'll get back to you as soon as we can.
Michael profile
Hi Peter, It looks like there is only one commit in your repo. Can you make another git commit and try again?
January 4
Thanks, interesting gotcha you guys should note this in the quick start or link to a FAQ about it. I'll see if I can do a PR for the storybook book tutorial
it works btw
14m ago. Not seen yet
We run on Intercom

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

Create a new repo and attempt `npx chromatic --project-token=<token>` expect failure, add 1 commit, try again another failure, add a 2nd commit try again expect success.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
