### PR TITLE
CLI: Default new vite projects to storyStoreV7

### DIFF
--- a/lib/cli/src/generators/baseGenerator.ts
+++ b/lib/cli/src/generators/baseGenerator.ts
@@ -137,6 +137,15 @@ export async function baseGenerator(
           ...extraMain,
         }
       : extraMain;
+
+  // Default vite builder to storyStoreV7
+  if (expandedBuilder === '@storybook/builder-vite') {
+    mainOptions.features = {
+      ...mainOptions.features,
+      storyStoreV7: true,
+    };
+  }
+
   configure(framework, {
     framework: frameworkPackage,
     addons: [...addons, ...stripVersions(extraAddons)],


### PR DESCRIPTION
Issue:

## What I did

The vite builder benefits greatly from the on-demand story store, especially in dev-mode where modules are all sent to the browser unbundled (for better HMR and faster server startup).  In large vite storybook apps, this can mean thousands of network requests, which can take some time for the browser to process, causing a longer time-to-interactive.  (Note, this isn't a problem in built storybooks, since vite bundles them with rollup to avoid this problem).  

Furthermore, the new store is much more reliable and less likely to encounter bugs and subtle differences between the vite and webpack builders. A PR, https://github.com/storybookjs/builder-vite/pull/303, is currently open which would allow the use of the new store while not lazy-loading, in case users prefer or require that approach.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

I'm not sure how the cli is currently tested, other than in e2e tests, which do not use the vite builder (maybe we should add a few?)

But, I did build my changes, create a new vite project, and run the changed cli against it, and verified that `features: {storyStoreV7: true}` was in the generated config.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
