### PR TITLE
add back CacheProvider from emotion to lib/theming

### DIFF
--- a/lib/theming/src/index.ts
+++ b/lib/theming/src/index.ts
@@ -1,9 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="./typings.d.ts" />
 
+import { CacheProvider } from '@emotion/core';
 import emotionStyled, { CreateStyled } from '@emotion/styled';
 
 import { Theme } from './types';
+
+export { CacheProvider };
 
 export type { StyledComponent } from '@emotion/styled';
 export { Global, keyframes, css, jsx, ClassNames } from '@emotion/core';


### PR DESCRIPTION
## What I did

In the pre-bundling work a bunch of exports from emotion were no longer exported, seems this one is needed from some occasions