### PR TITLE
Docs: Update link to Initial Setup section

### DIFF
--- a/docs/contribute/code.md
+++ b/docs/contribute/code.md
@@ -20,7 +20,7 @@ yarn && yarn bootstrap --core
 
 ## Run tests & examples
 
-Once you've completed the [initial setup](#run-tests-&-examples), you should have a fully functional version of Storybook built on your local machine. Before making any code changes, it's helpful to verify that everything is working as it should. More specifically, the test suite and examples.
+Once you've completed the [initial setup](#initial-setup), you should have a fully functional version of Storybook built on your local machine. Before making any code changes, it's helpful to verify that everything is working as it should. More specifically, the test suite and examples.
 
 Run the following command to execute the tests:
 


### PR DESCRIPTION
Issue:

## What I did

In the Contribute page, under the **Run tests & examples** section, there's an internal link to the previous section **Initial setup**, but the link is incorrect. It points to the section **Run tests & examples** itself. I just updated it. 

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
