### PR TITLE
Addon-docs: Fix preset to pass MDX loader options properly

### DIFF
--- a/addons/docs/src/preset.ts
+++ b/addons/docs/src/preset.ts
@@ -123,6 +123,7 @@ export async function webpack(
             },
             {
               loader: mdxLoader,
+              options: { ...mdxLoaderOptions, skipCsf: false },
             },
           ],
         },

--- a/app/angular/src/builders/build-storybook/index.spec.ts
+++ b/app/angular/src/builders/build-storybook/index.spec.ts
@@ -175,9 +175,9 @@ describe('Build Storybook Builder', () => {
     expect(cpSpawnMock.spawn).toHaveBeenCalledWith(
       'npx',
       ['compodoc', '-p', './storybook/tsconfig.ts', '-d', '', '-e', 'json'],
-      {
+      expect.objectContaining({
         cwd: '',
-      }
+      })
     );
     expect(buildStandaloneMock).toHaveBeenCalledWith({
       angularBrowserTarget: 'angular-cli:build-2',

--- a/app/angular/src/builders/start-storybook/index.spec.ts
+++ b/app/angular/src/builders/start-storybook/index.spec.ts
@@ -157,9 +157,9 @@ describe('Start Storybook Builder', () => {
     expect(cpSpawnMock.spawn).toHaveBeenCalledWith(
       'npx',
       ['compodoc', '-p', './storybook/tsconfig.ts', '-d', '', '-e', 'json'],
-      {
+      expect.objectContaining({
         cwd: '',
-      }
+      })
     );
     expect(buildStandaloneMock).toHaveBeenCalledWith({
       angularBrowserTarget: 'angular-cli:build-2',

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-dev-posix
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-dev-posix
@@ -40,7 +40,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod-posix
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_manager-prod-posix
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cra-ts-essentials manager prod 1`] = `
+exports[`cra-ts-essentials manager dev 1`] = `
 Object {
   "entry": Array [
     "NODE_MODULES/@storybook/addon-ie11/dist/event-source-polyfill.js",
@@ -40,7 +40,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
@@ -211,7 +211,7 @@ Object {
       Object {
         "loader": "NODE_MODULES/file-loader/dist/cjs.js",
         "options": Object {
-          "name": "static/media/[name].[contenthash:8].[ext]",
+          "name": "static/media/[path][name].[ext]",
         },
         "test": "/\\\\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\\\\?.*)?$/",
       },
@@ -219,7 +219,7 @@ Object {
         "loader": "NODE_MODULES/url-loader/dist/cjs.js",
         "options": Object {
           "limit": 10000,
-          "name": "static/media/[name].[contenthash:8].[ext]",
+          "name": "static/media/[path][name].[ext]",
         },
         "test": "/\\\\.(mp4|webm|wav|mp3|m4a|aac|oga)(\\\\?.*)?$/",
       },

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-dev-posix
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-dev-posix
@@ -387,6 +387,13 @@ Object {
           },
           Object {
             "loader": "NODE_MODULES/@storybook/mdx1-csf/loader.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+              "skipCsf": false,
+            },
           },
         ],
       },

--- a/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod-posix
+++ b/lib/core-server/src/__snapshots__/cra-ts-essentials_preview-prod-posix
@@ -405,6 +405,13 @@ Object {
           },
           Object {
             "loader": "NODE_MODULES/@storybook/mdx1-csf/loader.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+              "skipCsf": false,
+            },
           },
         ],
       },

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-dev-posix
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-dev-posix
@@ -41,7 +41,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-prod-posix
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_manager-prod-posix
@@ -41,7 +41,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev-posix
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev-posix
@@ -39,7 +39,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev-posix
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-dev-posix
@@ -308,6 +308,13 @@ Object {
           },
           Object {
             "loader": "NODE_MODULES/@storybook/mdx1-csf/loader.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+              "skipCsf": false,
+            },
           },
         ],
       },

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod-posix
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod-posix
@@ -38,7 +38,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod-posix
+++ b/lib/core-server/src/__snapshots__/html-kitchen-sink_preview-prod-posix
@@ -307,6 +307,13 @@ Object {
           },
           Object {
             "loader": "NODE_MODULES/@storybook/mdx1-csf/loader.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+              "skipCsf": false,
+            },
           },
         ],
       },

--- a/lib/core-server/src/__snapshots__/vue-3-cli_manager-dev-posix
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_manager-dev-posix
@@ -42,7 +42,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_manager-prod-posix
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_manager-prod-posix
@@ -42,7 +42,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev-posix
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-dev-posix
@@ -41,7 +41,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
@@ -339,6 +339,13 @@ Object {
           },
           Object {
             "loader": "NODE_MODULES/@storybook/mdx1-csf/loader.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+              "skipCsf": false,
+            },
           },
         ],
       },

--- a/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod-posix
+++ b/lib/core-server/src/__snapshots__/vue-3-cli_preview-prod-posix
@@ -40,7 +40,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",
@@ -338,6 +338,13 @@ Object {
           },
           Object {
             "loader": "NODE_MODULES/@storybook/mdx1-csf/loader.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+              "skipCsf": false,
+            },
           },
         ],
       },

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-dev-posix
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-dev-posix
@@ -42,7 +42,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-prod-posix
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_manager-prod-posix
@@ -42,7 +42,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev-posix
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev-posix
@@ -40,7 +40,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev-posix
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-dev-posix
@@ -341,6 +341,13 @@ Object {
           },
           Object {
             "loader": "NODE_MODULES/@storybook/mdx1-csf/loader.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+              "skipCsf": false,
+            },
           },
         ],
       },

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod-posix
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod-posix
@@ -340,6 +340,13 @@ Object {
           },
           Object {
             "loader": "NODE_MODULES/@storybook/mdx1-csf/loader.js",
+            "options": Object {
+              "remarkPlugins": Array [
+                [Function],
+                [Function],
+              ],
+              "skipCsf": false,
+            },
           },
         ],
       },

--- a/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod-posix
+++ b/lib/core-server/src/__snapshots__/web-components-kitchen-sink_preview-prod-posix
@@ -39,7 +39,7 @@ Object {
         "include": Array [
           "ROOT",
         ],
-        "test": "/\\\\.(cjs|mjs|tsx?|jsx?)$/",
+        "test": "/\\\\.(mjs|tsx?|jsx?)$/",
         "use": Array [
           Object {
             "loader": "NODE_MODULES/babel-loader/lib/index.js",

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -78,7 +78,7 @@ export async function buildStaticStandalone(options: CLIOptions & LoadOptions & 
       Conflict when trying to read staticDirs:
       * Storybook's configuration option: 'staticDirs'
       * Storybook's CLI flag: '--staticDir' or '-s'
-      
+
       Choose one of them, but not both.
     `);
   }

--- a/lib/core-server/src/core-presets.test.ts
+++ b/lib/core-server/src/core-presets.test.ts
@@ -21,7 +21,7 @@ import htmlOptions from '../../../app/html/src/server/options';
 import webComponentsOptions from '../../../app/web-components/src/server/options';
 import { outputStats } from './utils/output-stats';
 
-const { SNAPSHOT_OS } = global;
+const { SNAPSHOT_OS } = global as unknown as { SNAPSHOT_OS: 'windows' | 'posix' };
 const mkdtemp = promisify(mkdtempCb);
 
 // this only applies to this file
@@ -151,14 +151,17 @@ const getConfig = (fn: any, name): Configuration | null => {
   return call[0];
 };
 
-const prepareSnap = (get: any, name): Pick<Configuration, 'module' | 'entry' | 'plugins'> => {
+const prepareSnap = (
+  get: any,
+  name
+): Pick<Configuration, 'module' | 'entry' | 'plugins'> | null => {
   const config = getConfig(get(), name);
   if (!config) return null;
 
   const keys = Object.keys(config);
   const { module, entry, plugins } = config;
 
-  return cleanRoots({ keys, module, entry, plugins: plugins.map((p) => p.constructor.name) });
+  return cleanRoots({ keys, module, entry, plugins: plugins?.map((p) => p.constructor.name) });
 };
 
 const snap = (name: string) => `__snapshots__/${name}`;

--- a/lib/core-server/typings.d.ts
+++ b/lib/core-server/typings.d.ts
@@ -11,4 +11,3 @@ declare module '@aw-web-design/x-default-browser';
 declare module '@storybook/ui';
 declare module '@discoveryjs/json-ext';
 declare module 'watchpack';
-


### PR DESCRIPTION
This relates to https://github.com/storybookjs/mdx2-csf/pull/12 and https://github.com/storybookjs/mdx2-csf/issues/11.

Issue:

## What I did

Fixed the usage of mdxLoader without passing mdxLoaderOptions. Without this change, MDX headers will not be linked via remark-slug + addon-docs.

I negated the `skipCsf` flag for this use case because in local testing when that was set to true it caused the MDX story to not be loadable (generic error with "CSF not found".)