### PR TITLE
Changing component file format to .vue for vue component in 'Where to…

### DIFF
--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -11,7 +11,7 @@ Storybook uses the generic term arguments (args for short) when talking about Re
 A component’s stories are defined in a story file that lives alongside the component file. The story file is for development-only, and it won't be included in your production bundle.
 
 ```
-Button.js | ts | jsx | tsx
+Button.vue | js | ts | jsx | tsx 
 Button.stories.js | ts | jsx | tsx | mdx
 ```
 


### PR DESCRIPTION
Changing component file format to .vue for vue component in 'Where to put stories' section

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
