### PR TITLE
Fix typo in presets docs

### DIFF
--- a/docs/addons/writing-presets.md
+++ b/docs/addons/writing-presets.md
@@ -194,7 +194,7 @@ If it doesn't exist yet, create a file `.storybook/main.js`:
 
 ### Preview/Manager templates
 
-It's also possible to to programmatically modify the preview head/body HTML using a preset, similar to the way `preview-head.html`/`preview-body.html` can be used to [configure story rendering](../configure/story-rendering.md). The `previewHead` and `previewBody` functions accept a string, which is the existing head/body, and return a modified string.
+It's also possible to programmatically modify the preview head/body HTML using a preset, similar to the way `preview-head.html`/`preview-body.html` can be used to [configure story rendering](../configure/story-rendering.md). The `previewHead` and `previewBody` functions accept a string, which is the existing head/body, and return a modified string.
 
 For example, the following snippet adds a style tag to the preview head programatically:
 


### PR DESCRIPTION
Issue: I've spotted a typo in the Preview/Manager templates page.

## What I did
- change from `It's also possible to to` to `It's also possible to`

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
