### PR TITLE
Webpack5: Add lazy compilation

### DIFF
--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -258,7 +258,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
       },
       runtimeChunk: true,
       sideEffects: true,
-      usedExports: true,
+      usedExports: isProd,
       moduleIds: 'named',
       minimizer: isProd
         ? [

--- a/lib/builder-webpack5/src/preview/base-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/base-webpack.config.ts
@@ -1,6 +1,6 @@
 import { logger } from '@storybook/node-logger';
 import type { Options, CoreConfig, Webpack5BuilderConfig } from '@storybook/core-common';
-import type { Configuration } from 'webpack';
+import { Configuration, experiments } from 'webpack';
 
 export async function createDefaultWebpackConfig(
   storybookBaseConfig: Configuration,
@@ -45,10 +45,12 @@ export async function createDefaultWebpackConfig(
   const isProd = storybookBaseConfig.mode !== 'development';
 
   const coreOptions = await options.presets.apply<CoreConfig>('core');
-  const cacheConfig = (coreOptions.builder as Webpack5BuilderConfig).options?.fsCache
-    ? {
-        cache: { type: 'filesystem' as 'filesystem' },
-      }
+  const builderOptions = (coreOptions.builder as Webpack5BuilderConfig).options;
+  const cacheConfig = builderOptions?.fsCache
+    ? { cache: { type: 'filesystem' as 'filesystem' } }
+    : {};
+  const lazyCompilationConfig = builderOptions?.lazyCompilation
+    ? { lazyCompilation: { entries: false } }
     : {};
   return {
     ...storybookBaseConfig,
@@ -91,5 +93,6 @@ export async function createDefaultWebpackConfig(
       },
     },
     ...cacheConfig,
+    experiments: lazyCompilationConfig,
   };
 }

--- a/lib/builder-webpack5/src/preview/base-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/base-webpack.config.ts
@@ -1,6 +1,6 @@
 import { logger } from '@storybook/node-logger';
 import type { Options, CoreConfig, Webpack5BuilderConfig } from '@storybook/core-common';
-import { Configuration, experiments } from 'webpack';
+import { Configuration } from 'webpack';
 
 export async function createDefaultWebpackConfig(
   storybookBaseConfig: Configuration,
@@ -92,6 +92,6 @@ export async function createDefaultWebpackConfig(
       },
     },
     ...cacheConfig,
-    experiments: lazyCompilationConfig,
+    experiments: { ...storybookBaseConfig.experiments, ...lazyCompilationConfig },
   };
 }

--- a/lib/builder-webpack5/src/preview/base-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/base-webpack.config.ts
@@ -49,9 +49,8 @@ export async function createDefaultWebpackConfig(
   const cacheConfig = builderOptions?.fsCache
     ? { cache: { type: 'filesystem' as 'filesystem' } }
     : {};
-  const lazyCompilationConfig = builderOptions?.lazyCompilation
-    ? { lazyCompilation: { entries: false } }
-    : {};
+  const lazyCompilationConfig =
+    builderOptions?.lazyCompilation && !isProd ? { lazyCompilation: { entries: false } } : {};
   return {
     ...storybookBaseConfig,
     module: {

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -259,7 +259,7 @@ export default async (options: Options & Record<string, any>): Promise<Configura
       },
       runtimeChunk: true,
       sideEffects: true,
-      usedExports: true,
+      usedExports: isProd,
       moduleIds: 'named',
       minimizer: isProd
         ? [

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -32,6 +32,7 @@ export interface Webpack5BuilderConfig extends BuilderConfigObject {
   name: 'webpack5';
   options?: {
     fsCache?: boolean;
+    lazyCompilation?: boolean;
   };
 }
 


### PR DESCRIPTION
## What I did

Add `builderOptions.lazyCompilation` to allow users to opt-into webpack's lazy compilation experiment.

NOTE: this disables the "entry" compilation, as otherwise that just needs to be compiled straight away when the user visits the SB anyway.

## TODO

- [x] Disable in build mode
- [x] Fix webpack issue with story files that import each other
- [ ] Investigate/fix issue with enabling fs cache + lazy compilation in larger projects.

## How to test

```js
// in main.js

core: {
  builder: {
    name: 'webpack5',
    lazyCompilation: true,
  }
}
```