### PR TITLE
Controls/Essentials/Interactions: Add support for main.cjs/mjs/tsx files

### DIFF
--- a/addons/controls/src/preset/checkDocsLoaded.ts
+++ b/addons/controls/src/preset/checkDocsLoaded.ts
@@ -1,4 +1,4 @@
-import { checkAddonOrder } from '@storybook/core-common';
+import { checkAddonOrder, serverRequire } from '@storybook/core-common';
 import path from 'path';
 
 export const checkDocsLoaded = (configDir: string) => {
@@ -14,6 +14,6 @@ export const checkDocsLoaded = (configDir: string) => {
     configFile: path.isAbsolute(configDir)
       ? path.join(configDir, 'main')
       : path.join(process.cwd(), configDir, 'main'),
-    getConfig: (configFile) => import(configFile),
+    getConfig: (configFile) => serverRequire(configFile),
   });
 };

--- a/addons/essentials/package.json
+++ b/addons/essentials/package.json
@@ -49,6 +49,7 @@
     "@storybook/addon-viewport": "6.5.0-alpha.41",
     "@storybook/addons": "6.5.0-alpha.41",
     "@storybook/api": "6.5.0-alpha.41",
+    "@storybook/core-common": "6.5.0-alpha.41",
     "@storybook/node-logger": "6.5.0-alpha.41",
     "core-js": "^3.8.2",
     "regenerator-runtime": "^0.13.7",

--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -18,7 +18,14 @@ const requireMain = (configDir: string) => {
     // eslint-disable-next-line global-require,import/no-dynamic-require
     main = require(mainFile);
   } catch (err) {
-    logger.warn(`Unable to find main.js: ${mainFile}`);
+    try {
+      // Try finding a .cjs version of the main file
+      const mainFileCjs = path.join(absoluteConfigDir, 'main.cjs');
+      // eslint-disable-next-line global-require,import/no-dynamic-require
+      main = require(mainFileCjs);
+    } catch (cjsErr) {
+      logger.warn(`Unable to find main.js or main.cjs: ${mainFile}`);
+    }
   }
   return main;
 };

--- a/addons/essentials/src/index.ts
+++ b/addons/essentials/src/index.ts
@@ -1,5 +1,6 @@
 import path, { join } from 'path';
 import { logger } from '@storybook/node-logger';
+import { serverRequire } from '@storybook/core-common';
 
 interface PresetOptions {
   configDir?: string;
@@ -9,25 +10,12 @@ interface PresetOptions {
 }
 
 const requireMain = (configDir: string) => {
-  let main = {};
   const absoluteConfigDir = path.isAbsolute(configDir)
     ? configDir
     : path.join(process.cwd(), configDir);
   const mainFile = path.join(absoluteConfigDir, 'main');
-  try {
-    // eslint-disable-next-line global-require,import/no-dynamic-require
-    main = require(mainFile);
-  } catch (err) {
-    try {
-      // Try finding a .cjs version of the main file
-      const mainFileCjs = path.join(absoluteConfigDir, 'main.cjs');
-      // eslint-disable-next-line global-require,import/no-dynamic-require
-      main = require(mainFileCjs);
-    } catch (cjsErr) {
-      logger.warn(`Unable to find main.js or main.cjs: ${mainFile}`);
-    }
-  }
-  return main;
+
+  return serverRequire(mainFile) ?? {};
 };
 
 export function addons(options: PresetOptions = {}) {

--- a/addons/interactions/src/preset/checkActionsLoaded.ts
+++ b/addons/interactions/src/preset/checkActionsLoaded.ts
@@ -1,4 +1,4 @@
-import { checkAddonOrder } from '@storybook/core-common';
+import { checkAddonOrder, serverRequire } from '@storybook/core-common';
 import path from 'path';
 
 export const checkActionsLoaded = (configDir: string) => {
@@ -14,6 +14,6 @@ export const checkActionsLoaded = (configDir: string) => {
     configFile: path.isAbsolute(configDir)
       ? path.join(configDir, 'main')
       : path.join(process.cwd(), configDir, 'main'),
-    getConfig: (configFile) => import(configFile),
+    getConfig: (configFile) => serverRequire(configFile),
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6527,6 +6527,7 @@ __metadata:
     "@storybook/addon-viewport": 6.5.0-alpha.41
     "@storybook/addons": 6.5.0-alpha.41
     "@storybook/api": 6.5.0-alpha.41
+    "@storybook/core-common": 6.5.0-alpha.41
     "@storybook/node-logger": 6.5.0-alpha.41
     "@storybook/vue": 6.5.0-alpha.41
     "@types/jest": ^26.0.16


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/11587

## What I did

Even though storybook has been working fine for me with my `main.cjs` file, I got tired of seeing the warnings when I start it up, and there are a lot of :+1: on the referenced issue, so I took a crack at fixing it.  I found that `require` statements to `.cjs` files need to actually include the extension `.cjs` (see https://nodejs.org/api/esm.html#commonjs-namespaces, https://github.com/nodejs/modules/issues/500 for examples).  

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

There were no existing tests for this code that I could find.  But if there are some that I should update, please let me know.

I did update the `dist` in my own project's node_modules, and verified that the warning went away, and that the proper module was returned.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
