### PR TITLE
Chore: (DOCS) Address broken links in monorepo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,7 +15,7 @@ This document outlines some of the processes that the maintainers should adhere 
 | api:(name)                     | Issue, bug, or pull request related to Storybook's API (e.g.,[makeDecorator](/docs/addons/addons-api.md#makeDecorator-API))                         |
 | args                           | Issue, bug, or pull request related to Storybook's [args](/docs/writing-stories/args.md)                                                            |
 | babel/webpack                  | Issue, bug, or pull request related to Storybook's build system (e.g., Webpack or Babel), for Webpack 5 issues see below                            |
-| block:(name)                   | Issue or bug within a certain surface are of Storybook (e.g., [argsTable](/docs/writing-docs/doc-blocks.md#argstable))                              |
+| block:(name)                   | Issue or bug within a certain surface are of Storybook (e.g., [argsTable](/docs/writing-docs/doc-block-argstable.md))                              |
 | BREAKING CHANGE                | Issue or pull request that introduces a breaking change within Storybook's ecosystem.                                                               |
 | BREAKING PRERELASE             | Breaking, but only for prerelease users (not relative to the stable release)                                                                        |
 | build-storybook                | Issue, bug, or pull request related to Storybook's production build                                                                                 |
@@ -24,7 +24,7 @@ This document outlines some of the processes that the maintainers should adhere 
 | cli                            | Issue, bug, or pull request that affects the Storybook's CLI                                                                                        |
 | compatibility with other tools | Issue, bug, or pull request between Storybook and other tools (e.g., [Nuxt](https://nuxtjs.org/))                                                   |
 | components                     | Issue, bug, or pull request related to Storybook's internal components                                                                              |
-| composition                    | Issue, bug, or pull request related to Storybook [Composition](/docs/workflows/storybook-composition.md)                                            |
+| composition                    | Issue, bug, or pull request related to Storybook [Composition](/docs/sharing/storybook-composition.md)                                            |
 | configuration                  | Issue, bug, or pull request related to Storybook [configuration](/docs/configure/overview.md)                                                       |
 | core                           | Issue, bug, or pull request related to Storybook's Core                                                                                             |
 | cra                            | Issue, bug, or pull request that affects Storybook's compatibility with Create React APP ([CRA](https://create-react-app.dev/docs/getting-started/))|

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2153,7 +2153,7 @@ Theming has been rewritten in v5. If you used theming in v4, please consult the 
 
 ### Story hierarchy defaults
 
-Storybook's UI contains a hierarchical tree of stories that can be configured by `hierarchySeparator` and `hierarchyRootSeparator` [options](./addons/options/README.md).
+Storybook's UI contains a hierarchical tree of stories that can be configured by `hierarchySeparator` and `hierarchyRootSeparator` [options](https://github.com/storybookjs/deprecated-addons/blob/master/MIGRATION.md#options-addon-deprecated).
 
 In Storybook 4.x the values defaulted to `null` for both of these options, so that there would be no hierarchy by default.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Documentation can be found [Storybook's docs site](https://storybook.js.org/docs
 
 ### Examples
 
-Here are some featured examples that you can reference to see how Storybook works: <https://storybook.js.org/docs/react/get-started/examples>
+Here are some featured examples that you can reference to see how Storybook works: <https://storybook.js.org/showcase>
 
 Storybook comes with a lot of [addons](https://storybook.js.org/docs/react/configure/storybook-addons) for component design, documentation, testing, interactivity, and so on. Storybook's API makes it possible to configure and extend in various ways. It has even been extended to support React Native, Android, iOS, and Flutter development for mobile.
 
@@ -98,12 +98,12 @@ For additional help, join us in the [Storybook Discord](https://discord.gg/story
 | [Vue](app/vue)                                                 | [v6.4.x](https://storybookjs.netlify.com/vue-kitchen-sink/)                                 | [![Vue](https://img.shields.io/npm/dm/@storybook/vue.svg)](app/vue)                                     |
 | [Angular](app/angular)                                         | [v6.4.x](https://storybookjs.netlify.com/angular-cli/)                                      | [![Angular](https://img.shields.io/npm/dm/@storybook/angular.svg)](app/angular)                         |
 | [Web components](app/web-components)                           | [v6.4.x](https://storybookjs.netlify.com/web-components-kitchen-sink/)                      | [![Svelte](https://img.shields.io/npm/dm/@storybook/web-components.svg)](app/web-components)            |
-| [React Native](https://github.com/storybookjs/react-native)    | -                                                                                           | [![React Native](https://img.shields.io/npm/dm/@storybook/react-native.svg)](app/react-native)          |
+| [React Native](https://github.com/storybookjs/react-native)    | -                                                                                           | [![React Native](https://img.shields.io/npm/dm/@storybook/react-native.svg)](https://github.com/storybookjs/react-native)          |
 | [HTML](app/html)                                               | [v6.4.x](https://storybookjs.netlify.com/html-kitchen-sink/)                                | [![HTML](https://img.shields.io/npm/dm/@storybook/html.svg)](app/html)                                  |
 | [Ember](app/ember)                                             | [v6.4.x](https://storybookjs.netlify.com/ember-cli/)                                        | [![Ember](https://img.shields.io/npm/dm/@storybook/ember.svg)](app/ember)                               |
 | [Svelte](app/svelte)                                           | [v6.4.x](https://storybookjs.netlify.com/svelte-kitchen-sink/)                              | [![Svelte](https://img.shields.io/npm/dm/@storybook/svelte.svg)](app/svelte)                            |
 | [Preact](app/preact)                                           | [v6.4.x](https://storybookjs.netlify.com/preact-kitchen-sink/)                              | [![Preact](https://img.shields.io/npm/dm/@storybook/preact.svg)](app/preact)                            |
-| [Marionette.js](https://github.com/storybookjs/marionette)     | -                                                                                           | [![Marionette.js](https://img.shields.io/npm/dm/@storybook/marionette.svg)](app/marionette)             |
+| [Marionette.js](https://github.com/storybookjs/marionette)     | -                                                                                           | [![Marionette.js](https://img.shields.io/npm/dm/@storybook/marionette.svg)](https://github.com/storybookjs/marionette)             |
 | [Android, iOS, Flutter](https://github.com/storybookjs/native) | [v6.4.x](https://storybookjs.github.io/native/@storybook/native-flutter-example/index.html) | [![Native](https://img.shields.io/npm/dm/@storybook/native.svg)](https://github.com/storybookjs/native) |
 
 ### Sub Projects

--- a/addons/storyshots/storyshots-core/README.md
+++ b/addons/storyshots/storyshots-core/README.md
@@ -470,7 +470,7 @@ Whenever you change your data requirements by adding (and rendering) or (acciden
 
 ## Using a custom directory
 
-Depending on your project's needs, you can configure the `@storybook/addon-storyshots` to use a custom directory for the snapshots. You can read more about it in the [official docs](https://storybook.js.org/docs/react/workflows/snapshot-testing).
+Depending on your project's needs, you can configure the `@storybook/addon-storyshots` to use a custom directory for the snapshots. You can read more about it in the [official docs](https://storybook.js.org/docs/react/writing-tests/snapshot-testing).
 
 ## Options
 
@@ -654,7 +654,7 @@ This option needs to be set if either:
 
 ### `serializer` (deprecated)
 
-Pass a custom serializer (such as enzyme-to-json) to serialize components to snapshot-comparable data. The functionality of this option is completely covered by [snapshotSerializers](`snapshotSerializers`) which should be used instead.
+Pass a custom serializer (such as enzyme-to-json) to serialize components to snapshot-comparable data. The functionality of this option is completely covered by [snapshotSerializers](#snapshotserializers) which should be used instead.
 
 ```js
 import initStoryshots from '@storybook/addon-storyshots';

--- a/docs/addons/install-addons.md
+++ b/docs/addons/install-addons.md
@@ -2,7 +2,7 @@
 title: Install addons
 ---
 
-Storybook has [hundreds of reusable addons](/addons) that are packaged as NPM modules. Let's walk through how to extend Storybook by installing and registering addons.
+Storybook has [hundreds of reusable addons](https://storybook.js.org/addons) that are packaged as NPM modules. Let's walk through how to extend Storybook by installing and registering addons.
 
 ### Using addons
 

--- a/docs/addons/introduction.md
+++ b/docs/addons/introduction.md
@@ -5,7 +5,7 @@ title: 'Introduction to addons'
 Addons extend Storybook with features and integrations that are not built into the core. Most Storybook features are implemented as addons. For instance: [documentation](../writing-docs/introduction.md), [accessibility testing](https://github.com/storybookjs/storybook/tree/master/addons/a11y), [interactive controls](../essentials/controls.md), among others.
 The [addon API](./addons-api.md) makes it easy for you to configure and customize Storybook in new ways. There are countless addons made by the community that unlock time-saving workflows.
 
-Browse our [addon catalog](/addons) to install an existing addon or as inspiration for your own addon.
+Browse our [addon catalog](https://storybook.js.org/addons) to install an existing addon or as inspiration for your own addon.
 
 ## Storybook basics
 

--- a/docs/configure/overview.md
+++ b/docs/configure/overview.md
@@ -177,7 +177,7 @@ You can also use Storybook's API to configure your project with TypeScript. Unde
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stories`             | The array of globs that indicates the [location of your story files](#configure-story-loading), relative to `main.ts`                                                            |
 | `staticDirs`          | Sets a list of directories of [static files](./images-and-assets.md#serving-static-files-via-storybook-configuration) to be loaded by Storybook <br/> `staticDirs:['../public']` |
-| `addons`              | Sets the list of [addons](/addons) loaded by Storybook <br/> `addons:['@storybook/addon-essentials']`                                                                            |
+| `addons`              | Sets the list of [addons](/https://storybook.js.org/addons/) loaded by Storybook <br/> `addons:['@storybook/addon-essentials']`                                                                            |
 | `typescript`          | Configures how Storybook handles [TypeScript files](./typescript.md) <br/> `typescript: { check: false, checkOptions: {} }`                                                      |
 | `framework`           | Configures Storybook based on a set of framework-specific settings <br/> `framework:'@storybook/svelte'`                                                                         |
 | `core`                | Sets Storybook's Webpack configuration <br/> `core:{ builder: 'webpack5'}`                                                                                                       |

--- a/docs/configure/upgrading.md
+++ b/docs/configure/upgrading.md
@@ -6,7 +6,7 @@ The frontend ecosystem is a fast-moving place. Regular dependency upgrades are a
 
 ## Upgrade script
 
-The most common upgrade is Storybook itself. [Storybook releases](/releases) follow [Semantic Versioning](https://semver.org/). We publish patch releases with bug fixes continuously, minor versions of Storybook with new features every few months, and major versions of Storybook with breaking changes roughly once per year.
+The most common upgrade is Storybook itself. [Storybook releases](https://storybook.js.org/releases) follow [Semantic Versioning](https://semver.org/). We publish patch releases with bug fixes continuously, minor versions of Storybook with new features every few months, and major versions of Storybook with breaking changes roughly once per year.
 
 To help ease the pain of keeping Storybook up-to-date, we provide a command-line script:
 

--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -2,7 +2,7 @@
 title: 'Essential addons'
 ---
 
-A major strength of Storybook are [addons](/addons/) that extend Storybook’s UI and behavior. Storybook ships by default with a set of “essential” addons that add to the initial user experience. There are many third-party addons as well as “official” addons developed by the Storybook core team.
+A major strength of Storybook are [addons](https://storybook.js.org/addons) that extend Storybook’s UI and behavior. Storybook ships by default with a set of “essential” addons that add to the initial user experience. There are many third-party addons as well as “official” addons developed by the Storybook core team.
 
 - [Docs](../writing-docs/introduction.md)
 - [Controls](./controls.md)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -273,7 +273,7 @@ Yes, with the release of version 6.2, the [`Storyshots addon`](https://www.npmjs
 
 If you run into a situation where this is not the case, you can adjust the `config` object and manually specify the framework (e.g., `vue3`).
 
-See our documentation on how to customize the [Storyshots configuration](./snapshot-testing.md).
+See our documentation on how to customize the [Storyshots configuration](./writing-tests/snapshot-testing.md).
 
 ### Why are my MDX stories not working in IE11?
 

--- a/lib/components/src/blocks/DocsPageExampleCaption.md
+++ b/lib/components/src/blocks/DocsPageExampleCaption.md
@@ -76,12 +76,12 @@ A basic table:
 
 Let's throw in a crazy table, because why not?
 
-|                                   | [React](app/react) | [React Native](app/react-native) | [Vue](app/vue) | [Angular](app/angular) | [HTML](app/html) | [Svelte](app/svelte) | [Ember](app/ember) | [Preact](app/preact) |
-| --------------------------------- | :----------------: | :------------------------------: | :------------: | :--------------------: | :--------------: | :------------------: | :----------------: | :------------------: |
-| [a11y](addons/a11y)               |         +          |                                  |       +        |           +            |        +         |                      |         +          |          +           |
-| [actions](addons/actions)         |         +          |                +                 |       +        |           +            |        +         |          +           |         +          |          +           |
-| [backgrounds](addons/backgrounds) |         +          |                \*                |       +        |           +            |        +         |          +           |         +          |          +           |
-| [centered](addons/centered)       |         +          |                                  |       +        |           +            |        +         |          +           |         +          |          +           |
+|                                               | [React](../../../../app/react) | [React Native](https://github.com/storybookjs/react-native) | [Vue](../../../../app/vue) | [Angular](../../../../app/angular) | [HTML](../../../../app/html) | [Svelte](../../../../app/svelte) | [Ember](../../../../app/ember) | [Preact](../../../../app/preact) |
+|-----------------------------------------------|--------------------------------|----------------------------------|----------------------------|------------------------------------|------------------------------|----------------------------------|--------------------------------|----------------------------------|
+| [a11y](../../../../addons/a11y/)              | +                              |                                  | +                          | +                                  | +                            |                                  | +                              | +                                |
+| [actions](../../../../addons/actions)         | +                              | +                                | +                          | +                                  | +                            | +                                | +                              | +                                |
+| [backgrounds](../../../../addons/backgrounds) | +                              | \*                               | +                          | +                                  | +                            | +                                | +                              | +                                |
+| [measure](../../../../addons/measure)         | +                              |                                  | +                          | +                                  | +                            | +                                | +                              | +                                |
 
 ## Code
 


### PR DESCRIPTION
With this pull request links across the monorepo are fixed based on the "Markdown Links check" set in place by @yannbf!

What was done:
- Fixed broken links
- Updated the table in "DocumentFormattingSample.md" to avoid further issues with broken links.

Let me know of any additional feedback @yannbf and @shilman!
