### PR TITLE
Your component snippets for html

### DIFF
--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -23,6 +23,7 @@ Pick a simple component from your project, like a Button, and write a `.stories.
     'svelte/your-component.native-format.mdx',
     'svelte/your-component.mdx.mdx',
     'web-components/your-component.js.mdx',
+    'html/your-component.js.mdx',
   ]}
 />
 

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -24,6 +24,7 @@ Pick a simple component from your project, like a Button, and write a `.stories.
     'svelte/your-component.mdx.mdx',
     'web-components/your-component.js.mdx',
     'html/your-component.js.mdx',
+    'html/your-component.ts.mdx',
   ]}
 />
 

--- a/docs/snippets/html/your-component.js.mdx
+++ b/docs/snippets/html/your-component.js.mdx
@@ -1,0 +1,22 @@
+```js
+// YourComponent.stories.js
+
+import { createYourComponent } from './YourComponent';
+
+// 👇 This default export determines where your story goes in the story list
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'YourComponent',
+};
+
+// 👇 We create a “template” of how args map to rendering
+const Template = (args) => createYourComponent(args);
+
+export const FirstStory = Template.bind({});
+FirstStory.args = {
+  // 👇 The args you need here will depend on your component
+};
+```

--- a/docs/snippets/html/your-component.ts.mdx
+++ b/docs/snippets/html/your-component.ts.mdx
@@ -1,0 +1,23 @@
+```ts
+// YourComponent.stories.ts
+
+import { Meta, StoryFn } from '@storybook/html';
+import { createYourComponent } from './YourComponent';
+
+//👇 This default export determines where your story goes in the story list
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'YourComponent',
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: StoryFn = (args): HTMLElement => createYourComponent(args);
+
+export const FirstStory = Template.bind({});
+FirstStory.args = {
+  //👇 The args you need here will depend on your component
+};
+```


### PR DESCRIPTION
## What I did
I've add `your-component` code snippets to `setup.md` documentation for `html` framework. Code snippets contain javascript and typescript versions of `your-component` snippet.

## How to test
It's possible to test by using [frontpage repo ](https://github.com/storybookjs/frontpage) with a link to docs in current branch. 
1. Follow the instructions from [preview your work documentation](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) to start frontpage server
2. Open in browser http://localhost:8000/docs/html/get-started/setup/ to see how code snippets will be displayed on a webpage
