### PR TITLE
[Addon-interactions] Do not rely on `global`

### DIFF
--- a/addons/interactions/src/preset/argsEnhancers.ts
+++ b/addons/interactions/src/preset/argsEnhancers.ts
@@ -1,11 +1,13 @@
 import { addons } from '@storybook/addons';
 import type { Args } from '@storybook/addons';
+import { window as globalWindow } from 'global';
 import { FORCE_REMOUNT, STORY_RENDER_PHASE_CHANGED } from '@storybook/core-events';
 import type { AnyFramework, ArgsEnhancer } from '@storybook/csf';
 import { instrument } from '@storybook/instrumenter';
 import { ModuleMocker } from 'jest-mock';
 
-const JestMock = new ModuleMocker(global);
+// The global env is `window` in the browser, and vite does not polyfill `global` as webpack does.
+const JestMock = new ModuleMocker(globalWindow);
 const fn = JestMock.fn.bind(JestMock);
 
 // Aliasing `fn` to `action` here, so we get a more descriptive label in the UI.


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17516

## What I did

It seems that https://github.com/storybookjs/storybook/pull/17614 was unintentionally reverted by https://github.com/storybookjs/storybook/pull/17627.  This adds it back, with a comment to hopefully catch the eye in the future so it is not changed back again.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
