### PR TITLE
Core: Restore preview-web composeConfigs export

### DIFF
--- a/lib/preview-web/src/index.ts
+++ b/lib/preview-web/src/index.ts
@@ -1,3 +1,6 @@
+// FIXME: breaks builder-vite, remove this in 7.0
+export { composeConfigs } from '@storybook/store';
+
 export { PreviewWeb } from './PreviewWeb';
 
 export { simulatePageLoad, simulateDOMContentLoaded } from './simulate-pageload';


### PR DESCRIPTION
Issue: N/A

Fixes https://github.com/storybookjs/builder-vite/issues/304

## What I did

Re-export `composeConfigs` from `@storybook/store` for back-compat

cc @yannbf 

## How to test

N/A - haven't tested, we'll be adding some e2e tests soon