### PR TITLE
Chore: (Docs) Updates to the sidebar toc file

### DIFF
--- a/docs/toc.js
+++ b/docs/toc.js
@@ -197,6 +197,105 @@ module.exports = {
       ],
     },
     {
+      title: '🧩 Essential addons',
+      pathSegment: 'essentials',
+      type: 'menu',
+      children: [
+        {
+          pathSegment: 'introduction',
+          title: 'Introduction',
+          type: 'link',
+        },
+        {
+          pathSegment: 'controls',
+          title: 'Controls',
+          type: 'link',
+        },
+        {
+          pathSegment: 'actions',
+          title: 'Actions',
+          type: 'link',
+        },
+        {
+          pathSegment: 'viewport',
+          title: 'Viewport',
+          type: 'link',
+        },
+        {
+          pathSegment: 'backgrounds',
+          title: 'Backgrounds',
+          type: 'link',
+        },
+        {
+          pathSegment: 'toolbars-and-globals',
+          title: 'Toolbars & globals',
+          type: 'link',
+        },
+        {
+          pathSegment: 'measure-and-outline',
+          title: 'Measure & Outline',
+          type: 'link',
+        },
+        {
+          pathSegment: 'interactions',
+          title: 'Interactions',
+          type: 'link',
+        },
+      ],
+    },
+    {
+      title: '🔧 Addons',
+      pathSegment: 'addons',
+      type: 'menu',
+      children: [
+        {
+          pathSegment: 'introduction',
+          title: 'Introduction',
+          type: 'link',
+        },
+        {
+          pathSegment: 'install-addons',
+          title: 'Install',
+          type: 'link',
+        },
+        {
+          pathSegment: 'writing-addons',
+          title: 'Write',
+          type: 'link',
+        },
+        {
+          pathSegment: 'configure-addons',
+          title: 'Configure addons',
+          type: 'link',
+        },
+        {
+          pathSegment: 'writing-presets',
+          title: 'Write a preset',
+          type: 'link',
+        },
+        {
+          pathSegment: 'addon-catalog',
+          title: 'Add to catalog',
+          type: 'link',
+        },
+        {
+          pathSegment: 'addon-types',
+          title: 'Types of addons',
+          type: 'link',
+        },
+        {
+          pathSegment: 'addon-knowledge-base',
+          title: 'Knowledge base',
+          type: 'link',
+        },
+        {
+          pathSegment: 'addons-api',
+          title: 'Addon API',
+          type: 'link',
+        },
+      ],
+    },
+    {
       title: '⚙️ Configure',
       pathSegment: 'configure',
       type: 'menu',
@@ -283,105 +382,6 @@ module.exports = {
         {
           pathSegment: 'environment-variables',
           title: 'Environment variables',
-          type: 'link',
-        },
-      ],
-    },
-    {
-      title: '🔧 Addons',
-      pathSegment: 'addons',
-      type: 'menu',
-      children: [
-        {
-          pathSegment: 'introduction',
-          title: 'Introduction',
-          type: 'link',
-        },
-        {
-          pathSegment: 'install-addons',
-          title: 'Install',
-          type: 'link',
-        },
-        {
-          pathSegment: 'writing-addons',
-          title: 'Write',
-          type: 'link',
-        },
-        {
-          pathSegment: 'configure-addons',
-          title: 'Configure addons',
-          type: 'link',
-        },
-        {
-          pathSegment: 'writing-presets',
-          title: 'Write a preset',
-          type: 'link',
-        },
-        {
-          pathSegment: 'addon-catalog',
-          title: 'Add to catalog',
-          type: 'link',
-        },
-        {
-          pathSegment: 'addon-types',
-          title: 'Types of addons',
-          type: 'link',
-        },
-        {
-          pathSegment: 'addon-knowledge-base',
-          title: 'Knowledge base',
-          type: 'link',
-        },
-        {
-          pathSegment: 'addons-api',
-          title: 'Addon API',
-          type: 'link',
-        },
-      ],
-    },
-    {
-      title: '🧩 Essential addons',
-      pathSegment: 'essentials',
-      type: 'menu',
-      children: [
-        {
-          pathSegment: 'introduction',
-          title: 'Introduction',
-          type: 'link',
-        },
-        {
-          pathSegment: 'controls',
-          title: 'Controls',
-          type: 'link',
-        },
-        {
-          pathSegment: 'actions',
-          title: 'Actions',
-          type: 'link',
-        },
-        {
-          pathSegment: 'viewport',
-          title: 'Viewport',
-          type: 'link',
-        },
-        {
-          pathSegment: 'backgrounds',
-          title: 'Backgrounds',
-          type: 'link',
-        },
-        {
-          pathSegment: 'toolbars-and-globals',
-          title: 'Toolbars & globals',
-          type: 'link',
-        },
-        {
-          pathSegment: 'measure-and-outline',
-          title: 'Measure & Outline',
-          type: 'link',
-        },
-        {
-          pathSegment: 'interactions',
-          title: 'Interactions',
           type: 'link',
         },
       ],


### PR DESCRIPTION
With this pull request, the documentation structure (i.e., the toc.js file) is organized to conciseness.

What was done:
- Moved the Essentials addons and Addons upwards in the hierarchy and one after the other. The reasoning behind this is that we start by introducing people to the Essentials addons and how to use them and immediately after that we let them know how to write their own Storybook addon.

@kylegach and @domyen are you both ok with this?