### PR TITLE
Bump min vue-loader dependency version

### DIFF
--- a/app/vue3/package.json
+++ b/app/vue3/package.json
@@ -63,7 +63,7 @@
     "ts-loader": "^8.0.14",
     "vue-docgen-api": "^4.44.15",
     "vue-docgen-loader": "^1.5.0",
-    "vue-loader": "^16.0.0",
+    "vue-loader": "^16.4.1",
     "webpack": ">=4.0.0 <6.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8872,7 +8872,7 @@ __metadata:
     vue: 3.0.0
     vue-docgen-api: ^4.44.15
     vue-docgen-loader: ^1.5.0
-    vue-loader: ^16.0.0
+    vue-loader: ^16.4.1
     webpack: 4
   peerDependencies:
     "@babel/core": "*"
@@ -45752,7 +45752,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-loader-v16@npm:vue-loader@^16.1.0, vue-loader@npm:^16.0.0, vue-loader@npm:^16.1.2":
+"vue-loader-v16@npm:vue-loader@^16.1.0, vue-loader@npm:^16.1.2, vue-loader@npm:^16.4.1":
   version: 16.8.3
   resolution: "vue-loader@npm:16.8.3"
   dependencies:


### PR DESCRIPTION
Issue:

## What I did

After https://github.com/storybookjs/storybook/pull/17834, it's possible that the vue project will use webpack 5, but versions of vue-loader earlier than https://github.com/vuejs/vue-loader/releases/tag/v16.4.1 will fail, as seen in https://github.com/storybookjs/builder-vite/pull/320#issuecomment-1091063983.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

I checked this by setting `resolutions` in my yarn.lock to force vue-loader 16.4.1, and my error was resolved.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
