### PR TITLE
Scripts: Clean verdaccio cache when running locally

### DIFF
--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -1,4 +1,5 @@
 import { exec } from 'child_process';
+import { remove, pathExists } from 'fs-extra';
 import chalk from 'chalk';
 import path from 'path';
 import program from 'commander';
@@ -176,6 +177,16 @@ const run = async () => {
 
   logger.log(`📐 reading version of storybook`);
   logger.log(`🚛 listing storybook packages`);
+
+  if (!process.env.CI) {
+    // when running e2e locally, clear cache to avoid EPUBLISHCONFLICT errors
+    const verdaccioCache = path.resolve(__dirname, '..', '.verdaccio-cache');
+    if (await pathExists(verdaccioCache)) {
+      logger.log(`🗑 cleaning up cache`);
+      await remove(verdaccioCache);
+    }
+  }
+
   logger.log(`🎬 starting verdaccio (this takes ±5 seconds, so be patient)`);
 
   const [verdaccioServer, packages, version] = await Promise.all<any, Package[], string>([


### PR DESCRIPTION
Issue: N/A

## What I did

When running verdaccio locally, having ran it before, devs will get a `EPUBLISHCONFLICT` error.
This PR clears cache if it exists, but not in CI.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
