### PR TITLE
React: Restore webpack as a dependency, updated webpack 5 docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -607,6 +607,17 @@ yarn add webpack@5 --dev
 npm install webpack@5 --save-dev
 ```
 
+Alternatively or additionally you might need to add a resolution to your package.json to ensure that a consistent webpack version is provided across all of storybook packages. Replacing the {app} with the app (react, vue, etc.) that you're using:
+
+```js
+// package.json
+...
+resolutions: {
+  "@storybook/{app}/webpack": "^5"
+}
+...
+```
+
 ### Angular 12 upgrade
 
 Storybook 6.3 supports Angular 12 out of the box when you install it fresh. However, if you're upgrading your project from a previous version, you'll need to [follow the steps for opting-in to webpack 5](#webpack-5).

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -69,12 +69,12 @@
     "react-refresh": "^0.11.0",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
-    "ts-dedent": "^2.0.0"
+    "ts-dedent": "^2.0.0",
+    "webpack": ">=4.43.0 <6.0.0"
   },
   "devDependencies": {
     "@storybook/client-api": "6.5.0-alpha.14",
-    "@types/prompts": "^2.0.9",
-    "@types/webpack": "*"
+    "@types/prompts": "^2.0.9"
   },
   "peerDependencies": {
     "@babel/core": "^7.11.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10770,7 +10770,6 @@ __metadata:
     "@storybook/store": 6.5.0-alpha.14
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/prompts": ^2.0.9
-    "@types/webpack": "*"
     "@types/webpack-env": ^1.16.0
     babel-plugin-add-react-displayname: ^0.0.5
     babel-plugin-named-asset-import: ^0.3.1
@@ -10783,6 +10782,7 @@ __metadata:
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
+    webpack: ">=4.43.0 <6.0.0"
   peerDependencies:
     "@babel/core": ^7.11.5
     react: ^16.8.0 || ^17.0.0
@@ -49163,7 +49163,7 @@ resolve@1.19.0:
   languageName: node
   linkType: hard
 
-"webpack@npm:4, webpack@npm:^4.0.0":
+"webpack@npm:4, webpack@npm:>=4.43.0 <6.0.0, webpack@npm:^4.0.0":
   version: 4.46.0
   resolution: "webpack@npm:4.46.0"
   dependencies:


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/pull/17192#issuecomment-1010242271

## What I did

Restored webpack as a dependency with a version string that's a little more flexible (matches the strictest overlap of the dependencies peers). As this could result in a separate webpack version to be installed, I also added more to the migration guide about forcing a webpack 5 resolution if the user is attempting to use builder/manager webpack 5 and is running into issues.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
