### PR TITLE
Update shelljs dependency version

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -69,7 +69,7 @@
     "prompts": "^2.4.0",
     "puppeteer-core": "^2.1.1",
     "read-pkg-up": "^7.0.1",
-    "shelljs": "^0.8.4",
+    "shelljs": "^0.8.5",
     "strip-json-comments": "^3.0.1",
     "ts-dedent": "^2.0.0",
     "update-notifier": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "rollup-plugin-jsx": "^1.0.3",
     "rollup-plugin-terser": "^7.0.2",
     "serve-static": "^1.14.1",
-    "shelljs": "^0.8.4",
+    "shelljs": "^0.8.5",
     "shx": "^0.3.2",
     "sort-package-json": "^1.48.1",
     "teamcity-service-messages": "^0.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7301,7 +7301,7 @@ __metadata:
     prompts: ^2.4.0
     puppeteer-core: ^2.1.1
     read-pkg-up: ^7.0.1
-    shelljs: ^0.8.4
+    shelljs: ^0.8.5
     strip-json-comments: ^3.1.1
     ts-dedent: ^2.0.0
     update-notifier: ^5.0.1
@@ -8417,7 +8417,7 @@ __metadata:
     rollup-plugin-jsx: ^1.0.3
     rollup-plugin-terser: ^7.0.2
     serve-static: ^1.14.1
-    shelljs: ^0.8.4
+    shelljs: ^0.8.5
     shx: ^0.3.2
     sort-package-json: ^1.48.1
     teamcity-service-messages: ^0.1.11
@@ -41142,7 +41142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shelljs@npm:^0.8.3, shelljs@npm:^0.8.4, shelljs@npm:^0.8.5":
+"shelljs@npm:^0.8.3, shelljs@npm:^0.8.5":
   version: 0.8.5
   resolution: "shelljs@npm:0.8.5"
   dependencies:


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17312

## What I did

Updated the shelljs range to only allow versions that do not have active CVEs.

Of note, storybook itself already had the `^0.8.4` version resolving to `0.8.5` in its lockfile, but the range should still be updated for those who depend on libraries like `@storybook/cli` to ensure that their versions are safe

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
