### PR TITLE
Export `createCache` from `@storybook/theming`

### DIFF
--- a/lib/theming/package.json
+++ b/lib/theming/package.json
@@ -45,6 +45,7 @@
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
+    "@emotion/cache": "^11.7.1",
     "@emotion/is-prop-valid": "^1.1.2",
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",

--- a/lib/theming/src/index.ts
+++ b/lib/theming/src/index.ts
@@ -27,6 +27,7 @@ export const styled = emotionStyled as CreateStyled<Theme>;
 export * from './base';
 export * from './types';
 
+export { default as createCache } from '@emotion/cache';
 export { default as isPropValid } from '@emotion/is-prop-valid';
 
 export { createGlobal, createReset } from './global';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8773,6 +8773,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/theming@workspace:lib/theming"
   dependencies:
+    "@emotion/cache": ^11.7.1
     "@emotion/is-prop-valid": ^1.1.2
     "@emotion/react": ^11.8.1
     "@emotion/styled": ^11.8.1


### PR DESCRIPTION
Since you bundle Emotion stuff at the moment - it's probably best to export this from here (it's already bundled anyway since it's used internally by Emotion). This will allow other consuming projects (such as Chromatic) to reuse the bundled `createCache` without having to add dependency on `@emotion/cache` and thus duplicating its code.