### PR TITLE
Add contributing instructions to PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ If your answer is yes to any of these, please make sure to include it in your PR
 
 <!--
 
-Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.
+Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md
 
 Maintainers: Please tag your pull request with at least one of the following:
 `["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ If your answer is yes to any of these, please make sure to include it in your PR
 
 <!--
 
-Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md
+Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute
 
 Maintainers: Please tag your pull request with at least one of the following:
 `["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`


### PR DESCRIPTION
Issue: An ignorant new contributor may not see the "Helpful resources" links (example: #17703).

## What I did
Add helpful link about contribution to the PR description. (This may help new contributors who only read the template.)

<details><summary>What I thought about doing…</summary>

- I thought about writing `For additional guidance, see https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md`, but then there's the weird period-after-a-link legibility and usability issue.
- I also used the word "guidance" instead of "direction" so as to suggest more that the contributor has a choice (because everyone is sensitive nowadays).

</details>

## How to test

Might not be testable.

_Change is in a PR template, so I don't think it is usable without being in `master`._
_Change is in a comment, so it will not render in a preview of the document._

- ~~Is this testable with Jest or Chromatic screenshots?~~
- ~~Does this need a new example in the kitchen sink apps?~~
- ~~Does this need an update to the documentation?~~

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
