### PR TITLE
Interactions: Prevent showing child exception while parent is still playing

### DIFF
--- a/addons/interactions/src/Panel.tsx
+++ b/addons/interactions/src/Panel.tsx
@@ -134,43 +134,11 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
   const [isRerunAnimating, setIsRerunAnimating] = React.useState(false);
   const [scrollTarget, setScrollTarget] = React.useState<HTMLElement>();
   const [collapsed, setCollapsed] = React.useState<Set<Call['id']>>(new Set());
+  const [log, setLog] = React.useState<LogItem[]>([]);
 
   // Calls are tracked in a ref so we don't needlessly rerender.
   const calls = React.useRef<Map<Call['id'], Omit<Call, 'status'>>>(new Map());
   const setCall = ({ status, ...call }: Call) => calls.current.set(call.id, call);
-
-  const [log, setLog] = React.useState<LogItem[]>([]);
-  const callsById = new Map<Call['id'], Call>();
-  const childCallMap = new Map<Call['id'], Call['id'][]>();
-  const interactions = log
-    .filter((call) => {
-      if (!call.parentId) return true;
-      childCallMap.set(call.parentId, (childCallMap.get(call.parentId) || []).concat(call.callId));
-      return !collapsed.has(call.parentId);
-    })
-    .map(({ callId, status }) => {
-      const call = calls.current.get(callId);
-      const value = {
-        ...call,
-        status,
-        childCallIds: childCallMap.get(callId),
-        isCollapsed: collapsed.has(callId),
-        toggleCollapsed: () =>
-          setCollapsed((ids) => {
-            if (ids.has(callId)) ids.delete(callId);
-            else ids.add(callId);
-            return new Set(ids);
-          }),
-      };
-      if (
-        status === CallStates.ERROR &&
-        callsById.get(call.parentId)?.status === CallStates.ACTIVE
-      ) {
-        value.status = CallStates.ACTIVE;
-      }
-      callsById.set(callId, value);
-      return value;
-    });
 
   const endRef = React.useRef();
   React.useEffect(() => {
@@ -223,6 +191,38 @@ export const Panel: React.FC<AddonPanelProps> = (props) => {
 
   const showStatus = log.length > 0 && !isPlaying;
   const hasException = log.some((item) => item.status === CallStates.ERROR);
+
+  const interactions = React.useMemo(() => {
+    const callsById = new Map<Call['id'], Call>();
+    const childCallMap = new Map<Call['id'], Call['id'][]>();
+    return log
+      .filter(({ callId, parentId }) => {
+        if (!parentId) return true;
+        childCallMap.set(parentId, (childCallMap.get(parentId) || []).concat(callId));
+        return !collapsed.has(parentId);
+      })
+      .map(({ callId, status }) => ({ ...calls.current.get(callId), status } as Call))
+      .map((call) => {
+        const status =
+          call.status === CallStates.ERROR &&
+          callsById.get(call.parentId)?.status === CallStates.ACTIVE
+            ? CallStates.ACTIVE
+            : call.status;
+        callsById.set(call.id, { ...call, status });
+        return {
+          ...call,
+          status,
+          childCallIds: childCallMap.get(call.id),
+          isCollapsed: collapsed.has(call.id),
+          toggleCollapsed: () =>
+            setCollapsed((ids) => {
+              if (ids.has(call.id)) ids.delete(call.id);
+              else ids.add(call.id);
+              return new Set(ids);
+            }),
+        };
+      });
+  }, [log, collapsed]);
 
   return (
     <React.Fragment key="interactions">


### PR DESCRIPTION
Issue: #16492

## What I did

Override the "error" `status` of a child interaction to "playing" if its parent is still playing. This prevents exceptions within a `waitFor` callback to be rendered while it is still retrying.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? no
- [ ] Does this need a new example in the kitchen sink apps? no
- [ ] Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
