### PR TITLE
Upgrade node-fetch to latest version

### DIFF
--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -70,7 +70,7 @@
     "globby": "^11.0.2",
     "ip": "^1.1.5",
     "lodash": "^4.17.21",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "open": "^8.4.0",
     "pretty-hrtime": "^1.0.3",
     "prompts": "^2.4.0",

--- a/lib/manager-webpack4/package.json
+++ b/lib/manager-webpack4/package.json
@@ -64,7 +64,7 @@
     "find-up": "^5.0.0",
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "^4.0.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "pnp-webpack-plugin": "1.6.4",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",

--- a/lib/manager-webpack5/package.json
+++ b/lib/manager-webpack5/package.json
@@ -62,7 +62,7 @@
     "find-up": "^5.0.0",
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "^5.0.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "process": "^0.11.10",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7570,7 +7570,7 @@ __metadata:
     ip: ^1.1.5
     jest-specific-snapshot: ^4.0.0
     lodash: ^4.17.21
-    node-fetch: ^2.6.1
+    node-fetch: ^2.6.7
     open: ^8.4.0
     pretty-hrtime: ^1.0.3
     prompts: ^2.4.0
@@ -7910,7 +7910,7 @@ __metadata:
     find-up: ^5.0.0
     fs-extra: ^9.0.1
     html-webpack-plugin: ^4.0.0
-    node-fetch: ^2.6.1
+    node-fetch: ^2.6.7
     pnp-webpack-plugin: 1.6.4
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
@@ -7961,7 +7961,7 @@ __metadata:
     find-up: ^5.0.0
     fs-extra: ^9.0.1
     html-webpack-plugin: ^5.0.0
-    node-fetch: ^2.6.1
+    node-fetch: ^2.6.7
     process: ^0.11.10
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
@@ -32344,7 +32344,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1":
+"node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:


### PR DESCRIPTION
Issue: Upgrade node-fetch version due to a security vulnerability.
This is the vulnerability:
https://www.whitesourcesoftware.com/vulnerability-database/CVE-2022-0235

And it was patched a few hours ago:
https://github.com/node-fetch/node-fetch/issues/1467

## What I did
Upgrade the `package.json` file in the relevant packages.
I might have missed something so please let me know if I have :)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
