### PR TITLE
[documentation] Remove duplicate statement in React snippet from docs

### DIFF
--- a/docs/snippets/react/page-story-with-args-composition.ts.mdx
+++ b/docs/snippets/react/page-story-with-args-composition.ts.mdx
@@ -18,7 +18,6 @@ export default {
   */
   title: 'DocumentScreen',
   component: DocumentScreen,
-  title: 'DocumentScreen',
 } as ComponentMeta<typeof DocumentScreen>;
 
 


### PR DESCRIPTION
## What I did

`title: 'DocumentScreen',` appears twice in the component meta so I removed the duplicate line.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [X] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
