### PR TITLE
Build: Add weekly check for broken markdown links

### DIFF
--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -20,6 +20,9 @@ jobs:
           use-verbose-mode: 'yes'
           config-file: '.github/workflows/markdown-link-check-config.json'
           folder-path: 'addons, app, docs, lib'
+  check-root-links:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v2
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         # checks all markdown files from root but ignores subfolders

--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -19,15 +19,3 @@ jobs:
           # output full HTTP info for broken links
           use-verbose-mode: 'yes'
           config-file: '.github/workflows/markdown-link-check-config.json'
-          folder-path: 'addons, app, docs, lib'
-  check-root-links:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        # checks all markdown files from root but ignores subfolders
-        with:
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
-          config-file: '.github/workflows/markdown-link-check-config.json'
-          max-depth: 0

--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -1,0 +1,30 @@
+name: Markdown Links Check
+# runs every monday at 9 am
+on:
+  push:
+  # TODO: Change from push to schedule once the testing is done
+  # schedule:
+  #   - cron: "0 9 * * 1"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from important folders including all subfolders
+        with:
+          # only show errors that occur instead of successful links + errors
+          use-quiet-mode: 'yes'
+          # output full HTTP info for broken links
+          use-verbose-mode: 'yes'
+          config-file: '.github/workflows/markdown-link-check-config.json'
+          folder-path: 'addons, app, docs, lib'
+      - uses: actions/checkout@v2
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from root but ignores subfolders
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.github/workflows/markdown-link-check-config.json'
+          max-depth: 0

--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -1,10 +1,8 @@
 name: Markdown Links Check
 # runs every monday at 9 am
 on:
-  push:
-  # TODO: Change from push to schedule once the testing is done
-  # schedule:
-  #   - cron: "0 9 * * 1"
+  schedule:
+    - cron: "0 9 * * 1"
 
 jobs:
   check-links:

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -4,5 +4,16 @@
       "pattern": "^/",
       "replacement": "./"
     }
+  ],
+  "ignorePatterns": [
+    {
+      "pattern": "localhost"
+    },
+    {
+      "pattern": "https://github.com/storybookjs/storybook/pull/*"
+    },
+    {
+      "pattern": "https://stackblitz.com/*"
+    }
   ]
 }

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,0 +1,8 @@
+{
+  "replacementPatterns": [
+    {
+      "pattern": "^/",
+      "replacement": "./"
+    }
+  ]
+}


### PR DESCRIPTION
Issue: N/A

## What I did

With this action we should never have issues where users complain about broken links 🎉 

As of the time this PR ran, the repository has a total of 6624 links, of which 138 are broken.

For reference, here's the list of broken links we should fix:
https://github.com/storybookjs/storybook/runs/5726975177?check_suite_focus=true

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
