### PR TITLE
CLI: Add additional files api to sb repro

### DIFF
--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -124,7 +124,7 @@ const baseAngular: Parameters = {
   framework: 'angular',
   name: 'angular',
   version: 'latest',
-  generator: `npx -p @angular/cli@{{version}} ng new {{appName}} --routing=true --minimal=true --style=scss --skipInstall=true --strict`,
+  generator: `npx -p @angular/cli@{{version}} ng new {{appName}} --routing=true --minimal=true --style=scss --skip-install=true --strict`,
 };
 
 export const angular10: Parameters = {

--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -13,6 +13,11 @@ export interface Parameters {
   autoDetect?: boolean;
   /** Dependencies to add before building Storybook */
   additionalDeps?: string[];
+  /** Files to add before building Storybook */
+  additionalFiles?: {
+    path: string;
+    contents: string;
+  }[];
   /** Add typescript dependency and creates a tsconfig.json file */
   typescript?: boolean;
   /** Merge configurations to main.js before running the tests */

--- a/lib/cli/src/repro-generators/configs.ts
+++ b/lib/cli/src/repro-generators/configs.ts
@@ -13,7 +13,7 @@ export interface Parameters {
   autoDetect?: boolean;
   /** Dependencies to add before building Storybook */
   additionalDeps?: string[];
-  /** Files to add before building Storybook */
+  /** Files to add before installing Storybook */
   additionalFiles?: {
     path: string;
     contents: string;

--- a/lib/cli/src/repro-generators/scripts.ts
+++ b/lib/cli/src/repro-generators/scripts.ts
@@ -22,7 +22,7 @@ export interface Parameters {
   ensureDir?: boolean;
   /** Dependencies to add before building Storybook */
   additionalDeps?: string[];
-  /** Files to add before building Storybook */
+  /** Files to add before installing Storybook */
   additionalFiles?: {
     path: string;
     contents: string;

--- a/lib/cli/src/repro-generators/scripts.ts
+++ b/lib/cli/src/repro-generators/scripts.ts
@@ -142,15 +142,13 @@ const generate = async ({ cwd, name, appName, version, generator }: Options) => 
 };
 
 const addAdditionalFiles = async ({ additionalFiles, cwd }: Options) => {
-  if (!additionalFiles || additionalFiles.length === 0) {
-    return;
-  }
-
   logger.info(`⤵️ Adding required files`);
 
-  additionalFiles.forEach(async (file) => {
-    await outputFile(path.resolve(cwd, file.path), file.contents, { encoding: 'UTF-8' });
-  });
+  await Promise.all(
+    additionalFiles.map(async (file) => {
+      await outputFile(path.resolve(cwd, file.path), file.contents, { encoding: 'UTF-8' });
+    })
+  );
 };
 
 const initStorybook = async ({ cwd, autoDetect = true, name, e2e }: Options) => {
@@ -245,8 +243,7 @@ export const createAndInit = async (
   logger.log();
 
   await doTask(generate, { ...options, cwd: options.creationPath });
-  console.log({ options });
-  await doTask(addAdditionalFiles, { ...options, cwd });
+  await doTask(addAdditionalFiles, { ...options, cwd }, !!options.additionalFiles);
   if (e2e) {
     await doTask(addPackageResolutions, options);
   }


### PR DESCRIPTION
Issue: N/A

## What I did

Added `additionalFiles` to repro config, so that we can add files before initializing Storybook.

Looks like this:
```js
export const react = {
  framework: 'react',
  name: 'react',
  version: 'latest',
  generator: fromDeps('react', 'react-dom'),
  additionalDeps: ['prop-types'],
  additionalFiles: [
    { 
      path: '.babelrc',
      contents: dedent`
        {
          "presets": ["@babel/preset-env"]
        }
      `,
    }
  ]
};
```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
