### PR TITLE
Storyshots: Add typescript webpack env dep

### DIFF
--- a/addons/storyshots/storyshots-core/package.json
+++ b/addons/storyshots/storyshots-core/package.json
@@ -55,6 +55,7 @@
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.16",
     "@types/jest-specific-snapshot": "^0.5.3",
+    "@types/webpack-env": "1.16.3",
     "core-js": "^3.8.2",
     "glob": "^7.1.6",
     "global": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6862,6 +6862,7 @@ __metadata:
     "@types/glob": ^7.1.3
     "@types/jest": ^26.0.16
     "@types/jest-specific-snapshot": ^0.5.3
+    "@types/webpack-env": 1.16.3
     babel-loader: ^8.0.0
     core-js: ^3.8.2
     enzyme: ^3.11.0
@@ -10722,7 +10723,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/webpack-env@npm:^1.15.1, @types/webpack-env@npm:^1.15.2, @types/webpack-env@npm:^1.16.0":
+"@types/webpack-env@npm:1.16.3, @types/webpack-env@npm:^1.15.1, @types/webpack-env@npm:^1.15.2, @types/webpack-env@npm:^1.16.0":
   version: 1.16.3
   resolution: "@types/webpack-env@npm:1.16.3"
   checksum: 136ece45e58fbcb4d8e02fe7892213105d6874223a66209bccaf4a18ca78ab81a10d121ee9d0944904cfad1274ca730efc9643b9cd8444239f505676adee22a0


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18392

## What I did

Added a dependency to types @storybook/addon-storyshots depends on for Typescript and Yarn with PnP enabled.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
