### PR TITLE
Fix prettier transpile problems

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -92,7 +92,7 @@
     "lodash": "^4.17.21",
     "nanoid": "^3.1.23",
     "p-limit": "^3.1.0",
-    "prettier": "^2.2.1",
+    "prettier": "<=2.3.0",
     "prop-types": "^15.7.2",
     "react-element-to-jsx-string": "^14.3.4",
     "regenerator-runtime": "^0.13.7",

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -51,7 +51,7 @@
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "loader-utils": "^2.0.0",
-    "prettier": "^2.2.1",
+    "prettier": "<=2.3.0",
     "prop-types": "^15.7.2",
     "react-syntax-highlighter": "^15.4.5",
     "regenerator-runtime": "^0.13.7"

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -51,7 +51,7 @@
     "globby": "^11.0.2",
     "jscodeshift": "^0.7.0",
     "lodash": "^4.17.21",
-    "prettier": "^2.2.1",
+    "prettier": "<=2.3.0",
     "recast": "^0.19.0",
     "regenerator-runtime": "^0.13.7"
   },

--- a/lib/csf-tools/package.json
+++ b/lib/csf-tools/package.json
@@ -54,7 +54,7 @@
     "global": "^4.4.0",
     "js-string-escape": "^1.0.1",
     "lodash": "^4.17.21",
-    "prettier": "^2.2.1",
+    "prettier": "<=2.3.0",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0"
   },

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -49,7 +49,7 @@
     "global": "^4.4.0",
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.21",
-    "prettier": "^2.2.1",
+    "prettier": "<=2.3.0",
     "regenerator-runtime": "^0.13.7"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "npmlog": "^5.0.1",
     "p-limit": "^3.1.0",
     "postcss-loader": "^4.2.0",
-    "prettier": "^2.2.1",
+    "prettier": "<=2.3.0",
     "prompts": "^2.4.0",
     "raf": "^3.4.1",
     "regenerator-runtime": "^0.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9005,7 +9005,7 @@ __metadata:
     lodash: ^4.17.21
     nanoid: ^3.1.23
     p-limit: ^3.1.0
-    prettier: ^2.2.1
+    prettier: <=2.3.0
     prop-types: ^15.7.2
     react-element-to-jsx-string: ^14.3.4
     regenerator-runtime: ^0.13.7
@@ -9409,7 +9409,7 @@ __metadata:
     core-js: ^3.8.2
     estraverse: ^5.2.0
     loader-utils: ^2.0.0
-    prettier: ^2.2.1
+    prettier: <=2.3.0
     prop-types: ^15.7.2
     react-syntax-highlighter: ^15.4.5
     regenerator-runtime: ^0.13.7
@@ -9982,7 +9982,7 @@ __metadata:
     jest-specific-snapshot: ^4.0.0
     jscodeshift: ^0.7.0
     lodash: ^4.17.21
-    prettier: ^2.2.1
+    prettier: <=2.3.0
     recast: ^0.19.0
     regenerator-runtime: ^0.13.7
   languageName: unknown
@@ -10252,7 +10252,7 @@ __metadata:
     js-string-escape: ^1.0.1
     js-yaml: ^3.14.1
     lodash: ^4.17.21
-    prettier: ^2.2.1
+    prettier: <=2.3.0
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
   languageName: unknown
@@ -10960,7 +10960,7 @@ __metadata:
     npmlog: ^5.0.1
     p-limit: ^3.1.0
     postcss-loader: ^4.2.0
-    prettier: ^2.2.1
+    prettier: <=2.3.0
     prompts: ^2.4.0
     puppeteer: ^2.1.1
     raf: ^3.4.1
@@ -11129,7 +11129,7 @@ __metadata:
     global: ^4.4.0
     loader-utils: ^2.0.0
     lodash: ^4.17.21
-    prettier: ^2.2.1
+    prettier: <=2.3.0
     regenerator-runtime: ^0.13.7
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -39464,21 +39464,21 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"prettier@npm:<=2.3.0":
+  version: 2.3.0
+  resolution: "prettier@npm:2.3.0"
+  bin:
+    prettier: bin-prettier.js
+  checksum: b9f434af2f25a37aad0b133894827e980885eb8bf317444c9dde0401ed2c7f463f9996d691f5ee5a0a4450ab46a894cd6557516b561e2522821522ce1f4c6668
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^1.18.2":
   version: 1.19.1
   resolution: "prettier@npm:1.19.1"
   bin:
     prettier: ./bin-prettier.js
   checksum: 12efb4e486c1e1d006e9eadd3b6585fc6beb9481dc801080fc23d3e75ec599d88c6fea1b40aef167128069e8fe76b4205bb8306ad145575d1b051b8fa70cfaae
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "prettier@npm:2.2.1"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 4041ff87d6cba9134a8e0eb74a9e7f50f7091de6b95f5a6fb1928795c7d0584ae46806e0d75588fbc912b2cda2439d28a14fb84416946384cf71d60f5a0a68a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #16820 

## What I did

Our IE compatibility transpilation are having problems with prettier versions greater than 2.3.0

This workaround makes sure we use a compatible version of prettier, according to @prashantpalikhe 's comment https://github.com/storybookjs/storybook/issues/16820#issuecomment-1012161244

## How to test

CI passes?
