### PR TITLE
CLI: Add webpack4/5 detection

### DIFF
--- a/lib/cli/src/detect.ts
+++ b/lib/cli/src/detect.ts
@@ -112,7 +112,7 @@ export function detectBuilder(packageManager: JsPackageManager) {
     return CoreBuilder.Vite;
   }
 
-  const out = packageManager.executeCommand(packageManager.type, ['why']);
+  const out = packageManager.executeCommand(packageManager.type, ['why', 'webpack']);
 
   // if the user has BOTH webpack 4 and 5 installed already, we'll pick the safest options (4)
   if (out.includes('webpack@4') || out.includes('webpack@npm:4')) {

--- a/lib/cli/src/detect.ts
+++ b/lib/cli/src/detect.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import fs from 'fs';
 import findUp from 'find-up';
 
-import e from 'express';
 import {
   ProjectType,
   supportedTemplates,

--- a/lib/cli/src/detect.ts
+++ b/lib/cli/src/detect.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import findUp from 'find-up';
 
+import e from 'express';
 import {
   ProjectType,
   supportedTemplates,
@@ -112,16 +113,31 @@ export function detectBuilder(packageManager: JsPackageManager) {
     return CoreBuilder.Vite;
   }
 
-  const out = packageManager.executeCommand(packageManager.type, ['why', 'webpack']);
+  try {
+    let out = '';
+    if (packageManager.type === 'npm') {
+      try {
+        // npm <= v7
+        out = packageManager.executeCommand('npm', ['ls', 'webpack']);
+      } catch (e2) {
+        // npm >= v8
+        out = packageManager.executeCommand('npm', ['why', 'webpack']);
+      }
+    } else {
+      out = packageManager.executeCommand('yarn', ['why', 'webpack']);
+    }
 
-  // if the user has BOTH webpack 4 and 5 installed already, we'll pick the safest options (4)
-  if (out.includes('webpack@4') || out.includes('webpack@npm:4')) {
-    return CoreBuilder.Webpack5;
-  }
+    // if the user has BOTH webpack 4 and 5 installed already, we'll pick the safest options (4)
+    if (out.includes('webpack@4') || out.includes('webpack@npm:4')) {
+      return CoreBuilder.Webpack5;
+    }
 
-  // the user has webpack 4 installed, but not 5
-  if (out.includes('webpack@5') || out.includes('webpack@npm:5')) {
-    return CoreBuilder.Webpack5;
+    // the user has webpack 4 installed, but not 5
+    if (out.includes('webpack@5') || out.includes('webpack@npm:5')) {
+      return CoreBuilder.Webpack5;
+    }
+  } catch (err) {
+    //
   }
 
   // Fallback to webpack4

--- a/lib/cli/src/generators/VUE3/index.ts
+++ b/lib/cli/src/generators/VUE3/index.ts
@@ -1,10 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
-import { CoreBuilder } from '../../project_types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  const updatedOptions = { ...options, builder: CoreBuilder.Webpack5 };
-
-  baseGenerator(packageManager, npmOptions, updatedOptions, 'vue3', {
+  baseGenerator(packageManager, npmOptions, options, 'vue3', {
     extraPackages: ['vue-loader@^16.0.0'],
   });
 };

--- a/lib/cli/src/generators/baseGenerator.ts
+++ b/lib/cli/src/generators/baseGenerator.ts
@@ -49,7 +49,7 @@ const defaultOptions: FrameworkOptions = {
 const builderDependencies = (builder: Builder) => {
   switch (builder) {
     case CoreBuilder.Webpack4:
-      return [];
+      return ['@storybook/builder-webpack4', '@storybook/manager-webpack4'];
     case CoreBuilder.Webpack5:
       return ['@storybook/builder-webpack5', '@storybook/manager-webpack5'];
     case CoreBuilder.Vite:

--- a/lib/cli/src/initiate.ts
+++ b/lib/cli/src/initiate.ts
@@ -57,7 +57,7 @@ const installStorybook = (projectType: ProjectType, options: CommandOptions): Pr
 
   const generatorOptions = {
     language,
-    builder: options.builder || detectBuilder(),
+    builder: options.builder || detectBuilder(packageManager),
     linkable: !!options.linkable,
     commonJs: options.commonJs,
   };


### PR DESCRIPTION
## What I did

The CLI can now detect which version of webpack you are using. If it detects you have webpack version 4 installed anywhere, it will use builder-webpack4, if you do not, and you have webpack v5 installed instead, it will use builder-webpack5.

It will still default to use builder-webpack4 if it can't detect anything.

I also added the builder-webpack4 and manager-webpack4 in the case the builder is indeed webpack4. Seems like the right thing to do, if we don't want core-server to depend on any builder in particular.