### PR TITLE
Core: Use correct framework version in telemetry

### DIFF
--- a/lib/core-common/src/utils/get-storybook-info.ts
+++ b/lib/core-common/src/utils/get-storybook-info.ts
@@ -6,6 +6,7 @@ import { PackageJson } from '../types';
 interface StorybookInfo {
   framework: string;
   version: string;
+  frameworkPackage: string;
   configDir?: string;
   mainConfig?: string;
   previewConfig?: string;
@@ -57,7 +58,7 @@ const getFrameworkInfo = (packageJson: PackageJson) => {
     );
   }
 
-  return { framework, version };
+  return { framework, version, frameworkPackage: pkg };
 };
 
 const validConfigExtensions = ['ts', 'js', 'tsx', 'jsx', 'mjs', 'cjs'];

--- a/lib/telemetry/src/storybook-metadata.ts
+++ b/lib/telemetry/src/storybook-metadata.ts
@@ -187,9 +187,13 @@ export const computeStorybookMetadata = async ({
   const hasStorybookEslint = !!allDependencies['eslint-plugin-storybook'];
 
   const storybookInfo = getStorybookInfo(packageJson);
+
+  const storybookVersion =
+    storybookPackages[storybookInfo.frameworkPackage]?.version || storybookInfo.version;
+
   return {
     ...metadata,
-    storybookVersion: storybookInfo.version,
+    storybookVersion,
     language,
     storybookPackages,
     framework: {


### PR DESCRIPTION
Issue: N/A

## What I did

Previously the version was coming from root's package json which was not precise. Now it does get it correctly from data which already existed

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
