### PR TITLE
Fix homepage core-server

### DIFF
--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -12,7 +12,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/storybookjs/storybook.git",
-    "directory": "lib/core"
+    "directory": "lib/core-server"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
Issue:

## What I did

Currently, `homepage` is linked to `@storybook/core`, I update the link to `@storybook/core-server`

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? N/A
- [x] Does this need a new example in the kitchen sink apps? N/A
- [x] Does this need an update to the documentation? N/A

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
