### PR TITLE
fix : typo in props name

### DIFF
--- a/docs/snippets/react/button-story-using-args.js.mdx
+++ b/docs/snippets/react/button-story-using-args.js.mdx
@@ -19,7 +19,7 @@ const Template = (args) => <Button {...args} />;
 
 // 👇 Each story then reuses that template
 export const Primary = Template.bind({});
-Primary.args = { background: '#ff0', label: 'Button' };
+Primary.args = { backgroundColor: '#ff0', label: 'Button' };
 
 export const Secondary = Template.bind({});
 Secondary.args = { ...Primary.args, label: '😄👍😍💯' };

--- a/docs/snippets/react/button-story-with-emojis.mdx.mdx
+++ b/docs/snippets/react/button-story-with-emojis.mdx.mdx
@@ -8,14 +8,14 @@ import { Button } from './Button';
 <Meta title="Button" component={Button}/>
 
 <Story name="Primary">
-  <Button background="#ff0" label="Button" />
+  <Button backgroundColor="#ff0" label="Button" />
 </Story>
 
 <Story name="Secondary">
-  <Button background="#ff0" label="😄👍😍💯" />
+  <Button backgroundColor="#ff0" label="😄👍😍💯" />
 </Story>
 
 <Story name="Tertiary">
-  <Button background="#ff0" label="📚📕📈🤓" />
+  <Button backgroundColor="#ff0" label="📚📕📈🤓" />
 </Story>
 ```

--- a/docs/snippets/react/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/react/button-story-with-emojis.ts.mdx
@@ -21,10 +21,10 @@ export const Primary: ComponentStory<typeof Button> = () => (
 );
 
 export const Secondary: ComponentStory<typeof Button> = () => (
-  <Button background="#ff0" label="😄👍😍💯" />
+  <Button backgroundColor="#ff0" label="😄👍😍💯" />
 );
 
 export const Tertiary: ComponentStory<typeof Button> = () => (
-  <Button background="#ff0" label="📚📕📈🤓" />
+  <Button backgroundColor="#ff0" label="📚📕📈🤓" />
 );
 ```


### PR DESCRIPTION
Issue:

## What I did
I fixed typo of wrong props name in react document snippets. 
I found that some example snippets take `background` props and some take `backgroundColor` props, 
so I fixed `background` to `backgroundColor`.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
