### PR TITLE
Addon-interactions: Use 'global' package instead of `global`

### DIFF
--- a/addons/interactions/src/preset/argsEnhancers.ts
+++ b/addons/interactions/src/preset/argsEnhancers.ts
@@ -1,10 +1,12 @@
-import { Args, addons } from '@storybook/addons';
+import { addons } from '@storybook/addons';
+import type { Args } from '@storybook/addons';
+import { window as globalWindow } from 'global';
 import { FORCE_REMOUNT, STORY_RENDER_PHASE_CHANGED } from '@storybook/core-events';
 import { AnyFramework, ArgsEnhancer } from '@storybook/csf';
 import { instrument } from '@storybook/instrumenter';
 import { ModuleMocker } from 'jest-mock';
 
-const JestMock = new ModuleMocker(global);
+const JestMock = new ModuleMocker(globalWindow);
 const fn = JestMock.fn.bind(JestMock);
 
 // Aliasing `fn` to `action` here, so we get a more descriptive label in the UI.


### PR DESCRIPTION
Issue: #17516

## What I did

I totally flubbed https://github.com/storybookjs/storybook/pull/17535, by using `global` instead of what I meant to use, `globalThis`.  But, then I looked in the storybook codebase, and `globalThis` is not used anywhere else, and eslint doesn't like it, so this PR is going back to the initial way I opened that PR, using the `global` package, which storybook does use in multiple spots to handle globals across node and browsers.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
