### PR TITLE
CLI: Add version update argument to generate-sb-packages-versions utility

### DIFF
--- a/lib/cli/scripts/generate-sb-packages-versions.js
+++ b/lib/cli/scripts/generate-sb-packages-versions.js
@@ -1,12 +1,19 @@
+#!/usr/bin/env node
+
 const { writeJson, readJson } = require('fs-extra');
 const path = require('path');
 const globby = require('globby');
+const semver = require('@storybook/semver');
 
 const rootDirectory = path.join(__dirname, '..', '..', '..');
 
 const logger = console;
 
 const run = async () => {
+  const updatedVersion = process.argv[process.argv.length - 1];
+
+  if (!semver.valid(updatedVersion)) throw new Error(`Invalid version: ${updatedVersion}`);
+
   const storybookPackagesPaths = await globby(
     `${rootDirectory}/@(app|addons|lib)/**/package.json`,
     {
@@ -30,7 +37,7 @@ const run = async () => {
     .filter(({ name }) => /@storybook/.test(name))
     // As some previous steps are asynchronous order is not always the same so sort them to avoid that
     .sort((package1, package2) => package1.name.localeCompare(package2.name))
-    .reduce((acc, { name, version }) => ({ ...acc, [name]: version }), {});
+    .reduce((acc, { name }) => ({ ...acc, [name]: updatedVersion }), {});
 
   await writeJson(path.join(__dirname, '..', 'src', 'versions.json'), packageToVersionMap, {
     spaces: 2,


### PR DESCRIPTION
Issue: N/A

## What I did

Update this to be called from publish script

self-merging @ndelangen 

## How to test

```sh
./lib/cli/scripts/generate-sb-packages-versions.js 6.3.2
```