### PR TITLE
make command for html explicit

### DIFF
--- a/docs/get-started/installation-command-section/html.mdx
+++ b/docs/get-started/installation-command-section/html.mdx
@@ -2,7 +2,7 @@ Use the Storybook CLI to install it in a single command. Run this inside your _e
 
 ```shell
 # Add Storybook:
-npx sb init
+npx sb init --type html
 ```
 
 If you run into issues with the installation, check the [Troubleshooting section](#troubleshooting) below for guidance on how to solve it.


### PR DESCRIPTION
Since HTML projects can't be detected, it might as well be called out to use the HTML type explicitly in the docs

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
