### PR TITLE
Remove errant `,` in example that causes compilation errors

### DIFF
--- a/docs/snippets/common/component-story-mdx-dedent.mdx.mdx
+++ b/docs/snippets/common/component-story-mdx-dedent.mdx.mdx
@@ -10,7 +10,7 @@ import dedent from 'ts-dedent';
 <Source
   language='css'
   dark
-  format={false},
+  format={false}
   code={dedent`
      .container {
        display: grid | inline-grid;


### PR DESCRIPTION
```
Error: Module build failed (from ../../node_modules/@mdx-js/loader/index.js):
SyntaxError: unknown: Unexpected token (195:16)

  193 |   language='css'
  194 |   dark
> 195 |   format={false},
      |                 ^
  196 |   code={`
  197 |      .container {
  198 |        display: grid | inline-grid;
```

Issue:

The example in "Working with MDX" on https://storybook.js.org/docs/react/writing-docs/doc-block-source has an errant `,` that causes a compilation error if copied/pasted in one's code.

## What I did

Remove errant `,` in example code.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
