### PR TITLE
fix: addons-background not updating default value

### DIFF
--- a/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -78,7 +78,14 @@ export const BackgroundSelector: FunctionComponent = memo(() => {
   );
 
   const [globals, updateGlobals] = useGlobals();
-
+  if (!globals[BACKGROUNDS_PARAM_KEY] && backgroundsConfig.values.length) {
+    const defaultSetting = backgroundsConfig.values.find(
+      (value) => value.name === backgroundsConfig.default
+    );
+    globals[BACKGROUNDS_PARAM_KEY] = {
+      value: defaultSetting.value,
+    };
+  }
   const globalsBackgroundColor = globals[BACKGROUNDS_PARAM_KEY]?.value;
 
   const selectedBackgroundColor = useMemo(() => {


### PR DESCRIPTION
Issue: fixes #15632 

## What I did

- I checked if the `globals` object has the `backgrounds` property
- If yes, read the default background color setting from `backgroundsConfig`
- Populate the `globals` object with default background color

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [x] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
