### PR TITLE
CLI: Add vue3 webpack5 automigration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,7 @@
 <h1>Migration</h1>
 
 - [From version 6.4.x to 6.5.0](#from-version-64x-to-650)
+  - [Vue 3 upgrade](#vue-3-upgrade)
   - [React18 new root API](#react18-new-root-api)
   - [Renamed isToolshown to showToolbar](#renamed-istoolshown-to-showtoolbar)
   - [Deprecated register.js](#deprecated-registerjs)
@@ -201,6 +202,10 @@
   - [Deprecated embedded addons](#deprecated-embedded-addons)
 
 ## From version 6.4.x to 6.5.0
+
+### Vue 3 upgrade
+
+Storybook 6.5 supports Vue 3 out of the box when you install it fresh. However, if you're upgrading your project from a previous version, you'll need to [follow the steps for opting-in to webpack 5](#webpack-5).
 
 ### React18 new root API
 
@@ -748,7 +753,29 @@ The `--static-dir` flag has been deprecated and will be removed in Storybook 7.0
 
 ### Webpack 5
 
-Storybook 6.3 brings opt-in support for building both your project and the manager UI with webpack 5. To do so:
+Storybook 6.3 brings opt-in support for building both your project and the manager UI with webpack 5. To do so, there are two ways:
+
+1 - Upgrade command
+
+If you're upgrading your Storybook version, run this command, which will both upgrade your dependencies but also detect whether you should migrate to webpack5 builders and apply the changes automatically:
+
+```shell
+npx storybook upgrade
+```
+
+2 - Automigrate command
+
+If you don't want to change your Storybook version but want Storybook to detect whether you should migrate to webpack5 builders and apply the changes automatically:
+
+```shell
+npx storybook automigrate
+```
+
+3 - Manually
+
+If either methods did not work or you just want to proceed manually, do the following steps:
+
+Install the dependencies:
 
 ```shell
 yarn add @storybook/builder-webpack5 @storybook/manager-webpack5 --dev

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -760,7 +760,7 @@ Storybook 6.3 brings opt-in support for building both your project and the manag
 If you're upgrading your Storybook version, run this command, which will both upgrade your dependencies but also detect whether you should migrate to webpack5 builders and apply the changes automatically:
 
 ```shell
-npx storybook upgrade
+npx sb upgrade
 ```
 
 2 - Automigrate command
@@ -768,7 +768,7 @@ npx storybook upgrade
 If you don't want to change your Storybook version but want Storybook to detect whether you should migrate to webpack5 builders and apply the changes automatically:
 
 ```shell
-npx storybook automigrate
+npx sb automigrate
 ```
 
 3 - Manually

--- a/lib/cli/src/automigrate/fixes/angular12.test.ts
+++ b/lib/cli/src/automigrate/fixes/angular12.test.ts
@@ -6,7 +6,7 @@ import { angular12 } from './angular12';
 // eslint-disable-next-line global-require, jest/no-mocks-import
 jest.mock('fs-extra', () => require('../../../../../__mocks__/fs-extra'));
 
-const checkCra5 = async ({ packageJson, main }) => {
+const checkAngular12 = async ({ packageJson, main }) => {
   // eslint-disable-next-line global-require
   require('fs-extra').__setMockFiles({
     [path.join('.storybook', 'main.js')]: `module.exports = ${JSON.stringify(main)};`,
@@ -25,7 +25,7 @@ describe('angular12 fix', () => {
       };
       it('should fail', async () => {
         await expect(
-          checkCra5({
+          checkAngular12({
             packageJson,
             main: {},
           })
@@ -36,7 +36,7 @@ describe('angular12 fix', () => {
       const packageJson = { dependencies: { '@storybook/react': '^6.2.0' } };
       it('should no-op', async () => {
         await expect(
-          checkCra5({
+          checkAngular12({
             packageJson,
             main: {},
           })
@@ -52,7 +52,7 @@ describe('angular12 fix', () => {
       describe('webpack5 builder', () => {
         it('should no-op', async () => {
           await expect(
-            checkCra5({
+            checkAngular12({
               packageJson,
               main: { core: { builder: 'webpack5' } },
             })
@@ -62,7 +62,7 @@ describe('angular12 fix', () => {
       describe('custom builder', () => {
         it('should no-op', async () => {
           await expect(
-            checkCra5({
+            checkAngular12({
               packageJson,
               main: { core: { builder: 'storybook-builder-vite' } },
             })
@@ -72,7 +72,7 @@ describe('angular12 fix', () => {
       describe('webpack4 builder', () => {
         it('should add webpack5 builder', async () => {
           await expect(
-            checkCra5({
+            checkAngular12({
               packageJson,
               main: { core: { builder: 'webpack4' } },
             })
@@ -85,7 +85,7 @@ describe('angular12 fix', () => {
       describe('no builder', () => {
         it('should add webpack5 builder', async () => {
           await expect(
-            checkCra5({
+            checkAngular12({
               packageJson,
               main: {},
             })
@@ -99,7 +99,7 @@ describe('angular12 fix', () => {
     describe('no angular dependency', () => {
       it('should no-op', async () => {
         await expect(
-          checkCra5({
+          checkAngular12({
             packageJson: {},
             main: {},
           })
@@ -109,7 +109,7 @@ describe('angular12 fix', () => {
     describe('angular11 dependency', () => {
       it('should no-op', async () => {
         await expect(
-          checkCra5({
+          checkAngular12({
             packageJson: {
               dependencies: {
                 '@angular/core': '11',
@@ -128,7 +128,7 @@ describe('angular12 fix', () => {
       };
       it('should no-op', async () => {
         await expect(
-          checkCra5({
+          checkAngular12({
             packageJson,
             main: {},
           })

--- a/lib/cli/src/automigrate/fixes/index.ts
+++ b/lib/cli/src/automigrate/fixes/index.ts
@@ -1,10 +1,19 @@
 import { cra5 } from './cra5';
 import { webpack5 } from './webpack5';
 import { angular12 } from './angular12';
+import { vue3 } from './vue3';
 import { mainjsFramework } from './mainjsFramework';
 import { eslintPlugin } from './eslint-plugin';
 import { builderVite } from './builder-vite';
 import { Fix } from '../types';
 
 export * from '../types';
-export const fixes: Fix[] = [cra5, webpack5, angular12, mainjsFramework, eslintPlugin, builderVite];
+export const fixes: Fix[] = [
+  cra5,
+  webpack5,
+  angular12,
+  vue3,
+  mainjsFramework,
+  eslintPlugin,
+  builderVite,
+];

--- a/lib/cli/src/automigrate/fixes/vue3.test.ts
+++ b/lib/cli/src/automigrate/fixes/vue3.test.ts
@@ -6,7 +6,7 @@ import { vue3 } from './vue3';
 // eslint-disable-next-line global-require, jest/no-mocks-import
 jest.mock('fs-extra', () => require('../../../../../__mocks__/fs-extra'));
 
-const checkCra5 = async ({ packageJson, main }) => {
+const checkVue3 = async ({ packageJson, main }) => {
   // eslint-disable-next-line global-require
   require('fs-extra').__setMockFiles({
     [path.join('.storybook', 'main.js')]: `module.exports = ${JSON.stringify(main)};`,
@@ -25,7 +25,7 @@ describe('vue3 fix', () => {
       };
       it('should fail', async () => {
         await expect(
-          checkCra5({
+          checkVue3({
             packageJson,
             main: {},
           })
@@ -36,7 +36,7 @@ describe('vue3 fix', () => {
       const packageJson = { dependencies: { '@storybook/vue': '^6.2.0' } };
       it('should no-op', async () => {
         await expect(
-          checkCra5({
+          checkVue3({
             packageJson,
             main: {},
           })
@@ -52,7 +52,7 @@ describe('vue3 fix', () => {
       describe('webpack5 builder', () => {
         it('should no-op', async () => {
           await expect(
-            checkCra5({
+            checkVue3({
               packageJson,
               main: { core: { builder: 'webpack5' } },
             })
@@ -62,7 +62,7 @@ describe('vue3 fix', () => {
       describe('custom builder', () => {
         it('should no-op', async () => {
           await expect(
-            checkCra5({
+            checkVue3({
               packageJson,
               main: { core: { builder: 'storybook-builder-vite' } },
             })
@@ -72,7 +72,7 @@ describe('vue3 fix', () => {
       describe('webpack4 builder', () => {
         it('should add webpack5 builder', async () => {
           await expect(
-            checkCra5({
+            checkVue3({
               packageJson,
               main: { core: { builder: 'webpack4' } },
             })
@@ -85,7 +85,7 @@ describe('vue3 fix', () => {
       describe('no builder', () => {
         it('should add webpack5 builder', async () => {
           await expect(
-            checkCra5({
+            checkVue3({
               packageJson,
               main: {},
             })
@@ -99,7 +99,7 @@ describe('vue3 fix', () => {
     describe('no vue dependency', () => {
       it('should no-op', async () => {
         await expect(
-          checkCra5({
+          checkVue3({
             packageJson: {},
             main: {},
           })
@@ -109,7 +109,7 @@ describe('vue3 fix', () => {
     describe('vue2 dependency', () => {
       it('should no-op', async () => {
         await expect(
-          checkCra5({
+          checkVue3({
             packageJson: {
               dependencies: {
                 vue: '2',
@@ -128,7 +128,7 @@ describe('vue3 fix', () => {
       };
       it('should no-op', async () => {
         await expect(
-          checkCra5({
+          checkVue3({
             packageJson,
             main: {},
           })

--- a/lib/cli/src/automigrate/fixes/vue3.test.ts
+++ b/lib/cli/src/automigrate/fixes/vue3.test.ts
@@ -1,0 +1,139 @@
+/* eslint-disable no-underscore-dangle */
+import path from 'path';
+import { JsPackageManager } from '../../js-package-manager';
+import { vue3 } from './vue3';
+
+// eslint-disable-next-line global-require, jest/no-mocks-import
+jest.mock('fs-extra', () => require('../../../../../__mocks__/fs-extra'));
+
+const checkCra5 = async ({ packageJson, main }) => {
+  // eslint-disable-next-line global-require
+  require('fs-extra').__setMockFiles({
+    [path.join('.storybook', 'main.js')]: `module.exports = ${JSON.stringify(main)};`,
+  });
+  const packageManager = {
+    retrievePackageJson: () => ({ dependencies: {}, devDependencies: {}, ...packageJson }),
+  } as JsPackageManager;
+  return vue3.check({ packageManager });
+};
+
+describe('vue3 fix', () => {
+  describe('sb < 6.3', () => {
+    describe('vue3 dependency', () => {
+      const packageJson = {
+        dependencies: { '@storybook/vue': '^6.2.0', vue: '^3.0.0' },
+      };
+      it('should fail', async () => {
+        await expect(
+          checkCra5({
+            packageJson,
+            main: {},
+          })
+        ).rejects.toThrow();
+      });
+    });
+    describe('no vue dependency', () => {
+      const packageJson = { dependencies: { '@storybook/vue': '^6.2.0' } };
+      it('should no-op', async () => {
+        await expect(
+          checkCra5({
+            packageJson,
+            main: {},
+          })
+        ).resolves.toBeFalsy();
+      });
+    });
+  });
+  describe('sb 6.3 - 7.0', () => {
+    describe('vue3 dependency', () => {
+      const packageJson = {
+        dependencies: { '@storybook/vue': '^6.3.0', vue: '^3.0.0' },
+      };
+      describe('webpack5 builder', () => {
+        it('should no-op', async () => {
+          await expect(
+            checkCra5({
+              packageJson,
+              main: { core: { builder: 'webpack5' } },
+            })
+          ).resolves.toBeFalsy();
+        });
+      });
+      describe('custom builder', () => {
+        it('should no-op', async () => {
+          await expect(
+            checkCra5({
+              packageJson,
+              main: { core: { builder: 'storybook-builder-vite' } },
+            })
+          ).resolves.toBeFalsy();
+        });
+      });
+      describe('webpack4 builder', () => {
+        it('should add webpack5 builder', async () => {
+          await expect(
+            checkCra5({
+              packageJson,
+              main: { core: { builder: 'webpack4' } },
+            })
+          ).resolves.toMatchObject({
+            vueVersion: '^3.0.0',
+            storybookVersion: '^6.3.0',
+          });
+        });
+      });
+      describe('no builder', () => {
+        it('should add webpack5 builder', async () => {
+          await expect(
+            checkCra5({
+              packageJson,
+              main: {},
+            })
+          ).resolves.toMatchObject({
+            vueVersion: '^3.0.0',
+            storybookVersion: '^6.3.0',
+          });
+        });
+      });
+    });
+    describe('no vue dependency', () => {
+      it('should no-op', async () => {
+        await expect(
+          checkCra5({
+            packageJson: {},
+            main: {},
+          })
+        ).resolves.toBeFalsy();
+      });
+    });
+    describe('vue2 dependency', () => {
+      it('should no-op', async () => {
+        await expect(
+          checkCra5({
+            packageJson: {
+              dependencies: {
+                vue: '2',
+              },
+            },
+            main: {},
+          })
+        ).resolves.toBeFalsy();
+      });
+    });
+  });
+  describe('sb 7.0+', () => {
+    describe('vue3 dependency', () => {
+      const packageJson = {
+        dependencies: { '@storybook/vue': '^7.0.0-alpha.0', vue: '^3.0.0' },
+      };
+      it('should no-op', async () => {
+        await expect(
+          checkCra5({
+            packageJson,
+            main: {},
+          })
+        ).resolves.toBeFalsy();
+      });
+    });
+  });
+});

--- a/lib/cli/src/automigrate/fixes/vue3.ts
+++ b/lib/cli/src/automigrate/fixes/vue3.ts
@@ -1,0 +1,60 @@
+import chalk from 'chalk';
+import dedent from 'ts-dedent';
+import semver from '@storybook/semver';
+import { ConfigFile } from '@storybook/csf-tools';
+import { Fix } from '../types';
+import { webpack5 } from './webpack5';
+
+interface Vue3RunOptions {
+  vueVersion: string;
+  storybookVersion: string;
+  main: ConfigFile;
+}
+
+/**
+ * Is the user upgrading to Vue3?
+ *
+ * If so:
+ * - Run webpack5 fix
+ */
+export const vue3: Fix<Vue3RunOptions> = {
+  id: 'vue3',
+
+  async check({ packageManager }) {
+    const packageJson = packageManager.retrievePackageJson();
+    const { dependencies, devDependencies } = packageJson;
+    const vueVersion = dependencies.vue || devDependencies.vue;
+    const vueCoerced = semver.coerce(vueVersion)?.version;
+
+    if (!vueCoerced || semver.lt(vueCoerced, '3.0.0')) {
+      return null;
+    }
+
+    const builderInfo = await webpack5.checkWebpack5Builder(packageJson);
+    return builderInfo ? { vueVersion, ...builderInfo } : null;
+  },
+
+  prompt({ vueVersion, storybookVersion }) {
+    const vueFormatted = chalk.cyan(`Vue ${vueVersion}`);
+    const sbFormatted = chalk.cyan(`Storybook ${storybookVersion}`);
+    return dedent`
+      We've detected you are running ${vueFormatted} with Storybook.
+      ${sbFormatted} runs webpack4 by default, which is incompatible.
+
+      In order to work with your version of Vue, we need to install Storybook's ${chalk.cyan(
+        'webpack5 builder'
+      )}.
+
+      More info: ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#vue3-upgrade'
+      )}
+    `;
+  },
+
+  async run(options) {
+    return webpack5.run({
+      ...options,
+      result: { webpackVersion: null, ...options.result },
+    });
+  },
+};


### PR DESCRIPTION
Issue: #18264

## What I did

Similar to Angular12, this adds Vue3 migration that will change builders to use webpack5.

TODO in the future: refactor the migrations to run "Webpack5" and check all libs rather than having X checks per lib

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
