### PR TITLE
#14360: Relative links are broken in descriptions

### DIFF
--- a/lib/components/src/typography/DocumentFormatting.tsx
+++ b/lib/components/src/typography/DocumentFormatting.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import { styled, CSSObject } from '@storybook/theming';
+import { window } from 'global';
 import { withReset, withMargin, headerCommon, codeCommon } from './shared';
 import { StyledSyntaxHighlighter } from '../blocks/Source';
 
@@ -71,9 +72,13 @@ export const Pre = styled.pre<{}>(withReset, withMargin, ({ theme }) => ({
 }));
 
 const Link: FunctionComponent<any> = ({ href: input, children, ...props }) => {
+  const storybookBaseUrl = typeof window !== 'undefined' 
+    ? (window.parent.document.location.origin + window.parent.document.location.pathname) 
+    : '';
+
   const isStorybookPath = /^\//.test(input);
   const isAnchorUrl = /^#.*/.test(input);
-  const href = isStorybookPath ? `?path=${input}` : input;
+  const href = isStorybookPath ? `${storybookBaseUrl}?path=${input}` : input;
   const target = isAnchorUrl ? '_self' : '_top';
 
   return (


### PR DESCRIPTION
Issue: [Relative links are broken in descriptions](https://github.com/storybookjs/storybook/issues/14360)

## What I did
To avoid adding "iframe.html?" to the url, we need to lookup for location origin and pathname.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
