### PR TITLE
Fixed PnP compatibility for bundled components package

### DIFF
--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -45,8 +45,10 @@
     "@storybook/theming": "6.5.0-beta.7",
     "@types/react-syntax-highlighter": "11.0.5",
     "core-js": "^3.8.2",
+    "qs": "^6.10.0",
     "react-syntax-highlighter": "^15.4.5",
-    "regenerator-runtime": "^0.13.7"
+    "regenerator-runtime": "^0.13.7",
+    "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@popperjs/core": "^2.6.0",
@@ -64,13 +66,11 @@
     "polished": "^4.2.2",
     "prettier": ">=2.2.1 <=2.3.0",
     "prop-types": "^15.7.2",
-    "qs": "^6.10.0",
     "react-colorful": "^5.1.2",
     "react-popper-tooltip": "^3.1.1",
     "react-textarea-autosize": "^8.3.0",
     "ts-dedent": "^2.0.0",
-    "ts-node": "^10.4.0",
-    "util-deprecate": "^1.0.2"
+    "ts-node": "^10.4.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/scripts/bundle-package.ts
+++ b/scripts/bundle-package.ts
@@ -21,11 +21,19 @@ interface Options {
   watch?: boolean;
 }
 
+const makeExternalPredicate = (externals: string[]) => {
+  if (externals.length === 0) {
+    return () => false;
+  }
+  const pattern = new RegExp(`^(${externals.join('|')})($|/)`);
+  return (id: string) => pattern.test(id);
+};
+
 async function build(options: Options) {
   const { input, externals, cwd, optimized } = options;
   const setting: RollupOptions = {
     input,
-    external: externals,
+    external: makeExternalPredicate(externals),
     plugins: [
       nodeResolve({
         preferBuiltins: true,


### PR DESCRIPTION
hopefully, fixes https://github.com/storybookjs/storybook/issues/17978 caused by regression from https://github.com/storybookjs/storybook/pull/17947

1. `util-deprecate` has `package.json#browser`
2. `qs` depends on `object-inspect` and that package has `package.json#browser`

We can't bundle anything that has an alias field like that, such packages should always be external to leave the aliased stuff untouched for the consumers so they can resolve this on their own, based on the consuming environment.

