### PR TITLE
 docs: replaced 'as ComponentMeta' in TypeScript stories

### DIFF
--- a/addons/interactions/src/Panel.stories.tsx
+++ b/addons/interactions/src/Panel.stories.tsx
@@ -20,7 +20,7 @@ const StyledWrapper = styled.div(({ theme }) => ({
   overflow: 'auto',
 }));
 
-const Meta: ComponentMeta<typeof AddonPanelPure> = {
+const StoryMeta: ComponentMeta<typeof AddonPanelPure> = {
   title: 'Addons/Interactions/Panel',
   component: AddonPanelPure,
   decorators: [
@@ -48,7 +48,7 @@ const Meta: ComponentMeta<typeof AddonPanelPure> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 type Story = ComponentStoryObj<typeof AddonPanelPure>;
 

--- a/addons/interactions/src/Panel.stories.tsx
+++ b/addons/interactions/src/Panel.stories.tsx
@@ -20,7 +20,7 @@ const StyledWrapper = styled.div(({ theme }) => ({
   overflow: 'auto',
 }));
 
-export default {
+const Meta: ComponentMeta<typeof AddonPanelPure> = {
   title: 'Addons/Interactions/Panel',
   component: AddonPanelPure,
   decorators: [
@@ -46,7 +46,9 @@ export default {
     // prop for the AddonPanel used as wrapper of Panel
     active: true,
   },
-} as ComponentMeta<typeof AddonPanelPure>;
+};
+
+export default Meta;
 
 type Story = ComponentStoryObj<typeof AddonPanelPure>;
 

--- a/addons/interactions/src/components/Interaction/Interaction.stories.tsx
+++ b/addons/interactions/src/components/Interaction/Interaction.stories.tsx
@@ -9,7 +9,7 @@ import SubnavStories from '../Subnav/Subnav.stories';
 
 type Story = ComponentStoryObj<typeof Interaction>;
 
-export default {
+const Meta: ComponentMeta<typeof Interaction> = {
   title: 'Addons/Interactions/Interaction',
   component: Interaction,
   args: {
@@ -17,7 +17,9 @@ export default {
     controls: SubnavStories.args.controls,
     controlStates: SubnavStories.args.controlStates,
   },
-} as ComponentMeta<typeof Interaction>;
+};
+
+export default Meta;
 
 export const Active: Story = {
   args: {

--- a/addons/interactions/src/components/Interaction/Interaction.stories.tsx
+++ b/addons/interactions/src/components/Interaction/Interaction.stories.tsx
@@ -9,7 +9,7 @@ import SubnavStories from '../Subnav/Subnav.stories';
 
 type Story = ComponentStoryObj<typeof Interaction>;
 
-const Meta: ComponentMeta<typeof Interaction> = {
+const StoryMeta: ComponentMeta<typeof Interaction> = {
   title: 'Addons/Interactions/Interaction',
   component: Interaction,
   args: {
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof Interaction> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const Active: Story = {
   args: {

--- a/app/react/src/client/preview/types-6-3.ts
+++ b/app/react/src/client/preview/types-6-3.ts
@@ -7,8 +7,8 @@ export * from './types-6-0';
  * For the common case where a component's stories are simple components that receives args as props:
  *
  * ```tsx
- * const Meta: ComponentMeta<typeof Button> = { ... };
- * export default Meta;
+ * const StoryMeta: ComponentMeta<typeof Button> = { ... };
+ * export default StoryMeta;
  * ```
  */
 export type ComponentMeta<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> =

--- a/app/react/src/client/preview/types-6-3.ts
+++ b/app/react/src/client/preview/types-6-3.ts
@@ -7,7 +7,8 @@ export * from './types-6-0';
  * For the common case where a component's stories are simple components that receives args as props:
  *
  * ```tsx
- * export default { ... } as ComponentMeta<typeof Button>;
+ * const Meta: ComponentMeta<typeof Button> = { ... };
+ * export default Meta;
  * ```
  */
 export type ComponentMeta<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> =

--- a/docs/snippets/react/app-story-with-mock.ts.mdx
+++ b/docs/snippets/react/app-story-with-mock.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import App from './App';
 
-export default {
+const Meta: ComponentMeta<typeof App> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'App',
   component: App,
-} as ComponentMeta<typeof App>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof App> = () => <App />;
 

--- a/docs/snippets/react/app-story-with-mock.ts.mdx
+++ b/docs/snippets/react/app-story-with-mock.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import App from './App';
 
-const Meta: ComponentMeta<typeof App> = {
+const StoryMeta: ComponentMeta<typeof App> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof App> = {
   component: App,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof App> = () => <App />;
 

--- a/docs/snippets/react/button-group-story.ts.mdx
+++ b/docs/snippets/react/button-group-story.ts.mdx
@@ -10,14 +10,16 @@ import { ButtonGroup } from '../ButtonGroup';
 //👇 Imports the Button stories
 import * as ButtonStories from './Button.stories';
 
-export default {
+const Meta: ComponentMeta<typeof ButtonGroup> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'ButtonGroup',
   component: ButtonGroup,
-} as ComponentMeta<typeof ButtonGroup>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof ButtonGroup> = (args) => <ButtonGroup {...args} />;
 

--- a/docs/snippets/react/button-group-story.ts.mdx
+++ b/docs/snippets/react/button-group-story.ts.mdx
@@ -10,7 +10,7 @@ import { ButtonGroup } from '../ButtonGroup';
 //👇 Imports the Button stories
 import * as ButtonStories from './Button.stories';
 
-const Meta: ComponentMeta<typeof ButtonGroup> = {
+const StoryMeta: ComponentMeta<typeof ButtonGroup> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof ButtonGroup> = {
   component: ButtonGroup,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof ButtonGroup> = (args) => <ButtonGroup {...args} />;
 

--- a/docs/snippets/react/button-story-click-handler.ts.mdx
+++ b/docs/snippets/react/button-story-click-handler.ts.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const Basic: ComponentStory<typeof Button> = () => <Button label="Hello" onClick={action('clicked')} />;
 ```

--- a/docs/snippets/react/button-story-click-handler.ts.mdx
+++ b/docs/snippets/react/button-story-click-handler.ts.mdx
@@ -9,14 +9,16 @@ import { action } from '@storybook/addon-actions';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button', 
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 
 export const Basic: ComponentStory<typeof Button> = () => <Button label="Hello" onClick={action('clicked')} />;
 ```

--- a/docs/snippets/react/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -24,5 +24,5 @@ const Meta: ComponentMeta<typeof Button> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 ```

--- a/docs/snippets/react/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -22,5 +22,7 @@ export default {
     //👇 Now all Button stories will be primary.
     primary: true,
   },
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 ```

--- a/docs/snippets/react/button-story-component-decorator.story-function-ts.ts.mdx
+++ b/docs/snippets/react/button-story-component-decorator.story-function-ts.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -21,5 +21,7 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 ```

--- a/docs/snippets/react/button-story-component-decorator.story-function-ts.ts.mdx
+++ b/docs/snippets/react/button-story-component-decorator.story-function-ts.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -23,5 +23,5 @@ const Meta: ComponentMeta<typeof Button> = {
   ],
 };
 
-export default Meta;
+export default StoryMeta;
 ```

--- a/docs/snippets/react/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-component-decorator.ts.mdx
@@ -23,5 +23,5 @@ const Meta: ComponentMeta<typeof Button> = {
   ],
 };
 
-export const Meta;
+export default Meta;
 ```

--- a/docs/snippets/react/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-component-decorator.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -23,5 +23,5 @@ const Meta: ComponentMeta<typeof Button> = {
   ],
 };
 
-export default Meta;
+export default StoryMeta;
 ```

--- a/docs/snippets/react/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-component-decorator.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -21,5 +21,7 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof Button>;
+};
+
+export const Meta;
 ```

--- a/docs/snippets/react/button-story-decorator.story-function-ts.ts.mdx
+++ b/docs/snippets/react/button-story-decorator.story-function-ts.ts.mdx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -14,7 +14,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/button-story-decorator.story-function-ts.ts.mdx
+++ b/docs/snippets/react/button-story-decorator.story-function-ts.ts.mdx
@@ -14,7 +14,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export const Meta;
+export default Meta;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/button-story-decorator.story-function-ts.ts.mdx
+++ b/docs/snippets/react/button-story-decorator.story-function-ts.ts.mdx
@@ -5,14 +5,16 @@ import React from 'react';
 
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export const Meta;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/button-story-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-decorator.ts.mdx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -14,7 +14,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/button-story-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-decorator.ts.mdx
@@ -14,7 +14,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export const Meta;
+export default Meta;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/button-story-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-decorator.ts.mdx
@@ -5,14 +5,16 @@ import React from 'react';
 
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export const Meta;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/button-story-default-docs-code.ts.mdx
+++ b/docs/snippets/react/button-story-default-docs-code.ts.mdx
@@ -12,7 +12,7 @@ const someFunction = (someValue: String) => {
   return `i am a ${someValue}`;
 };
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -25,7 +25,7 @@ const Meta: ComponentMeta<typeof Button> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const ExampleStory: ComponentStory<typeof Button> = (args) => {
   //👇 Destructure the label from the args object

--- a/docs/snippets/react/button-story-default-docs-code.ts.mdx
+++ b/docs/snippets/react/button-story-default-docs-code.ts.mdx
@@ -12,7 +12,7 @@ const someFunction = (someValue: String) => {
   return `i am a ${someValue}`;
 };
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -23,7 +23,9 @@ export default {
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-} as ComponentMeta<typeof Button>;
+};
+
+export const Meta;
 
 export const ExampleStory: ComponentStory<typeof Button> = (args) => {
   //👇 Destructure the label from the args object

--- a/docs/snippets/react/button-story-default-docs-code.ts.mdx
+++ b/docs/snippets/react/button-story-default-docs-code.ts.mdx
@@ -25,7 +25,7 @@ const Meta: ComponentMeta<typeof Button> = {
   },
 };
 
-export const Meta;
+export default Meta;
 
 export const ExampleStory: ComponentStory<typeof Button> = (args) => {
   //👇 Destructure the label from the args object

--- a/docs/snippets/react/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,5 +16,5 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 ```

--- a/docs/snippets/react/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.ts.mdx
@@ -7,12 +7,14 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export const Meta;
 ```

--- a/docs/snippets/react/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.ts.mdx
@@ -16,5 +16,5 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export const Meta;
+export default Meta;
 ```

--- a/docs/snippets/react/button-story-rename-story.ts.mdx
+++ b/docs/snippets/react/button-story-rename-story.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export const Meta;
 
 export const Primary: ComponentStory<typeof Button> = () => <Button primary label="Button"/>;
 Primary.storyName = 'I am the primary';

--- a/docs/snippets/react/button-story-rename-story.ts.mdx
+++ b/docs/snippets/react/button-story-rename-story.ts.mdx
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export const Meta;
+export default Meta;
 
 export const Primary: ComponentStory<typeof Button> = () => <Button primary label="Button"/>;
 Primary.storyName = 'I am the primary';

--- a/docs/snippets/react/button-story-rename-story.ts.mdx
+++ b/docs/snippets/react/button-story-rename-story.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const Primary: ComponentStory<typeof Button> = () => <Button primary label="Button"/>;
 Primary.storyName = 'I am the primary';

--- a/docs/snippets/react/button-story-using-args.ts.mdx
+++ b/docs/snippets/react/button-story-using-args.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;

--- a/docs/snippets/react/button-story-using-args.ts.mdx
+++ b/docs/snippets/react/button-story-using-args.ts.mdx
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export const Meta;
+export default Meta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;

--- a/docs/snippets/react/button-story-using-args.ts.mdx
+++ b/docs/snippets/react/button-story-using-args.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export const Meta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;

--- a/docs/snippets/react/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/react/button-story-with-addon-example.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -20,7 +20,9 @@ export default {
       data: 'this data is passed to the addon',
     },
   },
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 
 const Basic: ComponentStory<typeof Button> = () => <Button>hello</Button>;
 ```

--- a/docs/snippets/react/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/react/button-story-with-addon-example.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -22,7 +22,7 @@ const Meta: ComponentMeta<typeof Button> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Basic: ComponentStory<typeof Button> = () => <Button>hello</Button>;
 ```

--- a/docs/snippets/react/button-story-with-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-args.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button, ButtonProps } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;

--- a/docs/snippets/react/button-story-with-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-args.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button, ButtonProps } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;

--- a/docs/snippets/react/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-blue-args.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -26,5 +26,5 @@ const Meta: ComponentMeta<typeof Button> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 ```

--- a/docs/snippets/react/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-blue-args.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -24,5 +24,7 @@ export default {
       ],
     },
   },
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 ```

--- a/docs/snippets/react/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/react/button-story-with-emojis.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const Primary: ComponentStory<typeof Button> = () => (
   <Button backgroundColor="#ff0" label="Button" />

--- a/docs/snippets/react/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/react/button-story-with-emojis.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 
 export const Primary: ComponentStory<typeof Button> = () => (
   <Button backgroundColor="#ff0" label="Button" />

--- a/docs/snippets/react/button-story-with-parameters.ts.mdx
+++ b/docs/snippets/react/button-story-with-parameters.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 import { ComponentMeta } from '@storybook/react';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -25,5 +25,5 @@ const Meta: ComponentMeta<typeof Button> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 ```

--- a/docs/snippets/react/button-story-with-parameters.ts.mdx
+++ b/docs/snippets/react/button-story-with-parameters.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 import { ComponentMeta } from '@storybook/react';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,10 +18,12 @@ export default {
   parameters: {
     backgrounds: {
       values: [
-         { name: 'red', value: '#f00', },
-         { name: 'green', value: '#0f0', },
+        { name: 'red', value: '#f00', },
+        { name: 'green', value: '#0f0', },
       ],
     }
   },
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 ```

--- a/docs/snippets/react/button-story.ts.mdx
+++ b/docs/snippets/react/button-story.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
   component: Button,
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 
 export const Primary: ComponentStory<typeof Button> = () => <Button primary>Button</Button>;
 ```

--- a/docs/snippets/react/button-story.ts.mdx
+++ b/docs/snippets/react/button-story.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Button> = {
   component: Button,
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const Primary: ComponentStory<typeof Button> = () => <Button primary>Button</Button>;
 ```

--- a/docs/snippets/react/checkbox-story-csf.ts.mdx
+++ b/docs/snippets/react/checkbox-story-csf.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { Checkbox } from './Checkbox';
 
-const Meta: ComponentMeta<typeof Checkbox> = {
+const StoryMeta: ComponentMeta<typeof Checkbox> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Checkbox> = {
   component: Checkbox,
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const allCheckboxes: ComponentStory<typeof Checkbox> = () => (
   <form>

--- a/docs/snippets/react/checkbox-story-csf.ts.mdx
+++ b/docs/snippets/react/checkbox-story-csf.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { Checkbox } from './Checkbox';
 
-export default {
+const Meta: ComponentMeta<typeof Checkbox> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Checkbox', 
   component: Checkbox,
-} as ComponentMeta<typeof Checkbox>;
+};
+
+export default Meta;
 
 export const allCheckboxes: ComponentStory<typeof Checkbox> = () => (
   <form>

--- a/docs/snippets/react/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.ts.mdx
@@ -12,7 +12,7 @@ const someFunction = (valuePropertyA, valuePropertyB) => {
   // Makes some computations and returns something
 };
 
-const Meta: ComponentMeta<typeof YourComponent> = {
+const StoryMeta: ComponentMeta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -30,7 +30,7 @@ const Meta: ComponentMeta<typeof YourComponent> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof YourComponent> = ({ propertyA, propertyB, ...rest }) => {
   //👇 Assigns the result from the function to a variable

--- a/docs/snippets/react/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.ts.mdx
@@ -12,7 +12,7 @@ const someFunction = (valuePropertyA, valuePropertyB) => {
   // Makes some computations and returns something
 };
 
-export default {
+const Meta: ComponentMeta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -28,7 +28,9 @@ export default {
       options: ['Another Item One', 'Another Item Two', 'Another Item Three'],
     },
   },
-} as ComponentMeta<typeof YourComponent>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof YourComponent> = ({ propertyA, propertyB, ...rest }) => {
   //👇 Assigns the result from the function to a variable

--- a/docs/snippets/react/component-story-with-accessibility.ts.mdx
+++ b/docs/snippets/react/component-story-with-accessibility.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading to learn how to generate automatic titles
   */
@@ -16,8 +16,9 @@ export default {
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-} as ComponentMeta<typeof Button>;
+};
 
+export default Meta;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/component-story-with-accessibility.ts.mdx
+++ b/docs/snippets/react/component-story-with-accessibility.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Button } from './Button';
 
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading to learn how to generate automatic titles
   */
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof Button> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 

--- a/docs/snippets/react/list-story-expanded.ts.mdx
+++ b/docs/snippets/react/list-story-expanded.ts.mdx
@@ -8,14 +8,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { List } from './List';
 import { ListItem } from './ListItem';
 
-export default {
+const Meta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'List',
   component: List,
-} as ComponentMeta<typeof List>;
+};
+
+export default Meta;
 
 export const Empty: ComponentStory<typeof List> = (args) => <List {...args} />;
 

--- a/docs/snippets/react/list-story-expanded.ts.mdx
+++ b/docs/snippets/react/list-story-expanded.ts.mdx
@@ -8,7 +8,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { List } from './List';
 import { ListItem } from './ListItem';
 
-const Meta: ComponentMeta<typeof List> = {
+const StoryMeta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -17,7 +17,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const Empty: ComponentStory<typeof List> = (args) => <List {...args} />;
 

--- a/docs/snippets/react/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/react/list-story-reuse-data.ts.mdx
@@ -11,14 +11,16 @@ import { ListItem } from './ListItem';
 //👇 All ListItem stories are imported
 import * as ListItemStories from './ListItemStories';
 
-export default {
+const Meta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'List',
   component: List,
-} as ComponentMeta<typeof List>;
+};
+
+export default Meta;
 
 export const ManyItems: ComponentStory<typeof List> = (args) => (
   <List {...args}>

--- a/docs/snippets/react/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/react/list-story-reuse-data.ts.mdx
@@ -11,7 +11,7 @@ import { ListItem } from './ListItem';
 //👇 All ListItem stories are imported
 import * as ListItemStories from './ListItemStories';
 
-const Meta: ComponentMeta<typeof List> = {
+const StoryMeta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -20,7 +20,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const ManyItems: ComponentStory<typeof List> = (args) => (
   <List {...args}>

--- a/docs/snippets/react/list-story-starter.ts.mdx
+++ b/docs/snippets/react/list-story-starter.ts.mdx
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export const Meta;
+export default Meta;
 
 //👇 Always an empty list, not super interesting
 const Template: ComponentStory<typeof List> = (args) => <List {...args} />;

--- a/docs/snippets/react/list-story-starter.ts.mdx
+++ b/docs/snippets/react/list-story-starter.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { List } from './List';
 
-export default {
+const Meta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'List',
   component: List,
-} as ComponentMeta<typeof List>;
+};
+
+export const Meta;
 
 //👇 Always an empty list, not super interesting
 const Template: ComponentStory<typeof List> = (args) => <List {...args} />;

--- a/docs/snippets/react/list-story-starter.ts.mdx
+++ b/docs/snippets/react/list-story-starter.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { List } from './List';
 
-const Meta: ComponentMeta<typeof List> = {
+const StoryMeta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export default Meta;
+export default StoryMeta;
 
 //👇 Always an empty list, not super interesting
 const Template: ComponentStory<typeof List> = (args) => <List {...args} />;

--- a/docs/snippets/react/list-story-template.ts.mdx
+++ b/docs/snippets/react/list-story-template.ts.mdx
@@ -20,7 +20,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export const Meta;
+export default Meta;
 
 const ListTemplate: ComponentStory<typeof ButtonGroup> = (args) => {
   const { items } = args;

--- a/docs/snippets/react/list-story-template.ts.mdx
+++ b/docs/snippets/react/list-story-template.ts.mdx
@@ -11,14 +11,16 @@ import { ListItem } from './ListItem';
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
-export default {
+const Meta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'List',
   component: List,
-} as ComponentMeta<typeof List>;
+};
+
+export const Meta;
 
 const ListTemplate: ComponentStory<typeof ButtonGroup> = (args) => {
   const { items } = args;

--- a/docs/snippets/react/list-story-template.ts.mdx
+++ b/docs/snippets/react/list-story-template.ts.mdx
@@ -11,7 +11,7 @@ import { ListItem } from './ListItem';
 //👇 Imports a specific story from ListItem stories
 import { Unchecked } from './ListItem.stories';
 
-const Meta: ComponentMeta<typeof List> = {
+const StoryMeta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -20,7 +20,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const ListTemplate: ComponentStory<typeof ButtonGroup> = (args) => {
   const { items } = args;

--- a/docs/snippets/react/list-story-unchecked.ts.mdx
+++ b/docs/snippets/react/list-story-unchecked.ts.mdx
@@ -10,14 +10,16 @@ import { List } from './List';
 //👇 Instead of importing ListItem, we import the stories
 import { Unchecked } from './ListItem.stories';
 
-export default {
+const Meta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'List',
   component: List,
-} as ComponentMeta<typeof List>;
+};
+
+export const Meta;
 
 const OneItem: ComponentStory<typeof List> = (args) => (
   <List {...args}>

--- a/docs/snippets/react/list-story-unchecked.ts.mdx
+++ b/docs/snippets/react/list-story-unchecked.ts.mdx
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export const Meta;
+export default Meta;
 
 const OneItem: ComponentStory<typeof List> = (args) => (
   <List {...args}>

--- a/docs/snippets/react/list-story-unchecked.ts.mdx
+++ b/docs/snippets/react/list-story-unchecked.ts.mdx
@@ -10,7 +10,7 @@ import { List } from './List';
 //👇 Instead of importing ListItem, we import the stories
 import { Unchecked } from './ListItem.stories';
 
-const Meta: ComponentMeta<typeof List> = {
+const StoryMeta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const OneItem: ComponentStory<typeof List> = (args) => (
   <List {...args}>

--- a/docs/snippets/react/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/react/list-story-with-subcomponents.ts.mdx
@@ -8,7 +8,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { List } from './List';
 import { ListItem } from './ListItem';
 
-export default {
+const Meta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -17,7 +17,9 @@ export default {
   component: List,
   subcomponents: { ListItem }, //👈 Adds the ListItem component as a subcomponent
   title: 'List',
-} as ComponentMeta<typeof List>;
+};
+
+export const Meta;
 
 const Empty: ComponentStory<typeof List> = (args) => <List {...args} />;
 

--- a/docs/snippets/react/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/react/list-story-with-subcomponents.ts.mdx
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof List> = {
   title: 'List',
 };
 
-export const Meta;
+export default Meta;
 
 const Empty: ComponentStory<typeof List> = (args) => <List {...args} />;
 

--- a/docs/snippets/react/list-story-with-subcomponents.ts.mdx
+++ b/docs/snippets/react/list-story-with-subcomponents.ts.mdx
@@ -8,7 +8,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { List } from './List';
 import { ListItem } from './ListItem';
 
-const Meta: ComponentMeta<typeof List> = {
+const StoryMeta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof List> = {
   title: 'List',
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Empty: ComponentStory<typeof List> = (args) => <List {...args} />;
 

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -10,14 +10,16 @@ import { List } from './List';
 //👇 Instead of importing ListItem, we import the stories
 import { Unchecked } from './ListItem.stories';
 
-export default {
+const Meta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'List',
   component: List,
-} as ComponentMeta<typeof List>;
+};
+
+export const Meta;
 
 const Template: ComponentStory<typeof List> = (args) => <List {...args} />;
 

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export const Meta;
+export default Meta;
 
 const Template: ComponentStory<typeof List> = (args) => <List {...args} />;
 

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -10,7 +10,7 @@ import { List } from './List';
 //👇 Instead of importing ListItem, we import the stories
 import { Unchecked } from './ListItem.stories';
 
-const Meta: ComponentMeta<typeof List> = {
+const StoryMeta: ComponentMeta<typeof List> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof List> = {
   component: List,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof List> = (args) => <List {...args} />;
 

--- a/docs/snippets/react/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/react/login-form-with-play-function.ts.mdx
@@ -9,14 +9,16 @@ import { within, userEvent } from '@storybook/testing-library';
 
 import { LoginForm } from './LoginForm';
 
-export default {
+const Meta: ComponentMeta<typeof LoginForm> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Form',
   component: LoginForm,
-} as ComponentMeta<typeof LoginForm>;
+};
+
+export const Meta;
 
 const Template: ComponentStory<typeof LoginForm> = (args) => <LoginForm {...args} />;
 

--- a/docs/snippets/react/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/react/login-form-with-play-function.ts.mdx
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof LoginForm> = {
   component: LoginForm,
 };
 
-export const Meta;
+export default Meta;
 
 const Template: ComponentStory<typeof LoginForm> = (args) => <LoginForm {...args} />;
 

--- a/docs/snippets/react/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/react/login-form-with-play-function.ts.mdx
@@ -9,7 +9,7 @@ import { within, userEvent } from '@storybook/testing-library';
 
 import { LoginForm } from './LoginForm';
 
-const Meta: ComponentMeta<typeof LoginForm> = {
+const StoryMeta: ComponentMeta<typeof LoginForm> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof LoginForm> = {
   component: LoginForm,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof LoginForm> = (args) => <LoginForm {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-alt-queries.ts.mdx
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export const Meta;
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-alt-queries.ts.mdx
@@ -9,14 +9,16 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'QueryMethods',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export const Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-alt-queries.ts.mdx
@@ -9,7 +9,7 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.ts.mdx
@@ -9,7 +9,7 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/eact/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.ts.mdx
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export const Meta;
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.ts.mdx
@@ -9,14 +9,16 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/eact/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'MyComponent',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export const Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-waitfor.ts.mdx
@@ -9,7 +9,7 @@ import { screen, userEvent, waitFor } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-waitfor.ts.mdx
@@ -9,14 +9,16 @@ import { screen, userEvent, waitFor } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'WithAsync',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-with-canvas.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-canvas.ts.mdx
@@ -9,7 +9,7 @@ import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-with-canvas.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-canvas.ts.mdx
@@ -9,14 +9,16 @@ import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'WithCanvasElement',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-clickevent.ts.mdx
@@ -9,14 +9,16 @@ import { fireEvent, screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'ClickExamples',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-clickevent.ts.mdx
@@ -9,7 +9,7 @@ import { fireEvent, screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-with-delay.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-delay.ts.mdx
@@ -9,7 +9,7 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-with-delay.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-delay.ts.mdx
@@ -9,14 +9,16 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'WithDelay',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-play-function-with-selectevent.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-selectevent.ts.mdx
@@ -9,14 +9,16 @@ import { userEvent, screen } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'WithSelectEvent',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 // Function to emulate pausing between interactions
 function sleep(ms: number) {

--- a/docs/snippets/react/my-component-play-function-with-selectevent.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-selectevent.ts.mdx
@@ -9,7 +9,7 @@ import { userEvent, screen } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 // Function to emulate pausing between interactions
 function sleep(ms: number) {

--- a/docs/snippets/react/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/react/my-component-story-basic-and-props.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const Basic: ComponentStory<typeof MyComponent> = () => <MyComponent/>;
 

--- a/docs/snippets/react/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/react/my-component-story-basic-and-props.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Path/To/MyComponent',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 export const Basic: ComponentStory<typeof MyComponent> = () => <MyComponent/>;
 

--- a/docs/snippets/react/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.ts.mdx
@@ -9,7 +9,7 @@ import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -25,7 +25,9 @@ export default {
       defaultViewport: 'iphone6',
     },
   },
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 export const MyStory: ComponentStory<typeof MyComponent> = () => <MyComponent />;
 MyStory.parameters = {

--- a/docs/snippets/react/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.ts.mdx
@@ -9,7 +9,7 @@ import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -27,7 +27,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const MyStory: ComponentStory<typeof MyComponent> = () => <MyComponent />;
 MyStory.parameters = {

--- a/docs/snippets/react/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/react/my-component-story-with-nonstory.ts.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 import someData from './data.json';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,9 @@ export default {
   component: MyComponent,
   includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
   excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 export const simpleData = { foo: 1, bar: 'baz' };
 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };

--- a/docs/snippets/react/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/react/my-component-story-with-nonstory.ts.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 import someData from './data.json';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -20,7 +20,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
 };
 
-export default Meta;
+export default StoryMeta;
 
 export const simpleData = { foo: 1, bar: 'baz' };
 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };

--- a/docs/snippets/react/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'MyComponent',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...args} />;
 

--- a/docs/snippets/react/page-story-slots.ts.mdx
+++ b/docs/snippets/react/page-story-slots.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Page } from './Page';
 
-const Meta: ComponentMeta<typeof Page> = {
+const StoryMeta: ComponentMeta<typeof Page> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof Page> = {
   component: Page,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof Page> = (args) => (
   <Page {...args}>

--- a/docs/snippets/react/page-story-slots.ts.mdx
+++ b/docs/snippets/react/page-story-slots.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Page } from './Page';
 
-export default {
+const Meta: ComponentMeta<typeof Page> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Page',
   component: Page,
-} as ComponentMeta<typeof Page>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof Page> = (args) => (
   <Page {...args}>

--- a/docs/snippets/react/page-story-with-args-composition.ts.mdx
+++ b/docs/snippets/react/page-story-with-args-composition.ts.mdx
@@ -11,7 +11,7 @@ import PageLayout from './PageLayout.stories';
 import DocumentHeader from './DocumentHeader.stories';
 import DocumentList from './DocumentList.stories';
 
-const Meta: ComponentMeta<typeof DocumentScreen> = {
+const StoryMeta: ComponentMeta<typeof DocumentScreen> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -21,7 +21,7 @@ const Meta: ComponentMeta<typeof DocumentScreen> = {
   title: 'DocumentScreen',
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof DocumentScreen> = (args) => <DocumentScreen {...args} />;
 

--- a/docs/snippets/react/page-story-with-args-composition.ts.mdx
+++ b/docs/snippets/react/page-story-with-args-composition.ts.mdx
@@ -11,7 +11,7 @@ import PageLayout from './PageLayout.stories';
 import DocumentHeader from './DocumentHeader.stories';
 import DocumentList from './DocumentList.stories';
 
-export default {
+const Meta: ComponentMeta<typeof DocumentScreen> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -19,8 +19,9 @@ export default {
   title: 'DocumentScreen',
   component: DocumentScreen,
   title: 'DocumentScreen',
-} as ComponentMeta<typeof DocumentScreen>;
+};
 
+export default Meta;
 
 const Template: ComponentStory<typeof DocumentScreen> = (args) => <DocumentScreen {...args} />;
 

--- a/docs/snippets/react/page-story.ts.mdx
+++ b/docs/snippets/react/page-story.ts.mdx
@@ -10,14 +10,16 @@ import { Page } from './Page';
 //👇 Imports all Header stories
 import * as HeaderStories from './Header.stories';
 
-export default {
+const Meta: ComponentMeta<typeof Page> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Page',
   component: Page,
-} as ComponentMeta<typeof Page>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
 

--- a/docs/snippets/react/page-story.ts.mdx
+++ b/docs/snippets/react/page-story.ts.mdx
@@ -10,7 +10,7 @@ import { Page } from './Page';
 //👇 Imports all Header stories
 import * as HeaderStories from './Header.stories';
 
-const Meta: ComponentMeta<typeof Page> = {
+const StoryMeta: ComponentMeta<typeof Page> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -19,7 +19,7 @@ const Meta: ComponentMeta<typeof Page> = {
   component: Page,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
 

--- a/docs/snippets/react/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/react/register-component-with-play-function.ts.mdx
@@ -9,7 +9,7 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { RegistrationForm } from './RegistrationForm';
 
-const Meta: ComponentMeta<typeof RegistrationForm> = {
+const StoryMeta: ComponentMeta<typeof RegistrationForm> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -18,7 +18,7 @@ const Meta: ComponentMeta<typeof RegistrationForm> = {
   component: RegistrationForm,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof RegistrationForm> = (args) => <RegistrationForm {...args} />;
 

--- a/docs/snippets/react/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/react/register-component-with-play-function.ts.mdx
@@ -9,14 +9,16 @@ import { screen, userEvent } from '@storybook/testing-library';
 
 import { RegistrationForm } from './RegistrationForm';
 
-export default {
+const Meta: ComponentMeta<typeof RegistrationForm> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'RegistrationForm',
   component: RegistrationForm,
-} as ComponentMeta<typeof RegistrationForm>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof RegistrationForm> = (args) => <RegistrationForm {...args} />;
 

--- a/docs/snippets/react/storybook-addon-a11y-disable.ts.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-disable.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading 
   * to learn how to generate automatic titles
   */
   title: 'Disable a11y addon',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = () => <MyComponent />;
 

--- a/docs/snippets/react/storybook-addon-a11y-disable.ts.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-disable.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading 
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = () => <MyComponent />;
 

--- a/docs/snippets/react/storybook-addon-a11y-story-config.ts.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-story-config.ts.mdx
@@ -7,7 +7,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { MyComponent } from './MyComponent';
 
-const Meta: ComponentMeta<typeof MyComponent> = {
+const StoryMeta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading 
   * to learn how to generate automatic titles
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof MyComponent> = {
   component: MyComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof MyComponent> = () => <MyComponent />;
 

--- a/docs/snippets/react/storybook-addon-a11y-story-config.ts.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-story-config.ts.mdx
@@ -7,14 +7,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const Meta: ComponentMeta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading 
   * to learn how to generate automatic titles
   */
   title: 'Configure a11y addon',
   component: MyComponent,
-} as ComponentMeta<typeof MyComponent>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof MyComponent> = () => <MyComponent />;
 

--- a/docs/snippets/react/your-component-with-decorator.story-function-ts.ts.mdx
+++ b/docs/snippets/react/your-component-with-decorator.story-function-ts.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent';
 
 // Replacing the <Story/> element with a Story function is also a good way of writing decorators.
 // Useful to prevent the full remount of the component's story.
-const Meta: ComponentMeta<typeof YourComponent> = {
+const StoryMeta: ComponentMeta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -23,5 +23,5 @@ const Meta: ComponentMeta<typeof YourComponent> = {
   ],
 };
 
-export default Meta;
+export default StoryMeta;
 ```

--- a/docs/snippets/react/your-component-with-decorator.story-function-ts.ts.mdx
+++ b/docs/snippets/react/your-component-with-decorator.story-function-ts.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent';
 
 // Replacing the <Story/> element with a Story function is also a good way of writing decorators.
 // Useful to prevent the full remount of the component's story.
-export default {
+const Meta: ComponentMeta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -21,5 +21,7 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof YourComponent>;
+};
+
+export default Meta;
 ```

--- a/docs/snippets/react/your-component-with-decorator.ts.mdx
+++ b/docs/snippets/react/your-component-with-decorator.ts.mdx
@@ -5,7 +5,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { YourComponent } from './YourComponent';
 
-export default {
+const Meta: ComponentMeta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -19,5 +19,7 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof YourComponent>;
+};
+
+export default Meta;
 ```

--- a/docs/snippets/react/your-component-with-decorator.ts.mdx
+++ b/docs/snippets/react/your-component-with-decorator.ts.mdx
@@ -5,7 +5,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { YourComponent } from './YourComponent';
 
-const Meta: ComponentMeta<typeof YourComponent> = {
+const StoryMeta: ComponentMeta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -21,5 +21,5 @@ const Meta: ComponentMeta<typeof YourComponent> = {
   ],
 };
 
-export default Meta;
+export default StoryMeta;
 ```

--- a/docs/snippets/react/your-component.ts.mdx
+++ b/docs/snippets/react/your-component.ts.mdx
@@ -8,7 +8,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { YourComponent } from './YourComponent';
 
 //👇 This default export determines where your story goes in the story list
-const Meta: ComponentMeta<typeof YourComponent> = {
+const StoryMeta: ComponentMeta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
@@ -17,7 +17,7 @@ const Meta: ComponentMeta<typeof YourComponent> = {
   component: YourComponent,
 };
 
-export default Meta;
+export default StoryMeta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof YourComponent> = (args) => <YourComponent {...args} />;

--- a/docs/snippets/react/your-component.ts.mdx
+++ b/docs/snippets/react/your-component.ts.mdx
@@ -8,14 +8,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { YourComponent } from './YourComponent';
 
 //👇 This default export determines where your story goes in the story list
-export default {
+const Meta: ComponentMeta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'YourComponent',
   component: YourComponent,
-} as ComponentMeta<typeof YourComponent>;
+};
+
+export default Meta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof YourComponent> = (args) => <YourComponent {...args} />;

--- a/examples/official-storybook/stories/demo/typed-button.stories.tsx
+++ b/examples/official-storybook/stories/demo/typed-button.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta, Story, ComponentStory } from '@storybook/react';
 import TsButton from '../../components/TsButton';
 
-export default {
+const Meta: ComponentMeta<typeof TsButton> = {
   title: 'Other/Demo/TsButton',
   component: TsButton,
   decorators: [
@@ -12,7 +12,9 @@ export default {
       </>
     ),
   ],
-} as ComponentMeta<typeof TsButton>;
+};
+
+export const Meta;
 
 const Template: Story = (args) => <TsButton {...args} />;
 

--- a/examples/official-storybook/stories/demo/typed-button.stories.tsx
+++ b/examples/official-storybook/stories/demo/typed-button.stories.tsx
@@ -14,7 +14,7 @@ const Meta: ComponentMeta<typeof TsButton> = {
   ],
 };
 
-export const Meta;
+export default Meta;
 
 const Template: Story = (args) => <TsButton {...args} />;
 

--- a/examples/official-storybook/stories/demo/typed-button.stories.tsx
+++ b/examples/official-storybook/stories/demo/typed-button.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta, Story, ComponentStory } from '@storybook/react';
 import TsButton from '../../components/TsButton';
 
-const Meta: ComponentMeta<typeof TsButton> = {
+const StoryMeta: ComponentMeta<typeof TsButton> = {
   title: 'Other/Demo/TsButton',
   component: TsButton,
   decorators: [
@@ -14,7 +14,7 @@ const Meta: ComponentMeta<typeof TsButton> = {
   ],
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: Story = (args) => <TsButton {...args} />;
 

--- a/examples/react-ts/src/AccountForm.stories.tsx
+++ b/examples/react-ts/src/AccountForm.stories.tsx
@@ -7,7 +7,7 @@ import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { AccountForm } from './AccountForm';
 
-const Meta: ComponentMeta<typeof AccountForm> = {
+const StoryMeta: ComponentMeta<typeof AccountForm> = {
   // Title not needed due to CSF3 auto-title
   // title: 'Demo/AccountForm',
   component: AccountForm,
@@ -16,7 +16,7 @@ const Meta: ComponentMeta<typeof AccountForm> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 // export const Standard = (args: any) => <AccountForm {...args} />;
 // Standard.args = { passwordVerification: false };

--- a/examples/react-ts/src/AccountForm.stories.tsx
+++ b/examples/react-ts/src/AccountForm.stories.tsx
@@ -7,14 +7,16 @@ import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { AccountForm } from './AccountForm';
 
-export default {
+const Meta: ComponentMeta<typeof AccountForm> = {
   // Title not needed due to CSF3 auto-title
   // title: 'Demo/AccountForm',
   component: AccountForm,
   parameters: {
     layout: 'centered',
   },
-} as ComponentMeta<typeof AccountForm>;
+};
+
+export default Meta;
 
 // export const Standard = (args: any) => <AccountForm {...args} />;
 // Standard.args = { passwordVerification: false };

--- a/lib/cli/src/frameworks/react/ts/Button.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Button.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Button } from './Button';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
-const Meta: ComponentMeta<typeof Button> = {
+const StoryMeta: ComponentMeta<typeof Button> = {
   title: 'Example/Button',
   component: Button,
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
@@ -13,7 +13,7 @@ const Meta: ComponentMeta<typeof Button> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;

--- a/lib/cli/src/frameworks/react/ts/Button.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Button.stories.tsx
@@ -4,14 +4,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Button } from './Button';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
-export default {
+const Meta: ComponentMeta<typeof Button> = {
   title: 'Example/Button',
   component: Button,
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-} as ComponentMeta<typeof Button>;
+};
+
+export default Meta;
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;

--- a/lib/cli/src/frameworks/react/ts/Header.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Header.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Header } from './Header';
 
-const Meta: ComponentMeta<typeof Header> = {
+const StoryMeta: ComponentMeta<typeof Header> = {
   title: 'Example/Header',
   component: Header,
   parameters: {
@@ -12,7 +12,7 @@ const Meta: ComponentMeta<typeof Header> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof Header> = (args) => <Header {...args} />;
 

--- a/lib/cli/src/frameworks/react/ts/Header.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Header.stories.tsx
@@ -3,14 +3,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Header } from './Header';
 
-export default {
+const Meta: ComponentMeta<typeof Header> = {
   title: 'Example/Header',
   component: Header,
   parameters: {
     // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
-} as ComponentMeta<typeof Header>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof Header> = (args) => <Header {...args} />;
 

--- a/lib/cli/src/frameworks/react/ts/Page.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Page.stories.tsx
@@ -3,14 +3,16 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { within, userEvent } from '@storybook/testing-library';
 import { Page } from './Page';
 
-export default {
+const Meta: ComponentMeta<typeof Page> = {
   title: 'Example/Page',
   component: Page,
   parameters: {
     // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
-} as ComponentMeta<typeof Page>;
+};
+
+export default Meta;
 
 const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
 

--- a/lib/cli/src/frameworks/react/ts/Page.stories.tsx
+++ b/lib/cli/src/frameworks/react/ts/Page.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { within, userEvent } from '@storybook/testing-library';
 import { Page } from './Page';
 
-const Meta: ComponentMeta<typeof Page> = {
+const StoryMeta: ComponentMeta<typeof Page> = {
   title: 'Example/Page',
   component: Page,
   parameters: {
@@ -12,7 +12,7 @@ const Meta: ComponentMeta<typeof Page> = {
   },
 };
 
-export default Meta;
+export default StoryMeta;
 
 const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
 

--- a/lib/ui/src/components/sidebar/Heading.stories.tsx
+++ b/lib/ui/src/components/sidebar/Heading.stories.tsx
@@ -10,7 +10,7 @@ import { Heading } from './Heading';
 
 type Story = ComponentStory<typeof Heading>;
 
-export default {
+const Meta: ComponentMeta<typeof Heading> = {
   component: Heading,
   title: 'UI/Sidebar/Heading',
   excludeStories: /.*Data$/,
@@ -18,7 +18,9 @@ export default {
   decorators: [
     (storyFn) => <div style={{ padding: '0 20px', maxWidth: '230px' }}>{storyFn()}</div>,
   ],
-} as ComponentMeta<typeof Heading>;
+};
+
+export default Meta;
 
 const menuItems = [
   { title: 'Menu Item 1', onClick: action('onActivateMenuItem'), id: '1' },

--- a/lib/ui/src/components/sidebar/Heading.stories.tsx
+++ b/lib/ui/src/components/sidebar/Heading.stories.tsx
@@ -10,7 +10,7 @@ import { Heading } from './Heading';
 
 type Story = ComponentStory<typeof Heading>;
 
-const Meta: ComponentMeta<typeof Heading> = {
+const StoryMeta: ComponentMeta<typeof Heading> = {
   component: Heading,
   title: 'UI/Sidebar/Heading',
   excludeStories: /.*Data$/,
@@ -20,7 +20,7 @@ const Meta: ComponentMeta<typeof Heading> = {
   ],
 };
 
-export default Meta;
+export default StoryMeta;
 
 const menuItems = [
   { title: 'Menu Item 1', onClick: action('onActivateMenuItem'), id: '1' },


### PR DESCRIPTION
Issue: Unsafe TypeScript examples

## What I did

I refactored all TypeScript stories and removed the `as ComponentMeta<typeof Example>` type assertions. In my opinion, we should use the type as we would other types too (e.g. `const foo: Foo = { hello: 'world' }`). We should not use `as` as a way of typing this when it is not the last resort because TypeScript can't infer the type, shouldn't we? 🤔

I am curious to hear what you think. :)

## Maybe related PRs and Issues

- https://github.com/storybookjs/storybook/pull/14780
- https://github.com/storybookjs/storybook/pull/15292

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
