### PR TITLE
add insights snapshot widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://app.circleci.com/insights/github/storybookjs/storybook/workflows/test?branch=next">
+    <img src="https://dl.circleci.com/insights-snapshot/gh/angular/angular/next/test/badge.svg" alt="InsightsSnapshot" />
+  </a>
+</p>
+
 [Storybook](https://storybook.js.org) is a development environment for UI components.
 It allows you to browse a component library, view the different states of each component, and interactively develop and test components. Find out more at https://storybook.js.org.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@
 </p>
 
 <p align="center">
-  <a href="https://app.circleci.com/insights/github/storybookjs/storybook/workflows/test?branch=next">
-    <img src="https://dl.circleci.com/insights-snapshot/gh/angular/angular/next/test/badge.svg" alt="InsightsSnapshot" />
+  <a href="https://app.circleci.com/insights/github/storybookjs/storybook/workflows/master?branch=next">
+    <img src="https://dl.circleci.com/insights-snapshot/gh/angular/angular/next/master/badge.svg" alt="InsightsSnapshot" />
   </a>
 </p>
 


### PR DESCRIPTION
Issue: No issue - just adding an additional bit of insight to the README

## What I did
In addition to the existing badges which show the status of builds, etc., this new widget that shows the Insights metrics for your repo that shows how the main workflow is performing. More info can be found at: https://discuss.circleci.com/t/try-insights-snapshot-in-your-gh-repo/43169/

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
