### PR TITLE
Chore: (Docs) Fix dead link in sharing section

### DIFF
--- a/docs/sharing/storybook-composition.md
+++ b/docs/sharing/storybook-composition.md
@@ -2,7 +2,7 @@
 title: 'Storybook Composition'
 ---
 
-Composition allows you to browse components from any Storybook accessible via URL inside your local Storybook. You can compose any [Storybook published online](./storybook-publish.md) or running locally no matter the view layer, tech stack, or dependencies.
+Composition allows you to browse components from any Storybook accessible via URL inside your local Storybook. You can compose any [Storybook published online](./publish-storybook.md) or running locally no matter the view layer, tech stack, or dependencies.
 
 ![Storybook reference external](./reference-external-storybooks-composition.jpg)
 


### PR DESCRIPTION
With this small pull request, the Storybook composition documentation is updated to fix an incorrect link that was mentioned.

Closes the following [issue](https://github.com/storybookjs/frontpage/issues/330)