### PR TITLE
Core: Fix issue with recursive glob with prior special chars

### DIFF
--- a/lib/core-common/src/utils/__tests__/paths.test.ts
+++ b/lib/core-common/src/utils/__tests__/paths.test.ts
@@ -12,6 +12,16 @@ describe('paths - normalizeStoryPath()', () => {
     expect(normalizeStoryPath(filename)).toEqual(filename);
   });
 
+  it('returns a path equal to "." unchanged', () => {
+    const filename = '.';
+    expect(normalizeStoryPath(filename)).toEqual(filename);
+  });
+
+  it('returns a path equal to ".." unchanged', () => {
+    const filename = '..';
+    expect(normalizeStoryPath(filename)).toEqual(filename);
+  });
+
   it('adds "./" to a normalized relative path', () => {
     const filename = path.join('src', 'Comp.story.js');
     expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);

--- a/lib/core-common/src/utils/__tests__/to-require-context.test.ts
+++ b/lib/core-common/src/utils/__tests__/to-require-context.test.ts
@@ -238,6 +238,21 @@ const testCases = [
       '../src/stories/components/Icon/Icon.mdx',
     ],
   },
+  // Patterns before the **, see:
+  //   - https://github.com/storybookjs/storybook/issues/17038
+  //   - https://github.com/storybookjs/storybook/issues/16964
+  //   - https://github.com/storybookjs/storybook/issues/16924
+  {
+    glob: '../{dir1,dir2}/**/*.stories.js',
+    recursive: true,
+    validPaths: [
+      '../dir1/Icon.stories.js',
+      '../dir1/nested/Icon.stories.js',
+      '../dir2/Icon.stories.js',
+      '../dir2/nested/Icon.stories.js',
+    ],
+    invalidPaths: ['../dir3/Icon.stories.js', '../dir3/nested/Icon.stories.js'],
+  },
 ];
 
 describe('toRequireContext', () => {

--- a/lib/core-common/src/utils/paths.ts
+++ b/lib/core-common/src/utils/paths.ts
@@ -29,9 +29,9 @@ export const nodePathsToArray = (nodePath: string) =>
     .filter(Boolean)
     .map((p) => path.resolve('./', p));
 
-const relativePattern = /^\.{1,2}[/\\]/;
+const relativePattern = /^\.{1,2}([/\\]|$)/;
 /**
- * Ensures that a path starts with `./` or `../`
+ * Ensures that a path starts with `./` or `../`, or is entirely `.` or `..`
  */
 export function normalizeStoryPath(filename: string) {
   if (relativePattern.test(filename)) return filename;

--- a/lib/core-common/src/utils/to-require-context.ts
+++ b/lib/core-common/src/utils/to-require-context.ts
@@ -7,9 +7,10 @@ export const toRequireContext = (specifier: NormalizedStoriesSpecifier) => {
   // The importPathMatcher is a `./`-prefixed matcher that includes the directory
   // For `require.context()` we want the same thing, relative to directory
   const match = globToRegexp(`./${files}`);
+
   return {
     path: directory,
-    recursive: !!files.match(/^\*{1,2}\//),
+    recursive: files.includes('**') || files.split('/').length > 1,
     match,
   };
 };


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17038, https://github.com/storybookjs/storybook/issues/16964, https://github.com/storybookjs/storybook/issues/16924

In all three cases the issue is special glob patterns *before* the `**` in the glob. 

In 6.4, we incorrectly changed the condition for a recursive look up to be the `files` glob had to start with `**`, which is broken in the above cases.

## What I did

This goes back to the old condition (recursive if the glob contains `'**'` or `'/'` -- I suspect just the latter would be enough). Plus add a fix for our normalisation of directory names when they are just `'..'` or `'.'`

## How to test

See tests. You can also create a reproduction SB with one of the following `stories` fields:

```js
module.exports = {
  stories: [
    
    // https://github.com/storybookjs/storybook/issues/17038
    // '../sr*/**/*.stories.@(js|jsx|ts|tsx)',

    // https://github.com/storybookjs/storybook/issues/16964
    // '../!(foo)/**/*.stories.@(js|jsx|ts|tsx)',

    // https://github.com/storybookjs/storybook/issues/16924
    '../{src,random}/**/*.stories.@(js|jsx|ts|tsx)',
  ],
```