### PR TITLE
Core: Fix get-monorepo-type when no package.json at repo root

### DIFF
--- a/lib/telemetry/src/get-monorepo-type.ts
+++ b/lib/telemetry/src/get-monorepo-type.ts
@@ -27,6 +27,8 @@ export const getMonorepoType = (): MonorepoType => {
   if (monorepoType) {
     return monorepoType;
   }
+  
+  if (!fs.existsSync(path.join(projectRootPath, 'package.json'))) return undefined;
 
   const packageJson = fs.readJsonSync(path.join(projectRootPath, 'package.json')) as PackageJson;
 


### PR DESCRIPTION
Fixes issues when no package.json exists at the root of a repo

Issue:

## What I did

upgraded to newer version of storybook and ran into this issue

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
