### PR TITLE
Addon-docs: Fix `BuilderConfig` can be an object

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -4,7 +4,7 @@ import remarkExternalLinks from 'remark-external-links';
 
 // @ts-ignore
 import { createCompiler } from '@storybook/csf-tools/mdx';
-import type { Options } from '@storybook/core-common';
+import type { BuilderConfig, Options } from '@storybook/core-common';
 
 // for frameworks that are not working with react, we need to configure
 // the jsx to transpile mdx, for now there will be a flag for that
@@ -38,12 +38,15 @@ export async function webpack(
       typeof createCompiler
     >[0]
 ) {
-  const { builder = 'webpack4' } = await options.presets.apply<{ builder: any }>('core', {} as any);
+  const { builder = 'webpack4' } = await options.presets.apply<{
+    builder: BuilderConfig;
+  }>('core', {} as any);
 
+  const builderName = typeof builder === 'string' ? builder : builder.name;
   const resolvedBabelLoader = require.resolve('babel-loader', {
-    paths: builder.match(/(webpack4|webpack5)/)
+    paths: builderName.match(/(webpack4|webpack5)/)
       ? [require.resolve(`@storybook/builder-${builder}`)]
-      : [builder],
+      : [builderName],
   });
 
   const { module = {} } = webpackConfig;


### PR DESCRIPTION
In https://github.com/storybookjs/storybook/pull/16219, the `builder` key in `main.js` is allowed to be an object (with key `name`). However, some other code assumes it is a string.


```
ERR! TypeError: builder.match is not a function
ERR!     at _callee$ (/Users/tom/GitHub/chromatic/node_modules/@storybook/addon-docs/dist/cjs/frameworks/common/preset.js:133:30)
ERR!     at tryCatch (/Users/tom/GitHub/chromatic/node_modules/regenerator-runtime/runtime.js:63:40)
ERR!     at Generator.invoke [as _invoke] (/Users/tom/GitHub/chromatic/node_modules/regenerator-runtime/runtime.js:294:22)
ERR!     at Generator.next (/Users/tom/GitHub/chromatic/node_modules/regenerator-runtime/runtime.js:119:21)
ERR!     at asyncGeneratorStep (/Users/tom/GitHub/chromatic/node_modules/@storybook/addon-docs/dist/cjs/frameworks/common/preset.js:56:103)
ERR!     at _next (/Users/tom/GitHub/chromatic/node_modules/@storybook/addon-docs/dist/cjs/frameworks/common/preset.js:58:194)
```

## What I did

Fixed, actually used types properly.


## How to test

Create an app that uses the FS cache. Should we do that in an example @shilman?