### PR TITLE
change imports of types to be prefixed

### DIFF
--- a/addons/a11y/src/components/Report/Rules.tsx
+++ b/addons/a11y/src/components/Report/Rules.tsx
@@ -10,8 +10,8 @@ const List = styled.div({
   paddingBottom: 4,
   paddingRight: 4,
   paddingTop: 4,
-  fontWeight: '400',
-} as any);
+  fontWeight: 400,
+});
 
 const Item = styled.div<{ elementWidth: number }>(({ elementWidth }) => {
   const maxWidthBeforeBreak = 407;

--- a/addons/a11y/src/components/Report/Rules.tsx
+++ b/addons/a11y/src/components/Report/Rules.tsx
@@ -10,8 +10,8 @@ const List = styled.div({
   paddingBottom: 4,
   paddingRight: 4,
   paddingTop: 4,
-  fontWeight: 400,
-});
+  fontWeight: '400',
+} as any);
 
 const Item = styled.div<{ elementWidth: number }>(({ elementWidth }) => {
   const maxWidthBeforeBreak = 407;

--- a/addons/a11y/src/index.ts
+++ b/addons/a11y/src/index.ts
@@ -1,4 +1,4 @@
-import { AnyFramework, DecoratorFunction } from '@storybook/csf';
+import type { AnyFramework, DecoratorFunction } from '@storybook/csf';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 

--- a/addons/actions/src/components/ActionLogger/index.tsx
+++ b/addons/actions/src/components/ActionLogger/index.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
-import { styled, withTheme, Theme } from '@storybook/theming';
+import { styled, withTheme } from '@storybook/theming';
+import type { Theme } from '@storybook/theming';
 
 import Inspector from 'react-inspector';
 import { ActionBar, ScrollArea } from '@storybook/components';

--- a/addons/actions/src/preset/addArgsHelpers.test.ts
+++ b/addons/actions/src/preset/addArgsHelpers.test.ts
@@ -1,4 +1,4 @@
-import { StoryContext } from '@storybook/addons';
+import type { StoryContext } from '@storybook/addons';
 import { inferActionsFromArgTypesRegex, addActionsFromArgTypes } from './addArgsHelpers';
 
 describe('actions parameter enhancers', () => {

--- a/addons/backgrounds/src/decorators/withBackground.ts
+++ b/addons/backgrounds/src/decorators/withBackground.ts
@@ -1,5 +1,5 @@
 import { useMemo, useEffect } from '@storybook/addons';
-import { AnyFramework, PartialStoryFn as StoryFunction, StoryContext } from '@storybook/csf';
+import type { AnyFramework, PartialStoryFn as StoryFunction, StoryContext } from '@storybook/csf';
 
 import { PARAM_KEY as BACKGROUNDS_PARAM_KEY } from '../constants';
 import {

--- a/addons/backgrounds/src/decorators/withGrid.ts
+++ b/addons/backgrounds/src/decorators/withGrid.ts
@@ -1,7 +1,7 @@
 import dedent from 'ts-dedent';
 import deprecate from 'util-deprecate';
 import { useMemo, useEffect } from '@storybook/addons';
-import { AnyFramework, PartialStoryFn as StoryFunction, StoryContext } from '@storybook/csf';
+import type { AnyFramework, PartialStoryFn as StoryFunction, StoryContext } from '@storybook/csf';
 
 import { clearStyles, addGridStyle } from '../helpers';
 import { PARAM_KEY as BACKGROUNDS_PARAM_KEY } from '../constants';

--- a/addons/docs/src/blocks/DocsContext.ts
+++ b/addons/docs/src/blocks/DocsContext.ts
@@ -1,8 +1,8 @@
 import { Context, createContext } from 'react';
 import { window as globalWindow } from 'global';
 
-import { DocsContextProps } from '@storybook/preview-web';
-import { AnyFramework } from '@storybook/csf';
+import type { DocsContextProps } from '@storybook/preview-web';
+import type { AnyFramework } from '@storybook/csf';
 
 export type { DocsContextProps };
 

--- a/addons/docs/src/blocks/enhanceSource.test.ts
+++ b/addons/docs/src/blocks/enhanceSource.test.ts
@@ -1,4 +1,4 @@
-import { StoryContext } from '@storybook/addons';
+import type { StoryContext } from '@storybook/addons';
 import { enhanceSource } from './enhanceSource';
 
 const emptyContext: StoryContext = {

--- a/addons/docs/src/blocks/enhanceSource.ts
+++ b/addons/docs/src/blocks/enhanceSource.ts
@@ -1,5 +1,6 @@
-import { Parameters } from '@storybook/addons';
-import { Story, combineParameters } from '@storybook/store';
+import type { Parameters } from '@storybook/addons';
+import type { Story } from '@storybook/store';
+import { combineParameters } from '@storybook/store';
 
 // ============================================================
 // START @storybook/source-loader/extract-source

--- a/addons/docs/src/blocks/useStory.ts
+++ b/addons/docs/src/blocks/useStory.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { StoryId, AnyFramework } from '@storybook/csf';
-import { Story } from '@storybook/store';
+import type { StoryId, AnyFramework } from '@storybook/csf';
+import type { Story } from '@storybook/store';
 
 import { DocsContextProps } from './DocsContext';
 

--- a/addons/docs/src/frameworks/angular/compodoc.ts
+++ b/addons/docs/src/frameworks/angular/compodoc.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 /* global window */
 
-import { ArgType, ArgTypes } from '@storybook/api';
+import type { ArgType, ArgTypes } from '@storybook/api';
 import { logger } from '@storybook/client-logger';
-import {
+import type {
   Argument,
   Class,
   CompodocJson,

--- a/addons/docs/src/frameworks/angular/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/angular/sourceDecorator.ts
@@ -1,6 +1,6 @@
 import { addons, useEffect } from '@storybook/addons';
-import { PartialStoryFn } from '@storybook/csf';
-import { StoryContext, AngularFramework } from '@storybook/angular';
+import type { PartialStoryFn } from '@storybook/csf';
+import type { StoryContext, AngularFramework } from '@storybook/angular';
 import { computesTemplateSourceFromComponent } from '@storybook/angular/renderer';
 import { SNIPPET_RENDERED, SourceType } from '../../shared';
 

--- a/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
+++ b/addons/docs/src/frameworks/common/enhanceArgTypes.test.ts
@@ -1,5 +1,5 @@
-import { ArgTypes } from '@storybook/api';
-import { StrictInputType } from '@storybook/csf';
+import type { ArgTypes } from '@storybook/api';
+import type { StrictInputType } from '@storybook/csf';
 import { enhanceArgTypes } from './enhanceArgTypes';
 
 expect.addSnapshotSerializer({

--- a/addons/docs/src/frameworks/html/sourceDecorator.test.ts
+++ b/addons/docs/src/frameworks/html/sourceDecorator.test.ts
@@ -1,4 +1,5 @@
-import { addons, StoryContext, useEffect } from '@storybook/addons';
+import { addons, useEffect } from '@storybook/addons';
+import type { StoryContext } from '@storybook/addons';
 import { sourceDecorator } from './sourceDecorator';
 import { SNIPPET_RENDERED } from '../../shared';
 

--- a/addons/docs/src/frameworks/html/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/html/sourceDecorator.ts
@@ -1,8 +1,8 @@
 /* global window */
 import { addons, useEffect } from '@storybook/addons';
-import { ArgsStoryFn, PartialStoryFn, StoryContext } from '@storybook/csf';
+import type { ArgsStoryFn, PartialStoryFn, StoryContext } from '@storybook/csf';
 import dedent from 'ts-dedent';
-import { HtmlFramework } from '@storybook/html';
+import type { HtmlFramework } from '@storybook/html';
 
 import { SNIPPET_RENDERED, SourceType } from '../../shared';
 

--- a/addons/docs/src/frameworks/react/config.ts
+++ b/addons/docs/src/frameworks/react/config.ts
@@ -1,5 +1,5 @@
-import { PartialStoryFn } from '@storybook/csf';
-import { ReactFramework } from '@storybook/react';
+import type { PartialStoryFn } from '@storybook/csf';
+import type { ReactFramework } from '@storybook/react';
 
 import { extractArgTypes } from './extractArgTypes';
 import { extractComponentDescription } from '../../lib/docgen';

--- a/addons/docs/src/frameworks/react/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/react/extractArgTypes.ts
@@ -1,5 +1,5 @@
-import { StrictArgTypes } from '@storybook/csf';
-import { PropDef, ArgTypesExtractor } from '../../lib/docgen';
+import type { StrictArgTypes } from '@storybook/csf';
+import type { PropDef, ArgTypesExtractor } from '../../lib/docgen';
 import { extractProps } from './extractProps';
 
 export const extractArgTypes: ArgTypesExtractor = (component) => {

--- a/addons/docs/src/frameworks/react/react-properties.test.ts
+++ b/addons/docs/src/frameworks/react/react-properties.test.ts
@@ -4,8 +4,8 @@ import fs from 'fs';
 
 import { transformFileSync, transformSync } from '@babel/core';
 import { inferControls } from '@storybook/store';
-import { StoryContext } from '@storybook/react';
-import { AnyFramework } from '@storybook/csf';
+import type { StoryContext } from '@storybook/react';
+import type { AnyFramework } from '@storybook/csf';
 import requireFromString from 'require-from-string';
 
 import { extractProps } from './extractProps';

--- a/addons/docs/src/frameworks/svelte/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/svelte/extractArgTypes.ts
@@ -1,4 +1,4 @@
-import { SBScalarType, StrictArgTypes } from '@storybook/csf';
+import type { SBScalarType, StrictArgTypes } from '@storybook/csf';
 import { logger } from '@storybook/client-logger';
 import type {
   SvelteComponentDoc,
@@ -7,7 +7,7 @@ import type {
   JSDocTypeConst,
 } from 'sveltedoc-parser/typings';
 
-import { ArgTypesExtractor } from '../../lib/docgen';
+import type { ArgTypesExtractor } from '../../lib/docgen';
 
 type ComponentWithDocgen = {
   __docgen: SvelteComponentDoc;

--- a/addons/docs/src/frameworks/svelte/sourceDecorator.test.ts
+++ b/addons/docs/src/frameworks/svelte/sourceDecorator.test.ts
@@ -1,4 +1,4 @@
-import { Args } from '@storybook/api';
+import type { Args } from '@storybook/api';
 import { generateSvelteSource } from './sourceDecorator';
 
 expect.addSnapshotSerializer({

--- a/addons/docs/src/frameworks/svelte/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/svelte/sourceDecorator.ts
@@ -1,5 +1,5 @@
 import { addons, useEffect } from '@storybook/addons';
-import { ArgTypes, Args, StoryContext, AnyFramework } from '@storybook/csf';
+import type { ArgTypes, Args, StoryContext, AnyFramework } from '@storybook/csf';
 
 import { SourceType, SNIPPET_RENDERED } from '../../shared';
 

--- a/addons/docs/src/frameworks/vue/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue/extractArgTypes.ts
@@ -1,11 +1,6 @@
-import { StrictArgTypes } from '@storybook/csf';
-import {
-  ArgTypesExtractor,
-  hasDocgen,
-  extractComponentProps,
-  DocgenInfo,
-  PropDef,
-} from '../../lib/docgen';
+import type { StrictArgTypes } from '@storybook/csf';
+import { hasDocgen, extractComponentProps } from '../../lib/docgen';
+import type { ArgTypesExtractor, DocgenInfo, PropDef } from '../../lib/docgen';
 import { convert } from '../../lib/convert';
 
 const SECTIONS = ['props', 'events', 'slots', 'methods'];

--- a/addons/docs/src/frameworks/vue/prepareForInline.ts
+++ b/addons/docs/src/frameworks/vue/prepareForInline.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import Vue from 'vue';
-import { StoryContext, PartialStoryFn } from '@storybook/csf';
-import { VueFramework } from '@storybook/vue';
+import type { StoryContext, PartialStoryFn } from '@storybook/csf';
+import type { VueFramework } from '@storybook/vue';
 
 // Inspired by https://github.com/egoist/vue-to-react,
 // modified to store args as props in the root store

--- a/addons/docs/src/frameworks/vue/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/vue/sourceDecorator.ts
@@ -1,10 +1,10 @@
 /* eslint no-underscore-dangle: ["error", { "allow": ["_vnode"] }] */
 
-import { StoryContext } from '@storybook/csf';
+import type { StoryContext } from '@storybook/csf';
 import { addons } from '@storybook/addons';
 import { logger } from '@storybook/client-logger';
 import type Vue from 'vue';
-import { VueFramework } from '@storybook/vue';
+import type { VueFramework } from '@storybook/vue';
 
 import { SourceType, SNIPPET_RENDERED } from '../../shared';
 

--- a/addons/docs/src/frameworks/vue3/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/vue3/extractArgTypes.ts
@@ -1,5 +1,6 @@
-import { StrictArgTypes } from '@storybook/csf';
-import { ArgTypesExtractor, hasDocgen, extractComponentProps } from '../../lib/docgen';
+import type { StrictArgTypes } from '@storybook/csf';
+import { hasDocgen, extractComponentProps } from '../../lib/docgen';
+import type { ArgTypesExtractor } from '../../lib/docgen';
 import { convert } from '../../lib/convert';
 
 const SECTIONS = ['props', 'events', 'slots'];

--- a/addons/docs/src/frameworks/vue3/prepareForInline.ts
+++ b/addons/docs/src/frameworks/vue3/prepareForInline.ts
@@ -1,7 +1,8 @@
 import React from 'react';
 import * as Vue from 'vue';
-import { StoryContext, PartialStoryFn } from '@storybook/csf';
-import { app, VueFramework } from '@storybook/vue3';
+import { app } from '@storybook/vue3';
+import type { StoryContext, PartialStoryFn } from '@storybook/csf';
+import type { VueFramework } from '@storybook/vue3';
 
 // This is cast as `any` to workaround type errors caused by Vue 2 types
 const { render, h } = Vue as any;

--- a/addons/docs/src/frameworks/web-components/custom-elements.ts
+++ b/addons/docs/src/frameworks/web-components/custom-elements.ts
@@ -1,5 +1,5 @@
 import { getCustomElements, isValidComponent, isValidMetaData } from '@storybook/web-components';
-import { ArgType, ArgTypes } from '@storybook/api';
+import type { ArgType, ArgTypes } from '@storybook/api';
 import { logger } from '@storybook/client-logger';
 
 interface TagItem {

--- a/addons/docs/src/frameworks/web-components/sourceDecorator.test.ts
+++ b/addons/docs/src/frameworks/web-components/sourceDecorator.test.ts
@@ -1,6 +1,7 @@
 import { html } from 'lit-html';
 import { styleMap } from 'lit-html/directives/style-map';
-import { addons, StoryContext, useEffect } from '@storybook/addons';
+import { addons, useEffect } from '@storybook/addons';
+import type { StoryContext } from '@storybook/addons';
 import { sourceDecorator } from './sourceDecorator';
 import { SNIPPET_RENDERED } from '../../shared';
 

--- a/addons/docs/src/frameworks/web-components/sourceDecorator.ts
+++ b/addons/docs/src/frameworks/web-components/sourceDecorator.ts
@@ -1,8 +1,8 @@
 /* global window */
 import { render } from 'lit-html';
-import { ArgsStoryFn, PartialStoryFn, StoryContext } from '@storybook/csf';
+import type { ArgsStoryFn, PartialStoryFn, StoryContext } from '@storybook/csf';
 import { addons, useEffect } from '@storybook/addons';
-import { WebComponentsFramework } from '@storybook/web-components';
+import type { WebComponentsFramework } from '@storybook/web-components';
 
 import { SNIPPET_RENDERED, SourceType } from '../../shared';
 

--- a/addons/docs/src/lib/convert/flow/convert.ts
+++ b/addons/docs/src/lib/convert/flow/convert.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-case-declarations */
-import { SBType } from '@storybook/csf';
-import { FlowType, FlowSigType, FlowLiteralType } from './types';
+import type { SBType } from '@storybook/csf';
+import type { FlowType, FlowSigType, FlowLiteralType } from './types';
 
 const isLiteral = (type: FlowType) => type.name === 'literal';
 const toEnumOption = (element: FlowLiteralType) => element.value.replace(/['|"]/g, '');

--- a/addons/docs/src/lib/convert/proptypes/convert.ts
+++ b/addons/docs/src/lib/convert/proptypes/convert.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-case-declarations */
 import mapValues from 'lodash/mapValues';
-import { SBType } from '@storybook/csf';
-import { PTType } from './types';
+import type { SBType } from '@storybook/csf';
+import type { PTType } from './types';
 import { includesQuotes, trimQuotes } from '../utils';
 
 const SIGNATURE_REGEXP = /^\(.*\) => /;

--- a/addons/docs/src/lib/convert/typescript/convert.ts
+++ b/addons/docs/src/lib/convert/typescript/convert.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-case-declarations */
-import { SBType } from '@storybook/csf';
-import { TSType, TSSigType } from './types';
+import type { SBType } from '@storybook/csf';
+import type { TSType, TSSigType } from './types';
 
 const convertSig = (type: TSSigType) => {
   switch (type.type) {

--- a/addons/docs/src/lib/docgen/types.ts
+++ b/addons/docs/src/lib/docgen/types.ts
@@ -1,6 +1,6 @@
-import { StrictArgTypes } from '@storybook/csf';
-import { PropDef } from './PropDef';
-import { Component } from '../../blocks/types';
+import type { StrictArgTypes } from '@storybook/csf';
+import type { PropDef } from './PropDef';
+import type { Component } from '../../blocks/types';
 
 export type PropsExtractor = (component: Component) => { rows?: PropDef[] } | null;
 

--- a/addons/interactions/src/preset/argsEnhancers.ts
+++ b/addons/interactions/src/preset/argsEnhancers.ts
@@ -1,12 +1,11 @@
 import { addons } from '@storybook/addons';
 import type { Args } from '@storybook/addons';
-import { window as globalWindow } from 'global';
 import { FORCE_REMOUNT, STORY_RENDER_PHASE_CHANGED } from '@storybook/core-events';
-import { AnyFramework, ArgsEnhancer } from '@storybook/csf';
+import type { AnyFramework, ArgsEnhancer } from '@storybook/csf';
 import { instrument } from '@storybook/instrumenter';
 import { ModuleMocker } from 'jest-mock';
 
-const JestMock = new ModuleMocker(globalWindow);
+const JestMock = new ModuleMocker(global);
 const fn = JestMock.fn.bind(JestMock);
 
 // Aliasing `fn` to `action` here, so we get a more descriptive label in the UI.

--- a/addons/links/src/preview.ts
+++ b/addons/links/src/preview.ts
@@ -2,7 +2,8 @@ import global from 'global';
 import qs from 'qs';
 import { addons, makeDecorator } from '@storybook/addons';
 import { STORY_CHANGED, SELECT_STORY } from '@storybook/core-events';
-import { toId, StoryId, StoryName, ComponentTitle } from '@storybook/csf';
+import type { StoryId, StoryName, ComponentTitle } from '@storybook/csf';
+import { toId } from '@storybook/csf';
 import { PARAM_KEY } from './constants';
 
 const { document, HTMLElement } = global;

--- a/addons/measure/src/withMeasure.ts
+++ b/addons/measure/src/withMeasure.ts
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 import { useEffect } from '@storybook/addons';
-import { AnyFramework, PartialStoryFn as StoryFunction, StoryContext } from '@storybook/csf';
+import type { AnyFramework, PartialStoryFn as StoryFunction, StoryContext } from '@storybook/csf';
 import { drawSelectedElement } from './box-model/visualizer';
 import { init, rescale, destroy } from './box-model/canvas';
 import { deepElementFromPoint } from './util';

--- a/addons/outline/src/withOutline.ts
+++ b/addons/outline/src/withOutline.ts
@@ -1,5 +1,5 @@
 import { useMemo, useEffect } from '@storybook/addons';
-import { AnyFramework, PartialStoryFn as StoryFunction, StoryContext } from '@storybook/csf';
+import type { AnyFramework, PartialStoryFn as StoryFunction, StoryContext } from '@storybook/csf';
 
 import { clearStyles, addOutlineStyles } from './helpers';
 import { PARAM_KEY } from './constants';

--- a/addons/storyshots/storyshots-core/src/frameworks/Loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/Loader.ts
@@ -1,8 +1,8 @@
-import { AnyFramework } from '@storybook/csf';
-import { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { AnyFramework } from '@storybook/csf';
+import type { ClientStoryApi, Loadable } from '@storybook/addons';
 import { ClientApi as ClientApiClass } from '@storybook/client-api';
-import { StoryshotsOptions } from '../api/StoryshotsOptions';
-import { SupportedFramework } from './SupportedFramework';
+import type { StoryshotsOptions } from '../api/StoryshotsOptions';
+import type { SupportedFramework } from './SupportedFramework';
 
 export type RenderTree = (story: any, context?: any, options?: any) => any;
 

--- a/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -1,17 +1,18 @@
 import fs from 'fs';
 import path from 'path';
-import {
-  toRequireContext,
-  StoriesEntry,
-  normalizeStoriesEntry,
-  NormalizedStoriesSpecifier,
-} from '@storybook/core-common';
+import type { NormalizedStoriesSpecifier, StoriesEntry } from '@storybook/core-common';
+import { toRequireContext, normalizeStoriesEntry } from '@storybook/core-common';
 import registerRequireContextHook from '@storybook/babel-plugin-require-context-hook/register';
 import global from 'global';
-import { AnyFramework, ArgsEnhancer, ArgTypesEnhancer, DecoratorFunction } from '@storybook/csf';
+import type {
+  AnyFramework,
+  ArgsEnhancer,
+  ArgTypesEnhancer,
+  DecoratorFunction,
+} from '@storybook/csf';
 
 import { ClientApi } from './Loader';
-import { StoryshotsOptions } from '../api/StoryshotsOptions';
+import type { StoryshotsOptions } from '../api/StoryshotsOptions';
 
 registerRequireContextHook();
 

--- a/addons/toolbars/src/types.ts
+++ b/addons/toolbars/src/types.ts
@@ -1,5 +1,5 @@
-import { IconsProps } from '@storybook/components';
-import { ArgType } from '@storybook/api';
+import type { IconsProps } from '@storybook/components';
+import type { ArgType } from '@storybook/api';
 
 export type ToolbarShortcutType = 'next' | 'previous' | 'reset';
 

--- a/addons/viewport/src/shortcuts.ts
+++ b/addons/viewport/src/shortcuts.ts
@@ -1,4 +1,4 @@
-import { API } from '@storybook/api';
+import type { API } from '@storybook/api';
 import { ADDON_ID } from './constants';
 
 const getCurrentViewportIndex = (viewportsKeys: string[], current: string): number =>

--- a/app/angular/src/builders/build-storybook/index.ts
+++ b/app/angular/src/builders/build-storybook/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
 import { from, Observable, of, throwError } from 'rxjs';
-import { CLIOptions } from '@storybook/core-common';
+import type { CLIOptions } from '@storybook/core-common';
 import { catchError, map, mapTo, switchMap } from 'rxjs/operators';
 import { sync as findUpSync } from 'find-up';
 

--- a/app/angular/src/builders/start-storybook/index.ts
+++ b/app/angular/src/builders/start-storybook/index.ts
@@ -12,7 +12,7 @@ import {
   StylePreprocessorOptions,
 } from '@angular-devkit/build-angular';
 import { from, Observable, of } from 'rxjs';
-import { CLIOptions } from '@storybook/core-common';
+import type { CLIOptions } from '@storybook/core-common';
 import { map, switchMap, mapTo } from 'rxjs/operators';
 import { sync as findUpSync } from 'find-up';
 

--- a/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.test.ts
+++ b/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.test.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ArgTypes } from '@storybook/api';
+import type { ArgTypes } from '@storybook/api';
 import { computesTemplateSourceFromComponent } from './ComputesTemplateFromComponent';
 import { ButtonAccent, InputComponent, ISomeInterface } from './__testfixtures__/input.component';
 

--- a/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.ts
+++ b/app/angular/src/client/preview/angular-beta/ComputesTemplateFromComponent.ts
@@ -1,6 +1,6 @@
-import { Type } from '@angular/core';
-import { ArgType, ArgTypes } from '@storybook/api';
-import { ICollection } from '../types';
+import type { Type } from '@angular/core';
+import type { ArgType, ArgTypes } from '@storybook/api';
+import type { ICollection } from '../types';
 import {
   ComponentInputsOutputs,
   getComponentDecoratorMetadata,

--- a/app/angular/src/client/preview/angular/helpers.ts
+++ b/app/angular/src/client/preview/angular/helpers.ts
@@ -5,11 +5,11 @@ import { FormsModule } from '@angular/forms';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { BrowserModule } from '@angular/platform-browser';
 import { Observable, ReplaySubject, Subscriber } from 'rxjs';
-import { PartialStoryFn } from '@storybook/csf';
+import type { PartialStoryFn } from '@storybook/csf';
 import { AppComponent } from './components/app.component';
 import { STORY } from './app.token';
-import { NgModuleMetadata, StoryFnAngularReturnType } from '../types';
-import { AngularFramework } from '../types-6-0';
+import type { NgModuleMetadata, StoryFnAngularReturnType } from '../types';
+import type { AngularFramework } from '../types-6-0';
 
 const { document } = global;
 

--- a/app/angular/src/client/preview/decorateStory.test.ts
+++ b/app/angular/src/client/preview/decorateStory.test.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output } from '@angular/core';
-import { DecoratorFunction, StoryContext } from '@storybook/addons';
+import type { DecoratorFunction, StoryContext } from '@storybook/addons';
 import { componentWrapperDecorator } from './decorators';
 
 import decorateStory from './decorateStory';

--- a/app/angular/src/client/preview/decorateStory.ts
+++ b/app/angular/src/client/preview/decorateStory.ts
@@ -1,8 +1,8 @@
-import { DecoratorFunction, LegacyStoryFn, StoryContext } from '@storybook/csf';
+import type { DecoratorFunction, LegacyStoryFn, StoryContext } from '@storybook/csf';
 import { sanitizeStoryContextUpdate } from '@storybook/store';
 import { computesTemplateFromComponent } from './angular-beta/ComputesTemplateFromComponent';
 
-import { AngularFramework } from './types-6-0';
+import type { AngularFramework } from './types-6-0';
 
 export default function decorateStory(
   mainStoryFn: LegacyStoryFn<AngularFramework>,

--- a/app/angular/src/client/preview/decorators.test.ts
+++ b/app/angular/src/client/preview/decorators.test.ts
@@ -1,4 +1,5 @@
-import { addons, mockChannel, StoryContext } from '@storybook/addons';
+import { addons, mockChannel } from '@storybook/addons';
+import type { StoryContext } from '@storybook/addons';
 
 import { Component } from '@angular/core';
 import { moduleMetadata } from './decorators';

--- a/app/angular/src/client/preview/decorators.ts
+++ b/app/angular/src/client/preview/decorators.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-param-reassign */
-import { Type } from '@angular/core';
-import { DecoratorFunction, StoryContext } from '@storybook/csf';
+import type { Type } from '@angular/core';
+import type { DecoratorFunction, StoryContext } from '@storybook/csf';
 import { computesTemplateFromComponent } from './angular-beta/ComputesTemplateFromComponent';
 import { isComponent } from './angular-beta/utils/NgComponentAnalyzer';
-import { ICollection, NgModuleMetadata } from './types';
-import { AngularFramework } from './types-6-0';
+import type { ICollection, NgModuleMetadata } from './types';
+import type { AngularFramework } from './types-6-0';
 
 // We use `any` here as the default type rather than `Args` because we need something that is
 // castable to any component-specific args type when the user is being careful.

--- a/app/angular/src/client/preview/index.ts
+++ b/app/angular/src/client/preview/index.ts
@@ -1,11 +1,11 @@
 /* eslint-disable prefer-destructuring */
-import { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { ClientStoryApi, Loadable } from '@storybook/addons';
 import { start } from '@storybook/core/client';
 import './globals';
 import { renderToDOM, render } from './render';
 import decorateStory from './decorateStory';
-import { IStorybookSection } from './types';
-import { AngularFramework } from './types-6-0';
+import type { IStorybookSection } from './types';
+import type { AngularFramework } from './types-6-0';
 
 const framework = 'angular';
 

--- a/app/angular/src/client/preview/render.ts
+++ b/app/angular/src/client/preview/render.ts
@@ -1,8 +1,8 @@
-import { RenderContext } from '@storybook/store';
-import { ArgsStoryFn } from '@storybook/csf';
+import type { RenderContext } from '@storybook/store';
+import type { ArgsStoryFn } from '@storybook/csf';
 
 import { renderNgApp } from './angular/helpers';
-import { AngularFramework } from './types-6-0';
+import type { AngularFramework } from './types-6-0';
 
 import { RendererFactory } from './angular-beta/RendererFactory';
 

--- a/app/angular/src/client/preview/types-6-0.ts
+++ b/app/angular/src/client/preview/types-6-0.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Args,
   Parameters as DefaultParameters,
   StoryContext as DefaultStoryContext,
@@ -7,7 +7,7 @@ import {
   AnnotatedStoryFn,
 } from '@storybook/csf';
 
-import { StoryFnAngularReturnType } from './types';
+import type { StoryFnAngularReturnType } from './types';
 
 export type { Args, ArgTypes } from '@storybook/csf';
 

--- a/app/angular/src/client/preview/types-7-0.ts
+++ b/app/angular/src/client/preview/types-7-0.ts
@@ -1,5 +1,4 @@
-import { Args } from '@storybook/csf';
-
+import type { Args } from '@storybook/csf';
 import type { StoryObj } from './types-6-0';
 
 export type { StoryFn, StoryObj, Meta } from './types-6-0';

--- a/app/angular/src/server/framework-preset-angular-cli.test.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 import { logger } from '@storybook/node-logger';
 import { normalize, getSystemPath } from '@angular-devkit/core';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';

--- a/app/angular/src/server/options.ts
+++ b/app/angular/src/server/options.ts
@@ -1,5 +1,5 @@
 import { sync } from 'read-pkg-up';
-import { LoadOptions, Options as CoreOptions } from '@storybook/core-common';
+import type { LoadOptions, Options as CoreOptions } from '@storybook/core-common';
 
 import { BuilderContext } from '@angular-devkit/architect';
 import { ExtraEntryPoint, StylePreprocessorOptions } from '@angular-devkit/build-angular';

--- a/app/angular/src/types/index.ts
+++ b/app/angular/src/types/index.ts
@@ -1,4 +1,4 @@
-import { StorybookConfig as BaseConfig } from '@storybook/core-common';
+import type { StorybookConfig as BaseConfig } from '@storybook/core-common';
 
 export interface StorybookConfig extends BaseConfig {
   angularOptions?: {

--- a/app/angular/standalone.d.ts
+++ b/app/angular/standalone.d.ts
@@ -1,5 +1,5 @@
-import { CLIOptions, LoadOptions, BuilderOptions } from '@storybook/core-common';
-import { BuilderContext } from '@angular-devkit/architect';
+import type { CLIOptions, LoadOptions, BuilderOptions } from '@storybook/core-common';
+import type { BuilderContext } from '@angular-devkit/architect';
 
 export type StandaloneOptions = Partial<
   CLIOptions &

--- a/app/ember/src/server/framework-preset-babel-ember.ts
+++ b/app/ember/src/server/framework-preset-babel-ember.ts
@@ -1,6 +1,7 @@
-import { TransformOptions } from '@babel/core';
+import type { TransformOptions } from '@babel/core';
 import { precompile } from 'ember-source/dist/ember-template-compiler';
-import { findDistEsm, StorybookConfig, Options } from '@storybook/core-common';
+import { findDistEsm } from '@storybook/core-common';
+import type { StorybookConfig, Options } from '@storybook/core-common';
 
 let emberOptions: any;
 

--- a/app/ember/src/server/options.ts
+++ b/app/ember/src/server/options.ts
@@ -1,5 +1,5 @@
 import { sync } from 'read-pkg-up';
-import { LoadOptions } from '@storybook/core-common';
+import type { LoadOptions } from '@storybook/core-common';
 
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,

--- a/app/html/src/client/preview/index.ts
+++ b/app/html/src/client/preview/index.ts
@@ -1,11 +1,11 @@
 /* eslint-disable prefer-destructuring */
 import { start } from '@storybook/core/client';
-import { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { ClientStoryApi, Loadable } from '@storybook/addons';
 import { HtmlFramework } from './types-6-0';
 
 import './globals';
 import { renderToDOM } from './render';
-import { IStorybookSection } from './types';
+import type { IStorybookSection } from './types';
 
 const framework = 'html';
 

--- a/app/html/src/client/preview/types-6-0.ts
+++ b/app/html/src/client/preview/types-6-0.ts
@@ -1,6 +1,11 @@
-import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
+import type {
+  Args,
+  ComponentAnnotations,
+  StoryAnnotations,
+  AnnotatedStoryFn,
+} from '@storybook/csf';
 
-import { StoryFnHtmlReturnType } from './types';
+import type { StoryFnHtmlReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/addons';
 

--- a/app/html/src/client/preview/types-7-0.ts
+++ b/app/html/src/client/preview/types-7-0.ts
@@ -1,4 +1,4 @@
-import { Args } from '@storybook/csf';
+import type { Args } from '@storybook/csf';
 
 import type { StoryObj } from './types-6-0';
 

--- a/app/html/src/server/framework-preset-html.ts
+++ b/app/html/src/server/framework-preset-html.ts
@@ -1,6 +1,6 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { Configuration } from 'webpack';
-import { findDistEsm, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm } from '@storybook/core-common';
+import type { Configuration } from 'webpack';
+import type { StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration) {
   config.module.rules.push({

--- a/app/html/src/server/options.ts
+++ b/app/html/src/server/options.ts
@@ -1,5 +1,5 @@
 import { sync } from 'read-pkg-up';
-import { LoadOptions } from '@storybook/core-common';
+import type { LoadOptions } from '@storybook/core-common';
 
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,

--- a/app/preact/src/client/preview/index.ts
+++ b/app/preact/src/client/preview/index.ts
@@ -1,11 +1,11 @@
 /* eslint-disable prefer-destructuring */
 import { start } from '@storybook/core/client';
-import { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
 import { renderToDOM } from './render';
-import { IStorybookSection } from './types';
-import { PreactFramework } from './types-6-0';
+import type { IStorybookSection } from './types';
+import type { PreactFramework } from './types-6-0';
 
 export interface ClientApi extends ClientStoryApi<PreactFramework['storyResult']> {
   setAddon(addon: any): void;

--- a/app/preact/src/client/preview/types-6-0.ts
+++ b/app/preact/src/client/preview/types-6-0.ts
@@ -1,6 +1,11 @@
-import { AnyComponent } from 'preact';
-import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
-import { StoryFnPreactReturnType } from './types';
+import type { AnyComponent } from 'preact';
+import type {
+  Args,
+  ComponentAnnotations,
+  StoryAnnotations,
+  AnnotatedStoryFn,
+} from '@storybook/csf';
+import type { StoryFnPreactReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
 

--- a/app/preact/src/client/preview/types-7-0.ts
+++ b/app/preact/src/client/preview/types-7-0.ts
@@ -1,4 +1,4 @@
-import { Args } from '@storybook/csf';
+import type { Args } from '@storybook/csf';
 
 import type { StoryObj } from './types-6-0';
 

--- a/app/preact/src/server/framework-preset-preact.ts
+++ b/app/preact/src/server/framework-preset-preact.ts
@@ -1,7 +1,8 @@
 import path from 'path';
-import { TransformOptions } from '@babel/core';
-import { Configuration } from 'webpack';
-import { findDistEsm, StorybookConfig } from '@storybook/core-common';
+import type { TransformOptions } from '@babel/core';
+import type { Configuration } from 'webpack';
+import { findDistEsm } from '@storybook/core-common';
+import type { StorybookConfig } from '@storybook/core-common';
 
 export function babelDefault(config: TransformOptions): TransformOptions {
   return {

--- a/app/preact/src/server/options.ts
+++ b/app/preact/src/server/options.ts
@@ -1,5 +1,5 @@
 import { sync } from 'read-pkg-up';
-import { LoadOptions } from '@storybook/core-common';
+import type { LoadOptions } from '@storybook/core-common';
 
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,

--- a/app/react/src/client/preview/types-6-0.ts
+++ b/app/react/src/client/preview/types-6-0.ts
@@ -1,6 +1,11 @@
-import { ComponentType } from 'react';
-import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
-import { StoryFnReactReturnType } from './types';
+import type { ComponentType } from 'react';
+import type {
+  Args,
+  ComponentAnnotations,
+  StoryAnnotations,
+  AnnotatedStoryFn,
+} from '@storybook/csf';
+import type { StoryFnReactReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
 

--- a/app/react/src/client/preview/types-7-0.ts
+++ b/app/react/src/client/preview/types-7-0.ts
@@ -1,5 +1,5 @@
-import { JSXElementConstructor } from 'react';
-import { Args } from '@storybook/csf';
+import type { JSXElementConstructor } from 'react';
+import type { Args } from '@storybook/csf';
 
 import type { StoryObj } from './types-6-0';
 import type { ComponentStoryObj } from './types-6-3';

--- a/app/react/src/server/options.ts
+++ b/app/react/src/server/options.ts
@@ -1,5 +1,5 @@
 import { sync } from 'read-pkg-up';
-import { LoadOptions } from '@storybook/core-common';
+import type { LoadOptions } from '@storybook/core-common';
 
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,

--- a/app/react/src/server/preset.ts
+++ b/app/react/src/server/preset.ts
@@ -1,4 +1,5 @@
-import { findDistEsm, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm } from '@storybook/core-common';
+import type { StorybookConfig } from '@storybook/core-common';
 
 export const config: StorybookConfig['config'] = (entries = []) => [
   ...entries,

--- a/app/react/types/index.ts
+++ b/app/react/types/index.ts
@@ -1,4 +1,4 @@
-import { StorybookConfig as BaseConfig } from '@storybook/core-common';
+import type { StorybookConfig as BaseConfig } from '@storybook/core-common';
 
 /**
  * The interface for Storybook configuration in `main.ts` files.

--- a/app/server/src/client/preview/index.ts
+++ b/app/server/src/client/preview/index.ts
@@ -1,9 +1,9 @@
 import { start } from '@storybook/core/client';
-import { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
 import { renderToDOM, render } from './render';
-import { IStorybookSection, ServerFramework } from './types';
+import type { IStorybookSection, ServerFramework } from './types';
 
 const framework = 'server';
 

--- a/app/server/src/client/preview/render.ts
+++ b/app/server/src/client/preview/render.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-param-reassign */
 import global from 'global';
 import dedent from 'ts-dedent';
-import { RenderContext } from '@storybook/store';
+import type { RenderContext } from '@storybook/store';
 import { simulatePageLoad, simulateDOMContentLoaded } from '@storybook/preview-web';
-import { StoryFn, Args, ArgTypes } from '@storybook/csf';
-import { FetchStoryHtmlType, ServerFramework } from './types';
+import type { StoryFn, Args, ArgTypes } from '@storybook/csf';
+import type { FetchStoryHtmlType, ServerFramework } from './types';
 
 const { fetch, Node } = global;
 

--- a/app/server/src/client/preview/types.ts
+++ b/app/server/src/client/preview/types.ts
@@ -1,4 +1,4 @@
-import { StoryContext } from '@storybook/csf';
+import type { StoryContext } from '@storybook/csf';
 
 export type { RenderContext } from '@storybook/core';
 

--- a/app/server/src/server/framework-preset-server.ts
+++ b/app/server/src/server/framework-preset-server.ts
@@ -1,7 +1,7 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { Configuration } from 'webpack';
 import path from 'path';
-import { findDistEsm, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm } from '@storybook/core-common';
+import type { StorybookConfig } from '@storybook/core-common';
+import type { Configuration } from 'webpack';
 
 export function webpack(config: Configuration) {
   config.module.rules.push({

--- a/app/server/src/server/options.ts
+++ b/app/server/src/server/options.ts
@@ -1,5 +1,5 @@
 import { sync } from 'read-pkg-up';
-import { LoadOptions } from '@storybook/core-common';
+import type { LoadOptions } from '@storybook/core-common';
 
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,

--- a/app/svelte/src/client/preview/decorators.ts
+++ b/app/svelte/src/client/preview/decorators.ts
@@ -1,4 +1,4 @@
-import { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/csf';
+import type { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/csf';
 import { sanitizeStoryContextUpdate } from '@storybook/store';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import SlotDecorator from '@storybook/svelte/templates/SlotDecorator.svelte';

--- a/app/svelte/src/client/preview/render.ts
+++ b/app/svelte/src/client/preview/render.ts
@@ -1,5 +1,5 @@
 import global from 'global';
-import { ArgsStoryFn } from '@storybook/csf';
+import type { ArgsStoryFn } from '@storybook/csf';
 import type { RenderContext } from '@storybook/store';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import PreviewRender from '@storybook/svelte/templates/PreviewRender.svelte';

--- a/app/svelte/src/server/framework-preset-svelte.ts
+++ b/app/svelte/src/server/framework-preset-svelte.ts
@@ -1,6 +1,6 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { Configuration } from 'webpack';
-import { findDistEsm, Options, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm } from '@storybook/core-common';
+import type { Options, StorybookConfig } from '@storybook/core-common';
+import type { Configuration } from 'webpack';
 
 export async function webpack(config: Configuration, options: Options): Promise<Configuration> {
   const { preprocess = undefined, loader = {} } = await options.presets.apply(

--- a/app/vue/src/client/preview/decorateStory.ts
+++ b/app/vue/src/client/preview/decorateStory.ts
@@ -1,9 +1,9 @@
 import Vue, { VueConstructor, ComponentOptions } from 'vue';
-import { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/csf';
+import type { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/csf';
 import { sanitizeStoryContextUpdate } from '@storybook/store';
 
-import { StoryFnVueReturnType } from './types';
-import { VueFramework } from './types-6-0';
+import type { StoryFnVueReturnType } from './types';
+import type { VueFramework } from './types-6-0';
 import { extractProps } from './util';
 import { VALUES } from './render';
 

--- a/app/vue/src/client/preview/index.ts
+++ b/app/vue/src/client/preview/index.ts
@@ -1,10 +1,10 @@
 /* eslint-disable prefer-destructuring */
 import { start } from '@storybook/core/client';
-import { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
-import { IStorybookSection } from './types';
-import { VueFramework } from './types-6-0';
+import type { IStorybookSection } from './types';
+import type { VueFramework } from './types-6-0';
 import { renderToDOM, render } from './render';
 import { decorateStory } from './decorateStory';
 

--- a/app/vue/src/client/preview/render.ts
+++ b/app/vue/src/client/preview/render.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 import dedent from 'ts-dedent';
 import Vue from 'vue';
-import { RenderContext } from '@storybook/store';
-import { ArgsStoryFn } from '@storybook/csf';
-import { VueFramework } from './types-6-0';
+import type { RenderContext } from '@storybook/store';
+import type { ArgsStoryFn } from '@storybook/csf';
+import type { VueFramework } from './types-6-0';
 
 export const COMPONENT = 'STORYBOOK_COMPONENT';
 export const VALUES = 'STORYBOOK_VALUES';

--- a/app/vue/src/client/preview/types-6-0.ts
+++ b/app/vue/src/client/preview/types-6-0.ts
@@ -1,6 +1,11 @@
-import { Component, AsyncComponent } from 'vue';
-import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
-import { StoryFnVueReturnType } from './types';
+import type { Component, AsyncComponent } from 'vue';
+import type {
+  Args,
+  ComponentAnnotations,
+  StoryAnnotations,
+  AnnotatedStoryFn,
+} from '@storybook/csf';
+import type { StoryFnVueReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
 

--- a/app/vue/src/client/preview/types-7-0.ts
+++ b/app/vue/src/client/preview/types-7-0.ts
@@ -1,4 +1,4 @@
-import { Args } from '@storybook/csf';
+import type { Args } from '@storybook/csf';
 
 import type { StoryObj } from './types-6-0';
 

--- a/app/vue/src/server/framework-preset-vue.ts
+++ b/app/vue/src/server/framework-preset-vue.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-param-reassign */
 import { VueLoaderPlugin } from 'vue-loader';
-import type { Configuration } from 'webpack';
+import { findDistEsm } from '@storybook/core-common';
 
-import { findDistEsm, Options, TypescriptConfig, StorybookConfig } from '@storybook/core-common';
+import type { Configuration } from 'webpack';
+import type { Options, TypescriptConfig, StorybookConfig } from '@storybook/core-common';
 
 export async function webpack(config: Configuration, { presets }: Options) {
   const typescriptOptions = await presets.apply<TypescriptConfig>('typescript', {} as any);

--- a/app/vue3/src/client/preview/decorateStory.ts
+++ b/app/vue3/src/client/preview/decorateStory.ts
@@ -1,9 +1,9 @@
 import type { ConcreteComponent, Component, ComponentOptions } from 'vue';
 import { h } from 'vue';
-import { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/csf';
+import type { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/csf';
 import { sanitizeStoryContextUpdate } from '@storybook/store';
 
-import { VueFramework } from './types-6-0';
+import type { VueFramework } from './types-6-0';
 
 /*
   This normalizes a functional component into a render method in ComponentOptions.

--- a/app/vue3/src/client/preview/index.ts
+++ b/app/vue3/src/client/preview/index.ts
@@ -1,10 +1,10 @@
 import type { App } from 'vue';
 import { start } from '@storybook/core/client';
-import { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
-import { IStorybookSection } from './types';
-import { VueFramework } from './types-6-0';
+import type { IStorybookSection } from './types';
+import type { VueFramework } from './types-6-0';
 import { decorateStory } from './decorateStory';
 
 import { render, renderToDOM, storybookApp } from './render';

--- a/app/vue3/src/client/preview/render.ts
+++ b/app/vue3/src/client/preview/render.ts
@@ -1,7 +1,7 @@
 import dedent from 'ts-dedent';
 import { createApp, h, shallowRef, ComponentPublicInstance } from 'vue';
-import { RenderContext } from '@storybook/store';
-import { ArgsStoryFn } from '@storybook/csf';
+import type { RenderContext } from '@storybook/store';
+import type { ArgsStoryFn } from '@storybook/csf';
 
 import { StoryFnVueReturnType } from './types';
 import { VueFramework } from './types-6-0';

--- a/app/vue3/src/client/preview/types-6-0.ts
+++ b/app/vue3/src/client/preview/types-6-0.ts
@@ -1,6 +1,11 @@
-import { ConcreteComponent } from 'vue';
-import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
-import { StoryFnVueReturnType } from './types';
+import type { ConcreteComponent } from 'vue';
+import type {
+  Args,
+  ComponentAnnotations,
+  StoryAnnotations,
+  AnnotatedStoryFn,
+} from '@storybook/csf';
+import type { StoryFnVueReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
 

--- a/app/vue3/src/client/preview/types-7-0.ts
+++ b/app/vue3/src/client/preview/types-7-0.ts
@@ -1,4 +1,4 @@
-import { Args } from '@storybook/csf';
+import type { Args } from '@storybook/csf';
 
 import type { StoryObj } from './types-6-0';
 

--- a/app/vue3/src/server/framework-preset-vue3.ts
+++ b/app/vue3/src/server/framework-preset-vue3.ts
@@ -1,6 +1,7 @@
 import { VueLoaderPlugin } from 'vue-loader';
 import { Configuration, DefinePlugin } from 'webpack';
-import { findDistEsm, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm } from '@storybook/core-common';
+import type { StorybookConfig } from '@storybook/core-common';
 
 export function webpack(config: Configuration): Configuration {
   return {

--- a/app/vue3/src/server/options.ts
+++ b/app/vue3/src/server/options.ts
@@ -1,5 +1,5 @@
 import { sync } from 'read-pkg-up';
-import { LoadOptions } from '@storybook/core-common';
+import type { LoadOptions } from '@storybook/core-common';
 
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,

--- a/app/web-components/src/client/preview/index.ts
+++ b/app/web-components/src/client/preview/index.ts
@@ -1,11 +1,11 @@
 /* eslint-disable prefer-destructuring */
 import { start } from '@storybook/core/client';
-import { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
 import { renderToDOM } from './render';
-import { IStorybookSection } from './types';
-import { WebComponentsFramework } from './types-6-0';
+import type { IStorybookSection } from './types';
+import type { WebComponentsFramework } from './types-6-0';
 
 const framework = 'web-components';
 

--- a/app/web-components/src/client/preview/types-6-0.ts
+++ b/app/web-components/src/client/preview/types-6-0.ts
@@ -1,5 +1,10 @@
-import { Args, ComponentAnnotations, StoryAnnotations, AnnotatedStoryFn } from '@storybook/csf';
-import { StoryFnHtmlReturnType } from './types';
+import type {
+  Args,
+  ComponentAnnotations,
+  StoryAnnotations,
+  AnnotatedStoryFn,
+} from '@storybook/csf';
+import type { StoryFnHtmlReturnType } from './types';
 
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
 

--- a/app/web-components/src/client/preview/types-7-0.ts
+++ b/app/web-components/src/client/preview/types-7-0.ts
@@ -1,4 +1,4 @@
-import { Args } from '@storybook/csf';
+import type { Args } from '@storybook/csf';
 
 import type { StoryObj } from './types-6-0';
 

--- a/app/web-components/src/client/preview/types.ts
+++ b/app/web-components/src/client/preview/types.ts
@@ -1,4 +1,4 @@
-import { TemplateResult, SVGTemplateResult } from 'lit-html';
+import type { TemplateResult, SVGTemplateResult } from 'lit-html';
 
 export type { RenderContext } from '@storybook/core';
 export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/addons';

--- a/app/web-components/src/server/framework-preset-web-components.ts
+++ b/app/web-components/src/server/framework-preset-web-components.ts
@@ -1,6 +1,7 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { Configuration } from 'webpack';
-import { findDistEsm, Options, StorybookConfig } from '@storybook/core-common';
+import { findDistEsm } from '@storybook/core-common';
+
+import type { Options, StorybookConfig } from '@storybook/core-common';
+import type { Configuration } from 'webpack';
 
 export function webpack(config: Configuration, options: Options) {
   const babelrcOptions = options.features?.babelModeV7 ? null : { babelrc: false };

--- a/app/web-components/src/server/options.ts
+++ b/app/web-components/src/server/options.ts
@@ -1,5 +1,5 @@
 import { sync } from 'read-pkg-up';
-import { LoadOptions } from '@storybook/core-common';
+import type { LoadOptions } from '@storybook/core-common';
 
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,

--- a/docs/snippets/vue/list-story-with-sub-components.3.js.mdx
+++ b/docs/snippets/vue/list-story-with-sub-components.3.js.mdx
@@ -19,7 +19,7 @@ export const Empty = (args) => ({
   setup() {
     //👇 The args will now be passed down to the template
     return { args };
-  },
+  }
   template: '<List v-bind="args"/>',
 });
 
@@ -28,7 +28,7 @@ export const OneItem = (args) => ({
   setup() {
     //👇 The args will now be passed down to the template
     return { args };
-  },
+  }
   template: '<List v-bind="args"><ListItem /></List>',
 });
 ```

--- a/examples/angular-cli/src/stories/addons/toolbars/locales/locales.stories.ts
+++ b/examples/angular-cli/src/stories/addons/toolbars/locales/locales.stories.ts
@@ -1,6 +1,7 @@
-import { DecoratorFunction } from '@storybook/addons';
-import { Meta, moduleMetadata } from '@storybook/angular';
-import { Story } from '@storybook/angular/types-6-0';
+import type { DecoratorFunction } from '@storybook/addons';
+import { moduleMetadata } from '@storybook/angular';
+import type { Meta } from '@storybook/angular';
+import type { Story } from '@storybook/angular/types-6-0';
 
 import { TranslatePipe } from './translate.pipe';
 import { DEFAULT_LOCALE } from './translate.service';

--- a/examples/cra-ts-kitchen-sink/.storybook/main.ts
+++ b/examples/cra-ts-kitchen-sink/.storybook/main.ts
@@ -1,4 +1,4 @@
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 
 const path = require('path');
 

--- a/lib/addons/src/hooks.ts
+++ b/lib/addons/src/hooks.ts
@@ -1,6 +1,6 @@
 import global from 'global';
 import { logger } from '@storybook/client-logger';
-import {
+import type {
   AnyFramework,
   DecoratorFunction,
   DecoratorApplicator,

--- a/lib/addons/src/index.ts
+++ b/lib/addons/src/index.ts
@@ -1,10 +1,10 @@
 import global from 'global';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { Channel } from '@storybook/channels';
-import { API } from '@storybook/api';
-import { RenderData as RouterData } from '@storybook/router';
+import type { API } from '@storybook/api';
+import type { RenderData as RouterData } from '@storybook/router';
 import { logger } from '@storybook/client-logger';
-import { ThemeVars } from '@storybook/theming';
+import type { ThemeVars } from '@storybook/theming';
 import { mockChannel } from './storybook-channel-mock';
 import { types, Types } from './types';
 

--- a/lib/addons/src/make-decorator.test.ts
+++ b/lib/addons/src/make-decorator.test.ts
@@ -1,10 +1,10 @@
-import { StoryContext, StoryGetter } from './types';
+import { StoryContext } from './types';
 import { makeDecorator } from './make-decorator';
 
 // Copy & paste from internal api: client-api/src/client_api
-type DecoratorFn = (fn: StoryGetter, context: StoryContext) => any;
+type DecoratorFn = (fn: any, context: StoryContext) => any;
 
-const defaultDecorateStory = (getStory: StoryGetter, decorators: DecoratorFn[]) =>
+const defaultDecorateStory = (getStory: any, decorators: DecoratorFn[]) =>
   decorators.reduce(
     (decorated, decorator) => (context: StoryContext) =>
       decorator(() => decorated(context), context),

--- a/lib/addons/src/types.ts
+++ b/lib/addons/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AnyFramework,
   InputType,
   StoryContext as StoryContextForFramework,

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -4,7 +4,7 @@ import dedent from 'ts-dedent';
 import mapValues from 'lodash/mapValues';
 import countBy from 'lodash/countBy';
 import global from 'global';
-import {
+import type {
   StoryId,
   ComponentTitle,
   StoryKind,
@@ -12,13 +12,13 @@ import {
   Args,
   ArgTypes,
   Parameters,
-  sanitize,
 } from '@storybook/csf';
+import { sanitize } from '@storybook/csf';
 
 import { combineParameters } from '../index';
 import merge from './merge';
-import { Provider } from '../modules/provider';
-import { ViewMode } from '../modules/addons';
+import type { Provider } from '../modules/provider';
+import type { ViewMode } from '../modules/addons';
 
 const { FEATURES } = global;
 

--- a/lib/api/src/modules/globals.ts
+++ b/lib/api/src/modules/globals.ts
@@ -1,9 +1,9 @@
 import { SET_GLOBALS, UPDATE_GLOBALS, GLOBALS_UPDATED } from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 import deepEqual from 'fast-deep-equal';
-import { Globals, GlobalTypes } from '@storybook/csf';
+import type { Globals, GlobalTypes } from '@storybook/csf';
 
-import { ModuleFn } from '../index';
+import type { ModuleFn } from '../index';
 
 import { getEventMetadata } from '../lib/events';
 

--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -1,10 +1,11 @@
 import global from 'global';
 import pick from 'lodash/pick';
 import deepEqual from 'fast-deep-equal';
-import { themes, ThemeVars } from '@storybook/theming';
+import { themes } from '@storybook/theming';
+import type { ThemeVars } from '@storybook/theming';
 
 import merge from '../lib/merge';
-import { State, ModuleFn } from '../index';
+import type { State, ModuleFn } from '../index';
 
 const { DOCS_MODE, document } = global;
 

--- a/lib/api/src/modules/provider.ts
+++ b/lib/api/src/modules/provider.ts
@@ -1,10 +1,10 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Channel } from '@storybook/channels';
-import { ThemeVars } from '@storybook/theming';
+import type { ThemeVars } from '@storybook/theming';
 
-import { API, State, ModuleFn, Root, Group, Story } from '../index';
-import { StoryMapper, Refs } from './refs';
-import { UIOptions } from './layout';
+import type { API, State, ModuleFn, Root, Group, Story } from '../index';
+import type { StoryMapper, Refs } from './refs';
+import type { UIOptions } from './layout';
 
 interface SidebarOptions {
   showRoots?: boolean;

--- a/lib/builder-webpack4/src/index.ts
+++ b/lib/builder-webpack4/src/index.ts
@@ -4,12 +4,8 @@ import webpackType, { Stats, Configuration } from '@types/webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import { logger } from '@storybook/node-logger';
-import {
-  Builder,
-  useProgressReporting,
-  checkWebpackVersion,
-  Options,
-} from '@storybook/core-common';
+import type { Builder, Options } from '@storybook/core-common';
+import { useProgressReporting, checkWebpackVersion } from '@storybook/core-common';
 
 let compilation: ReturnType<typeof webpackDevMiddleware>;
 let reject: (reason?: any) => void;

--- a/lib/builder-webpack4/src/presets/custom-webpack-preset.ts
+++ b/lib/builder-webpack4/src/presets/custom-webpack-preset.ts
@@ -1,6 +1,7 @@
 import * as webpackReal from 'webpack';
 import { logger } from '@storybook/node-logger';
-import { CoreConfig, loadCustomWebpackConfig, Options } from '@storybook/core-common';
+import type { CoreConfig, Options } from '@storybook/core-common';
+import { loadCustomWebpackConfig } from '@storybook/core-common';
 import type { Configuration } from 'webpack';
 import { createDefaultWebpackConfig } from '../preview/base-webpack.config';
 

--- a/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack4/src/preview/iframe-webpack.config.ts
@@ -18,13 +18,12 @@ import {
   es6Transpiler,
   handlebars,
   interpolate,
-  Options,
   toImportFn,
   normalizeStories,
   loadPreviewOrConfigFile,
   readTemplate,
-  CoreConfig,
 } from '@storybook/core-common';
+import type { Options, CoreConfig } from '@storybook/core-common';
 import { createBabelLoader } from './babel-loader-preview';
 
 import { useBaseTsSupport } from './useBaseTsSupport';

--- a/lib/builder-webpack5/src/index.ts
+++ b/lib/builder-webpack5/src/index.ts
@@ -2,12 +2,8 @@ import webpack, { Stats, Configuration, ProgressPlugin } from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import { logger } from '@storybook/node-logger';
-import {
-  Builder,
-  useProgressReporting,
-  checkWebpackVersion,
-  Options,
-} from '@storybook/core-common';
+import { useProgressReporting, checkWebpackVersion } from '@storybook/core-common';
+import type { Builder, Options } from '@storybook/core-common';
 
 let compilation: ReturnType<typeof webpackDevMiddleware>;
 let reject: (reason?: any) => void;

--- a/lib/builder-webpack5/src/preview/base-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/base-webpack.config.ts
@@ -1,6 +1,6 @@
 import { logger } from '@storybook/node-logger';
 import type { Options, CoreConfig, Webpack5BuilderConfig } from '@storybook/core-common';
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 
 export async function createDefaultWebpackConfig(
   storybookBaseConfig: Configuration,

--- a/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -1,11 +1,6 @@
 import path from 'path';
-import {
-  Configuration,
-  DefinePlugin,
-  HotModuleReplacementPlugin,
-  ProgressPlugin,
-  ProvidePlugin,
-} from 'webpack';
+import { DefinePlugin, HotModuleReplacementPlugin, ProgressPlugin, ProvidePlugin } from 'webpack';
+import type { Configuration } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
@@ -14,18 +9,17 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 import themingPaths from '@storybook/theming/paths';
 
+import type { Options, CoreConfig } from '@storybook/core-common';
 import {
   toRequireContextString,
   es6Transpiler,
   stringifyProcessEnvs,
   handlebars,
   interpolate,
-  Options,
   toImportFn,
   normalizeStories,
   readTemplate,
   loadPreviewOrConfigFile,
-  CoreConfig,
 } from '@storybook/core-common';
 import { createBabelLoader } from './babel-loader-preview';
 

--- a/lib/client-api/src/ClientApi.test.ts
+++ b/lib/client-api/src/ClientApi.test.ts
@@ -1,4 +1,4 @@
-import addons, { mockChannel } from '@storybook/addons';
+import { addons, mockChannel } from '@storybook/addons';
 import { ClientApi } from './ClientApi';
 
 beforeEach(() => {

--- a/lib/client-api/src/ClientApi.ts
+++ b/lib/client-api/src/ClientApi.ts
@@ -2,32 +2,25 @@ import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 import global from 'global';
 import { logger } from '@storybook/client-logger';
-import {
+import { toId, sanitize } from '@storybook/csf';
+import type {
   Args,
   ArgTypes,
   AnyFramework,
-  toId,
   DecoratorFunction,
   Parameters,
   ArgTypesEnhancer,
   ArgsEnhancer,
   LoaderFunction,
   StoryFn,
-  sanitize,
   ComponentTitle,
   Globals,
   GlobalTypes,
   LegacyStoryFn,
 } from '@storybook/csf';
-import {
-  NormalizedComponentAnnotations,
-  Path,
-  ModuleImportFn,
-  combineParameters,
-  StoryStore,
-  normalizeInputTypes,
-} from '@storybook/store';
-import { ClientApiAddons, StoryApi } from '@storybook/addons';
+import { combineParameters, StoryStore, normalizeInputTypes } from '@storybook/store';
+import type { NormalizedComponentAnnotations, Path, ModuleImportFn } from '@storybook/store';
+import type { ClientApiAddons, StoryApi } from '@storybook/addons';
 
 import { StoryStoreFacade } from './StoryStoreFacade';
 

--- a/lib/client-api/src/StoryStoreFacade.ts
+++ b/lib/client-api/src/StoryStoreFacade.ts
@@ -1,25 +1,16 @@
 import global from 'global';
 import dedent from 'ts-dedent';
 import { SynchronousPromise } from 'synchronous-promise';
-import {
-  StoryId,
-  AnyFramework,
-  toId,
-  isExportStory,
-  Parameters,
-  StoryFn,
-  storyNameFromExport,
-} from '@storybook/csf';
-import {
+import { toId, isExportStory, storyNameFromExport } from '@storybook/csf';
+import type { StoryId, AnyFramework, Parameters, StoryFn } from '@storybook/csf';
+import { StoryStore, autoTitle, sortStoriesV6 } from '@storybook/store';
+import type {
   NormalizedProjectAnnotations,
   NormalizedStoriesSpecifier,
   Path,
   StoryIndex,
   ModuleExports,
-  StoryStore,
   Story,
-  autoTitle,
-  sortStoriesV6,
   StoryIndexEntry,
 } from '@storybook/store';
 import { logger } from '@storybook/client-logger';

--- a/lib/client-api/src/types.ts
+++ b/lib/client-api/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Addon,
   StoryId,
   StoryName,
@@ -14,7 +14,8 @@ import {
   StoryContext,
 } from '@storybook/addons';
 import { AnyFramework, StoryIdentifier, ProjectAnnotations } from '@storybook/csf';
-import { StoryStore, HooksContext, RenderContext } from '@storybook/store';
+import type { RenderContext } from '@storybook/store';
+import { StoryStore, HooksContext } from '@storybook/store';
 
 export type {
   SBType,

--- a/lib/components/src/ScrollArea/GlobalScrollAreaStyles.tsx
+++ b/lib/components/src/ScrollArea/GlobalScrollAreaStyles.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Global, Theme, CSSObject, keyframes } from '@storybook/theming';
+import { Global, keyframes } from '@storybook/theming';
+import type { Theme, CSSObject } from '@storybook/theming';
 
 const hsResizeObserverDummyAnimation = keyframes`0%{z-index:0}to{z-index:-1}`;
 

--- a/lib/components/src/controls/options/Select.tsx
+++ b/lib/components/src/controls/options/Select.tsx
@@ -1,5 +1,6 @@
 import React, { FC, ChangeEvent } from 'react';
-import { styled, CSSObject } from '@storybook/theming';
+import { styled } from '@storybook/theming';
+import type { CSSObject } from '@storybook/theming';
 import { logger } from '@storybook/client-logger';
 import { ControlProps, OptionsSelection, NormalizedOptionsConfig } from '../types';
 import { selectedKey, selectedKeys, selectedValues } from './helpers';

--- a/lib/components/src/form/input/input.tsx
+++ b/lib/components/src/form/input/input.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, forwardRef, HTMLProps, SelectHTMLAttributes } from 'react';
-import { styled, Theme, CSSObject } from '@storybook/theming';
+import type { Theme, CSSObject } from '@storybook/theming';
+import { styled } from '@storybook/theming';
 
 import TextareaAutoResize, { TextareaAutosizeProps } from 'react-textarea-autosize';
 

--- a/lib/core-client/src/manager/provider.ts
+++ b/lib/core-client/src/manager/provider.ts
@@ -1,6 +1,7 @@
 import global from 'global';
 import { Provider } from '@storybook/ui';
-import { addons, AddonStore, Channel, Config, Types } from '@storybook/addons';
+import { addons, AddonStore, Channel } from '@storybook/addons';
+import type { Config, Types } from '@storybook/addons';
 import createPostMessageChannel from '@storybook/channel-postmessage';
 import createWebSocketChannel from '@storybook/channel-websocket';
 import Events from '@storybook/core-events';

--- a/lib/core-client/src/preview/start.ts
+++ b/lib/core-client/src/preview/start.ts
@@ -1,12 +1,13 @@
 import global from 'global';
 import deprecate from 'util-deprecate';
 import { ClientApi } from '@storybook/client-api';
-import { WebProjectAnnotations, PreviewWeb } from '@storybook/preview-web';
-import { AnyFramework, ArgsStoryFn } from '@storybook/csf';
+import { PreviewWeb } from '@storybook/preview-web';
+import type { WebProjectAnnotations } from '@storybook/preview-web';
+import type { AnyFramework, ArgsStoryFn } from '@storybook/csf';
 import createChannel from '@storybook/channel-postmessage';
 import { addons } from '@storybook/addons';
 import Events from '@storybook/core-events';
-import { Path } from '@storybook/store';
+import type { Path } from '@storybook/store';
 
 import { Loadable } from './types';
 import { executeLoadableForChanges } from './executeLoadable';

--- a/lib/core-client/src/typings.d.ts
+++ b/lib/core-client/src/typings.d.ts
@@ -3,7 +3,6 @@ declare module '@storybook/semver';
 declare module 'unfetch/dist/unfetch';
 declare module 'lazy-universal-dotenv';
 declare module 'pnp-webpack-plugin';
-declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
 declare module 'open';

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -1,8 +1,8 @@
 import type ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import type { Options as TelejsonOptions } from 'telejson';
 import type { PluginOptions } from '@storybook/react-docgen-typescript-plugin';
-import { Configuration, Stats } from 'webpack';
-import { TransformOptions } from '@babel/core';
+import type { Configuration, Stats } from 'webpack';
+import type { TransformOptions } from '@babel/core';
 import { Router } from 'express';
 import { Server } from 'http';
 import { FileSystemCache } from './utils/file-cache';
@@ -317,12 +317,12 @@ export interface StorybookConfig {
   logLevel?: string;
   features?: {
     /**
-     * Allows to disable deprecated implicit PostCSS loader.
+     * Allows to disable deprecated implicit PostCSS loader. (will be removed in 7.0)
      */
     postcss?: boolean;
 
     /**
-     * Allows to disable deprecated implicit PostCSS loader.
+     * Allows to disable emotion webpack alias for emotion packages. (will be removed in 7.0)
      */
     emotionAlias?: boolean;
 

--- a/lib/core-common/src/utils/__tests__/merge-webpack-config.test.ts
+++ b/lib/core-common/src/utils/__tests__/merge-webpack-config.test.ts
@@ -1,4 +1,4 @@
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 import { mergeConfigs } from '../merge-webpack-config';
 
 const config: Configuration = {

--- a/lib/core-common/src/utils/merge-webpack-config.ts
+++ b/lib/core-common/src/utils/merge-webpack-config.ts
@@ -1,4 +1,4 @@
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 
 function plugins(
   { plugins: defaultPlugins = [] }: Configuration,

--- a/lib/core-server/src/build-dev.ts
+++ b/lib/core-server/src/build-dev.ts
@@ -1,14 +1,12 @@
 import { logger, instance as npmLog } from '@storybook/node-logger';
-import {
+import type {
   CLIOptions,
   LoadOptions,
   BuilderOptions,
-  resolvePathInStorybookCache,
-  loadAllPresets,
   Options,
-  cache,
   StorybookConfig,
 } from '@storybook/core-common';
+import { resolvePathInStorybookCache, loadAllPresets, cache } from '@storybook/core-common';
 import dedent from 'ts-dedent';
 import prompts from 'prompts';
 import global from 'global';

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -7,19 +7,16 @@ import global from 'global';
 
 import { logger } from '@storybook/node-logger';
 
-import {
-  loadAllPresets,
+import type {
   LoadOptions,
   CLIOptions,
   BuilderOptions,
   Options,
   Builder,
   StorybookConfig,
-  cache,
-  normalizeStories,
-  logConfig,
   CoreConfig,
 } from '@storybook/core-common';
+import { loadAllPresets, cache, normalizeStories, logConfig } from '@storybook/core-common';
 
 import { getProdCli } from './cli';
 import { outputStats } from './utils/output-stats';

--- a/lib/core-server/src/cli/dev.ts
+++ b/lib/core-server/src/cli/dev.ts
@@ -1,7 +1,7 @@
 import program, { CommanderStatic } from 'commander';
 import chalk from 'chalk';
 import { logger } from '@storybook/node-logger';
-import { CLIOptions } from '@storybook/core-common';
+import type { CLIOptions } from '@storybook/core-common';
 import { parseList, getEnvConfig, checkDeprecatedFlags } from './utils';
 
 export async function getDevCli(packageJson: {

--- a/lib/core-server/src/core-presets.test.ts
+++ b/lib/core-server/src/core-presets.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { mkdtemp as mkdtempCb } from 'fs';
 import os from 'os';
 import { promisify } from 'util';
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 import { resolvePathInStorybookCache, createFileSystemCache } from '@storybook/core-common';
 import { executor as previewExecutor } from '@storybook/builder-webpack4';
 import { executor as managerExecutor } from '@storybook/manager-webpack4';

--- a/lib/core-server/src/dev-server.ts
+++ b/lib/core-server/src/dev-server.ts
@@ -1,7 +1,8 @@
 import express, { Router } from 'express';
 import compression from 'compression';
 
-import { Builder, logConfig, Options, StorybookConfig } from '@storybook/core-common';
+import type { Builder, Options, StorybookConfig } from '@storybook/core-common';
+import { logConfig } from '@storybook/core-common';
 
 import { getMiddleware } from './utils/middleware';
 import { getServerAddresses } from './utils/server-address';

--- a/lib/core-server/src/presets/common-preset.ts
+++ b/lib/core-server/src/presets/common-preset.ts
@@ -6,8 +6,8 @@ import {
   loadCustomBabelConfig,
   getStorybookBabelConfig,
   loadEnvs,
-  Options,
 } from '@storybook/core-common';
+import type { Options } from '@storybook/core-common';
 
 export const babel = async (_: unknown, options: Options) => {
   const { configDir, presets } = options;
@@ -64,6 +64,6 @@ export const typescript = () => ({
 export const features = async (existing: Record<string, boolean>) => ({
   ...existing,
   postcss: true,
-  emotionAlias: true,
+  emotionAlias: false, // TODO remove in 7.0, this no longer does anything
   warnOnLegacyHierarchySeparator: true,
 });

--- a/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { normalizeStoriesEntry, NormalizedStoriesSpecifier } from '@storybook/core-common';
+import { normalizeStoriesEntry } from '@storybook/core-common';
+import type { NormalizedStoriesSpecifier } from '@storybook/core-common';
 import { readCsfOrMdx, getStorySortParameter } from '@storybook/csf-tools';
 
 import { StoryIndexGenerator } from './StoryIndexGenerator';

--- a/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -3,18 +3,13 @@ import fs from 'fs-extra';
 import glob from 'globby';
 import slash from 'slash';
 
-import {
-  autoTitleFromSpecifier,
-  sortStoriesV7,
-  Path,
-  StoryIndex,
-  V2CompatIndexEntry,
-  StoryId,
-} from '@storybook/store';
-import { NormalizedStoriesSpecifier, normalizeStoryPath } from '@storybook/core-common';
+import type { Path, StoryIndex, V2CompatIndexEntry, StoryId } from '@storybook/store';
+import { autoTitleFromSpecifier, sortStoriesV7 } from '@storybook/store';
+import type { NormalizedStoriesSpecifier } from '@storybook/core-common';
+import { normalizeStoryPath } from '@storybook/core-common';
 import { logger } from '@storybook/node-logger';
 import { readCsfOrMdx, getStorySortParameter } from '@storybook/csf-tools';
-import { ComponentTitle } from '@storybook/csf';
+import type { ComponentTitle } from '@storybook/csf';
 
 type SpecifierStoriesCache = Record<Path, StoryIndex['stories'] | false>;
 

--- a/lib/core-server/src/utils/get-manager-builder.ts
+++ b/lib/core-server/src/utils/get-manager-builder.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { getInterpretedFile, serverRequire, Options } from '@storybook/core-common';
+import { getInterpretedFile, serverRequire } from '@storybook/core-common';
+import type { Options } from '@storybook/core-common';
 
 export async function getManagerBuilder(configDir: Options['configDir']) {
   const main = path.resolve(configDir, 'main');

--- a/lib/core-server/src/utils/get-preview-builder.ts
+++ b/lib/core-server/src/utils/get-preview-builder.ts
@@ -1,12 +1,13 @@
 import path from 'path';
-import { getInterpretedFile, serverRequire, Options } from '@storybook/core-common';
+import { getInterpretedFile, serverRequire } from '@storybook/core-common';
+import type { Options } from '@storybook/core-common';
 
 export async function getPreviewBuilder(configDir: Options['configDir']) {
   const main = path.resolve(configDir, 'main');
   const mainFile = getInterpretedFile(main);
   const { core } = mainFile ? serverRequire(mainFile) : { core: null };
   let builderPackage: string;
-  if (core?.builder) {
+  if (core) {
     const builderName = typeof core.builder === 'string' ? core.builder : core.builder?.name;
     builderPackage = require.resolve(
       ['webpack4', 'webpack5'].includes(builderName)

--- a/lib/core-server/src/utils/output-startup-information.ts
+++ b/lib/core-server/src/utils/output-startup-information.ts
@@ -4,7 +4,7 @@ import boxen from 'boxen';
 import dedent from 'ts-dedent';
 import Table from 'cli-table3';
 import prettyTime from 'pretty-hrtime';
-import { VersionCheck } from '@storybook/core-common';
+import type { VersionCheck } from '@storybook/core-common';
 import { createUpdateMessage } from './update-check';
 
 export function outputStartupInformation(options: {

--- a/lib/core-server/src/utils/release-notes.ts
+++ b/lib/core-server/src/utils/release-notes.ts
@@ -1,5 +1,5 @@
 import semver from '@storybook/semver';
-import { ReleaseNotesData } from '@storybook/core-common';
+import type { ReleaseNotesData } from '@storybook/core-common';
 
 // We only expect to have release notes available for major and minor releases.
 // For this reason, we convert the actual version of the build here so that

--- a/lib/core-server/src/utils/stories-json.ts
+++ b/lib/core-server/src/utils/stories-json.ts
@@ -1,11 +1,7 @@
 import { Router, Request, Response } from 'express';
 import fs from 'fs-extra';
-import {
-  Options,
-  normalizeStories,
-  NormalizedStoriesSpecifier,
-  StorybookConfig,
-} from '@storybook/core-common';
+import type { Options, NormalizedStoriesSpecifier, StorybookConfig } from '@storybook/core-common';
+import { normalizeStories } from '@storybook/core-common';
 import Events from '@storybook/core-events';
 import debounce from 'lodash/debounce';
 

--- a/lib/core-server/src/utils/update-check.ts
+++ b/lib/core-server/src/utils/update-check.ts
@@ -3,7 +3,8 @@ import chalk from 'chalk';
 import { colors } from '@storybook/node-logger';
 import semver from '@storybook/semver';
 import dedent from 'ts-dedent';
-import { VersionCheck, cache } from '@storybook/core-common';
+import { cache } from '@storybook/core-common';
+import type { VersionCheck } from '@storybook/core-common';
 
 const { STORYBOOK_VERSION_BASE = 'https://storybook.js.org', CI } = process.env;
 

--- a/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -4,8 +4,8 @@ import fs from 'fs';
 import path from 'path';
 import glob from 'globby';
 
-import { NormalizedStoriesSpecifier } from '@storybook/core-common';
-import { Path } from '@storybook/store';
+import type { NormalizedStoriesSpecifier } from '@storybook/core-common';
+import type { Path } from '@storybook/store';
 
 const isDirectory = (directory: Path) => {
   try {

--- a/lib/instrumenter/src/instrumenter.test.ts
+++ b/lib/instrumenter/src/instrumenter.test.ts
@@ -9,7 +9,7 @@ import {
 import global from 'global';
 
 import { EVENTS, Instrumenter } from './instrumenter';
-import { Options } from './types';
+import type { Options } from './types';
 
 const callSpy = jest.fn();
 const syncSpy = jest.fn();

--- a/lib/instrumenter/src/instrumenter.ts
+++ b/lib/instrumenter/src/instrumenter.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import { addons, Channel, StoryId } from '@storybook/addons';
+import { addons, Channel } from '@storybook/addons';
+import type { StoryId } from '@storybook/addons';
 import { once } from '@storybook/client-logger';
 import {
   FORCE_REMOUNT,

--- a/lib/instrumenter/src/types.ts
+++ b/lib/instrumenter/src/types.ts
@@ -1,4 +1,4 @@
-import { StoryId } from '@storybook/addons';
+import type { StoryId } from '@storybook/addons';
 
 export interface Call {
   id: string;

--- a/lib/manager-webpack4/src/index.ts
+++ b/lib/manager-webpack4/src/index.ts
@@ -1,12 +1,9 @@
-import webpack, { Stats, Configuration, ProgressPlugin } from 'webpack';
+import webpack, { ProgressPlugin } from 'webpack';
+import type { Stats, Configuration } from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import { logger } from '@storybook/node-logger';
-import {
-  Builder,
-  useProgressReporting,
-  checkWebpackVersion,
-  Options,
-} from '@storybook/core-common';
+import { useProgressReporting, checkWebpackVersion } from '@storybook/core-common';
+import type { Builder, Options } from '@storybook/core-common';
 
 import findUp from 'find-up';
 import fs from 'fs-extra';

--- a/lib/manager-webpack4/src/manager-config.ts
+++ b/lib/manager-webpack4/src/manager-config.ts
@@ -6,8 +6,8 @@ import fetch from 'node-fetch';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 
-import { Configuration } from 'webpack';
-import { Ref, Options } from '@storybook/core-common';
+import type { Configuration } from 'webpack';
+import type { Ref, Options } from '@storybook/core-common';
 
 export const getAutoRefs = async (
   options: Options,

--- a/lib/manager-webpack4/src/presets/manager-preset.ts
+++ b/lib/manager-webpack4/src/presets/manager-preset.ts
@@ -1,16 +1,17 @@
 import path from 'path';
 import fse from 'fs-extra';
-import { DefinePlugin, Configuration, WebpackPluginInstance } from 'webpack';
+import { DefinePlugin } from 'webpack';
+import type { Configuration, WebpackPluginInstance } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
 
-import themingPaths from '@storybook/theming/paths';
 import uiPaths from '@storybook/ui/paths';
 
 import readPackage from 'read-pkg-up';
+import type { Options, ManagerWebpackOptions } from '@storybook/core-common';
 import {
   loadManagerOrAddonsFile,
   resolvePathInStorybookCache,
@@ -18,8 +19,6 @@ import {
   es6Transpiler,
   getManagerHeadTemplate,
   getManagerMainTemplate,
-  Options,
-  ManagerWebpackOptions,
 } from '@storybook/core-common';
 
 import { babelLoader } from './babel-loader-manager';
@@ -161,7 +160,6 @@ export async function managerWebpack(
       modules: ['node_modules'].concat(envs.NODE_PATH || []),
       mainFields: [modern ? 'sbmodern' : null, 'browser', 'module', 'main'].filter(Boolean),
       alias: {
-        ...themingPaths,
         ...uiPaths,
       },
       plugins: [

--- a/lib/manager-webpack4/src/utils/manager-cache.ts
+++ b/lib/manager-webpack4/src/utils/manager-cache.ts
@@ -1,4 +1,4 @@
-import { Options } from '@storybook/core-common';
+import type { Options } from '@storybook/core-common';
 import { logger } from '@storybook/node-logger';
 import fs from 'fs-extra';
 import path from 'path';

--- a/lib/manager-webpack4/src/utils/output-stats.ts
+++ b/lib/manager-webpack4/src/utils/output-stats.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import path from 'path';
 import { logger } from '@storybook/node-logger';
-import { Stats } from 'webpack';
+import type { Stats } from 'webpack';
 
 import fs from 'fs-extra';
 

--- a/lib/manager-webpack4/src/utils/prebuilt-manager.ts
+++ b/lib/manager-webpack4/src/utils/prebuilt-manager.ts
@@ -1,11 +1,7 @@
 import { pathExists } from 'fs-extra';
 import path from 'path';
-import {
-  getInterpretedFile,
-  loadManagerOrAddonsFile,
-  serverRequire,
-  Options,
-} from '@storybook/core-common';
+import type { Options } from '@storybook/core-common';
+import { getInterpretedFile, loadManagerOrAddonsFile, serverRequire } from '@storybook/core-common';
 
 import { getAutoRefs } from '../manager-config';
 

--- a/lib/manager-webpack5/src/index.ts
+++ b/lib/manager-webpack5/src/index.ts
@@ -1,12 +1,9 @@
-import webpack, { Stats, Configuration, ProgressPlugin } from 'webpack';
+import webpack, { ProgressPlugin } from 'webpack';
+import type { Stats, Configuration } from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import { logger } from '@storybook/node-logger';
-import {
-  Builder,
-  useProgressReporting,
-  checkWebpackVersion,
-  Options,
-} from '@storybook/core-common';
+import { useProgressReporting, checkWebpackVersion } from '@storybook/core-common';
+import type { Builder, Options } from '@storybook/core-common';
 
 import findUp from 'find-up';
 import fs from 'fs-extra';

--- a/lib/manager-webpack5/src/manager-config.ts
+++ b/lib/manager-webpack5/src/manager-config.ts
@@ -6,8 +6,8 @@ import fetch from 'node-fetch';
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
 
-import { Configuration } from 'webpack';
-import { Ref, Options } from '@storybook/core-common';
+import type { Configuration } from 'webpack';
+import type { Ref, Options } from '@storybook/core-common';
 
 export const getAutoRefs = async (
   options: Options,

--- a/lib/manager-webpack5/src/presets/manager-preset.ts
+++ b/lib/manager-webpack5/src/presets/manager-preset.ts
@@ -1,12 +1,12 @@
 import path from 'path';
 import fse from 'fs-extra';
-import { DefinePlugin, Configuration, WebpackPluginInstance, ProvidePlugin } from 'webpack';
+import { DefinePlugin, ProvidePlugin } from 'webpack';
+import type { Configuration, WebpackPluginInstance } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
 
-import themingPaths from '@storybook/theming/paths';
 import uiPaths from '@storybook/ui/paths';
 
 import readPackage from 'read-pkg-up';
@@ -17,9 +17,8 @@ import {
   es6Transpiler,
   getManagerHeadTemplate,
   getManagerMainTemplate,
-  Options,
-  ManagerWebpackOptions,
 } from '@storybook/core-common';
+import type { Options, ManagerWebpackOptions } from '@storybook/core-common';
 
 import { babelLoader } from './babel-loader-manager';
 
@@ -165,7 +164,6 @@ export async function managerWebpack(
       modules: ['node_modules'].concat(envs.NODE_PATH || []),
       mainFields: [modern ? 'sbmodern' : null, 'browser', 'module', 'main'].filter(Boolean),
       alias: {
-        ...themingPaths,
         ...uiPaths,
       },
     },

--- a/lib/manager-webpack5/src/utils/output-stats.ts
+++ b/lib/manager-webpack5/src/utils/output-stats.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import path from 'path';
 import { logger } from '@storybook/node-logger';
-import { Stats } from 'webpack';
+import type { Stats } from 'webpack';
 
 import fs from 'fs-extra';
 

--- a/lib/manager-webpack5/src/utils/prebuilt-manager.ts
+++ b/lib/manager-webpack5/src/utils/prebuilt-manager.ts
@@ -1,11 +1,7 @@
 import { pathExists } from 'fs-extra';
 import path from 'path';
-import {
-  getInterpretedFile,
-  loadManagerOrAddonsFile,
-  serverRequire,
-  Options,
-} from '@storybook/core-common';
+import { getInterpretedFile, loadManagerOrAddonsFile, serverRequire } from '@storybook/core-common';
+import type { Options } from '@storybook/core-common';
 
 import { getAutoRefs } from '../manager-config';
 

--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -3,8 +3,8 @@ import * as ReactDOM from 'react-dom';
 import merge from 'lodash/merge';
 import Events, { IGNORED_EXCEPTION } from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
-import addons, { mockChannel as createMockChannel } from '@storybook/addons';
-import { AnyFramework } from '@storybook/csf';
+import { addons, mockChannel as createMockChannel } from '@storybook/addons';
+import type { AnyFramework } from '@storybook/csf';
 import type { ModuleImportFn } from '@storybook/store';
 
 import { PreviewWeb } from './PreviewWeb';
@@ -22,7 +22,7 @@ import {
   waitForQuiescence,
   waitForRenderPhase,
 } from './PreviewWeb.mockdata';
-import { WebProjectAnnotations } from './types';
+import type { WebProjectAnnotations } from './types';
 
 jest.mock('./WebView');
 const { history, document } = global;

--- a/lib/preview-web/src/UrlStore.ts
+++ b/lib/preview-web/src/UrlStore.ts
@@ -1,9 +1,9 @@
-import { SelectionSpecifier, Selection } from '@storybook/store';
+import type { SelectionSpecifier, Selection } from '@storybook/store';
 
 import global from 'global';
 import qs from 'qs';
 import deprecate from 'util-deprecate';
-import { ViewMode } from '@storybook/addons';
+import type { ViewMode } from '@storybook/addons';
 
 import { parseArgsParam } from './parseArgsParam';
 

--- a/lib/preview-web/src/composeConfigs.ts
+++ b/lib/preview-web/src/composeConfigs.ts
@@ -1,6 +1,7 @@
-import { AnyFramework } from '@storybook/csf';
-import { combineParameters, ModuleExports } from '@storybook/store';
-import { WebProjectAnnotations } from './types';
+import type { AnyFramework } from '@storybook/csf';
+import { combineParameters } from '@storybook/store';
+import type { ModuleExports } from '@storybook/store';
+import type { WebProjectAnnotations } from './types';
 
 function getField(moduleExportList: ModuleExports[], field: string): any[] {
   return moduleExportList.map((xs) => xs[field]).filter(Boolean);

--- a/lib/preview-web/src/parseArgsParam.ts
+++ b/lib/preview-web/src/parseArgsParam.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 import dedent from 'ts-dedent';
-import { Args } from '@storybook/addons';
+import type { Args } from '@storybook/addons';
 import { once } from '@storybook/client-logger';
 import isPlainObject from 'lodash/isPlainObject';
 

--- a/lib/preview-web/src/types.ts
+++ b/lib/preview-web/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   StoryId,
   StoryName,
   AnyFramework,
@@ -8,7 +8,7 @@ import {
   Args,
   Globals,
 } from '@storybook/csf';
-import { RenderContext, Story } from '@storybook/store';
+import type { RenderContext, Story } from '@storybook/store';
 import { PreviewWeb } from './PreviewWeb';
 
 export type WebProjectAnnotations<TFramework extends AnyFramework> =

--- a/lib/store/src/ArgsStore.ts
+++ b/lib/store/src/ArgsStore.ts
@@ -1,6 +1,6 @@
-import { StoryId, Args } from '@storybook/csf';
+import type { StoryId, Args } from '@storybook/csf';
 
-import { Story } from './types';
+import type { Story } from './types';
 import { combineArgs, mapArgsToTypes, validateOptions, deepDiff, DEEPLY_EQUAL } from './args';
 
 function deleteUndefined(obj: Record<string, any>) {

--- a/lib/store/src/GlobalsStore.ts
+++ b/lib/store/src/GlobalsStore.ts
@@ -1,6 +1,6 @@
 import deprecate from 'util-deprecate';
 import dedent from 'ts-dedent';
-import { Globals, GlobalTypes } from '@storybook/csf';
+import type { Globals, GlobalTypes } from '@storybook/csf';
 
 import { deepDiff, DEEPLY_EQUAL } from './args';
 import { getValuesFromArgTypes } from './csf/getValuesFromArgTypes';

--- a/lib/store/src/StoryIndexStore.ts
+++ b/lib/store/src/StoryIndexStore.ts
@@ -1,8 +1,8 @@
 import dedent from 'ts-dedent';
 import { Channel } from '@storybook/addons';
-import { StoryId } from '@storybook/csf';
+import type { StoryId } from '@storybook/csf';
 
-import { StorySpecifier, StoryIndex, StoryIndexEntry } from './types';
+import type { StorySpecifier, StoryIndex, StoryIndexEntry } from './types';
 
 export class StoryIndexStore {
   channel: Channel;

--- a/lib/store/src/StoryStore.test.ts
+++ b/lib/store/src/StoryStore.test.ts
@@ -1,9 +1,9 @@
-import { AnyFramework, ProjectAnnotations } from '@storybook/csf';
+import type { AnyFramework, ProjectAnnotations } from '@storybook/csf';
 import global from 'global';
 
 import { prepareStory, processCSFFile } from './csf';
 import { StoryStore } from './StoryStore';
-import { StoryIndex } from './types';
+import type { StoryIndex } from './types';
 import { HooksContext } from './hooks';
 
 // Spy on prepareStory/processCSFFile

--- a/lib/store/src/StoryStore.ts
+++ b/lib/store/src/StoryStore.ts
@@ -1,5 +1,5 @@
 import memoize from 'memoizerific';
-import {
+import type {
   Parameters,
   StoryId,
   StoryContextForLoaders,
@@ -18,7 +18,7 @@ import { StoryIndexStore } from './StoryIndexStore';
 import { ArgsStore } from './ArgsStore';
 import { GlobalsStore } from './GlobalsStore';
 import { processCSFFile, prepareStory, normalizeProjectAnnotations } from './csf';
-import {
+import type {
   CSFFile,
   ModuleImportFn,
   Story,

--- a/lib/store/src/args.ts
+++ b/lib/store/src/args.ts
@@ -1,5 +1,5 @@
 import deepEqual from 'fast-deep-equal';
-import { SBType, Args, ArgTypes, StoryContext, AnyFramework } from '@storybook/csf';
+import type { SBType, Args, ArgTypes, StoryContext, AnyFramework } from '@storybook/csf';
 import { once } from '@storybook/client-logger';
 import isPlainObject from 'lodash/isPlainObject';
 import dedent from 'ts-dedent';

--- a/lib/store/src/csf/normalizeComponentAnnotations.ts
+++ b/lib/store/src/csf/normalizeComponentAnnotations.ts
@@ -1,6 +1,7 @@
-import { sanitize, AnyFramework } from '@storybook/csf';
+import { sanitize } from '@storybook/csf';
+import type { AnyFramework } from '@storybook/csf';
 
-import { ModuleExports, NormalizedComponentAnnotations } from '../types';
+import type { ModuleExports, NormalizedComponentAnnotations } from '../types';
 import { normalizeInputTypes } from './normalizeInputTypes';
 
 export function normalizeComponentAnnotations<TFramework extends AnyFramework>(

--- a/lib/store/src/csf/normalizeInputTypes.ts
+++ b/lib/store/src/csf/normalizeInputTypes.ts
@@ -1,5 +1,5 @@
 import mapValues from 'lodash/mapValues';
-import {
+import type {
   ArgTypes,
   GlobalTypes,
   InputType,

--- a/lib/store/src/csf/normalizeProjectAnnotations.ts
+++ b/lib/store/src/csf/normalizeProjectAnnotations.ts
@@ -1,8 +1,8 @@
-import { AnyFramework, ProjectAnnotations } from '@storybook/csf';
+import type { AnyFramework, ProjectAnnotations } from '@storybook/csf';
 
 import { inferArgTypes } from '../inferArgTypes';
 import { inferControls } from '../inferControls';
-import { NormalizedProjectAnnotations } from '../types';
+import type { NormalizedProjectAnnotations } from '../types';
 import { normalizeInputTypes } from './normalizeInputTypes';
 
 export function normalizeProjectAnnotations<TFramework extends AnyFramework>({

--- a/lib/store/src/csf/normalizeStory.ts
+++ b/lib/store/src/csf/normalizeStory.ts
@@ -1,6 +1,4 @@
-import {
-  storyNameFromExport,
-  toId,
+import type {
   ComponentAnnotations,
   AnyFramework,
   LegacyStoryAnnotationsOrFn,
@@ -8,10 +6,11 @@ import {
   StoryAnnotations,
   StoryFn,
 } from '@storybook/csf';
+import { storyNameFromExport, toId } from '@storybook/csf';
 import dedent from 'ts-dedent';
 import { logger } from '@storybook/client-logger';
 import deprecate from 'util-deprecate';
-import { NormalizedStoryAnnotations } from '../types';
+import type { NormalizedStoryAnnotations } from '../types';
 import { normalizeInputTypes } from './normalizeInputTypes';
 
 const deprecatedStoryAnnotation = dedent`

--- a/lib/store/src/csf/prepareStory.test.ts
+++ b/lib/store/src/csf/prepareStory.test.ts
@@ -1,6 +1,6 @@
 import global from 'global';
-import addons, { HooksContext } from '@storybook/addons';
-import {
+import { addons, HooksContext } from '@storybook/addons';
+import type {
   AnyFramework,
   ArgsEnhancer,
   SBObjectType,

--- a/lib/store/src/csf/prepareStory.ts
+++ b/lib/store/src/csf/prepareStory.ts
@@ -2,7 +2,7 @@ import dedent from 'ts-dedent';
 import deprecate from 'util-deprecate';
 import global from 'global';
 
-import {
+import type {
   Parameters,
   Args,
   LegacyStoryFn,
@@ -13,7 +13,7 @@ import {
   StrictArgTypes,
 } from '@storybook/csf';
 
-import {
+import type {
   NormalizedComponentAnnotations,
   Story,
   NormalizedStoryAnnotations,

--- a/lib/store/src/csf/processCSFFile.ts
+++ b/lib/store/src/csf/processCSFFile.ts
@@ -1,4 +1,5 @@
-import { isExportStory, Parameters, AnyFramework, ComponentTitle } from '@storybook/csf';
+import type { Parameters, AnyFramework, ComponentTitle } from '@storybook/csf';
+import { isExportStory } from '@storybook/csf';
 import { logger } from '@storybook/client-logger';
 
 import { normalizeStory } from './normalizeStory';

--- a/lib/store/src/decorators.test.ts
+++ b/lib/store/src/decorators.test.ts
@@ -1,4 +1,4 @@
-import { AnyFramework, StoryContext } from '@storybook/csf';
+import type { AnyFramework, StoryContext } from '@storybook/csf';
 
 import { defaultDecorateStory } from './decorators';
 

--- a/lib/store/src/decorators.ts
+++ b/lib/store/src/decorators.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DecoratorFunction,
   StoryContext,
   StoryContextUpdate,

--- a/lib/store/src/inferArgTypes.ts
+++ b/lib/store/src/inferArgTypes.ts
@@ -1,7 +1,7 @@
 import mapValues from 'lodash/mapValues';
 import dedent from 'ts-dedent';
 import { logger } from '@storybook/client-logger';
-import { AnyFramework, SBType, ArgTypesEnhancer } from '@storybook/csf';
+import type { AnyFramework, SBType, ArgTypesEnhancer } from '@storybook/csf';
 import { combineParameters } from './parameters';
 
 const inferType = (value: any, name: string, visited: Set<any>): SBType => {

--- a/lib/store/src/inferControls.ts
+++ b/lib/store/src/inferControls.ts
@@ -1,6 +1,6 @@
 import mapValues from 'lodash/mapValues';
 import { logger } from '@storybook/client-logger';
-import { AnyFramework, SBEnumType, StrictInputType, ArgTypesEnhancer } from '@storybook/csf';
+import type { AnyFramework, SBEnumType, StrictInputType, ArgTypesEnhancer } from '@storybook/csf';
 import { filterArgTypes } from './filterArgTypes';
 import { combineParameters } from './parameters';
 

--- a/lib/store/src/parameters.ts
+++ b/lib/store/src/parameters.ts
@@ -1,5 +1,5 @@
 // Utilities for handling parameters
-import { Parameters } from '@storybook/addons';
+import type { Parameters } from '@storybook/addons';
 import isPlainObject from 'lodash/isPlainObject';
 
 /**

--- a/lib/store/src/sortStories.ts
+++ b/lib/store/src/sortStories.ts
@@ -1,8 +1,8 @@
 import stable from 'stable';
 import dedent from 'ts-dedent';
-import { Comparator, StorySortParameter, StorySortParameterV7 } from '@storybook/addons';
+import type { Comparator, StorySortParameter, StorySortParameterV7 } from '@storybook/addons';
 import { storySort } from './storySort';
-import { Story, StoryIndexEntry, Path, Parameters } from './types';
+import type { Story, StoryIndexEntry, Path, Parameters } from './types';
 
 const sortStoriesCommon = (
   stories: StoryIndexEntry[],

--- a/lib/store/src/types.ts
+++ b/lib/store/src/types.ts
@@ -1,5 +1,5 @@
 import { SynchronousPromise } from 'synchronous-promise';
-import {
+import type {
   DecoratorFunction,
   Args,
   StoryContextForEnhancers,

--- a/lib/ui/src/components/layout/container.tsx
+++ b/lib/ui/src/components/layout/container.tsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment, FunctionComponent, CSSProperties, ReactNode } from 'react';
-import { styled, withTheme, Theme } from '@storybook/theming';
-import { State } from '@storybook/api';
+import { styled, withTheme } from '@storybook/theming';
+import type { Theme } from '@storybook/theming';
+import type { State } from '@storybook/api';
 import * as persistence from './persist';
 
 import { Draggable, Handle, DraggableData, DraggableEvent } from './draggers';

--- a/lib/ui/src/components/notifications/NotificationList.tsx
+++ b/lib/ui/src/components/notifications/NotificationList.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
-import { State } from '@storybook/api';
-import { styled, CSSObject } from '@storybook/theming';
+import type { State } from '@storybook/api';
+import { styled } from '@storybook/theming';
+import type { CSSObject } from '@storybook/theming';
 import NotificationItem from './NotificationItem';
 
 const List = styled.div<{ placement?: CSSObject }>(

--- a/lib/ui/src/components/preview/FramesRenderer.tsx
+++ b/lib/ui/src/components/preview/FramesRenderer.tsx
@@ -1,7 +1,9 @@
 import React, { Fragment, FunctionComponent, useMemo, useEffect, useState } from 'react';
-import { Consumer, Combo } from '@storybook/api';
+import type { Combo } from '@storybook/api';
+import { Consumer } from '@storybook/api';
 import { Button, getStoryHref } from '@storybook/components';
-import { Global, CSSObject, styled } from '@storybook/theming';
+import { Global, styled } from '@storybook/theming';
+import type { CSSObject } from '@storybook/theming';
 import { IFrame } from './iframe';
 import { FramesRendererProps } from './utils/types';
 import { stringifyQueryParams } from './utils/stringifyQueryParams';

--- a/lib/ui/src/components/preview/preview.stories.tsx
+++ b/lib/ui/src/components/preview/preview.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { parsePath, createPath } from 'history';
-import { Provider as ManagerProvider, Combo, Consumer } from '@storybook/api';
+import type { Combo } from '@storybook/api';
+import { Provider as ManagerProvider, Consumer } from '@storybook/api';
 import { Location, BaseLocationProvider } from '@storybook/router';
 
 import { ThemeProvider, ensure as ensureTheme, themes } from '@storybook/theming';

--- a/lib/ui/src/components/sidebar/Heading.stories.tsx
+++ b/lib/ui/src/components/sidebar/Heading.stories.tsx
@@ -2,7 +2,8 @@
 // @TODO: use addon-interactions and remove the rule disable above
 import React from 'react';
 import type { ComponentStory, ComponentMeta, ComponentStoryObj } from '@storybook/react';
-import { ThemeProvider, useTheme, Theme } from '@storybook/theming';
+import { ThemeProvider, useTheme } from '@storybook/theming';
+import type { Theme } from '@storybook/theming';
 import { action } from '@storybook/addon-actions';
 import { screen } from '@testing-library/dom';
 

--- a/lib/ui/src/components/sidebar/TreeNode.tsx
+++ b/lib/ui/src/components/sidebar/TreeNode.tsx
@@ -1,4 +1,5 @@
-import { styled, Color, Theme } from '@storybook/theming';
+import { styled } from '@storybook/theming';
+import type { Color, Theme } from '@storybook/theming';
 import { Icons } from '@storybook/components';
 import global from 'global';
 import { transparentize } from 'polished';

--- a/lib/ui/src/containers/menu.tsx
+++ b/lib/ui/src/containers/menu.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, FunctionComponent } from 'react';
 
 import { Badge } from '@storybook/components';
-import { API } from '@storybook/api';
-import { styled, useTheme, Theme } from '@storybook/theming';
+import type { API } from '@storybook/api';
+import type { Theme } from '@storybook/theming';
+import { styled, useTheme } from '@storybook/theming';
 
 import { shortcutToHumanString } from '@storybook/api/shortcut';
 import { MenuItemIcon } from '../components/sidebar/Menu';

--- a/lib/ui/src/provider.ts
+++ b/lib/ui/src/provider.ts
@@ -1,4 +1,4 @@
-import { Types } from '@storybook/addons';
+import type { Types } from '@storybook/addons';
 
 export default class Provider {
   getElements(_type: Types) {


### PR DESCRIPTION
## What I did

I changes most imports of types and interfaces to be imported with the `type` prefix.

This fixes:
- eslint warnings
- makes babel transform faster, because some files will not need to be evaluated
- it's clear which imports will make an impact at runtime