### PR TITLE
UI: Make panel position a persistent preference

### DIFF
--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -136,7 +136,7 @@ export const init: ModuleFn = ({ store, provider, singleStory }) => {
               panelPosition: position,
             },
           }),
-          { persistence: 'session' }
+          { persistence: 'permanent' }
         );
       }
 

--- a/lib/api/src/modules/layout.ts
+++ b/lib/api/src/modules/layout.ts
@@ -147,7 +147,7 @@ export const init: ModuleFn = ({ store, provider, singleStory }) => {
             panelPosition: state.layout.panelPosition === 'right' ? 'bottom' : 'right',
           },
         }),
-        { persistence: 'session' }
+        { persistence: 'permanent' }
       );
     },
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17938

## What I did

Made `layout.panelPosition` a `permanent` config

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
