### PR TITLE
Angular: Add webpackStatsJson to angular-builder

### DIFF
--- a/app/angular/src/builders/build-storybook/index.spec.ts
+++ b/app/angular/src/builders/build-storybook/index.spec.ts
@@ -84,6 +84,7 @@ describe('Build Storybook Builder', () => {
       outputDir: 'storybook-static',
       mode: 'static',
       tsConfig: './storybook/tsconfig.ts',
+      webpackStatsJson: false,
     });
   });
 
@@ -109,6 +110,34 @@ describe('Build Storybook Builder', () => {
       outputDir: 'storybook-static',
       mode: 'static',
       tsConfig: 'path/to/tsConfig.json',
+      webpackStatsJson: false,
+    });
+  });
+
+  it('should build storybook with webpack stats.json', async () => {
+    const run = await architect.scheduleBuilder('@storybook/angular:build-storybook', {
+      tsConfig: 'path/to/tsConfig.json',
+      compodoc: false,
+      webpackStatsJson: true,
+    });
+
+    const output = await run.result;
+
+    await run.stop();
+
+    expect(output.success).toBeTruthy();
+    expect(cpSpawnMock.spawn).not.toHaveBeenCalledWith();
+    expect(buildStandaloneMock).toHaveBeenCalledWith({
+      angularBrowserTarget: null,
+      angularBuilderContext: expect.any(Object),
+      angularBuilderOptions: {},
+      configDir: '.storybook',
+      loglevel: undefined,
+      quiet: false,
+      outputDir: 'storybook-static',
+      mode: 'static',
+      tsConfig: 'path/to/tsConfig.json',
+      webpackStatsJson: true,
     });
   });
 
@@ -162,6 +191,7 @@ describe('Build Storybook Builder', () => {
       outputDir: 'storybook-static',
       mode: 'static',
       tsConfig: './storybook/tsconfig.ts',
+      webpackStatsJson: false,
     });
   });
 
@@ -188,6 +218,7 @@ describe('Build Storybook Builder', () => {
       outputDir: 'storybook-static',
       mode: 'static',
       tsConfig: 'path/to/tsConfig.json',
+      webpackStatsJson: false,
     });
   });
 });

--- a/app/angular/src/builders/build-storybook/index.ts
+++ b/app/angular/src/builders/build-storybook/index.ts
@@ -31,7 +31,7 @@ export type StorybookBuilderOptions = JsonObject & {
 } & Pick<
     // makes sure the option exists
     CLIOptions,
-    'outputDir' | 'configDir' | 'loglevel' | 'quiet' | 'docs'
+    'outputDir' | 'configDir' | 'loglevel' | 'quiet' | 'docs' | 'webpackStatsJson'
   >;
 
 export type StorybookBuilderOutput = JsonObject & BuilderOutput & {};
@@ -62,6 +62,7 @@ function commandBuilder(
         loglevel,
         outputDir,
         quiet,
+        webpackStatsJson,
       } = options;
 
       const standaloneOptions: StandaloneOptions = {
@@ -77,6 +78,7 @@ function commandBuilder(
           ...(styles ? { styles } : {}),
         },
         tsConfig,
+        webpackStatsJson,
       };
       return standaloneOptions;
     }),

--- a/app/angular/src/builders/build-storybook/schema.json
+++ b/app/angular/src/builders/build-storybook/schema.json
@@ -52,6 +52,11 @@
         "type": "string"
       }
     },
+    "webpackStatsJson": {
+      "type": "boolean",
+      "description": "Write Webpack Stats JSON to disk",
+      "default": false
+    },
     "styles": {
       "type": "array",
       "description": "Global styles to be included in the build.",


### PR DESCRIPTION
Issue:

## What I did

For Chromatic to work with Turbosnap, the cli option webpackStatsJson is required when building the static Storybook. This is currently not supported in the builder-schema. This PR fixes this

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

Updated the specs for the builder to verify default value (false), and that the cli-option is sent if it's provided in angular.json.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
