### PR TITLE
Controls: Fix date control width in addons panel

### DIFF
--- a/lib/components/src/controls/Date.tsx
+++ b/lib/components/src/controls/Date.tsx
@@ -52,6 +52,10 @@ const FlexSpaced = styled.div(({ theme }) => ({
   },
   'input:first-of-type': {
     marginLeft: 0,
+    flexGrow: 4,
+  },
+  'input:last-of-type': {
+    flexGrow: 3,
   },
 }));
 


### PR DESCRIPTION
Issue: #17225 

## What I did

I changed the `width` ratio between the `date-input` and `time-input` in the addons panel. Instead of an even division of `1 to 1`, I changed it to `4 to 3` using `flex-grow`, since the date in the `date-input` needs more space. This solves the issue where the date in the `date-input` was not fully visible, as can be seen in #17225. 

See the screenshots for how it looks now, in the issue ticket there is a screenshot on how it looked before. 

With the addons panel on the right of the page:
![image](https://user-images.githubusercontent.com/23527182/159512236-ba8a619c-dd7b-4376-a78c-02a09351ea14.png)

With the addons panel on the bottom of the page:
![image](https://user-images.githubusercontent.com/23527182/159512302-37b71170-652f-4d3a-b3e7-a782295d6d0c.png)


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
