### PR TITLE
Telemetry: Add safecheck for crash reports

### DIFF
--- a/lib/telemetry/src/index.ts
+++ b/lib/telemetry/src/index.ts
@@ -28,7 +28,7 @@ export const telemetry = async (
       telemetryData.payload.error = sanitizeError(error);
     }
 
-    if (!telemetryData.payload.error || options.enableCrashReports) {
+    if (!telemetryData.payload.error || options?.enableCrashReports) {
       if (process.env?.STORYBOOK_DEBUG_TELEMETRY) {
         logger.info('\n[telemetry]');
         logger.info(JSON.stringify(telemetryData, null, 2));


### PR DESCRIPTION
Issue: 

## What I did

I added an optional chaining opetator to a check in telemetry

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
