### PR TITLE
Controls: Fix URL deserialization for argTypes with mapping

### DIFF
--- a/examples/react-ts/src/__snapshots__/storyshots.test.ts.snap
+++ b/examples/react-ts/src/__snapshots__/storyshots.test.ts.snap
@@ -3801,6 +3801,7 @@ exports[`Storyshots Docs/ButtonMdx Basic 1`] = `
 <button
   type="button"
 >
+   
   Click me
 </button>
 `;
@@ -3809,6 +3810,7 @@ exports[`Storyshots Docs/ButtonMdx Controls 1`] = `
 <button
   type="button"
 >
+   
   Hello
 </button>
 `;
@@ -3817,6 +3819,7 @@ exports[`Storyshots Examples / Button Basic 1`] = `
 <button
   type="button"
 >
+   
   Click me
 </button>
 `;
@@ -3825,6 +3828,7 @@ exports[`Storyshots Examples / Button CSF 2 Story With Play 1`] = `
 <button
   type="button"
 >
+   
   Hello
 </button>
 `;
@@ -3833,6 +3837,7 @@ exports[`Storyshots Examples / Button Process Env 1`] = `
 <button
   type="button"
 >
+   
   Hello
 </button>
 `;
@@ -3841,6 +3846,7 @@ exports[`Storyshots Examples / Button Story No Render 1`] = `
 <button
   type="button"
 >
+   
   magic!
 </button>
 `;
@@ -3851,6 +3857,7 @@ exports[`Storyshots Examples / Button Story With Play 1`] = `
 <button
   type="button"
 >
+   
   play
 </button>
 `;
@@ -3859,6 +3866,7 @@ exports[`Storyshots Examples / Button With Args 1`] = `
 <button
   type="button"
 >
+   
   With args
 </button>
 `;

--- a/examples/react-ts/src/button.stories.tsx
+++ b/examples/react-ts/src/button.stories.tsx
@@ -7,10 +7,23 @@ import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { Button } from './button';
 
+const icons = {
+  foo: () => <>Foo</>,
+  bar: () => <>Bar</>,
+};
+
 export default {
   component: Button,
   title: 'Examples / Button',
-  argTypes: { onClick: { action: 'click ' } },
+  argTypes: {
+    onClick: { action: 'click ' },
+    icon: {
+      description: 'An icon, displayed to the left of the title.',
+      control: { type: 'select' },
+      options: Object.keys(icons),
+      mapping: icons,
+    },
+  },
   // render: () => <>hohoho</>,
 } as Meta;
 

--- a/examples/react-ts/src/button.tsx
+++ b/examples/react-ts/src/button.tsx
@@ -1,14 +1,19 @@
-import React, { ButtonHTMLAttributes } from 'react';
+import React, { ReactElement, ButtonHTMLAttributes } from 'react';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * A label to show on the button
    */
   label: string;
+
+  /**
+   * An icon to show on the left of the label
+   */
+  icon: ReactElement;
 }
 
-export const Button = ({ label = 'Hello', ...props }: ButtonProps) => (
+export const Button = ({ label = 'Hello', icon: Icon, ...props }: ButtonProps) => (
   <button type="button" {...props}>
-    {label}
+    {Icon ? <Icon /> : null} {label}
   </button>
 );

--- a/examples/react-ts/src/button.tsx
+++ b/examples/react-ts/src/button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ButtonHTMLAttributes } from 'react';
+import React, { ComponentType, ButtonHTMLAttributes } from 'react';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
@@ -9,7 +9,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * An icon to show on the left of the label
    */
-  icon?: ReactElement;
+  icon?: ComponentType;
 }
 
 export const Button = ({ label = 'Hello', icon: Icon, ...props }: ButtonProps) => (

--- a/examples/react-ts/src/button.tsx
+++ b/examples/react-ts/src/button.tsx
@@ -9,7 +9,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * An icon to show on the left of the label
    */
-  icon: ReactElement;
+  icon?: ReactElement;
 }
 
 export const Button = ({ label = 'Hello', icon: Icon, ...props }: ButtonProps) => (

--- a/lib/store/src/args.test.ts
+++ b/lib/store/src/args.test.ts
@@ -83,6 +83,25 @@ describe('mapArgsToTypes', () => {
     expect(mapArgsToTypes({ a: 'something' }, { a: { type: functionType } })).toStrictEqual({});
   });
 
+  it('includes functions if there is a mapping', () => {
+    expect(
+      mapArgsToTypes(
+        { a: 'something' },
+        { a: { type: functionType, mapping: { something: () => 'foo' } } }
+      )
+    ).toStrictEqual({
+      a: 'something',
+    });
+  });
+
+  it('skips default mapping if there is a user-specified mapping', () => {
+    expect(
+      mapArgsToTypes({ a: 'something' }, { a: { type: numberType, mapping: { something: 10 } } })
+    ).toStrictEqual({
+      a: 'something',
+    });
+  });
+
   it('omits unknown keys', () => {
     expect(mapArgsToTypes({ a: 'string' }, { b: { type: stringType } })).toStrictEqual({});
   });

--- a/lib/store/src/args.ts
+++ b/lib/store/src/args.ts
@@ -1,12 +1,16 @@
 import deepEqual from 'fast-deep-equal';
-import type { SBType, Args, ArgTypes, StoryContext, AnyFramework } from '@storybook/csf';
+import type { SBType, Args, InputType, ArgTypes, StoryContext, AnyFramework } from '@storybook/csf';
 import { once } from '@storybook/client-logger';
 import isPlainObject from 'lodash/isPlainObject';
 import dedent from 'ts-dedent';
 
 const INCOMPATIBLE = Symbol('incompatible');
-const map = (arg: unknown, type: SBType): any => {
+const map = (arg: unknown, argType: InputType): any => {
+  const type = argType.type as SBType;
   if (arg === undefined || arg === null || !type) return arg;
+  if (argType.mapping) {
+    return arg;
+  }
   switch (type.name) {
     case 'string':
       return String(arg);
@@ -19,7 +23,7 @@ const map = (arg: unknown, type: SBType): any => {
     case 'array':
       if (!type.value || !Array.isArray(arg)) return INCOMPATIBLE;
       return arg.reduce((acc, item, index) => {
-        const mapped = map(item, type.value);
+        const mapped = map(item, { type: type.value });
         if (mapped !== INCOMPATIBLE) acc[index] = mapped;
         return acc;
       }, new Array(arg.length));
@@ -27,7 +31,7 @@ const map = (arg: unknown, type: SBType): any => {
       if (typeof arg === 'string' || typeof arg === 'number') return arg;
       if (!type.value || typeof arg !== 'object') return INCOMPATIBLE;
       return Object.entries(arg).reduce((acc, [key, val]) => {
-        const mapped = map(val, type.value[key]);
+        const mapped = map(val, { type: type.value[key] });
         return mapped === INCOMPATIBLE ? acc : Object.assign(acc, { [key]: mapped });
       }, {} as Args);
     default:
@@ -38,7 +42,7 @@ const map = (arg: unknown, type: SBType): any => {
 export const mapArgsToTypes = (args: Args, argTypes: ArgTypes): Args => {
   return Object.entries(args).reduce((acc, [key, value]) => {
     if (!argTypes[key]) return acc;
-    const mapped = map(value, argTypes[key].type as SBType);
+    const mapped = map(value, argTypes[key]);
     return mapped === INCOMPATIBLE ? acc : Object.assign(acc, { [key]: mapped });
   }, {});
 };


### PR DESCRIPTION
Issue: N/A

## What I did

Controls with complex types and `mapping` in the argTypes (the common case of using a `mapping`) were not being properly deserialized from the URL. This PR:
- [x] Fixes the bug
- [x] Adds unit tests
- [x] Adds an e2e example

Self-merging @tmeasday 

## How to test

- [ ] See attached tests