### PR TITLE
Chore: (Docs) Removes missing note from asides

### DIFF
--- a/docs/addons/addon-catalog.md
+++ b/docs/addons/addon-catalog.md
@@ -38,18 +38,26 @@ Customize your addon's appearance by adding the `storybook` property with the fo
 | `unsupportedFrameworks` | List of unsupported frameworks                            | `["vue"]`                             |
 | `supportedFrameworks`   | List of supported frameworks                              | `["react", "angular"]`                |
 
+Use the list below as a reference when filling in the values for both the `supportedFrameworks` and `unsupportedFrameworks` fields.
 
-Use the table below as a reference when filling in the values for both the `supportedFrameworks` and `unsupportedFrameworks` metadata properties.
-
-| react          | vue        | angular      |
-|----------------|------------|--------------|
-| web-components | ember      | html         |
-| mithril        | marko      | svelte       |
-| riot           | preact     | rax          |
-| aurelia        | marionette | react-native |
+- react
+- vue
+- angular
+- web-components
+- ember
+- html
+- mithril
+- marko
+- svelte
+- riot
+- preact
+- rax
+- aurelia
+- marionette
+- react-native
 
 <div class="aside">
-Note: Make sure to copy each item <strong>exactly</strong> as listed so that we can properly index your addon in our catalog.
+💡 Make sure to copy each item <strong>exactly</strong> as listed so that we can properly index your addon in our catalog.
 </div>
 
 ```json
@@ -67,8 +75,8 @@ Note: Make sure to copy each item <strong>exactly</strong> as listed so that we 
   "keywords": ["storybook-addons", "style", "debug", "layout", "css"],
   "storybook": {
     "displayName": "Outline",
-    "unsupportedFrameworks": ["Vue"],
-    "supportedFrameworks": ["React", "Angular"],
+    "unsupportedFrameworks": ["vue"],
+    "supportedFrameworks": ["react", "angular"],
     "icon": "https://yoursite.com/outline-icon.png"
   }
 }

--- a/docs/configure/babel.md
+++ b/docs/configure/babel.md
@@ -162,6 +162,8 @@ BABEL_SHOW_CONFIG_FOR=.storybook/preview.js yarn storybook
 
 When the command finishes running, it will display the available babel configuration for the `.storybook/preview.js` file. You can use this information to debug issues with transpilation.
 
-> NOTE: Due to what appears to be a Babel bug, setting this flag causes Babel transpilation to fail on the file provided. Thus you cannot actually _RUN_ Storybook using this command. However, it will print out the configuration information as advertised, and therefore you can use this to debug your Storybook. You'll need to remove the flag to actually run your Storybook.
+<div class="aside">
+💡 Due to what appears to be a Babel bug, setting this flag causes Babel transpilation to fail on the file provided. Thus you cannot actually <strong>run</strong> Storybook using this command. However, it will print out the configuration information as advertised, and therefore you can use this to debug your Storybook. You'll need to remove the flag to actually run your Storybook.
+</div>
 
 For more info, please refer to the [Babel documentation](https://babeljs.io/docs/en/configuration#print-effective-configs).

--- a/docs/contribute/new-snippets.md
+++ b/docs/contribute/new-snippets.md
@@ -80,7 +80,7 @@ Create the file `ember/your-component.js.mdx`, similar to the other frameworks, 
 ```
 
 <div class="aside">
-💡 <strong>Note:</strong> Code snippets are divided into various file extensions, if you're contributing a TypeScript file use <code>.ts.mdx</code>, or if you're adding MDX files use <code>.mdx.mdx</code> .
+💡 Code snippets are divided into various file extensions, if you're contributing a TypeScript file use <code>.ts.mdx</code>, or if you're adding MDX files use <code>.mdx.mdx</code> .
 </div>
 
 Go through the rest of the documentation and repeat the process.
@@ -110,7 +110,7 @@ yarn start:skip-addons
 ```
 
 <div class="aside">
-💡 <strong>Note:</strong> During the start process if there's an issue with the the documentation, the process will stop and you'll get a notification.
+💡 During the start process if there's an issue with the the documentation, the process will stop and you'll get a notification.
 </div>
 
 Open a browser window to `http://localhost:8000`, click the Docs link, and select your framework from the dropdown.

--- a/docs/contribute/new-snippets.md
+++ b/docs/contribute/new-snippets.md
@@ -10,12 +10,12 @@ Storybook maintains code snippets for a [variety of frameworks](./../api/framewo
 
 We welcome community contributions to the code snippets. Here's a matrix of the frameworks we have snippets for. Help us add snippets for your favorite framework.
 
-| React                                                                        | Vue                                                                        | Angular                                                                        | Web Components                                                                                   | Svelte                                                                        | Ember | HTML | Mithril | Marko | Riot | Preact | Rax |
-| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ----- | ---- | ------- | ----- | ---- | ------ | --- |
-| [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/react) | [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/vue) | [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/angular) | [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/web-components) (See note) | [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/svelte) | ❌    | ❌   | ❌      | ❌    | ❌   | ❌     | ❌  |
+| React                                                                        | Vue                                                                        | Angular                                                                        | Web Components                                                                                    | Svelte                                                                        | Ember | HTML | Mithril | Marko | Riot | Preact | Rax |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----- | ---- | ------- | ----- | ---- | ------ | --- |
+| [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/react) | [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/vue) | [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/angular) | [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/web-components) (See below) | [✅](https://github.com/storybookjs/storybook/tree/next/docs/snippets/svelte) | ❌    | ❌   | ❌      | ❌    | ❌   | ❌     | ❌  |
 
 <div class="aside">
-💡 Note: The <code>Web Components</code> snippets are present but not fully documented. If you're willing to help, submit a pull request.
+💡 The <code>Web Components</code> snippets are present but not fully documented. If you're willing to help, submit a pull request.
 </div>
 
 ## Setup
@@ -80,7 +80,7 @@ Create the file `ember/your-component.js.mdx`, similar to the other frameworks, 
 ```
 
 <div class="aside">
-💡 Code snippets are divided into various file extensions, if you're contributing a TypeScript file use <code>.ts.mdx</code>, or if you're adding MDX files use <code>.mdx.mdx</code> .
+💡 <strong>Note:</strong> Code snippets are divided into various file extensions, if you're contributing a TypeScript file use <code>.ts.mdx</code>, or if you're adding MDX files use <code>.mdx.mdx</code> .
 </div>
 
 Go through the rest of the documentation and repeat the process.
@@ -110,7 +110,7 @@ yarn start:skip-addons
 ```
 
 <div class="aside">
-💡 During the start process if there's an issue with the the documentation, the process will stop and you'll get a notification.
+💡 <strong>Note:</strong> During the start process if there's an issue with the the documentation, the process will stop and you'll get a notification.
 </div>
 
 Open a browser window to `http://localhost:8000`, click the Docs link, and select your framework from the dropdown.

--- a/docs/essentials/interactions.md
+++ b/docs/essentials/interactions.md
@@ -39,8 +39,11 @@ Next, update [`.storybook/main.js`](../configure/overview.md#configure-story-ren
 <!-- prettier-ignore-end -->
 
 <div class="aside">
-💡 Make sure to list `@storybook/addon-interactions` **after** `addon-essentials` (or `addon-actions`).
+
+💡 Make sure to list `@storybook/addon-interactions` **after** the [`@storybook/addon-essentials`](./introduction.md) addon (or the [`@storybook/addon-actions`](./actions.md) if you've installed it individually).
+
 </div>
+
 
 Now when you run Storybook, the Interactions addon will be enabled.
 

--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -94,7 +94,7 @@ You can customize what's shown in the `ArgsTable` by customizing the `ArgTypes` 
 
 <div class="aside">
 
-NOTE: This API is experimental and may change outside of the typical semver release cycle
+💡 This API is experimental and may change outside of the typical semver release cycle.
 
 </div>
 


### PR DESCRIPTION
With this pull request, the documentation is updated to remove the usage of `Note:` inside asides as it adds redundancy. Follows up on #17085

What was done:
- Removed last items containing `Note` from the documentation.
- Polished some docs in light of the changes above.

