### PR TITLE
CLI: Fix open in browser doesn't work in WSL

### DIFF
--- a/lib/core-server/src/utils/open-in-browser.ts
+++ b/lib/core-server/src/utils/open-in-browser.ts
@@ -7,7 +7,7 @@ import dedent from 'ts-dedent';
 export function openInBrowser(address: string) {
   getDefaultBrowser(async (err: any, res: any) => {
     try {
-      if (res.isChrome || res.isChromium) {
+      if (res && (res.isChrome || res.isChromium)) {
         // We use betterOpn for Chrome because it is better at handling which chrome tab
         // or window the preview loads in.
         betterOpn(address);


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18304

On Linux, `x-default-browser` requires `xdg-utils` to be installed to determine a default browser. So it fails when it's not installed. However, in WSL, we still can open a browser without it. Now it fallbacks to `open` when `x-default-browser` fails which makes it work on WSL without `xdg-utils`.

Tags: ["bug"]

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
