### PR TITLE
Web components: add addon-interactions example story

### DIFF
--- a/examples/web-components-kitchen-sink/.storybook/main.js
+++ b/examples/web-components-kitchen-sink/.storybook/main.js
@@ -16,4 +16,7 @@ module.exports = {
   core: {
     builder: 'webpack4',
   },
+  features: {
+    interactionsDebugger: true,
+  },
 };

--- a/examples/web-components-kitchen-sink/src/stories/addons/interactions/addon-interactions.stories.ts
+++ b/examples/web-components-kitchen-sink/src/stories/addons/interactions/addon-interactions.stories.ts
@@ -1,0 +1,30 @@
+import { html } from 'lit';
+import { Meta, Story } from '@storybook/web-components';
+import { expect } from '@storybook/jest';
+import { within, userEvent } from '@storybook/testing-library';
+
+import './counter';
+import type { Counter } from './counter';
+
+export default {
+  title: 'Addons/Interactions',
+  component: 'sb-counter',
+} as Meta;
+
+const Template: Story<Counter> = () => html`<sb-counter></sb-counter>`;
+
+export const Default = Template.bind({});
+
+Default.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement.querySelector('sb-counter').shadowRoot);
+
+  await userEvent.click(canvas.getByTestId('increment'));
+  await userEvent.click(canvas.getByTestId('increment'));
+  await userEvent.click(canvas.getByTestId('increment'));
+
+  await expect(canvas.getByTestId('count').textContent).toEqual('You clicked 3 times');
+
+  await userEvent.click(canvas.getByTestId('decrement'));
+
+  await expect(canvas.getByTestId('count').textContent).toEqual('You clicked 2 times');
+};

--- a/examples/web-components-kitchen-sink/src/stories/addons/interactions/counter.ts
+++ b/examples/web-components-kitchen-sink/src/stories/addons/interactions/counter.ts
@@ -1,0 +1,35 @@
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('sb-counter')
+export class Counter extends LitElement {
+  static get properties() {
+    return {
+      count: { type: Number },
+    };
+  }
+
+  count = 0;
+
+  decrement = () => {
+    this.count -= 1;
+  };
+
+  increment = () => {
+    this.count += 1;
+  };
+
+  render() {
+    const { count } = this;
+    return html`
+      <h1>Lit Element - Counter</h1>
+      <h2 data-testid="count">You clicked ${count} times</h2>
+      <button type="button" data-testid="decrement" @click=${() => this.decrement()}>
+        Decrement
+      </button>
+      <button type="button" data-testid="increment" @click=${() => this.increment()}>
+        Increment
+      </button>
+    `;
+  }
+}


### PR DESCRIPTION
Issue: N/A

## What I did

Experimented with a recipe to use addon-interactions with web elements and that worked perfectly!

```js
Default.play = async ({ canvasElement }) => {
  const canvas = within(canvasElement.querySelector('web-component-name-here').shadowRoot);
  ... rest of the code like any other framework example
}
```

![image](https://user-images.githubusercontent.com/1671563/150384104-60568805-57db-44dd-9141-52fe1fa0c6cf.png)

## How to test

- Open the story [here](https://5def65ac9aec2800201cd814-axffbaqrjh.chromatic.com/?path=/story/addons-interactions--default)
