### PR TITLE
Fix lib preview web story change event

### DIFF
--- a/app/angular/src/client/preview/angular-beta/DocsRenderer.ts
+++ b/app/angular/src/client/preview/angular-beta/DocsRenderer.ts
@@ -27,15 +27,6 @@ export class DocsRenderer extends AbstractRenderer {
       await DocsRenderer.resetPlatformBrowserDynamic();
     });
 
-    /**
-     * Destroy and recreate the PlatformBrowserDynamic of angular
-     * when doc re render. Allows to call ngOnDestroy of angular
-     * for previous component
-     */
-    channel.once(Events.DOCS_RENDERED, async () => {
-      await DocsRenderer.resetPlatformBrowserDynamic();
-    });
-
     await super.render({ ...options, forced: false });
   }
 

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -248,6 +248,10 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
     const storyIdChanged = this.currentSelection?.storyId !== storyId;
     const viewModeChanged = this.currentSelection?.viewMode !== selection.viewMode;
 
+    const prevComponentId = this.storyStore.fromId(this.currentSelection?.storyId)?.componentId;
+    const nextComponentId = this.storyStore.fromId(storyId)?.componentId;
+    const hasComponentChanged = prevComponentId !== nextComponentId;
+
     // Show a spinner while we load the next story
     if (selection.viewMode === 'story') {
       this.view.showPreparingStory({ immediate: viewModeChanged });
@@ -317,7 +321,12 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
     await this.teardownRender(lastRender, { viewModeChanged });
 
     // If we are rendering something new (as opposed to re-rendering the same or first story), emit
-    if (lastSelection && (storyIdChanged || viewModeChanged)) {
+
+    const hasPreviouslyRendered = !!lastSelection;
+    const storyOrViewModeHasChanged = storyIdChanged || viewModeChanged;
+    const isSamePage = !viewModeChanged && !hasComponentChanged;
+
+    if (hasPreviouslyRendered && storyOrViewModeHasChanged && !isSamePage) {
       this.channel.emit(STORY_CHANGED, storyId);
     }
 


### PR DESCRIPTION
Issue: #18176 #18175

## What I did

app/angular listens to the `STORY_CHANGED` in the DocsRenderer and this event has fired even if you are in the same docs tab and switch between stories of the same docs page. 

This broke the whole docs tab because app/angular needs to reset the underlying Angular instance but could not recover from that inside the docs page. (see #18176 for more details)

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

## Todos

- [ ] Add a test
