### PR TITLE
Vue: map args correctly in CSF3 implicit render function

### DIFF
--- a/app/vue/src/client/preview/config.ts
+++ b/app/vue/src/client/preview/config.ts
@@ -1,4 +1,4 @@
-export { renderToDOM } from './render';
+export { render, renderToDOM } from './render';
 export { decorateStory } from './decorateStory';
 
 export const parameters = { framework: 'vue' };

--- a/app/vue/src/client/preview/render.ts
+++ b/app/vue/src/client/preview/render.ts
@@ -22,7 +22,7 @@ const root = new Vue({
 });
 
 export const render: ArgsStoryFn<VueFramework> = (props, context) => {
-  const { id, component: Component } = context;
+  const { id, component: Component, argTypes } = context;
   const component = Component as VueFramework['component'] & {
     __docgenInfo?: { displayName: string };
     props: Record<string, any>;
@@ -49,7 +49,7 @@ export const render: ArgsStoryFn<VueFramework> = (props, context) => {
   }
 
   return {
-    props,
+    props: Object.keys(argTypes),
     components: { [componentName]: component },
     template: `<${componentName} v-bind="$props" />`,
   };

--- a/app/vue/src/client/preview/render.ts
+++ b/app/vue/src/client/preview/render.ts
@@ -49,7 +49,7 @@ export const render: ArgsStoryFn<VueFramework> = (props, context) => {
   }
 
   return {
-    props: component.props,
+    props,
     components: { [componentName]: component },
     template: `<${componentName} v-bind="$props" />`,
   };

--- a/examples/vue-cli/src/button/Button.stories.ts
+++ b/examples/vue-cli/src/button/Button.stories.ts
@@ -19,3 +19,10 @@ export const ButtonWithProps: Story = (args, { argTypes }) => ({
 ButtonWithProps.args = {
   size: 'big',
 };
+
+export const WithDefaultRender = {
+  args: {
+    size: 'small',
+    label: 'Button with default render',
+  },
+};

--- a/examples/vue-cli/src/button/Button.vue
+++ b/examples/vue-cli/src/button/Button.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="button" :class="`size-${size}`">
     <!-- @slot Button content, e.g. label text -->
-    <slot></slot>
+    <slot>
+      {{label}}
+    </slot>
   </div>
 </template>
 
@@ -21,6 +23,11 @@ export default class Button extends Vue {
    * @values default,small,big
    */
   @Prop({ type: String, default: 'default' }) readonly size!: ButtonSize;
+  
+  /**
+   * Label of the button
+   */
+  @Prop({ type: String, default: '' }) readonly label!: string;
 }
 </script>
 


### PR DESCRIPTION
Issue: N/A

## What I did

The implicit render function was not being exported nor props from components that are defined via `@Prop` were correctly passed to the component. Both of these things are now fixed!

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
