### PR TITLE
Fix `ci:matrix` label in CI

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Core Unit Tests node-${{ matrix.node_version }}, ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event.label.name == 'ci:matrix'
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci:matrix')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Issue: none

## What I did

In my own project, I attempted to set up a similar github workflow, which would not run unless a tag was present.  After experimenting a bit, I found that the way the check here in storybook is set up is not correct.  The approach in this PR is what I landed on in my own project, and seems to work correctly.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

Verify that the unit test matrix does not run on this PR.  Add the label, verify that the unit test matrix starts running.  Push a commit to the PR, verify that they run again.


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
