### PR TITLE
Core: Ensure we show an error when `configure()` throws

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -10,6 +10,7 @@ import {
   SET_STORIES,
   STORY_SPECIFIED,
   STORY_INDEX_INVALIDATED,
+  CONFIG_ERROR,
 } from '@storybook/core-events';
 import deprecate from 'util-deprecate';
 import { logger } from '@storybook/client-logger';
@@ -511,6 +512,13 @@ export const init: ModuleFn = ({
         fullAPI.updateStory(storyId, { args }, ref);
       }
     );
+
+    fullAPI.on(CONFIG_ERROR, function handleConfigError(err) {
+      store.setState({
+        storiesConfigured: true,
+        storiesFailed: err,
+      });
+    });
 
     if (FEATURES?.storyStoreV7) {
       provider.serverChannel?.on(STORY_INDEX_INVALIDATED, () => fullAPI.fetchStoryList());

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -6,6 +6,7 @@ import {
   STORY_SPECIFIED,
   STORY_PREPARED,
   STORY_INDEX_INVALIDATED,
+  CONFIG_ERROR,
 } from '@storybook/core-events';
 import { EventEmitter } from 'events';
 import global from 'global';
@@ -1133,6 +1134,25 @@ describe('stories API', () => {
       expect(fullAPI.updateRef.mock.calls[1][1]).toEqual({
         ready: true,
       });
+    });
+  });
+
+  describe('CONFIG_ERROR', () => {
+    it('shows error to user', async () => {
+      const navigate = jest.fn();
+      const store = createMockStore();
+      const fullAPI = Object.assign(new EventEmitter(), {});
+
+      const { api, init } = initStories({ store, navigate, provider, fullAPI });
+      Object.assign(fullAPI, api);
+
+      await init();
+
+      fullAPI.emit(CONFIG_ERROR, { message: 'Failed to run configure' });
+
+      const { storiesConfigured, storiesFailed } = store.getState();
+      expect(storiesConfigured).toBe(true);
+      expect(storiesFailed.message).toMatch(/Failed to run configure/);
     });
   });
 


### PR DESCRIPTION
Issue: When user's `configure()` threw, we didn't show an error: 

![image](https://user-images.githubusercontent.com/132554/152729904-e1add100-7c56-4403-96ab-93b3c140353a.png)

## What I did

Ensure we handle the (old) `CONFIG_ERROR` event in the manager to show the underlying iframe.

![image](https://user-images.githubusercontent.com/132554/152730013-d9f8e9af-8688-4fdb-8a2b-8dd61c89625f.png)


## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

Yes, see test.
