### PR TITLE
documentation: Syntax error in vite builder docs

### DIFF
--- a/docs/snippets/common/storybook-vite-builder-aliasing.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-aliasing.js.mdx
@@ -13,7 +13,7 @@ module.exports = {
     // Merge custom configuration into the default config
     return mergeConfig(config, {
       // Use the same "resolve" configuration as your app
-      resolve: (await import('../vite.config.js')).default.resolve
+      resolve: (await import('../vite.config.js')).default.resolve,
       // Add dependencies to pre-optimization
       optimizeDeps: {
         include: ['storybook-dark-mode'],


### PR DESCRIPTION
Just a missing comma in the example.

Issue:

## What I did

Fixed a small syntax error in the docs.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
