### PR TITLE
Addon-docs: Fix typo in ArgsTable tooltip

### DIFF
--- a/lib/components/src/blocks/ArgsTable/SectionRow.tsx
+++ b/lib/components/src/blocks/ArgsTable/SectionRow.tsx
@@ -100,7 +100,7 @@ export const SectionRow: FC<SectionRowProps> = ({
   const caption = level === 'subsection' ? `${itemCount} item${itemCount !== 1 ? 's' : ''}` : '';
   const icon = expanded ? 'arrowdown' : 'arrowright';
 
-  const helperText = `${expanded ? 'Hide' : 'Side'} ${
+  const helperText = `${expanded ? 'Hide' : 'Show'} ${
     level === 'subsection' ? itemCount : label
   } item${itemCount !== 1 ? 's' : ''}`;
 


### PR DESCRIPTION
Issue: The tooltip for collapsing and showing sections in ArgsTable says "Hide [Section Name]" when visible, and "Side [Section Name]" when hidden.

## What I did

Changed "Side" to "Show".

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
