### PR TITLE
Angular: Workaround for compodoc on windows machines

### DIFF
--- a/app/angular/src/builders/utils/run-compodoc.ts
+++ b/app/angular/src/builders/utils/run-compodoc.ts
@@ -16,7 +16,7 @@ export const runCompodoc = (
   context: BuilderContext
 ): Observable<void> => {
   return new Observable<void>((observer) => {
-    const tsConfigPath = toRelativePath('./tsconfig.json');
+    const tsConfigPath = toRelativePath(tsconfig);
     const finalCompodocArgs = [
       'compodoc',
       // Default options

--- a/app/angular/src/builders/utils/run-compodoc.ts
+++ b/app/angular/src/builders/utils/run-compodoc.ts
@@ -1,18 +1,26 @@
 import { BuilderContext } from '@angular-devkit/architect';
 import { spawn } from 'child_process';
 import { Observable } from 'rxjs';
+import * as path from 'path';
 
 const hasTsConfigArg = (args: string[]) => args.indexOf('-p') !== -1;
+
+// path.relative is necessary to workaround a compodoc issue with
+// absolute paths on windows machines
+const toRelativePath = (pathToTsConfig: string) => {
+  return path.isAbsolute(pathToTsConfig) ? path.relative('.', pathToTsConfig) : pathToTsConfig;
+};
 
 export const runCompodoc = (
   { compodocArgs, tsconfig }: { compodocArgs: string[]; tsconfig: string },
   context: BuilderContext
 ): Observable<void> => {
   return new Observable<void>((observer) => {
+    const tsConfigPath = toRelativePath('./tsconfig.json');
     const finalCompodocArgs = [
       'compodoc',
       // Default options
-      ...(hasTsConfigArg(compodocArgs) ? [] : ['-p', tsconfig]),
+      ...(hasTsConfigArg(compodocArgs) ? [] : ['-p', tsConfigPath]),
       '-d',
       `${context.workspaceRoot}`,
       ...compodocArgs,


### PR DESCRIPTION
path.relative is necessary to workaround a compodoc issue with
absolute paths on windows machines

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
