### PR TITLE
Controls: Fix Boolean control parsing

### DIFF
--- a/lib/components/src/controls/Boolean.tsx
+++ b/lib/components/src/controls/Boolean.tsx
@@ -79,7 +79,7 @@ const Label = styled.label(({ theme }) => ({
 }));
 
 const format = (value: BooleanValue): string | null => (value ? String(value) : null);
-const parse = (value: string | null) => value === 'true';
+const parse = (value: string | null): boolean => value === 'true';
 
 export type BooleanProps = ControlProps<BooleanValue> & BooleanConfig;
 export const BooleanControl: FC<BooleanProps> = ({ name, value, onChange, onBlur, onFocus }) => {
@@ -92,13 +92,15 @@ export const BooleanControl: FC<BooleanProps> = ({ name, value, onChange, onBlur
     );
   }
 
+  const parsedValue = (typeof value === 'string') ? parse(value) : value
+
   return (
-    <Label htmlFor={name} title={value ? 'Change to false' : 'Change to true'}>
+    <Label htmlFor={name} title={parsedValue ? 'Change to false' : 'Change to true'}>
       <input
         id={getControlId(name)}
         type="checkbox"
         onChange={(e) => onChange(e.target.checked)}
-        checked={value || false}
+        checked={parsedValue}
         {...{ name, onBlur, onFocus }}
       />
       <span>False</span>


### PR DESCRIPTION
Issue:

## What I did
I improved the Controls section related to the boolean, since there were some scenarios where the value provided to `checked` was a string (`true` or `false`) instead of booleans and React was complaining.


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
