### PR TITLE
Future - Replace syntax highlighter in lib/components

### DIFF
--- a/addons/storysource/src/StoryPanel.tsx
+++ b/addons/storysource/src/StoryPanel.tsx
@@ -2,12 +2,9 @@ import React from 'react';
 import { API, useParameter } from '@storybook/api';
 import { styled } from '@storybook/theming';
 import { Link } from '@storybook/router';
-import {
-  SyntaxHighlighter,
-  SyntaxHighlighterProps,
-  SyntaxHighlighterRendererProps,
-} from '@storybook/components';
+import { SyntaxHighlighter } from '@storybook/components';
 
+// TODO this is just broken. We need to figure out how to get selected & click-able areas on this new syntax-highlighter
 // @ts-expect-error Typedefs don't currently expose `createElement` even though it exists
 import { createElement as createSyntaxHighlighterElement } from 'react-syntax-highlighter';
 
@@ -29,7 +26,7 @@ const SelectedStoryHighlight = styled.div(({ theme }) => ({
   borderRadius: theme.appBorderRadius,
 }));
 
-const StyledSyntaxHighlighter = styled(SyntaxHighlighter)<SyntaxHighlighterProps>(({ theme }) => ({
+const StyledSyntaxHighlighter = styled(SyntaxHighlighter)(({ theme }) => ({
   fontSize: theme.typography.size.s2 - 1,
 }));
 
@@ -67,8 +64,8 @@ export const StoryPanel: React.FC<StoryPanelProps> = ({ api }) => {
     }
   }, [selectedStoryRef.current]);
 
-  const createPart = ({ rows, stylesheet, useInlineStyles }: SyntaxHighlighterRendererProps) =>
-    rows.map((node, i) =>
+  const createPart = ({ rows, stylesheet, useInlineStyles }: any) =>
+    rows.map((node: any, i: number) =>
       createSyntaxHighlighterElement({
         node,
         stylesheet,
@@ -84,7 +81,14 @@ export const StoryPanel: React.FC<StoryPanelProps> = ({ api }) => {
     location,
     id,
     refId,
-  }: SyntaxHighlighterRendererProps & { location: SourceBlock; id: string; refId?: string }) => {
+  }: {
+    location: SourceBlock;
+    id: string;
+    refId?: string;
+    rows: any;
+    stylesheet: any;
+    useInlineStyles: any;
+  }) => {
     const first = location.startLoc.line - 1;
     const last = location.endLoc.line;
 
@@ -106,7 +110,7 @@ export const StoryPanel: React.FC<StoryPanelProps> = ({ api }) => {
     );
   };
 
-  const createParts = ({ rows, stylesheet, useInlineStyles }: SyntaxHighlighterRendererProps) => {
+  const createParts = ({ rows, stylesheet, useInlineStyles }: any) => {
     const parts = [];
     let lastRow = 0;
 
@@ -134,17 +138,15 @@ export const StoryPanel: React.FC<StoryPanelProps> = ({ api }) => {
     return parts;
   };
 
-  const lineRenderer = ({
-    rows,
-    stylesheet,
-    useInlineStyles,
-  }: SyntaxHighlighterRendererProps): React.ReactNode => {
+  const lineRenderer = ({ rows, stylesheet, useInlineStyles }: any): React.ReactNode => {
     // because of the usage of lineRenderer, all lines will be wrapped in a span
     // these spans will receive all classes on them for some reason
     // which makes colours cascade incorrectly
     // this removed that list of classnames
+    // @ts-ignore
     const myrows = rows.map(({ properties, ...rest }) => ({
       ...rest,
+      // @ts-ignore
       properties: { className: [] },
     }));
 

--- a/examples/external-docs/pages/api/hello.js
+++ b/examples/external-docs/pages/api/hello.js
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default function handler(req, res) {
-  res.status(200).json({ name: 'John Doe' })
+  res.status(200).json({ name: 'John Doe' });
 }

--- a/lib/blocks/src/components/Preview.tsx
+++ b/lib/blocks/src/components/Preview.tsx
@@ -118,7 +118,7 @@ const getSource = (
   setExpanded: Function
 ): SourceItem => {
   switch (true) {
-    case !!(withSource && withSource.error): {
+    case !!(withSource && 'error' in withSource): {
       return {
         source: null,
         actionItem: {

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -55,6 +55,7 @@
     "@storybook/theming": "7.0.0-alpha.8",
     "core-js": "^3.8.2",
     "memoizerific": "^1.11.3",
+    "prism-react-renderer": "^1.3.1",
     "qs": "^6.10.0",
     "util-deprecate": "^1.0.2"
   },

--- a/lib/components/src/index.ts
+++ b/lib/components/src/index.ts
@@ -34,7 +34,6 @@ export { DocumentWrapper } from './typography/DocumentWrapper';
 export type {
   SyntaxHighlighterFormatTypes,
   SyntaxHighlighterProps,
-  SyntaxHighlighterRendererProps,
 } from './syntaxhighlighter/syntaxhighlighter-types';
 export { SyntaxHighlighter } from './syntaxhighlighter/lazy-syntaxhighlighter';
 export { createCopyToClipboardFunction } from './syntaxhighlighter/syntaxhighlighter';

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter-types.ts
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter-types.ts
@@ -1,39 +1,14 @@
 import type { BuiltInParserName } from 'prettier';
-import type { ReactNode } from 'react';
 
-export interface SyntaxHighlighterRendererProps {
-  rows: any[];
-  stylesheet: string;
-  useInlineStyles: boolean;
-}
+export type SyntaxHighlighterFormatTypes = boolean | 'dedent' | BuiltInParserName;
 
-export interface SyntaxHighlighterCustomProps {
+export interface SyntaxHighlighterProps {
   language: string;
   copyable?: boolean;
   bordered?: boolean;
   padded?: boolean;
   format?: SyntaxHighlighterFormatTypes;
   formatter?: (type: SyntaxHighlighterFormatTypes, source: string) => string;
-  className?: string;
-  renderer?: (props: SyntaxHighlighterRendererProps) => ReactNode;
-}
-
-export type SyntaxHighlighterFormatTypes = boolean | 'dedent' | BuiltInParserName;
-
-// these are copied from the `react-syntax-highlighter` package
-// the reason these a COPIED is the types for this package are defining modules by filename
-// which will not match one we've localized type-definitions
-type lineTagPropsFunction = (lineNumber: number) => React.HTMLProps<HTMLElement>;
-export interface SyntaxHighlighterBaseProps {
-  language?: string;
-  style?: any;
-  customStyle?: any;
-  lineProps?: lineTagPropsFunction | React.HTMLProps<HTMLElement>;
-  codeTagProps?: React.HTMLProps<HTMLElement>;
-  useInlineStyles?: boolean;
   showLineNumbers?: boolean;
-  startingLineNumber?: number;
-  lineNumberStyle?: any;
+  className?: string;
 }
-
-export type SyntaxHighlighterProps = SyntaxHighlighterBaseProps & SyntaxHighlighterCustomProps;

--- a/lib/components/src/syntaxhighlighter/syntaxhighlighter.stories.tsx
+++ b/lib/components/src/syntaxhighlighter/syntaxhighlighter.stories.tsx
@@ -96,6 +96,7 @@ storiesOf('Basics/SyntaxHighlighter', module)
     </SyntaxHighlighter>
   ))
   .add('unsupported', () => (
+    /* @ts-expect-error We want to pass unsupported language here */
     <SyntaxHighlighter language="C#" bordered copyable>
       {`
         // A Hello World! program in C#.
@@ -121,6 +122,7 @@ storiesOf('Basics/SyntaxHighlighter', module)
     const theme = ensure(themes.dark);
     return (
       <ThemeProvider theme={theme}>
+        {/* @ts-expect-error We want to pass unsupported language here */}
         <SyntaxHighlighter bordered language="C#" copyable>
           {`
             // A Hello World! program in C#.

--- a/yarn.lock
+++ b/yarn.lock
@@ -8099,6 +8099,7 @@ __metadata:
     overlayscrollbars: ^1.13.1
     polished: ^4.2.2
     prettier: ">=2.2.1 <=2.3.0"
+    prism-react-renderer: ^1.3.1
     prop-types: ^15.7.2
     qs: ^6.10.0
     react-colorful: ^5.1.2
@@ -36577,6 +36578,15 @@ __metadata:
   peerDependencies:
     react: ">=0.14.9"
   checksum: 95c53e0702bc2a2ca902c96dd586eaad1cef06e451a1523b19f70b278534f31a6a2cbf409dc4c03bbf16bfbc0d200d675586cf2f229d3943b47aedb7eca21f27
+  languageName: node
+  linkType: hard
+
+"prism-react-renderer@npm:^1.3.1":
+  version: 1.3.5
+  resolution: "prism-react-renderer@npm:1.3.5"
+  peerDependencies:
+    react: ">=0.14.9"
+  checksum: 9caada97fa7325fc99484cff409a84ed947a061615851bd0aedf4fcfd4b3496e2eff4b252dbfd4465dd6ea7310134ed67d737cabf0c78b192969c3c7da383237
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18090

## What I did

After the investigation, I found out that the issue was related to https://github.com/react-syntax-highlighter/react-syntax-highlighter and specifically to global PrismJS instance that would replace the already rendered contents of `code` blocks.

This PR replaces the rendering engine `SyntaxHighlighter` component to use https://github.com/FormidableLabs/prism-react-renderer.

## How to test

Check out https://github.com/storybookjs/storybook/issues/18090

## Breaking changes

Technically it's a breaking change since the external API of `SyntaxHighlighter` has been changed. Check out https://github.com/storybookjs/storybook/pull/18146/files#diff-067280cfd28572f546ce2152e8b22d2b2736bf7cb3dc354e908d3e8bd5208b5e. Since we consider this component as an internal component, I think it's still fine to release this under `6.5` and adding this to the release notes. 

Other than that, I preserved the current API as much as possible as well as underlying class names to some extent. So if someone relies on class names like `token tag` etc. for custom styling it should still work. 

### Before
<img width="240" alt="CleanShot 2022-05-05 at 16 51 19@2x" src="https://user-images.githubusercontent.com/11071/166950790-08c3a109-c922-4e55-9a44-77c92bcd92ac.png">

### After
<img width="347" alt="CleanShot 2022-05-05 at 16 50 48@2x" src="https://user-images.githubusercontent.com/11071/166950809-039676f9-a528-4804-88c2-96f32ed022d5.png">

## Bundle size (bytes)

Running `cd examples/react-ts && yarn && yarn build-storybook` yields

`next`:  `373192`
`replace-syntax-highlighter`: `333416`
Diff: `-39776`
