### PR TITLE
Build: Fix package.json warnings in JetBrains IDEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,9 @@
       "yarn lint:package"
     ]
   },
-  "browserslist": "defaults",
+  "browserslist": [
+    "defaults"
+  ],
   "resolutions": {
     "serialize-javascript": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     "@storybook/preact": "workspace:*",
     "@storybook/preview-web": "workspace:*",
     "@storybook/react": "workspace:*",
-    "@storybook/root": "workspace:*",
     "@storybook/router": "workspace:*",
     "@storybook/semver": "^7.3.2",
     "@storybook/server": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10798,7 +10798,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/root@workspace:*, @storybook/root@workspace:.":
+"@storybook/root@workspace:.":
   version: 0.0.0-use.local
   resolution: "@storybook/root@workspace:."
   dependencies:
@@ -10871,7 +10871,6 @@ __metadata:
     "@storybook/preact": "workspace:*"
     "@storybook/preview-web": "workspace:*"
     "@storybook/react": "workspace:*"
-    "@storybook/root": "workspace:*"
     "@storybook/router": "workspace:*"
     "@storybook/semver": ^7.3.2
     "@storybook/server": "workspace:*"


### PR DESCRIPTION
Issue: -

## What I did

I fixed several problems in package.json.

1. browserslist value was in a not expected format.
![image](https://user-images.githubusercontent.com/13823215/148771245-5568f421-9575-4b26-83d6-5c82936dd45f.png)
It's supposed to be an array https://github.com/browserslist/browserslist#best-practices
2. @storybook/root including itself as a dev dependency.
![image](https://user-images.githubusercontent.com/13823215/148771607-f6a0667d-323e-466f-b345-50a43e64f0a4.png)
We don't need to have that record, and that record produces a warning, so it's easy to just drop it.


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

