### PR TITLE
Angular: Retrieve version from core package

### DIFF
--- a/app/angular/src/server/framework-preset-angular-cli.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.ts
@@ -23,7 +23,9 @@ export async function webpackFinal(baseConfig: webpack.Configuration, options: P
     return baseConfig;
   }
 
-  const angularCliVersion = await import('@angular/cli').then((m) => semver.coerce(m.VERSION.full));
+  const angularCliVersion = await import('@angular/core').then((m) =>
+    semver.coerce(m.VERSION.full)
+  );
 
   /**
    * Ordered array to use the specific  getWebpackConfig according to some condition like angular-cli version


### PR DESCRIPTION
Issue:

## What I did

I have a `nx v13.1.3` monorepo and today I've tried to update `@storybook/*` from `~6.3.0` to `~6.4.0` and got an error:
![image](https://user-images.githubusercontent.com/260185/151586409-d4be43ec-d427-47c2-a8dd-8fe377a47366.png)

## Solution

Looking at the mentioned file (`node_modules/@storybook/angular/dist/ts3.9/server/framework-preset-angular-cli.js`)
I see that it tries to extract the `VERSION` of the `@angular/cli` package but my Nx monorepo doesn't have it.
I also see that it's just an indication to use different files of `@angular-devkit/build-angular` but that package doesn't expose its version, so I got a successful build just extracting the version from `@angular/core` instead, which should be similar to the CLI in use :)


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
