### PR TITLE
Build: Use playright version of sb-bench

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: install playright
+          command: npx playwright install
+      - run:
           name: Running local registry
           command: yarn local-registry --port 6000 --open
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
             cd ..
             npx create-react-app cra-bench
             cd cra-bench
-            npx @storybook/bench@latest 'npx sb init' --label cra
+            npx @storybook/bench@0.8.0--canary.11.edeef38.0 'npx sb init' --label cra
   e2e-tests-pnp:
     executor:
       class: medium


### PR DESCRIPTION
testing a sb-bench version that uses playright instead of puppeteer