### PR TITLE
CLI: Upgrade vue3 template to use webpack5 builder

### DIFF
--- a/lib/cli/src/generators/VUE3/index.ts
+++ b/lib/cli/src/generators/VUE3/index.ts
@@ -1,7 +1,10 @@
 import { baseGenerator, Generator } from '../baseGenerator';
+import { CoreBuilder } from '../../project_types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'vue3', {
+  const updatedOptions = { ...options, builder: CoreBuilder.Webpack5 };
+
+  baseGenerator(packageManager, npmOptions, updatedOptions, 'vue3', {
     extraPackages: ['vue-loader@^16.0.0'],
   });
 };


### PR DESCRIPTION
Issue: N/A CI is failing due to `sb init` errors on vue3 project

## What I did

- [x] Add webpack5 builder to CLI template
- [ ] Add version detection for webpack to conditionally trigger it

@ndelangen can we figure out the second step together? I think this change will break users running `sb init` on older projects.

## How to test

- [ ] CI passes
