### PR TITLE
Webpack: Fix for `process` fallback using `require.resolve`

### DIFF
--- a/lib/builder-webpack5/package.json
+++ b/lib/builder-webpack5/package.json
@@ -86,6 +86,7 @@
     "glob-promise": "^3.4.0",
     "html-webpack-plugin": "^5.0.0",
     "path-browserify": "^1.0.1",
+    "process": "^0.11.10",
     "stable": "^0.1.8",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^5.0.3",

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -214,7 +214,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
         ...stringifyProcessEnvs(envs),
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       }),
-      new ProvidePlugin({ process: 'process/browser.js' }),
+      new ProvidePlugin({ process: require.resolve('process/browser.js') }),
       isProd ? null : new HotModuleReplacementPlugin(),
       new CaseSensitivePathsPlugin(),
       quiet ? null : new ProgressPlugin({}),

--- a/lib/manager-webpack5/package.json
+++ b/lib/manager-webpack5/package.json
@@ -63,6 +63,7 @@
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "^5.0.0",
     "node-fetch": "^2.6.1",
+    "process": "^0.11.10",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
     "resolve-from": "^5.0.0",

--- a/lib/manager-webpack5/src/presets/manager-preset.ts
+++ b/lib/manager-webpack5/src/presets/manager-preset.ts
@@ -114,7 +114,7 @@ export async function managerWebpack(
         ...stringifyProcessEnvs(envs),
         NODE_ENV: JSON.stringify(envs.NODE_ENV),
       }),
-      new ProvidePlugin({ process: 'process/browser.js' }),
+      new ProvidePlugin({ process: require.resolve('process/browser.js') }),
       // isProd &&
       //   BundleAnalyzerPlugin &&
       //   new BundleAnalyzerPlugin({ analyzerMode: 'static', openAnalyzer: false }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10577,6 +10577,7 @@ __metadata:
     fs-extra: ^9.0.1
     html-webpack-plugin: ^5.0.0
     node-fetch: ^2.6.1
+    process: ^0.11.10
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     resolve-from: ^5.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -9805,6 +9805,7 @@ __metadata:
     glob-promise: ^3.4.0
     html-webpack-plugin: ^5.0.0
     path-browserify: ^1.0.1
+    process: ^0.11.10
     stable: ^0.1.8
     style-loader: ^2.0.0
     terser-webpack-plugin: ^5.0.3


### PR DESCRIPTION
Issue: #16896

`@storybook/builder-webpack5` uses the `ProvidePlugin` to provide a polyfill of the `process` module but doesn't resolve the absolute path to it nor declare it as a dependency.

There are more dependency issues but I'll leave those for another time.

## What I did

Use `require.resolve` to get the absolute path to `process/browser.js` and declare `process` as a dependency.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

The PnP e2e test should catch this but it seems it has other issues at the moment.