### PR TITLE
[core-common] fix babel loader don't load user config

### DIFF
--- a/lib/core-common/src/utils/es6Transpiler.ts
+++ b/lib/core-common/src/utils/es6Transpiler.ts
@@ -48,6 +48,8 @@ export const es6Transpiler: () => RuleSetRule = () => {
         loader: require.resolve('babel-loader'),
         options: {
           sourceType: 'unambiguous',
+          babelrc: false,
+          configFile: false,
           presets: [
             [
               require.resolve('@babel/preset-env'),


### PR DESCRIPTION
## What I did

Prevent applying user config additional to this config. Found this while investigating warnings about loose mode being true and false in different configs.
Similar to https://github.com/storybookjs/storybook/pull/17979

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

<!--

If your answer is yes to any of these, please make sure to include it in your PR.

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
