### PR TITLE
Core: Fix staticDirs favicon handling by refactor

### DIFF
--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -7,7 +7,7 @@
     "build-storybook": "build-storybook",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "storybook": "start-storybook -p 9009 --no-manager-cache",
+    "storybook": "start-storybook -p 9009 --no-manager-cache -s ./public",
     "test": "react-scripts test"
   },
   "browserslist": {

--- a/examples/cra-ts-kitchen-sink/package.json
+++ b/examples/cra-ts-kitchen-sink/package.json
@@ -7,7 +7,7 @@
     "build-storybook": "build-storybook",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "storybook": "start-storybook -p 9009 --no-manager-cache -s ./public",
+    "storybook": "start-storybook -p 9009 --no-manager-cache",
     "test": "react-scripts test"
   },
   "browserslist": {

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod-posix
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod-posix
@@ -1,5 +1,250 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cra-ts-essentials manager dev 1`] = `
+Object {
+  "entry": Array [
+    "NODE_MODULES/@storybook/addon-ie11/dist/event-source-polyfill.js",
+    "ROOT/lib/core-client/dist/esm/globals/polyfills.js",
+    "ROOT/lib/core-client/dist/esm/manager/index.js",
+    "ROOT/addons/docs/dist/esm/register.js",
+    "ROOT/addons/controls/dist/esm/register.js",
+    "ROOT/addons/actions/dist/esm/register.js",
+    "ROOT/addons/backgrounds/dist/esm/register.js",
+    "ROOT/addons/toolbars/dist/esm/register.js",
+    "ROOT/addons/measure/dist/esm/register.js",
+    "ROOT/addons/outline/dist/esm/register.js",
+  ],
+  "keys": Array [
+    "name",
+    "mode",
+    "bail",
+    "devtool",
+    "entry",
+    "output",
+    "watchOptions",
+    "plugins",
+    "module",
+    "resolve",
+    "resolveLoader",
+    "recordsPath",
+    "performance",
+    "optimization",
+  ],
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": Array [
+          "NODE_MODULES/",
+          "/dist/",
+        ],
+        "include": Array [
+          "ROOT",
+        ],
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "babelrc": false,
+              "configFile": false,
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "*",
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-template-literals/lib/index.js",
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "shippedProposals": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-typescript/lib/index.js",
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "include": [Function],
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "plugins": Array [
+                "NODE_MODULES/@babel/plugin-transform-shorthand-properties/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-block-scoping/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-decorators/lib/index.js",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-class-properties/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-private-methods/lib/index.js",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "NODE_MODULES/@babel/plugin-syntax-dynamic-import/lib/index.js",
+                Array [
+                  "NODE_MODULES/@babel/plugin-proposal-object-rest-spread/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "useBuiltIns": true,
+                  },
+                ],
+                "NODE_MODULES/@babel/plugin-transform-classes/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-arrow-functions/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-parameters/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-destructuring/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-spread/lib/index.js",
+                "NODE_MODULES/@babel/plugin-transform-for-of/lib/index.js",
+                "NODE_MODULES/babel-plugin-macros/dist/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-optional-chaining/lib/index.js",
+                "NODE_MODULES/@babel/plugin-proposal-nullish-coalescing-operator/lib/index.js",
+                Array [
+                  "NODE_MODULES/babel-plugin-polyfill-corejs3/lib/index.js",
+                  Object {
+                    "absoluteImports": "NODE_MODULES/core-js/index.js",
+                    "method": "usage-global",
+                    "version": "*",
+                  },
+                ],
+              ],
+              "presets": Array [
+                Array [
+                  "NODE_MODULES/@babel/preset-env/lib/index.js",
+                  Object {
+                    "loose": true,
+                    "modules": false,
+                    "shippedProposals": true,
+                    "targets": "defaults",
+                  },
+                ],
+                "NODE_MODULES/@babel/preset-react/lib/index.js",
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+      Object {
+        "test": "/\\\\.css$/",
+        "use": Array [
+          "NODE_MODULES/style-loader/dist/cjs.js",
+          Object {
+            "loader": "NODE_MODULES/css-loader/dist/cjs.js",
+            "options": Object {
+              "importLoaders": 1,
+            },
+          },
+        ],
+      },
+      Object {
+        "loader": "NODE_MODULES/file-loader/dist/cjs.js",
+        "options": Object {
+          "name": "static/media/[name].[contenthash:8].[ext]",
+        },
+        "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
+      },
+      Object {
+        "loader": "NODE_MODULES/url-loader/dist/cjs.js",
+        "options": Object {
+          "limit": 10000,
+          "name": "static/media/[name].[contenthash:8].[ext]",
+        },
+        "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
+      },
+      Object {
+        "include": "NODE_MODULES[\\\\\\\\/](@storybook[\\\\\\\\/]node_logger|@testing-library[\\\\\\\\/]dom|@testing-library[\\\\\\\\/]user-event|acorn-jsx|ansi-align|ansi-colors|ansi-escapes|ansi-regex|ansi-styles|better-opn|boxen|camelcase|chalk|color-convert|commander|find-cache-dir|find-up|fs-extra|highlight.js|json5|node-fetch|pkg-dir|prettier|pretty-format|react-dev-utils|resolve-from|semver|slash|strip-ansi|uuid)/",
+        "test": "/\\\\.js$/",
+        "use": Array [
+          Object {
+            "loader": "NODE_MODULES/babel-loader/lib/index.js",
+            "options": Object {
+              "presets": Array [
+                Array [
+                  "@babel/preset-env",
+                  Object {
+                    "targets": Object {
+                      "ie": "11",
+                    },
+                  },
+                  "storybook-addon-ie11",
+                ],
+              ],
+              "sourceType": "unambiguous",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "plugins": Array [
+    "VirtualModulesPlugin",
+    "HtmlWebpackPlugin",
+    "CaseSensitivePathsPlugin",
+    "DefinePlugin",
+  ],
+}
+`;
+
 exports[`cra-ts-essentials manager prod 1`] = `
 Object {
   "entry": Array [

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod-posix
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod-posix
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cra-ts-essentials preview dev 1`] = `null`;
+
 exports[`cra-ts-essentials preview prod 1`] = `
 Object {
   "entry": Array [

--- a/lib/core-server/src/utils/server-statics.ts
+++ b/lib/core-server/src/utils/server-statics.ts
@@ -25,27 +25,22 @@ export async function useStatics(router: any, options: Options) {
     `);
   }
 
-  if (staticDirs) {
-    staticDirs.forEach(async (dir) => {
-      const staticDirAndTarget = typeof dir === 'string' ? dir : `${dir.from}:${dir.to}`;
-      const { staticPath: from, targetEndpoint: to } = await parseStaticDir(
-        getDirectoryFromWorkingDir({
-          configDir: options.configDir,
-          workingDir: process.cwd(),
-          directory: staticDirAndTarget,
-        })
-      );
+  const statics = staticDirs
+    ? staticDirs.map((dir) => (typeof dir === 'string' ? dir : `${dir.from}:${dir.to}`))
+    : options.staticDir;
 
-      logger.info(chalk`=> Serving static files from {cyan ${from}} at {cyan ${to}}`);
-      router.use(to, express.static(from, { index: false }));
-    });
-  }
-
-  if (options.staticDir && options.staticDir.length > 0) {
+  if (statics && statics.length > 0) {
     await Promise.all(
-      options.staticDir.map(async (dir) => {
+      statics.map(async (dir) => {
         try {
-          const { staticDir, staticPath, targetEndpoint } = await parseStaticDir(dir);
+          const relativeDir = staticDirs
+            ? getDirectoryFromWorkingDir({
+                configDir: options.configDir,
+                workingDir: process.cwd(),
+                directory: dir,
+              })
+            : dir;
+          const { staticDir, staticPath, targetEndpoint } = await parseStaticDir(relativeDir);
           logger.info(
             chalk`=> Serving static files from {cyan ${staticDir}} at {cyan ${targetEndpoint}}`
           );


### PR DESCRIPTION
Issue: #17008 

## What I did

Refactored static directory handling to share code between `staticDirs` and `-s` CLI flag

Self-merging @yannbf 

## How to test

Run it on `examples/cra-ts-kitchen-sink` which has a custom favicon
- [ ] With `staticDirs`
- [ ] With legacy `-s` CLI flag
