### PR TITLE
Addon-docs: Fix preset handling for builder with options

### DIFF
--- a/addons/docs/src/frameworks/common/preset.ts
+++ b/addons/docs/src/frameworks/common/preset.ts
@@ -44,8 +44,8 @@ export async function webpack(
 
   const builderName = typeof builder === 'string' ? builder : builder.name;
   const resolvedBabelLoader = require.resolve('babel-loader', {
-    paths: builderName.match(/(webpack4|webpack5)/)
-      ? [require.resolve(`@storybook/builder-${builder}`)]
+    paths: builderName.match(/^webpack(4|5)$/)
+      ? [require.resolve(`@storybook/builder-${builderName}`)]
       : [builderName],
   });
 

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -22,7 +22,7 @@ const config: StorybookConfig = {
     },
   },
   core: {
-    builder: 'webpack4',
+    builder: { name: 'webpack4' },
     channelOptions: { allowFunction: false, maxDepth: 10 },
   },
   features: {


### PR DESCRIPTION
Issue: N/A

## What I did

Fix addon-docs babel resolution logic for builders that are specified with options, e.g.

```
builder: {
  name: 'webpack5',
  options: { ... }
}
```

## How to test

See attached example