### PR TITLE
Cleanup noise from unit tests

### DIFF
--- a/app/angular/setup-jest.ts
+++ b/app/angular/setup-jest.ts
@@ -1,4 +1,4 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import 'jest-preset-angular';
+import 'jest-preset-angular/setup-jest';
 
 global.EventSource = class {} as any;

--- a/app/angular/src/builders/build-storybook/index.spec.ts
+++ b/app/angular/src/builders/build-storybook/index.spec.ts
@@ -142,7 +142,7 @@ describe('Build Storybook Builder', () => {
   });
 
   it('should throw error', async () => {
-    buildStandaloneMock.mockRejectedValue(new Error());
+    buildStandaloneMock.mockRejectedValue(true);
 
     const run = await architect.scheduleBuilder('@storybook/angular:start-storybook', {
       browserTarget: 'angular-cli:build-2',

--- a/app/angular/src/builders/start-storybook/index.spec.ts
+++ b/app/angular/src/builders/start-storybook/index.spec.ts
@@ -124,7 +124,7 @@ describe('Start Storybook Builder', () => {
   });
 
   it('should throw error', async () => {
-    buildStandaloneMock.mockRejectedValue(new Error());
+    buildStandaloneMock.mockRejectedValue(true);
 
     const run = await architect.scheduleBuilder('@storybook/angular:start-storybook', {
       browserTarget: 'angular-cli:build-2',

--- a/app/angular/src/client/preview/angular-beta/RendererFactory.test.ts
+++ b/app/angular/src/client/preview/angular-beta/RendererFactory.test.ts
@@ -22,6 +22,7 @@ describe('RendererFactory', () => {
     rootTargetDOMNode = global.document.getElementById('root');
     rootDocstargetDOMNode = global.document.getElementById('root-docs');
     (platformBrowserDynamic as any).mockImplementation(platformBrowserDynamicTesting);
+    jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/app/angular/src/server/__mocks-ng-workspace__/with-lib/projects/pattern-lib/tsconfig.lib.json
+++ b/app/angular/src/server/__mocks-ng-workspace__/with-lib/projects/pattern-lib/tsconfig.lib.json
@@ -2,6 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "../../out-tsc/lib",
     "target": "es2015",
     "declaration": true,

--- a/app/angular/src/server/__mocks-ng-workspace__/without-projects-entry/projects/pattern-lib/tsconfig.lib.json
+++ b/app/angular/src/server/__mocks-ng-workspace__/without-projects-entry/projects/pattern-lib/tsconfig.lib.json
@@ -2,6 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "../../out-tsc/lib",
     "target": "es2015",
     "declaration": true,

--- a/examples/angular-cli/jest-config/setup.ts
+++ b/examples/angular-cli/jest-config/setup.ts
@@ -1,4 +1,4 @@
-import 'jest-preset-angular';
+import 'jest-preset-angular/setup-jest';
 import './globalMocks';
 
 require('@storybook/babel-plugin-require-context-hook/register')();

--- a/examples/angular-cli/jest.config.js
+++ b/examples/angular-cli/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   preset: 'jest-preset-angular',
   globals: {
     'ts-jest': {
-      tsConfig: path.join(__dirname, 'src/tsconfig.spec.json'),
+      tsconfig: path.join(__dirname, 'src/tsconfig.spec.json'),
       stringifyContentPathRegex: '\\.html$',
       astTransformers: {
         before: [
@@ -26,9 +26,9 @@ module.exports = {
   },
   moduleFileExtensions: [...config.moduleFileExtensions, 'html'],
   snapshotSerializers: [
-    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
-    'jest-preset-angular/build/AngularSnapshotSerializer.js',
-    'jest-preset-angular/build/HTMLCommentSerializer.js',
+    'jest-preset-angular/build/serializers/html-comment',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/no-ng-attributes',
   ],
   setupFilesAfterEnv: ['./jest-config/setup.ts'],
   testPathIgnorePatterns: ['app.component.spec.ts'],


### PR DESCRIPTION
Issue:

## What I did

Added baseUrl to mocked ng workspace tsconfigs, to get rid of this error:

```
Failed to load /tmp/storybook/app/angular/src/server/__mocks-ng-workspace__/with-lib/projects/pattern-lib/tsconfig.lib.json: Missing baseUrl in compilerOptions
Failed to load /tmp/storybook/app/angular/src/server/__mocks-ng-workspace__/with-lib/projects/pattern-lib/tsconfig.lib.json: Missing baseUrl in compilerOptions
Failed to load /tmp/storybook/app/angular/src/server/__mocks-ng-workspace__/without-projects-entry/projects/pattern-lib/tsconfig.lib.json: Missing baseUrl in compilerOptions
 PASS  app/angular/src/server/framework-preset-angular-cli.test.ts (11.773 s)
```

Updated jest-preset-angular usage, to get rid of this error:

```
ts-jest[root] (WARN) Import setup jest file via `import 'jest-preset-angular';` is deprecated and will be removed in v9.0.0. Please switch to `import 'jest-preset-angular/setup-jest';`
```

Switched rejected value mock in a test to get rid of this noise:
```
ERR! Error: 
ERR!     at /tmp/storybook/app/angular/src/builders/start-storybook/index.spec.ts:127:43
ERR!     at Generator.next (<anonymous>)
ERR!     at /tmp/storybook/app/angular/src/builders/start-storybook/index.spec.ts:27:71
ERR!     at new ZoneAwarePromise (/tmp/storybook/node_modules/zone.js/bundles/zone-testing-bundle.umd.js:1347:33)
ERR!     at Object.<anonymous>.__awaiter (/tmp/storybook/app/angular/src/builders/start-storybook/index.spec.ts:23:12)
ERR!     at /tmp/storybook/app/angular/src/builders/start-storybook/index.spec.ts:126:39
ERR!     at ZoneDelegate.Object.<anonymous>.ZoneDelegate.invoke (/tmp/storybook/node_modules/zone.js/bundles/zone-testing-bundle.umd.js:407:30)
ERR!     at ProxyZoneSpec.Object.<anonymous>.ProxyZoneSpec.onInvoke (/tmp/storybook/node_modules/zone.js/bundles/zone-testing-bundle.umd.js:3765:43)
ERR!     at ZoneDelegate.Object.<anonymous>.ZoneDelegate.invoke (/tmp/storybook/node_modules/zone.js/bundles/zone-testing-bundle.umd.js:406:56)
ERR!     at Zone.Object.<anonymous>.Zone.run (/tmp/storybook/node_modules/zone.js/bundles/zone-testing-bundle.umd.js:167:47)
ERR!     at Object.wrappedFunc (/tmp/storybook/node_modules/zone.js/bundles/zone-testing-bundle.umd.js:4250:34)
ERR!     at Object.asyncJestTest (/tmp/storybook/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:106:37)
ERR!     at /tmp/storybook/node_modules/jest-jasmine2/build/queueRunner.js:45:12
ERR!     at new Promise (<anonymous>)
ERR!     at mapper (/tmp/storybook/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
ERR!     at /tmp/storybook/node_modules/jest-jasmine2/build/queueRunner.js:75:41
```

Suppressed console logs in angular test, to get rid of the incredible amount of logs about enableProdMode:

```
PASS  app/angular/src/client/preview/angular-beta/RendererFactory.test.ts
  ● Console

    console.log
      Angular is running in development mode. Call enableProdMode() to enable production mode.

      at Console.Object.<anonymous>.Console.log (../../../packages/core/src/console.ts:15:13)
          at Array.forEach (<anonymous>)

    console.log
      Angular is running in development mode. Call enableProdMode() to enable production mode.

      at Console.Object.<anonymous>.Console.log (../../../packages/core/src/console.ts:15:13)
          at Array.forEach (<anonymous>)

    console.log
      Angular is running in development mode. Call enableProdMode() to enable production mode.

      at Console.Object.<anonymous>.Console.log (../../../packages/core/src/console.ts:15:13)
          at Array.forEach (<anonymous>)
```

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
