### PR TITLE
Build: Add main overrides to e2e config and test runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
           name: Wait for registry
           command: yarn wait-on http://localhost:6000
       - run:
-          name: Run E2E tests
+          name: Run smoke tests
           command: yarn test:e2e-framework angular_modern_inline_rendering --test-runner --docs-mode
           no_output_timeout: 5m
   cra-bench:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,27 @@ jobs:
       - store_artifacts:
           path: /tmp/cypress-record
           destination: cypress
+  e2e-tests-sb-docs:
+    executor:
+      class: large
+      name: sb_cypress_8_node_14
+    parallelism: 2
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: '--depth 1 --verbose'
+      - attach_workspace:
+          at: .
+      - run:
+          name: Running local registry
+          command: yarn local-registry --port 6000 --open
+          background: true
+      - run:
+          name: Wait for registry
+          command: yarn wait-on http://localhost:6000
+      - run:
+          name: Run E2E tests
+          command: yarn test:e2e-framework angular_modern_inline_rendering --test-runner --docs-mode
+          no_output_timeout: 5m
   cra-bench:
     executor:
       class: medium
@@ -437,6 +458,9 @@ workflows:
           requires:
             - publish
       - e2e-tests-core:
+          requires:
+            - publish
+      - e2e-tests-sb-docs:
           requires:
             - publish
       - e2e-tests-pnp:

--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -1,4 +1,5 @@
-import { SupportedFrameworks } from '../project_types';
+import type { StorybookConfig } from '@storybook/core-common';
+import type { SupportedFrameworks } from '../project_types';
 
 export interface Parameters {
   framework: SupportedFrameworks;
@@ -14,6 +15,8 @@ export interface Parameters {
   additionalDeps?: string[];
   /** Add typescript dependency and creates a tsconfig.json file */
   typescript?: boolean;
+  /** Merge configurations to main.js before running the tests */
+  mainOverrides?: Partial<StorybookConfig> & Record<string, any>;
 }
 
 const fromDeps = (...args: string[]): string =>
@@ -127,6 +130,18 @@ export const angular13: Parameters = {
   ...baseAngular,
   name: 'angular13',
   version: '13.1.x',
+};
+
+export const angular_modern_inline_rendering: Parameters = {
+  ...baseAngular,
+  name: 'angular_modern_inline_rendering',
+  additionalDeps: ['jest', 'expect', '@storybook/test-runner'],
+  mainOverrides: {
+    features: {
+      storyStoreV7: true,
+      modernInlineRender: true,
+    },
+  },
 };
 
 export const angular: Parameters = baseAngular;

--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -135,7 +135,7 @@ export const angular13: Parameters = {
 export const angular_modern_inline_rendering: Parameters = {
   ...baseAngular,
   name: 'angular_modern_inline_rendering',
-  additionalDeps: ['jest', 'expect', '@storybook/test-runner'],
+  additionalDeps: ['jest', '@storybook/test-runner'],
   mainOverrides: {
     features: {
       storyStoreV7: true,

--- a/lib/cli/src/repro-generators/scripts.ts
+++ b/lib/cli/src/repro-generators/scripts.ts
@@ -1,8 +1,9 @@
 import path from 'path';
-import { writeJSON } from 'fs-extra';
+import { readJSON, writeJSON } from 'fs-extra';
 import shell, { ExecOptions } from 'shelljs';
 import chalk from 'chalk';
 import { cra, cra_typescript } from './configs';
+import storybookVersions from '../versions';
 
 const logger = console;
 
@@ -68,6 +69,14 @@ export const exec = async (
       }
     });
   });
+};
+
+const addPackageResolutions = async ({ cwd }: Options) => {
+  logger.info(`🔢 Adding package resolutions:`);
+  const packageJsonPath = path.join(cwd, 'package.json');
+  const packageJson = await readJSON(packageJsonPath);
+  packageJson.resolutions = storybookVersions;
+  await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };
 
 const installYarn2 = async ({ cwd, pnp, name }: Options) => {
@@ -219,6 +228,9 @@ export const createAndInit = async (
   logger.log();
 
   await doTask(generate, { ...options, cwd: options.creationPath });
+  if (e2e) {
+    await doTask(addPackageResolutions, options);
+  }
   await doTask(installYarn2, options);
   await doTask(configureYarn2ForE2E, options, e2e);
   await doTask(addTypescript, options, !!options.typescript);

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -63,6 +63,10 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
+  '@storybook/test-runner':
+    access: $all
+    publish: $all
+    proxy: npmjs
   '@storybook/mdx1-csf':
     access: $all
     publish: $all


### PR DESCRIPTION
Issue: N/A

## What I did

Extended the E2E config to be able to add overrides to mainjs for feature testing, as well as use the Storybook test runner instead of Cypress, either in story mode or docs mode.

Additionally I added a new CI step called `e2e-tests-sb-docs` (please help me name this better) where we can add new configs to test storybook docs. Initially I added angular latest + modern inline rendering + test runner + docs mode

There were failures happening because some libraries had peerdeps on different versions of Storybook packages so I added an extra step to repro where if you pass the --e2e flag it will add storybook packages in resolutions with the correct version (thanks @ndelangen!)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
