### PR TITLE
Core: Followup changing CJS entrypoints to ESM

### DIFF
--- a/addons/links/react.js
+++ b/addons/links/react.js
@@ -1,1 +1,3 @@
-module.exports = require('./dist/esm/react');
+import LinkTo from './dist/esm/react';
+
+export default LinkTo;

--- a/lib/components/html.js
+++ b/lib/components/html.js
@@ -1,1 +1,2 @@
-module.exports = require('./dist/esm/html');
+// eslint-disable-next-line import/no-unresolved
+export * from './dist/esm/html';

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -1,3 +1,2 @@
 // @storybook/core was split into core-client and core-server.  This file is for backwards-compat.
-// TODO: remove in 7.0
-module.exports = require('./dist/esm/index');
+export * from './dist/esm/index';

--- a/lib/router/utils.js
+++ b/lib/router/utils.js
@@ -1,1 +1,2 @@
-module.exports = require('./dist/esm/utils');
+// eslint-disable-next-line import/no-unresolved
+export * from './dist/esm/utils';

--- a/lib/theming/create.js
+++ b/lib/theming/create.js
@@ -1,1 +1,2 @@
-module.exports = require('./dist/esm/create');
+// eslint-disable-next-line import/no-unresolved
+export * from './dist/esm/create';


### PR DESCRIPTION
Following up on https://github.com/storybookjs/storybook/pull/17868 -- rather than importing the ESM files, we also need to actually write ESM code! Thanks @IanVS 

I would also be OK with just reverting the original PR and removing all these files in 7.0 (three of the 5 files don't work already, as noted below, anyway).

Now that https://github.com/storybookjs/storybook/pull/17875 has gone out, there is less obvious need for this change.