### PR TITLE
Controls: Rework conditional controls with globals, queries

### DIFF
--- a/addons/a11y/package.json
+++ b/addons/a11y/package.json
@@ -51,7 +51,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/components": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/theming": "6.5.0-alpha.55",
     "axe-core": "^4.2.0",
     "core-js": "^3.8.2",

--- a/addons/backgrounds/package.json
+++ b/addons/backgrounds/package.json
@@ -50,7 +50,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/components": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/theming": "6.5.0-alpha.55",
     "core-js": "^3.8.2",
     "global": "^4.4.0",

--- a/addons/controls/package.json
+++ b/addons/controls/package.json
@@ -50,7 +50,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/components": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/node-logger": "6.5.0-alpha.55",
     "@storybook/store": "6.5.0-alpha.55",
     "@storybook/theming": "6.5.0-alpha.55",

--- a/addons/controls/src/ControlsPanel.tsx
+++ b/addons/controls/src/ControlsPanel.tsx
@@ -1,5 +1,12 @@
 import React, { FC } from 'react';
-import { ArgTypes, useArgs, useArgTypes, useParameter, useStorybookState } from '@storybook/api';
+import {
+  ArgTypes,
+  useArgs,
+  useGlobals,
+  useArgTypes,
+  useParameter,
+  useStorybookState,
+} from '@storybook/api';
 import { ArgsTable, NoControlsWarning, PresetColor, SortType } from '@storybook/components';
 
 import { PARAM_KEY } from './constants';
@@ -13,6 +20,7 @@ interface ControlsParameters {
 
 export const ControlsPanel: FC = () => {
   const [args, updateArgs, resetArgs] = useArgs();
+  const [globals] = useGlobals();
   const rows = useArgTypes();
   const isArgsStory = useParameter<boolean>('__isArgsStory', false);
   const {
@@ -41,6 +49,7 @@ export const ControlsPanel: FC = () => {
           compact: !expanded && hasControls,
           rows: withPresetColors,
           args,
+          globals,
           updateArgs,
           resetArgs,
           inAddonPanel: true,

--- a/addons/docs/docs/multiframework.md
+++ b/addons/docs/docs/multiframework.md
@@ -53,8 +53,6 @@ export interface ArgType {
   name?: string;
   description?: string;
   defaultValue?: any;
-  addIf?: string;
-  removeIf?: string;
   [key: string]: any;
 }
 

--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -64,7 +64,7 @@
     "@storybook/components": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/docs-tools": "6.5.0-alpha.55",
     "@storybook/mdx1-csf": "canary",
     "@storybook/node-logger": "6.5.0-alpha.55",

--- a/addons/docs/src/blocks/ArgsTable.tsx
+++ b/addons/docs/src/blocks/ArgsTable.tsx
@@ -11,7 +11,7 @@ import { ArgTypesExtractor } from '@storybook/docs-tools';
 import { addons } from '@storybook/addons';
 import { filterArgTypes, PropDescriptor } from '@storybook/store';
 import Events from '@storybook/core-events';
-import { StrictArgTypes, Args } from '@storybook/csf';
+import { StrictArgTypes, Args, Globals } from '@storybook/csf';
 
 import { DocsContext, DocsContextProps } from './DocsContext';
 import { Component, CURRENT_SELECTION, PRIMARY_STORY } from './types';
@@ -42,18 +42,20 @@ type StoryProps = BaseProps & {
 
 type ArgsTableProps = BaseProps | OfProps | ComponentsProps | StoryProps;
 
+const getContext = (storyId: string, context: DocsContextProps) => {
+  const story = context.storyById(storyId);
+  if (!story) {
+    throw new Error(`Unknown story: ${storyId}`);
+  }
+  return context.getStoryContext(story);
+};
+
 const useArgs = (
   storyId: string,
   context: DocsContextProps
 ): [Args, (args: Args) => void, (argNames?: string[]) => void] => {
   const channel = addons.getChannel();
-
-  const story = context.storyById(storyId);
-  if (!story) {
-    throw new Error(`Unknown story: ${storyId}`);
-  }
-
-  const storyContext = context.getStoryContext(story);
+  const storyContext = getContext(storyId, context);
 
   const [args, setArgs] = useState(storyContext.args);
   useEffect(() => {
@@ -74,6 +76,22 @@ const useArgs = (
     [storyId]
   );
   return [args, updateArgs, resetArgs];
+};
+
+const useGlobals = (storyId: string, context: DocsContextProps): [Globals] => {
+  const channel = addons.getChannel();
+  const storyContext = getContext(storyId, context);
+  const [globals, setGlobals] = useState(storyContext.globals);
+
+  useEffect(() => {
+    const cb = (changed: { globals: Globals }) => {
+      setGlobals(changed.globals);
+    };
+    channel.on(Events.GLOBALS_UPDATED, cb);
+    return () => channel.off(Events.GLOBALS_UPDATED, cb);
+  }, []);
+
+  return [globals];
 };
 
 export const extractComponentArgTypes = (
@@ -162,13 +180,14 @@ export const StoryTable: FC<
     const story = useStory(storyId, context);
     // eslint-disable-next-line prefer-const
     let [args, updateArgs, resetArgs] = useArgs(storyId, context);
+    const [globals] = useGlobals(storyId, context);
     if (!story) return <PureArgsTable isLoading updateArgs={updateArgs} resetArgs={resetArgs} />;
 
     const argTypes = filterArgTypes(story.argTypes, include, exclude);
 
     const mainLabel = getComponentName(component) || 'Story';
 
-    let tabs = { [mainLabel]: { rows: argTypes, args, updateArgs, resetArgs } } as Record<
+    let tabs = { [mainLabel]: { rows: argTypes, args, globals, updateArgs, resetArgs } } as Record<
       string,
       PureArgsTableProps
     >;

--- a/addons/links/package.json
+++ b/addons/links/package.json
@@ -44,7 +44,7 @@
     "@storybook/addons": "6.5.0-alpha.55",
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/router": "6.5.0-alpha.55",
     "@types/qs": "^6.9.5",
     "core-js": "^3.8.2",

--- a/addons/measure/package.json
+++ b/addons/measure/package.json
@@ -49,7 +49,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/components": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "core-js": "^3.8.2",
     "global": "^4.4.0"
   },

--- a/addons/outline/package.json
+++ b/addons/outline/package.json
@@ -52,7 +52,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/components": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "core-js": "^3.8.2",
     "global": "^4.4.0",
     "regenerator-runtime": "^0.13.7",

--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -51,7 +51,7 @@
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-client": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.16",
     "@types/jest-specific-snapshot": "^0.5.3",

--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/node-logger": "6.5.0-alpha.55",
     "@types/jest-image-snapshot": "^4.1.3",
     "core-js": "^3.8.2",
@@ -49,7 +49,7 @@
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@types/puppeteer": "^5.4.0"
   },
   "peerDependencies": {

--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -51,7 +51,7 @@
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/docs-tools": "6.5.0-alpha.55",
     "@storybook/node-logger": "6.5.0-alpha.55",
     "@storybook/semver": "^7.3.2",

--- a/app/html/package.json
+++ b/app/html/package.json
@@ -48,7 +48,7 @@
     "@storybook/addons": "6.5.0-alpha.55",
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/docs-tools": "6.5.0-alpha.55",
     "@storybook/preview-web": "6.5.0-alpha.55",
     "@storybook/store": "6.5.0-alpha.55",

--- a/app/preact/package.json
+++ b/app/preact/package.json
@@ -49,7 +49,7 @@
     "@storybook/addons": "6.5.0-alpha.55",
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/store": "6.5.0-alpha.55",
     "@types/node": "^14.14.20 || ^16.0.0",
     "@types/webpack-env": "^1.16.0",

--- a/app/react/package.json
+++ b/app/react/package.json
@@ -53,7 +53,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/docs-tools": "6.5.0-alpha.55",
     "@storybook/node-logger": "6.5.0-alpha.55",
     "@storybook/react-docgen-typescript-plugin": "1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -50,7 +50,7 @@
     "@storybook/client-api": "6.5.0-alpha.55",
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/node-logger": "6.5.0-alpha.55",
     "@storybook/preview-web": "6.5.0-alpha.55",
     "@storybook/store": "6.5.0-alpha.55",

--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -50,7 +50,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/docs-tools": "6.5.0-alpha.55",
     "@storybook/node-logger": "6.5.0-alpha.55",
     "@storybook/store": "6.5.0-alpha.55",

--- a/app/vue/package.json
+++ b/app/vue/package.json
@@ -49,7 +49,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/docs-tools": "6.5.0-alpha.55",
     "@storybook/store": "6.5.0-alpha.55",
     "@types/node": "^14.14.20 || ^16.0.0",

--- a/app/vue3/package.json
+++ b/app/vue3/package.json
@@ -48,7 +48,7 @@
     "@storybook/addons": "6.5.0-alpha.55",
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/docs-tools": "6.5.0-alpha.55",
     "@storybook/store": "6.5.0-alpha.55",
     "@types/node": "^14.14.20 || ^16.0.0",

--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -55,7 +55,7 @@
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/docs-tools": "6.5.0-alpha.55",
     "@storybook/preview-web": "6.5.0-alpha.55",
     "@storybook/store": "6.5.0-alpha.55",

--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -302,7 +302,7 @@ paths={[
 
 ### Conditional controls
 
-In some cases, it's useful to be able to conditionally exclude a control based on the value of another control. Controls supports basic versions of these use cases with the `addIf` and `removeIf` options, which can take a boolean value, or a string which can refer to the value of another arg.
+In some cases, it's useful to be able to conditionally exclude a control based on the value of another control. Controls supports basic versions of these use cases with the `if`, which can takes a simple query object to determine whether to include the control.
 
 Consider a collection of "advanced" settings that are only visible when the user toggles an "advanced" toggle.
 

--- a/docs/snippets/common/component-story-conditional-controls-mutual-exclusion.js.mdx
+++ b/docs/snippets/common/component-story-conditional-controls-mutual-exclusion.js.mdx
@@ -6,10 +6,13 @@ export default {
   title: 'Button',
   argTypes: {
     // button can be passed a label or an image, not both
-    label: { control: 'text', removeIf: 'image' },
+    label: {
+      control: 'text',
+      if: { arg: 'image', truthy: false },
+    },
     image: {
       control: { type: 'select', options: ['foo.jpg', 'bar.jpg'] },
-      removeIf: 'label',
+      if: { arg: 'label', truthy: false },
     },
   },
 };

--- a/docs/snippets/common/component-story-conditional-controls-toggle.js.mdx
+++ b/docs/snippets/common/component-story-conditional-controls-toggle.js.mdx
@@ -8,9 +8,9 @@ export default {
     label: { control: 'text' }, // always shows
     advanced: { control: 'boolean' },
     // below are only included when advanced is true
-    margin: { control: 'number', addIf: 'advanced' },
-    padding: { control: 'number', addIf: 'advanced' },
-    cornerRadius: { control: 'number', addIf: 'advanced' },
+    margin: { control: 'number', if: { arg: 'advanced' } },
+    padding: { control: 'number', if: { arg: 'advanced' } },
+    cornerRadius: { control: 'number', if: { arg: 'advanced' } },
   },
 };
 ```

--- a/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -28,17 +28,17 @@ export default {
         ],
       },
     },
-    mutuallyExclusiveA: { control: 'text', removeIf: 'mutuallyExclusiveB' },
-    mutuallyExclusiveB: { control: 'text', removeIf: 'mutuallyExclusiveA' },
+    mutuallyExclusiveA: { control: 'text', if: { arg: 'mutuallyExclusiveB', truthy: false } },
+    mutuallyExclusiveB: { control: 'text', if: { arg: 'mutuallyExclusiveA', truthy: false } },
     colorMode: {
       control: 'boolean',
     },
     dynamicText: {
-      removeIf: 'colorMode',
+      if: { arg: 'colorMode', truthy: false },
       control: 'text',
     },
     dynamicColor: {
-      addIf: 'colorMode',
+      if: { arg: 'colorMode' },
       control: 'color',
     },
     advanced: {
@@ -46,19 +46,22 @@ export default {
     },
     margin: {
       control: 'number',
-      addIf: 'advanced',
+      if: { arg: 'advanced' },
     },
     padding: {
       control: 'number',
-      addIf: 'advanced',
+      if: { arg: 'advanced' },
     },
     cornerRadius: {
       control: 'number',
-      addIf: 'advanced',
+      if: { arg: 'advanced' },
     },
     someText: { control: 'text' },
-    subText: { control: 'text', addIf: 'someText' },
-    anotherText: { control: 'text', addIf: 'someText' },
+    subText: { control: 'text', if: { arg: 'someText' } },
+    ifThemeExists: { control: 'text', if: { global: 'theme' } },
+    ifThemeNotExists: { control: 'text', if: { global: 'theme', exists: false } },
+    ifLightTheme: { control: 'text', if: { global: 'theme', eq: 'light' } },
+    ifNotLightTheme: { control: 'text', if: { global: 'theme', neq: 'light' } },
   },
   parameters: {
     chromatic: { disable: true },

--- a/lib/addons/package.json
+++ b/lib/addons/package.json
@@ -44,7 +44,7 @@
     "@storybook/channels": "6.5.0-alpha.55",
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/router": "6.5.0-alpha.55",
     "@storybook/theming": "6.5.0-alpha.55",
     "@types/webpack-env": "^1.16.0",

--- a/lib/api/package.json
+++ b/lib/api/package.json
@@ -41,7 +41,7 @@
     "@storybook/channels": "6.5.0-alpha.55",
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/router": "6.5.0-alpha.55",
     "@storybook/semver": "^7.3.2",
     "@storybook/theming": "6.5.0-alpha.55",

--- a/lib/api/src/index.tsx
+++ b/lib/api/src/index.tsx
@@ -11,6 +11,7 @@ import React, {
   useRef,
 } from 'react';
 import mergeWith from 'lodash/mergeWith';
+import { Conditional } from '@storybook/csf';
 
 import {
   STORY_CHANGED,
@@ -117,8 +118,7 @@ export interface ArgType {
   name?: string;
   description?: string;
   defaultValue?: any;
-  addIf?: string;
-  removeIf?: string;
+  if?: Conditional;
   [key: string]: any;
 }
 

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -45,7 +45,7 @@
     "@storybook/channels": "6.5.0-alpha.55",
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/store": "6.5.0-alpha.55",
     "@types/qs": "^6.9.5",
     "@types/webpack-env": "^1.16.0",

--- a/lib/codemod/package.json
+++ b/lib/codemod/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/types": "^7.12.11",
     "@mdx-js/mdx": "^1.6.22",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/csf-tools": "6.5.0-alpha.55",
     "@storybook/node-logger": "6.5.0-alpha.55",
     "core-js": "^3.8.2",

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@storybook/client-logger": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/theming": "6.5.0-alpha.55",
     "core-js": "^3.8.2",
     "regenerator-runtime": "^0.13.7"

--- a/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
+++ b/lib/components/src/blocks/ArgsTable/ArgsTable.tsx
@@ -6,7 +6,7 @@ import { includeConditionalArg } from '@storybook/csf';
 import { Icons } from '../../icon/icon';
 import { ArgRow } from './ArgRow';
 import { SectionRow } from './SectionRow';
-import { ArgType, ArgTypes, Args } from './types';
+import { ArgType, ArgTypes, Args, Globals } from './types';
 import { EmptyBlock } from '../EmptyBlock';
 import { Link } from '../../typography/link/link';
 import { ResetWrapper } from '../../typography/ResetWrapper';
@@ -271,6 +271,7 @@ export interface ArgsTableOptionProps {
 export interface ArgsTableDataProps {
   rows: ArgTypes;
   args?: Args;
+  globals?: Globals;
 }
 
 export interface ArgsTableErrorProps {
@@ -396,10 +397,13 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     sort = 'none',
   } = props;
   const isLoading = 'isLoading' in props;
-  const { rows, args } = 'rows' in props ? props : argsTableLoadingData;
+  const { rows, args, globals } = 'rows' in props ? props : argsTableLoadingData;
 
   const groups = groupRows(
-    pickBy(rows, (row) => !row?.table?.disable && includeConditionalArg(row, args)),
+    pickBy(
+      rows,
+      (row) => !row?.table?.disable && includeConditionalArg(row, args || {}, globals || {})
+    ),
     sort
   );
 

--- a/lib/components/src/blocks/ArgsTable/types.ts
+++ b/lib/components/src/blocks/ArgsTable/types.ts
@@ -1,3 +1,5 @@
+import type { Conditional } from '@storybook/csf';
+
 export interface JsDocParam {
   name: string;
   description?: string;
@@ -32,8 +34,7 @@ export interface ArgType {
   name?: string;
   description?: string;
   defaultValue?: any;
-  addIf?: string;
-  removeIf?: string;
+  if?: Conditional;
   [key: string]: any;
 }
 
@@ -44,3 +45,5 @@ export interface ArgTypes {
 export interface Args {
   [key: string]: any;
 }
+
+export type Globals = { [name: string]: any };

--- a/lib/core-client/package.json
+++ b/lib/core-client/package.json
@@ -46,7 +46,7 @@
     "@storybook/client-api": "6.5.0-alpha.55",
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/preview-web": "6.5.0-alpha.55",
     "@storybook/store": "6.5.0-alpha.55",
     "@storybook/ui": "6.5.0-alpha.55",

--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -44,7 +44,7 @@
     "@storybook/core-client": "6.5.0-alpha.55",
     "@storybook/core-common": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/csf-tools": "6.5.0-alpha.55",
     "@storybook/manager-webpack4": "6.5.0-alpha.55",
     "@storybook/node-logger": "6.5.0-alpha.55",

--- a/lib/csf-tools/package.json
+++ b/lib/csf-tools/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-env": "^7.12.11",
     "@babel/traverse": "^7.12.11",
     "@babel/types": "^7.12.11",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/mdx1-csf": "canary",
     "core-js": "^3.8.2",
     "fs-extra": "^9.0.1",

--- a/lib/docs-tools/package.json
+++ b/lib/docs-tools/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.10",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/store": "6.5.0-alpha.55",
     "core-js": "^3.8.2",
     "doctrine": "^3.0.0",

--- a/lib/preview-web/package.json
+++ b/lib/preview-web/package.json
@@ -44,7 +44,7 @@
     "@storybook/channel-postmessage": "6.5.0-alpha.55",
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "@storybook/store": "6.5.0-alpha.55",
     "ansi-to-html": "^0.6.11",
     "core-js": "^3.8.2",

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@storybook/addons": "6.5.0-alpha.55",
     "@storybook/client-logger": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "global": "^4.4.0",

--- a/lib/store/package.json
+++ b/lib/store/package.json
@@ -43,7 +43,7 @@
     "@storybook/addons": "6.5.0-alpha.55",
     "@storybook/client-logger": "6.5.0-alpha.55",
     "@storybook/core-events": "6.5.0-alpha.55",
-    "@storybook/csf": "0.0.2--canary.507502b.0",
+    "@storybook/csf": "0.0.2--canary.7c6c115.0",
     "core-js": "^3.8.2",
     "fast-deep-equal": "^3.1.3",
     "global": "^4.4.0",

--- a/lib/store/src/csf/prepareStory.test.ts
+++ b/lib/store/src/csf/prepareStory.test.ts
@@ -511,7 +511,7 @@ describe('prepareStory', () => {
           id,
           name,
           args: { a: 1, b: 2 },
-          argTypes: { b: { name: 'b', removeIf: 'a' } },
+          argTypes: { b: { name: 'b', if: { arg: 'a', truthy: false } } },
         },
         { id, title },
         { render: renderMock }

--- a/lib/store/src/csf/prepareStory.ts
+++ b/lib/store/src/csf/prepareStory.ts
@@ -169,7 +169,7 @@ export function prepareStory<TFramework extends AnyFramework>(
 
     const includedArgs = Object.entries(mappedArgs).reduce((acc, [key, val]) => {
       const argType = context.argTypes[key] || {};
-      if (includeConditionalArg(argType, mappedArgs)) acc[key] = val;
+      if (includeConditionalArg(argType, mappedArgs, context.globals)) acc[key] = val;
       return acc;
     }, {} as Args);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6185,7 +6185,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/components": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/theming": 6.5.0-alpha.55
     "@testing-library/react": ^11.2.2
     "@types/webpack-env": ^1.16.0
@@ -6253,7 +6253,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/components": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/theming": 6.5.0-alpha.55
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -6282,7 +6282,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/components": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/node-logger": 6.5.0-alpha.55
     "@storybook/store": 6.5.0-alpha.55
     "@storybook/theming": 6.5.0-alpha.55
@@ -6314,7 +6314,7 @@ __metadata:
     "@storybook/components": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/docs-tools": 6.5.0-alpha.55
     "@storybook/mdx1-csf": canary
     "@storybook/mdx2-csf": canary
@@ -6495,7 +6495,7 @@ __metadata:
     "@storybook/addons": 6.5.0-alpha.55
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/router": 6.5.0-alpha.55
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
@@ -6525,7 +6525,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/components": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -6549,7 +6549,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/components": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -6584,7 +6584,7 @@ __metadata:
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": ^4.2.0
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/node-logger": 6.5.0-alpha.55
     "@types/jest-image-snapshot": ^4.1.3
     "@types/puppeteer": ^5.4.0
@@ -6615,7 +6615,7 @@ __metadata:
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-client": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/react": 6.5.0-alpha.55
     "@storybook/vue": 6.5.0-alpha.55
     "@storybook/vue3": 6.5.0-alpha.55
@@ -6777,7 +6777,7 @@ __metadata:
     "@storybook/channels": 6.5.0-alpha.55
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/router": 6.5.0-alpha.55
     "@storybook/theming": 6.5.0-alpha.55
     "@types/webpack-env": ^1.16.0
@@ -6834,7 +6834,7 @@ __metadata:
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/docs-tools": 6.5.0-alpha.55
     "@storybook/node-logger": 6.5.0-alpha.55
     "@storybook/semver": ^7.3.2
@@ -6907,7 +6907,7 @@ __metadata:
     "@storybook/channels": 6.5.0-alpha.55
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/router": 6.5.0-alpha.55
     "@storybook/semver": ^7.3.2
     "@storybook/theming": 6.5.0-alpha.55
@@ -7192,7 +7192,7 @@ __metadata:
     "@storybook/channels": 6.5.0-alpha.55
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/store": 6.5.0-alpha.55
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
@@ -7248,7 +7248,7 @@ __metadata:
   dependencies:
     "@babel/types": ^7.12.11
     "@mdx-js/mdx": ^1.6.22
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/csf-tools": 6.5.0-alpha.55
     "@storybook/node-logger": 6.5.0-alpha.55
     core-js: ^3.8.2
@@ -7270,7 +7270,7 @@ __metadata:
   dependencies:
     "@popperjs/core": ^2.6.0
     "@storybook/client-logger": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/theming": 6.5.0-alpha.55
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
@@ -7329,7 +7329,7 @@ __metadata:
     "@storybook/client-api": 6.5.0-alpha.55
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/preview-web": 6.5.0-alpha.55
     "@storybook/store": 6.5.0-alpha.55
     "@storybook/ui": 6.5.0-alpha.55
@@ -7449,7 +7449,7 @@ __metadata:
     "@storybook/core-client": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/csf-tools": 6.5.0-alpha.55
     "@storybook/manager-webpack4": 6.5.0-alpha.55
     "@storybook/node-logger": 6.5.0-alpha.55
@@ -7537,7 +7537,7 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/traverse": ^7.12.11
     "@babel/types": ^7.12.11
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/mdx1-csf": canary
     "@storybook/mdx2-csf": canary
     "@types/fs-extra": ^9.0.6
@@ -7561,6 +7561,15 @@ __metadata:
   dependencies:
     lodash: ^4.17.15
   checksum: 1d48f1d320a6dbbdc7932943ffdba51783a16d86ea870a7c1b4438978fc8a6bd0600399cf748bcdf295f7fcd8ac80b62c6aebc1c68aac9ffe30ba8f3fbbf8f13
+  languageName: node
+  linkType: hard
+
+"@storybook/csf@npm:0.0.2--canary.7c6c115.0":
+  version: 0.0.2--canary.7c6c115.0
+  resolution: "@storybook/csf@npm:0.0.2--canary.7c6c115.0"
+  dependencies:
+    lodash: ^4.17.15
+  checksum: 85a179664d18eeca8462c1b6ff36f9b68b856c9f9c5143aa6f19b17e4cc97bc08ed69921a5287a61d8c90f61366ff6a5ab89930d158402e7c04d07a3ffaad8bb
   languageName: node
   linkType: hard
 
@@ -7610,7 +7619,7 @@ __metadata:
   resolution: "@storybook/docs-tools@workspace:lib/docs-tools"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/store": 6.5.0-alpha.55
     core-js: ^3.8.2
     doctrine: ^3.0.0
@@ -7733,7 +7742,7 @@ __metadata:
     "@storybook/addons": 6.5.0-alpha.55
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/docs-tools": 6.5.0-alpha.55
     "@storybook/preview-web": 6.5.0-alpha.55
     "@storybook/store": 6.5.0-alpha.55
@@ -8001,7 +8010,7 @@ __metadata:
     "@storybook/addons": 6.5.0-alpha.55
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/store": 6.5.0-alpha.55
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/webpack-env": ^1.16.0
@@ -8063,7 +8072,7 @@ __metadata:
     "@storybook/channel-postmessage": 6.5.0-alpha.55
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/store": 6.5.0-alpha.55
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
@@ -8110,7 +8119,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/docs-tools": 6.5.0-alpha.55
     "@storybook/node-logger": 6.5.0-alpha.55
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0
@@ -8479,7 +8488,7 @@ __metadata:
     "@storybook/client-api": 6.5.0-alpha.55
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/node-logger": 6.5.0-alpha.55
     "@storybook/preview-web": 6.5.0-alpha.55
     "@storybook/store": 6.5.0-alpha.55
@@ -8509,7 +8518,7 @@ __metadata:
   dependencies:
     "@storybook/addons": 6.5.0-alpha.55
     "@storybook/client-logger": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     core-js: ^3.8.2
     estraverse: ^5.2.0
     global: ^4.4.0
@@ -8530,7 +8539,7 @@ __metadata:
     "@storybook/addons": 6.5.0-alpha.55
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core-events": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -8556,7 +8565,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/docs-tools": 6.5.0-alpha.55
     "@storybook/node-logger": 6.5.0-alpha.55
     "@storybook/store": 6.5.0-alpha.55
@@ -8721,7 +8730,7 @@ __metadata:
     "@storybook/addons": 6.5.0-alpha.55
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/docs-tools": 6.5.0-alpha.55
     "@storybook/store": 6.5.0-alpha.55
     "@types/node": ^14.14.20 || ^16.0.0
@@ -8760,7 +8769,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/docs-tools": 6.5.0-alpha.55
     "@storybook/store": 6.5.0-alpha.55
     "@types/node": ^14.14.20 || ^16.0.0
@@ -8805,7 +8814,7 @@ __metadata:
     "@storybook/client-logger": 6.5.0-alpha.55
     "@storybook/core": 6.5.0-alpha.55
     "@storybook/core-common": 6.5.0-alpha.55
-    "@storybook/csf": 0.0.2--canary.507502b.0
+    "@storybook/csf": 0.0.2--canary.7c6c115.0
     "@storybook/docs-tools": 6.5.0-alpha.55
     "@storybook/preview-web": 6.5.0-alpha.55
     "@storybook/store": 6.5.0-alpha.55


### PR DESCRIPTION
Issue: #11984

## What I did

Redid #17536 to include globals, query objects based on community feedback in #11984

Here's the new version:

```js
argTypes: {
  field1: { if: { arg: 'foo' } }, // truthy: true
  field1: { if: { arg: 'foo', truthy: true } },
  field1: { if: { arg: 'foo', truthy: false } },
  field3: { if: { arg: 'foo', exists: true } },
  field3: { if: { arg: 'foo', exists: false } },
  field4: { if: { arg: 'foo', eq: 'bar' } },
  field5: { if: { arg: 'foo', neq: 'bar' } },
  field6: { if: { global: 'theme', eq: 'dark' } },
  field7: { if: { arg: 'foo', global: 'foo' } }, // => ERROR
  field8: { if: { } }, // => ERROR
  field8: { if: { arg: 'foo', eq: 'foo', exists: true } }, // => ERROR
}
```

The query object must contain either an `arg` or `global` target:

| field  | type   | meaning                       |
| ------ | ------ | ----------------------------- |
| arg    | string | The ID of the arg to test.    |
| global | string | The ID of the global to test. |

It may also contain at most one of the following operators:

| operator | type    | meaning                                              |
| -------- | ------- | ---------------------------------------------------- |
| truthy   | boolean | Is the target value truthy?                          |
| exists   | boolean | Is the target value defined?                         |
| eq       | any     | Is the target value equal to the provided value?     |
| neq      | any     | Is the target value NOT equal to the provided value? |

If no operator is provided, that is equivalent to `{ truthy: true }`.

## How to test

See updated stories. Most of the tests are in the CSF PR https://github.com/ComponentDriven/csf/pull/36