### PR TITLE
CLI: Update the exclude list for upgrade warnings

### DIFF
--- a/lib/cli/src/upgrade.ts
+++ b/lib/cli/src/upgrade.ts
@@ -36,6 +36,12 @@ const excludeList = [
   '@storybook/addon-console',
   '@storybook/csf',
   '@storybook/storybook-deployer',
+  '@storybook/addon-postcss',
+  '@storybook/react-docgen-typescript-plugin',
+  '@storybook/babel-plugin-require-context-hook',
+  '@storybook/builder-vite',
+  '@storybook/mdx1-csf',
+  '@storybook/mdx2-csf',
 ];
 export const isCorePackage = (pkg: string) =>
   pkg.startsWith('@storybook/') &&


### PR DESCRIPTION
Issue: N/A

## What I did

`sb upgrade` warns on `@storybook/x` packages that are not up to the current version of `core`. This list has grown over time, so I added a few more new `@storybook/x` packages. Should improve this somehow in future releases!

Thanks @brendonco!

## How to test

N/A