### PR TITLE
fix(addon-docs): assume links starting with "https://" are external

### DIFF
--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -111,7 +111,7 @@ export const AnchorMdx: FC<AnchorMdxProps> = (props) => {
   }
 
   // External URL dont need any modification.
-  return <A target="_blank" {...props} />;
+  return <A {...props} />;
 };
 
 const SUPPORTED_MDX_HEADERS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];

--- a/addons/docs/src/blocks/mdx.tsx
+++ b/addons/docs/src/blocks/mdx.tsx
@@ -91,7 +91,7 @@ export const AnchorMdx: FC<AnchorMdxProps> = (props) => {
     }
 
     // Links to other pages of SB should use the base URL of the top level iframe instead of the base URL of the preview iframe.
-    if (target !== '_blank') {
+    if (target !== '_blank' && !href.startsWith('https://')) {
       return (
         <A
           href={href}
@@ -111,7 +111,7 @@ export const AnchorMdx: FC<AnchorMdxProps> = (props) => {
   }
 
   // External URL dont need any modification.
-  return <A {...props} />;
+  return <A target="_blank" {...props} />;
 };
 
 const SUPPORTED_MDX_HEADERS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];


### PR DESCRIPTION
Issue: #17308

## What I did

- I updated the check for MDX links to see if the link starts with `https://`. Not all external links will, but this seems like a pretty easy way to detect most cases.
- I set `target="_blank"` as default for external links, but it can be overridden by the user. Let me know if you agree with this, or would prefer not to have this.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
