### PR TITLE
Controls: Fix undefined args handling in the URL

### DIFF
--- a/examples/official-storybook/stories/core/args.stories.js
+++ b/examples/official-storybook/stories/core/args.stories.js
@@ -64,3 +64,23 @@ DifferentSet.args = {
   foo: 'bar',
   bar: 2,
 };
+
+export const TestUndefinedArgs = Template.bind({});
+TestUndefinedArgs.args = {
+  first: 'Bob',
+  last: 'Miller',
+  foo: 'bar',
+};
+TestUndefinedArgs.argTypes = {
+  first: {
+    control: { type: 'select' },
+    options: ['Bob', 'Alice'],
+  },
+  last: {
+    control: { type: 'select' },
+    options: ['Miller', 'Meyer'],
+  },
+  foo: {
+    control: { type: 'text' },
+  },
+};

--- a/lib/store/src/args.test.ts
+++ b/lib/store/src/args.test.ts
@@ -226,6 +226,11 @@ describe('validateOptions', () => {
     expect(validateOptions({ a: 1 }, { a: { options: [1, 2] } })).toStrictEqual({ a: 1 });
   });
 
+  // https://github.com/storybookjs/storybook/issues/17063
+  it('does not set args to `undefined` if they are unset and there are options', () => {
+    expect(validateOptions({}, { a: { options: [2, 3] } })).toStrictEqual({});
+  });
+
   it('includes arg if value is undefined', () => {
     expect(validateOptions({ a: undefined }, { a: { options: [1, 2] } })).toStrictEqual({
       a: undefined,

--- a/lib/store/src/args.ts
+++ b/lib/store/src/args.ts
@@ -105,7 +105,8 @@ export const validateOptions = (args: Args, argTypes: ArgTypes): Args => {
     const isValidArray = isArray && invalidIndex === -1;
 
     if (args[key] === undefined || options.includes(args[key]) || isValidArray) {
-      acc[key] = args[key];
+      // set available args only, see https://github.com/storybookjs/storybook/issues/17063
+      if (key in args) acc[key] = args[key];
       return acc;
     }
 

--- a/lib/store/src/args.ts
+++ b/lib/store/src/args.ts
@@ -73,12 +73,17 @@ export const combineArgs = (value: any, update: any): Args => {
 
 export const validateOptions = (args: Args, argTypes: ArgTypes): Args => {
   return Object.entries(argTypes).reduce((acc, [key, { options }]) => {
-    if (!options) {
+    // Don't set args that are not defined in `args` (they can be undefined in there)
+    // see https://github.com/storybookjs/storybook/issues/15630 and
+    //   https://github.com/storybookjs/storybook/issues/17063
+    function allowArg() {
       if (key in args) {
         acc[key] = args[key];
       }
       return acc;
     }
+
+    if (!options) return allowArg();
 
     if (!Array.isArray(options)) {
       once.error(dedent`
@@ -86,8 +91,7 @@ export const validateOptions = (args: Args, argTypes: ArgTypes): Args => {
 
         More info: https://storybook.js.org/docs/react/api/argtypes
       `);
-      acc[key] = args[key];
-      return acc;
+      return allowArg();
     }
 
     if (options.some((opt) => opt && ['object', 'function'].includes(typeof opt))) {
@@ -96,8 +100,7 @@ export const validateOptions = (args: Args, argTypes: ArgTypes): Args => {
 
         More info: https://storybook.js.org/docs/react/writing-stories/args#mapping-to-complex-arg-values
       `);
-      acc[key] = args[key];
-      return acc;
+      return allowArg();
     }
 
     const isArray = Array.isArray(args[key]);
@@ -105,9 +108,7 @@ export const validateOptions = (args: Args, argTypes: ArgTypes): Args => {
     const isValidArray = isArray && invalidIndex === -1;
 
     if (args[key] === undefined || options.includes(args[key]) || isValidArray) {
-      // set available args only, see https://github.com/storybookjs/storybook/issues/17063
-      if (key in args) acc[key] = args[key];
-      return acc;
+      return allowArg();
     }
 
     const field = isArray ? `${key}[${invalidIndex}]` : key;


### PR DESCRIPTION
Issue: #17063

## What I did

Fix a bug where args were erroneously getting set to `undefined` when they weren't present in the URL and the page was reloaded.

## How to test

```
cd examples/official-storybook
yarn storybook
```

1. Open the new story in this PR
2. Change one of the args via controls, observe that the new value gets added to the URL
3. Reload the browser, observe that the new value from step 2 gets restored to that arg.
4. Also observe that the other args remain unchanged. If you perform these steps in `next`, you'll see that the other args get erroneously set to `undefined` in both the URL and the args.
