### PR TITLE
Add missing peer dependencies

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -55,6 +55,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "dependencies": {
+    "@babel/core": "^7.12.10",
     "@babel/plugin-transform-react-jsx": "^7.12.12",
     "@babel/preset-env": "^7.12.11",
     "@jest/transform": "^26.6.2",
@@ -85,14 +86,14 @@
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.10",
     "@storybook/mdx2-csf": "^0.0.3",
     "@types/util-deprecate": "^1.0.0"
   },
   "peerDependencies": {
     "@storybook/mdx2-csf": "^0.0.3",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "webpack": "*"
   },
   "peerDependenciesMeta": {
     "@storybook/mdx2-csf": {
@@ -102,6 +103,9 @@
       "optional": true
     },
     "react-dom": {
+      "optional": true
+    },
+    "webpack": {
       "optional": true
     }
   },

--- a/lib/docs-tools/package.json
+++ b/lib/docs-tools/package.json
@@ -52,6 +52,10 @@
     "jest-specific-snapshot": "^4.0.0",
     "require-from-string": "^2.0.2"
   },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/lib/telemetry/package.json
+++ b/lib/telemetry/package.json
@@ -53,6 +53,10 @@
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7"
   },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6577,12 +6577,15 @@ __metadata:
     "@storybook/mdx2-csf": ^0.0.3
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    webpack: "*"
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
       optional: true
     react:
       optional: true
     react-dom:
+      optional: true
+    webpack:
       optional: true
   languageName: unknown
   linkType: soft
@@ -7831,6 +7834,9 @@ __metadata:
     lodash: ^4.17.21
     regenerator-runtime: ^0.13.7
     require-from-string: ^2.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -8848,6 +8854,9 @@ __metadata:
     nanoid: ^3.3.1
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Issue: N/A

## What I did

Fixed these [implicit transitive peer dependency](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0) warnings:
```
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [2cbe1] doesn't provide @babel/core (p3913f), requested by @babel/preset-env
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [2cbe1] doesn't provide @babel/core (p621a8), requested by @babel/plugin-transform-react-jsx
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [2cbe1] doesn't provide @babel/core (paa0c6), requested by babel-loader
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [2cbe1] doesn't provide webpack (pb1704), requested by babel-loader
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [70eb4] doesn't provide @babel/core (pb7024), requested by @babel/preset-env
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [70eb4] doesn't provide @babel/core (p2b684), requested by @babel/plugin-transform-react-jsx
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [70eb4] doesn't provide @babel/core (p7f302), requested by babel-loader
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [70eb4] doesn't provide webpack (pf5769), requested by babel-loader
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [95ddb] doesn't provide @babel/core (pc8e40), requested by @babel/preset-env
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [95ddb] doesn't provide @babel/core (p35056), requested by @babel/plugin-transform-react-jsx
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [95ddb] doesn't provide @babel/core (p0084f), requested by babel-loader
➤ YN0002: │ @storybook/addon-docs@npm:6.5.6 [95ddb] doesn't provide webpack (p3996c), requested by babel-loader
➤ YN0002: │ @storybook/docs-tools@npm:6.5.6 doesn't provide react (p240ce), requested by @storybook/store
➤ YN0002: │ @storybook/docs-tools@npm:6.5.6 doesn't provide react-dom (p183b2), requested by @storybook/store
➤ YN0002: │ @storybook/telemetry@npm:6.5.6 doesn't provide react (p1b80e), requested by @storybook/core-common
➤ YN0002: │ @storybook/telemetry@npm:6.5.6 doesn't provide react-dom (p81d68), requested by @storybook/core-common
```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
