### PR TITLE
Update Vite builder docs a bit

### DIFF
--- a/docs/builders/vite.md
+++ b/docs/builders/vite.md
@@ -103,13 +103,13 @@ If you need to override it, you can use the `viteFinal` function and adjust it.
 
 ### ArgTypes are not generated automatically
 
-Storybook’s [automatic argType inference](https://storybook.js.org/docs/react/api/argtypes#automatic-argtype-inference) is currently only available for React and Vue3 projects. In react projects, if typescript is found in the project's package.json, we assume the components are written in typescript, and use `react-docgen-typescript`. If this causes problems, you can use `react-docgen` by configuring the `typescript` option in your `.storybook/main.js`:
+Currently, [automatic argType inference](../api/argtypes.md#automatic-argtype-inference) is only available for React and Vue3. With React, the Vite builder defaults to `react-docgen-typescript` if TypeScript is listed as a dependency. If you run into any issues, you can revert to `react-docgen` by updating your Storybook configuration file as follows:
 
 <!-- prettier-ignore-start -->
 
 <CodeSnippets
   paths={[
-    'common/storybook-vite-builder-react-docgen.ts.mdx',
+    'common/storybook-vite-builder-react-docgen.js.mdx',
   ]}
 />
 

--- a/docs/builders/vite.md
+++ b/docs/builders/vite.md
@@ -96,38 +96,24 @@ If you need, you can also configure Storybook's Vite builder using TypeScript. R
 
 ## Troubleshooting
 
-### Prebundle errors
-
-Vite automatically restarts and begins the prebundling process if it detects a new dependency. This pattern breaks with Storybook and throws confusing error messages. If you see the following message in your terminal:
-
-```shell
-[vite] new dependencies found:
-```
-
-Update your `viteFinal` configuration and include the new dependencies as follows:
-
-<!-- prettier-ignore-start -->
-
-<CodeSnippets
-  paths={[
-    'common/storybook-vite-builder-error-optimized.js.mdx',
-  ]}
-/>
-
-<!-- prettier-ignore-end -->
-
 ### Working directory not being detected
 
 By default, the Vite builder enables Vite's [`server.fs.strict`](https://vitejs.dev/config/#server-fs-strict) option for increased security, defining the project's `root` to Storybook's configuration directory
 If you need to override it, you can use the `viteFinal` function and adjust it.
 
-### HMR seems flaky
-
-Saving a component story does not initiate a hot module replacement. Instead, a complete reload happens. You can update your component file or save it to see the changes in effect.
-
 ### ArgTypes are not generated automatically
 
-Storybook’s [automatic argType inference](https://storybook.js.org/docs/react/api/argtypes#automatic-argtype-inference) is currently only available for React TypeScript projects. The builder will include additional framework support in future releases.
+Storybook’s [automatic argType inference](https://storybook.js.org/docs/react/api/argtypes#automatic-argtype-inference) is currently only available for React and Vue3 projects. In react projects, if typescript is found in the project's package.json, we assume the components are written in typescript, and use `react-docgen-typescript`. If this causes problems, you can use `react-docgen` by configuring the `typescript` option in your `.storybook/main.js`:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-vite-builder-react-docgen.ts.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
 
 #### Learn more about builders
 

--- a/docs/snippets/common/storybook-builder-api-dev-server.ts.mdx
+++ b/docs/snippets/common/storybook-builder-api-dev-server.ts.mdx
@@ -4,11 +4,19 @@
 import { createServer } from 'vite';
 
 export async function createViteServer(options: ExtendedOptions, devServer: Server) {
+  const { port } = options;
   // Remainder server configuration
 
   // Creates the server.
   return createServer({
     // The server configuration goes here
+    server: {
+      middlewareMode: true,
+      hmr: {
+        port,
+        server: devServer,
+      },
+    },
   });
 }
 ```

--- a/docs/snippets/common/storybook-vite-builder-aliasing.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-aliasing.js.mdx
@@ -1,5 +1,7 @@
 ```js
-// .storybook/main.js|ts
+// .storybook/main.js|cjs|ts
+
+const { mergeConfig } = require('vite');
 
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -7,12 +9,14 @@ module.exports = {
   core: {
     builder: '@storybook/builder-vite',
   },
-  async viteFinal(config, { configType }) {
-    // Return the updated configuration
+  async viteFinal(config) {
+    // Merge custom configuration into the default config
     return mergeConfig(config, {
-      // Adds a new alias
-      resolve: {
-        alias: { exampleAlias: 'something' },
+      // Use the same "resolve" configuration as your app
+      resolve: (await import('../vite.config.js')).default.resolve
+      // Add dependencies to pre-optimization
+      optimizeDeps: {
+        include: ['storybook-dark-mode'],
       },
     });
   },

--- a/docs/snippets/common/storybook-vite-builder-react-docgen.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-react-docgen.js.mdx
@@ -7,12 +7,8 @@ module.exports = {
   core: {
     builder: '@storybook/builder-vite',
   },
-  async viteFinal(config, { configType }) {
-    config.optimizeDeps.include = [
-      ...(config.optimizeDeps?.include ?? []),
-      // Other dependencies go here
-    ];
-    return config;
+  typescript: {
+    reactDocgen: 'react-docgen', // 👈 react-docgen configured here.
   },
 };
 ```

--- a/docs/snippets/common/storybook-vite-builder-react-docgen.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-react-docgen.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// .storybook/main.js|ts
+// .storybook/main.js
 
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],


### PR DESCRIPTION
Issue:

## What I did

This makes a few tweaks to the new docs for the vite builder (https://storybook.js.org/docs/6.5/react/builders/vite).  I'll leave some inline comments to explain my reasoning.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
