### PR TITLE
Svelte: Fix webpack5/babelModeV7

### DIFF
--- a/app/svelte/src/server/framework-preset-svelte.ts
+++ b/app/svelte/src/server/framework-preset-svelte.ts
@@ -1,6 +1,7 @@
 import { findDistEsm } from '@storybook/core-common';
 import type { Options, StorybookConfig } from '@storybook/core-common';
 import type { Configuration } from 'webpack';
+import type { TransformOptions } from '@babel/core';
 
 export async function webpack(config: Configuration, options: Options): Promise<Configuration> {
   const { preprocess = undefined, loader = {} } = await options.presets.apply(
@@ -30,6 +31,14 @@ export async function webpack(config: Configuration, options: Options): Promise<
       alias: config.resolve.alias,
       mainFields: ['svelte', ...mainFields],
     },
+  };
+}
+
+export async function babelDefault(config: TransformOptions): Promise<TransformOptions> {
+  return {
+    ...config,
+    presets: [...(config?.presets || [])],
+    plugins: [...(config?.plugins || [])],
   };
 }
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17914

## What I did

Providing defaults for babel to fix a bug related to babelModeV7 in combination with Svelte

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
