### PR TITLE
Telemetry: Strip out preset from addon name

### DIFF
--- a/lib/telemetry/src/storybook-metadata.test.ts
+++ b/lib/telemetry/src/storybook-metadata.test.ts
@@ -82,18 +82,27 @@ describe('await computeStorybookMetadata', () => {
         devDependencies: {
           '@storybook/react': 'x.y.z',
           '@storybook/addon-essentials': 'x.x.x',
-          'storybook-addon-deprecated': 'x.x.x',
+          '@storybook/addon-knobs': 'x.x.y',
+          'storybook-addon-deprecated': 'x.x.z',
         },
       },
       mainConfig: {
         ...mainJsMock,
-        addons: ['@storybook/addon-essentials', 'storybook-addon-deprecated/register'],
+        addons: [
+          '@storybook/addon-essentials',
+          'storybook-addon-deprecated/register',
+          '@storybook/addon-knobs/preset',
+        ],
       },
     });
 
     expect(result.addons).toMatchInlineSnapshot(`
       Object {
         "@storybook/addon-essentials": Object {
+          "options": undefined,
+          "version": "x.x.x",
+        },
+        "@storybook/addon-knobs": Object {
           "options": undefined,
           "version": "x.x.x",
         },

--- a/lib/telemetry/src/storybook-metadata.ts
+++ b/lib/telemetry/src/storybook-metadata.ts
@@ -12,22 +12,6 @@ import type { StorybookMetadata, Dependency, StorybookAddon } from './types';
 import { getActualPackageVersion, getActualPackageVersions } from './package-versions';
 import { getMonorepoType } from './get-monorepo-type';
 
-let cachedMetadata: StorybookMetadata;
-export const getStorybookMetadata = async (_configDir: string) => {
-  if (cachedMetadata) {
-    return cachedMetadata;
-  }
-
-  const packageJson = readPkgUp.sync({ cwd: process.cwd() }).packageJson as PackageJson;
-  const configDir =
-    (_configDir ||
-      (getStorybookConfiguration(packageJson.scripts.storybook, '-c', '--config-dir') as string)) ??
-    '.storybook';
-  const mainConfig = loadMainConfig({ configDir });
-  cachedMetadata = await computeStorybookMetadata({ mainConfig, packageJson });
-  return cachedMetadata;
-};
-
 export const metaFrameworks = {
   next: 'Next',
   'react-scripts': 'CRA',
@@ -147,7 +131,7 @@ export const computeStorybookMetadata = async ({
       let result;
       let options;
       if (typeof addon === 'string') {
-        result = addon.replace('/register', '');
+        result = addon.replace('/register', '').replace('/preset', '');
       } else {
         options = addon.options;
         result = addon.name;
@@ -203,4 +187,20 @@ export const computeStorybookMetadata = async ({
     addons,
     hasStorybookEslint,
   };
+};
+
+let cachedMetadata: StorybookMetadata;
+export const getStorybookMetadata = async (_configDir: string) => {
+  if (cachedMetadata) {
+    return cachedMetadata;
+  }
+
+  const packageJson = readPkgUp.sync({ cwd: process.cwd() }).packageJson as PackageJson;
+  const configDir =
+    (_configDir ||
+      (getStorybookConfiguration(packageJson.scripts.storybook, '-c', '--config-dir') as string)) ??
+    '.storybook';
+  const mainConfig = loadMainConfig({ configDir });
+  cachedMetadata = await computeStorybookMetadata({ mainConfig, packageJson });
+  return cachedMetadata;
 };


### PR DESCRIPTION
Issue: N/A

## What I did

Take into account that some addons are registered with `'addon-name/preset'` and strip that out in the metadata.

Also move getStorybookMetadata method to the bottom so it's used after the definition of computeStorybookMetadata, as eslint has warned:
```ts
error  'computeStorybookMetadata' was used before it was defined  no-use-before-define
```


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
