### PR TITLE
Chore: (Docs) Complements the Addon API docs

### DIFF
--- a/docs/addons/addons-api.md
+++ b/docs/addons/addons-api.md
@@ -18,7 +18,7 @@ This is the core addon API. This is how to get the addon API:
 
 ### addons.getChannel()
 
-Get an instance to the channel where you can communicate with the manager and the preview. You can find this in both the addon register code and your addon’s wrapper component (where used inside a story).
+Get an instance to the channel to communicate with the manager and the preview. You can find this in both the addon register code and your addon’s wrapper component (where used inside a story).
 
 It has a NodeJS [EventEmitter](https://nodejs.org/api/events.html) compatible API. So, you can use it to emit events and listen for events.
 
@@ -54,11 +54,9 @@ See how you can use this method:
 
 <!-- prettier-ignore-end -->
 
-The render function is called with `active` and `key`.
+The render function is called with `active` and `key`. The `active` value will be true when the panel is focused on the UI.
 
-When the panel is in focus in the UI, the `active` will be true.
-
-As you can see, you can set any React Component as the panel. Currently, it's one line of text. But you can do anything you want. 
+As you can see, you can set any React Component as the panel. Currently, it's one line of text. But you can do anything you want.
 It's a good practice to specify the panel title with the `title` key. You can use any plain text with it.
 
 ## makeDecorator API
@@ -140,7 +138,7 @@ Details on the Storybook API are further down.
 
 <!-- prettier-ignore-end -->
 
-Allows for both setting subscriptions to events and getting the emitter for emitting custom events unto the channel.
+Allows both setting subscriptions to events and getting the emitter for emitting custom events to the channel.
 
 The messages can be listened to on both the iframe and the manager side.
 
@@ -158,11 +156,11 @@ The messages can be listened to on both the iframe and the manager side.
 
 Extremely useful for addons that need to persist in some form of state.
 
-Storybook may unmount your addon component, and so keeping local state might not work well.
+Storybook may unmount your addon component, so keeping local state might not work well.
 
-Also, some addons consist of multiple parts, some parts being in a panel, some in the toolbar, etc.
+Also, some addons consist of multiple parts, some parts in a panel, some in the toolbar, etc.
 
-With this hook, addons can get access to the same portion of the state, persisted even if the components are unmounted.
+With this hook, addons can access the same portion of the state, persisted even if the components are unmounted.
 
 ### useParameter
 
@@ -198,7 +196,6 @@ It allows you to retrieve and update any Storybook Globals you want.
 
 If you use this hook, remember that your component will render a lot, and you may need to optimize for that using [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`useMemo`](https://reactjs.org/docs/hooks-reference.html#usememo) or [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback).
 
-
 ### useArgs
 
 <!-- prettier-ignore-start -->
@@ -211,13 +208,13 @@ If you use this hook, remember that your component will render a lot, and you ma
 
 <!-- prettier-ignore-end -->
 
-A handy Storybook hook that you can use in your addon if you need to read or update [`args`](../writing-stories/args.md). 
+You can use this handy Storybook hook in your addon if you need to read or update [`args`](../writing-stories/args.md).
 
 ---
 
 ## Storybook API
 
-Storybook API allows you to access different functionalities of Storybook UI. You can move an instance to the Storybook API when you register an addon.
+Storybook API allows you to access different functionalities of Storybook UI. You can move an instance to the Storybook API when registering an addon.
 
 Let's have a look at API methods.
 
@@ -286,7 +283,7 @@ This method allows you to set query string parameters. You can use that as tempo
 
 <div class="aside">
 
-💡 If you need to remove a query param, use `null` for that. For example, let's say we need to remove the `bbc` query param. See below how to do it:
+💡 If you need to remove a query param, use `null` for that. For example, we need to remove the `bbc` query param. See below how to do it:
 
 </div>
 
@@ -302,7 +299,7 @@ This method allows you to set query string parameters. You can use that as tempo
 
 ### api.getQueryParam()
 
-This method allows you to get a query param set by the above API `setQueryParams`. For example, let's say we need to get the `bbc` query param. Then this how we do it:
+This method allows you to get a query param set by the above API `setQueryParams`. For example, we need to get the `bbc` query param. Then this is how we do it:
 
 <!-- prettier-ignore-start -->
 
@@ -341,3 +338,47 @@ This method allows you to register a handler function called whenever the user n
 />
 
 <!-- prettier-ignore-end -->
+
+### addons.setConfig(config)
+
+This method allows you to override the default Storybook UI configuration (e.g., set up a [theme](../configure/theming.md) or hide UI elements):
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-config-layout.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+The following table details how to use the API values:
+
+| Name                |     Type      |                    Description                     |             Example Value             |
+| ------------------- | :-----------: | :------------------------------------------------: | :-----------------------------------: |
+| **isFullscreen**    |    Boolean    |        Show story component as full screen         |                `false`                |
+| **showNav**         |    Boolean    |     Display panel that shows a list of stories     |                `true`                 |
+| **showPanel**       |    Boolean    |   Display panel that shows addon configurations    |                `true`                 |
+| **panelPosition**   | String/Object |           Where to show the addon panel            |          `bottom` or `right`          |
+| **enableShortcuts** |    Boolean    |              Enable/disable shortcuts              |                `true`                 |
+| **isToolshown**     |    Boolean    |                 Show/hide tool bar                 |                `true`                 |
+| **theme**           |    Object     |         Storybook Theme, see next section          |              `undefined`              |
+| **selectedPanel**   |    String     |            Id to select an addon panel             |       `storybook/actions/panel`       |
+| **initialActive**   |    String     |      Select the default active tab on Mobile       |   `sidebar` or `canvas` or `addons`   |
+| **sidebar**         |    Object     |             Sidebar options, see below             |        `{ showRoots: false }`         |
+| **toolbar**         |    Object     | Modify the tools in the toolbar using the addon id | `{ fullscreen: { hidden: false } } }` |
+
+The following options are configurable under the `sidebar` namespace:
+
+| Name               |   Type   |                          Description                          |                  Example Value                   |
+| ------------------ | :------: | :-----------------------------------------------------------: | :----------------------------------------------: |
+| **showRoots**      | Boolean  |    Display the top-level nodes as a "root" in the sidebar     |                     `false`                      |
+| **collapsedRoots** |  Array   |     Set of root node IDs to visually collapse by default      |               `['misc', 'other']`                |
+| **renderLabel**    | Function | Create a custom label for tree nodes; must return a ReactNode | `(item) => <abbr title="...">{item.name}</abbr>` |
+
+The following options are configurable under the `toolbar` namespace:
+
+| Name   |  Type  |            Description             |    Example Value    |
+| ------ | :----: | :--------------------------------: | :-----------------: |
+| **id** | String | Toggle visibility for toolbar item | `{ hidden: false }` |


### PR DESCRIPTION
With this pull request, the Addon API docs are complemented to include information on some missing methods. Closes #16262 .


What was done:
- Updated the Addon API methods with the missing information