### PR TITLE
CLI: Add non-monorepo testing tools to exclude lists

### DIFF
--- a/lib/cli/src/upgrade.ts
+++ b/lib/cli/src/upgrade.ts
@@ -42,6 +42,10 @@ const excludeList = [
   '@storybook/builder-vite',
   '@storybook/mdx1-csf',
   '@storybook/mdx2-csf',
+  '@storybook/expect',
+  '@storybook/jest',
+  '@storybook/test-runner',
+  '@storybook/testing-library',
 ];
 export const isCorePackage = (pkg: string) =>
   pkg.startsWith('@storybook/') &&

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -79,6 +79,14 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
+  '@storybook/expect':
+    access: $all
+    publish: $all
+    proxy: npmjs
+  '@storybook/jest':
+    access: $all
+    publish: $all
+    proxy: npmjs
 
   # storybook packages are NOT proxied to global registry
   # allowing us to republish any version during tests


### PR DESCRIPTION
Issue:

When running `npx sb@next upgrade --prerelease`, I got the following warning:

```
WARN Found 11 outdated packages (relative to '@storybook/expect@27.5.2-0')
WARN Please make sure your packages are updated to ensure a consistent experience.
WARN - @storybook/addon-a11y@6.5.0-beta.1
WARN - @storybook/addon-actions@6.5.0-beta.1
WARN - @storybook/addon-docs@6.5.0-beta.1
WARN - @storybook/addon-essentials@6.5.0-beta.1
WARN - @storybook/addon-links@6.5.0-beta.1
WARN - @storybook/addons@6.5.0-beta.1
WARN - @storybook/react@6.5.0-beta.1
WARN - @storybook/testing-react@1.2.4
WARN - @storybook/testing-library@0.0.11
WARN - @storybook/jest@0.0.10
WARN - @storybook/test-runner@0.0.8-next.0
```

I think that's because storybook thought that `@storybook/expect` is a "core" package.

## What I did

I added `@storybook/expect` and the other non-monorepo testing libraries to the `excludes` list, as well as the verdaccio config so they are not proxied when publishing monorepo packages for e2e tests.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
