### PR TITLE
fix dts-localize script

### DIFF
--- a/lib/core-common/src/utils/file-cache.ts
+++ b/lib/core-common/src/utils/file-cache.ts
@@ -31,7 +31,7 @@ export class FileSystemCache {
   }
 
   getSync(key: string, defaultValue?: any): any | typeof defaultValue {
-    this.internal.getSync(key, defaultValue);
+    return this.internal.getSync(key, defaultValue);
   }
 
   set(key: string, value: any): Promise<{ path: string }> {

--- a/scripts/dts-localize.ts
+++ b/scripts/dts-localize.ts
@@ -275,6 +275,9 @@ export const run = async (entrySourceFiles: string[], outputPath: string, option
         if (externals.includes(k)) {
           return;
         }
+        if (!v) {
+          return;
+        }
         const x = sourceFiles.find((f) => f.fileName === v.resolvedFileName);
         if (!x) {
           return;


### PR DESCRIPTION
## What I did

When types are missing for a file entirely, ignore it

This can happen is `// @ignore-ts` is used.
