### PR TITLE
docs(addon-links): correct the import statement of LinkTo

### DIFF
--- a/addons/links/README.md
+++ b/addons/links/README.md
@@ -55,7 +55,8 @@ With that, you can link an event in a component to any story in the Storybook.
 You can also pass a function instead for any of above parameter. That function accepts arguments emitted by the event and it should return a string:
 
 ```js
-import { LinkTo, linkTo } from '@storybook/addon-links';
+import { linkTo } from '@storybook/addon-links';
+import LinkTo from '@storybook/addon-links/react';
 
 export default {
   title: 'Select',


### PR DESCRIPTION
Issue:

## What I did

Updated the import statement of `LinkTo` in the documentation of `addon-links`. `LinkTo` has been moved to `/react` and should be imported from `addon-links/react` instead of the package root.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
