### PR TITLE
Fix typo in Source documentation

### DIFF
--- a/docs/writing-docs/doc-block-source.md
+++ b/docs/writing-docs/doc-block-source.md
@@ -23,7 +23,7 @@ It includes additional customization via parameters. Below is a condensed exampl
 
 <div class="aside">
 
-💡 The pattern demonstrated here applies only to the story. If you need, you can it this to all the component stories, introducing a [component parameter](../writing-stories/parameters.md#component-parameters).
+💡 The pattern demonstrated here applies only to the story. If you need, you can apply this to all the component stories, introducing a [component parameter](../writing-stories/parameters.md#component-parameters).
 
 </div>
 


### PR DESCRIPTION
Issue: Typo in the `Source` documentation

## What I did
Fixed the typo, replacing `it` with `apply`, because it was grammatically incorrect.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
