### PR TITLE
Core: Fix __namedExportsOrder warning from preview.js

### DIFF
--- a/lib/builder-webpack4/src/preview/virtualModuleEntry.template.js
+++ b/lib/builder-webpack4/src/preview/virtualModuleEntry.template.js
@@ -44,6 +44,7 @@ Object.keys(config).forEach((key) => {
       v[key] = value;
       return addParameters(v, false);
     }
+    case '__namedExportsOrder':
     case 'decorateStory':
     case 'renderToDOM': {
       return null; // This key is not handled directly in v6 mode.

--- a/lib/builder-webpack5/src/preview/virtualModuleEntry.template.js
+++ b/lib/builder-webpack5/src/preview/virtualModuleEntry.template.js
@@ -44,6 +44,7 @@ Object.keys(config).forEach((key) => {
       v[key] = value;
       return addParameters(v, false);
     }
+    case '__namedExportsOrder':
     case 'decorateStory':
     case 'renderToDOM': {
       return null; // This key is not handled directly in v6 mode.


### PR DESCRIPTION
Issue: #15574 

## What I did

Ignore that key which gets added by babel-plugin-named-exports-order

Self-merging @tmeasday 

## How to test

N/A