### PR TITLE
fix : add missing await for an async function

### DIFF
--- a/docs/snippets/react/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.js.mdx
@@ -20,7 +20,7 @@ const Template = (args) => <MyComponent {...args} />;
 
 export const FirstStory = Template.bind({});
 FirstStory.play = async () => {
-  userEvent.type(screen.getByTestId('an-element'), 'example-value');
+  await userEvent.type(screen.getByTestId('an-element'), 'example-value');
 };
 
 export const SecondStory = Template.bind({});

--- a/docs/snippets/react/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.ts.mdx
@@ -22,7 +22,7 @@ const Template: ComponentStory<typeof MyComponent> = (args) => <MyComponent {...
 
 export const FirstStory = Template.bind({});
 FirstStory.play = async () => {
-  userEvent.type(screen.getByTestId('an-element'), 'example-value');
+  await userEvent.type(screen.getByTestId('an-element'), 'example-value');
 };
 
 export const SecondStory = Template.bind({});


### PR DESCRIPTION
Issue: `await` is missing in async functions

## What I did
added missing `await` for an async function

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
