### PR TITLE
Add new Function() to evaluate string for defaultValue from compodoc

### DIFF
--- a/addons/docs/src/frameworks/angular/compodoc.test.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.test.ts
@@ -129,7 +129,7 @@ describe('extractType', () => {
       [{ foo: 1 }, { name: 'object' }],
       [undefined, { name: 'void' }],
     ])('%s', (defaultValue, expected) => {
-      expect((makeProperty(null), defaultValue)).toEqual(expected);
+      expect(extractType(makeProperty(null), defaultValue)).toEqual(expected);
     });
   });
 });

--- a/addons/docs/src/frameworks/angular/compodoc.test.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.test.ts
@@ -1,11 +1,12 @@
-import { extractType, setCompodocJson } from './compodoc';
+import { extractType, setCompodocJson, extractDefaultValue } from './compodoc';
 import { CompodocJson, Decorator } from './types';
 
-const makeProperty = (compodocType?: string) => ({
+const makeProperty = (compodocType?: string, defaultValue?: string) => ({
   type: compodocType,
   name: 'dummy',
   decorators: [] as Decorator[],
   optional: true,
+  defaultValue,
 });
 
 const getDummyCompodocJson = () => {
@@ -128,7 +129,21 @@ describe('extractType', () => {
       [{ foo: 1 }, { name: 'object' }],
       [undefined, { name: 'void' }],
     ])('%s', (defaultValue, expected) => {
-      expect(extractType(makeProperty(null), defaultValue)).toEqual(expected);
+      expect((makeProperty(null), defaultValue)).toEqual(expected);
     });
+  });
+});
+
+describe('extract defaultValue', () => {
+  setCompodocJson(getDummyCompodocJson());
+  it.each([
+    ['string', 'string value', 'string value'],
+    ['string', undefined, undefined],
+    ['boolean', 'true', true],
+    ['number', '123', 123],
+    ['IObj', '{test: true, another: "test"}', { test: true, another: 'test' }],
+    ['[]', '[true, false, true]', [true, false, true]],
+  ])('%s', (compodocType, defaultValue, expected) => {
+    expect(extractDefaultValue(makeProperty(compodocType, defaultValue))).toEqual(expected);
   });
 });

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -3,6 +3,7 @@
 
 import { ArgType, ArgTypes } from '@storybook/api';
 import { logger } from '@storybook/client-logger';
+import { _$LH } from 'lit-html';
 import {
   Argument,
   Class,
@@ -169,7 +170,7 @@ const castDefaultValue = (property: Property, defaultValue: any) => {
       case 'EventEmitter':
         return undefined;
       default:
-        return defaultValue;
+        return extractCodeValue(defaultValue);
     }
   } else {
     switch (defaultValue) {
@@ -182,8 +183,18 @@ const castDefaultValue = (property: Property, defaultValue: any) => {
       case 'undefined':
         return undefined;
       default:
-        return defaultValue;
+        return extractCodeValue(defaultValue);
     }
+  }
+};
+
+const extractCodeValue = (defaultValue: string) => {
+  try {
+    // eslint-disable-next-line no-new-func
+    const func = new Function(`return ${defaultValue}`);
+    return func();
+  } catch (error) {
+    return defaultValue;
   }
 };
 
@@ -199,7 +210,7 @@ const extractDefaultValueFromComments = (property: Property, value: any) => {
   return commentValue;
 };
 
-const extractDefaultValue = (property: Property) => {
+export const extractDefaultValue = (property: Property) => {
   try {
     let value: string | boolean = property.defaultValue?.replace(/^'(.*)'$/, '$1');
     value = castDefaultValue(property, value);

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -3,7 +3,6 @@
 
 import { ArgType, ArgTypes } from '@storybook/api';
 import { logger } from '@storybook/client-logger';
-import { _$LH } from 'lit-html';
 import {
   Argument,
   Class,

--- a/examples/angular-cli/src/stories/addons/docs/doc-button/doc-button.component.ts
+++ b/examples/angular-cli/src/stories/addons/docs/doc-button/doc-button.component.ts
@@ -78,6 +78,10 @@ export class DocButtonComponent<T> {
   @Input()
   public aNumericValue = 123;
 
+  /** Test function default value. */
+  @Input()
+  public aFunctionValue = (test) => console.log(test);
+
   /** Appearance style of the button. */
   @Input()
   public appearance: 'primary' | 'secondary' = 'secondary';
@@ -92,6 +96,12 @@ export class DocButtonComponent<T> {
 
   /** Specifies some arbitrary object. This comment is to test certain chars like apostrophes - it's working */
   @Input() public someDataObject: ISomeInterface;
+
+  @Input() public someSetDataObject: ISomeInterface = {
+    one: 'test',
+    two: false,
+    three: [false, 'test'],
+  };
 
   /**
    * The inner text of the button.
@@ -150,6 +160,7 @@ export class DocButtonComponent<T> {
   @HostListener('click', ['$event'])
   onClickListener(event) {
     console.log('button', event.target);
+    this.aFunctionValue('aFunctionValue called');
     this.handleClick(event);
   }
 


### PR DESCRIPTION
Issue: #17004 #17001 #16959 #16865 

## What I did
Instead of returning the string for the default value from compodoc I ran the value through new Function(...) so the javascript in the string can be recreated to the original value from the component typescript file.

## How to test

- [X] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
