### PR TITLE
fix(#16232): use a11y params > element properly

### DIFF
--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -36,8 +36,8 @@ const run = async (storyId: string) => {
       channel.emit(EVENTS.RUNNING);
       const axe = await import('axe-core');
 
-      const { element = 'root', config, options = {} } = input;
-      const htmlElement = document.querySelector(`#${element}`);
+      const { element = '#root', config, options = {} } = input;
+      const htmlElement = document.querySelector(element);
       axe.reset();
       if (config) {
         axe.configure(config);

--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -15,11 +15,6 @@ let active = false;
 // Holds latest story we requested a run
 let activeStoryId: string | undefined;
 
-const getElement = () => {
-  const storyRoot = document.getElementById('story-root');
-  return storyRoot ? storyRoot.childNodes : document.getElementById('root');
-};
-
 /**
  * Handle A11yContext events.
  * Because the event are sent without manual check, we split calls
@@ -41,13 +36,14 @@ const run = async (storyId: string) => {
       channel.emit(EVENTS.RUNNING);
       const axe = await import('axe-core');
 
-      const { element = getElement(), config, options = {} } = input;
+      const { element = 'root', config, options = {} } = input;
+      const htmlElement = document.getElementById(element);
       axe.reset();
       if (config) {
         axe.configure(config);
       }
 
-      const result = await axe.run(element, options);
+      const result = await axe.run(htmlElement, options);
       // It's possible that we requested a new run on a different story.
       // Unfortunately, axe doesn't support a cancel method to abort current run.
       // We check if the story we run against is still the current one,

--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -37,7 +37,7 @@ const run = async (storyId: string) => {
       const axe = await import('axe-core');
 
       const { element = 'root', config, options = {} } = input;
-      const htmlElement = document.querySelector(element);
+      const htmlElement = document.querySelector(`#${element}`);
       axe.reset();
       if (config) {
         axe.configure(config);

--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -37,7 +37,7 @@ const run = async (storyId: string) => {
       const axe = await import('axe-core');
 
       const { element = 'root', config, options = {} } = input;
-      const htmlElement = document.getElementById(element);
+      const htmlElement = document.querySelector(element);
       axe.reset();
       if (config) {
         axe.configure(config);

--- a/examples/official-storybook/stories/addon-a11y/parameters.stories.js
+++ b/examples/official-storybook/stories/addon-a11y/parameters.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import BaseButton from '../../components/BaseButton';
+
+export default {
+  title: 'Addons/A11y/Parameters',
+  component: BaseButton,
+  parameters: {
+    options: { selectedPanel: 'storybook/a11y/panel' },
+  },
+};
+
+export const ElementId = () => (
+  <>
+    <p>
+      The a11y story <strong>element</strong> parameter is set to the invalid contrast div only{' '}
+    </p>
+
+    <div id="no-text" style={{ border: '1px solid gray', padding: '1rem', marginBottom: '1rem' }}>
+      <h1>Missing text div</h1>
+      <p>The a11y issue on alt text should not appear as this is not scanned</p>
+      <BaseButton label="" />
+    </div>
+    <div id="invalid-contrast" style={{ border: '1px solid gray', padding: '1rem' }}>
+      <h1>Invalid contrast div</h1>
+      <p>The a11y issue on invalid contract should appear</p>
+      <BaseButton style={{ color: 'black', backgroundColor: 'black' }} label="Invalid contrast" />
+    </div>
+  </>
+);
+ElementId.parameters = {
+  a11y: {
+    element: 'invalid-contrast',
+  },
+};

--- a/examples/official-storybook/stories/addon-a11y/parameters.stories.js
+++ b/examples/official-storybook/stories/addon-a11y/parameters.stories.js
@@ -12,23 +12,27 @@ export default {
 export const ElementId = () => (
   <>
     <p>
-      The a11y story <strong>element</strong> parameter is set to the invalid contrast div only{' '}
+      The <code>a11y.element</code> parameter is set to the <strong>Insufficient contrast</strong>{' '}
+      section.{' '}
     </p>
 
     <div id="no-text" style={{ border: '1px solid gray', padding: '1rem', marginBottom: '1rem' }}>
-      <h1>Missing text div</h1>
-      <p>The a11y issue on alt text should not appear as this is not scanned</p>
+      <strong>No discernable button text</strong>
+      <p>This a11y violation should not be reported, as this section is not scanned.</p>
       <BaseButton label="" />
     </div>
-    <div id="invalid-contrast" style={{ border: '1px solid gray', padding: '1rem' }}>
-      <h1>Invalid contrast div</h1>
-      <p>The a11y issue on invalid contract should appear</p>
-      <BaseButton style={{ color: 'black', backgroundColor: 'black' }} label="Invalid contrast" />
+    <div id="insufficient-contrast" style={{ border: '1px solid gray', padding: '1rem' }}>
+      <strong>Insufficient contrast</strong>
+      <p>This a11y issue (incomplete) should be reported.</p>
+      <BaseButton
+        style={{ color: 'black', backgroundColor: 'black' }}
+        label="Insufficient contrast"
+      />
     </div>
   </>
 );
 ElementId.parameters = {
   a11y: {
-    element: 'invalid-contrast',
+    element: '#insufficient-contrast',
   },
 };


### PR DESCRIPTION
Issue: #16232

## What I did
The a11y param > element was not used properly. It is supposed to be an element id too serve as scan root, but the code takes it as the element itself.
Furthermore, if no element is passed in params, it queries a `#story-root` element first that comes from nowhere (no ref found in the repo) before taking `#root`.

I removed this unknown `#story-root` and take the `element` param properly as element id.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [x] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
Added a story about a11 parameters in official-storybook example

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
