### PR TITLE
UI: Fix display skip to sidebar button

### DIFF
--- a/lib/ui/src/components/preview/FramesRenderer.tsx
+++ b/lib/ui/src/components/preview/FramesRenderer.tsx
@@ -20,6 +20,7 @@ const SkipToSidebarLink = styled(Button)(({ theme }) => ({
   display: 'none',
   '@media (min-width: 600px)': {
     position: 'absolute',
+    display: 'block',
     top: 10,
     right: 15,
     padding: '10px 15px',


### PR DESCRIPTION
## Issue:
Skip to Sidebar button was not visible or executable after striking ENTER on the "Skip to Canvas" button and then striking TAB.

## What I did

Made the "Skip to Sidebar" button visible and focusable by reverting a previous change. For context, [click here](https://github.com/storybookjs/storybook/commit/ddada5195159d0f4b40fe502b3f299e4bd6ed201#diff-e48ebd08b3fd6a657f6d91ea64cc450131cb2afa5c59a6ccb496eee6ee771e38L22) to see where the breaking change occurred.

## Screenshots
Before:

https://user-images.githubusercontent.com/17681528/173661861-fca5eeb8-a59f-4411-a174-81fdbf6b16cb.mov

After:

https://user-images.githubusercontent.com/17681528/173661879-ed68acf1-4682-45fa-b68d-9a5e95df598e.mov


## How to test

Run a build and view the core storybook. Hit TAB until "Skip to Canvas" is selected, strike ENTER, strike TAB -- Skip to Sidebar button should be selected.

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
