### PR TITLE
Core: Fix IE support by transpiling more libs to es5

### DIFF
--- a/addons/interactions/src/Panel.tsx
+++ b/addons/interactions/src/Panel.tsx
@@ -121,12 +121,15 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
 
   const endRef = React.useRef();
   React.useEffect(() => {
-    const observer = new global.window.IntersectionObserver(
-      ([end]: any) => setScrollTarget(end.isIntersecting ? undefined : end.target),
-      { root: global.window.document.querySelector('#panel-tab-content') }
-    );
-    if (endRef.current) observer.observe(endRef.current);
-    return () => observer.disconnect();
+    let observer: IntersectionObserver;
+    if (global.window.IntersectionObserver) {
+      observer = new global.window.IntersectionObserver(
+        ([end]: any) => setScrollTarget(end.isIntersecting ? undefined : end.target),
+        { root: global.window.document.querySelector('#panel-tab-content') }
+      );
+      if (endRef.current) observer.observe(endRef.current);
+    }
+    return () => observer?.disconnect();
   }, []);
 
   const emit = useChannel(

--- a/lib/core-common/src/utils/es6Transpiler.ts
+++ b/lib/core-common/src/utils/es6Transpiler.ts
@@ -4,6 +4,7 @@ import { getStorybookBabelConfig } from './babel';
 const { plugins } = getStorybookBabelConfig();
 
 const nodeModulesThatNeedToBeParsedBecauseTheyExposeES6 = [
+  '@storybook[\\\\/]expect',
   '@storybook[\\\\/]node_logger',
   '@testing-library[\\\\/]dom',
   '@testing-library[\\\\/]user-event',
@@ -22,14 +23,18 @@ const nodeModulesThatNeedToBeParsedBecauseTheyExposeES6 = [
   'find-up',
   'fs-extra',
   'highlight.js',
+  'jest-mock',
   'json5',
   'node-fetch',
   'pkg-dir',
   'prettier',
   'pretty-format',
+  'react-router',
+  'react-router-dom',
   'resolve-from',
   'semver',
   'slash',
+  'strip-ansi',
 ].map((n) => new RegExp(`[\\\\/]node_modules[\\\\/]${n}`));
 
 export const es6Transpiler: () => RuleSetRule = () => {


### PR DESCRIPTION
Issue: #17057

## What I did
- Add more libs to be transpiled
- Remove IntersectionObserver usage in IE

## How to test

IE 11