### PR TITLE
fix(CLI): Don't throw is Ctrl + C was pressed when selecting a package

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -91,7 +91,7 @@ async function run() {
       },
     ]).then(({ mode, todo }) => {
       watchMode = mode;
-      return todo.map((key) => tasks[key]);
+      return todo?.map((key) => tasks[key]);
     });
   } else {
     // hits here when running yarn build --packagename
@@ -101,7 +101,7 @@ async function run() {
       .filter((item) => item.name !== 'watch' && item.value === true);
   }
 
-  selection.filter(Boolean).forEach((v) => {
+  selection?.filter(Boolean).forEach((v) => {
     const sub = execa.command(`yarn prepare${watchMode ? ' --watch' : ''}`, {
       cwd: resolve(__dirname, '..', v.location),
       buffer: false,


### PR DESCRIPTION
Issue: N/A

## What I did

This removes unhandled errors from CLI when <kbd>Ctrl+C</kbd> was pressed during package selection.

## How to test

Run `yarn build` and when asked about what packages to run it on, press <kbd>Ctrl+C</kbd>. You should not see any error stack traces anymore.

Todo:

- [ ] Do the same for `bootstrap` command.