### PR TITLE
React: Fix version detection for older versions of `react-dom`

### DIFF
--- a/app/react/src/client/preview/render.tsx
+++ b/app/react/src/client/preview/render.tsx
@@ -48,7 +48,7 @@ const renderElement = async (node: ReactElement, el: Element) => {
 };
 
 const canUseNewReactRootApi =
-  reactDomVersion.startsWith('18') || reactDomVersion.startsWith('0.0.0');
+  reactDomVersion && (reactDomVersion.startsWith('18') || reactDomVersion.startsWith('0.0.0'));
 
 const shouldUseNewRootApi = FRAMEWORK_OPTIONS?.legacyRootApi !== true;
 


### PR DESCRIPTION
Issue: reactDomVersion (version) in older versions of react-dom is undefined

## What I did
make logic for reactDomVersion null safe

## How to test
run SB 6.5 beta with react 16

