### PR TITLE
Angular: Fix multiple calls of Input setter 

### DIFF
--- a/app/angular/src/client/preview/angular-beta/StorybookModule.test.ts
+++ b/app/angular/src/client/preview/angular-beta/StorybookModule.test.ts
@@ -14,6 +14,7 @@ describe('StorybookModule', () => {
         template: `
           <p id="input">{{ input }}</p>
           <p id="inputBindingPropertyName">{{ localPropertyName }}</p>
+          <p id="setterCallNb">{{ setterCallNb }}</p>
           <p id="localProperty">{{ localProperty }}</p>
           <p id="localFunction">{{ localFunction() }}</p>
           <p id="output" (click)="output.emit('outputEmitted')"></p>
@@ -27,6 +28,11 @@ describe('StorybookModule', () => {
         @Input('inputBindingPropertyName')
         public localPropertyName: string;
 
+        @Input()
+        public set setter(value: string) {
+          this.setterCallNb += 1;
+        }
+
         @Output()
         public output = new EventEmitter<string>();
 
@@ -36,6 +42,8 @@ describe('StorybookModule', () => {
         public localProperty: string;
 
         public localFunction = () => '';
+
+        public setterCallNb = 0;
       }
 
       it('should initialize inputs', async () => {
@@ -104,6 +112,7 @@ describe('StorybookModule', () => {
       it('should change inputs if storyProps$ Subject emit', async () => {
         const initialProps = {
           input: 'input',
+          inputBindingPropertyName: '',
         };
         const storyProps$ = new BehaviorSubject<ICollection>(initialProps);
 
@@ -150,6 +159,7 @@ describe('StorybookModule', () => {
         let expectedOutputValue;
         let expectedOutputBindingValue;
         const initialProps = {
+          input: '',
           output: (value: string) => {
             expectedOutputValue = value;
           },
@@ -224,6 +234,34 @@ describe('StorybookModule', () => {
 
         expect(fixture.nativeElement.querySelector('p').style.color).toEqual('black');
         expect(fixture.nativeElement.querySelector('p#input').innerHTML).toEqual(newProps.input);
+      });
+
+      it('should call the Input() setter the right number of times', async () => {
+        const initialProps = {
+          setter: 'init',
+        };
+        const storyProps$ = new BehaviorSubject<ICollection>(initialProps);
+
+        const ngModule = getStorybookModuleMetadata(
+          {
+            storyFnAngular: { props: initialProps },
+            component: FooComponent,
+            targetSelector: 'my-selector',
+          },
+          storyProps$
+        );
+        const { fixture } = await configureTestingModule(ngModule);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('p#setterCallNb').innerHTML).toEqual('1');
+
+        const newProps = {
+          setter: 'new setter value',
+        };
+        storyProps$.next(newProps);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('p#setterCallNb').innerHTML).toEqual('2');
       });
     });
 


### PR DESCRIPTION
Maybe : https://github.com/storybookjs/storybook/issues/15610

Potential link : https://github.com/storybookjs/storybook/issues/11613

## What I did

Investigate why in some case we have multiple call with some Input setter. 

Reasons : 
When a Story does not define a template and lets storybook build it from the component 
or
When Meta define component and this component is used in the story template

the props are set twice. One for the wrapper component. And also directly set into the target component. 
Now only none Input / Output are directly send to the target component
The values for the normal Input will be sent by the angular property biding


## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
