### PR TITLE
Chore: (Docs) Updates the env vars docs for sb env field

### DIFF
--- a/docs/configure/environment-variables.md
+++ b/docs/configure/environment-variables.md
@@ -69,6 +69,34 @@ You can also pass these environment variables when you are [building your Storyb
 
 Then they'll be hardcoded to the static version of your Storybook.
 
+
+### Using Storybook configuration
+
+Additionally, you can extend your Storybook configuration file (i.e., [`.storybook/main.js`](../configure/overview.md#configure-story-rendering)) and provide a configuration field that you can use to define specific variables (e.g., API URLs). For example:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-main-env-field-config.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+When Storybook loads, it will enable you to access them in your stories similar as you would do if you were working with an `env` file:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/my-component-env-var-config.js.mdx',
+    'common/my-component-env-var-config.mdx.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
 ### Using environment variables to choose the browser
 
 Storybook allows you to choose the browser you want to preview your stories. Either through a `.env` file entry or directly in your `storybook` script.

--- a/docs/configure/environment-variables.md
+++ b/docs/configure/environment-variables.md
@@ -84,6 +84,12 @@ Additionally, you can extend your Storybook configuration file (i.e., [`.storybo
 
 <!-- prettier-ignore-end -->
 
+<div class="aside">
+
+💡 `STORYBOOK` prefixed environment variables provided via a `.env` file or script will be **filtered out** using this approach. It's is a known limitation that will be solved with a future release.
+
+</div>
+
 When Storybook loads, it will enable you to access them in your stories similar as you would do if you were working with an `env` file:
 
 <!-- prettier-ignore-start -->

--- a/docs/configure/environment-variables.md
+++ b/docs/configure/environment-variables.md
@@ -84,12 +84,6 @@ Additionally, you can extend your Storybook configuration file (i.e., [`.storybo
 
 <!-- prettier-ignore-end -->
 
-<div class="aside">
-
-💡 `STORYBOOK` prefixed environment variables provided via a `.env` file or script will be **filtered out** using this approach. It's is a known limitation that will be solved with a future release.
-
-</div>
-
 When Storybook loads, it will enable you to access them in your stories similar as you would do if you were working with an `env` file:
 
 <!-- prettier-ignore-start -->

--- a/docs/snippets/common/my-component-env-var-config.js.mdx
+++ b/docs/snippets/common/my-component-env-var-config.js.mdx
@@ -1,0 +1,23 @@
+```js
+// MyComponent.stories.js|jsx|ts|tsx
+
+import { MyComponent } from './MyComponent';
+
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'MyComponent',
+  component: MyComponent,
+};
+
+const Template = (args) => ({
+  //👇 Your template goes here
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  exampleProp: process.env.EXAMPLE_VAR,
+};
+```

--- a/docs/snippets/common/my-component-env-var-config.mdx.mdx
+++ b/docs/snippets/common/my-component-env-var-config.mdx.mdx
@@ -1,0 +1,23 @@
+```md
+<!-- MyComponent.stories.mdx -->
+
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+
+import { MyComponent } from './MyComponent';
+
+<Meta title="MyComponent" component={MyComponent}/>
+
+export const Template = (args) => ({
+  //👇 Your template goes here
+});
+
+<Canvas>
+  <Story
+    name="ExampleStory"
+    args={{
+      exampleProp: process.env.EXAMPLE_VAR,
+    }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+```

--- a/docs/snippets/common/storybook-main-env-field-config.js.mdx
+++ b/docs/snippets/common/storybook-main-env-field-config.js.mdx
@@ -10,7 +10,7 @@ module.exports = {
   ],
   /* 
    * 👇 The `config` argument contains all the other existing environment variables.
-   * Either configured in an `.env` file or passed as command line arguments.
+   * Either configured in an `.env` file or configured on the command line.
   */
   env: (config) => ({
     ...config,

--- a/docs/snippets/common/storybook-main-env-field-config.js.mdx
+++ b/docs/snippets/common/storybook-main-env-field-config.js.mdx
@@ -1,0 +1,15 @@
+```js
+// .storybook/main.js
+
+module.exports = {
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+  ],
+  env: () => ({
+    EXAMPLE_VAR: 'An environment variable configured in Storybook',
+  }),
+};
+```

--- a/docs/snippets/common/storybook-main-env-field-config.js.mdx
+++ b/docs/snippets/common/storybook-main-env-field-config.js.mdx
@@ -8,7 +8,12 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
   ],
-  env: () => ({
+  /* 
+   * 👇 The `config` argument contains all the other existing environment variables.
+   * Either configured in an `.env` file or passed as command line arguments.
+  */
+  env: (config) => ({
+    ...config,
     EXAMPLE_VAR: 'An environment variable configured in Storybook',
   }),
 };


### PR DESCRIPTION
With this pull request, the Environment variables documentation is updated to feature Storybook's `env` field.

Closes #17631

What was done:
- Updated the documentation
- Created the snippets

@shilman if you'd be so kind to take a look and follow up with me on this, I'd appreciate it. Thanks in advance