### PR TITLE
Remove invalid example link

### DIFF
--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -126,8 +126,6 @@ class ReactProvider extends Provider {
 
 If you like to add features to the Storybook UI or fix bugs, this is the guide you need to follow.
 
-First of all, you can need to start the [example](./example) app to see your changes.
-
 ### The App
 
 This is a Redux app written based on the [Mantra architecture](https://github.com/kadirahq/mantra/).


### PR DESCRIPTION
Issue: The example link is no longer available

## What I did

Remove it from the doc

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
