### PR TITLE
CI: skip e2e-pnp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,6 +440,9 @@ workflows:
           requires:
             - publish
       - e2e-tests-pnp:
+          filters:
+            branches:
+              ignore: /.*/
           requires:
             - publish
       - cra-bench:


### PR DESCRIPTION
Issue: N/A

## What I did

Tie PnP tests to the extended tests label until we fix the PnP tests.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

**edit:**
On second thought, maybe we should just skip them altogether. Tying to a label feels misleading and we might forget about it?
![image](https://user-images.githubusercontent.com/1671563/158136895-fb69a1a4-0f4a-4d5d-8f01-732e6a4259be.png)


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
