### PR TITLE
CLI: Pin version of `@mdx-js/react` to 1.x.x until we are compatible

### DIFF
--- a/lib/cli/src/generators/baseGenerator.ts
+++ b/lib/cli/src/generators/baseGenerator.ts
@@ -87,7 +87,7 @@ export async function baseGenerator(
   const addonPackages = [...addons, '@storybook/addon-actions'];
 
   const yarn2Dependencies =
-    packageManager.type === 'yarn2' ? ['@storybook/addon-docs', '@mdx-js/react'] : [];
+    packageManager.type === 'yarn2' ? ['@storybook/addon-docs', '@mdx-js/react@1.x.x'] : [];
 
   const files = await fse.readdir(process.cwd());
   const isNewFolder = !files.some(


### PR DESCRIPTION
(cherry picked from commit 6c24ebab35b8c56c542ce821d9de859451dbcc72)

Issue: MDX v2 was released, and we are installing it, but we are not compatible with it

## What I did

Fixed the version to 1.x

## How to test

![Screenshot 2022-02-02 at 12 12 11](https://user-images.githubusercontent.com/3070389/152143209-2df7681e-5098-4de4-b866-40b58e568524.png)

