### PR TITLE
CLI: Fix `init` to install correct version of sb/storybook

### DIFF
--- a/lib/cli/scripts/generate-sb-packages-versions.js
+++ b/lib/cli/scripts/generate-sb-packages-versions.js
@@ -35,8 +35,7 @@ const run = async () => {
       })
     )
   )
-    // Remove non-`@storybook/XXX` package (like: `cli-sb`, `cli-storybook`)
-    .filter(({ name }) => /@storybook/.test(name))
+    .filter(({ name }) => /(@storybook|^sb$|^storybook$)/.test(name))
     // As some previous steps are asynchronous order is not always the same so sort them to avoid that
     .sort((package1, package2) => package1.name.localeCompare(package2.name))
     .reduce((acc, { name }) => ({ ...acc, [name]: updatedVersion }), {});

--- a/lib/cli/scripts/generate-sb-packages-versions.js
+++ b/lib/cli/scripts/generate-sb-packages-versions.js
@@ -35,7 +35,7 @@ const run = async () => {
       })
     )
   )
-    .filter(({ name }) => /(@storybook|^sb$|^storybook$)/.test(name))
+    .filter(({ name }) => /^(@storybook|sb$|storybook$)/.test(name))
     // As some previous steps are asynchronous order is not always the same so sort them to avoid that
     .sort((package1, package2) => package1.name.localeCompare(package2.name))
     .reduce((acc, { name }) => ({ ...acc, [name]: updatedVersion }), {});

--- a/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -170,7 +170,7 @@ export abstract class JsPackageManager {
   public async getVersion(packageName: string, constraint?: string): Promise<string> {
     let current: string;
 
-    if (/@storybook/.test(packageName)) {
+    if (/(@storybook|^sb$|^storybook$)/.test(packageName)) {
       // @ts-ignore
       current = storybookPackagesVersions[packageName];
     }


### PR DESCRIPTION
Issue: N/A

## What I did

We're now installing `sb` on `init`, so we need the correct version in the versions map.

We also need to update the lookup to find sb/storybook

Self-merging @ndelangen 

## How to test

- [ ] CI passes