### PR TITLE
Addon-a11y: fix axe-core import syntax for vite

### DIFF
--- a/addons/a11y/src/a11yRunner.ts
+++ b/addons/a11y/src/a11yRunner.ts
@@ -39,7 +39,7 @@ const run = async (storyId: string) => {
     if (!active) {
       active = true;
       channel.emit(EVENTS.RUNNING);
-      const axe = await import('axe-core');
+      const axe = (await import('axe-core')).default;
 
       const { element = getElement(), config, options = {} } = input;
       axe.reset();


### PR DESCRIPTION
Issue: #12622

`Axe-core` exposes a commonjs module equivalent to 
```javascript
const axe = {};
// a bunch of code adding functions in axe object

module.exports = axe;
```
Storybook with builder-vite wraps axe-core dynamic import and ends up with a module containing only default export.
```javascript
// axe-core module with vite
{
  default: { run, reset, ... }
}
```

Webpack has another behavior, and ends up with a module containing default and all the named export function.
```javascript
// axe-core module with vite
{
  default: { run, reset, ... },
  run,
  reset,
  ...
}
```

But `addon-a11y` imports `axe-core` and use it directly with `axe.run()` for example, consuming the named exports.
For storybook with vite, it fails as `axe.run()` doesn't exist, whereas `axe.default.run()` exists.

## What I did

In `addon-a11y`, consume axe default export as it is always available.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
