### PR TITLE
Interactions: Collapse child interactions

### DIFF
--- a/addons/interactions/src/Panel.tsx
+++ b/addons/interactions/src/Panel.tsx
@@ -31,8 +31,8 @@ interface InteractionsPanelProps {
   interactions: (Call & {
     status?: CallStates;
     childCallIds: Call['id'][];
-    isExpanded: boolean;
-    toggleExpanded: () => void;
+    isCollapsed: boolean;
+    toggleCollapsed: () => void;
   })[];
   fileName?: string;
   hasException?: boolean;
@@ -103,8 +103,8 @@ export const AddonPanelPure: React.FC<InteractionsPanelProps> = React.memo(
             controls={controls}
             controlStates={controlStates}
             childCallIds={call.childCallIds}
-            isExpanded={call.isExpanded}
-            toggleExpanded={call.toggleExpanded}
+            isCollapsed={call.isCollapsed}
+            toggleCollapsed={call.toggleCollapsed}
             pausedAt={pausedAt}
           />
         ))}
@@ -133,7 +133,7 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
   const [isPlaying, setPlaying] = React.useState(false);
   const [isRerunAnimating, setIsRerunAnimating] = React.useState(false);
   const [scrollTarget, setScrollTarget] = React.useState<HTMLElement>();
-  const [expanded, setExpanded] = React.useState<Set<Call['id']>>(new Set());
+  const [collapsed, setCollapsed] = React.useState<Set<Call['id']>>(new Set());
 
   // Calls are tracked in a ref so we don't needlessly rerender.
   const calls = React.useRef<Map<Call['id'], Omit<Call, 'status'>>>(new Map());
@@ -145,15 +145,15 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
     .filter((call) => {
       if (!call.parentId) return true;
       childCallMap.set(call.parentId, (childCallMap.get(call.parentId) || []).concat(call.callId));
-      return expanded.has(call.parentId);
+      return !collapsed.has(call.parentId);
     })
     .map(({ callId, status }) => ({
       ...calls.current.get(callId),
       status,
       childCallIds: childCallMap.get(callId),
-      isExpanded: expanded.has(callId),
-      toggleExpanded: () =>
-        setExpanded((ids) => {
+      isCollapsed: collapsed.has(callId),
+      toggleCollapsed: () =>
+        setCollapsed((ids) => {
           if (ids.has(callId)) ids.delete(callId);
           else ids.add(callId);
           return new Set(ids);

--- a/addons/interactions/src/components/Interaction/Interaction.stories.tsx
+++ b/addons/interactions/src/components/Interaction/Interaction.stories.tsx
@@ -49,12 +49,6 @@ export const WithParent: Story = {
   },
 };
 
-export const WithParent: Story = {
-  args: {
-    call: { ...getCall(CallStates.DONE), parentId: 'parent-id' },
-  },
-};
-
 export const Disabled: Story = {
   args: { ...Done.args, controlStates: { ...SubnavStories.args.controlStates, goto: false } },
 };

--- a/addons/interactions/src/components/Interaction/Interaction.stories.tsx
+++ b/addons/interactions/src/components/Interaction/Interaction.stories.tsx
@@ -49,6 +49,12 @@ export const WithParent: Story = {
   },
 };
 
+export const WithParent: Story = {
+  args: {
+    call: { ...getCall(CallStates.DONE), parentId: 'parent-id' },
+  },
+};
+
 export const Disabled: Story = {
   args: { ...Done.args, controlStates: { ...SubnavStories.args.controlStates, goto: false } },
 };

--- a/addons/interactions/src/components/Interaction/Interaction.tsx
+++ b/addons/interactions/src/components/Interaction/Interaction.tsx
@@ -132,8 +132,8 @@ export const Interaction = ({
   controls,
   controlStates,
   childCallIds,
-  isExpanded,
-  toggleExpanded,
+  isCollapsed,
+  toggleCollapsed,
   pausedAt,
 }: {
   call: Call;
@@ -141,8 +141,8 @@ export const Interaction = ({
   controls: Controls;
   controlStates: ControlStates;
   childCallIds?: Call['id'][];
-  isExpanded: boolean;
-  toggleExpanded: () => void;
+  isCollapsed: boolean;
+  toggleCollapsed: () => void;
   pausedAt?: Call['id'];
 }) => {
   const [isHovered, setIsHovered] = React.useState(false);
@@ -167,11 +167,11 @@ export const Interaction = ({
               hasChrome={false}
               tooltip={
                 <Note
-                  note={`${isExpanded ? 'Hide' : 'Show'} interactions (${childCallIds.length})`}
+                  note={`${isCollapsed ? 'Show' : 'Hide'} interactions (${childCallIds.length})`}
                 />
               }
             >
-              <StyledIconButton containsIcon onClick={toggleExpanded}>
+              <StyledIconButton containsIcon onClick={toggleCollapsed}>
                 <Icons icon="listunordered" />
               </StyledIconButton>
             </WithTooltip>

--- a/addons/interactions/src/components/Interaction/Interaction.tsx
+++ b/addons/interactions/src/components/Interaction/Interaction.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IconButton, Icons, TooltipNote, WithTooltip, Bar } from '@storybook/components';
+import { IconButton, Icons, TooltipNote, WithTooltip } from '@storybook/components';
 import { Call, CallStates, ControlStates } from '@storybook/instrumenter';
 import { styled, typography } from '@storybook/theming';
 import { transparentize } from 'polished';

--- a/addons/interactions/src/components/MethodCall.tsx
+++ b/addons/interactions/src/components/MethodCall.tsx
@@ -272,7 +272,11 @@ export const ClassNode = ({ name }: { name: string }) => {
 
 export const FunctionNode = ({ name }: { name: string }) => {
   const colors = useThemeColors();
-  return <span style={{ color: colors.function }}>{name || <i>anonymous</i>}</span>;
+  return name ? (
+    <span style={{ color: colors.function }}>{name}</span>
+  ) : (
+    <span style={{ color: colors.nullish, fontStyle: 'italic' }}>anonymous</span>
+  );
 };
 
 export const ElementNode = ({


### PR DESCRIPTION
Issue:
AP-1856

This collapses child interactions on `waitFor` and provides a toggle icon to reveal them.

https://user-images.githubusercontent.com/321738/173844722-4aaf0a08-89c0-4110-9cab-4c6ef6f49f93.mov

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
