### PR TITLE
chore: fix jest 27 in angular e2e modern inline rendering config

### DIFF
--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -155,7 +155,7 @@ export const angular13: Parameters = {
 export const angular_modern_inline_rendering: Parameters = {
   ...baseAngular,
   name: 'angular_modern_inline_rendering',
-  additionalDeps: ['jest', '@storybook/test-runner'],
+  additionalDeps: ['jest@27', '@storybook/test-runner'],
   mainOverrides: {
     features: {
       storyStoreV7: true,


### PR DESCRIPTION
Issue: N/A

## What I did

@storybook/test-runner does not work with Jest 28, so I changed the angular e2e config to use 27 instead.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
