### PR TITLE
Fix mobile fullscreen UI

### DIFF
--- a/lib/ui/src/app.tsx
+++ b/lib/ui/src/app.tsx
@@ -61,7 +61,13 @@ const App = React.memo<AppProps>(
     if (!width || !height) {
       content = <div />;
     } else if (width < 600) {
-      content = <Mobile {...props} viewMode={viewMode} options={layout} docsOnly={docsOnly} />;
+      content =
+        <Mobile
+          {...props}
+          viewMode={viewMode}
+          options={layout}
+          docsOnly={docsOnly}
+        />;
     } else {
       content = (
         <Desktop

--- a/lib/ui/src/components/layout/mobile.tsx
+++ b/lib/ui/src/components/layout/mobile.tsx
@@ -103,21 +103,21 @@ const PanelsContainer = styled.div({
   height: 'calc(100% - 40px)',
 });
 
-const Bar = styled.nav(
+const Bar = styled.nav<{ isFullscreen: boolean }>(
   {
     position: 'fixed',
     bottom: 0,
     left: 0,
     width: '100vw',
     height: 40,
-    display: 'flex',
     boxShadow: '0 1px 5px 0 rgba(0, 0, 0, 0.1)',
 
     '& > *': {
       flex: 1,
     },
   },
-  ({ theme }) => ({
+  ({ theme, isFullscreen }) => ({
+    display: isFullscreen ? 'none' : 'flex',
     background: theme.barBg,
   })
 );
@@ -132,6 +132,7 @@ export interface MobileProps {
   options: {
     initialActive: ActiveTabsType;
     isToolshown: boolean;
+    isFullscreen: boolean;
   };
   Sidebar: ComponentType<any>;
   Preview: ComponentType<any>;
@@ -186,7 +187,7 @@ class Mobile extends Component<MobileProps, MobileState> {
           </div>
           <Panel hidden={!viewMode} />
         </Panels>
-        <Bar>
+        <Bar isFullscreen={options.isFullscreen}>
           <TabButton onClick={() => this.setState({ active: SIDEBAR })} active={active === SIDEBAR}>
             Sidebar
           </TabButton>

--- a/lib/ui/src/components/layout/mobile.tsx
+++ b/lib/ui/src/components/layout/mobile.tsx
@@ -83,8 +83,8 @@ const Pane = styled.div<{ index: number; active: ActiveTabsType }>(
   }
 );
 
-const Panels = React.memo((({ children, active }) => (
-  <PanelsContainer>
+const Panels = React.memo((({ children, active, isFullscreen }) => (
+  <PanelsContainer isFullscreen={isFullscreen}>
     {Children.toArray(children).map((item, index) => (
       // eslint-disable-next-line react/no-array-index-key
       <Pane key={index} index={index} active={active}>
@@ -92,16 +92,19 @@ const Panels = React.memo((({ children, active }) => (
       </Pane>
     ))}
   </PanelsContainer>
-)) as FunctionComponent<{ active: ActiveTabsType; children: ReactNode }>);
+)) as FunctionComponent<{ active: ActiveTabsType; children: ReactNode, isFullscreen: boolean }>);
 Panels.displayName = 'Panels';
 
-const PanelsContainer = styled.div({
-  position: 'fixed',
-  top: 0,
-  left: 0,
-  width: '100vw',
-  height: 'calc(100% - 40px)',
-});
+const PanelsContainer = styled.div<{ isFullscreen: boolean }>(
+  {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100vw',
+  }, ({ isFullscreen }) => ({
+    height: isFullscreen ? '100vh' : 'calc(100% - 40px)',
+  })
+);
 
 const Bar = styled.nav<{ isFullscreen: boolean }>(
   {
@@ -173,7 +176,7 @@ class Mobile extends Component<MobileProps, MobileState> {
           }}
         />
 
-        <Panels active={active}>
+        <Panels active={active} isFullscreen={options.isFullscreen}>
           <Sidebar />
           <div>
             <div hidden={!viewMode}>

--- a/lib/ui/src/components/layout/mobile.tsx
+++ b/lib/ui/src/components/layout/mobile.tsx
@@ -106,21 +106,21 @@ const PanelsContainer = styled.div<{ isFullscreen: boolean }>(
   })
 );
 
-const Bar = styled.nav<{ isFullscreen: boolean }>(
+const Bar = styled.nav(
   {
     position: 'fixed',
     bottom: 0,
     left: 0,
     width: '100vw',
     height: 40,
+    display: 'flex',
     boxShadow: '0 1px 5px 0 rgba(0, 0, 0, 0.1)',
 
     '& > *': {
       flex: 1,
     },
   },
-  ({ theme, isFullscreen }) => ({
-    display: isFullscreen ? 'none' : 'flex',
+  ({ theme }) => ({
     background: theme.barBg,
   })
 );
@@ -190,22 +190,24 @@ class Mobile extends Component<MobileProps, MobileState> {
           </div>
           <Panel hidden={!viewMode} />
         </Panels>
-        <Bar isFullscreen={options.isFullscreen}>
-          <TabButton onClick={() => this.setState({ active: SIDEBAR })} active={active === SIDEBAR}>
-            Sidebar
-          </TabButton>
-          <TabButton onClick={() => this.setState({ active: CANVAS })} active={active === CANVAS}>
-            {viewMode ? 'Canvas' : null}
-            {pages.map(({ key, route: Route }) => (
-              <Route key={key}>{key}</Route>
-            ))}
-          </TabButton>
-          {viewMode && !docsOnly ? (
-            <TabButton onClick={() => this.setState({ active: ADDONS })} active={active === ADDONS}>
-              Addons
+        {!options.isFullscreen && (
+          <Bar>
+            <TabButton onClick={() => this.setState({ active: SIDEBAR })} active={active === SIDEBAR}>
+              Sidebar
             </TabButton>
-          ) : null}
-        </Bar>
+            <TabButton onClick={() => this.setState({ active: CANVAS })} active={active === CANVAS}>
+              {viewMode ? 'Canvas' : null}
+              {pages.map(({ key, route: Route }) => (
+                <Route key={key}>{key}</Route>
+              ))}
+            </TabButton>
+            {viewMode && !docsOnly ? (
+              <TabButton onClick={() => this.setState({ active: ADDONS })} active={active === ADDONS}>
+                Addons
+              </TabButton>
+            ) : null}
+          </Bar>
+        )}
       </Root>
     );
   }

--- a/lib/ui/src/components/preview/toolbar.tsx
+++ b/lib/ui/src/components/preview/toolbar.tsx
@@ -56,15 +56,13 @@ export const fullScreenTool: Addon = {
     <Consumer filter={fullScreenMapper}>
       {({ toggle, value, shortcut, hasPanel, singleStory }) =>
         (!singleStory || (singleStory && hasPanel)) && (
-          <S.DesktopOnly>
-            <IconButton
-              key="full"
-              onClick={toggle as any}
-              title={`${value ? 'Exit full screen' : 'Go full screen'} [${shortcut}]`}
-            >
-              <Icons icon={value ? 'close' : 'expand'} />
-            </IconButton>
-          </S.DesktopOnly>
+          <IconButton
+            key="full"
+            onClick={toggle as any}
+            title={`${value ? 'Exit full screen' : 'Go full screen'} [${shortcut}]`}
+          >
+            <Icons icon={value ? 'close' : 'expand'} />
+          </IconButton>
         )
       }
     </Consumer>


### PR DESCRIPTION
Issue: #17808 

## What Pepijn and I did
- Show fullscreen toggle button on mobile UI
- Hide nav when fullscreen active

## How to test
Open an example storybook, change the screen size to < 600px, then check if the fullscreen button is visible and whether the nav is hidden when fullscreen is active.

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bugs and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
