### PR TITLE
Update some references to use ESM rather than CJS

### DIFF
--- a/addons/links/react.js
+++ b/addons/links/react.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/react');
+module.exports = require('./dist/esm/react');

--- a/app/angular/src/server/framework-preset-angular-cli.test.ts
+++ b/app/angular/src/server/framework-preset-angular-cli.test.ts
@@ -766,8 +766,8 @@ const newWebpackConfiguration = (
     bail: false,
     devtool: 'cheap-module-source-map',
     entry: [
-      '/Users/joe/storybook/lib/core-server/dist/cjs/globals/polyfills.js',
-      '/Users/joe/storybook/lib/core-server/dist/cjs/globals/globals.js',
+      '/Users/joe/storybook/lib/core-server/dist/esm/globals/polyfills.js',
+      '/Users/joe/storybook/lib/core-server/dist/esm/globals/globals.js',
       '/Users/joe/storybook/examples/angular-cli/.storybook/storybook-init-framework-entry.js',
       '/Users/joe/storybook/addons/docs/dist/esm/frameworks/common/config.js-generated-other-entry.js',
       '/Users/joe/storybook/addons/docs/dist/esm/frameworks/angular/config.js-generated-other-entry.js',

--- a/examples/official-storybook/components/addon-measure/ShadowRoot.js
+++ b/examples/official-storybook/components/addon-measure/ShadowRoot.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { drawSelectedElement } from '@storybook/addon-measure/dist/cjs/box-model/visualizer';
+import { drawSelectedElement } from '@storybook/addon-measure/dist/esm/box-model/visualizer';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { init, destroy } from '@storybook/addon-measure/dist/cjs/box-model/canvas';
+import { init, destroy } from '@storybook/addon-measure/dist/esm/box-model/canvas';
 
 export const ShadowRoot = ({ label = 'Hello from shadow DOM', drawMode = 'ROOT' }) => {
   const ref = React.useRef();

--- a/examples/official-storybook/components/addon-measure/Visualization.js
+++ b/examples/official-storybook/components/addon-measure/Visualization.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { drawSelectedElement } from '@storybook/addon-measure/dist/cjs/box-model/visualizer';
+import { drawSelectedElement } from '@storybook/addon-measure/dist/esm/box-model/visualizer';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { init, destroy } from '@storybook/addon-measure/dist/cjs/box-model/canvas';
+import { init, destroy } from '@storybook/addon-measure/dist/esm/box-model/canvas';
 
 export const Visualization = ({ render }) => {
   const element = useRef(null);

--- a/lib/components/html.js
+++ b/lib/components/html.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/html');
+module.exports = require('./dist/esm/html');

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/index');
+module.exports = require('./dist/esm/index');

--- a/lib/router/utils.js
+++ b/lib/router/utils.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/utils');
+module.exports = require('./dist/esm/utils');

--- a/lib/theming/create.js
+++ b/lib/theming/create.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/create');
+module.exports = require('./dist/esm/create');


### PR DESCRIPTION
## What I did

@IanVS found some places in the codebase where web-based entries end up using CJS built files. These seem like mistakes, we should always use ESM on web, AFAIK.

## How to test

Hopefully any problems will get picked up by automated testing.