### PR TITLE
Core: Mock channel if not present

### DIFF
--- a/lib/addons/src/index.ts
+++ b/lib/addons/src/index.ts
@@ -5,6 +5,7 @@ import { API } from '@storybook/api';
 import { RenderData as RouterData } from '@storybook/router';
 import { logger } from '@storybook/client-logger';
 import { ThemeVars } from '@storybook/theming';
+import { mockChannel } from './storybook-channel-mock';
 import { types, Types } from './types';
 
 export { Channel };
@@ -70,11 +71,9 @@ export class AddonStore {
   private resolve: any;
 
   getChannel = (): Channel => {
-    // this.channel should get overwritten by setChannel. If it wasn't called (e.g. in non-browser environment), throw.
+    // this.channel should get overwritten by setChannel. If it wasn't called (e.g. in non-browser environment), set a mock instead.
     if (!this.channel) {
-      throw new Error(
-        'Accessing non-existent addons channel, see https://storybook.js.org/basics/faq/#why-is-there-no-addons-channel'
-      );
+      this.setChannel(mockChannel());
     }
 
     return this.channel;


### PR DESCRIPTION
Issue: N/A

## What I did

Currently when the channel is accessed via addons outside of a browser environment (e.g. tests with testing-react), the following error is thrown:

```
Error: Uncaught [Error: Accessing non-existent addons channel, see https://storybook.js.org/basics/faq/#why-is-there-no-addons-channel]
```

This PR sets a mock automatically so users don't have to. I'm not sure about all implications of this change so @tmeasday I'd love if you could check this out!

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
