### PR TITLE
docs(MIGRATION): add CRA preset disclaimer in Webpack 5 section

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -583,6 +583,8 @@ module.exports = {
 };
 ```
 
+> NOTE: If you're using `@storybook/preset-create-react-app` make sure to update it to version 4.0.0 as well.
+
 #### Fixing hoisting issues
 
 ##### Webpack 5 manager build


### PR DESCRIPTION
Issue: N/A

## What I did

When migrating a CRA based project to use Webpack 5, Storybook will break with:

```
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
```

And that is because `@storybook/preset-react-app` has to be updated as well

So I added a small disclaimer in the MIGRATION docs.
