### PR TITLE
Fix: Storybook documentation generation exits with error 1

### DIFF
--- a/docs/writing-tests/test-runner.md
+++ b/docs/writing-tests/test-runner.md
@@ -45,7 +45,6 @@ Start your Storybook with:
     'angular/storybook-run-dev.with-builder.js.mdx',
     'common/storybook-run-dev.yarn.js.mdx',
     'common/storybook-run-dev.npm.js.mdx',
-
   ]}
 />
 


### PR DESCRIPTION
yarn start:skip-addons currently exits with error 1 due to an
extra space in test-runner.md code snippet leading to a module build failure.
Removing the space in code snippet fixes the issue.

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
