### PR TITLE
Fix typo in Annotation section

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -197,7 +197,7 @@ As shown above, you can configure individual controls with the “control" annot
 |             | `select`       | Provides a drop-down list component to handle single value selection. `argTypes: { age: { control: 'select', options: [20, 30, 40, 50] }}`                                                                                 |
 |             | `multi-select` | Provides a drop-down list that allows multiple selected values. `argTypes: { countries: { control: 'multi-select', options: ['USA', 'Canada', 'Mexico'] }}`                                                                |
 | **string**  | `text`         | Provides a freeform text input. <br/> `argTypes: { label: { control: 'text' }}`                                                                                                                                            |
-|             | `color`        | Provides a color picker component to handle color values.<br/> Can be additionally configured to include a set of color presets.<br/> `argTypes: { color: { control: { type: 'color', presetsColors: ['red', 'green']} }}` |
+|             | `color`        | Provides a color picker component to handle color values.<br/> Can be additionally configured to include a set of color presets.<br/> `argTypes: { color: { control: { type: 'color', presetColors: ['red', 'green']} }}` |
 |             | `date`         | Provides a datepicker component to handle date selection. `argTypes: { startDate: { control: 'date' }}`                                                                                                                    |
 
 <div class="aside">


### PR DESCRIPTION
Issue: `presetsColors` does not work as a prop for the color control

## What I did

In the Annotation section, the 'color' description says you can add color presets. This is listed as a `presetsColors` in the controls, but I tried to use this in my project and it doesn't work. I think this is a typo for `presetColors` (this spelling _does_ work for me locally).

TLDR; change `presetsColors` -> `presetColors`

## How to test

Using the [Annotations](https://storybook.js.org/docs/react/essentials/controls#annotation) section of the Controls guide, 
- Create a color control 
- Give the control several color presets
- Set a default value

To replicate my setup:
```
iconColor: {
    control: { type: 'color', presetsColors: ['tan', 'paleturquoise', 'white'] },
    defaultValue: 'black',
}
```

Verify that this does not work—only the default value color is displayed with the color picker:

<img width="501" alt="presetsColors" src="https://user-images.githubusercontent.com/86622050/163253389-c2773ba8-d17b-46f7-914a-c10460097fc7.png">

Change presetsColors to presetColors and verify that the preset colors are now displayed with the color picker:

<img width="498" alt="presetColors" src="https://user-images.githubusercontent.com/86622050/163253609-1d246e3f-017c-49ce-bd50-51c4286420cf.png">
