### PR TITLE
Core: Ensure that we do not render a story twice if re-rendered during preparing

### DIFF
--- a/lib/preview-web/src/DocsRender.ts
+++ b/lib/preview-web/src/DocsRender.ts
@@ -7,25 +7,23 @@ import { DOCS_RENDERED } from '@storybook/core-events';
 import { DocsContextProps } from './types';
 
 export class DocsRender<TFramework extends AnyFramework> {
-  public story?: Story<TFramework>;
-
   private canvasElement?: HTMLElement;
 
   private context?: DocsContextProps;
 
   public disableKeyListeners = false;
 
+  // eslint-disable-next-line no-useless-constructor
   constructor(
     private channel: Channel,
     private store: StoryStore<TFramework>,
     public id: StoryId,
-    story?: Story<TFramework>
-  ) {
-    if (story) this.story = story;
-  }
+    public story: Story<TFramework>
+  ) {}
 
-  async prepare() {
-    this.story = await this.store.loadStory({ storyId: this.id });
+  // DocsRender doesn't prepare, it is created *from* a prepared StoryRender
+  isPreparing() {
+    return false;
   }
 
   async renderToElement(

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -435,6 +435,8 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       this.view.showPreparingDocs();
     }
 
+    const { currentSelection, currentRender } = this;
+
     const storyRender: PreviewWeb<TFramework>['currentRender'] = new StoryRender<
       HTMLElement,
       TFramework
@@ -446,32 +448,37 @@ export class PreviewWeb<TFramework extends AnyFramework> {
       storyId,
       'story'
     );
+    // We need to store this right away, so if the story changes during
+    // the async `.prepare()` below, we can (potentially) cancel it
+    this.currentSelection = selection;
+    // Note this may be replaced by a docsRender after preparing
+    this.currentRender = storyRender;
 
     try {
       await storyRender.prepare();
     } catch (err) {
-      await this.teardownRender(this.currentRender);
+      await this.teardownRender(currentRender);
       this.currentRender = null;
       this.renderStoryLoadingException(storyId, err);
       return;
     }
-    const implementationChanged = !storyIdChanged && !storyRender.isEqual(this.currentRender);
+    const implementationChanged = !storyIdChanged && !storyRender.isEqual(currentRender);
 
     if (persistedArgs) this.storyStore.args.updateFromPersisted(storyRender.story, persistedArgs);
 
     const { parameters, initialArgs, argTypes, args } = storyRender.context();
 
     // Don't re-render the story if nothing has changed to justify it
-    if (this.currentRender && !storyIdChanged && !implementationChanged && !viewModeChanged) {
+    if (currentRender && !storyIdChanged && !implementationChanged && !viewModeChanged) {
       this.channel.emit(Events.STORY_UNCHANGED, storyId);
       this.view.showMain();
       return;
     }
 
-    await this.teardownRender(this.currentRender, { viewModeChanged });
+    await this.teardownRender(currentRender, { viewModeChanged });
 
     // If we are rendering something new (as opposed to re-rendering the same or first story), emit
-    if (this.currentSelection && (storyIdChanged || viewModeChanged)) {
+    if (currentSelection && (storyIdChanged || viewModeChanged)) {
       this.channel.emit(Events.STORY_CHANGED, storyId);
     }
 
@@ -491,10 +498,6 @@ export class PreviewWeb<TFramework extends AnyFramework> {
     if (implementationChanged || persistedArgs) {
       this.channel.emit(Events.STORY_ARGS_UPDATED, { storyId, args });
     }
-
-    // Record the previous selection *before* awaiting the rendering, in cases things change before it is done.
-    this.currentSelection = selection;
-    this.currentRender = storyRender; // may be replaced immedately below
 
     if (selection.viewMode === 'docs' || parameters.docsOnly) {
       this.currentRender = storyRender.toDocsRender();

--- a/lib/preview-web/src/StoryRender.ts
+++ b/lib/preview-web/src/StoryRender.ts
@@ -95,8 +95,10 @@ export class StoryRender<
       this.story = await this.store.loadStory({ storyId: this.id });
     });
 
-    if (this.abortController.signal.aborted)
+    if (this.abortController.signal.aborted) {
+      this.store.cleanupStory(this.story);
       throw new Error('Story render aborted during preparation');
+    }
   }
 
   // The two story "renders" are equal and have both loaded the same story
@@ -225,7 +227,8 @@ export class StoryRender<
   async teardown(options: {} = {}) {
     this.cancelRender();
 
-    this.store.cleanupStory(this.story);
+    // If the story has loaded, we need to cleanup
+    if (this.story) this.store.cleanupStory(this.story);
 
     // Check if we're done rendering/playing. If not, we may have to reload the page.
     // Wait several ticks that may be needed to handle the abort, then try again.

--- a/lib/preview-web/src/StoryRender.ts
+++ b/lib/preview-web/src/StoryRender.ts
@@ -106,6 +106,10 @@ export class StoryRender<
     return other && this.id === other.id && this.story && this.story === other.story;
   }
 
+  isPreparing() {
+    return ['preparing'].includes(this.phase);
+  }
+
   isPending() {
     return ['rendering', 'playing'].includes(this.phase);
   }

--- a/lib/preview-web/src/StoryRender.ts
+++ b/lib/preview-web/src/StoryRender.ts
@@ -39,6 +39,8 @@ export type RenderContextCallbacks<TFramework extends AnyFramework> = Pick<
   'showMain' | 'showError' | 'showException'
 >;
 
+export const PREPARE_ABORTED = new Error('prepareAborted');
+
 export class StoryRender<
   CanvasElement extends HTMLElement | void,
   TFramework extends AnyFramework
@@ -97,7 +99,7 @@ export class StoryRender<
 
     if (this.abortController.signal.aborted) {
       this.store.cleanupStory(this.story);
-      throw new Error('Story render aborted during preparation');
+      throw PREPARE_ABORTED;
     }
   }
 


### PR DESCRIPTION
Issue: #17214

Telescoping on #17598

## What I did

Abort a render if `setCurrentStory` is called during its `preparing` phase.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

See test, and original repro on issue.