### PR TITLE
Addon-docs: Fix Canvas block CURRENT_SELECTION handling

### DIFF
--- a/addons/docs/src/blocks/Canvas.tsx
+++ b/addons/docs/src/blocks/Canvas.tsx
@@ -11,6 +11,7 @@ import { DocsContext, DocsContextProps } from './DocsContext';
 import { SourceContext, SourceContextProps } from './SourceContainer';
 import { getSourceProps, SourceState } from './Source';
 import { useStories } from './useStory';
+import { CURRENT_SELECTION } from './types';
 
 export { SourceState };
 
@@ -53,7 +54,10 @@ const getPreviewProps = (
   );
   const sourceProps = getSourceProps({ ids: targetIds }, docsContext, sourceContext);
   if (!sourceState) sourceState = sourceProps.state;
-  const stories = useStories(targetIds, docsContext);
+  const storyIds = targetIds.map((targetId) =>
+    targetId === CURRENT_SELECTION ? docsContext.id : targetId
+  );
+  const stories = useStories(storyIds, docsContext);
   isLoading = stories.some((s) => !s);
 
   return {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18128

## What I did

Added handling for the `CURRENT_SELECTION` token in the Canvas doc block before passing story IDs to `useStories`, similar to other doc blocks.

## How to test

* Open `/?path=/docs/addons-docs-mdx-id--hello-story` in `official-storybook`
* Verify that the entire "Selection" section loads without error
