### PR TITLE
CLI: Detect vite project, use vite builder automatically

### DIFF
--- a/lib/cli/src/automigrate/fixes/builder-vite.ts
+++ b/lib/cli/src/automigrate/fixes/builder-vite.ts
@@ -39,7 +39,6 @@ export const builderVite: Fix<BuilderViteOptions> = {
     const builderName = typeof builder === 'string' ? builder : builder?.name;
 
     if (builderName !== 'storybook-builder-vite') {
-      logger.info(`Not using community vite builder, skipping`);
       return null;
     }
 

--- a/lib/cli/src/detect.test.ts
+++ b/lib/cli/src/detect.test.ts
@@ -15,6 +15,9 @@ jest.mock('./js-package-manager', () => ({
 
 jest.mock('fs', () => ({
   existsSync: jest.fn(),
+  stat: jest.fn(),
+  lstat: jest.fn(),
+  access: jest.fn(),
 }));
 
 jest.mock('path', () => ({

--- a/lib/cli/src/detect.ts
+++ b/lib/cli/src/detect.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import findUp from 'find-up';
 
 import {
   ProjectType,
@@ -9,9 +10,12 @@ import {
   TemplateConfiguration,
   TemplateMatcher,
   unsupportedTemplate,
+  CoreBuilder,
 } from './project_types';
-import { getBowerJson } from './helpers';
+import { getBowerJson, paddedLog } from './helpers';
 import { PackageJson, readPackageJson } from './js-package-manager';
+
+const viteConfigFiles = ['vite.config.ts', 'vite.config.js', 'vite.config.mjs'];
 
 const hasDependency = (
   packageJson: PackageJson,
@@ -92,6 +96,24 @@ export function detectFrameworkPreset(packageJson = {}) {
   });
 
   return result ? result.preset : ProjectType.UNDETECTED;
+}
+
+/**
+ * Attempts to detect which builder to use, by searching for a vite config file.  If one is found, the vite builder
+ * will be used, otherwise, webpack 4 is the default.
+ *
+ * @returns CoreBuilder
+ */
+export function detectBuilder() {
+  const viteConfig = findUp.sync(viteConfigFiles);
+
+  if (viteConfig) {
+    paddedLog('Detected vite project, setting builder to @storybook/builder-vite');
+    return CoreBuilder.Vite;
+  }
+
+  // Fallback to webpack 4
+  return CoreBuilder.Webpack4;
 }
 
 export function isStorybookInstalled(dependencies: PackageJson | false, force?: boolean) {

--- a/lib/cli/src/detect.ts
+++ b/lib/cli/src/detect.ts
@@ -100,7 +100,7 @@ export function detectFrameworkPreset(packageJson = {}) {
 
 /**
  * Attempts to detect which builder to use, by searching for a vite config file.  If one is found, the vite builder
- * will be used, otherwise, webpack 4 is the default.
+ * will be used, otherwise, webpack4 is the default.
  *
  * @returns CoreBuilder
  */
@@ -112,7 +112,7 @@ export function detectBuilder() {
     return CoreBuilder.Vite;
   }
 
-  // Fallback to webpack 4
+  // Fallback to webpack4
   return CoreBuilder.Webpack4;
 }
 

--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -92,7 +92,7 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
       case ProjectType.UPDATE_PACKAGE_ORGANIZATIONS:
         return updateOrganisationsGenerator(packageManager, options.parser, npmOptions)
           .then(() => null) // commandLog doesn't like to see output
-          .then(commandLog('Upgrading your project to the new Storybook packages.'))
+          .then(commandLog('Upgrading your project to the new Storybook packages.\n'))
           .then(end);
 
       case ProjectType.REACT_SCRIPTS:
@@ -102,7 +102,7 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
 
       case ProjectType.REACT:
         return reactGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "React" app'))
+          .then(commandLog('Adding Storybook support to your "React" app\n'))
           .then(end);
 
       case ProjectType.REACT_NATIVE: {
@@ -120,7 +120,7 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
               ]) as Promise<{ server: boolean }>)
         )
           .then(({ server }) => reactNativeGenerator(packageManager, npmOptions, server))
-          .then(commandLog('Adding Storybook support to your "React Native" app'))
+          .then(commandLog('Adding Storybook support to your "React Native" app\n'))
           .then(end)
           .then(() => {
             logger.log(chalk.red('NOTE: installation is not 100% automated.'));
@@ -134,97 +134,97 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
 
       case ProjectType.METEOR:
         return meteorGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Meteor" app'))
+          .then(commandLog('Adding Storybook support to your "Meteor" app\n'))
           .then(end);
 
       case ProjectType.WEBPACK_REACT:
         return webpackReactGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Webpack React" app'))
+          .then(commandLog('Adding Storybook support to your "Webpack React" app\n'))
           .then(end);
 
       case ProjectType.REACT_PROJECT:
         return reactGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "React" library'))
+          .then(commandLog('Adding Storybook support to your "React" library\n'))
           .then(end);
 
       case ProjectType.SFC_VUE:
         return sfcVueGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Single File Components Vue" app'))
+          .then(commandLog('Adding Storybook support to your "Single File Components Vue" app\n'))
           .then(end);
 
       case ProjectType.VUE:
         return vueGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Vue" app'))
+          .then(commandLog('Adding Storybook support to your "Vue" app\n'))
           .then(end);
 
       case ProjectType.VUE3:
         return vue3Generator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Vue 3" app'))
+          .then(commandLog('Adding Storybook support to your "Vue 3" app\n'))
           .then(end);
 
       case ProjectType.ANGULAR:
         return angularGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Angular" app'))
+          .then(commandLog('Adding Storybook support to your "Angular" app\n'))
           .then(end);
 
       case ProjectType.EMBER:
         return emberGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Ember" app'))
+          .then(commandLog('Adding Storybook support to your "Ember" app\n'))
           .then(end);
 
       case ProjectType.MITHRIL:
         return mithrilGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Mithril" app'))
+          .then(commandLog('Adding Storybook support to your "Mithril" app\n'))
           .then(end);
 
       case ProjectType.MARIONETTE:
         return marionetteGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Marionette.js" app'))
+          .then(commandLog('Adding Storybook support to your "Marionette.js" app\n'))
           .then(end);
 
       case ProjectType.MARKO:
         return markoGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Marko" app'))
+          .then(commandLog('Adding Storybook support to your "Marko" app\n'))
           .then(end);
 
       case ProjectType.HTML:
         return htmlGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "HTML" app'))
+          .then(commandLog('Adding Storybook support to your "HTML" app\n'))
           .then(end);
 
       case ProjectType.WEB_COMPONENTS:
         return webComponentsGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "web components" app'))
+          .then(commandLog('Adding Storybook support to your "web components" app\n'))
           .then(end);
 
       case ProjectType.RIOT:
         return riotGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "riot.js" app'))
+          .then(commandLog('Adding Storybook support to your "riot.js" app\n'))
           .then(end);
 
       case ProjectType.PREACT:
         return preactGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Preact" app'))
+          .then(commandLog('Adding Storybook support to your "Preact" app\n'))
           .then(end);
 
       case ProjectType.SVELTE:
         return svelteGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Svelte" app'))
+          .then(commandLog('Adding Storybook support to your "Svelte" app\n'))
           .then(end);
 
       case ProjectType.RAX:
         return raxGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Rax" app'))
+          .then(commandLog('Adding Storybook support to your "Rax" app\n'))
           .then(end);
 
       case ProjectType.AURELIA:
         return aureliaGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Aurelia" app'))
+          .then(commandLog('Adding Storybook support to your "Aurelia" app\n'))
           .then(end);
 
       case ProjectType.SERVER:
         return serverGenerator(packageManager, npmOptions, generatorOptions)
-          .then(commandLog('Adding Storybook support to your "Server" app'))
+          .then(commandLog('Adding Storybook support to your "Server" app\n'))
           .then(end);
 
       case ProjectType.UNSUPPORTED:

--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -1,8 +1,8 @@
 import { UpdateNotifier, Package } from 'update-notifier';
 import chalk from 'chalk';
 import prompts from 'prompts';
-import { detect, isStorybookInstalled, detectLanguage } from './detect';
-import { installableProjectTypes, ProjectType, Builder, CoreBuilder } from './project_types';
+import { detect, isStorybookInstalled, detectLanguage, detectBuilder } from './detect';
+import { installableProjectTypes, ProjectType, Builder } from './project_types';
 import { commandLog, codeLog, paddedLog } from './helpers';
 import angularGenerator from './generators/ANGULAR';
 import aureliaGenerator from './generators/AURELIA';
@@ -57,7 +57,7 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
 
   const generatorOptions = {
     language,
-    builder: options.builder || CoreBuilder.Webpack4,
+    builder: options.builder || detectBuilder(),
     linkable: !!options.linkable,
     commonJs: options.commonJs,
   };


### PR DESCRIPTION
Issue:

## What I did

This is intended to aid discoverability of the vite builder by automatically initializing a project with the vite builder if a vite config file is detected.  It uses a similar approach of looking for a vite config file as [vitest](https://github.com/vitest-dev/vitest/blob/382aa351421d378c4b16301b7d94184e061e9a72/packages/vitest/src/node/create.ts#L16).

I could see also detecting whether to use the webpack5 builder, but I didn't do that here, it will fall back to webpack4, as before.  

If a `--builder` option is explicitly provided, it will be used and autodetection won't run.

This also cleans up a few other things, which I can remove if desired:

1) No longer logs `Not using community vite builder, skipping` after `init`, since the distinction between the community vite builder and official vite builder is subtle and might be confusing to users setting up a new storybook project.
2) Added a newline after messages like `Adding Storybook support to your "React" app`, since otherwise npm overwrote them once it started installs.  

The logs now look something like this:

```
▶ npx sb@next init

 sb init - the simplest way to add a Storybook to your project.

 • Detecting project type. ✓
    Detected vite project, setting builder to @storybook/builder-vite
 • Adding Storybook support to your "React" app
(#########⠂⠂⠂⠂⠂⠂⠂⠂⠂) ⠋ idealTree:@storybook/builder-vite: sill fetch manifest unfetch@^4.2.0
```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

Without some vite examples for e2e tests, I'm not sure how to write automated tests for this.  I did test it out locally, though, and it worked great.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
