### PR TITLE
Addon-actions: Don't override undefined args

### DIFF
--- a/addons/actions/src/preset/addArgsHelpers.test.ts
+++ b/addons/actions/src/preset/addArgsHelpers.test.ts
@@ -38,11 +38,20 @@ describe('actions parameter enhancers', () => {
 
     it('should override pre-existing args, if undefined', () => {
       const args = inferActionsFromArgTypesRegex({
-        initialArgs: { onClick: undefined },
+        initialArgs: {},
         argTypes,
         parameters,
       } as unknown as StoryContext);
       expect(args).toEqual({ onClick: expect.any(Function), onFocus: expect.any(Function) });
+    });
+
+    it('should NOT override pre-existing args, if set undefined on purpose', () => {
+      const args = inferActionsFromArgTypesRegex({
+        initialArgs: { onClick: undefined },
+        argTypes,
+        parameters,
+      } as unknown as StoryContext);
+      expect(args).toEqual({ onClick: undefined, onFocus: expect.any(Function) });
     });
 
     it('should do nothing if actions are disabled', () => {
@@ -100,10 +109,20 @@ describe('actions parameter enhancers', () => {
       expect(
         addActionsFromArgTypes({
           argTypes: { onClick: { action: 'clicked!' } },
-          initialArgs: { onClick: undefined },
+          initialArgs: {},
           parameters: {},
         } as unknown as StoryContext)
       ).toEqual({ onClick: expect.any(Function) });
+    });
+
+    it('should NOT override pre-existing args, if set undefined on purpose', () => {
+      expect(
+        addActionsFromArgTypes({
+          argTypes: { onClick: { action: 'clicked!' } },
+          initialArgs: { onClick: undefined },
+          parameters: {},
+        } as unknown as StoryContext)
+      ).toEqual({ onClick: undefined });
     });
 
     it('should do nothing if actions are disabled', () => {

--- a/addons/actions/src/preset/addArgsHelpers.ts
+++ b/addons/actions/src/preset/addArgsHelpers.ts
@@ -1,11 +1,13 @@
-import { Args } from '@storybook/addons';
-import { AnyFramework, ArgsEnhancer } from '@storybook/csf';
+import type { Args, AnyFramework, ArgsEnhancer } from '@storybook/csf';
 import { action } from '../index';
 
 // interface ActionsParameter {
 //   disable?: boolean;
 //   argTypesRegex?: RegExp;
 // }
+
+const isInInitialArgs = (name: string, initialArgs: Args) =>
+  typeof initialArgs[name] === 'undefined' && !(name in initialArgs);
 
 /**
  * Automatically add action args for argTypes whose name
@@ -28,7 +30,7 @@ export const inferActionsFromArgTypesRegex: ArgsEnhancer<AnyFramework> = (contex
   );
 
   return argTypesMatchingRegex.reduce((acc, [name, argType]) => {
-    if (typeof initialArgs[name] === 'undefined' && !(name in initialArgs)) {
+    if (isInInitialArgs(name, initialArgs)) {
       acc[name] = action(name);
     }
     return acc;
@@ -51,7 +53,7 @@ export const addActionsFromArgTypes: ArgsEnhancer<AnyFramework> = (context) => {
   const argTypesWithAction = Object.entries(argTypes).filter(([name, argType]) => !!argType.action);
 
   return argTypesWithAction.reduce((acc, [name, argType]) => {
-    if (typeof initialArgs[name] === 'undefined' && !(name in initialArgs)) {
+    if (isInInitialArgs(name, initialArgs)) {
       acc[name] = action(typeof argType.action === 'string' ? argType.action : name);
     }
     return acc;

--- a/addons/actions/src/preset/addArgsHelpers.ts
+++ b/addons/actions/src/preset/addArgsHelpers.ts
@@ -28,7 +28,7 @@ export const inferActionsFromArgTypesRegex: ArgsEnhancer<AnyFramework> = (contex
   );
 
   return argTypesMatchingRegex.reduce((acc, [name, argType]) => {
-    if (typeof initialArgs[name] === 'undefined') {
+    if (typeof initialArgs[name] === 'undefined' && !(name in initialArgs)) {
       acc[name] = action(name);
     }
     return acc;
@@ -51,7 +51,7 @@ export const addActionsFromArgTypes: ArgsEnhancer<AnyFramework> = (context) => {
   const argTypesWithAction = Object.entries(argTypes).filter(([name, argType]) => !!argType.action);
 
   return argTypesWithAction.reduce((acc, [name, argType]) => {
-    if (typeof initialArgs[name] === 'undefined') {
+    if (typeof initialArgs[name] === 'undefined' && !(name in initialArgs)) {
       acc[name] = action(typeof argType.action === 'string' ? argType.action : name);
     }
     return acc;


### PR DESCRIPTION
Issue:  https://github.com/storybookjs/storybook/issues/16867

## What I did

I changed the behaviour of the actions addon so you can specify `undefined` as an arg for any `on*` handler, which can be a valid case



## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
