### PR TITLE
Addon-docs/Vue: Add tests for sourceDecorator vnodeToString

### DIFF
--- a/app/vue/src/client/docs/sourceDecorator.test.ts
+++ b/app/vue/src/client/docs/sourceDecorator.test.ts
@@ -141,4 +141,56 @@ describe('vnodeToString', () => {
       )
     ).toMatchInlineSnapshot(`<div ><form ><button >Button</button></form></div>`);
   });
+
+  it('empty tag', () => {
+    expect(
+      vnodeToString(
+        getVNode({
+          template: `
+          <div>
+          </div>`,
+        })
+      )
+    ).toMatchInlineSnapshot(`<div />`);
+  });
+
+  it('tag in text', () => {
+    expect(
+      vnodeToString(
+        getVNode({
+          template: `
+          <div>
+          <>
+          </div>`,
+        })
+      )
+    ).toMatchInlineSnapshot(`
+      <div >{{\`
+                <>
+                \`}}</div>
+    `);
+  });
+
+  it('component element with children', () => {
+    const MyComponent: ComponentOptions<any, any, any> = {
+      props: ['propA'],
+      template: '<div/>',
+    };
+
+    expect(
+      vnodeToString(
+        getVNode({
+          components: { MyComponent },
+          data(): { props: Record<string, any> } {
+            return {
+              props: {
+                propA: 'propA',
+              },
+            };
+          },
+          template: `<my-component v-bind="props"><div /></my-component>`,
+        })
+      )
+    ).toMatchInlineSnapshot(`<my-component propA="propA"><div /></my-component>`);
+  });
 });

--- a/app/vue/src/client/docs/sourceDecorator.test.ts
+++ b/app/vue/src/client/docs/sourceDecorator.test.ts
@@ -174,7 +174,7 @@ describe('vnodeToString', () => {
   it('component element with children', () => {
     const MyComponent: ComponentOptions<any, any, any> = {
       props: ['propA'],
-      template: '<div/>',
+      template: '<div><slot /></div>',
     };
 
     expect(


### PR DESCRIPTION
Issue: Vue sourceDecorator vnodeToString has 3 branches that are not covered by tests
- [Line 98](https://github.com/storybookjs/storybook/blob/next/app/vue/src/client/docs/sourceDecorator.ts#L98)
- [Line 109](https://github.com/storybookjs/storybook/blob/next/app/vue/src/client/docs/sourceDecorator.ts#L109)
- [Lines 127-129](https://github.com/storybookjs/storybook/blob/next/app/vue/src/client/docs/sourceDecorator.ts#L127-L129)

## What I did
Added three tests to cover the untested branches in Vue sourceDecorator vnodeToString

## How to test
Testable by running the tests in app/vue/src/client/docs/sourceDecorator.test.ts with ```jest --coverage```