### PR TITLE
React: Fix React 18 react-dom/client dynamic import syntax

### DIFF
--- a/app/react/src/client/preview/render.tsx
+++ b/app/react/src/client/preview/render.tsx
@@ -72,9 +72,8 @@ const getReactRoot = async (el: Element): Promise<ReactRoot | null> => {
   let root = nodes.get(el);
 
   if (!root) {
-    // Skipping webpack's static analysis of import paths by defining the path value outside the import statement.
     // eslint-disable-next-line import/no-unresolved
-    const reactDomClient = await import('react-dom/client');
+    const reactDomClient = (await import('react-dom/client')).default;
     root = reactDomClient.createRoot(el);
 
     nodes.set(el, root);


### PR DESCRIPTION
Issue: https://github.com/storybookjs/builder-vite/issues/340

## What I did

Currently, the dynamic import of `react-dom/client` does not use the `.default`, as it should, since dynamic imports work like namespace imports (e.g. `import * as dep from 'library'`).  Perhaps webpack has a compat layer when dealing with commonjs files that is making this work as written, but it's more correct in terms of the es module spec to reference the default property from the module, I believe.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

This was passing the tests previously in the vite builder because rollup seems to hoist the default property up to the module, which maybe webpack is doing as well?  But, it fails in vite dev.  With this change, it passes.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
