### PR TITLE
Router: Fix navigating to hash links

### DIFF
--- a/lib/router/src/router.tsx
+++ b/lib/router/src/router.tsx
@@ -61,6 +61,10 @@ const useQueryNavigate = () => {
   const navigate = useNavigate();
 
   return useCallback((to: string | number, options?: ExpandedNavigateOptions) => {
+    if (typeof to === 'string' && to.startsWith('#')) {
+      document.location.hash = to;
+      return undefined;
+    }
     if (typeof to === 'string') {
       const target = options?.plain ? to : `?path=${to}`;
       return navigate(target, options);


### PR DESCRIPTION
Issue: #16918 

## What I did

- fix the handling of the hash-urls which are apparently not supported by react-router

## How to test

- go to a component with many stories
- go to docs mode
- click on the bottom story
- expect a hash to be in the manager's URL
- refresh the manager page
- expect the preview to scroll to the bottom
