### PR TITLE
Web-components: Fix CSS class usage in CLI template

### DIFF
--- a/lib/cli/src/frameworks/web-components/js/Page.js
+++ b/lib/cli/src/frameworks/web-components/js/Page.js
@@ -43,8 +43,8 @@ export const Page = ({ user, onLogin, onLogout, onCreateAccount }) => html`
         <a href="https://storybook.js.org/docs" target="_blank" rel="noopener noreferrer"> docs </a>
         .
       </p>
-      <div className="tip-wrapper">
-        <span className="tip">Tip</span> Adjust the width of the canvas with the
+      <div class="tip-wrapper">
+        <span class="tip">Tip</span> Adjust the width of the canvas with the
         <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
             <path

--- a/lib/cli/src/frameworks/web-components/ts/Page.ts
+++ b/lib/cli/src/frameworks/web-components/ts/Page.ts
@@ -50,8 +50,8 @@ export const Page = ({ user, onLogin, onLogout, onCreateAccount }: PageProps) =>
         <a href="https://storybook.js.org/docs" target="_blank" rel="noopener noreferrer"> docs </a>
         .
       </p>
-      <div className="tip-wrapper">
-        <span className="tip">Tip</span> Adjust the width of the canvas with the
+      <div class="tip-wrapper">
+        <span class="tip">Tip</span> Adjust the width of the canvas with the
         <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
             <path


### PR DESCRIPTION
Issue: Styles were not being applied to an element using attribute `className`.

## What I did

Change `.js` file's `lit-html` markup to use `class` attribute instead of `className`.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- ~~Does this need a new example in the kitchen sink apps?~~
- Does this need an update to the documentation? — _Maybe._

> If your answer is yes to any of these, please make sure to include it in your PR.

No "Jest or Chromatic screenshots". I tried. <del>Storybook</del> <ins>I</ins> failed: #17703

_**Edit**: I found Chromatic runs automatically. It is recorded as having passed, and though I agree<del>, I think it is a broken test</del>.[^1]_

_**Update**: I was ignorant of the complexity and feature set of the Storybook pipelines. See https://github.com/storybookjs/storybook/pull/17702#issuecomment-1066195295._

[^1]: I found the [relevant test suite ("regression-test-webcomponents")](https://www.chromatic.com/build?appId=5def65ac9aec2800201cd814&number=10896). The [relevant stories ("Example" > "Page")](https://www.chromatic.com/component?appId=5def65ac9aec2800201cd814&name=Example%2FPage&buildNumber=10896&componentInspectorKey=622e4e401883df003a21e209-1200-interactive-true&historyLengthAtIndex=2&distanceToMoveBack=-1) do not reflect my change. I see `classname` is still used, and styles are still not applied. I don't understand the purpose of this automation.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
