### PR TITLE
Theming: Re-export correct bundled file

### DIFF
--- a/lib/theming/create.js
+++ b/lib/theming/create.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/no-unresolved
-export * from './dist/esm/create';
+export * from './dist/esm';

--- a/lib/theming/create.js
+++ b/lib/theming/create.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-unresolved
 export * from './dist/esm';


### PR DESCRIPTION
Issue:

This might fix https://github.com/storybookjs/storybook/issues/17916.

When trying to use `@storybook/theming` with the latest storybook 6.5.0-alpha.62, in the mealdrop repo, I got errors like:

```
ERROR in ./node_modules/@storybook/theming/create.js 2:0-34
Module not found: Error: Can't resolve './dist/esm/create' in '/Users/ianvs/code/storybook-benchmarks/mealdrop/node_modules/@storybook/theming'
resolve './dist/esm/create' in '/Users/ianvs/code/storybook-benchmarks/mealdrop/node_modules/@storybook/theming'
```

## What I did

I found that `@storybook/theming/create.js` tries to re-export from `./dist/esm/create`, which no longer exists (after https://github.com/storybookjs/storybook/pull/17000, I think).  So, I changed the path to just `./dist/esm`, and found that this indeed solves my error.

cc/ @yannbf, since it looks like you might have hit this as well, in https://github.com/yannbf/mealdrop/commit/c973a5562b667fd6b047ef9a479544596e7b6775, since you renamed the manager file, presumably to avoid the problem.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
