### PR TITLE
Fix typo examples & docs

### DIFF
--- a/app/react/src/client/docs/lib/inspection/acornParser.test.ts
+++ b/app/react/src/client/docs/lib/inspection/acornParser.test.ts
@@ -148,7 +148,7 @@ describe('parse', () => {
     });
 
     it('support array', () => {
-      const result = parse("['bottom-left', 'botton-center', 'bottom-right']");
+      const result = parse("['bottom-left', 'bottom-center', 'bottom-right']");
       const inferredType = result.inferredType as InspectionArray;
 
       expect(inferredType.type).toBe(InspectionType.ARRAY);

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -304,7 +304,7 @@ export default {
   plugins: [
     // Other plugins
 
-    // Configures the replace plugin to allow Grapqhl Queries to work properly
+    // Configures the replace plugin to allow Graphql Queries to work properly
     replace({
       'process.env.NODE_ENV': JSON.stringify('development'),
     }),

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -304,7 +304,7 @@ export default {
   plugins: [
     // Other plugins
 
-    // Configures the replace plugin to allow Graphql Queries to work properly
+    // Configures the replace plugin to allow GraphQL Queries to work properly
     replace({
       'process.env.NODE_ENV': JSON.stringify('development'),
     }),

--- a/examples/angular-cli/src/stories/basics/component-with-ng-on-destroy/component-with-on-destroy.stories.ts
+++ b/examples/angular-cli/src/stories/basics/component-with-ng-on-destroy/component-with-on-destroy.stories.ts
@@ -4,7 +4,7 @@ import { Story, Meta } from '@storybook/angular';
 @Component({
   selector: 'on-destroy',
   template: `Current time: {{ time }} <br />
-    📝 The current time in console should no longer display after a change of stroy`,
+    📝 The current time in console should no longer display after a change of story`,
 })
 class OnDestroyComponent implements OnInit, OnDestroy {
   time: string;

--- a/examples/cra-ts-essentials/src/stories/testing-react/components/AccountForm.tsx
+++ b/examples/cra-ts-essentials/src/stories/testing-react/components/AccountForm.tsx
@@ -25,7 +25,7 @@ const errorMap = {
   password: {
     required: {
       normal: 'Please enter a password',
-      tooltip: 'A password is requried to create an account',
+      tooltip: 'A password is required to create an account',
     },
     length: {
       normal: 'Please enter a password of minimum 6 characters',

--- a/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/types/prop-types.js
+++ b/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/types/prop-types.js
@@ -215,7 +215,7 @@ PropTypesProps.propTypes = {
   oneOfComponents: PropTypes.oneOf([FunctionalComponent, ClassComponent]),
   oneOfEval: PropTypes.oneOf((() => ['News', 'Photos'])()),
   oneOfVar: PropTypes.oneOf(POSITIONS),
-  oneOfNested: PropTypes.oneOf(['News', ['bottom-left', 'botton-center', 'bottom-right']]),
+  oneOfNested: PropTypes.oneOf(['News', ['bottom-left', 'bottom-center', 'bottom-right']]),
   oneOfNestedSimpleInlineObject: PropTypes.oneOf(['News', [{ foo: PropTypes.string }]]),
   oneOfNestedComplexInlineObject: PropTypes.oneOf([
     'News',

--- a/examples/external-docs/README.md
+++ b/examples/external-docs/README.md
@@ -1,3 +1,3 @@
 # Storybook External Docs Example
 
-This example demostrates using Stories in an app built outside of SB's build process.
+This example demonstrates using Stories in an app built outside of SB's build process.

--- a/examples/external-docs/src/components/AccountForm.tsx
+++ b/examples/external-docs/src/components/AccountForm.tsx
@@ -25,7 +25,7 @@ const errorMap = {
   password: {
     required: {
       normal: 'Please enter a password',
-      tooltip: 'A password is requried to create an account',
+      tooltip: 'A password is required to create an account',
     },
     length: {
       normal: 'Please enter a password of minimum 6 characters',

--- a/examples/react-ts/src/AccountForm.tsx
+++ b/examples/react-ts/src/AccountForm.tsx
@@ -25,7 +25,7 @@ const errorMap = {
   password: {
     required: {
       normal: 'Please enter a password',
-      tooltip: 'A password is requried to create an account',
+      tooltip: 'A password is required to create an account',
     },
     length: {
       normal: 'Please enter a password of minimum 6 characters',


### PR DESCRIPTION
Issue: typo in `examples`, `docs`

## What I did
Fixed the typos

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

I hope it helps.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
