### PR TITLE
Core: Fix staticDirs path issue on Windows

### DIFF
--- a/lib/core-server/src/utils/__tests__/server-statics.test.ts
+++ b/lib/core-server/src/utils/__tests__/server-statics.test.ts
@@ -72,6 +72,13 @@ describe('parseStaticDir', () => {
       targetDir: './custom-endpoint',
       targetEndpoint: '/custom-endpoint',
     });
+
+    await expect(parseStaticDir('C:\\foo\\bar:\\custom-endpoint')).resolves.toEqual({
+      staticDir: expect.any(String), // can't test this properly on unix
+      staticPath: path.resolve('C:\\foo\\bar'),
+      targetDir: './custom-endpoint',
+      targetEndpoint: '/custom-endpoint',
+    });
   });
 
   it('pins relative endpoint at root', async () => {


### PR DESCRIPTION
Issue: #17271 

## What I did

Noticed that the test *"supports absolute file paths with custom endpoint"* didn't cover the reality for Windows.

The `relativeDir` provided by `getDirectoryFromWorkingDir()` resolves all paths to OS separators (e.g. `\` on Windows). The result of which would look like `C:\\foo\\bar:\\custom-endpoint` and not `C:\\foo\\bar:/custom-endpoint` which the test was covering; so I added a test to cover the **actual** case.

---

Digging in,  the regex split in `parseStaticDir` didn't account for the **actual** path, as it was ignoring all cases of `:\` to cover the `X:\` scenario, which is what resulted in bug #17271. 

To work around this, I changed the code to look for the *last* colon `:`, and use that to split. However, in case the last colon is actually part of a Windows absolute path (e.g. `C:\`), needed to check a few conditions:

- Is the path Windows absolute? (We don't care if Unix absolute because it won't have a colon)
- Is the path just a single path (i.e. doesn't contain the `:` delimiter for static and target dirs.

Once this was determined, the final piece of the puzzle was ensuring the `target` was converted from `\` to `/`, for which I just split on `path.sep` and joined on `path.posix.sep` to ensure a forward-slash `/`.

---

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
