### PR TITLE
Build: Swap order of e2e tests around

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -77,6 +77,7 @@
     "fast-deep-equal": "^3.1.3",
     "global": "^4.4.0",
     "lodash": "^4.17.21",
+    "regenerator-runtime": "^0.13.7",
     "remark-external-links": "^8.0.0",
     "remark-slug": "^6.0.0",
     "ts-dedent": "^2.0.0",

--- a/cypress/generated/basic.spec.ts
+++ b/cypress/generated/basic.spec.ts
@@ -58,18 +58,18 @@ describe('Basic CLI', () => {
   });
 
   describe('Page story', () => {
-    it('should load and display logged in', () => {
-      cy.navigateToStory('example-page', 'logged-in');
-      cy.getStoryElement().find('header').should('contain.text', 'Acme');
-      cy.getStoryElement().find('button').should('contain.text', 'Log out');
-      cy.getStoryElement().should('contain.text', 'Pages in Storybook');
-    });
-
     it('should load and display logged out', () => {
       cy.navigateToStory('example-page', 'logged-out');
       cy.getStoryElement().should('contain.text', 'Acme');
       cy.getStoryElement().find('button').first().should('contain.text', 'Log in');
       cy.getStoryElement().find('button').last().should('contain.text', 'Sign up');
+      cy.getStoryElement().should('contain.text', 'Pages in Storybook');
+    });
+
+    it('should load and display logged in', () => {
+      cy.navigateToStory('example-page', 'logged-in');
+      cy.getStoryElement().find('header').should('contain.text', 'Acme');
+      cy.getStoryElement().find('button').should('contain.text', 'Log out');
       cy.getStoryElement().should('contain.text', 'Pages in Storybook');
     });
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -97,6 +97,7 @@ Cypress.Commands.add('navigateToStory', (kind, name) => {
   const storyLinkId = `#${kindId}--${storyId}`;
   cy.log(`navigateToStory ${kind} ${name}`);
 
+  // docs-only stories
   if (name !== 'page') {
     // Section might be collapsed
     cy.get(`#${kindId}`).then(($item) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -100,10 +100,15 @@ Cypress.Commands.add('navigateToStory', (kind, name) => {
   // docs-only stories
   if (name !== 'page') {
     // Section might be collapsed
-    cy.get(`#${kindId}`).then(($item) => {
-      if ($item.attr('aria-expanded') === 'false') $item.click();
+    cy.get(`#${kindId}`).then(async ($item) => {
+      if ($item.attr('aria-expanded') === 'false') {
+        await $item.click();
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(300);
+      }
     });
   }
+
   cy.get(storyLinkId).click({ force: true });
 
   // FIXME: Find a way to not wait like this but check for an element in the UI

--- a/yarn.lock
+++ b/yarn.lock
@@ -6346,6 +6346,7 @@ __metadata:
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
     lodash: ^4.17.21
+    regenerator-runtime: ^0.13.7
     remark-external-links: ^8.0.0
     remark-slug: ^6.0.0
     ts-dedent: ^2.0.0


### PR DESCRIPTION
Issue: e2e pnp tests are failing

## What I did

- swap order of e2e tests around

this makes them pass, we think that perhaps some tests are leaking into each other.
We plan to migrate off of cypress in the future,
so I'm not going to spend more time on improving this.