### PR TITLE
Chore: (Docs) Updates to the Writing Docs asides

### DIFF
--- a/docs/writing-docs/build-documentation.md
+++ b/docs/writing-docs/build-documentation.md
@@ -2,12 +2,6 @@
 title: 'Preview and build docs'
 ---
 
-<div class="aside">
-
-💡 Currently there's an issue when using MDX stories with IE11. This issue does <strong>not</strong> apply to [DocsPage](./docs-page.md). If you're interested in helping us fix this issue, read our <a href="https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md">Contribution guidelines</a> and submit a pull request.
-
-</div>
-
 Storybook allows you to create rich and extensive [documentation](./introduction.md) that will help you and any other stakeholder involved in the development process. Out of the box you have the tooling required to not only write it but also to preview it and build it.
 
 ## Preview Storybook's documentation

--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -2,12 +2,6 @@
 title: 'DocsPage'
 ---
 
-<div class="aside">
-
-💡 Currently there's an issue when using MDX stories with IE11. This issue does <strong>not</strong> apply to DocsPage. If you're interested in helping us fix this issue, read our <a href="https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md">Contribution guidelines</a> and submit a pull request.
-
-</div>
-
 When you install [Storybook Docs](https://storybook.js.org/addons/@storybook/addon-docs), DocsPage is the zero-config default documentation that all stories get out of the box. It aggregates your [stories](../get-started/whats-a-story.md), text descriptions, docgen comments, [args tables](./doc-block-argstable.md), and code examples into a single page for each component.
 
 The best practice for docs is for each component to have its own set of documentation and stories.

--- a/docs/writing-docs/introduction.md
+++ b/docs/writing-docs/introduction.md
@@ -2,12 +2,6 @@
 title: 'How to document components'
 ---
 
-<div class="aside">
-
-💡 Currently there's an issue when using MDX stories with IE11. This issue does <strong>not</strong> apply to [DocsPage](./docs-page.md). If you're interested in helping us fix this issue, read our <a href="https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md">Contribution guidelines</a> and submit a pull request.
-
-</div>
-
 When you write component stories during development, you also create basic documentation to revisit later.
 
 Storybook gives you tools to expand this basic documentation with prose and layout that feature your components and stories prominently. That allows you to create UI library usage guidelines, design system sites, and more.

--- a/docs/writing-docs/mdx.md
+++ b/docs/writing-docs/mdx.md
@@ -4,7 +4,7 @@ title: 'MDX'
 
 <div class="aside">
 
-💡 Currently there's an issue when using MDX stories with IE11. This issue does <strong>not</strong> apply to [Docs page](./docs-page.md). If you're interested in helping us fix this issue, read our <a href="https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md">Contribution guidelines</a> and submit a pull request.
+💡 Currently, there's an issue using MDX stories with IE11, which **doesn't affect** the [Docs page](./docs-page.md). It's a known MDX issue, and once it's solved, Storybook's MDX implementation will be updated accordingly.
 
 </div>
 


### PR DESCRIPTION
With this small pull request the aside addressing the known issue with MDX stories and IE11 is updated based on the feedback provided [here](https://github.com/storybookjs/storybook/pull/17551#discussion_r812564409).

What was done:
- Updated the aside wording


Let me know if you're ok with this @shilman. Thanks in advance for putting it on my radar!