### PR TITLE
Remove mock directories from Jest test coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -77,6 +77,8 @@ module.exports = {
     '/generators/',
     '/dll/',
     '/__mocks__ /',
+    '/__mockdata__/',
+    '/__mocks-ng-workspace__/',
     '/__testfixtures__/',
     '^.*\\.stories\\.[jt]sx?$',
   ],


### PR DESCRIPTION
Issue: the test coverage report included 9 mock files

## What I did
Added ``` /__mockdata__/``` and  ```/__mocks-ng-workspace__/``` to the 'coveragePathIgnorePatterns'.

## How to test
Run Jest with test coverage