### PR TITLE
Addon-a11y: Don't run check when rendering docs entries

### DIFF
--- a/addons/a11y/src/components/A11yContext.test.tsx
+++ b/addons/a11y/src/components/A11yContext.test.tsx
@@ -50,16 +50,16 @@ const axeResult: Partial<AxeResults> = {
 };
 
 describe('A11YPanel', () => {
+  const getCurrentStoryData = jest.fn();
   beforeEach(() => {
     mockedApi.useChannel.mockReset();
-    mockedApi.useStorybookState.mockReset();
+    mockedApi.useStorybookApi.mockReset();
     mockedApi.useAddonState.mockReset();
 
     mockedApi.useAddonState.mockImplementation((_, defaultState) => React.useState(defaultState));
     mockedApi.useChannel.mockReturnValue(jest.fn());
-    const storyState: Partial<api.State> = { storyId };
-    // Lazy to mock entire state
-    mockedApi.useStorybookState.mockReturnValue(storyState as any);
+    getCurrentStoryData.mockReset().mockReturnValue({ id: storyId, type: 'story' });
+    mockedApi.useStorybookApi.mockReturnValue({ getCurrentStoryData } as any);
   });
 
   it('should render children', () => {

--- a/addons/a11y/src/components/A11yContext.tsx
+++ b/addons/a11y/src/components/A11yContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { themes, convert } from '@storybook/theming';
 import { Result } from 'axe-core';
-import { useChannel, useStorybookState, useAddonState } from '@storybook/api';
+import { useChannel, useStorybookState, useAddonState, useStorybookApi } from '@storybook/api';
 import { STORY_CHANGED, STORY_RENDERED } from '@storybook/core-events';
 import { ADDON_ID, EVENTS } from '../constants';
 
@@ -55,7 +55,8 @@ export const A11yContextProvider: React.FC<A11yContextProviderProps> = ({ active
   const [results, setResults] = useAddonState<Results>(ADDON_ID, defaultResult);
   const [tab, setTab] = React.useState(0);
   const [highlighted, setHighlighted] = React.useState<string[]>([]);
-  const { storyId } = useStorybookState();
+  const api = useStorybookApi();
+  const storyEntry = api.getCurrentStoryData();
 
   const handleToggleHighlight = React.useCallback((target: string[], highlight: boolean) => {
     setHighlighted((prevHighlighted) =>
@@ -89,12 +90,12 @@ export const A11yContextProvider: React.FC<A11yContextProviderProps> = ({ active
   }, [highlighted, tab]);
 
   React.useEffect(() => {
-    if (active) {
-      handleRun(storyId);
+    if (active && storyEntry?.type === 'story') {
+      handleRun(storyEntry.id);
     } else {
       handleClearHighlights();
     }
-  }, [active, handleClearHighlights, emit, storyId]);
+  }, [active, handleClearHighlights, emit, storyEntry]);
 
   if (!active) return null;
 

--- a/addons/a11y/src/components/A11yContext.tsx
+++ b/addons/a11y/src/components/A11yContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { themes, convert } from '@storybook/theming';
 import { Result } from 'axe-core';
-import { useChannel, useStorybookState, useAddonState, useStorybookApi } from '@storybook/api';
+import { useChannel, useAddonState, useStorybookApi } from '@storybook/api';
 import { STORY_CHANGED, STORY_RENDERED } from '@storybook/core-events';
 import { ADDON_ID, EVENTS } from '../constants';
 


### PR DESCRIPTION
## What I did

Prevent a11y checks for running when current "story" is a docs entry.

Note it will still respond to `STORY_RENDERED` events and run a check for each rendered sub-story. We should think about if we want to make addons inactive at a higher level when you enter docs mode (right now the previously focussed addon stays active).

## How to test

1. Run react-ts
2. Visit any story, open a11y panel
3. Change to docs-only story (legacy or otherwise)