### PR TITLE
Core: Fix `useParameter` with nullish coalescing

### DIFF
--- a/lib/addons/src/hooks.test.js
+++ b/lib/addons/src/hooks.test.js
@@ -1,0 +1,57 @@
+import { useParameter, useStoryContext } from './hooks';
+
+const { window: globalWindow } = global;
+
+describe('addons/hooks', () => {
+  beforeEach(() => {
+    globalWindow.STORYBOOK_HOOKS_CONTEXT = undefined;
+  });
+
+  afterEach(() => {
+    globalWindow.STORYBOOK_HOOKS_CONTEXT = undefined;
+  });
+
+  describe('useStoryContext', () => {
+    test('should throw', () => {
+      expect(() => useStoryContext()).toThrowError(
+        'Storybook preview hooks can only be called inside decorators and story functions.'
+      );
+    });
+  });
+
+  describe('useParameter', () => {
+    beforeEach(() => {
+      globalWindow.STORYBOOK_HOOKS_CONTEXT = {
+        currentContext: {
+          parameters: {
+            'undefined key': undefined,
+            'null key': null,
+            'false key': false,
+            'zero key': 0,
+            'object key': { defined: true },
+          },
+        },
+      };
+    });
+
+    test('undefined key', () => {
+      expect(useParameter('undefined key', 'undefined default')).toEqual('undefined default');
+    });
+
+    test('null key', () => {
+      expect(useParameter('null key', 'null default')).toEqual('null default');
+    });
+
+    test('false key', () => {
+      expect(useParameter('false key', 'false default')).toEqual(false);
+    });
+
+    test('zero key', () => {
+      expect(useParameter('zero key', 'zero default')).toEqual(0);
+    });
+
+    test('object key', () => {
+      expect(useParameter('object key', 'object default')).toMatchObject({ defined: true });
+    });
+  });
+});

--- a/lib/addons/src/hooks.ts
+++ b/lib/addons/src/hooks.ts
@@ -418,7 +418,7 @@ export function useStoryContext<TFramework extends AnyFramework>(): StoryContext
 export function useParameter<S>(parameterKey: string, defaultValue?: S): S | undefined {
   const { parameters } = useStoryContext();
   if (parameterKey) {
-    return parameters[parameterKey] || (defaultValue as S);
+    return parameters[parameterKey] ?? (defaultValue as S);
   }
   return undefined;
 }


### PR DESCRIPTION
# Issue

The `useParameter(..)` hook accepts a key and a default value. It then
provides the default value if the current story has not provided a
desired value for the relevant `parameters` object.

## What I did

This change updates the logic of when to fall back to the default. The
old logic used a boolean operator (`||`), which worked as long as the
provided value wasn't falsey. Instead, account for this by using the
nullish coalescing operator (`??`).

## How to test

1. Create an addon which consumes a parameter like:

   ```js
   const parameters = useParameter("myAddon", { defaultValue: true });
   ```

2. Create a story which looks like:

   ```js
   export const Bug = {
     parameters: {
       myAddon: false
     }
   };
   ```

 3. Note that the value of `parameters` in your addon will always be
    the default object, _not_ `false` (as was requested by the story).

- [X] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
