### PR TITLE
Build: Add vite-react to e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
           name: Run E2E (core) tests
           # Do not test CRA here because it's done in PnP part
           # TODO: Remove `web_components_typescript` as soon as Lit 2 stable is released
-          command: yarn test:e2e-framework vue3 angular130 angular13 angular12 angular11 web_components_typescript web_components_lit2 react
+          command: yarn test:e2e-framework vue3 angular130 angular13 angular12 angular11 web_components_typescript web_components_lit2 react vite_react
           no_output_timeout: 5m
       - store_artifacts:
           path: /tmp/cypress-record

--- a/cypress/generated/addon-interactions.spec.ts
+++ b/cypress/generated/addon-interactions.spec.ts
@@ -30,4 +30,8 @@ describe('addon-interactions', () => {
   onlyOn('react', () => {
     it('should have interactions', test);
   });
+
+  onlyOn('vite_react', () => {
+    it('should have interactions', test);
+  });
 });

--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -79,6 +79,13 @@ export const webpack_react: Parameters = {
   generator: fromDeps('react', 'react-dom', 'webpack@webpack-4'),
 };
 
+export const vite_react: Parameters = {
+  framework: 'react',
+  name: 'vite_react',
+  version: 'latest',
+  generator: 'npx -p create-vite@{{version}} create-vite {{appName}} --template react-ts',
+};
+
 export const react_in_yarn_workspace: Parameters = {
   framework: 'react',
   name: 'react_in_yarn_workspace',


### PR DESCRIPTION
Issue: N/A

## What I did

Added vite builder example to E2E, so we guarantee there are no unintended breaking changes 👌 

cc @IanVS 

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
