### PR TITLE
Angular: Fix 13.1 and add CI test cases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
           # Do not test CRA here because it's done in PnP part
           # TODO: Remove `web_components_typescript` as soon as Lit 2 stable is released
           # TODO: Add `angular` as soon as Storybook is compatible with Angular 13
-          command: yarn test:e2e-framework vue3 angular12 angular11 web_components_typescript web_components_lit2
+          command: yarn test:e2e-framework vue3 angular130 angular13 angular12 angular11 web_components_typescript web_components_lit2
           no_output_timeout: 5m
       - store_artifacts:
           path: /tmp/cypress-record

--- a/app/angular/src/server/angular-cli-webpack-13.x.x.js
+++ b/app/angular/src/server/angular-cli-webpack-13.x.x.js
@@ -6,7 +6,7 @@ const {
   getCommonConfig,
   getStylesConfig,
   getDevServerConfig,
-  getTypescriptWorkerPlugin,
+  getTypeScriptConfig,
 } = require('@angular-devkit/build-angular/src/webpack/configs');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
@@ -45,7 +45,7 @@ exports.getWebpackConfig = async (baseConfig, { builderOptions, builderContext }
     (wco) => [
       getCommonConfig(wco),
       getStylesConfig(wco),
-      getTypescriptWorkerPlugin ? getTypescriptWorkerPlugin(wco) : getDevServerConfig(wco),
+      getTypeScriptConfig ? getTypeScriptConfig(wco) : getDevServerConfig(wco),
     ]
   );
 

--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -47,8 +47,8 @@ export async function webpackFinal(baseConfig: webpack.Configuration, options: P
         return getWebpackConfig13_x_x(_baseConfig, {
           builderOptions: {
             watch: options.configType === 'DEVELOPMENT',
-            ...builderOptions,
             ...legacyDefaultOptions,
+            ...builderOptions,
           },
           builderContext,
         });

--- a/lib/cli/src/generators/ANGULAR/template-csf/.storybook/tsconfig.json
+++ b/lib/cli/src/generators/ANGULAR/template-csf/.storybook/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "%SET_DURING_SB_INIT%",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "allowSyntheticDefaultImports": true
   },
   "exclude": ["../src/test.ts", "../src/**/*.spec.ts", "../projects/**/*.spec.ts"],
   "include": ["../src/**/*", "../projects/**/*"],

--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -117,6 +117,18 @@ export const angular12: Parameters = {
   version: 'v12-lts',
 };
 
+export const angular130: Parameters = {
+  ...baseAngular,
+  name: 'angular130',
+  version: '13.0.x',
+};
+
+export const angular13: Parameters = {
+  ...baseAngular,
+  name: 'angular13',
+  version: '13.1.x',
+};
+
 export const angular: Parameters = baseAngular;
 // #endregion
 


### PR DESCRIPTION

Issue: https://github.com/storybookjs/storybook/issues/17201 https://github.com/storybookjs/storybook/issues/16977

## What I did

Add e2e for angular 13.0.x and for 13.x.x
Fix issue with 13.0 
- first error with : 
```
ModuleParseError: Module parse failed: Unexpected token (36:2)
File was processed with these loaders:
 * ./node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js
 * ./node_modules/@storybook/source-loader/dist/cjs/index.js
You may need an additional loader to handle the result of these loaders.
|     })
|   ]
> } as Meta;
|
| const template: Story<BadgeGroupComponent> = args => {
```

- second error with bad tsConfig from legacy options fetch inside angular.json

- And add `allowSyntheticDefaultImports: true` for angular generate to fix sb init for angular 13..x
✏️ I really think that all this part could be remade for Angular 13 with .ts config files, a clean tsconfig and use the default angular builder



## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
