### PR TITLE
clear verdaccio cache in bootstrap registry

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -10,6 +10,8 @@ function run() {
   const program = require('commander');
   const chalk = require('chalk');
   const log = require('npmlog');
+  const shell = require('shelljs');
+  const { join } = require('path');
 
   log.heading = 'storybook';
   const prefix = 'bootstrap';
@@ -127,14 +129,28 @@ function run() {
       },
       order: 3,
     }),
+    clearVerdaccioCache: createTask({
+      name: `Clear verdaccio cache ${chalk.gray('(clear-verdaccio-cache)')}`,
+      defaultValue: false,
+      option: '--clear-verdaccio-cache',
+      command: () => {
+        shell.rm('-rf', [
+          join(__dirname, '..', '.verdaccio-cache/@storybook/**'),
+          join(__dirname, '..', '.verdaccio-cache/storybook'),
+          join(__dirname, '..', '.verdaccio-cache/sb'),
+          join(__dirname, '..', '.verdaccio-cache/.verdaccio-db.json'),
+        ]);
+      },
+      order: 10,
+    }),
     registry: createTask({
       name: `Run local registry ${chalk.gray('(reg)')}`,
       defaultValue: false,
       option: '--reg',
       command: () => {
-        spawn('yarn local-registry --publish --open');
+        spawn('yarn local-registry --port 6000 --publish --open');
       },
-      pre: ['prepublish'],
+      pre: ['clearVerdaccioCache', 'prepublish'],
       order: 11,
     }),
     dev: createTask({

--- a/scripts/prepare-localize.ts
+++ b/scripts/prepare-localize.ts
@@ -150,12 +150,19 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
       writeJSON(join(location, 'package.json'), p.packageJson, { spaces: 2 });
     });
 
+    // Make sure the registries for both npm and yarn are reset to their original urls
+    await command(`npm config set registry https://registry.npmjs.org`, {
+      cwd: location,
+    });
+    await command(`yarn config set npmRegistryServer https://registry.yarnpkg.com`, {
+      cwd: location,
+    });
+
     const afterInstall = await command(
       `yarn install --ignore-scripts --ignore-engines --no-bin-links`,
       { cwd: location }
     );
     if (afterInstall.failed) {
-      console.error(afterInstall.stderr);
       throw new Error('Failed to install dependencies');
     }
 

--- a/scripts/prepare-localize.ts
+++ b/scripts/prepare-localize.ts
@@ -41,9 +41,7 @@ const ignoredPackagesWithWarnings = [
   'worker-farm',
 ];
 const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
-  if (flags.includes('--reset')) {
-    await prebundle.removeDist();
-  }
+  await prebundle.removeDist();
 
   const { packageJson: pkg } = await readPkgUp({ cwd });
   const message = gray(`Built: ${bold(`${pkg.name}@${pkg.version}`)}`);

--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -172,11 +172,11 @@ const run = async () => {
 
   logger.log(`🔖 reading current registry settings`);
   let [originalYarnRegistryUrl, originalNpmRegistryUrl] = await registriesUrl();
-  if (
-    originalYarnRegistryUrl.includes('localhost') ||
-    originalNpmRegistryUrl.includes('localhost')
-  ) {
-    originalYarnRegistryUrl = 'https://registry.npmjs.org/';
+  if (originalYarnRegistryUrl.includes('localhost')) {
+    originalYarnRegistryUrl = 'https://registry.yarnpkg.org/';
+  }
+
+  if (originalNpmRegistryUrl.includes('localhost')) {
     originalNpmRegistryUrl = 'https://registry.npmjs.org/';
   }
 


### PR DESCRIPTION
Issue: N/A

## What I did

The registry command in bootstrap did not take into account clearing verdaccio cache

Also there was a problem with the registry which was also fixed in this PR

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
