### PR TITLE
Examples: Update example to restore 6.4 auto-title behavior in UI

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -296,7 +296,7 @@ import startCase from 'lodash/startCase';
 
 addons.setConfig({
   sidebar: {
-    renderLabel: ({ name, isLeaf }) => (isLeaf ? name : startCase(name)),
+    renderLabel: ({ name, type }) => (type === 'story' ? name : startCase(name)),
   },
 });
 ```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -288,6 +288,19 @@ This might be considered a breaking change. However, we feel justified to releas
 1. We consider it a bug in the initial auto-title implementation
 2. CSF3 and the auto-title feature are experimental, and we reserve the right to make breaking changes outside of semver (tho we try to avoid it)
 
+If you want to restore the old titles in the UI, you can customize your sidebar with the following code snippet in `.storybook/manager.js`:
+
+```js
+import { addons } from '@storybook/addons';
+import startCase from 'lodash/startCase';
+
+addons.setConfig({
+  sidebar: {
+    renderLabel: ({ name, isLeaf }) => (isLeaf ? name : startCase(name)),
+  },
+});
+```
+
 #### Auto-title redundant filename
 
 The heuristic failed in the common scenario in which each component gets its own directory, e.g. `atoms/Button/Button.stories.js`, which would result in the redundant title `Atoms/Button/Button`. Alternatively, `atoms/Button/index.stories.js` would result in `Atoms/Button/Index`.

--- a/examples/react-ts/.storybook/manager.js
+++ b/examples/react-ts/.storybook/manager.js
@@ -1,0 +1,8 @@
+import { addons } from '@storybook/addons';
+import startCase from 'lodash/startCase';
+
+addons.setConfig({
+  sidebar: {
+    renderLabel: ({ name, isLeaf }) => (isLeaf ? name : startCase(name)),
+  },
+});

--- a/examples/react-ts/.storybook/manager.js
+++ b/examples/react-ts/.storybook/manager.js
@@ -3,6 +3,6 @@ import startCase from 'lodash/startCase';
 
 addons.setConfig({
   sidebar: {
-    renderLabel: ({ name, isLeaf }) => (isLeaf ? name : startCase(name)),
+    renderLabel: ({ name, type }) => (type === 'story' ? name : startCase(name)),
   },
 });

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -21,6 +21,7 @@
     "@storybook/addon-essentials": "6.5.0-beta.1",
     "@storybook/addon-storyshots": "6.5.0-beta.1",
     "@storybook/addon-storysource": "6.5.0-beta.1",
+    "@storybook/addons": "6.5.0-beta.1",
     "@storybook/cli": "6.5.0-beta.1",
     "@storybook/components": "6.5.0-beta.1",
     "@storybook/react": "6.5.0-beta.1",
@@ -32,6 +33,7 @@
     "@types/react": "^16.14.23",
     "@types/react-dom": "^16.9.14",
     "cross-env": "^7.0.3",
+    "lodash": "^4.17.21",
     "typescript": "^3.9.7",
     "webpack": "4"
   }

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -26,6 +26,7 @@ const { FEATURES } = global;
 export type { StoryId };
 
 export interface Root {
+  type: 'root';
   id: StoryId;
   depth: 0;
   name: string;
@@ -39,6 +40,7 @@ export interface Root {
 }
 
 export interface Group {
+  type: 'group' | 'component';
   id: StoryId;
   depth: number;
   name: string;
@@ -57,6 +59,7 @@ export interface Group {
 }
 
 export interface Story {
+  type: 'story' | 'docs';
   id: StoryId;
   depth: number;
   parent: StoryId;
@@ -234,6 +237,7 @@ export const transformStoriesRawToStoriesHash = (
 
       if (root.length && index === 0) {
         list.push({
+          type: 'root',
           id,
           name,
           depth: index,
@@ -246,6 +250,7 @@ export const transformStoriesRawToStoriesHash = (
         });
       } else {
         list.push({
+          type: 'group',
           id,
           name,
           parent,
@@ -278,6 +283,7 @@ export const transformStoriesRawToStoriesHash = (
     });
 
     acc[item.id] = {
+      type: item.parameters?.docsOnly ? 'docs' : 'story',
       ...item,
       depth: rootAndGroups.length,
       parent: rootAndGroups[rootAndGroups.length - 1].id,
@@ -298,7 +304,10 @@ export const transformStoriesRawToStoriesHash = (
       const { children } = item;
       if (children) {
         const childNodes = children.map((id) => storiesHashOutOfOrder[id]) as (Story | Group)[];
-        acc[item.id].isComponent = childNodes.every((childNode) => childNode.isLeaf);
+        if (childNodes.every((childNode) => childNode.isLeaf)) {
+          acc[item.id].isComponent = true;
+          acc[item.id].type = 'component';
+        }
         childNodes.forEach((childNode) => addItem(acc, childNode));
       }
     }

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -167,6 +167,7 @@ describe('stories API', () => {
         'custom-id--1',
       ]);
       expect(storedStoriesHash.a).toMatchObject({
+        type: 'component',
         id: 'a',
         children: ['a--1', 'a--2'],
         isRoot: false,
@@ -174,6 +175,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['a--1']).toMatchObject({
+        type: 'story',
         id: 'a--1',
         parent: 'a',
         kind: 'a',
@@ -184,6 +186,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['a--2']).toMatchObject({
+        type: 'story',
         id: 'a--2',
         parent: 'a',
         kind: 'a',
@@ -194,6 +197,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash.b).toMatchObject({
+        type: 'group',
         id: 'b',
         children: ['b-c', 'b-d', 'b-e'],
         isRoot: false,
@@ -201,6 +205,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['b-c']).toMatchObject({
+        type: 'component',
         id: 'b-c',
         parent: 'b',
         children: ['b-c--1'],
@@ -209,6 +214,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['b-c--1']).toMatchObject({
+        type: 'story',
         id: 'b-c--1',
         parent: 'b-c',
         kind: 'b/c',
@@ -219,6 +225,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['b-d']).toMatchObject({
+        type: 'component',
         id: 'b-d',
         parent: 'b',
         children: ['b-d--1', 'b-d--2'],
@@ -227,6 +234,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['b-d--1']).toMatchObject({
+        type: 'story',
         id: 'b-d--1',
         parent: 'b-d',
         kind: 'b/d',
@@ -237,6 +245,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['b-d--2']).toMatchObject({
+        type: 'story',
         id: 'b-d--2',
         parent: 'b-d',
         kind: 'b/d',
@@ -247,6 +256,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['b-e']).toMatchObject({
+        type: 'component',
         id: 'b-e',
         parent: 'b',
         children: ['custom-id--1'],
@@ -255,6 +265,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['custom-id--1']).toMatchObject({
+        type: 'story',
         id: 'custom-id--1',
         parent: 'b-e',
         kind: 'b/e',
@@ -293,14 +304,17 @@ describe('stories API', () => {
         'design-system-some-component--my-story',
       ]);
       expect(storedStoriesHash['design-system']).toMatchObject({
+        type: 'root',
         isRoot: true,
         name: 'Design System', // root name originates from `kind`, so it gets trimmed
       });
       expect(storedStoriesHash['design-system-some-component']).toMatchObject({
+        type: 'component',
         isComponent: true,
         name: 'Some Component', // component name originates from `kind`, so it gets trimmed
       });
       expect(storedStoriesHash['design-system-some-component--my-story']).toMatchObject({
+        type: 'story',
         isLeaf: true,
         kind: '  Design System  /  Some Component  ', // kind is kept as-is, because it may be used as identifier
         name: '  My Story  ', // story name is kept as-is, because it's set directly on the story
@@ -332,12 +346,14 @@ describe('stories API', () => {
       // We need exact key ordering, even if in theory JS doens't guarantee it
       expect(Object.keys(storedStoriesHash)).toEqual(['a', 'a-b', 'a-b--1']);
       expect(storedStoriesHash.a).toMatchObject({
+        type: 'root',
         id: 'a',
         children: ['a-b'],
         isRoot: true,
         isComponent: false,
       });
       expect(storedStoriesHash['a-b']).toMatchObject({
+        type: 'component',
         id: 'a-b',
         parent: 'a',
         children: ['a-b--1'],
@@ -345,6 +361,7 @@ describe('stories API', () => {
         isComponent: true,
       });
       expect(storedStoriesHash['a-b--1']).toMatchObject({
+        type: 'story',
         id: 'a-b--1',
         parent: 'a-b',
         kind: 'a/b',
@@ -379,12 +396,14 @@ describe('stories API', () => {
       // We need exact key ordering, even if in theory JS doens't guarantee it
       expect(Object.keys(storedStoriesHash)).toEqual(['a', 'a--1']);
       expect(storedStoriesHash.a).toMatchObject({
+        type: 'component',
         id: 'a',
         children: ['a--1'],
         isRoot: false,
         isComponent: true,
       });
       expect(storedStoriesHash['a--1']).toMatchObject({
+        type: 'story',
         id: 'a--1',
         parent: 'a',
         kind: 'a',
@@ -415,6 +434,7 @@ describe('stories API', () => {
       // We need exact key ordering, even if in theory JS doens't guarantee it
       expect(Object.keys(storedStoriesHash)).toEqual(['a', 'a--1', 'a--2', 'b', 'b--1']);
       expect(storedStoriesHash.a).toMatchObject({
+        type: 'component',
         id: 'a',
         children: ['a--1', 'a--2'],
         isRoot: false,
@@ -422,6 +442,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash.b).toMatchObject({
+        type: 'component',
         id: 'b',
         children: ['b--1'],
         isRoot: false,
@@ -989,6 +1010,7 @@ describe('stories API', () => {
         'component-b--story-3',
       ]);
       expect(storedStoriesHash['component-a']).toMatchObject({
+        type: 'component',
         id: 'component-a',
         children: ['component-a--story-1', 'component-a--story-2'],
         isRoot: false,
@@ -996,6 +1018,7 @@ describe('stories API', () => {
       });
 
       expect(storedStoriesHash['component-a--story-1']).toMatchObject({
+        type: 'story',
         id: 'component-a--story-1',
         parent: 'component-a',
         kind: 'Component A',
@@ -1040,21 +1063,25 @@ describe('stories API', () => {
     it('infers docs only if there is only one story and it has the name "Page"', async () => {
       mockStories.mockReset().mockReturnValue({
         'component-a--page': {
+          type: 'story',
           title: 'Component A',
           name: 'Page', // Called "Page" but not only story
           importPath: './path/to/component-a.ts',
         },
         'component-a--story-2': {
+          type: 'story',
           title: 'Component A',
           name: 'Story 2',
           importPath: './path/to/component-a.ts',
         },
         'component-b--page': {
+          type: 'docs',
           title: 'Component B',
           name: 'Page', // Page and only story
           importPath: './path/to/component-b.ts',
         },
         'component-c--story-4': {
+          type: 'story',
           title: 'Component c',
           name: 'Story 4', // Only story but not page
           importPath: './path/to/component-c.ts',
@@ -1112,6 +1139,7 @@ describe('stories API', () => {
 
       const { storiesHash: storedStoriesHash } = store.getState();
       expect(storedStoriesHash['component-a--story-1']).toMatchObject({
+        type: 'story',
         id: 'component-a--story-1',
         parent: 'component-a',
         kind: 'Component A',

--- a/lib/ui/src/components/sidebar/__tests__/data.test.ts
+++ b/lib/ui/src/components/sidebar/__tests__/data.test.ts
@@ -5,6 +5,7 @@ type Item = StoriesHash[keyof StoriesHash];
 
 const docsOnly = { parameters: { docsOnly: true } };
 const root: Item = {
+  type: 'root',
   id: 'root',
   name: 'root',
   depth: 0,
@@ -14,6 +15,7 @@ const root: Item = {
   isLeaf: false,
 };
 const a: Item = {
+  type: 'component',
   id: 'a',
   name: 'a',
   depth: 1,
@@ -24,6 +26,7 @@ const a: Item = {
   children: ['a1'],
 };
 const a1: Item = {
+  type: 'story',
   id: 'a1',
   name: 'a1',
   kind: 'a',
@@ -35,6 +38,7 @@ const a1: Item = {
   args: {},
 };
 const b: Item = {
+  type: 'component',
   id: 'b',
   name: 'b',
   depth: 1,
@@ -45,6 +49,7 @@ const b: Item = {
   children: ['b1', 'b2'],
 };
 const b1: Item = {
+  type: 'story',
   id: 'b1',
   name: 'b1',
   kind: 'b',
@@ -56,6 +61,7 @@ const b1: Item = {
   args: {},
 };
 const b2: Item = {
+  type: 'story',
   id: 'b2',
   name: 'b2',
   kind: 'b',
@@ -97,6 +103,7 @@ describe('collapse all stories', () => {
 
     const expected: StoriesHash = {
       a1: {
+        type: 'component',
         id: 'a1',
         depth: 1,
         name: 'a',
@@ -109,6 +116,7 @@ describe('collapse all stories', () => {
         args: {},
       },
       b1: {
+        type: 'component',
         id: 'b1',
         depth: 1,
         name: 'b',
@@ -121,6 +129,7 @@ describe('collapse all stories', () => {
         args: {},
       },
       root: {
+        type: 'root',
         id: 'root',
         name: 'root',
         depth: 0,
@@ -143,6 +152,7 @@ describe('collapse all stories', () => {
     const collapsed = collapseAllStories(hasDocsOnly);
 
     expect(collapsed.a1).toEqual({
+      type: 'component',
       id: 'a1',
       name: 'a',
       kind: 'a',
@@ -158,6 +168,7 @@ describe('collapse all stories', () => {
 
   it('collapses mixtures of leaf and non-leaf children', () => {
     const mixedRoot: Item = {
+      type: 'root',
       id: 'root',
       name: 'root',
       depth: 0,
@@ -177,6 +188,7 @@ describe('collapse all stories', () => {
 
     expect(collapsed).toEqual({
       a1: {
+        type: 'component',
         id: 'a1',
         depth: 1,
         name: 'a',
@@ -189,6 +201,7 @@ describe('collapse all stories', () => {
         args: {},
       },
       b1: {
+        type: 'story',
         id: 'b1',
         name: 'b1',
         kind: 'b',
@@ -200,6 +213,7 @@ describe('collapse all stories', () => {
         args: {},
       },
       root: {
+        type: 'root',
         id: 'root',
         name: 'root',
         depth: 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7910,6 +7910,7 @@ __metadata:
     "@storybook/addon-essentials": 6.5.0-beta.1
     "@storybook/addon-storyshots": 6.5.0-beta.1
     "@storybook/addon-storysource": 6.5.0-beta.1
+    "@storybook/addons": 6.5.0-beta.1
     "@storybook/cli": 6.5.0-beta.1
     "@storybook/components": 6.5.0-beta.1
     "@storybook/react": 6.5.0-beta.1
@@ -7922,6 +7923,7 @@ __metadata:
     "@types/react-dom": ^16.9.14
     cross-env: ^7.0.3
     formik: ^2.2.9
+    lodash: ^4.17.21
     prop-types: 15.7.2
     react: 16.14.0
     react-dom: 16.14.0


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Update `MIGRATION.md` with instructions for restoring old behavior
- [x] Update `examples/react-ts` with working example

@tmeasday Any suggestions for how to make this snippet forward-compatible with 7.0?

## How to test

```
yarn bootstrap --core
cd examples/react-ts
yarn storybook
# remove manager.js & re-run to see difference
```