### PR TITLE
feat(cli): Add support for angular/cli@14.0.0

### DIFF
--- a/lib/cli/src/generators/ANGULAR/angular-helpers.ts
+++ b/lib/cli/src/generators/ANGULAR/angular-helpers.ts
@@ -10,7 +10,7 @@ type TsConfig = {
 
 export function getAngularAppTsConfigPath() {
   const angularJson = readFileAsJson('angular.json', true);
-  const { defaultProject } = angularJson;
+  const defaultProject = getDefaultProjectName(angularJson);
   const tsConfigPath = angularJson.projects[defaultProject].architect.build.options.tsConfig;
 
   if (!tsConfigPath || !fs.existsSync(path.resolve(tsConfigPath))) {
@@ -50,9 +50,33 @@ export function editStorybookTsConfig(tsconfigPath: string) {
   writeFileAsJson(tsconfigPath, tsConfigJson);
 }
 
-export function isDefaultProjectSet() {
-  const angularJson = readFileAsJson('angular.json', true);
-  return angularJson && !!angularJson.defaultProject;
+export function getDefaultProjectName(angularJson: any): string | undefined {
+  const { defaultProject, projects } = angularJson;
+
+  if (projects?.storybook) {
+    return 'storybook';
+  }
+
+  if (defaultProject) {
+    return defaultProject;
+  }
+
+  const firstProjectName = projects ? Object.keys(projects)[0] : undefined;
+  if (firstProjectName) {
+    return firstProjectName;
+  }
+
+  return undefined;
+}
+
+export function checkForProjects() {
+  const { projects } = readFileAsJson('angular.json', true);
+
+  if (!projects || Object.keys(projects).length === 0) {
+    throw new Error(
+      'Could not find a project in your Angular workspace. \nAdd a project and re-run the installation'
+    );
+  }
 }
 
 export async function getBaseTsConfigName() {

--- a/lib/cli/src/generators/ANGULAR/index.ts
+++ b/lib/cli/src/generators/ANGULAR/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import semver from '@storybook/semver';
 import {
-  isDefaultProjectSet,
+  checkForProjects,
   editStorybookTsConfig,
   getAngularAppTsConfigJson,
   getAngularAppTsConfigPath,
@@ -28,11 +28,8 @@ function editAngularAppTsConfig() {
 }
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  if (!isDefaultProjectSet()) {
-    throw new Error(
-      'Could not find a default project in your Angular workspace.\nSet a defaultProject in your angular.json and re-run the installation.'
-    );
-  }
+  checkForProjects();
+
   const angularVersion = semver.coerce(
     packageManager.retrievePackageJson().dependencies['@angular/core']
   )?.version;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18316

## What I did
I have explained already in the [issue](https://github.com/storybookjs/storybook/issues/18316) what is the problem.

When the `angular.json` file doesn't contain the `defaultProject` property (which is the case when you create a project with angular/cli@14.0.0), then the default project is the first available project.

The solution is backwards compatible with the previous versions of the angular-cli

## How to test

1. npm install -g @angular/cli@next
2. under the `storybook/examples` folder run `ng new sb-ng14`
3. run `npx sb init`

_Maybe there is a better way to test it_

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
