### PR TITLE
Add missing () to code snippet

### DIFF
--- a/docs/snippets/common/storybook-main-using-existing-config.js.mdx
+++ b/docs/snippets/common/storybook-main-using-existing-config.js.mdx
@@ -6,7 +6,7 @@ const custom = require('../webpack.config.js');
 
 module.exports = {
   webpackFinal: async (config) => {
-    return { ...config, module: { ...config.module, rules: custom.module.rules } };
+    return { ...config, module: { ...config.module, rules: custom().module.rules } };
   },
 };
 ```


### PR DESCRIPTION
Issue:
Without the () after custom the code throws the error 
ERR! TypeError: Cannot read properties of undefined (reading 'rules')
## What I did
added ()
## How to test
add code snippet to main.js and run stroybook

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
