### PR TITLE
Svelte: Fix missing templates dir in package.json publish files

### DIFF
--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -37,6 +37,7 @@
   "files": [
     "bin/**/*",
     "dist/**/*",
+    "templates/**/*",
     "README.md",
     "*.js",
     "*.d.ts"


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17360

## What I did

Add the templates directory and it's contents to package.json files array