### PR TITLE
UI: Fix composition support in safari

### DIFF
--- a/lib/ui/src/components/preview/FramesRenderer.tsx
+++ b/lib/ui/src/components/preview/FramesRenderer.tsx
@@ -19,7 +19,6 @@ const getActive = (refId: FramesRendererProps['refId']) => {
 const SkipToSidebarLink = styled(Button)(({ theme }) => ({
   display: 'none',
   '@media (min-width: 600px)': {
-    display: 'block',
     position: 'absolute',
     top: 10,
     right: 15,
@@ -57,12 +56,13 @@ export const FramesRenderer: FunctionComponent<FramesRendererProps> = ({
   const active = getActive(refId);
 
   const styles = useMemo<CSSObject>(() => {
+    // add #root to make the selector high enough in specificity
     return {
-      '[data-is-storybook="false"]': {
-        visibility: 'hidden',
+      '#root [data-is-storybook="false"]': {
+        display: 'none',
       },
-      '[data-is-storybook="true"]': {
-        visibility: 'visible',
+      '#root [data-is-storybook="true"]': {
+        display: 'block',
       },
     };
   }, []);


### PR DESCRIPTION
Issue: #15920 

## What I did

I changed the way of hiding frames from using css `visibility` property, to using `display: none|block`

This is relevant for refs / composition.

The problem was that visibility:hidden is sometimes used by click-jacking attempt, and thus safari protects the user by ignoring the css, when the frames are cross-origin.

By changing the use to `display:none`, the element is no longer a click-target.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?
