### PR TITLE
chore(docs): path in the examples seems wrong

### DIFF
--- a/lib/cli/src/frameworks/common/Introduction.stories.mdx
+++ b/lib/cli/src/frameworks/common/Introduction.stories.mdx
@@ -207,5 +207,5 @@ We recommend building UIs with a [**component-driven**](https://componentdriven.
 
 <div className="tip-wrapper">
   <span className="tip">Tip</span>Edit the Markdown in{' '}
-  <code>src/stories/Introduction.stories.mdx</code>
+  <code>stories/Introduction.stories.mdx</code>
 </div>

--- a/lib/cli/src/frameworks/common/Introduction.stories.mdx
+++ b/lib/cli/src/frameworks/common/Introduction.stories.mdx
@@ -120,7 +120,7 @@ Storybook helps you build UI components in isolation from your app's business lo
 That makes it easy to develop hard-to-reach states. Save these UI states as **stories** to revisit during development, testing, or QA.
 
 Browse example stories now by navigating to them in the sidebar.
-View their code in the `src/stories` directory to learn how they work.
+View their code in the `stories` directory to learn how they work.
 We recommend building UIs with a [**component-driven**](https://componentdriven.org) process starting with atomic components and ending with pages.
 
 <div className="subheading">Configure</div>


### PR DESCRIPTION
Issue: When using CLI to init a new storybook instance, it comes with MDX example and the path seems wrong

## What I did

Fix the path

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
