### PR TITLE
Core: Avoid framework imports from core/client

### DIFF
--- a/app/angular/src/client/preview/index.ts
+++ b/app/angular/src/client/preview/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-destructuring */
 import type { ClientStoryApi, Loadable } from '@storybook/addons';
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import './globals';
 import { renderToDOM, render } from './render';
 import decorateStory from './decorateStory';

--- a/app/ember/src/client/preview/index.ts
+++ b/app/ember/src/client/preview/index.ts
@@ -1,4 +1,4 @@
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 
 import './globals';
 import { renderToDOM } from './render';

--- a/app/html/src/client/preview/index.ts
+++ b/app/html/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import type { ClientStoryApi, Loadable } from '@storybook/addons';
 import { HtmlFramework } from './types-6-0';
 

--- a/app/preact/src/client/preview/index.ts
+++ b/app/preact/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';

--- a/app/react/src/client/preview/index.tsx
+++ b/app/react/src/client/preview/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';

--- a/app/server/src/client/preview/index.ts
+++ b/app/server/src/client/preview/index.ts
@@ -1,4 +1,4 @@
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';

--- a/app/svelte/src/client/preview/index.ts
+++ b/app/svelte/src/client/preview/index.ts
@@ -1,4 +1,4 @@
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import { decorateStory } from './decorators';
 
 import './globals';

--- a/app/vue/src/client/preview/index.ts
+++ b/app/vue/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';

--- a/app/vue3/src/client/preview/index.ts
+++ b/app/vue3/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 import type { App } from 'vue';
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';

--- a/app/web-components/src/client/preview/index.ts
+++ b/app/web-components/src/client/preview/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-destructuring */
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 import type { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';

--- a/docs/snippets/common/storybook-client-preview.ts.mdx
+++ b/docs/snippets/common/storybook-client-preview.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // your-framework/src/client/preview/index.ts
 
-import { start } from '@storybook/core/client';
+import { start } from '@storybook/core';
 
 import './globals';
 

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -1,1 +1,3 @@
+// @storybook/core was split into core-client and core-server.  This file is for backwards-compat.
+// TODO: remove in 7.0
 module.exports = require('./dist/esm/index');


### PR DESCRIPTION
Issue:

## What I did

I found that the vite builder needed to pre-bundle some of the storybook dependencies, even though they distribute ESM.  One cause was the framework packages importing directly from `@storybook/core/client`, which is a cjs file that just re-exports the package index.  

This change allows imports of either cjs or esm in the normal fashion.

This may not be strictly necessary after https://github.com/storybookjs/storybook/pull/17868/files#diff-ed67a6365c9248d5f4412c4c904d2e3789155a763f681f8c48a63af38ba8a0f2R1 is merged, but it does seem strange to use this file to force one or the other packages to be used, rather than allowing normal node/bundler behavior.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
