### PR TITLE
Fix typo on last-of-type pseudo-class

### DIFF
--- a/lib/core-common/templates/base-preview-head.html
+++ b/lib/core-common/templates/base-preview-head.html
@@ -237,8 +237,8 @@
   .sb-argstableBlock td:nth-of-type(3) {
     width: 15%;
   }
-  .sb-argstableBlock th:laste-of-type,
-  .sb-argstableBlock td:laste-of-type {
+  .sb-argstableBlock th:last-of-type,
+  .sb-argstableBlock td:last-of-type {
     width: 25%;
     padding-right: 20px;
   }


### PR DESCRIPTION
Issue: Typo on pseudo-class name for last-of-type, its currently "laste-of-type"

## What I did

Fix typo on last-of-type pseudo-class

## How to test

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
