### PR TITLE
add setup-node version for danger

### DIFF
--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -8,6 +8,9 @@ jobs:
     name: Danger JS
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - uses: actions/checkout@master
       - name: Danger JS
         uses: danger/danger-js@main

--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: '14'
       - uses: actions/checkout@master
       - name: Danger JS
-        uses: danger/danger-js@main
+        uses: danger/danger-js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: '14'
       - uses: actions/checkout@master
       - name: Danger JS
-        uses: danger/danger-js
+        uses: danger/danger-js@10.9.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Issue: danger is broken on next

## What I did
I noticed in the logs that danger needs node version 14 or higher, so I added a step in the action yaml to setup node 14 to be used

I also changed it from using the main branch directly to using a older tagged version, that seems to resolve the issue.