### PR TITLE
CLI: Force use of NPM during bootstrap of CRA repros

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -159,6 +159,9 @@
     "@storybook/angular": {
       "optional": true
     },
+    "@storybook/builder-webpack5": {
+      "optional": true
+    },
     "@storybook/html": {
       "optional": true
     },

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -71,6 +71,9 @@
     "webpack": "*"
   },
   "peerDependenciesMeta": {
+    "@storybook/builder-webpack5": {
+      "optional": true
+    },
     "@storybook/vue": {
       "optional": true
     },

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -85,6 +85,9 @@
     "@babel/core": {
       "optional": true
     },
+    "@storybook/manager-webpack5": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }

--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -35,8 +35,8 @@ export const cra: Parameters = {
   name: 'cra',
   version: 'latest',
   generator: [
-    // Force npm otherwise we have a mess between Yarn 1 and Yarn 2
-    'npx create-react-app@{{version}} {{appName}} --use-npm',
+    // Force npm otherwise we have a mess between Yarn 1, Yarn 2 and NPM
+    'npm_config_user_agent=npm npx create-react-app@{{version}} {{appName}}',
     'cd {{appName}}',
     'echo "FAST_REFRESH=true" > .env',
     'echo "SKIP_PREFLIGHT_CHECK=true" > .env',
@@ -48,8 +48,8 @@ export const cra_typescript: Parameters = {
   name: 'cra_typescript',
   version: 'latest',
   generator: [
-    // Force npm otherwise we have a mess between Yarn 1 and Yarn 2
-    'npx create-react-app@{{version}} {{appName}} --template typescript --use-npm',
+    // Force npm otherwise we have a mess between Yarn 1, Yarn 2 and NPM
+    'npm_config_user_agent=npm npx create-react-app@{{version}} {{appName}} --template typescript',
   ].join(' && '),
 };
 

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -53,6 +53,9 @@
     "@storybook/builder-webpack5": {
       "optional": true
     },
+    "@storybook/manager-webpack5": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8209,6 +8209,8 @@ __metadata:
   peerDependenciesMeta:
     "@storybook/angular":
       optional: true
+    "@storybook/builder-webpack5":
+      optional: true
     "@storybook/html":
       optional: true
     "@storybook/react":
@@ -8270,6 +8272,8 @@ __metadata:
     react-dom: ^16.8.0 || ^17.0.0
     webpack: "*"
   peerDependenciesMeta:
+    "@storybook/builder-webpack5":
+      optional: true
     "@storybook/vue":
       optional: true
     "@storybook/web-components":
@@ -9396,6 +9400,8 @@ __metadata:
   peerDependenciesMeta:
     "@storybook/builder-webpack5":
       optional: true
+    "@storybook/manager-webpack5":
+      optional: true
     typescript:
       optional: true
   languageName: unknown
@@ -9958,6 +9964,8 @@ __metadata:
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
     "@babel/core":
+      optional: true
+    "@storybook/manager-webpack5":
       optional: true
     typescript:
       optional: true


### PR DESCRIPTION
Issue: CRA E2E tests are crashing because CRA app isn't bootstrap properly

## What I did

As of CRA 5 `--use-npm` option has been removed.
To force usage of NPM the only hacky way I found is to override `npm_config_user_agent` env var.

See related PR: https://github.com/facebook/create-react-app/pull/11322
And changelog: https://github.com/facebook/create-react-app/releases/tag/v5.0.0

---

Fixing this highlighted a dependency issue, I will investigate on this:
![image](https://user-images.githubusercontent.com/4112568/150126934-a63a355b-9bc9-4c92-803f-d843d2966d73.png)


## How to test

- [ ] CRA e2e should be in better shape

Before:
![image](https://user-images.githubusercontent.com/4112568/150119656-745c18fb-700b-4308-8503-2012593cd6c1.png)


After:
![image](https://user-images.githubusercontent.com/4112568/150119681-7d61ddd1-ed25-4f6d-93e6-fd0a792f3b73.png)
