### PR TITLE
Chore: (Docs) Removes misleading info from documentation

### DIFF
--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -10,8 +10,6 @@ title: 'Doc Blocks'
 
 Doc Blocks are the building blocks of Storybook documentation pages. By default, [DocsPage](./docs-page.md) uses a combination of the blocks below to build a page for each of your components automatically.
 
-Custom [addons](../addons/writing-addons.md) can also provide their own doc blocks.
-
 ## ArgsTable
 
 Storybook Docs automatically generates component args tables for components in supported frameworks. These tables list the arguments ([args for short](../writing-stories/args.md)) of the component, and even integrate with [controls](../essentials/controls.md) to allow you to change the args of the currently rendered story.


### PR DESCRIPTION
With this small pull request, the documentation is updated to remove a misleading reference telling our users that they can set up their own custom DocBlocks using addons. This is an API that exists but requires some additional work and polish and better documentation on it.

Closes #12314

What was done:
- Removed the incorrect sentence from the docs

