### PR TITLE
Run `prebundle` script without `browser: true` in Rollup config

### DIFF
--- a/scripts/bundle-package.ts
+++ b/scripts/bundle-package.ts
@@ -28,7 +28,6 @@ async function build(options: Options) {
     external: externals,
     plugins: [
       nodeResolve({
-        browser: true,
         preferBuiltins: true,
       }),
       commonjs(),


### PR DESCRIPTION
This is a tricky PR - but ultimately I think it's for the better. The problem is that there is a chance that you might want to use `browser: true` for some packages but not for some other ones (like Emotion). There is no way to control this per-package though and since you don't control the consuming environment, you can't assume that it's going to be a browser - so, in a way, this setting was used incorrectly here.

However, there is some chance that not using it might break something - it's quite hard to test it though unless you already know what it might break or if automated tests (or manual smoke tests) show the problem.