### PR TITLE
Add sveltekit config file to vite builder detection

### DIFF
--- a/lib/cli/src/detect.ts
+++ b/lib/cli/src/detect.ts
@@ -17,7 +17,15 @@ import { PackageJson, readPackageJson, JsPackageManager } from './js-package-man
 import { detectWebpack } from './detect-webpack';
 import { detectNextJS } from './detect-nextjs';
 
-const viteConfigFiles = ['vite.config.ts', 'vite.config.js', 'vite.config.mjs'];
+const viteConfigFiles = [
+  'vite.config.ts',
+  'vite.config.js',
+  'vite.config.mjs',
+  'svelte.config.js',
+  'svelte.config.cjs',
+  'svelte.config.mjs',
+  'svelte.config.ts',
+];
 
 const hasDependency = (
   packageJson: PackageJson,


### PR DESCRIPTION
Issue:

## What I did

Sveltekit uses vite under the hood, and the vite builder should be used for those projects, which don't contain a `vite.config.js` file, but rather a `svelte.config.js` file (or similar).  This change looks for those files during `npx sb init`, and use the vite builder if it finds one.

I believe this should be ported to 6.5.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

I'm curious to see if this will have any effect on the svelte e2e test.

