### PR TITLE
Core: Apply Docs mode to composed storybooks

### DIFF
--- a/lib/ui/src/components/sidebar/Sidebar.tsx
+++ b/lib/ui/src/components/sidebar/Sidebar.tsx
@@ -109,10 +109,14 @@ export const Sidebar: FunctionComponent<SidebarProps> = React.memo(
       if (DOCS_MODE) {
         return Object.keys(refs).reduce((acc: Refs, cur) => {
           const ref = refs[cur];
-          acc[cur] = {
-            ...ref,
-            stories: collapseDocsOnlyStories(ref.stories),
-          };
+          if (ref.stories) {
+            acc[cur] = {
+              ...ref,
+              stories: collapseDocsOnlyStories(ref.stories),
+            };
+          } else {
+            acc[cur] = ref;
+          }
           return acc;
         }, {});
       }

--- a/lib/ui/src/components/sidebar/Sidebar.tsx
+++ b/lib/ui/src/components/sidebar/Sidebar.tsx
@@ -105,7 +105,20 @@ export const Sidebar: FunctionComponent<SidebarProps> = React.memo(
       () => (DOCS_MODE ? collapseAllStories : collapseDocsOnlyStories)(storiesHash),
       [DOCS_MODE, storiesHash]
     );
-    const dataset = useCombination(stories, storiesConfigured, storiesFailed, refs);
+    const adaptedRefs = useMemo(() => {
+      if (DOCS_MODE) {
+        return Object.keys(refs).reduce((acc: Refs, cur) => {
+          const ref = refs[cur];
+          acc[cur] = {
+            ...ref,
+            stories: collapseDocsOnlyStories(ref.stories),
+          };
+          return acc;
+        }, {});
+      }
+      return refs;
+    }, [DOCS_MODE, refs]);
+    const dataset = useCombination(stories, storiesConfigured, storiesFailed, adaptedRefs);
     const isLoading = !dataset.hash[DEFAULT_REF_ID].ready;
     const lastViewedProps = useLastViewed(selected);
 


### PR DESCRIPTION
Issue: #17291

## What I did

If refs change in the Manager's sidebar, and you're in Docs mode (`--docs`), then adapt our tree

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
