### PR TITLE
CLI: Preserve quote style in automigrate

### DIFF
--- a/lib/csf-tools/src/ConfigFile.test.ts
+++ b/lib/csf-tools/src/ConfigFile.test.ts
@@ -174,7 +174,7 @@ describe('ConfigFile', () => {
         ).toMatchInlineSnapshot(`
           export const core = {
             foo: 'bar',
-            builder: "webpack5"
+            builder: 'webpack5'
           };
         `);
       });
@@ -189,7 +189,7 @@ describe('ConfigFile', () => {
           )
         ).toMatchInlineSnapshot(`
           export const core = {
-            builder: "webpack5"
+            builder: 'webpack5'
           };
         `);
       });
@@ -205,7 +205,7 @@ describe('ConfigFile', () => {
         ).toMatchInlineSnapshot(`
           export const core = {
             builder: {
-              "name": "webpack5"
+              name: 'webpack5'
             }
           };
         `);
@@ -222,7 +222,7 @@ describe('ConfigFile', () => {
           )
         ).toMatchInlineSnapshot(`
           const coreVar = {
-            builder: "webpack5"
+            builder: 'webpack5'
           };
           export const core = coreVar;
         `);
@@ -260,7 +260,7 @@ describe('ConfigFile', () => {
           module.exports = {
             core: {
               foo: 'bar',
-              builder: "webpack5"
+              builder: 'webpack5'
             }
           };
         `);
@@ -277,8 +277,35 @@ describe('ConfigFile', () => {
         ).toMatchInlineSnapshot(`
           module.exports = {
             core: {
-              builder: "webpack5"
+              builder: 'webpack5'
             }
+          };
+        `);
+      });
+    });
+    describe('quotes', () => {
+      it('no quotes', () => {
+        expect(setField(['foo', 'bar'], 'baz', '')).toMatchInlineSnapshot(`
+          export const foo = {
+            bar: "baz"
+          };
+        `);
+      });
+      it('more single quotes', () => {
+        expect(setField(['foo', 'bar'], 'baz', `export const stories = ['a', 'b', "c"]`))
+          .toMatchInlineSnapshot(`
+          export const stories = ['a', 'b', "c"];
+          export const foo = {
+            bar: 'baz'
+          };
+        `);
+      });
+      it('more double quotes', () => {
+        expect(setField(['foo', 'bar'], 'baz', `export const stories = ['a', "b", "c"]`))
+          .toMatchInlineSnapshot(`
+          export const stories = ['a', "b", "c"];
+          export const foo = {
+            bar: "baz"
           };
         `);
       });

--- a/lib/csf-tools/src/babelParse.ts
+++ b/lib/csf-tools/src/babelParse.ts
@@ -10,4 +10,5 @@ export const babelParse = (code: string) =>
       ['decorators', { decoratorsBeforeExport: true }],
       'classProperties',
     ],
+    tokens: true,
   });


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Use babel generator instead of `JSON.stringify` so keys are not wrapped in quotes
- [x] Infer single vs. double quotes based on number of occurrences

Self-merging @yannbf 

## How to test

See attached tests
