### PR TITLE
fix invalid regexp error: added string escaping in interpolate function

### DIFF
--- a/lib/core-common/src/utils/template.ts
+++ b/lib/core-common/src/utils/template.ts
@@ -3,7 +3,10 @@ import { sync } from 'pkg-dir';
 import fs from 'fs';
 
 const interpolate = (string: string, data: Record<string, string> = {}) =>
-  Object.entries(data).reduce((acc, [k, v]) => acc.replace(new RegExp(`%${k}%`, 'g'), v), string);
+  Object.entries(data).reduce((acc, [k, v]) => {
+    const escaped = k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return acc.replace(new RegExp(`%${escaped}%`, 'g'), v);
+  }, string);
 
 export function getPreviewBodyTemplate(
   configDirPath: string,


### PR DESCRIPTION
Issue:
Storybook dev server and build fails in new project: invalid regular expression error
Problem is: 
![Снимок экрана 2022-03-05 в 12 21 38](https://user-images.githubusercontent.com/10755349/156878122-d0d829bb-af7f-42cc-8f8e-2c13977a42b3.png)

## What I did
Added escaping for special characters in RegEx at interpolate function
![Снимок экрана 2022-03-05 в 12 40 38](https://user-images.githubusercontent.com/10755349/156878157-85540b06-caa6-465c-a211-4958ab9cd1c3.png)

# Steps to reproduce
1) Clone repo: `git clone -b storybook-bug-example https://github.com/mderkach/webpack-blank.git`
2) Install storybook `npx sb itit`
3) Run storybook

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
