### PR TITLE
Addon-Outline: add 'o' keyboard shortcut to toggle the outline addon

### DIFF
--- a/addons/outline/README.md
+++ b/addons/outline/README.md
@@ -20,4 +20,4 @@ module.exports = {
 };
 ```
 
-You can now click on the outline button in the toolbar to toggle the outlines.
+You can now click on the outline button or press the <kbd>o</kbd> key in the toolbar to toggle the outlines.

--- a/addons/outline/src/OutlineSelector.tsx
+++ b/addons/outline/src/OutlineSelector.tsx
@@ -1,10 +1,11 @@
-import React, { memo, useCallback } from 'react';
-import { useGlobals } from '@storybook/api';
+import React, { memo, useCallback, useEffect } from 'react';
+import { useGlobals, useStorybookApi } from '@storybook/api';
 import { Icons, IconButton } from '@storybook/components';
-import { PARAM_KEY } from './constants';
+import { ADDON_ID, PARAM_KEY } from './constants';
 
 export const OutlineSelector = memo(() => {
   const [globals, updateGlobals] = useGlobals();
+  const api = useStorybookApi();
 
   const isActive = globals[PARAM_KEY] || false;
 
@@ -15,6 +16,16 @@ export const OutlineSelector = memo(() => {
       }),
     [isActive]
   );
+
+  useEffect(() => {
+    api.setAddonShortcut(ADDON_ID, {
+      label: 'Toggle Measure [O]',
+      defaultShortcut: ['O'],
+      actionName: 'outline',
+      showInMenu: false,
+      action: toggleOutline,
+    });
+  }, [toggleOutline, api]);
 
   return (
     <IconButton


### PR DESCRIPTION
In response to #15831

Issue: 

## What I did
Added ability to use 'o' keyboard shortcut to toggle the outline addon. Added note to addon documentation referencing shortcut. All tests passing after running yarn test.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
