### PR TITLE
Prevent lint hook from running on all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "github-release": "github-release-from-changelog",
     "linear-export": "ts-node --project=./scripts/tsconfig.json ./scripts/linear-export.ts",
     "lint": "yarn lint:js && yarn lint:md",
-    "lint:js": "cross-env NODE_ENV=production eslint . --cache --cache-location=.cache/eslint --ext .js,.jsx,.json,.html,.ts,.tsx,.mjs --report-unused-disable-directives",
+    "lint:js": "yarn lint:js:cmd .",
+    "lint:js:cmd": "cross-env NODE_ENV=production eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.json,.html,.ts,.tsx,.mjs --report-unused-disable-directives",
     "lint:md": "remark -q .",
     "lint:package": "sort-package-json",
     "local-registry": "ts-node --project=./scripts/tsconfig.json ./scripts/run-registry.ts ",
@@ -87,7 +88,7 @@
   },
   "lint-staged": {
     "*.{html,js,json,jsx,mjs,ts,tsx}": [
-      "yarn lint:js --fix"
+      "yarn lint:js:cmd --fix"
     ],
     "package.json": [
       "yarn lint:package"


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/pull/17661

## What I did

https://github.com/storybookjs/storybook/commit/7b038313155de06cc55f921ab87a8e35b7aae348 caused eslint to run against all files during the husky hook.

This PR adds a new `lint:js:cmd` script which is the same as the `lint:js` from before the commit above, which means it does not specify a target and can therefore be used in the pre-commit hook.  This also allows us to follow the "principle of least surprise" in that `yarn lint:js` will run against all files.

I was concerned initially that running eslint against a different target, using the same cache location, would invalidate/evict the entire cache.  Turns out it doesn't, and that it only evicts the individual files being linted (and then, only because `--fix` is being used).  

