### PR TITLE
Webpack5: Switch to using `import.meta.webpackHot.accept`

### DIFF
--- a/lib/builder-webpack5/src/preview/virtualModuleModernEntry.js.handlebars
+++ b/lib/builder-webpack5/src/preview/virtualModuleModernEntry.js.handlebars
@@ -33,12 +33,12 @@ window.__STORYBOOK_CLIENT_API__ = new ClientApi({ storyStore: preview.storyStore
 preview.initialize({ importFn, getProjectAnnotations });
 
 if (module.hot) {
-  module.hot.accept('./{{storiesFilename}}', () => {
+  import.meta.webpackHot.accept('./{{storiesFilename}}', () => {
     // importFn has changed so we need to patch the new one in
     preview.onStoriesChanged({ importFn });
   });
 
-  module.hot.accept([{{#each configs}}'{{this}}',{{/each}}], () => {
+  import.meta.webpackHot.accept([{{#each configs}}'{{this}}',{{/each}}], () => {
     // getProjectAnnotations has changed so we need to patch the new one in
     preview.onGetProjectAnnotationsChanged({ getProjectAnnotations });
   });


### PR DESCRIPTION
This is primarily to work around this issue: https://github.com/webpack/webpack/issues/15190 although it is probably the more futuristic syntax anyway.

## How to test

1. Get a WP5 project
2. Enable lazy compilation (you need to disable entries for now, PR to WP to fix that coming):     

```js
// main.js

  webpackFinal: (config) => ({
    ...config,
    experiments: { lazyCompilation: { entries: false } },
  });
```

Note there isn't any easy way to test this pre-release that I am aware of right now 😭 