### PR TITLE
Chore: (Docs) Updates jest snippets to address jest 28

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -472,3 +472,7 @@ export default {
   },
 };
 ```
+
+### Why isn't Storybook's test runner working?
+
+There's an issue with Storybook's test runner and the latest version of Jest (i.e., version 28), which prevents it from running effectively. As a workaround, you can downgrade Jest to the previous stable version (i.e., version 27), and you'll be able to run it. See the following [issue](https://github.com/storybookjs/test-runner/issues/99) for more information.

--- a/docs/snippets/common/storybook-test-runner-install.npm.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-install.npm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-npm install @storybook/test-runner jest --save-dev
+npm install @storybook/test-runner jest@27.5.1 --save-dev
 ```

--- a/docs/snippets/common/storybook-test-runner-install.npm.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-install.npm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-npm install @storybook/test-runner jest@27.5.1 --save-dev
+npm install @storybook/test-runner jest@27 --save-dev
 ```

--- a/docs/snippets/common/storybook-test-runner-install.yarn.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-install.yarn.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-yarn add --dev @storybook/test-runner jest@27.5.1
+yarn add --dev @storybook/test-runner jest@27
 ```

--- a/docs/snippets/common/storybook-test-runner-install.yarn.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-install.yarn.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-yarn add --dev @storybook/test-runner jest
+yarn add --dev @storybook/test-runner jest@27.5.1
 ```


### PR DESCRIPTION
With this small pull request the documentation is updated to address the known issue with Jest 28 and the test runner.

What was done:
- Updated the FAQ to provide information about it and link it to the relevant issue.
- Updated the snippets to specify the version of jest 