### PR TITLE
Angular: Fix angular 13.1 JIT error and HMR reload

### DIFF
--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -3,6 +3,7 @@ import { logger } from '@storybook/node-logger';
 import { targetFromTargetString, BuilderContext, Target } from '@angular-devkit/architect';
 import { sync as findUpSync } from 'find-up';
 import semver from '@storybook/semver';
+import dedent from 'ts-dedent';
 
 import { logging, JsonObject } from '@angular-devkit/core';
 import { moduleIsAvailable } from './utils/module-is-available';
@@ -142,8 +143,12 @@ async function getLegacyDefaultBuildOptions(options: PresetOptions) {
     return {};
   }
 
-  // TODO ~ legacy way to get default options
-  // TODO ~ Add deprecation warning and ex for builder use ? `);
+  logger.warn(dedent`Your Storybook startup uses a solution that will not be supported in version 7.0. 
+            You must use angular builder to have an explicit configuration on the project used in angular.json
+            Read more at:
+            - https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#sb-angular-builder)
+            - https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#angular13)
+          `);
   const dirToSearch = process.cwd();
 
   // Read angular workspace

--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -45,7 +45,11 @@ export async function webpackFinal(baseConfig: webpack.Configuration, options: P
         const legacyDefaultOptions = await getLegacyDefaultBuildOptions(_options);
 
         return getWebpackConfig13_x_x(_baseConfig, {
-          builderOptions: { ...builderOptions, ...legacyDefaultOptions },
+          builderOptions: {
+            watch: options.configType === 'DEVELOPMENT',
+            ...builderOptions,
+            ...legacyDefaultOptions,
+          },
           builderContext,
         });
       },


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17039

## What I did

- Disable unnesasary webpack stuff if we use angular-cli >= 12
- Add deprecation warning when project use angular.json with legacy way
- Add watch option for angular 13.x

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?


Angular test by @ThibaudAV locally on project : 

- [x] Angular 12.x  (with csf3 and IRL project :p )
- [x] Angular 13.x
- [x] Angular 12.x with fresh install 

other ? 

If your answer is yes to any of these, please make sure to include it in your PR.
