### PR TITLE
Chore: (Docs) Fix typo in preact snippets

### DIFF
--- a/docs/snippets/preact/button-story-with-args.js.mdx
+++ b/docs/snippets/preact/button-story-with-args.js.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',

--- a/docs/snippets/preact/your-component.js.mdx
+++ b/docs/snippets/preact/your-component.js.mdx
@@ -9,7 +9,7 @@ import { YourComponent } from './YourComponent';
 //👇 This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'YourComponent',


### PR DESCRIPTION
With this pull request, the Preact snippets recently introduced by #17658 are updated to correctly form the URL for the documentation. 
