### PR TITLE
Core/CLI: Add `extract` function to `PreviewWeb` and use it in `sb extract` if available

### DIFF
--- a/lib/cli/src/extract.ts
+++ b/lib/cli/src/extract.ts
@@ -12,7 +12,7 @@ const read = async (url: string) => {
   await page.goto(url);
 
   await page.waitForFunction(
-    'window.__STORYBOOK_STORY_STORE__ && window.__STORYBOOK_STORY_STORE__.extract && window.__STORYBOOK_STORY_STORE__.extract()'
+    'window.__STORYBOOK_PREVIEW__ && window.__STORYBOOK_PREVIEW__.extract && window.__STORYBOOK_PREVIEW__.extract()'
   );
   const data = JSON.parse(
     await page.evaluate(async () => {

--- a/lib/cli/src/extract.ts
+++ b/lib/cli/src/extract.ts
@@ -11,9 +11,12 @@ const read = async (url: string) => {
 
   await page.goto(url);
 
-  await page.waitForFunction(
-    'window.__STORYBOOK_PREVIEW__ && window.__STORYBOOK_PREVIEW__.extract && window.__STORYBOOK_PREVIEW__.extract()'
-  );
+  // we don't know whether we are running against a new or old storybook
+  // FIXME: add tests for both
+  await page.waitForFunction(`
+    (window.__STORYBOOK_PREVIEW__ && window.__STORYBOOK_PREVIEW__.extract && window.__STORYBOOK_PREVIEW__.extract()) ||
+    (window.__STORYBOOK_STORY_STORE__ && window.__STORYBOOK_STORY_STORE__.extract && window.__STORYBOOK_STORY_STORE__.extract())
+  `);
   const data = JSON.parse(
     await page.evaluate(async () => {
       // eslint-disable-next-line no-undef


### PR DESCRIPTION
Issue: #13561 (related)

`StoryStore.extract()` would hang if there was an error in `preview.js`, as the store doesn't know about errors at that level. This would trip up the extract script and tools like Chromatic.

## What I did

Add `PreviewWeb.extract()` which encapsulates a bunch of different logic required to call `extract()` + co on the store:

 - Check if there were errors initializing (state on the preview)
 - Check if initializing happened at all
 - Cache CSF files (v7 store)
 - Call `extract()` on the store.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

Yes I added tests.

I am not quite sure how to test the `extract` script ahead of time. Can you help me here @ndelangen?