### PR TITLE
CSF3: Remove `path` from autoTitle browser code

### DIFF
--- a/lib/store/src/autoTitle.ts
+++ b/lib/store/src/autoTitle.ts
@@ -27,6 +27,18 @@ const startCaseTitle = (title: string) => {
   return title.split('/').map(startCase).join('/');
 };
 
+/**
+ * Combines path parts together, without duplicating separators (slashes).  Used instead of `path.join`
+ * because this code runs in the browser.
+ *
+ * @param paths array of paths to join together.
+ * @returns joined path string, with single '/' between parts
+ */
+function pathJoin(paths: string[]): string {
+  const slashes = new RegExp('/{1,}', 'g');
+  return paths.join('/').replace(slashes, '/');
+}
+
 export const autoTitleFromSpecifier = (fileName: string, entry: NormalizedStoriesSpecifier) => {
   const { directory, importPathMatcher, titlePrefix = '' } = entry || {};
   // On Windows, backslashes are used in paths, which can cause problems here
@@ -35,9 +47,7 @@ export const autoTitleFromSpecifier = (fileName: string, entry: NormalizedStorie
 
   if (importPathMatcher.exec(normalizedFileName)) {
     const suffix = normalizedFileName.replace(directory, '');
-    const slashes = new RegExp('/{1,}', 'g');
-    // Do not use path to join the parts, since this runs in the browser
-    const titleAndSuffix = slash([titlePrefix, suffix].join('/').replace(slashes, '/'));
+    const titleAndSuffix = slash(pathJoin([titlePrefix, suffix]));
     return startCaseTitle(stripExtension(titleAndSuffix));
   }
   return undefined;

--- a/lib/store/src/autoTitle.ts
+++ b/lib/store/src/autoTitle.ts
@@ -1,5 +1,4 @@
 import startCase from 'lodash/startCase';
-import path from 'path';
 import slash from 'slash';
 
 // FIXME: types duplicated type from `core-common', to be
@@ -36,7 +35,9 @@ export const autoTitleFromSpecifier = (fileName: string, entry: NormalizedStorie
 
   if (importPathMatcher.exec(normalizedFileName)) {
     const suffix = normalizedFileName.replace(directory, '');
-    const titleAndSuffix = slash(path.join(titlePrefix, suffix));
+    const slashes = new RegExp('/{1,}', 'g');
+    // Do not use path to join the parts, since this runs in the browser
+    const titleAndSuffix = slash([titlePrefix, suffix].join('/').replace(slashes, '/'));
     return startCaseTitle(stripExtension(titleAndSuffix));
   }
   return undefined;


### PR DESCRIPTION
Issue:

In attempting to get autoTitle functionality working in the vite builder, I found that `path` was being used in one of the modules which runs in the browser.  This is a node.js module, and while webpack polyfills it, vite does not.

See https://github.com/eirslett/storybook-builder-vite/issues/201 for context.

## What I did

I've replaced the usage of `path` with a simple join using `/`, and then performing a replacement of sets of one or more `/` with a single `/`. 

## How to test

- [X] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

Existing tests seem to be robust enough to cover this change (there are tests for both trailing slashes and no trailing slashes).

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
