### PR TITLE
Core: Refactor preview rendering out of `PreviewWeb`

### DIFF
--- a/addons/docs/src/blocks/Story.tsx
+++ b/addons/docs/src/blocks/Story.tsx
@@ -130,25 +130,8 @@ const Story: FunctionComponent<StoryProps> = (props) => {
   useEffect(() => {
     let cleanup: () => void;
     if (story && storyRef.current) {
-      const { componentId, id, title, name } = story;
-      const renderContext = {
-        componentId,
-        title,
-        kind: title,
-        id,
-        name,
-        story: name,
-        // TODO what to do when these fail?
-        showMain: () => {},
-        showError: () => {},
-        showException: () => {},
-      };
-      cleanup = context.renderStoryToElement({
-        story,
-        renderContext,
-        element: storyRef.current as HTMLElement,
-        viewMode: 'docs',
-      });
+      const element = storyRef.current as HTMLElement;
+      cleanup = context.renderStoryToElement(story, element);
       setShowLoader(false);
     }
     return () => cleanup && cleanup();

--- a/lib/core-client/src/preview/start.test.ts
+++ b/lib/core-client/src/preview/start.test.ts
@@ -4,13 +4,17 @@ import Events from '@storybook/core-events';
 import {
   waitForRender,
   waitForEvents,
+  waitForQuiescence,
   emitter,
   mockChannel,
 } from '@storybook/preview-web/dist/cjs/PreviewWeb.mockdata';
+// @ts-ignore
+import { WebView } from '@storybook/preview-web/dist/cjs/WebView';
 
 import { start } from './start';
 
 jest.mock('@storybook/preview-web/dist/cjs/WebView');
+jest.spyOn(WebView.prototype, 'prepareForDocs').mockReturnValue('docs-root');
 
 jest.mock('global', () => ({
   // @ts-ignore
@@ -202,6 +206,9 @@ describe('start', () => {
           "v": 2,
         }
       `);
+
+      // Wait a second to let the docs "render" finish (and maybe throw)
+      await waitForQuiescence();
     });
 
     it('deals with stories with "default" name', async () => {

--- a/lib/preview-web/README.md
+++ b/lib/preview-web/README.md
@@ -40,10 +40,17 @@ See `client-api` for more details on this process.
 
 ## Story Rendering and interruptions
 
+The Preview is split into three parts responsible for state management:
+
+- `PreviewWeb` - which story is rendered, receives events and (maybe) changes/re-renders stories
+- `StoryRender` - (imports +) prepares the story, renders it through the various phases
+- `DocsRender` - if a story renders in docs mode, it is "transformed" into a `DocsRender` once we know.
+
 A rendering story goes through these phases:
 
+- `preparing` - (maybe async) import the story file and prepare the story function.
 - `loading` - async loaders are running
-- `rendering` - the `renderToDom` function for the framework is running
+- `rendering` - the `renderToDOM` function for the framework is running
 - `playing` - the `play` function is running
 - `completed` - the story is done.
 
@@ -61,7 +68,7 @@ A story may re-render due to various events, which can have implications if the 
 
 If these events happen during a render:
 
-- if the story is `loading`, leave thing unchanged and let the new `args`/`globals` be picked up by the render phase
+- if the story is `preparing` or `loading`, leave thing unchanged and let the new `args`/`globals` be picked up by the render phase
 - otherwise, use the result of the previous `loaders` run, and simply re-render over the top
 
 - `FORCE_REMOUNT` - remount (or equivalent) the component and re-render.
@@ -71,4 +78,17 @@ If this happens during a render, treat `loading` similarly, but:
 - if the story is `rendering`, start a new render and abort the previous render immediately afterwards
 - if the story is `playing`, attempt to abort the previous play function, and start a new render.
 
-Also the `SET_CURRENT_STORY` event may change the current story. If the old story is not `completed`, we try to abort it immediately. If that fails (e.g. the `play` function doesn't respond to the `abort` event), then we reload the window.
+### Changing story
+
+Also the `SET_CURRENT_STORY` event may change the current story. We need to check:
+
+- If the `storyId` changed
+- If the `viewMode` changed
+- If the story implementation changed (i.e if HMR occurred).
+
+If the _previous_ story is still `preparing`, we cannot know if the implementation changed, so we
+abort the preparing immediately, and let the new story take over.
+
+Otherwise, if all of the above are the same, we do nothing.
+
+If they are different, and the old story is not `completed`, we try to abort it immediately. If that fails (e.g. the `play` function doesn't respond to the `abort` event), then we reload the window.

--- a/lib/preview-web/src/DocsRender.ts
+++ b/lib/preview-web/src/DocsRender.ts
@@ -1,0 +1,90 @@
+import global from 'global';
+import {
+  AnyFramework,
+  StoryId,
+  ViewMode,
+  StoryContextForLoaders,
+  StoryContext,
+} from '@storybook/csf';
+import { Story, StoryStore, CSFFile } from '@storybook/store';
+import { Channel } from '@storybook/addons';
+import { DOCS_RENDERED } from '@storybook/core-events';
+
+import { DocsContextProps } from './types';
+
+export class DocsRender<CanvasElement extends HTMLElement | void, TFramework extends AnyFramework> {
+  public story?: Story<TFramework>;
+
+  private canvasElement?: CanvasElement;
+
+  private context?: DocsContextProps;
+
+  public disableKeyListeners = false;
+
+  constructor(
+    private channel: Channel,
+    private store: StoryStore<TFramework>,
+    public id: StoryId,
+    story?: Story<TFramework>
+  ) {
+    if (story) this.story = story;
+  }
+
+  async prepare() {
+    this.story = await this.store.loadStory({ storyId: this.id });
+  }
+
+  async renderToElement(
+    canvasElement: CanvasElement,
+    renderStoryToElement: DocsContextProps['renderStoryToElement']
+  ) {
+    this.canvasElement = canvasElement;
+
+    const { id, title, name } = this.story;
+    const csfFile: CSFFile<TFramework> = await this.store.loadCSFFileByStoryId(this.id);
+
+    this.context = {
+      id,
+      title,
+      name,
+      // NOTE: these two functions are *sync* so cannot access stories from other CSF files
+      storyById: (storyId: StoryId) => this.store.storyFromCSFFile({ storyId, csfFile }),
+      componentStories: () => this.store.componentStoriesFromCSFFile({ csfFile }),
+      loadStory: (storyId: StoryId) => this.store.loadStory({ storyId }),
+      renderStoryToElement: renderStoryToElement.bind(this),
+      getStoryContext: (renderedStory: Story<TFramework>) =>
+        ({
+          ...this.store.getStoryContext(renderedStory),
+          viewMode: 'docs' as ViewMode,
+        } as StoryContextForLoaders<TFramework>),
+      // Put all the storyContext fields onto the docs context for back-compat
+      ...(!global.FEATURES?.breakingChangesV7 && this.store.getStoryContext(this.story)),
+    };
+
+    return this.render();
+  }
+
+  async render() {
+    if (!this.story || !this.context || !this.canvasElement)
+      throw new Error('DocsRender not ready to render');
+
+    const renderer = await import('./renderDocs');
+    renderer.renderDocs(this.story, this.context, this.canvasElement, () =>
+      this.channel.emit(DOCS_RENDERED, this.id)
+    );
+  }
+
+  async rerender() {
+    // NOTE: in modern inline render mode, each story is rendered via
+    // `preview.renderStoryToElement` which means the story will track
+    // its own re-renders. Thus there will be no need to re-render the whole
+    // docs page when a single story changes.
+    if (!global.FEATURES?.modernInlineRender) await this.render();
+  }
+
+  async teardown({ viewModeChanged }: { viewModeChanged?: boolean } = {}) {
+    if (!viewModeChanged || !this.canvasElement) return;
+    const renderer = await import('./renderDocs');
+    renderer.unmountDocs(this.canvasElement);
+  }
+}

--- a/lib/preview-web/src/DocsRender.ts
+++ b/lib/preview-web/src/DocsRender.ts
@@ -1,21 +1,15 @@
 import global from 'global';
-import {
-  AnyFramework,
-  StoryId,
-  ViewMode,
-  StoryContextForLoaders,
-  StoryContext,
-} from '@storybook/csf';
+import { AnyFramework, StoryId, ViewMode, StoryContextForLoaders } from '@storybook/csf';
 import { Story, StoryStore, CSFFile } from '@storybook/store';
 import { Channel } from '@storybook/addons';
 import { DOCS_RENDERED } from '@storybook/core-events';
 
 import { DocsContextProps } from './types';
 
-export class DocsRender<CanvasElement extends HTMLElement | void, TFramework extends AnyFramework> {
+export class DocsRender<TFramework extends AnyFramework> {
   public story?: Story<TFramework>;
 
-  private canvasElement?: CanvasElement;
+  private canvasElement?: HTMLElement;
 
   private context?: DocsContextProps;
 
@@ -35,7 +29,7 @@ export class DocsRender<CanvasElement extends HTMLElement | void, TFramework ext
   }
 
   async renderToElement(
-    canvasElement: CanvasElement,
+    canvasElement: HTMLElement,
     renderStoryToElement: DocsContextProps['renderStoryToElement']
   ) {
     this.canvasElement = canvasElement;

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -5,22 +5,11 @@ import { SynchronousPromise } from 'synchronous-promise';
 import Events, { IGNORED_EXCEPTION } from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 import { addons, Channel } from '@storybook/addons';
-import {
-  AnyFramework,
-  StoryId,
-  ProjectAnnotations,
-  Args,
-  Globals,
-  ViewMode,
-  StoryContextForLoaders,
-  StoryContext,
-} from '@storybook/csf';
+import { AnyFramework, StoryId, ProjectAnnotations, Args, Globals } from '@storybook/csf';
 import {
   ModuleImportFn,
   Selection,
   Story,
-  RenderContext,
-  CSFFile,
   StoryStore,
   StorySpecifier,
   StoryIndex,
@@ -33,22 +22,11 @@ import { WebView } from './WebView';
 import { StoryRender } from './StoryRender';
 import { DocsRender } from './DocsRender';
 
-const { window: globalWindow, AbortController, fetch } = global;
+const { window: globalWindow, fetch } = global;
 
 function focusInInput(event: Event) {
   const target = event.target as Element;
   return /input|textarea/i.test(target.tagName) || target.getAttribute('contenteditable') !== null;
-}
-
-function createController(): AbortController {
-  if (AbortController) return new AbortController();
-  // Polyfill for IE11
-  return {
-    signal: { aborted: false },
-    abort() {
-      this.signal.aborted = true;
-    },
-  } as AbortController;
 }
 
 type PromiseLike<T> = Promise<T> | SynchronousPromise<T>;
@@ -58,7 +36,7 @@ type StoryCleanupFn = () => MaybePromise<void>;
 const STORY_INDEX_PATH = './stories.json';
 
 type HTMLStoryRender<TFramework extends AnyFramework> = StoryRender<HTMLElement, TFramework>;
-type HTMLDocsRender<TFramework extends AnyFramework> = DocsRender<HTMLElement, TFramework>;
+type HTMLDocsRender<TFramework extends AnyFramework> = DocsRender<TFramework>;
 
 export class PreviewWeb<TFramework extends AnyFramework> {
   channel: Channel;

--- a/lib/preview-web/src/StoryRender.ts
+++ b/lib/preview-web/src/StoryRender.ts
@@ -1,0 +1,245 @@
+import global from 'global';
+import {
+  AnyFramework,
+  StoryId,
+  ViewMode,
+  StoryContextForLoaders,
+  StoryContext,
+} from '@storybook/csf';
+import { Story, RenderContext, StoryStore } from '@storybook/store';
+import { Channel } from '@storybook/addons';
+import { STORY_RENDER_PHASE_CHANGED, STORY_RENDERED } from '@storybook/core-events';
+import { DocsRender } from './DocsRender';
+
+const { AbortController } = global;
+
+export type RenderPhase =
+  | 'preparing'
+  | 'loading'
+  | 'rendering'
+  | 'playing'
+  | 'played'
+  | 'completed'
+  | 'aborted'
+  | 'errored';
+
+function createController(): AbortController {
+  if (AbortController) return new AbortController();
+  // Polyfill for IE11
+  return {
+    signal: { aborted: false },
+    abort() {
+      this.signal.aborted = true;
+    },
+  } as AbortController;
+}
+
+export type RenderContextCallbacks<TFramework extends AnyFramework> = Pick<
+  RenderContext<TFramework>,
+  'showMain' | 'showError' | 'showException'
+>;
+
+export class StoryRender<
+  CanvasElement extends HTMLElement | void,
+  TFramework extends AnyFramework
+> {
+  public story?: Story<TFramework>;
+
+  public phase?: RenderPhase;
+
+  private abortController?: AbortController;
+
+  private canvasElement?: CanvasElement;
+
+  private notYetRendered = true;
+
+  public disableKeyListeners = false;
+
+  constructor(
+    private channel: Channel,
+    private store: StoryStore<TFramework>,
+    private renderToScreen: (
+      renderContext: RenderContext<TFramework>,
+      canvasElement: CanvasElement
+    ) => void | Promise<void>,
+    private callbacks: RenderContextCallbacks<TFramework>,
+    public id: StoryId,
+    public viewMode: ViewMode,
+    story?: Story<TFramework>
+  ) {
+    this.abortController = createController();
+
+    // Allow short-circuiting preparing if we happen to already
+    // have the story (this is used by docs mode)
+    if (story) {
+      this.story = story;
+      // TODO -- what should the phase be now?
+      // TODO -- should we emit the render phase changed event?
+      this.phase = 'preparing';
+    }
+  }
+
+  private async runPhase(signal: AbortSignal, phase: RenderPhase, phaseFn?: () => Promise<void>) {
+    this.phase = phase;
+    this.channel.emit(STORY_RENDER_PHASE_CHANGED, { newPhase: this.phase, storyId: this.id });
+    if (phaseFn) await phaseFn();
+
+    if (signal.aborted) {
+      this.phase = 'aborted';
+      this.channel.emit(STORY_RENDER_PHASE_CHANGED, { newPhase: this.phase, storyId: this.id });
+    }
+  }
+
+  async prepare() {
+    await this.runPhase(this.abortController.signal, 'preparing', async () => {
+      this.story = await this.store.loadStory({ storyId: this.id });
+    });
+
+    if (this.abortController.signal.aborted)
+      throw new Error('Story render aborted during preparation');
+  }
+
+  // The two story "renders" are equal and have both loaded the same story
+  isEqual(other?: StoryRender<CanvasElement, TFramework> | DocsRender<CanvasElement, TFramework>) {
+    return other && this.id === other.id && this.story && this.story === other.story;
+  }
+
+  isPending() {
+    return ['rendering', 'playing'].includes(this.phase);
+  }
+
+  toDocsRender() {
+    return new DocsRender<CanvasElement, TFramework>(this.channel, this.store, this.id, this.story);
+  }
+
+  context() {
+    return this.store.getStoryContext(this.story);
+  }
+
+  async renderToElement(canvasElement: CanvasElement) {
+    this.canvasElement = canvasElement;
+
+    // FIXME: this comment
+    // Start the first (initial) render. We don't await here because we need to return the "cleanup"
+    // function below right away, so if the user changes story during the first render we can cancel
+    // it without having to first wait for it to finish.
+    // Whenever the selection changes we want to force the component to be remounted.
+    return this.render({ initial: true, forceRemount: true });
+  }
+
+  async render({
+    initial = false,
+    forceRemount = false,
+  }: {
+    initial?: boolean;
+    forceRemount?: boolean;
+  } = {}) {
+    if (!this.story) throw new Error('cannot render when not prepared');
+    const { id, componentId, title, name, applyLoaders, unboundStoryFn, playFunction } = this.story;
+
+    if (forceRemount && !initial) {
+      // NOTE: we don't check the cancel actually worked here, so the previous
+      // render could conceivably still be running after this call.
+      // We might want to change that in the future.
+      this.cancelRender();
+      this.abortController = createController();
+    }
+
+    // We need a stable reference to the signal -- if a re-mount happens the
+    // abort controller may be torn down (above) before we actually check the signal.
+    const abortSignal = this.abortController.signal;
+
+    try {
+      let loadedContext: StoryContext<TFramework>;
+      await this.runPhase(abortSignal, 'loading', async () => {
+        loadedContext = await applyLoaders({
+          ...this.context(),
+          viewMode: this.viewMode,
+        } as StoryContextForLoaders<TFramework>);
+      });
+      if (abortSignal.aborted) return;
+
+      const renderStoryContext: StoryContext<TFramework> = {
+        ...loadedContext,
+        // By this stage, it is possible that new args/globals have been received for this story
+        // and we need to ensure we render it with the new values
+        ...this.context(),
+        abortSignal,
+        canvasElement: this.canvasElement as HTMLElement,
+      };
+      const renderContext: RenderContext<TFramework> = {
+        componentId,
+        title,
+        kind: title,
+        id,
+        name,
+        story: name,
+        ...this.callbacks,
+        forceRemount: forceRemount || this.notYetRendered,
+        storyContext: renderStoryContext,
+        storyFn: () => unboundStoryFn(renderStoryContext),
+        unboundStoryFn,
+      };
+
+      await this.runPhase(abortSignal, 'rendering', async () =>
+        this.renderToScreen(renderContext, this.canvasElement)
+      );
+      this.notYetRendered = false;
+      if (abortSignal.aborted) return;
+
+      if (forceRemount && playFunction) {
+        this.disableKeyListeners = true;
+        await this.runPhase(abortSignal, 'playing', async () =>
+          playFunction(renderContext.storyContext)
+        );
+        await this.runPhase(abortSignal, 'played');
+        this.disableKeyListeners = false;
+        if (abortSignal.aborted) return;
+      }
+
+      await this.runPhase(abortSignal, 'completed', async () =>
+        this.channel.emit(STORY_RENDERED, id)
+      );
+    } catch (err) {
+      this.callbacks.showException(err);
+    }
+  }
+
+  async rerender() {
+    return this.render();
+  }
+
+  async remount() {
+    return this.render({ forceRemount: true });
+  }
+
+  // If the story is torn down (either a new story is rendered or the docs page removes it)
+  // we need to consider the fact that the initial render may not be finished
+  // (possibly the loaders or the play function are still running). We use the controller
+  // as a method to abort them, ASAP, but this is not foolproof as we cannot control what
+  // happens inside the user's code.
+  cancelRender() {
+    this.abortController.abort();
+  }
+
+  async teardown(options: {} = {}) {
+    this.cancelRender();
+
+    this.store.cleanupStory(this.story);
+
+    // Check if we're done rendering/playing. If not, we may have to reload the page.
+    // Wait several ticks that may be needed to handle the abort, then try again.
+    // Note that there's a max of 5 nested timeouts before they're no longer "instant".
+    for (let i = 0; i < 3; i += 1) {
+      if (!this.isPending()) return;
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    // If we still haven't completed, reload the page (iframe) to ensure we have a clean slate
+    // for the next render. Since the reload can take a brief moment to happen, we want to stop
+    // further rendering by awaiting a never-resolving promise (which is destroyed on reload).
+    global.window.location.reload();
+    await new Promise(() => {});
+  }
+}

--- a/lib/preview-web/src/StoryRender.ts
+++ b/lib/preview-web/src/StoryRender.ts
@@ -100,7 +100,7 @@ export class StoryRender<
   }
 
   // The two story "renders" are equal and have both loaded the same story
-  isEqual(other?: StoryRender<CanvasElement, TFramework> | DocsRender<CanvasElement, TFramework>) {
+  isEqual(other?: StoryRender<CanvasElement, TFramework> | DocsRender<TFramework>) {
     return other && this.id === other.id && this.story && this.story === other.story;
   }
 
@@ -109,7 +109,7 @@ export class StoryRender<
   }
 
   toDocsRender() {
-    return new DocsRender<CanvasElement, TFramework>(this.channel, this.store, this.id, this.story);
+    return new DocsRender<TFramework>(this.channel, this.store, this.id, this.story);
   }
 
   context() {


### PR DESCRIPTION
Precursor to #17214

## What I did

Pulled the rendering part of `PreviewWeb` out into two classes: `StoryRender` and `DocsRender`.

- `StoryRender` handles the job of "preparing" (ie. `import`-ing) the story
- Then, depending on whether the mode the story is rendering (which needs to know if the story is docs-only, thus the preparing ahead of time), either renders or converts to a `DocsRender`
- When `modernInlineRender` calls `renderStoryToElement` (one or more times on the docs page), this also creates additional `StoryRender`s.
- The `Preview` simply "multiplexes" channel messages that drive re-renders to the `StoryRender`s and `DocRender` that are on the screen.

Some notes:

- We don't yet handle the case of "tearing down" the render during preparing (PR to follow).
- We only reload the screen when you tear down a story (change page) not when you reload the story (I think this is intended @ghengeveld?).

In any case this PR is not intended to change functionality, just refactor.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

See existing tests. I also added some for checking the re-rendering behaviour in `modernInlineRender` docs mode.
