### PR TITLE
Interactions: Reset instrumenter state on HMR

### DIFF
--- a/lib/instrumenter/src/instrumenter.ts
+++ b/lib/instrumenter/src/instrumenter.ts
@@ -133,6 +133,9 @@ export class Instrumenter {
     this.channel.on(STORY_RENDER_PHASE_CHANGED, ({ storyId, newPhase }) => {
       const { isDebugging } = this.getState(storyId);
       this.setState(storyId, { renderPhase: newPhase });
+      if (newPhase === 'preparing' && isDebugging) {
+        resetState({ storyId });
+      }
       if (newPhase === 'playing') {
         resetState({ storyId, isDebugging });
       }


### PR DESCRIPTION
Issue: #17570

## What I did

Reset instrumenter state so we stop debugging on HMR.

## How to test

- Run a story with play function
- Start debugging
- Add new interaction to play function (code) and save the file to trigger HMR
- Verify the interaction panel resets (stop debugging) and the new interaction is displayed and run as normal

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
