### PR TITLE
UI: Update manager to respect `parameters.docsOnly` in `stories.json`

### DIFF
--- a/lib/api/src/lib/stories.ts
+++ b/lib/api/src/lib/stories.ts
@@ -122,6 +122,9 @@ export interface StoryIndexStory {
   name: StoryName;
   title: ComponentTitle;
   importPath: Path;
+
+  // v2 or v2-compatible story index includes this
+  parameters?: Parameters;
 }
 export interface StoryIndex {
   v: number;
@@ -183,16 +186,19 @@ export const transformStoryIndexToStoriesHash = (
   { provider }: { provider: Provider }
 ): StoriesHash => {
   const countByTitle = countBy(Object.values(index.stories), 'title');
-  const input = Object.entries(index.stories).reduce((acc, [id, { title, name, importPath }]) => {
-    const docsOnly = name === 'Page' && countByTitle[title] === 1;
-    acc[id] = {
-      id,
-      kind: title,
-      name,
-      parameters: { fileName: importPath, options: {}, docsOnly },
-    };
-    return acc;
-  }, {} as StoriesRaw);
+  const input = Object.entries(index.stories).reduce(
+    (acc, [id, { title, name, importPath, parameters }]) => {
+      const docsOnly = name === 'Page' && countByTitle[title] === 1;
+      acc[id] = {
+        id,
+        kind: title,
+        name,
+        parameters: { fileName: importPath, options: {}, docsOnly, ...parameters },
+      };
+      return acc;
+    },
+    {} as StoriesRaw
+  );
 
   return transformStoriesRawToStoriesHash(input, { provider, prepared: false });
 };

--- a/lib/api/src/tests/stories.test.js
+++ b/lib/api/src/tests/stories.test.js
@@ -1116,6 +1116,37 @@ describe('stories API', () => {
       expect(storedStoriesHash['component-b--page'].parameters.docsOnly).toBe(true);
       expect(storedStoriesHash['component-c--story-4'].parameters.docsOnly).toBe(false);
     });
+
+    it('prefers parameters.docsOnly to inferred docsOnly status', async () => {
+      mockStories.mockReset().mockReturnValue({
+        'component-a--docs': {
+          type: 'story',
+          title: 'Component A',
+          name: 'Docs', // Called 'Docs' rather than 'Page'
+          importPath: './path/to/component-a.ts',
+          parameters: {
+            docsOnly: true,
+          },
+        },
+      });
+
+      const navigate = jest.fn();
+      const store = createMockStore();
+      const fullAPI = Object.assign(new EventEmitter(), {
+        setStories: jest.fn(),
+      });
+
+      const { api, init } = initStories({ store, navigate, provider, fullAPI });
+      Object.assign(fullAPI, api);
+
+      await init();
+
+      const { storiesHash: storedStoriesHash } = store.getState();
+
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(storedStoriesHash)).toEqual(['component-a', 'component-a--docs']);
+      expect(storedStoriesHash['component-a--docs'].parameters.docsOnly).toBe(true);
+    });
   });
 
   describe('STORY_PREPARED', () => {


### PR DESCRIPTION
We sometimes set this in 6.x (if using `storyStoreV7 = false` and `breakingChangesV7 = false`), but we plan to use this for back-compat purposes in 7.x.

## How to test

See tests