### PR TITLE
Addon-links: Fix export statement in react.d.ts

### DIFF
--- a/addons/links/react.d.ts
+++ b/addons/links/react.d.ts
@@ -1,2 +1,2 @@
 export * from './dist/ts3.9/react';
-export { default as LinkTo } from './dist/ts3.9/react';
+export { default } from './dist/ts3.9/react';


### PR DESCRIPTION
Issue: Closes https://github.com/storybookjs/storybook/issues/14539

## What I did

The `LinkTo` component is exported using default export

https://github.com/storybookjs/storybook/blob/7064642e1aee7786c77fe735c064c0c29dbcee01/addons/links/src/react/index.ts#L1-L3

which is reflected in the `dist/ts3.9/react/index.d.ts` file

<img width="399" alt="Screen Shot 2022-02-07 at 10 10 55" src="https://user-images.githubusercontent.com/25715018/152718645-3a03af38-8dd0-4d10-8dbb-aa4072fdd609.png">

However, in the type definition file, we are exporting the component using named export

https://github.com/storybookjs/storybook/blob/7064642e1aee7786c77fe735c064c0c29dbcee01/addons/links/react.d.ts#L2

which causes a TypeScript error in the following code because there is no type definition for `LinkTo` as a default export:

<img width="980" alt="Screen Shot 2022-02-07 at 10 15 23" src="https://user-images.githubusercontent.com/25715018/152718957-42a66e29-c162-4040-8087-f90846579d16.png">

To fix the issue, I changed the export statement in `react.d.ts` to use default export.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

Tested with `examples/cra-ts-essentials` by adding `LinkTo` to a storybook file and confirm that no TS error occurs. Also, the "Go to definition" option should now point us to the correct file where the component's type definition is declared.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
