### PR TITLE
Update puppeteer to allow puppeteer >=4 < 14

### DIFF
--- a/addons/storyshots/storyshots-puppeteer/package.json
+++ b/addons/storyshots/storyshots-puppeteer/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@storybook/addon-storyshots": "6.5.0-rc.1",
-    "puppeteer": "^2.0.0 || ^3.0.0"
+    "puppeteer": ">=2.0.0 < 14"
   },
   "peerDependenciesMeta": {
     "puppeteer": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6832,7 +6832,7 @@ __metadata:
     regenerator-runtime: ^0.13.7
   peerDependencies:
     "@storybook/addon-storyshots": 6.5.0-rc.1
-    puppeteer: ^2.0.0 || ^3.0.0
+    puppeteer: ">=2.0.0 < 14"
   peerDependenciesMeta:
     puppeteer:
       optional: true


### PR DESCRIPTION
Issue:
#17561 #15079

Listed puppeteer is now 10 version older than `latest` (`13.x`)
- had been mentioned in #15079 that old version was unstable
- attempt to include newer version puppeteer as peer dependency or dev dependency is an error during `npm i` for `npm >= 8.6.0`, was warning at `npm <8.6.0`, so the outdated puppeteer version is now a more serious problem than a warning. https://github.com/npm/cli/issues/4669

Desirable package.json
```
{
  "devDependencies": {
    "@storybook/addon-storyshots": "^6.5.3",
    "@storybook/addon-storyshots-puppeteer": "^6.5.3",
    "storybook": "^6.5.3",
  },
  "optionalDependencies": {
    "puppeteer": "^13.7.0"
  }
}
```

Actual error
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @storybook/addon-storyshots-puppeteer@6.5.3
npm ERR! Found: puppeteer@13.7.0
npm ERR! node_modules/puppeteer
npm ERR!   optional puppeteer@"^13.7.0" from the root project
npm ERR!   peer puppeteer@">=1.10.0 <= 13" from @axe-core/puppeteer@4.4.2
npm ERR!   node_modules/@axe-core/puppeteer
npm ERR!     @axe-core/puppeteer@"^4.2.0" from @storybook/addon-storyshots-puppeteer@6.5.3
npm ERR!     node_modules/@storybook/addon-storyshots-puppeteer
npm ERR!       dev @storybook/addon-storyshots-puppeteer@"^6.5.3" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional puppeteer@"^2.0.0 || ^3.0.0" from @storybook/addon-storyshots-puppeteer@6.5.3
npm ERR! node_modules/@storybook/addon-storyshots-puppeteer
npm ERR!   dev @storybook/addon-storyshots-puppeteer@"^6.5.3" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: puppeteer@3.3.0
npm ERR! node_modules/puppeteer
npm ERR!   peerOptional puppeteer@"^2.0.0 || ^3.0.0" from @storybook/addon-storyshots-puppeteer@6.5.3
npm ERR!   node_modules/@storybook/addon-storyshots-puppeteer
npm ERR!     dev @storybook/addon-storyshots-puppeteer@"^6.5.3" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

## What I did

Bump version to include `>=4 <14`

Have checked the following before bumping
- `@axe-core/puppeteer` uses `puppeteer@>=1.10.0 <=13` https://github.com/dequelabs/axe-core-npm/blob/c67f3cc6ff10a2670b520b9af6159ab70f7e8d16/packages/puppeteer/package.json#L49
- In my previous attempt to force install `puppeteer==13.7.0` against `@storybook/storyshots-puppeteer>=6.4.0`, there is no sign of fatal error during practical snapshoting or image diff testing, empirically I have not seen incompatibility.
- Regarding aspect of UI correctness, the integration between `puppeteer@^13.0.0` and `@storybook/storyshots-puppeteer>=6.4.0` have not, and cannot be well tested by myself, empirically I have not seen major regression or difference with actual production.


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? No
- [ ] Does this need a new example in the kitchen sink apps? No
- [ ] Does this need an update to the documentation? No

Before this commit
```
[storybook]$ yarn test

Test Suites: 126 failed, 60 passed, 186 total
Tests:       15 failed, 624 passed, 639 total
Snapshots:   123 passed, 123 total
```

After this commit
```
[storybook]$ yarn test

Test Suites: 126 failed, 60 passed, 186 total
Tests:       15 failed, 624 passed, 639 total
Snapshots:   123 passed, 123 total
```

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
