### PR TITLE
Core: Fix global render fn

### DIFF
--- a/lib/preview-web/src/composeConfigs.test.ts
+++ b/lib/preview-web/src/composeConfigs.test.ts
@@ -144,9 +144,9 @@ describe('composeConfigs', () => {
       globals: {},
       globalTypes: {},
       loaders: [],
-      render: 'render-1',
-      renderToDOM: 'renderToDOM-1',
-      applyDecorators: 'applyDecorators-1',
+      render: 'render-2',
+      renderToDOM: 'renderToDOM-2',
+      applyDecorators: 'applyDecorators-2',
     });
   });
 });

--- a/lib/preview-web/src/composeConfigs.test.ts
+++ b/lib/preview-web/src/composeConfigs.test.ts
@@ -124,13 +124,11 @@ describe('composeConfigs', () => {
     expect(
       composeConfigs([
         {
-          play: 'play-1',
           render: 'render-1',
           renderToDOM: 'renderToDOM-1',
           applyDecorators: 'applyDecorators-1',
         },
         {
-          play: 'play-2',
           render: 'render-2',
           renderToDOM: 'renderToDOM-2',
           applyDecorators: 'applyDecorators-2',
@@ -146,7 +144,6 @@ describe('composeConfigs', () => {
       globals: {},
       globalTypes: {},
       loaders: [],
-      play: 'play-1',
       render: 'render-1',
       renderToDOM: 'renderToDOM-1',
       applyDecorators: 'applyDecorators-1',

--- a/lib/preview-web/src/composeConfigs.ts
+++ b/lib/preview-web/src/composeConfigs.ts
@@ -37,7 +37,6 @@ export function composeConfigs<TFramework extends AnyFramework>(
     globalTypes: getObjectField(moduleExportList, 'globalTypes'),
     loaders: getArrayField(moduleExportList, 'loaders'),
     render: getSingletonField(moduleExportList, 'render'),
-    play: getSingletonField(moduleExportList, 'play'),
     renderToDOM: getSingletonField(moduleExportList, 'renderToDOM'),
     applyDecorators: getSingletonField(moduleExportList, 'applyDecorators'),
   };

--- a/lib/preview-web/src/composeConfigs.ts
+++ b/lib/preview-web/src/composeConfigs.ts
@@ -15,7 +15,7 @@ function getObjectField(moduleExportList: ModuleExports[], field: string): Recor
 }
 
 function getSingletonField(moduleExportList: ModuleExports[], field: string): any {
-  return getField(moduleExportList, field)[0];
+  return getField(moduleExportList, field).pop();
 }
 
 export function composeConfigs<TFramework extends AnyFramework>(


### PR DESCRIPTION
Issue: N/A

## What I did

`composeConfigs` were taking only the first entries into consideration when composing project annotations, meaning that e.g. FrameworkPresets.render will always be picked up and users won't be able to set a global render function (but also renderToDOM and applyDecorators).

Additionally, I removed the `play` function as we discussed about not allowing that.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
