### PR TITLE
Core: Fix core.builder check

### DIFF
--- a/lib/core-server/src/utils/get-preview-builder.ts
+++ b/lib/core-server/src/utils/get-preview-builder.ts
@@ -6,7 +6,7 @@ export async function getPreviewBuilder(configDir: Options['configDir']) {
   const mainFile = getInterpretedFile(main);
   const { core } = mainFile ? serverRequire(mainFile) : { core: null };
   let builderPackage: string;
-  if (core) {
+  if (core?.builder) {
     const builderName = typeof core.builder === 'string' ? core.builder : core.builder?.name;
     builderPackage = require.resolve(
       ['webpack4', 'webpack5'].includes(builderName)


### PR DESCRIPTION
...because it took me way too long to figure out that my Storybook was b0rked because I had tried `storybook-builder-vite` in the past and my main.js had

```
core: {
  // builder: 'storybook-builder-vite'
}
```

It doesn't help that the error message was overly mysterious too.

