### PR TITLE
Fix github workflow syntax to run unit-tests on push

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Core Unit Tests node-${{ matrix.node_version }}, ${{ matrix.os }}
-    if: ${{ github.event.label.name == 'ci:matrix' || github.event.type == 'push' }}
+    if: github.event_name == 'push' || github.event.label.name == 'ci:matrix'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Issue:

Since https://github.com/storybookjs/storybook/commit/d3bc320f7f16f415f53c02ce5f1f13d88048b5ed, the unit-tests github workflow has not been running on each merge to `next`, as it was supposed to.  

## What I did

I think I had the syntax incorrect for determining whether the workflow was being triggered by a push (or alternatively by a pull_request).  This instead uses the `github.event_name` as shown here: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-contexts

I also removed the `${{}}` syntax, since it is optional, as mentioned in https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-contexts:

>When you use expressions in an if conditional, you may omit the expression syntax (${{ }}) because GitHub automatically evaluates the if conditional as an expression. For more information, see "Expressions."

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

😬 I think the only real way to test this is to verify that the workflow does not happen when I open this PR, and then someone should add the `ci:matrix` label and verify it does run, then the real test comes if/when it is merged, to see if the workflow runs on `next`.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
