### PR TITLE
docs: Point to the measure-and-outline page

### DIFF
--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -10,8 +10,7 @@ A major strength of Storybook are [addons](/addons/) that extend Storybook’s U
 - [Viewport](./viewport.md)
 - [Backgrounds](./backgrounds.md)
 - [Toolbars & globals](./toolbars-and-globals.md)
-- [Measure](/addons/@storybook/addon-measure)
-- [Outline](/addons/storybook-addon-outline)
+- [Measure & outline](./measure-and-outline.md)
 
 ### Installation
 


### PR DESCRIPTION
## What I did

Fix dead link to "Outline", and point to the intended sub-page (which then points to the actual addons)

## How to test

Read the documentation page and click the link :)