### PR TITLE
Chore: (Docs) Minor docs updates

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -97,31 +97,6 @@ A common error is that an addon tries to access the "channel", but the channel i
 
 2.  In React Native, it's a special case documented in [#1192](https://github.com/storybookjs/storybook/issues/1192)
 
-### Can I modify React component state in stories?
-
-Not directly. If you control the component source, you can do something like this:
-
-```js
-import React, { Component } from 'react';
-
-export default {
-  title: 'MyComponent',
-};
-
-class MyComponent extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      someVar: 'defaultValue',
-      ...props.initialState,
-    };
-  }
-  // ...
-}
-
-export const defaultView = () => <MyComponent initialState={} />;
-```
 
 ### Why aren't Controls visible in the Canvas panel but visible in the Docs panel?
 
@@ -384,3 +359,8 @@ export default meta;
 ```
 
 Although valid, it introduces additional boilerplate code to the story definition. Instead, we're working towards implementing a safer mechanism based on what's currently being discussed in the following [issue](https://github.com/microsoft/TypeScript/issues/7481). Once the feature is released, we'll migrate our existing examples and documentation accordingly.
+
+
+## Why is Storybook's source loader returning undefined with curried functions?
+
+This is a known issue with Storybook. If you're interested in getting it fixed, open an issue with a [working reproduction](./contribute/how-to-reproduce) so that it can be triaged and fixed in future releases.

--- a/docs/sharing/embed.md
+++ b/docs/sharing/embed.md
@@ -45,7 +45,7 @@ https://5ccbc373887ca40020446347-bysekhynzd.chromatic.com/iframe.html?id=/story/
   src="https://5ccbc373887ca40020446347-bysekhynzd.chromatic.com/iframe.html?id=shadowboxcta--default&viewMode=story&shortcuts=false&singleStory=true"
   width="800"
   height="200"
-></iframe>;
+></iframe>
 ```
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
With this small pull request, the Sharing/Embed docs were updated to remove an additional `;` from the example and some cleanup on the FAQ

Closes #12517


