### PR TITLE
Core: Remove useless unfetch

### DIFF
--- a/lib/builder-webpack4/src/preview/virtualModuleModernEntry.js.handlebars
+++ b/lib/builder-webpack4/src/preview/virtualModuleModernEntry.js.handlebars
@@ -1,4 +1,3 @@
-import fetch from 'unfetch';
 import global from 'global';
 
 import { composeConfigs, PreviewWeb } from '@storybook/preview-web';

--- a/lib/builder-webpack5/src/preview/virtualModuleModernEntry.js.handlebars
+++ b/lib/builder-webpack5/src/preview/virtualModuleModernEntry.js.handlebars
@@ -1,4 +1,3 @@
-import fetch from 'unfetch';
 import global from 'global';
 
 import { composeConfigs, PreviewWeb } from '@storybook/preview-web';


### PR DESCRIPTION
Issue:

## What I did

Removed unfetch imports from virtual entrypoint because it not used anywhere


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
