### PR TITLE
Addon-docs: DocsPage story order should match the index

### DIFF
--- a/lib/store/src/StoryStore.test.ts
+++ b/lib/store/src/StoryStore.test.ts
@@ -359,6 +359,25 @@ describe('StoryStore', () => {
       expect(stories).toHaveLength(2);
       expect(stories.map((s) => s.id)).toEqual(['component-one--a', 'component-one--b']);
     });
+
+    it('returns them in the order they are in the index, not the file', async () => {
+      const store = new StoryStore();
+      store.setProjectAnnotations(projectAnnotations);
+      const reversedIndex = {
+        v: 3,
+        stories: {
+          'component-one--b': storyIndex.stories['component-one--b'],
+          'component-one--a': storyIndex.stories['component-one--a'],
+        },
+      };
+      store.initialize({ storyIndex: reversedIndex, importFn, cache: false });
+
+      const csfFile = await store.loadCSFFileByStoryId('component-one--a');
+      const stories = store.componentStoriesFromCSFFile({ csfFile });
+
+      expect(stories).toHaveLength(2);
+      expect(stories.map((s) => s.id)).toEqual(['component-one--b', 'component-one--a']);
+    });
   });
 
   describe('getStoryContext', () => {

--- a/lib/store/src/StoryStore.ts
+++ b/lib/store/src/StoryStore.ts
@@ -190,9 +190,9 @@ export class StoryStore<TFramework extends AnyFramework> {
 
   // If we have a CSF file we can get all the stories from it synchronously
   componentStoriesFromCSFFile({ csfFile }: { csfFile: CSFFile<TFramework> }): Story<TFramework>[] {
-    return Object.keys(csfFile.stories).map((storyId: StoryId) =>
-      this.storyFromCSFFile({ storyId, csfFile })
-    );
+    return Object.keys(this.storyIndex.stories)
+      .filter((storyId: StoryId) => !!csfFile.stories[storyId])
+      .map((storyId: StoryId) => this.storyFromCSFFile({ storyId, csfFile }));
   }
 
   // A prepared story does not include args, globals or hooks. These are stored in the story store


### PR DESCRIPTION
Issue: #17611

## What I did

Ensure `store.componentStoriesFromCSFFile()` returns stories in the same order as the index

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?
