### PR TITLE
remove unused dependency that's also deprecated

### DIFF
--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -56,7 +56,6 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "terser-webpack-plugin": "^5.0.3",
-    "uuid": "^8.3.2",
     "uuid-browser": "^3.1.0",
     "webpack": "4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -33878,7 +33878,6 @@ __metadata:
     react: 16.14.0
     react-dom: 16.14.0
     terser-webpack-plugin: ^5.0.3
-    uuid: ^8.3.2
     uuid-browser: ^3.1.0
     webpack: 4
   peerDependencies:


### PR DESCRIPTION
Issue: https://socket.dev/npm/package/@storybook/core/issues/6.4.19?tab=dependencies

## What I did

I tried resolving more of the issues listed in the security report, but they are not because any of our code (or anything we can really do about)

The problem is we have some 'outdated' examples (angular's for example) for the purpose of making sure we stay backwards compatible. But this (as one might expect) uses old version of packages.

Another problem is MDX v1, which seems to be responsible for the majority of issues listed. This is something @shilman is already working on.

This ended up being a super small PR only removing 1 deprecated dependency we weren't even using.