### PR TITLE
UI: Fix canvas as initialActive for fullscreen mode in mobile

### DIFF
--- a/lib/ui/src/components/layout/mobile.stories.tsx
+++ b/lib/ui/src/components/layout/mobile.stories.tsx
@@ -33,6 +33,13 @@ export const InitialAddons = ({ props }: { props: MobileProps }) => (
   <Mobile {...props} options={{ ...props.options, initialActive: ActiveTabs.ADDONS }} />
 );
 
+export const Fullscreen = ({ props }: { props: MobileProps }) => (
+  <Mobile
+    {...props}
+    options={{ ...props.options, initialActive: ActiveTabs.SIDEBAR, isFullscreen: true }}
+  />
+);
+
 export const DocsOnly = ({ props }: { props: MobileProps }) => <Mobile {...props} docsOnly />;
 
 export const Page = ({ props }: { props: MobileProps }) => (

--- a/lib/ui/src/components/layout/mobile.tsx
+++ b/lib/ui/src/components/layout/mobile.tsx
@@ -132,6 +132,7 @@ export interface MobileProps {
   options: {
     initialActive: ActiveTabsType;
     isToolshown: boolean;
+    isFullscreen: boolean;
   };
   Sidebar: ComponentType<any>;
   Preview: ComponentType<any>;
@@ -152,7 +153,7 @@ class Mobile extends Component<MobileProps, MobileState> {
 
     const { options } = props;
     this.state = {
-      active: options.initialActive || SIDEBAR,
+      active: options.isFullscreen ? CANVAS : options.initialActive || SIDEBAR,
     };
   }
 


### PR DESCRIPTION
Issue:
If initialActive was configured to 'sidebar', it would cause the sidebar to show up in fullscreen mode within the mobile layout. 

## What I did

Check for isFullscreen when setting the initial active state within the Mobile component.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
