### PR TITLE
docs: The Template is a HOC

### DIFF
--- a/docs/snippets/react/page-story-slots.js.mdx
+++ b/docs/snippets/react/page-story-slots.js.mdx
@@ -14,7 +14,7 @@ export default {
   component: Page,
 };
 
-const Template = (args) => (args) => (
+const Template = (args) => (
   <Page {...args}>
     <footer>{args.footer}</footer>
   </Page>


### PR DESCRIPTION
The `Template` variable should receive the `args` and return a React component, instead of another function.

Issue:

## What I did

Reduce one level of function abstraction.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
