### PR TITLE
[dependencies] Remove dependency to trim newlines

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -50,7 +50,9 @@ module.exports = {
     '^.+\\.[jt]sx?$': '<rootDir>/scripts/utils/jest-transform-js.js',
     '^.+\\.mdx$': '@storybook/addon-docs/jest-transform-mdx',
   },
-  transformIgnorePatterns: ['/node_modules/(?!lit-html).+\\.js'],
+  transformIgnorePatterns: [
+    '/node_modules/(?!lit-html|default-browser|bundle-name|run-applescript).+\\.js',
+  ],
   testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
   testPathIgnorePatterns: [
     '/node_modules/',

--- a/lib/core-client/src/typings.d.ts
+++ b/lib/core-client/src/typings.d.ts
@@ -6,6 +6,5 @@ declare module 'pnp-webpack-plugin';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
 declare module 'open';
-declare module 'x-default-browser';
+declare module 'default-browser';
 declare module '@storybook/ui';
-

--- a/lib/core-server/package.json
+++ b/lib/core-server/package.json
@@ -63,6 +63,7 @@
     "compression": "^1.7.4",
     "core-js": "^3.8.2",
     "cpy": "^8.1.2",
+    "default-browser": "^3.0.0",
     "detect-port": "^1.3.0",
     "express": "^4.17.1",
     "fs-extra": "^9.0.1",
@@ -82,8 +83,7 @@
     "util-deprecate": "^1.0.2",
     "watchpack": "^2.2.0",
     "webpack": "4",
-    "ws": "^8.2.3",
-    "x-default-browser": "^0.4.0"
+    "ws": "^8.2.3"
   },
   "devDependencies": {
     "@storybook/builder-webpack5": "6.5.0-rc.1",

--- a/lib/core-server/src/utils/open-in-browser.ts
+++ b/lib/core-server/src/utils/open-in-browser.ts
@@ -1,25 +1,29 @@
 import { logger } from '@storybook/node-logger';
 import betterOpn from 'better-opn'; // betterOpn alias used because also loading open
 import open from 'open';
-import getDefaultBrowser from 'x-default-browser';
+import defaultBrowser from 'default-browser';
 import dedent from 'ts-dedent';
 
-export function openInBrowser(address: string) {
-  getDefaultBrowser(async (err: any, res: any) => {
-    try {
-      if (res && (res.isChrome || res.isChromium)) {
-        // We use betterOpn for Chrome because it is better at handling which chrome tab
-        // or window the preview loads in.
-        betterOpn(address);
-      } else {
-        await open(address);
-      }
-    } catch (error) {
-      logger.error(dedent`
-        Could not open ${address} inside a browser. If you're running this command inside a
-        docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
-        browser by default.
-      `);
+const isChrome = (browserId: string) => {
+  /** Chrome browser id com.google.chrome or com.google.chrome.canary */
+  return browserId.toLowerCase().includes('google');
+};
+
+export async function openInBrowser(address: string) {
+  try {
+    const res = await defaultBrowser();
+    if (res && isChrome(res.id)) {
+      // We use betterOpn for Chrome because it is better at handling which chrome tab
+      // or window the preview loads in.
+      betterOpn(address);
+    } else {
+      await open(address);
     }
-  });
+  } catch (error) {
+    logger.error(dedent`
+      Could not open ${address} inside a browser. If you're running this command inside a
+      docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
+      browser by default.
+    `);
+  }
 }

--- a/lib/core-server/src/utils/open-in-browser.ts
+++ b/lib/core-server/src/utils/open-in-browser.ts
@@ -4,15 +4,28 @@ import open from 'open';
 import defaultBrowser from 'default-browser';
 import dedent from 'ts-dedent';
 
-const isChrome = (browserId: string) => {
-  /** Chrome browser id com.google.chrome or com.google.chrome.canary */
-  return browserId.toLowerCase().includes('google');
+const chromiumBrowsers = [
+  'com.google.chrome',
+  'com.google.chrome.canary',
+  'com.microsoft.edge',
+  'com.microsoft.edgemac',
+  'com.microsoft.edgemac.beta',
+  'com.operasoftware.opera',
+  'com.brave.browser',
+  'com.brave.browser.beta',
+  'com.brave.browser.dev',
+  'org.blisk.blisk',
+  'com.vivaldi.vivaldi',
+];
+
+const isChromium = (browserId: string) => {
+  return chromiumBrowsers.includes(browserId.toLowerCase());
 };
 
 export async function openInBrowser(address: string) {
   try {
     const res = await defaultBrowser();
-    if (res && isChrome(res.id)) {
+    if (res && isChromium(res.id)) {
       // We use betterOpn for Chrome because it is better at handling which chrome tab
       // or window the preview loads in.
       betterOpn(address);

--- a/lib/core-server/typings.d.ts
+++ b/lib/core-server/typings.d.ts
@@ -7,8 +7,7 @@ declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
 declare module 'open';
-declare module 'x-default-browser';
+declare module 'default-browser';
 declare module '@storybook/ui';
 declare module '@discoveryjs/json-ext';
 declare module 'watchpack';
-

--- a/lib/manager-webpack4/typings.d.ts
+++ b/lib/manager-webpack4/typings.d.ts
@@ -7,5 +7,5 @@ declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
 declare module 'open';
-declare module 'x-default-browser';
+declare module 'default-browser';
 declare module '@storybook/ui';

--- a/lib/manager-webpack5/typings.d.ts
+++ b/lib/manager-webpack5/typings.d.ts
@@ -6,5 +6,5 @@ declare module '@storybook/theming/paths';
 declare module '@storybook/ui/paths';
 declare module 'better-opn';
 declare module 'open';
-declare module 'x-default-browser';
+declare module 'default-browser';
 declare module '@storybook/ui';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7684,6 +7684,7 @@ __metadata:
     compression: ^1.7.4
     core-js: ^3.8.2
     cpy: ^8.1.2
+    default-browser: ^3.0.0
     detect-port: ^1.3.0
     express: ^4.17.1
     fs-extra: ^9.0.1
@@ -7705,7 +7706,6 @@ __metadata:
     watchpack: ^2.2.0
     webpack: 4
     ws: ^8.2.3
-    x-default-browser: ^0.4.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -14764,7 +14764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"big-integer@npm:^1.6.7":
+"big-integer@npm:^1.6.44":
   version: 1.6.51
   resolution: "big-integer@npm:1.6.51"
   checksum: c8139662d57f8833a44802f4b65be911679c569535ea73c5cfd3c1c8994eaead1b84b6f63e1db63833e4d4cacb6b6a9e5522178113dfdc8e4c81ed8436f1e8cc
@@ -14994,12 +14994,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bplist-parser@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "bplist-parser@npm:0.1.1"
+"bplist-parser@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "bplist-parser@npm:0.2.0"
   dependencies:
-    big-integer: ^1.6.7
-  checksum: cd50206f956e74f6e46cb5ed14be5eb00b2e14676ea3dd36703470715177a2770fc22032eca63a36adb3b56a1e51138a95bb0fc6849a78c21e92caeedf219ea7
+    big-integer: ^1.6.44
+  checksum: ce79c69e0f6efe506281e7c84e3712f7d12978991675b6e3a58a295b16f13ca81aa9b845c335614a545e0af728c8311b6aa3142af76ba1cb616af9bbac5c4a9f
   languageName: node
   linkType: hard
 
@@ -15889,6 +15889,15 @@ __metadata:
   version: 1.0.3
   resolution: "builtins@npm:1.0.3"
   checksum: 493afcc1db0a56d174cc85bebe5ca69144f6fdd0007d6cbe6b2434185314c79d83cb867e492b56aa5cf421b4b8a8135bf96ba4c3ce71994cf3da154d1ea59747
+  languageName: node
+  linkType: hard
+
+"bundle-name@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bundle-name@npm:3.0.0"
+  dependencies:
+    run-applescript: ^5.0.0
+  checksum: 57bc7f8b025d83961b04db2f1eff6a87f2363c2891f3542a4b82471ff8ebb5d484af48e9784fcdb28ef1d48bb01f03d891966dc3ef58758e46ea32d750ce40f8
   languageName: node
   linkType: hard
 
@@ -18221,6 +18230,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-spawn-async@npm:^2.1.1":
+  version: 2.2.5
+  resolution: "cross-spawn-async@npm:2.2.5"
+  dependencies:
+    lru-cache: ^4.0.0
+    which: ^1.2.8
+  checksum: 2d7324afbcbb677e6717b10dec6e3cd8f746e622ded91ebc7f2d9e6e65dc3e0ab72f5d9793c78e52f33bebf6650c7f113fe44e5cecff486e7adaba7d6d29a00f
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:7.0.1":
   version: 7.0.1
   resolution: "cross-spawn@npm:7.0.1"
@@ -19274,16 +19293,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"default-browser-id@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "default-browser-id@npm:1.0.4"
+"default-browser-id@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "default-browser-id@npm:3.0.0"
   dependencies:
-    bplist-parser: ^0.1.0
-    meow: ^3.1.0
-    untildify: ^2.0.0
-  bin:
-    default-browser-id: cli.js
-  checksum: a00a2ab66beab70490b4d76258a1f2eadfadca6414bf67ab78aa25b33dc3de0c4c813bb8f204271aa7a08281c39474487db0229e325112456464fb97a0522a8a
+    bplist-parser: ^0.2.0
+    untildify: ^4.0.0
+  checksum: 8db3ab882eb3e1e8b59d84c8641320e6c66d8eeb17eb4bb848b7dd549b1e6fd313988e4a13542e95fbaeff03f6e9dedc5ad191ad4df7996187753eb0d45c00b7
+  languageName: node
+  linkType: hard
+
+"default-browser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "default-browser@npm:3.0.0"
+  dependencies:
+    bundle-name: ^3.0.0
+    default-browser-id: ^3.0.0
+    execa: ^5.0.0
+    xdg-default-browser: ^2.1.0
+  checksum: 72936309ea0155be3782dcdebab5401e107a92c13b48935949f9deab4aca32c481c84793e495350ca9476a7d30623eb1db06a9e469de4cdde3dece33c69d0734
   languageName: node
   linkType: hard
 
@@ -22295,6 +22323,19 @@ __metadata:
     signal-exit: ^3.0.2
     strip-final-newline: ^2.0.0
   checksum: 02211601bb1c52710260edcc68fb84c3c030dc68bafc697c90ada3c52cc31375337de8c24826015b8382a58d63569ffd203b79c94fef217d65503e3e8d2c52ba
+  languageName: node
+  linkType: hard
+
+"execa@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "execa@npm:0.2.2"
+  dependencies:
+    cross-spawn-async: ^2.1.1
+    npm-run-path: ^1.0.0
+    object-assign: ^4.0.1
+    path-key: ^1.0.0
+    strip-eof: ^1.0.0
+  checksum: 236ef930c7da8bc99727a3a14ad8072576748e0864e48a1c845a9caa80b253133502e9f976c888edd74139d8cd5988bf8725c0475a31b38f7797b69cc1c4ab68
   languageName: node
   linkType: hard
 
@@ -30950,7 +30991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^4.0.1, lru-cache@npm:^4.1.2, lru-cache@npm:^4.1.5":
+"lru-cache@npm:^4.0.0, lru-cache@npm:^4.0.1, lru-cache@npm:^4.1.2, lru-cache@npm:^4.1.5":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
   dependencies:
@@ -31758,7 +31799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"meow@npm:^3.1.0, meow@npm:^3.3.0":
+"meow@npm:^3.3.0":
   version: 3.7.0
   resolution: "meow@npm:3.7.0"
   dependencies:
@@ -33698,6 +33739,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "npm-run-path@npm:1.0.0"
+  dependencies:
+    path-key: ^1.0.0
+  checksum: 1404ef3d8d6db6418978f63b2062b4745734429b9cbf68371625c21a7e3f98ca022c57dbbf20f69ac22d1191be6cd00013f3afb91ef8603791d05f0623bca08f
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^2.0.0":
   version: 2.0.2
   resolution: "npm-run-path@npm:2.0.2"
@@ -34994,6 +35044,13 @@ __metadata:
   version: 1.0.2
   resolution: "path-is-inside@npm:1.0.2"
   checksum: 7fdd4b41672c70461cce734fc222b33e7b447fa489c7c4377c95e7e6852d83d69741f307d88ec0cc3b385b41cb4accc6efac3c7c511cd18512e95424f5fa980c
+  languageName: node
+  linkType: hard
+
+"path-key@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "path-key@npm:1.0.0"
+  checksum: 878099d48c5801baf8edc69952c0eea94406193432448d637b1755483ed053df1685db4f7146eaca3ef5cd03ee84024846b039d19e59dfbb3339cba04d7dcb2c
   languageName: node
   linkType: hard
 
@@ -40550,6 +40607,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"run-applescript@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "run-applescript@npm:5.0.0"
+  dependencies:
+    execa: ^5.0.0
+  checksum: f9977db5770929f3f0db434b8e6aa266498c70dec913c84320c0a06add510cf44e3a048c44da088abee312006f9cbf572fd065cdc8f15d7682afda8755f4114c
+  languageName: node
+  linkType: hard
+
 "run-async@npm:^2.2.0, run-async@npm:^2.4.0":
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
@@ -43772,6 +43838,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"titleize@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "titleize@npm:1.0.1"
+  checksum: 883cfadf59ede1f13a33fdb2821f03b905a118ca3e9f29163e264c203177f009cf650594a81eb1ff71c551bd45ac99d5b52c548c1abb12e604260d83347fb37f
+  languageName: node
+  linkType: hard
+
 "tlds@npm:^1.203.0":
   version: 1.230.0
   resolution: "tlds@npm:1.230.0"
@@ -45272,7 +45345,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"untildify@npm:^2.0.0, untildify@npm:^2.1.0":
+"untildify@npm:^2.1.0":
   version: 2.1.0
   resolution: "untildify@npm:2.1.0"
   dependencies:
@@ -47129,7 +47202,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^1.2.14, which@npm:^1.2.9, which@npm:^1.3.0, which@npm:^1.3.1":
+"which@npm:^1.2.14, which@npm:^1.2.8, which@npm:^1.2.9, which@npm:^1.3.0, which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:
@@ -47834,24 +47907,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"x-default-browser@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "x-default-browser@npm:0.4.0"
-  dependencies:
-    default-browser-id: ^1.0.4
-  dependenciesMeta:
-    default-browser-id:
-      optional: true
-  bin:
-    x-default-browser: bin/x-default-browser.js
-  checksum: a19e42ffeab19560ea05a423561f5b3b82bb3a5878dc932cfd0847fadc5890b8b685d6b39e2356c8304b3943f5a7120ba4b233365d686ff8f9bf2499ce11f052
-  languageName: node
-  linkType: hard
-
 "xdg-basedir@npm:^4.0.0":
   version: 4.0.0
   resolution: "xdg-basedir@npm:4.0.0"
   checksum: 1b5d70d58355af90363a4e0a51c992e77fc5a1d8de5822699c7d6e96a6afea9a1e048cb93312be6870f338ca45ebe97f000425028fa149c1e87d1b5b8b212a06
+  languageName: node
+  linkType: hard
+
+"xdg-default-browser@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "xdg-default-browser@npm:2.1.0"
+  dependencies:
+    execa: ^0.2.2
+    titleize: ^1.0.0
+  checksum: 4cad95741fc0fed9db09a2a1c0f4ac027eb520307dca2adb876573f4f8f7c47bb9cb01b7ffdbf22a6f68d9ed710a6434378f9cf7ac66a44d98a0eeb33690213e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18287 (also related to https://github.com/storybookjs/storybook/issues/17220)

## What I did

- Replaced "[x-default-browser](https://github.com/jakub-g/x-default-browser)" dependency with "[default-browser](https://github.com/sindresorhus/default-browser)" to remove dependency to "trim-newlines@v1.0.0" to remove [security vulnerability](https://snyk.io/test/npm/trim-newlines/1.0.0).
- Added a map of chromium browsers to use to check if better-opn can be used

Some notes: "default-browser" is an ESM package so it was causing some issues in jest. I added the new ESM packages to the `transformIgnorePatterns` but I'm not sure if this is the best approach. Suggestions welcome here :)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
