### PR TITLE
Improve link text (whats-a-story doc)

### DIFF
--- a/docs/get-started/whats-a-story.md
+++ b/docs/get-started/whats-a-story.md
@@ -93,6 +93,6 @@ Stories are also helpful for checking that UI continues to look correct as you m
   />
 </video>
 
-Checking component’s stories as you develop helps prevent accidental regressions. Tools that integrate with Storybook can also [automate](../writing-tests/introduction.md) this for you.
+Checking component’s stories as you develop helps prevent accidental regressions. [Tools that integrate with Storybook can automate this](../writing-tests/introduction.md) for you.
 
 Now that we’ve seen the basic anatomy of a story let’s see how we use Storybook’s UI to develop stories.


### PR DESCRIPTION
Issue: None

It's good practice to put all necessary context to understand a link within the link's text. This improves UX and accessibility.

## What I did

- Wrap the entire necessary context in the link tags
- Removed the word _also_ because it is unnecessary/doesn't make sense