### PR TITLE
UI: Fix root caret positioning

### DIFF
--- a/lib/ui/src/components/sidebar/Tree.tsx
+++ b/lib/ui/src/components/sidebar/Tree.tsx
@@ -81,7 +81,6 @@ const CollapseButton = styled.button(({ theme }) => ({
   transition: 'color 150ms, box-shadow 150ms',
 
   'span:first-of-type': {
-    marginTop: 4,
     marginRight: 7,
   },
 


### PR DESCRIPTION
## Issue
The caret position was slightly off vertical center for root items.  

| Before | After |
| ------ | ------ |
|  ![image](https://user-images.githubusercontent.com/40154944/159406819-5f32d19b-84c0-4be0-a361-d87db7929552.png) |  ![image](https://user-images.githubusercontent.com/40154944/159406692-e4121d90-e8e3-4caf-974a-5784c97cae29.png) |

This PR returns the caret to vertically centered alignment.