### PR TITLE
Angular: Do not use default for includePaths

### DIFF
--- a/app/angular/src/builders/build-storybook/schema.json
+++ b/app/angular/src/builders/build-storybook/schema.json
@@ -69,8 +69,7 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "default": []
+          }
         }
       },
       "additionalProperties": false,

--- a/app/angular/src/builders/start-storybook/schema.json
+++ b/app/angular/src/builders/start-storybook/schema.json
@@ -96,8 +96,7 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "default": []
+          }
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Issue: In Nx Workspaces, the CLI evaluates the `schema.json` file slightly differently to how Angular CLI evaluates it.

The Angular CLI will only look at the parent object's default value and return that when the option is not provided.

The Nx CLI will look at the parent object's childrens' default values and build out an object that matches those defaults, as would be expected.

This leads to erroneous behaviors in Nx Workspaces, as the `stylePreprocessorOptions` coming from the app's browser build target will get overridden by an object of the form: 
```ts
{
  stylePreprocessorOptions: {
    includePaths: []
  }
}
```

## What I did

I removed the default empty array form `includePaths` as this is the source of the erroneous behavior. It also does not need to have a default value as it is an optional property.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
