### PR TITLE
Webpack5: Apply named exports order logic for stories only

### DIFF
--- a/app/react/src/server/framework-preset-react-docs.ts
+++ b/app/react/src/server/framework-preset-react-docs.ts
@@ -19,6 +19,7 @@ export async function babel(config: TransformOptions, options: Options) {
   return {
     ...config,
     overrides: [
+      ...(config?.overrides || []),
       {
         test: reactDocgen === 'react-docgen' ? /\.(mjs|tsx?|jsx?)$/ : /\.(mjs|jsx?)$/,
         plugins: [

--- a/lib/builder-webpack5/src/presets/preview-preset.ts
+++ b/lib/builder-webpack5/src/presets/preview-preset.ts
@@ -20,8 +20,13 @@ export const entries = async (_: unknown, options: any) => {
   return result;
 };
 
-export const babel = async (config: any, options: any) => {
-  // FIXME: Add this to overrides to only apply to story files
-  config.plugins.push('babel-plugin-named-exports-order');
-  return config;
-};
+export const babel = async (config: any, options: any) => ({
+  ...config,
+  overrides: [
+    ...(config?.overrides || []),
+    {
+      test: /\.(story|stories).*$/,
+      plugins: [require.resolve('babel-plugin-named-exports-order')],
+    },
+  ],
+});


### PR DESCRIPTION
Issue: #17914 #17587 #18263

## What I did

Webpack5 does not preserve the order named exports. I created a babel plugin which inserts a special magic named export `__namedExportsOrder` to preserve this order. Unfortunately, this is being applied to all files in the project and can interfere with other tools that need this order.

This PR fixes it with:

- [x] Fix logic where incoming babel config can be undefined
- [x] Scope the named exports plugin to only apply to story files

## How to test

I'm not sure! I tested this by hand editing `node_modules` in a sample project 😭  and looking at the raw source in the browser dev tools... 
