### PR TITLE
Chore: (Docs) Minor addition to the faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -364,3 +364,40 @@ Although valid, it introduces additional boilerplate code to the story definitio
 ## Why is Storybook's source loader returning undefined with curried functions?
 
 This is a known issue with Storybook. If you're interested in getting it fixed, open an issue with a [working reproduction](./contribute/how-to-reproduce) so that it can be triaged and fixed in future releases.
+
+
+## Why are my args no longer displaying the default values?
+
+Before version 6.3, unset args were set to the `argTypes.defaultValue` if specified or inferred from the component's properties (e.g., React's prop types, Angular inputs, Vue props). Starting with version 6.3, Storybook no longer infers default values but instead defines the arg's value as `undefined` when unset, allowing the framework to supply its default value.
+
+If you are using `argTypes.defaultValue` to fix the above, you no longer need to, and you can safely remove it from your stories.
+
+Additionally, suppose you were using `argTypes.defaultValue` or relying on inference to set a default value for an arg. In that case, you should define the arg's value at the component level instead:
+
+```js
+// MyComponent.stories.js
+
+export default {
+  component: MyComponent,
+  args: {
+    //👇 Defining the arg's value at the component level.
+    text: 'Something',
+  },
+};
+```
+
+For Storybook's Docs, you can manually configure the displayed value by configuring the `table.defaultValue` setting:
+
+```js
+// MyComponent.stories.js
+
+export default {
+  component: MyComponent,
+  argTypes: {
+    //👇 Defining the arg's display value in docs.
+    text: {
+      table: { defaultValue: { summary: 'SomeType<T>' } },
+    },
+  },
+};
+```


### PR DESCRIPTION
With this pull request, the FAQ is updated to provide information on the deprecated `argTypes.defaultValue` usage that will be phased out in a future release.

What was done:
- Updated the FAQ to address the deprecation of said element

Closes #17438

