### PR TITLE
Preview: Default select to `viewMode` story

### DIFF
--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -1415,6 +1415,23 @@ describe('PreviewWeb', () => {
       });
     });
 
+    describe('if called on a storybook without selection', () => {
+      it('sets viewMode to story by default', async () => {
+        await createAndRenderPreview();
+
+        emitter.emit(SET_CURRENT_STORY, {
+          storyId: 'component-one--b',
+        });
+        await waitForSetCurrentStory();
+
+        expect(history.replaceState).toHaveBeenCalledWith(
+          {},
+          '',
+          'pathname?id=component-one--b&viewMode=story'
+        );
+      });
+    });
+
     describe('if the selection is unchanged', () => {
       it('emits STORY_UNCHANGED', async () => {
         document.location.search = '?id=component-one--a';

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -200,7 +200,7 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
   }
 
   onSetCurrentStory(selection: Selection) {
-    this.urlStore.setSelection(selection);
+    this.urlStore.setSelection({ viewMode: 'story', ...selection });
     this.channel.emit(CURRENT_STORY_WAS_SET, this.urlStore.selection);
     this.renderSelection();
   }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18347

Telescoping on https://github.com/storybookjs/storybook/pull/18369

When `setCurrentStory` is emitted with a `storyId` but no `viewMode`, no view mode is set, and our code defaults to docs in some places.

## What I did

Ensure we always set a view mode.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

1. Open any storybook's `iframe.html` without a selection
2. Run `__STORYBOOK_ADDONS_CHANNEL__.emit('setCurrentStory', { storyId: '$STORY_ID' })` where `$STORY_ID` is a story in the Storybook
3. Check the URL includes `viewMode=story`