### PR TITLE
Reload iframe when the url changes

### DIFF
--- a/lib/components/src/Zoom/ZoomIFrame.tsx
+++ b/lib/components/src/Zoom/ZoomIFrame.tsx
@@ -29,7 +29,8 @@ export class ZoomIFrame extends Component<IZoomIFrameProps> {
 
     // this component renders an iframe, which gets updates via post-messages
     // never update this component, it will cause the iframe to refresh
-    return false;
+    // the only exception is when the url changes, which happens when the version changes
+    return nextProps.children.props.src !== this.props.children.props.src;
   }
 
   setIframeInnerZoom(scale: number) {


### PR DESCRIPTION
Fixes #17135, where the iframe would not reload after a version change.

To solve the issue, I check if the url of the iframe has changed in the `componentDidUpdate`. When a version changes, it updates the refs which in turn updates the ZoomIframe. Unless the ZoomIframe updates, the change is not reflected and the preview keeps spinning.
