### PR TITLE
Exclude @storybook/builder-vite from verdaccio

### DIFF
--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -75,6 +75,10 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
+  '@storybook/builder-vite':
+    access: $all
+    publish: $all
+    proxy: npmjs
 
   # storybook packages are NOT proxied to global registry
   # allowing us to republish any version during tests


### PR DESCRIPTION
Issue:

## What I did

I believe this will fix the failing test in https://github.com/storybookjs/storybook/pull/17871, which was having problems because it was trying to get the version information of `@storybook/builder-vite` from the local verdaccio server instead of npm.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
