### PR TITLE
Remove jest from cli peerDependencies

### DIFF
--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -86,9 +86,6 @@
     "strip-json-comments": "^3.1.1",
     "update-notifier": "^5.0.1"
   },
-  "peerDependencies": {
-    "jest": "*"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7415,8 +7415,6 @@ __metadata:
     strip-json-comments: ^3.1.1
     ts-dedent: ^2.0.0
     update-notifier: ^5.0.1
-  peerDependencies:
-    jest: "*"
   bin:
     getstorybook: ./bin/index.js
     sb: ./bin/index.js


### PR DESCRIPTION
Issue:

Reference: https://github.com/storybookjs/storybook/issues/18111, but not sure this will fix it.

Someone else in discord also had a similar issue, and based on https://github.com/npm/cli/issues/4367, it sounds like it might have something to do with peer dependencies.

## What I did

I can't see any reason why the cli would need to have a peer dependency on jest being installed.  It was added in https://github.com/storybookjs/storybook/pull/10012, but I think that things have changed since then, because no other packages have a peer dependency on `jest@*` anymore.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
