### PR TITLE
feat: export AddonPanelProps interface

### DIFF
--- a/lib/components/src/index.ts
+++ b/lib/components/src/index.ts
@@ -59,7 +59,7 @@ export { Tabs, TabsState, TabBar, TabWrapper } from './tabs/tabs';
 export { IconButton, TabButton } from './bar/button';
 export { Separator, interleaveSeparators } from './bar/separator';
 export { Bar, FlexBar } from './bar/bar';
-export { AddonPanel } from './addon-panel/addon-panel';
+export { AddonPanel, AddonPanelProps } from './addon-panel/addon-panel';
 
 // Graphics
 export type { IconsProps } from './icon/icon';


### PR DESCRIPTION
## What I did

Export the `AddonPanelProps` so it can be used when creating addons without having to import from deep within the library.

| Before | After |
| --- | --- |
| <pre>import { AddonPanel } from "@storybook/components";<br />import { AddonPanelProps } from "@storybook/components/dist/ts3.9/addon-panel/addon-panel";</pre> | <pre>import { AddonPanel, AddonPanelProps } from "@storybook/components";</pre> |

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
