### PR TITLE
Chore: (Docs) Adds spacing to prevent issues with the link for telemetry

### DIFF
--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -90,7 +90,9 @@ Below are some of the most common installation issues and instructions on how to
 <!-- prettier-ignore-end -->
 
 <div class="aside">
+
 Storybook collects completely anonymous data to help us improve user experience. Participation is optional, and you may [opt-out](../configure/telemetry.md#how-to-opt-out) if you'd not like to share any information.
+
 </div>
 
 If all else fails, try asking for [help](https://storybook.js.org/support)


### PR DESCRIPTION
With this small pull request, the documentation (get-started/install) is updated to prevent an issue where the link for opting out of the telemetry is not properly rendered in the troubleshooting section.

