### PR TITLE
fix: Support react-dom/client dom hack on Windows machines

### DIFF
--- a/app/react/src/server/framework-preset-react-dom-hack.ts
+++ b/app/react/src/server/framework-preset-react-dom-hack.ts
@@ -15,7 +15,7 @@ export async function webpackFinal(config: Configuration) {
         ? null
         : new IgnorePlugin({
             resourceRegExp: /react-dom\/client$/,
-            contextRegExp: /(app\/react|@storybook\/react)/, // TODO this needs to work for both in our MONOREPO and in the user's NODE_MODULES
+            contextRegExp: /(app\/react|app\\react|@storybook\/react|@storybook\\react)/, // TODO this needs to work for both in our MONOREPO and in the user's NODE_MODULES
           }),
     ].filter(Boolean),
   };


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17926

## What I did

Support react-dom/client hack for React < 18 on Windows machines.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
