### PR TITLE
Fix example syntax by adding missing `=`

### DIFF
--- a/docs/snippets/angular/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/angular/component-story-custom-args-complex.ts.mdx
@@ -29,7 +29,7 @@ const someFunction = (valuePropertyA: String, valuePropertyB: String) => {
   // Makes some computations and returns something
 };
 
-const Template: Story (args) => {
+const Template: Story = (args) => {
   const { propertyA, propertyB } = args;
   
   //👇 Assigns the function result to a variable


### PR DESCRIPTION
Fixes typescript syntax error in code example.