### PR TITLE
Core: Fix single-story hoisting regression for auto-title changes

### DIFF
--- a/lib/ui/src/components/sidebar/Tree.tsx
+++ b/lib/ui/src/components/sidebar/Tree.tsx
@@ -15,13 +15,7 @@ import {
 } from './TreeNode';
 import { useExpanded, ExpandAction, ExpandedState } from './useExpanded';
 import { Highlight, Item } from './types';
-import {
-  isStoryAndComponentNameEqual,
-  createId,
-  getAncestorIds,
-  getDescendantIds,
-  getLink,
-} from './utils';
+import { isStoryHoistable, createId, getAncestorIds, getDescendantIds, getLink } from './utils';
 
 export const Action = styled.button(({ theme }) => ({
   display: 'inline-flex',
@@ -343,7 +337,7 @@ export const Tree = React.memo<{
           isComponent &&
           children.length === 1 &&
           isStory(data[children[0]]) &&
-          isStoryAndComponentNameEqual(data[children[0]].name, name)
+          isStoryHoistable(data[children[0]].name, name)
         );
       });
     }, [data, orphansFirst]);

--- a/lib/ui/src/components/sidebar/Tree.tsx
+++ b/lib/ui/src/components/sidebar/Tree.tsx
@@ -15,7 +15,13 @@ import {
 } from './TreeNode';
 import { useExpanded, ExpandAction, ExpandedState } from './useExpanded';
 import { Highlight, Item } from './types';
-import { createId, getAncestorIds, getDescendantIds, getLink } from './utils';
+import {
+  isStoryAndComponentNameEqual,
+  createId,
+  getAncestorIds,
+  getDescendantIds,
+  getLink,
+} from './utils';
 
 export const Action = styled.button(({ theme }) => ({
   display: 'inline-flex',
@@ -331,12 +337,13 @@ export const Tree = React.memo<{
     const singleStoryComponentIds = useMemo(() => {
       return orphansFirst.filter((nodeId) => {
         const { children = [], isComponent, isLeaf, name } = data[nodeId];
+
         return (
           !isLeaf &&
           isComponent &&
           children.length === 1 &&
           isStory(data[children[0]]) &&
-          data[children[0]].name === name
+          isStoryAndComponentNameEqual(data[children[0]].name, name)
         );
       });
     }, [data, orphansFirst]);

--- a/lib/ui/src/components/sidebar/utils.test.js
+++ b/lib/ui/src/components/sidebar/utils.test.js
@@ -79,3 +79,18 @@ describe('getParents', () => {
     expect(output).toEqual([]);
   });
 });
+
+describe('areStoryNamesEqual', () => {
+  test('return true for matching Story and Component name', () => {
+    const output = utils.isStoryAndComponentNameEqual(
+      'Very_Long-Button Story Name',
+      'VeryLongButtonStoryName'
+    );
+    expect(output).toEqual(true);
+  });
+
+  test('return false for non-matching names', () => {
+    const output = utils.isStoryAndComponentNameEqual('Butto Story', 'ButtonStory');
+    expect(output).toEqual(false);
+  });
+});

--- a/lib/ui/src/components/sidebar/utils.test.js
+++ b/lib/ui/src/components/sidebar/utils.test.js
@@ -80,17 +80,14 @@ describe('getParents', () => {
   });
 });
 
-describe('areStoryNamesEqual', () => {
+describe('isStoryHoistable', () => {
   test('return true for matching Story and Component name', () => {
-    const output = utils.isStoryAndComponentNameEqual(
-      'Very_Long-Button Story Name',
-      'VeryLongButtonStoryName'
-    );
+    const output = utils.isStoryHoistable('Very_Long-Button Story Name', 'VeryLongButtonStoryName');
     expect(output).toEqual(true);
   });
 
   test('return false for non-matching names', () => {
-    const output = utils.isStoryAndComponentNameEqual('Butto Story', 'ButtonStory');
+    const output = utils.isStoryHoistable('Butto Story', 'ButtonStory');
     expect(output).toEqual(false);
   });
 });

--- a/lib/ui/src/components/sidebar/utils.ts
+++ b/lib/ui/src/components/sidebar/utils.ts
@@ -95,3 +95,8 @@ export const isAncestor = (element?: Element, maybeAncestor?: Element): boolean 
   if (element === maybeAncestor) return true;
   return isAncestor(element.parentElement, maybeAncestor);
 };
+
+export const removeNoiseFromName = (storyName: string) => storyName.replaceAll(/(\s|-|_)/gi, '');
+
+export const isStoryAndComponentNameEqual = (storyName: string, componentName: string) =>
+  removeNoiseFromName(storyName) === removeNoiseFromName(componentName);

--- a/lib/ui/src/components/sidebar/utils.ts
+++ b/lib/ui/src/components/sidebar/utils.ts
@@ -98,5 +98,5 @@ export const isAncestor = (element?: Element, maybeAncestor?: Element): boolean 
 
 export const removeNoiseFromName = (storyName: string) => storyName.replaceAll(/(\s|-|_)/gi, '');
 
-export const isStoryAndComponentNameEqual = (storyName: string, componentName: string) =>
+export const isStoryHoistable = (storyName: string, componentName: string) =>
   removeNoiseFromName(storyName) === removeNoiseFromName(componentName);


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18039

## What I did
Fixed the auto-title regression for PascalCase filenames

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
