### PR TITLE
React: Remove webpack from dependencies, types as devDependencies

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -69,12 +69,12 @@
     "react-refresh": "^0.11.0",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
-    "ts-dedent": "^2.0.0",
-    "webpack": "4"
+    "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
     "@storybook/client-api": "6.5.0-alpha.13",
-    "@types/prompts": "^2.0.9"
+    "@types/prompts": "^2.0.9",
+    "@types/webpack": "*"
   },
   "peerDependencies": {
     "@babel/core": "^7.11.5",

--- a/app/react/src/server/framework-preset-cra.ts
+++ b/app/react/src/server/framework-preset-cra.ts
@@ -1,4 +1,4 @@
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 import { logger } from '@storybook/node-logger';
 import type { Options } from '@storybook/core-common';
 import { isReactScriptsInstalled } from './cra-config';

--- a/app/react/src/server/framework-preset-react.test.ts
+++ b/app/react/src/server/framework-preset-react.test.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import type { Configuration } from 'webpack';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import type { Options } from '@storybook/core-common';
 import * as preset from './framework-preset-react';
@@ -12,7 +12,7 @@ jest.mock('@pmmmwh/react-refresh-webpack-plugin', () => {
 
 describe('framework-preset-react', () => {
   const reactRefreshPath = require.resolve('react-refresh/babel');
-  const webpackConfigMock: webpack.Configuration = {
+  const webpackConfigMock: Configuration = {
     plugins: [],
     module: {
       rules: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -10770,6 +10770,7 @@ __metadata:
     "@storybook/store": 6.5.0-alpha.13
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/prompts": ^2.0.9
+    "@types/webpack": "*"
     "@types/webpack-env": ^1.16.0
     babel-plugin-add-react-displayname: ^0.0.5
     babel-plugin-named-asset-import: ^0.3.1
@@ -10782,7 +10783,6 @@ __metadata:
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
-    webpack: 4
   peerDependencies:
     "@babel/core": ^7.11.5
     react: ^16.8.0 || ^17.0.0


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/15336

## What I did

I'm not positive that this will fix the issue linked above, but this will certainly push the issue further down the resolution path. Since webpack was listed as a dependency of @storybook/react, webpack 4 was getting hoisted to the react-docgen-typescript-plugin even if webpack 5 was the version the user was using / running. This would cause a mismatch between which webpack was running vs which webpack would be resolved from react-docgen-typescript-plugin 's perspective. Since this package only relies on webpack's types and not any code from webpack, I think it's safe to move this to a devDependency.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
