### PR TITLE
fix: Router drop string args when validateArgs #18179

### DIFF
--- a/lib/preview-web/src/parseArgsParam.test.ts
+++ b/lib/preview-web/src/parseArgsParam.test.ts
@@ -242,7 +242,7 @@ describe('parseArgsParam', () => {
       expect(parseArgsParam('arr[0]:a!b')).toStrictEqual({});
     });
 
-    it.skip('completely omits an arg when a (deeply) nested value is invalid', () => {
+    it('completely omits an arg when a (deeply) nested value is invalid', () => {
       expect(parseArgsParam('obj.key:a!b;obj.foo:val;obj.bar.baz:val')).toStrictEqual({});
       expect(parseArgsParam('obj.arr[]:a!b;obj.foo:val;obj.bar.baz:val')).toStrictEqual({});
       expect(parseArgsParam('obj.arr[0]:val;obj.arr[1]:a!b;obj.foo:val')).toStrictEqual({});

--- a/lib/preview-web/src/parseArgsParam.test.ts
+++ b/lib/preview-web/src/parseArgsParam.test.ts
@@ -242,7 +242,7 @@ describe('parseArgsParam', () => {
       expect(parseArgsParam('arr[0]:a!b')).toStrictEqual({});
     });
 
-    it('completely omits an arg when a (deeply) nested value is invalid', () => {
+    it.skip('completely omits an arg when a (deeply) nested value is invalid', () => {
       expect(parseArgsParam('obj.key:a!b;obj.foo:val;obj.bar.baz:val')).toStrictEqual({});
       expect(parseArgsParam('obj.arr[]:a!b;obj.foo:val;obj.bar.baz:val')).toStrictEqual({});
       expect(parseArgsParam('obj.arr[0]:val;obj.arr[1]:a!b;obj.foo:val')).toStrictEqual({});

--- a/lib/preview-web/src/parseArgsParam.ts
+++ b/lib/preview-web/src/parseArgsParam.ts
@@ -5,7 +5,6 @@ import { once } from '@storybook/client-logger';
 import isPlainObject from 'lodash/isPlainObject';
 
 // Keep this in sync with validateArgs in router/src/utils.ts
-const ENCODED_ARRAY_OR_OBJECT_REGEX = /^((arr\[\])|(.+\.))/;
 const ALPHA_NUM_REGEXP = /^[a-zA-Z0-9 _-]*$/;
 const NUMBER_REGEXP = /^-?[0-9]+(\.[0-9]+)?$/;
 const HEX_REGEXP = /^#([a-f0-9]{3,4}|[a-f0-9]{6}|[a-f0-9]{8})$/i;

--- a/lib/router/src/utils.test.ts
+++ b/lib/router/src/utils.test.ts
@@ -118,7 +118,7 @@ describe('deepDiff', () => {
 describe('buildArgsParam', () => {
   it('builds a simple key-value pair', () => {
     const param = buildArgsParam({}, { key: 'val' });
-    expect(param).toEqual('key:!val');
+    expect(param).toEqual('key:val');
   });
 
   it('builds multiple values', () => {
@@ -170,7 +170,7 @@ describe('buildArgsParam', () => {
 
   it('builds nested object in array', () => {
     const param = buildArgsParam({}, { arr: [{ foo: { bar: 'val' } }] });
-    expect(param).toEqual('arr[0].foo.bar:!val');
+    expect(param).toEqual('arr[0].foo.bar:val');
   });
 
   it('encodes null values as !null', () => {

--- a/lib/router/src/utils.test.ts
+++ b/lib/router/src/utils.test.ts
@@ -118,7 +118,7 @@ describe('deepDiff', () => {
 describe('buildArgsParam', () => {
   it('builds a simple key-value pair', () => {
     const param = buildArgsParam({}, { key: 'val' });
-    expect(param).toEqual('key:val');
+    expect(param).toEqual('key:!val');
   });
 
   it('builds multiple values', () => {
@@ -170,12 +170,7 @@ describe('buildArgsParam', () => {
 
   it('builds nested object in array', () => {
     const param = buildArgsParam({}, { arr: [{ foo: { bar: 'val' } }] });
-    expect(param).toEqual('arr[0].foo.bar:val');
-  });
-
-  it('encodes space as +', () => {
-    const param = buildArgsParam({}, { key: 'foo bar baz' });
-    expect(param).toEqual('key:foo+bar+baz');
+    expect(param).toEqual('arr[0].foo.bar:!val');
   });
 
   it('encodes null values as !null', () => {
@@ -206,6 +201,13 @@ describe('buildArgsParam', () => {
   it('encodes Date objects as !date(ISO string)', () => {
     const param = buildArgsParam({}, { key: new Date('2001-02-03T04:05:06.789Z') });
     expect(param).toEqual('key:!date(2001-02-03T04:05:06.789Z)');
+  });
+
+  it('encodes string with non alphanumeric characters', () => {
+    const param = buildArgsParam({}, { key: 'f o;o:b=a,r.b?a/z\\+(-)"\'`$€*<>{}[]' });
+    expect(param).toEqual(
+      `key:f%20o%3Bo%3Ab%3Da%2Cr+b%3Fa%2Fz%5C%2B(-)%22'%60%24%E2%82%AC*%3C%3E%7B%7D%5B%5D`
+    );
   });
 
   describe('with initial state', () => {

--- a/lib/router/src/utils.ts
+++ b/lib/router/src/utils.ts
@@ -62,25 +62,18 @@ export const deepDiff = (value: any, update: any): any => {
 };
 
 // Keep this in sync with validateArgs in core-client/src/preview/parseArgsParam.ts
-const VALIDATION_REGEXP = /^[a-zA-Z0-9 _-]*$/;
+const ALPHA_NUM_REGEXP = /^[a-zA-Z0-9 _-]*$/;
 const NUMBER_REGEXP = /^-?[0-9]+(\.[0-9]+)?$/;
 const HEX_REGEXP = /^#([a-f0-9]{3,4}|[a-f0-9]{6}|[a-f0-9]{8})$/i;
 const COLOR_REGEXP =
   /^(rgba?|hsla?)\(([0-9]{1,3}),\s?([0-9]{1,3})%?,\s?([0-9]{1,3})%?,?\s?([0-9](\.[0-9]{1,2})?)?\)$/i;
 const validateArgs = (key = '', value: unknown): boolean => {
   if (key === null) return false;
-  if (key === '' || !VALIDATION_REGEXP.test(key)) return false;
+  if (key === '' || !ALPHA_NUM_REGEXP.test(key)) return false;
   if (value === null || value === undefined) return true; // encoded as `!null` or `!undefined`
   if (value instanceof Date) return true; // encoded as modified ISO string
   if (typeof value === 'number' || typeof value === 'boolean') return true;
-  if (typeof value === 'string') {
-    return (
-      VALIDATION_REGEXP.test(value) ||
-      NUMBER_REGEXP.test(value) ||
-      HEX_REGEXP.test(value) ||
-      COLOR_REGEXP.test(value)
-    );
-  }
+  if (typeof value === 'string') return true;
   if (Array.isArray(value)) return value.every((v) => validateArgs(key, v));
   if (isPlainObject(value)) return Object.entries(value).every(([k, v]) => validateArgs(k, v));
   return false;
@@ -92,7 +85,8 @@ const encodeSpecialValues = (value: unknown): any => {
   if (typeof value === 'string') {
     if (HEX_REGEXP.test(value)) return `!hex(${value.slice(1)})`;
     if (COLOR_REGEXP.test(value)) return `!${value.replace(/[\s%]/g, '')}`;
-    return value;
+    if (NUMBER_REGEXP.test(value)) return value;
+    return encodeURIComponent(value).replace(/\./g, '+');
   }
   if (Array.isArray(value)) return value.map(encodeSpecialValues);
   if (isPlainObject(value)) {
@@ -108,7 +102,6 @@ const QS_OPTIONS: IStringifyOptions = {
   encode: false, // we handle URL encoding ourselves
   delimiter: ';', // we don't actually create multiple query params
   allowDots: true, // encode objects using dot notation: obj.key=val
-  format: 'RFC1738', // encode spaces using the + sign
   serializeDate: (date: Date) => `!date(${date.toISOString()})`,
 };
 export const buildArgsParam = (initialArgs: Args, args: Args): string => {
@@ -127,7 +120,6 @@ export const buildArgsParam = (initialArgs: Args, args: Args): string => {
 
   return qs
     .stringify(encodeSpecialValues(object), QS_OPTIONS)
-    .replace(/ /g, '+')
     .split(';')
     .map((part: string) => part.replace('=', ':'))
     .join(';');


### PR DESCRIPTION
Issue: #18179

## What I did

I use encodeURIComponent to put any string into the url args param.  
From the [documentation](https://storybook.js.org/docs/react/writing-stories/args#setting-args-through-the-url), only alphanumeric strings were allowed to prevent XSS attacks.  
What kind of attacks ? Args are not eval'ed. Is it in case the component taking the arg does the eval/innerHtml itself ?

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? not sure
- [ ] Does this need a new example in the kitchen sink apps? no
- [ ] Does this need an update to the documentation? yes

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
