### PR TITLE
upgrade @storybook/testing-library to `0.0.14-next.0`

### DIFF
--- a/addons/interactions/package.json
+++ b/addons/interactions/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@storybook/jest": "^0.0.5",
-    "@storybook/testing-library": "^0.0.7",
+    "@storybook/testing-library": "0.0.14-next.0",
     "formik": "^2.2.9"
   },
   "peerDependencies": {

--- a/examples/angular-cli/package.json
+++ b/examples/angular-cli/package.json
@@ -54,7 +54,7 @@
     "@storybook/babel-plugin-require-context-hook": "1.0.1",
     "@storybook/jest": "^0.0.5",
     "@storybook/source-loader": "6.5.0-rc.1",
-    "@storybook/testing-library": "^0.0.7",
+    "@storybook/testing-library": "0.0.14-next.0",
     "@types/core-js": "^2.5.4",
     "@types/jest": "^26.0.16",
     "@types/node": "^14.14.20 || ^16.0.0",

--- a/examples/official-storybook/package.json
+++ b/examples/official-storybook/package.json
@@ -36,7 +36,7 @@
     "@storybook/react": "6.5.0-rc.1",
     "@storybook/router": "6.5.0-rc.1",
     "@storybook/source-loader": "6.5.0-rc.1",
-    "@storybook/testing-library": "^0.0.7",
+    "@storybook/testing-library": "0.0.14-next.0",
     "@storybook/theming": "6.5.0-rc.1",
     "@testing-library/dom": "^7.31.2",
     "@testing-library/user-event": "^13.1.9",

--- a/examples/svelte-kitchen-sink/package.json
+++ b/examples/svelte-kitchen-sink/package.json
@@ -24,7 +24,7 @@
     "@storybook/jest": "^0.0.5",
     "@storybook/source-loader": "6.5.0-rc.1",
     "@storybook/svelte": "6.5.0-rc.1",
-    "@storybook/testing-library": "^0.0.7",
+    "@storybook/testing-library": "0.0.14-next.0",
     "svelte-jester": "1.3.0",
     "svelte-preprocess": "4.6.8"
   },

--- a/examples/vue-3-cli/package.json
+++ b/examples/vue-3-cli/package.json
@@ -20,7 +20,7 @@
     "@storybook/addon-links": "6.5.0-rc.1",
     "@storybook/addon-storyshots": "6.5.0-rc.1",
     "@storybook/jest": "^0.0.5",
-    "@storybook/testing-library": "^0.0.7",
+    "@storybook/testing-library": "0.0.14-next.0",
     "@storybook/vue3": "6.5.0-rc.1",
     "@vue/cli-plugin-babel": "~4.5.0",
     "@vue/cli-plugin-typescript": "~4.5.0",

--- a/examples/vue-kitchen-sink/package.json
+++ b/examples/vue-kitchen-sink/package.json
@@ -27,7 +27,7 @@
     "@storybook/addons": "6.5.0-rc.1",
     "@storybook/jest": "^0.0.5",
     "@storybook/source-loader": "6.5.0-rc.1",
-    "@storybook/testing-library": "^0.0.7",
+    "@storybook/testing-library": "0.0.14-next.0",
     "@storybook/vue": "6.5.0-rc.1",
     "@vue/babel-preset-jsx": "^1.2.4",
     "babel-loader": "^8.0.0",

--- a/examples/web-components-kitchen-sink/package.json
+++ b/examples/web-components-kitchen-sink/package.json
@@ -51,7 +51,7 @@
     "@storybook/source-loader": "portal:../../lib/source-loader",
     "@storybook/store": "portal:../../lib/store",
     "@storybook/telemetry": "portal:../../lib/telemetry",
-    "@storybook/testing-library": "^0.0.7",
+    "@storybook/testing-library": "0.0.14-next.0",
     "@storybook/theming": "portal:../../lib/theming",
     "@storybook/ui": "portal:../../lib/ui",
     "@storybook/web-components": "portal:../../app/web-components",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "@storybook/store": "workspace:*",
     "@storybook/svelte": "workspace:*",
     "@storybook/telemetry": "workspace:*",
-    "@storybook/testing-library": "^0.0.7",
+    "@storybook/testing-library": "0.0.14-next.0",
     "@storybook/theming": "workspace:*",
     "@storybook/ui": "workspace:*",
     "@storybook/vue": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6681,7 +6681,7 @@ __metadata:
     "@storybook/csf": 0.0.2--canary.4566f4d.1
     "@storybook/instrumenter": 6.5.0-rc.1
     "@storybook/jest": ^0.0.5
-    "@storybook/testing-library": ^0.0.7
+    "@storybook/testing-library": 0.0.14-next.0
     "@storybook/theming": 6.5.0-rc.1
     core-js: ^3.8.2
     formik: ^2.2.9
@@ -7051,6 +7051,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addons@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/addons@npm:6.5.9"
+  dependencies:
+    "@storybook/api": 6.5.9
+    "@storybook/channels": 6.5.9
+    "@storybook/client-logger": 6.5.9
+    "@storybook/core-events": 6.5.9
+    "@storybook/csf": 0.0.2--canary.4566f4d.1
+    "@storybook/router": 6.5.9
+    "@storybook/theming": 6.5.9
+    "@types/webpack-env": ^1.16.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 3ee3e61abc7bff6b481374597cc6717936685222b187d173462483d77d9b284fe5650e9764f7232ae80678e4718440d712f182c01c16887d53c77a1abe262616
+  languageName: node
+  linkType: hard
+
 "@storybook/angular@6.5.0-rc.1, @storybook/angular@workspace:*, @storybook/angular@workspace:app/angular":
   version: 0.0.0-use.local
   resolution: "@storybook/angular@workspace:app/angular"
@@ -7197,6 +7219,34 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: cbf1ad699c3d879eaae183c8ddb70f6774ed311d16367237f942d2db45df59c37af0658891d4a6fbedc637828cc4914afbbec57dba26e4e478f3a0acb86112a3
+  languageName: node
+  linkType: hard
+
+"@storybook/api@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/api@npm:6.5.9"
+  dependencies:
+    "@storybook/channels": 6.5.9
+    "@storybook/client-logger": 6.5.9
+    "@storybook/core-events": 6.5.9
+    "@storybook/csf": 0.0.2--canary.4566f4d.1
+    "@storybook/router": 6.5.9
+    "@storybook/semver": ^7.3.2
+    "@storybook/theming": 6.5.9
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    store2: ^2.12.0
+    telejson: ^6.0.8
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 6f3aaed66c27715740397ff80a01fda1e363e75165c90cb5f50e4effc00e91b2d1f58b506d2279e83a905f794988e9aaaa75d5b7380c192c954f8c6520368d67
   languageName: node
   linkType: hard
 
@@ -7375,6 +7425,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channels@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/channels@npm:6.5.9"
+  dependencies:
+    core-js: ^3.8.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  checksum: 3011663b754fe9028076b2a27573c6ca2040eb227918c315b9e6ea4d23298b1ac305e26aa4e89c02c9120ddd475d0f49d42bcb287b84cb37953c5f99606c3ed1
+  languageName: node
+  linkType: hard
+
 "@storybook/cli@6.5.0-rc.1, @storybook/cli@workspace:*, @storybook/cli@workspace:lib/cli":
   version: 0.0.0-use.local
   resolution: "@storybook/cli@workspace:lib/cli"
@@ -7467,6 +7528,16 @@ __metadata:
     core-js: ^3.8.2
     global: ^4.4.0
   checksum: cb6b6ae5a6abfcb709424183d368cb33234794c9c4461466075d0436e4041e1b30dd1baf8c0d36bed75c0db08a706b75eec5e1dbbeb968548fde904eefd26984
+  languageName: node
+  linkType: hard
+
+"@storybook/client-logger@npm:6.5.9, @storybook/client-logger@npm:^6.4.0":
+  version: 6.5.9
+  resolution: "@storybook/client-logger@npm:6.5.9"
+  dependencies:
+    core-js: ^3.8.2
+    global: ^4.4.0
+  checksum: 764aacff6859c2cfe93f90498504e6628d8c7606490f1eec835639e21f177b10f0e93cad605dadf0ca6e08f6d5e62153597de6c80570ae65d76b4c71b6884e09
   languageName: node
   linkType: hard
 
@@ -7648,6 +7719,15 @@ __metadata:
   dependencies:
     core-js: ^3.8.2
   checksum: cc7bcda2677354575d7d9e74573662215beb608ceb9b5c08db6cac3c3febad860119a501dfa5bf426dc80dcc61f0d53142c703b118f97c7269cd51fe85dd8b6d
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/core-events@npm:6.5.9"
+  dependencies:
+    core-js: ^3.8.2
+  checksum: 5d9eb651ef528330bebe9048eec61d4e3af29fabcf3cc8d7572a94f199e2220dfa738c19d65a761de5ec377d7933316af5eb2bfd0dc8c4027cd7dd57951552bd
   languageName: node
   linkType: hard
 
@@ -8023,6 +8103,19 @@ __metadata:
     "@storybook/core-events": 6.4.0-rc.5
     global: ^4.4.0
   checksum: 91bbb54a730d011d51768482de2d3e664b7fc2f4964a89bcaa31269085e27e70f81bfd48f70872690a81b5ebb41fbb6377305ae68c2bd570e2af7aaf01ddaf45
+  languageName: node
+  linkType: hard
+
+"@storybook/instrumenter@npm:^6.4.0":
+  version: 6.5.9
+  resolution: "@storybook/instrumenter@npm:6.5.9"
+  dependencies:
+    "@storybook/addons": 6.5.9
+    "@storybook/client-logger": 6.5.9
+    "@storybook/core-events": 6.5.9
+    core-js: ^3.8.2
+    global: ^4.4.0
+  checksum: df6e535759540c09cb0addd65250121a10767ea7f43d6452417208eb09f565250f52c4417c707c964b61da063ee06d15c7aa3baaa86a0a585768fc94cdb8f31d
   languageName: node
   linkType: hard
 
@@ -8497,7 +8590,7 @@ __metadata:
     "@storybook/store": "workspace:*"
     "@storybook/svelte": "workspace:*"
     "@storybook/telemetry": "workspace:*"
-    "@storybook/testing-library": ^0.0.7
+    "@storybook/testing-library": 0.0.14-next.0
     "@storybook/theming": "workspace:*"
     "@storybook/ui": "workspace:*"
     "@storybook/vue": "workspace:*"
@@ -8705,6 +8798,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/router@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/router@npm:6.5.9"
+  dependencies:
+    "@storybook/client-logger": 6.5.9
+    core-js: ^3.8.2
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 765977adbcaa1d06958489bd1316056c35f712f04c603a3848ed04dea3155f65369a085759913ccf19ffda3de41d429f455fbc330c3bcf7b3fdc65e9a3ddd320
+  languageName: node
+  linkType: hard
+
 "@storybook/semver@npm:^7.3.2":
   version: 7.3.2
   resolution: "@storybook/semver@npm:7.3.2"
@@ -8851,16 +8960,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/testing-library@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "@storybook/testing-library@npm:0.0.7"
+"@storybook/testing-library@npm:0.0.14-next.0":
+  version: 0.0.14-next.0
+  resolution: "@storybook/testing-library@npm:0.0.14-next.0"
   dependencies:
-    "@storybook/client-logger": 6.4.0-rc.5
-    "@storybook/instrumenter": 6.4.0-rc.5
+    "@storybook/client-logger": ^6.4.0
+    "@storybook/instrumenter": ^6.4.0
     "@testing-library/dom": ^8.3.0
     "@testing-library/user-event": ^13.2.1
     ts-dedent: ^2.2.0
-  checksum: 6be4b2d418195417cd0a04e5a4f2b71a93364cb88780084714a0553c39e6b38943458511b25b101c830b332783afec98a40eefcdc663dca3f34e8f48609a4670
+  checksum: fd10ebddd305743f4388ad939b90fed155b6c3a755e96a73f72d38d9afe2546a22be0c9a5d83b8b6d91742dd7be5d2e7dfcbbd630b2fa97e4ef7dde00f0824b0
   languageName: node
   linkType: hard
 
@@ -8921,6 +9030,21 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 7449d09a6c883daaf1f024a11b42690a6cd10cdf80e1c0fa8c4ecd6cdd6a47bbb9bf41d45e5cd1cd84bad875fe2cb666fae56d8ef3154e6cbc1f0563da0762b8
+  languageName: node
+  linkType: hard
+
+"@storybook/theming@npm:6.5.9":
+  version: 6.5.9
+  resolution: "@storybook/theming@npm:6.5.9"
+  dependencies:
+    "@storybook/client-logger": 6.5.9
+    core-js: ^3.8.2
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 28b2626ab2ef4396d3e8d0fad651bf13b323318028e7b01a99c9b999f368655d7aa78dd8154396753828746d934cfbaee1575c890307893d6a3cca9655c9a60e
   languageName: node
   linkType: hard
 
@@ -12959,7 +13083,7 @@ __metadata:
     "@storybook/babel-plugin-require-context-hook": 1.0.1
     "@storybook/jest": ^0.0.5
     "@storybook/source-loader": 6.5.0-rc.1
-    "@storybook/testing-library": ^0.0.7
+    "@storybook/testing-library": 0.0.14-next.0
     "@types/core-js": ^2.5.4
     "@types/jest": ^26.0.16
     "@types/node": ^14.14.20 || ^16.0.0
@@ -34018,7 +34142,7 @@ __metadata:
     "@storybook/react": 6.5.0-rc.1
     "@storybook/router": 6.5.0-rc.1
     "@storybook/source-loader": 6.5.0-rc.1
-    "@storybook/testing-library": ^0.0.7
+    "@storybook/testing-library": 0.0.14-next.0
     "@storybook/theming": 6.5.0-rc.1
     "@testing-library/dom": ^7.31.2
     "@testing-library/user-event": ^13.1.9
@@ -42980,7 +43104,7 @@ __metadata:
     "@storybook/jest": ^0.0.5
     "@storybook/source-loader": 6.5.0-rc.1
     "@storybook/svelte": 6.5.0-rc.1
-    "@storybook/testing-library": ^0.0.7
+    "@storybook/testing-library": 0.0.14-next.0
     global: ^4.4.0
     svelte-jester: 1.3.0
     svelte-preprocess: 4.6.8
@@ -45921,7 +46045,7 @@ __metadata:
     "@storybook/addon-links": 6.5.0-rc.1
     "@storybook/addon-storyshots": 6.5.0-rc.1
     "@storybook/jest": ^0.0.5
-    "@storybook/testing-library": ^0.0.7
+    "@storybook/testing-library": 0.0.14-next.0
     "@storybook/vue3": 6.5.0-rc.1
     "@vue/cli-plugin-babel": ~4.5.0
     "@vue/cli-plugin-typescript": ~4.5.0
@@ -46018,7 +46142,7 @@ __metadata:
     "@storybook/addons": 6.5.0-rc.1
     "@storybook/jest": ^0.0.5
     "@storybook/source-loader": 6.5.0-rc.1
-    "@storybook/testing-library": ^0.0.7
+    "@storybook/testing-library": 0.0.14-next.0
     "@storybook/vue": 6.5.0-rc.1
     "@vue/babel-preset-jsx": ^1.2.4
     babel-loader: ^8.0.0


### PR DESCRIPTION
Issue: N/A

## What I did

Updated the monorepo and examples to use `0.0.14-next.0` version of `@storybook/testing-library` so the addon-interactions fixes work as they should

**Before:**
<img width="688" alt="image" src="https://user-images.githubusercontent.com/1671563/175051574-286fcc66-bd28-4b2d-b44b-78f9a820d76e.png">

**After:**
<img width="707" alt="image" src="https://user-images.githubusercontent.com/1671563/175051623-d5c311bc-4738-488b-bd56-8680e34de6a3.png">



## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
