### PR TITLE
feat: add dependency install automigration for react and react-dom

### DIFF
--- a/lib/cli/src/automigrate/fixes/index.ts
+++ b/lib/cli/src/automigrate/fixes/index.ts
@@ -6,6 +6,7 @@ import { mainjsFramework } from './mainjsFramework';
 import { eslintPlugin } from './eslint-plugin';
 import { builderVite } from './builder-vite';
 import { Fix } from '../types';
+import { reactDependencies } from './react-dependencies';
 
 export * from '../types';
 export const fixes: Fix[] = [
@@ -16,4 +17,5 @@ export const fixes: Fix[] = [
   mainjsFramework,
   eslintPlugin,
   builderVite,
+  reactDependencies,
 ];

--- a/lib/cli/src/automigrate/fixes/react-dependencies.test.ts
+++ b/lib/cli/src/automigrate/fixes/react-dependencies.test.ts
@@ -1,6 +1,5 @@
 import { JsPackageManager } from '../../js-package-manager';
 import { reactDependencies } from './react-dependencies';
-import * as isDependencyInstalled from '../helpers/is-dependency-installed';
 
 const checkReactDependencies = async ({ packageJson }) => {
   const packageManager = {
@@ -10,15 +9,7 @@ const checkReactDependencies = async ({ packageJson }) => {
 };
 
 describe('react dependencies fix', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('should install react if dependency is missing', async () => {
-    jest
-      .spyOn(isDependencyInstalled, 'isDependencyInstalled')
-      .mockImplementation((dep) => dep === 'react-dom');
-
     const packageJson = {
       dependencies: { 'react-dom': 'x.y.z' },
     };
@@ -30,8 +21,6 @@ describe('react dependencies fix', () => {
   });
 
   it('should install both react and react-dom if dependencies are missing', async () => {
-    jest.spyOn(isDependencyInstalled, 'isDependencyInstalled').mockImplementation(() => false);
-
     const packageJson = {
       dependencies: {},
     };

--- a/lib/cli/src/automigrate/fixes/react-dependencies.test.ts
+++ b/lib/cli/src/automigrate/fixes/react-dependencies.test.ts
@@ -1,0 +1,55 @@
+import { JsPackageManager } from '../../js-package-manager';
+import { reactDependencies } from './react-dependencies';
+import * as isDependencyInstalled from '../helpers/is-dependency-installed';
+
+const checkReactDependencies = async ({ packageJson }) => {
+  const packageManager = {
+    retrievePackageJson: () => ({ dependencies: {}, devDependencies: {}, ...packageJson }),
+  } as JsPackageManager;
+  return reactDependencies.check({ packageManager });
+};
+
+describe('react dependencies fix', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should install react if dependency is missing', async () => {
+    jest
+      .spyOn(isDependencyInstalled, 'isDependencyInstalled')
+      .mockImplementation((dep) => dep === 'react-dom');
+
+    const packageJson = {
+      dependencies: { 'react-dom': 'x.y.z' },
+    };
+    await expect(
+      checkReactDependencies({
+        packageJson,
+      })
+    ).resolves.toEqual({ dependenciesToInstall: ['react'] });
+  });
+
+  it('should install both react and react-dom if dependencies are missing', async () => {
+    jest.spyOn(isDependencyInstalled, 'isDependencyInstalled').mockImplementation(() => false);
+
+    const packageJson = {
+      dependencies: {},
+    };
+    await expect(
+      checkReactDependencies({
+        packageJson,
+      })
+    ).resolves.toEqual({ dependenciesToInstall: ['react', 'react-dom'] });
+  });
+
+  it('should no-op if react and react-dom are already installed', async () => {
+    const packageJson = {
+      dependencies: { react: 'x.y.z', 'react-dom': 'x.y.z' },
+    };
+    await expect(
+      checkReactDependencies({
+        packageJson,
+      })
+    ).resolves.toBeFalsy();
+  });
+});

--- a/lib/cli/src/automigrate/fixes/react-dependencies.ts
+++ b/lib/cli/src/automigrate/fixes/react-dependencies.ts
@@ -1,0 +1,73 @@
+import chalk from 'chalk';
+import dedent from 'ts-dedent';
+
+import { Fix } from '../types';
+import { PackageJsonWithDepsAndDevDeps } from '../../js-package-manager';
+import { isDependencyInstalled } from '../helpers/is-dependency-installed';
+
+const logger = console;
+
+interface CheckDependenciesRunOptions {
+  dependenciesToInstall: string[];
+}
+
+interface CheckDependencies {
+  checkReactDependencies: (packageJson: PackageJsonWithDepsAndDevDeps) => Promise<string[]>;
+}
+
+/**
+ * Is the user using react and react-dom in their project?
+ *
+ * If not,
+ * prompt them to install them as dev dependencies. Biggest motivation is to avoid
+ * possible conflicts with tools like npm 8.
+ *
+ */
+export const reactDependencies: Fix<CheckDependenciesRunOptions> & CheckDependencies = {
+  id: 'reactDependencies',
+
+  async checkReactDependencies(packageJson: PackageJsonWithDepsAndDevDeps) {
+    const allDeps = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+      ...packageJson.peerDependencies,
+    };
+
+    if (allDeps.react && allDeps['react-dom']) {
+      return null;
+    }
+
+    const dependenciesToInstall: string[] = [];
+
+    ['react', 'react-dom'].forEach((dep) => {
+      if (!isDependencyInstalled(dep)) {
+        dependenciesToInstall.push(dep);
+      }
+    });
+
+    return dependenciesToInstall.length > 0 ? dependenciesToInstall : null;
+  },
+
+  async check({ packageManager }) {
+    const packageJson = packageManager.retrievePackageJson();
+
+    const dependenciesToInstall = await this.checkReactDependencies(packageJson);
+    return dependenciesToInstall ? { dependenciesToInstall } : null;
+  },
+
+  prompt({ dependenciesToInstall }) {
+    const dependencies = chalk.cyan(dependenciesToInstall.join(' and '));
+
+    return dedent`
+      We've detected you don't have ${dependencies} installed.
+      Due to changes in modern package managers (e.g. npm8) we now recommend that you install these as dev dependencies in your project. We can do this automatically for you.
+    `;
+  },
+
+  async run({ result: { dependenciesToInstall }, packageManager, dryRun }) {
+    logger.info(`✅ Adding dependencies: ${dependenciesToInstall}`);
+    if (!dryRun) {
+      packageManager.addDependencies({ installAsDevDependencies: true }, dependenciesToInstall);
+    }
+  },
+};

--- a/lib/cli/src/automigrate/fixes/react-dependencies.ts
+++ b/lib/cli/src/automigrate/fixes/react-dependencies.ts
@@ -3,7 +3,6 @@ import dedent from 'ts-dedent';
 
 import { Fix } from '../types';
 import { PackageJsonWithDepsAndDevDeps } from '../../js-package-manager';
-import { isDependencyInstalled } from '../helpers/is-dependency-installed';
 
 const logger = console;
 
@@ -33,14 +32,10 @@ export const reactDependencies: Fix<CheckDependenciesRunOptions> & CheckDependen
       ...packageJson.peerDependencies,
     };
 
-    if (allDeps.react && allDeps['react-dom']) {
-      return null;
-    }
-
     const dependenciesToInstall: string[] = [];
 
     ['react', 'react-dom'].forEach((dep) => {
-      if (!isDependencyInstalled(dep)) {
+      if (!allDeps[dep]) {
         dependenciesToInstall.push(dep);
       }
     });

--- a/lib/cli/src/automigrate/helpers/is-dependency-installed.ts
+++ b/lib/cli/src/automigrate/helpers/is-dependency-installed.ts
@@ -1,0 +1,9 @@
+export const isDependencyInstalled = (dependency: string) => {
+  try {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`${dependency}/package.json`);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};

--- a/lib/cli/src/automigrate/helpers/is-dependency-installed.ts
+++ b/lib/cli/src/automigrate/helpers/is-dependency-installed.ts
@@ -1,9 +1,0 @@
-export const isDependencyInstalled = (dependency: string) => {
-  try {
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    require(`${dependency}/package.json`);
-    return true;
-  } catch (e) {
-    return false;
-  }
-};


### PR DESCRIPTION
Issue: #18314 

## What I did

Added react + react-dom dependency check to automigration:

![image](https://user-images.githubusercontent.com/1671563/174337839-48af01af-42b6-4b19-96e0-90b455755a9e.png)


## How to test

- Get a project that does not have react at all, meaning that if you run `node` then `require('react')` it should fail.
- Build the storybook CLI: `yarn build cli`
- Run `../../lib/cli/bin/index.js automigrate` (adjust the path relative to where you're at)
- See the banner

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
