### PR TITLE
Webpack5: Fix manager.js process references

### DIFF
--- a/lib/manager-webpack5/src/presets/manager-preset.ts
+++ b/lib/manager-webpack5/src/presets/manager-preset.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fse from 'fs-extra';
-import { DefinePlugin, Configuration, WebpackPluginInstance } from 'webpack';
+import { DefinePlugin, Configuration, WebpackPluginInstance, ProvidePlugin } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';
@@ -113,7 +113,8 @@ export async function managerWebpack(
       new DefinePlugin({
         ...stringifyProcessEnvs(envs),
         NODE_ENV: JSON.stringify(envs.NODE_ENV),
-      }) as WebpackPluginInstance,
+      }),
+      new ProvidePlugin({ process: 'process/browser.js' }),
       // isProd &&
       //   BundleAnalyzerPlugin &&
       //   new BundleAnalyzerPlugin({ analyzerMode: 'static', openAnalyzer: false }),


### PR DESCRIPTION
Issue: #16067 

## What I did

Add `ProvidePlugin` for manager (it was already added to preview)

Self-merging @tmeasday 

## How to test

See repro in issue (tested by hand) by @tylerjlawson 

```js
// .storybook/manager.js
console.log({ process });
```
