### PR TITLE
Fix typo in the sub component documentation

### DIFF
--- a/docs/snippets/vue/list-story-with-sub-components.3.js.mdx
+++ b/docs/snippets/vue/list-story-with-sub-components.3.js.mdx
@@ -19,7 +19,7 @@ export const Empty = (args) => ({
   setup() {
     //👇 The args will now be passed down to the template
     return { args };
-  }
+  },
   template: '<List v-bind="args"/>',
 });
 
@@ -28,7 +28,7 @@ export const OneItem = (args) => ({
   setup() {
     //👇 The args will now be passed down to the template
     return { args };
-  }
+  },
   template: '<List v-bind="args"><ListItem /></List>',
 });
 ```


### PR DESCRIPTION
Fix typo in the Empty and OneItem objects

Issue: N/A

## What I did

I updated the documentation related to the sub component /multi components stories

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
