### PR TITLE
Revert "Remove __namedExportsOrder handling from store"

### DIFF
--- a/lib/store/src/csf/processCSFFile.test.ts
+++ b/lib/store/src/csf/processCSFFile.test.ts
@@ -48,7 +48,7 @@ describe('processCSFFile', () => {
     });
   });
 
-  it('ignores __namedExportsOrder', () => {
+  it('adds stories in the right order if __namedExportsOrder is supplied', () => {
     const { stories } = processCSFFile(
       {
         default: { title: 'Component' },
@@ -63,10 +63,10 @@ describe('processCSFFile', () => {
     );
 
     expect(Object.keys(stories)).toEqual([
-      'component--x',
-      'component--y',
-      'component--z',
       'component--w',
+      'component--x',
+      'component--z',
+      'component--y',
     ]);
   });
 

--- a/lib/store/src/csf/processCSFFile.ts
+++ b/lib/store/src/csf/processCSFFile.ts
@@ -48,6 +48,7 @@ export function processCSFFile<TFramework extends AnyFramework>(
   // prefer a user/loader provided `__namedExportsOrder` array if supplied
   // we do this as es module exports are always ordered alphabetically
   // see https://github.com/storybookjs/storybook/issues/9136
+  // This directly affects the order of stories in the docs view and in folders on the sidebar.
   if (Array.isArray(__namedExportsOrder)) {
     exports = {};
     __namedExportsOrder.forEach((name) => {


### PR DESCRIPTION
Issue: Ordering is broken in the docs view for ES module environments e.g. vite builder https://github.com/eirslett/storybook-builder-vite/issues/227

## What I did
Reverted commit 0787dfcaadf66d4383ae9bff035cbeede11598b8
## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
