### PR TITLE
UI: Fix sidebar a11y by moving aria-expanded attribute to button

### DIFF
--- a/lib/ui/src/components/sidebar/Tree.tsx
+++ b/lib/ui/src/components/sidebar/Tree.tsx
@@ -190,7 +190,6 @@ const Node = React.memo<NodeProps>(
           data-ref-id={refId}
           data-item-id={item.id}
           data-nodetype="root"
-          aria-expanded={isExpanded}
         >
           <CollapseButton
             type="button"
@@ -199,6 +198,7 @@ const Node = React.memo<NodeProps>(
               event.preventDefault();
               setExpanded({ ids: [item.id], value: !isExpanded });
             }}
+            aria-expanded={isExpanded}
           >
             <CollapseIcon isExpanded={isExpanded} />
             {item.renderLabel?.(item) || item.name}


### PR DESCRIPTION
Issue: #18346 

## What I did

Moved the aria-expanded attribute from the RootNode to CollapseButton
![image](https://user-images.githubusercontent.com/81943522/170854401-ffa1c110-cc63-406c-804b-76665895bf67.png)

## How to test

You should see the changes reflected in the DOM
