### PR TITLE
Composition: Fix  metadata.json incorrectly overriding main.js refs versions

### DIFF
--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -206,11 +206,14 @@ export const init: ModuleFn = ({ store, provider, singleStory }, { runCheck = tr
         Object.assign(loadedData, { ...stories, ...metadata });
       }
 
+      const versions =
+        ref.versions && Object.keys(ref.versions).length ? ref.versions : loadedData.versions;
+
       await api.setRef(id, {
         id,
         url,
         ...loadedData,
-        versions: Object.keys(ref.versions).length ? ref.versions : loadedData.versions,
+        ...(versions ? { versions } : {}),
         error: loadedData.error,
         type: !loadedData.stories ? 'auto-inject' : 'lazy',
       });

--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -210,7 +210,7 @@ export const init: ModuleFn = ({ store, provider, singleStory }, { runCheck = tr
         id,
         url,
         ...loadedData,
-        versions: Object.keys(loadedData.versions).length ? loadedData.versions : ref.versions,
+        versions: Object.keys(ref.versions).length ? ref.versions : loadedData.versions,
         error: loadedData.error,
         type: !loadedData.stories ? 'auto-inject' : 'lazy',
       });

--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -160,7 +160,7 @@ export const init: ModuleFn = ({ store, provider, singleStory }, { runCheck = tr
       //
       // then we fetch metadata if the above fetch succeeded
 
-      const loadedData: { error?: Error; v?: number; stories?: StoriesRaw; loginUrl?: string } = {};
+      const loadedData: SetRefData = {};
       const query = version ? `?version=${version}` : '';
       const credentials = isPublic ? 'omit' : 'include';
 
@@ -210,6 +210,7 @@ export const init: ModuleFn = ({ store, provider, singleStory }, { runCheck = tr
         id,
         url,
         ...loadedData,
+        versions: Object.keys(loadedData.versions).length ? loadedData.versions : ref.versions,
         error: loadedData.error,
         type: !loadedData.stories ? 'auto-inject' : 'lazy',
       });

--- a/lib/api/src/tests/refs.test.js
+++ b/lib/api/src/tests/refs.test.js
@@ -328,6 +328,85 @@ describe('Refs API', () => {
       `);
     });
 
+    it('checks refs (not replace versions)', async () => {
+      // given
+      const { api } = initRefs({ provider, store }, { runCheck: false });
+
+      setupResponses(
+        {
+          ok: true,
+          response: async () => ({ v: 2, stories: {} }),
+        },
+        {
+          ok: true,
+          response: async () => ({ v: 3, stories: {} }),
+        },
+        {
+          ok: true,
+          response: async () => {
+            throw new Error('not ok');
+          },
+        },
+        {
+          ok: true,
+          response: async () => ({
+            versions: {},
+          }),
+        }
+      );
+
+      await api.checkRef({
+        id: 'fake',
+        url: 'https://example.com',
+        title: 'Fake',
+        versions: { a: 'http://example.com/a', b: 'http://example.com/b' },
+      });
+
+      expect(fetch.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            "https://example.com/stories.json",
+            Object {
+              "credentials": "include",
+              "headers": Object {
+                "Accept": "application/json",
+              },
+            },
+          ],
+          Array [
+            "https://example.com/metadata.json",
+            Object {
+              "cache": "no-cache",
+              "credentials": "include",
+              "headers": Object {
+                "Accept": "application/json",
+              },
+            },
+          ],
+        ]
+      `);
+
+      expect(store.setState.mock.calls[0][0]).toMatchInlineSnapshot(`
+        Object {
+          "refs": Object {
+            "fake": Object {
+              "error": undefined,
+              "id": "fake",
+              "ready": false,
+              "stories": Object {},
+              "title": "Fake",
+              "type": "lazy",
+              "url": "https://example.com",
+              "versions": Object {
+                "a": "http://example.com/a",
+                "b": "http://example.com/b",
+              },
+            },
+          },
+        }
+      `);
+    });
+
     it('checks refs (auth)', async () => {
       // given
       const { api } = initRefs({ provider, store }, { runCheck: false });


### PR DESCRIPTION
Issue:
When the user specifies versions for refs in `main.js` those are overloaded by `metadata.json` returning `versions: {}`.

## What I did

When the loaded data from metadata.json contains an empty versions object, disregard it.
Also added a tests for it.
