### PR TITLE
Update react-test-renderer version

### DIFF
--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -61,7 +61,7 @@
     "jest-specific-snapshot": "^4.0.0",
     "preact-render-to-string": "^5.1.19",
     "pretty-format": "^26.6.2",
-    "react-test-renderer": "^16.8.0 || ^17.0.0",
+    "react-test-renderer": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
     "ts-dedent": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6873,7 +6873,7 @@ __metadata:
     jest-vue-preprocessor: ^1.7.1
     preact-render-to-string: ^5.1.19
     pretty-format: ^26.6.2
-    react-test-renderer: ^16.8.0 || ^17.0.0
+    react-test-renderer: ^16.8.0 || ^17.0.0 || ^18.0.0
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     rxjs: ^6.6.3
@@ -38064,6 +38064,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "react-is@npm:18.0.0"
+  checksum: 1cffa48e45768fc49c6cfa67fdb6ccd2432bb1a5074575c1c48b425104e5ba03538a2d4496dfc6c844f34d1ab2b9304c97aab6c8a3b060d4f5587b2f128db8d4
+  languageName: node
+  linkType: hard
+
 "react-lifecycles-compat@npm:^3.0.0, react-lifecycles-compat@npm:^3.0.4":
   version: 3.0.4
   resolution: "react-lifecycles-compat@npm:3.0.4"
@@ -38432,17 +38439,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-test-renderer@npm:^16.8.0 || ^17.0.0":
-  version: 17.0.2
-  resolution: "react-test-renderer@npm:17.0.2"
+"react-test-renderer@npm:^16.8.0 || ^17.0.0 || ^18.0.0":
+  version: 18.0.0
+  resolution: "react-test-renderer@npm:18.0.0"
   dependencies:
-    object-assign: ^4.1.1
-    react-is: ^17.0.2
+    react-is: ^18.0.0
     react-shallow-renderer: ^16.13.1
-    scheduler: ^0.20.2
+    scheduler: ^0.21.0
   peerDependencies:
-    react: 17.0.2
-  checksum: a4ea1e745a87bb9015540d96a3077b614bf88e306a0edd639f8fb849a393fa5104e84eca4349bc4b026f2f0b115a4172d58950d7076316115795266557659276
+    react: ^18.0.0
+  checksum: 1c61b461247232455af1c6d75905a14dc819a239e58f39691067dbc582175cba6b31a223757dc6f82b595a5360646ded67139c1c54aab62cd631c920bfa51d8c
   languageName: node
   linkType: hard
 
@@ -40712,6 +40718,15 @@ __metadata:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
   checksum: b0982e4b0f34f4ffa4f2f486161c0fd9ce9b88680b045dccbf250eb1aa4fd27413570645455187a83535e2370f5c667a251045547765408492bd883cbe95fcdb
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "scheduler@npm:0.21.0"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: 083a9a0c83f4923f7f5bb28d8bcf13cff42c90f4303bc187166520fcfc576c97e946d426c707d5a9c0aa0a655819605dd0c741467c626824bbf191251c126f1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17831#issuecomment-1086731952

## What I did

I updated react-test-renderer to version 18.

The version we had depended on react 17, but this  PR should fix the peerDeps problem.
https://github.com/facebook/react/blob/main/packages/react-test-renderer/package.json#L26-L28

@cameron-martin @jcerri Thanks for telling me about this issue! 🙌 

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
