### PR TITLE
Controls: Fix number control update when using useArgs hook

### DIFF
--- a/lib/components/src/controls/Number.tsx
+++ b/lib/components/src/controls/Number.tsx
@@ -58,6 +58,13 @@ export const NumberControl: FC<NumberProps> = ({
     if (forceVisible && htmlElRef.current) htmlElRef.current.select();
   }, [forceVisible]);
 
+  useEffect(() => {
+    const newInputValue = typeof value === 'number' ? value : '';
+    if (inputValue !== newInputValue) {
+      setInputValue(value);
+    }
+  }, [value]);
+
   if (!forceVisible && value === undefined) {
     return (
       <Form.Button id={getControlSetterButtonId(name)} onClick={onForceVisible}>


### PR DESCRIPTION
Issue:  #15924 

Number control does not update when using useArgs hook 

## What I did
Added a useEffect hook to Number.tsx so that each time a new `value` is received, the value visible to the user is also changed.
```
useEffect(() => {
    const newInputValue = typeof value === 'number' ? value : '';
    if (inputValue !== newInputValue) {
      setInputValue(value);
    }
  }, [value]);
```

## How to test
The repo mentioned in the original issue has the code required to test this.
Keeping link here for convenience.
Repo to reproduce: https://github.com/zygisau/use-args-number-type-control-bug-repro

- [ ] Is this testable with Jest or Chromatic screenshots? I'm not sure
- [ ] Does this need a new example in the kitchen sink apps? No
- [ ] Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
