### PR TITLE
Core: Fix story index for CSF default exports as TS vars

### DIFF
--- a/lib/csf-tools/src/CsfFile.test.ts
+++ b/lib/csf-tools/src/CsfFile.test.ts
@@ -216,6 +216,29 @@ describe('CsfFile', () => {
       `);
     });
 
+    it('typescript meta var', () => {
+      expect(
+        parse(
+          dedent`
+          import { Meta, Story } from '@storybook/react';
+          type PropTypes = {};
+          const meta = { title: 'foo/bar/baz' } as Meta<PropTypes>;
+          export default meta;
+          export const A: Story<PropTypes> = () => <>A</>;
+          export const B: Story<PropTypes> = () => <>B</>;
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar/baz
+        stories:
+          - id: foo-bar-baz--a
+            name: A
+          - id: foo-bar-baz--b
+            name: B
+      `);
+    });
+
     it('component object', () => {
       expect(
         parse(

--- a/lib/csf-tools/src/CsfFile.ts
+++ b/lib/csf-tools/src/CsfFile.ts
@@ -211,22 +211,20 @@ export class CsfFile {
       ExportDefaultDeclaration: {
         enter({ node, parent }) {
           let metaNode: t.ObjectExpression;
-          if (t.isObjectExpression(node.declaration)) {
+          const decl =
+            t.isIdentifier(node.declaration) && t.isProgram(parent)
+              ? findVarInitialization(node.declaration.name, parent)
+              : node.declaration;
+
+          if (t.isObjectExpression(decl)) {
             // export default { ... };
-            metaNode = node.declaration;
+            metaNode = decl;
           } else if (
             // export default { ... } as Meta<...>
-            t.isTSAsExpression(node.declaration) &&
-            t.isObjectExpression(node.declaration.expression)
+            t.isTSAsExpression(decl) &&
+            t.isObjectExpression(decl.expression)
           ) {
-            metaNode = node.declaration.expression;
-          } else if (t.isIdentifier(node.declaration) && t.isProgram(parent)) {
-            const init = findVarInitialization(node.declaration.name, parent);
-            if (t.isObjectExpression(init)) {
-              metaNode = init;
-            } else if (t.isTSAsExpression(init) && t.isObjectExpression(init.expression)) {
-              metaNode = init.expression;
-            }
+            metaNode = decl.expression;
           }
 
           if (!self._meta && metaNode && t.isProgram(parent)) {

--- a/lib/csf-tools/src/CsfFile.ts
+++ b/lib/csf-tools/src/CsfFile.ts
@@ -224,6 +224,8 @@ export class CsfFile {
             const init = findVarInitialization(node.declaration.name, parent);
             if (t.isObjectExpression(init)) {
               metaNode = init;
+            } else if (t.isTSAsExpression(init) && t.isObjectExpression(init.expression)) {
+              metaNode = init.expression;
             }
           }
 


### PR DESCRIPTION
Issue: N/A

It was reported that `Button.stories.tsx` was not showing up in the sidebar when `storyStoreV7` was being used.

Repro here from @dannyhw  https://github.com/dannyhw/ReproStoryStoreV7

## What I did

This is an unhandled case in the code. I fixed the code by first checking if the default export is a variable declaration, and then applying the logic to either the declaration itself or the variable that it references.

This will handle the TS "as" case, and whatever other cases come up.

## How to test

See attached unit test