### PR TITLE
docs: Fix reference to essentials configuration 

### DIFF
--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -32,7 +32,7 @@ Update your Storybook configuration (in [`.storybook/main.js`](../configure/over
 
 <CodeSnippets
   paths={[
-    'common/storybook-main-register-individual-actions-addon.js.mdx',
+    'common/storybook-main-register-essentials-addon.js.mdx',
   ]}
 />
 

--- a/docs/snippets/common/storybook-main-register-essentials-addon.js.mdx
+++ b/docs/snippets/common/storybook-main-register-essentials-addon.js.mdx
@@ -1,0 +1,7 @@
+```js
+// .storybook/main.js
+
+module.exports = {
+  addons: ['@storybook/addon-essentials'],
+};
+```

--- a/docs/snippets/common/storybook-main-register-essentials-addon.js.mdx
+++ b/docs/snippets/common/storybook-main-register-essentials-addon.js.mdx
@@ -2,6 +2,7 @@
 // .storybook/main.js
 
 module.exports = {
-  addons: ['@storybook/addon-essentials'],
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
 };
 ```


### PR DESCRIPTION
Issue:

## What I did
The documentation for the essentials addon was showing the configuration example for the actions addon. I updated it to actually show adding the essentials addon.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
