### PR TITLE
Chore: (Docs) Minor fixes to snippets and docs

### DIFF
--- a/docs/configure/overview.md
+++ b/docs/configure/overview.md
@@ -180,10 +180,10 @@ You can also use Storybook's API to configure your project with TypeScript. Unde
 | `addons`              | Sets the list of [addons](/addons) loaded by Storybook <br/> `addons:['@storybook/addon-essentials']`                                                                            |
 | `typescript`          | Configures how Storybook handles [TypeScript files](./typescript.md) <br/> `typescript: { check: false, checkOptions: {} }`                                                      |
 | `framework`           | Configures Storybook based on a set of framework-specific settings <br/> `framework:'@storybook/svelte'`                                                                         |
-| `core`                | Sets Storybook's Webpack configuration <br/> `core:{ builder: 'webpack5'}`                                                                                                       |
-| `features`            | Enables Storybook's additional features <br/>. See table below for a list of available features `features: { storyStoreV7: true }`                                               |
+| `core`                | Configures Storybook's internal features.<br/> `core: { builder: 'webpack5' }`                                                                                                   |
+| `features`            | Enables Storybook's additional features.<br/> See table below for a list of available features `features: { storyStoreV7: true }`                                                |
 | `refs`                | Configures [Storybook composition](../sharing/storybook-composition.md) <br/> `refs:{ example: { title: 'ExampleStorybook', url:'https://your-url.com' } }`                      |
-| `logLevel`            | Configures Storybook's logs in the browser terminal. Useful for debugging <br/> `logLevel: 'debug'`                                                                                      |
+| `logLevel`            | Configures Storybook's logs in the browser terminal. Useful for debugging <br/> `logLevel: 'debug'`                                                                              |
 | `webpackFinal`        | Customize Storybook's [Webpack](./webpack.md) setup <br/> `webpackFinal: async (config:any) => { return config; }`                                                               |
 
 ## Configure story rendering

--- a/docs/snippets/common/storybook-storyloading-with-custom-object.js.mdx
+++ b/docs/snippets/common/storybook-storyloading-with-custom-object.js.mdx
@@ -8,7 +8,7 @@ module.exports = {
       directory: '../packages/stories',
       // 👇 The titlePrefix field will generate automatic titles for your stories
       titlePrefix: 'MyComponents',
-      // 👇 Storybook will load all files that contain the stories extensio
+      // 👇 Storybook will load all files that contain the stories extension
       files: '*.stories.*',
     },
   ],


### PR DESCRIPTION
With this small pull request the documentation and snippets are fixed per internal revision.

What was done:
- Fixed a typo in a snippet
- Polished documentation (configure/overview) for clarity