### PR TITLE
Fix global argTypes definition docs

### DIFF
--- a/docs/snippets/common/button-story-project-args-theme.js.mdx
+++ b/docs/snippets/common/button-story-project-args-theme.js.mdx
@@ -2,7 +2,7 @@
 // preview.js
 
 // All stories expect a theme arg
-export const argTypes = { theme: { control: { options: ['light', 'dark'] } } };
+export const argTypes = { theme: { control: 'select', options: ['light', 'dark'] } };
 
 // The default value of the theme arg to all stories
 export const args = { theme: 'light' };


### PR DESCRIPTION
Issue:

## What I did

While working on https://github.com/storybookjs/builder-vite/pull/399, I found that the example in the docs for global argTypes was incorrect.  So, this updates it so that it works correctly.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
