### PR TITLE
Chore: (Docs) Fixes the incorrect path in the snippets

### DIFF
--- a/docs/snippets/html/button-story-with-args.js.mdx
+++ b/docs/snippets/html/button-story-with-args.js.mdx
@@ -1,7 +1,7 @@
 ```js
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/html/button-story-with-args.ts.mdx
+++ b/docs/snippets/html/button-story-with-args.ts.mdx
@@ -3,7 +3,7 @@ import { Meta, StoryFn } from '@storybook/html';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/html/your-component.js.mdx
+++ b/docs/snippets/html/your-component.js.mdx
@@ -6,7 +6,7 @@ import { createYourComponent } from './YourComponent';
 // 👇 This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/html/your-component.ts.mdx
+++ b/docs/snippets/html/your-component.ts.mdx
@@ -7,7 +7,7 @@ import { createYourComponent } from './YourComponent';
 //👇 This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/preact/button-story.js.mdx
+++ b/docs/snippets/preact/button-story.js.mdx
@@ -6,6 +6,10 @@ import { h } from 'preact';
 import { Button } from './Button';
 
 export default {
+   /* 👇 The title prop is optional.
+  * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
+  * to learn how to generate automatic titles
+  */
   title: 'Button',
   component: Button,
 }

--- a/docs/snippets/react/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-waitfor.ts.mdx
@@ -11,7 +11,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docsreact/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'WithAsync',


### PR DESCRIPTION
With this pull request the snippets, more specifically the HTML ones are updated to correctly point the user to the proper place in the documentation (i.e., if they're using HTML to configure the story they should not be going to the react version of the docs).

What was done:
- Fixed the link in the HTML/preact snippets