### PR TITLE
[Fix] Broken code block storybook-main-enable-transcludemarkdown.js.mdx

### DIFF
--- a/docs/snippets/common/storybook-main-enable-transcludemarkdown.js.mdx
+++ b/docs/snippets/common/storybook-main-enable-transcludemarkdown.js.mdx
@@ -1,3 +1,4 @@
+```js
 // .storybook/main.js|ts
 
 module.exports = {
@@ -18,3 +19,4 @@ module.exports = {
     },
   ],
 };
+```


### PR DESCRIPTION
Issue:

## What I did

- Fix to code snippets in "https://storybook.js.org/docs/7.0/react/writing-docs/mdx#creating-a-changelog-story"
- Fix typo storybook-main-enable-transcludemarkdown.js.mdx

<img width="901" alt="image" src="https://user-images.githubusercontent.com/60910665/170831892-3081f937-393f-4fcc-b565-c48129fd2631.png">


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
