### PR TITLE
Core: replace git.io shortlink

### DIFF
--- a/lib/core-server/src/utils/update-check.ts
+++ b/lib/core-server/src/utils/update-check.ts
@@ -48,7 +48,7 @@ export function createUpdateMessage(updateInfo: VersionCheck, version: string): 
 
           ${chalk.gray('Upgrade now:')} ${colors.green(upgradeCommand)}
 
-          ${chalk.gray('Read full changelog:')} ${chalk.gray.underline('https://git.io/fhFYe')}
+          ${chalk.gray('Read full changelog:')} ${chalk.gray.underline('https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md')}
         `
         : '';
   } catch (e) {


### PR DESCRIPTION
Issue:

## What I did
I replaced soon-to-be-unavailable shortlink with a full URL.

Context:
https://github.blog/changelog/2022-04-25-git-io-deprecation/

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
