### PR TITLE
CLI: await generators for proper install

### DIFF
--- a/lib/cli/src/generators/ANGULAR/index.ts
+++ b/lib/cli/src/generators/ANGULAR/index.ts
@@ -39,7 +39,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   const isWebpack5 = semver.gte(angularVersion, '12.0.0');
   const updatedOptions = isWebpack5 ? { ...options, builder: CoreBuilder.Webpack5 } : options;
 
-  baseGenerator(packageManager, npmOptions, updatedOptions, 'angular', {
+  await baseGenerator(packageManager, npmOptions, updatedOptions, 'angular', {
     extraPackages: ['@compodoc/compodoc'],
     addScripts: false,
   });

--- a/lib/cli/src/generators/AURELIA/index.ts
+++ b/lib/cli/src/generators/AURELIA/index.ts
@@ -19,7 +19,7 @@ function addStorybookExcludeGlobToTsConfig() {
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
   addStorybookExcludeGlobToTsConfig();
-  baseGenerator(packageManager, npmOptions, options, 'aurelia', {
+  await baseGenerator(packageManager, npmOptions, options, 'aurelia', {
     extraPackages: ['aurelia'],
   });
   copyTemplate(__dirname);

--- a/lib/cli/src/generators/EMBER/index.ts
+++ b/lib/cli/src/generators/EMBER/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'ember', {
+  await baseGenerator(packageManager, npmOptions, options, 'ember', {
     extraPackages: [
       // babel-plugin-ember-modules-api-polyfill is a peerDep of @storybook/ember
       'babel-plugin-ember-modules-api-polyfill',

--- a/lib/cli/src/generators/HTML/index.ts
+++ b/lib/cli/src/generators/HTML/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'html');
+  await baseGenerator(packageManager, npmOptions, options, 'html');
 };
 
 export default generator;

--- a/lib/cli/src/generators/METEOR/index.ts
+++ b/lib/cli/src/generators/METEOR/index.ts
@@ -3,7 +3,7 @@ import JSON5 from 'json5';
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'react', {
+  await baseGenerator(packageManager, npmOptions, options, 'react', {
     extraPackages: ['react', 'react-dom', '@babel/preset-env', '@babel/preset-react'],
     staticDir: 'dist',
   });

--- a/lib/cli/src/generators/MITHRIL/index.ts
+++ b/lib/cli/src/generators/MITHRIL/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'mithril');
+  await baseGenerator(packageManager, npmOptions, options, 'mithril');
 };
 
 export default generator;

--- a/lib/cli/src/generators/PREACT/index.ts
+++ b/lib/cli/src/generators/PREACT/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'preact', {
+  await baseGenerator(packageManager, npmOptions, options, 'preact', {
     extraPackages: ['core-js'],
   });
 };

--- a/lib/cli/src/generators/RAX/index.ts
+++ b/lib/cli/src/generators/RAX/index.ts
@@ -18,7 +18,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
 
   writePackageJson(packageJson);
 
-  baseGenerator(packageManager, npmOptions, options, 'rax', {
+  await baseGenerator(packageManager, npmOptions, options, 'rax', {
     extraPackages: ['rax'],
   });
 };

--- a/lib/cli/src/generators/RIOT/index.ts
+++ b/lib/cli/src/generators/RIOT/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'riot', {
+  await baseGenerator(packageManager, npmOptions, options, 'riot', {
     extraPackages: ['riot-tag-loader'],
   });
 };

--- a/lib/cli/src/generators/SERVER/index.ts
+++ b/lib/cli/src/generators/SERVER/index.ts
@@ -2,7 +2,7 @@ import { baseGenerator, Generator } from '../baseGenerator';
 import { copyTemplate } from '../../helpers';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'server', {
+  await baseGenerator(packageManager, npmOptions, options, 'server', {
     extensions: ['json'],
   });
 

--- a/lib/cli/src/generators/SFC_VUE/index.ts
+++ b/lib/cli/src/generators/SFC_VUE/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'vue');
+  await baseGenerator(packageManager, npmOptions, options, 'vue');
 };
 
 export default generator;

--- a/lib/cli/src/generators/VUE/index.ts
+++ b/lib/cli/src/generators/VUE/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'vue', {
+  await baseGenerator(packageManager, npmOptions, options, 'vue', {
     extraPackages: ['vue-loader@^15.7.0'],
   });
 };

--- a/lib/cli/src/generators/VUE3/index.ts
+++ b/lib/cli/src/generators/VUE3/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'vue3', {
+  await baseGenerator(packageManager, npmOptions, options, 'vue3', {
     extraPackages: ['vue-loader@^16.0.0'],
   });
 };

--- a/lib/cli/src/generators/WEBPACK_REACT/index.ts
+++ b/lib/cli/src/generators/WEBPACK_REACT/index.ts
@@ -1,7 +1,7 @@
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  baseGenerator(packageManager, npmOptions, options, 'react');
+  await baseGenerator(packageManager, npmOptions, options, 'react');
 };
 
 export default generator;


### PR DESCRIPTION
Issue: N/A

## What I did

Some generators were not awaited which means that when running sb init, the steps have timing issues, making the `automigrate` command fail most migrations with `Unable to find storybook main.js config, skipping` because Storybook was not in a ready state yet.

Before:

![image](https://user-images.githubusercontent.com/1671563/165125497-885dde25-1408-4c7e-8a20-206c5d68707f.png)

After:

![image](https://user-images.githubusercontent.com/1671563/165125450-49f51ef8-ba1a-4fba-87c8-cc98fdc7cca2.png)


## How to test

- Checkout this branch
- Build cli locally (yarn build cli)
- Execute sb init (with the local sb binary) in any project affected by this change (webpack react, angular, aurelia, ember, vue...)

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
