### PR TITLE
Vue/Vue3: Fix decorators in StoryStoreV7

### DIFF
--- a/app/vue/src/client/preview/config.ts
+++ b/app/vue/src/client/preview/config.ts
@@ -1,4 +1,4 @@
 export { render, renderToDOM } from './render';
-export { decorateStory } from './decorateStory';
+export { decorateStory as applyDecorators } from './decorateStory';
 
 export const parameters = { framework: 'vue' };

--- a/app/vue3/src/client/preview/config.ts
+++ b/app/vue3/src/client/preview/config.ts
@@ -1,4 +1,4 @@
 export { render, renderToDOM } from './render';
-export { decorateStory } from './decorateStory';
+export { decorateStory as applyDecorators } from './decorateStory';
 
 export const parameters = { framework: 'vue3' };

--- a/examples/vue-3-cli/.storybook/main.js
+++ b/examples/vue-3-cli/.storybook/main.js
@@ -10,6 +10,7 @@ module.exports = {
     disableTelemetry: true,
   },
   features: {
+    storyStoreV7: !global.navigator?.userAgent?.match?.('jsdom'),
     buildStoriesJson: true,
     channelOptions: { allowFunction: false, maxDepth: 10 },
   },

--- a/examples/vue-cli/.storybook/main.js
+++ b/examples/vue-cli/.storybook/main.js
@@ -13,6 +13,7 @@ module.exports = {
     disableTelemetry: true,
   },
   features: {
+    storyStoreV7: true,
     buildStoriesJson: true,
   },
 };

--- a/examples/vue-kitchen-sink/.storybook/main.js
+++ b/examples/vue-kitchen-sink/.storybook/main.js
@@ -20,5 +20,6 @@ module.exports = {
   staticDirs: ['../public'],
   features: {
     buildStoriesJson: true,
+    storyStoreV7: !global.navigator?.userAgent?.match?.('jsdom'),
   },
 };

--- a/examples/vue-kitchen-sink/.storybook/preview.js
+++ b/examples/vue-kitchen-sink/.storybook/preview.js
@@ -10,4 +10,5 @@ export const parameters = {
   docs: {
     iframeHeight: '60px',
   },
+  globalParameter: 'globalParameter',
 };

--- a/examples/vue-kitchen-sink/src/App.vue
+++ b/examples/vue-kitchen-sink/src/App.vue
@@ -30,7 +30,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 #app {
   font-family: 'Avenir', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/core.stories.storyshot
@@ -8,9 +8,9 @@ exports[`Storyshots Core/Parameters passed to story 1`] = `
   "docs": {
     "iframeHeight": "60px"
   },
-  "framework": "vue",
   "globalParameter": "globalParameter",
-  "chapterParameter": "chapterParameter",
+  "framework": "vue",
+  "componentParameter": "componentParameter",
   "storyParameter": "storyParameter",
   "__isArgsStory": true,
   "__id": "core-parameters--passed-to-story",

--- a/examples/vue-kitchen-sink/src/stories/__snapshots__/custom-decorators.stories.storyshot
+++ b/examples/vue-kitchen-sink/src/stories/__snapshots__/custom-decorators.stories.storyshot
@@ -53,8 +53,8 @@ exports[`Storyshots Custom/Decorator for Vue With Data 1`] = `
     "docs": {
       "iframeHeight": "60px"
     },
-    "framework": "vue",
     "globalParameter": "globalParameter",
+    "framework": "vue",
     "__isArgsStory": true,
     "__id": "custom-decorator-for-vue--with-data",
     "args": {},

--- a/examples/vue-kitchen-sink/src/stories/core.stories.js
+++ b/examples/vue-kitchen-sink/src/stories/core.stories.js
@@ -1,15 +1,10 @@
-import { addParameters } from '@storybook/vue';
-
-const globalParameter = 'globalParameter';
-const chapterParameter = 'chapterParameter';
+const componentParameter = 'componentParameter';
 const storyParameter = 'storyParameter';
-
-addParameters({ globalParameter });
 
 export default {
   title: 'Core/Parameters',
   parameters: {
-    chapterParameter,
+    componentParameter,
   },
 };
 


### PR DESCRIPTION
Issue: N/A

## What I did

Both Storybook for Vue and Vue3 had issues when running in StoryStoreV7 mode. Reason being that Storybook needed a `applyDecorator` function as a preset, but it wasn't exported from the presets. This PR fixes that by exporting the function correctly.

For Vue2 projects the entire Storybook would break with 
<img width="666" alt="image" src="https://user-images.githubusercontent.com/1671563/171162574-6ae1bccc-347a-4b81-98ed-94c922167787.png">

For Vue3 projects, Storybook worked but decorators would not render the components.

With this PR, both Vue and Vue3 will render components correctly.

I also upgraded the vue example projects to use storyStoreV7

Thanks @prashantpalikhe @tmeasday for the investigation help! <3

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
