### PR TITLE
Build: Fix cra bench resolutions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,12 +263,13 @@ jobs:
           name: Wait for registry
           command: yarn wait-on http://localhost:6000
       - run:
-          name: Run @storybook/bench on a CRA project
+          name: set up cra repro, skip tests
+          command: node ./lib/cli/bin/index.js repro -t cra --e2e ../cra-bench
+      - run:
+          name: Run @storybook/bench on repro
           command: |
-            cd ..
-            npx create-react-app cra-bench
-            cd cra-bench
-            npx @storybook/bench@0.8.0--canary.11.edeef38.0 'npx sb init' --label cra
+            cd ../cra-bench
+            npx @storybook/bench@0.8.0--canary.11.edeef38.0 'echo noop' --label cra
   e2e-tests-pnp:
     executor:
       class: medium


### PR DESCRIPTION
Issue: Fix failing bench in CI

## What I did

- [x] Reuse `sb repro --e2e` which sets package resolutions
- [x] Set bench to no-op for installation command

**NOTE:** this eliminates the installation metrics from the benchmark. IMO the benefits of using `sb repro` outweigh the costs of losing that install time/size metric, but curious to hear others' opinions.

## How to test

- [ ] CI passes
