### PR TITLE
fix: throttle color controls and make `updateArgs` and `resetArgs` stable

### DIFF
--- a/lib/api/src/index.tsx
+++ b/lib/api/src/index.tsx
@@ -447,13 +447,14 @@ export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[])
 
   const data = getCurrentStoryData();
   const args = isStory(data) ? data.args : {};
+  const { id, refId } = data;
   const updateArgs = useCallback(
-    (newArgs: Args) => updateStoryArgs(data as Story, newArgs),
-    [data, updateStoryArgs]
+    (newArgs: Args) => updateStoryArgs({ id, refId }, newArgs),
+    [id, refId, updateStoryArgs]
   );
   const resetArgs = useCallback(
-    (argNames?: string[]) => resetStoryArgs(data as Story, argNames),
-    [data, resetStoryArgs]
+    (argNames?: string[]) => resetStoryArgs({ id, refId }, argNames),
+    [id, refId, resetStoryArgs]
   );
 
   return [args, updateArgs, resetArgs];

--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -128,6 +128,11 @@ export interface StoryIndex {
   stories: Record<StoryId, StoryIndexStory>;
 }
 
+export interface StoryKey {
+  id: StoryId;
+  refId?: string;
+}
+
 export type SetStoriesPayload =
   | {
       v: 2;

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -78,8 +78,8 @@ export interface SubAPI {
     parameterName?: ParameterName
   ) => Story['parameters'] | any;
   getCurrentParameter<S>(parameterName?: ParameterName): S;
-  updateStoryArgs(story: Story, newArgs: Args): void;
-  resetStoryArgs: (story: Story, argNames?: string[]) => void;
+  updateStoryArgs(story: Story | { id: StoryId; refId?: string }, newArgs: Args): void;
+  resetStoryArgs: (story: Story | { id: StoryId; refId?: string }, argNames?: string[]) => void;
   findLeafStoryId(StoriesHash: StoriesHash, storyId: StoryId): StoryId;
   findSiblingStoryId(
     storyId: StoryId,

--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -36,6 +36,7 @@ import type {
   StoriesRaw,
   SetStoriesPayload,
   StoryIndex,
+  StoryKey,
 } from '../lib/stories';
 
 import { Args, ModuleFn } from '../index';
@@ -78,8 +79,8 @@ export interface SubAPI {
     parameterName?: ParameterName
   ) => Story['parameters'] | any;
   getCurrentParameter<S>(parameterName?: ParameterName): S;
-  updateStoryArgs(story: Story | { id: StoryId; refId?: string }, newArgs: Args): void;
-  resetStoryArgs: (story: Story | { id: StoryId; refId?: string }, argNames?: string[]) => void;
+  updateStoryArgs(story: Story | StoryKey, newArgs: Args): void;
+  resetStoryArgs: (story: Story | StoryKey, argNames?: string[]) => void;
   findLeafStoryId(StoriesHash: StoriesHash, storyId: StoryId): StoryId;
   findSiblingStoryId(
     storyId: StoryId,

--- a/lib/components/src/controls/Color.tsx
+++ b/lib/components/src/controls/Color.tsx
@@ -307,9 +307,10 @@ export const ColorControl: FC<ColorControlProps> = ({
   presetColors,
   startOpen,
 }) => {
+  const throttledOnChange = useCallback(throttle(onChange, 200), [onChange]);
   const { value, realValue, updateValue, color, colorSpace, cycleColorSpace } = useColorInput(
     initialValue,
-    throttle(onChange, 200)
+    throttledOnChange
   );
   const { presets, addPreset } = usePresets(presetColors, color, colorSpace);
   const Picker = ColorPicker[colorSpace];


### PR DESCRIPTION
Issue:

## What I did

Fix a bug where Color controls are not throttled properly and causing sluggish preview

This is mainly caused by:

- `updateArgs` and `resetArgs` is not stable (It depends on `data` / `story` which contains reference to `args`, so it is re-created everytime args is updated)
- `throttle` for ColorControl is not called inside a memo function

To reproduce, go to this story https://storybookjs.netlify.app/official-storybook/?path=/story/addons-controls-sort--none and try to move around the color picker of the `color` control fast enough, the speed of re-rendering is too slow to catch up.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
