### PR TITLE
Core: Error when namedExportsOrder causes story to disappear

### DIFF
--- a/examples/react-ts/src/button.stories.tsx
+++ b/examples/react-ts/src/button.stories.tsx
@@ -47,13 +47,3 @@ CSF2StoryWithPlay.play = () => {
   console.log('play!!');
   userEvent.click(screen.getByRole('button'));
 };
-
-// eslint-disable-next-line no-underscore-dangle
-export const __namedExportsOrder = [
-  'Basic',
-  'WithArgs',
-  'StoryObject',
-  'StoryNoRender',
-  'StoryWithPlay',
-  'CSF2StoryWithPlay',
-];

--- a/lib/csf-tools/src/CsfFile.ts
+++ b/lib/csf-tools/src/CsfFile.ts
@@ -388,8 +388,18 @@ export class CsfFile {
     });
 
     if (self._namedExportsOrder) {
+      const unsortedExports = Object.keys(self._storyExports);
       self._storyExports = sortExports(self._storyExports, self._namedExportsOrder);
       self._stories = sortExports(self._stories, self._namedExportsOrder);
+
+      const sortedExports = Object.keys(self._storyExports);
+      if (unsortedExports.length !== sortedExports.length) {
+        throw new Error(
+          `Missing exports after sort: ${unsortedExports.filter(
+            (key) => !sortedExports.includes(key)
+          )}`
+        );
+      }
     }
 
     return self;


### PR DESCRIPTION
Issue: N/A

## What I did

There was a bug in the `react-ts` example (see diff) that caused stories to disappear in the story index.

This PR fixes the problem and also introduces a check in the story index and throw an error. The error could occur either because the user has hard-coded the sort as in the attached example (which should never happen in practice--they should just reorder their exports), or because there is a bug in `babel-plugin-named-exports-order` which should also never happen.

## How to test

Undo the changes to `button.stories.tsx` and run `storybook`
