### PR TITLE
Addon-docs: Add docs index configuration via main.js

### DIFF
--- a/addons/docs/src/preset.ts
+++ b/addons/docs/src/preset.ts
@@ -3,7 +3,7 @@ import remarkSlug from 'remark-slug';
 import remarkExternalLinks from 'remark-external-links';
 import global from 'global';
 
-import type { IndexerOptions, Options, StoryIndexer } from '@storybook/core-common';
+import type { DocsOptions, IndexerOptions, Options, StoryIndexer } from '@storybook/core-common';
 import { logger } from '@storybook/node-logger';
 import { loadCsf } from '@storybook/csf-tools';
 
@@ -137,7 +137,7 @@ export async function webpack(
   return result;
 }
 
-export const storyIndexers = async (indexers?: StoryIndexer[]) => {
+export const storyIndexers = async (indexers: StoryIndexer[] | null) => {
   const mdxIndexer = async (fileName: string, opts: IndexerOptions) => {
     let code = (await fs.readFile(fileName, 'utf-8')).toString();
     // @ts-ignore
@@ -154,4 +154,13 @@ export const storyIndexers = async (indexers?: StoryIndexer[]) => {
     },
     ...(indexers || []),
   ];
+};
+
+export const docs = (docsOptions: DocsOptions) => {
+  return {
+    ...docsOptions,
+    enabled: true,
+    defaultName: 'Docs',
+    docsPage: true,
+  };
 };

--- a/addons/docs/src/preset.ts
+++ b/addons/docs/src/preset.ts
@@ -137,7 +137,7 @@ export async function webpack(
   return result;
 }
 
-export const storyIndexers = async (indexers: StoryIndexer[] | null) => {
+export const storyIndexers = async (indexers?: StoryIndexer[]) => {
   const mdxIndexer = async (fileName: string, opts: IndexerOptions) => {
     let code = (await fs.readFile(fileName, 'utf-8')).toString();
     // @ts-ignore

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -23,11 +23,6 @@ const config: StorybookConfig = {
     '@storybook/addon-storyshots',
     '@storybook/addon-a11y',
   ],
-  docs: {
-    // enabled: false,
-    defaultName: 'Info',
-    // docsPage: false,
-  },
   typescript: {
     check: true,
     checkOptions: {},

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -23,6 +23,11 @@ const config: StorybookConfig = {
     '@storybook/addon-storyshots',
     '@storybook/addon-a11y',
   ],
+  docs: {
+    // enabled: false,
+    defaultName: 'Info',
+    // docsPage: false,
+  },
   typescript: {
     check: true,
     checkOptions: {},

--- a/lib/core-common/src/types.ts
+++ b/lib/core-common/src/types.ts
@@ -286,6 +286,21 @@ export type Entry = string;
 
 type StorybookRefs = Record<string, { title: string; url: string } | { disable: boolean }>;
 
+export type DocsOptions = {
+  /**
+   * Should we generate docs entries at all under any circumstances? (i.e. can they be rendered)
+   */
+  enabled?: boolean;
+  /**
+   * What should we call the generated docs entries?
+   */
+  defaultName?: string;
+  /**
+   * Should we generate a docs entry per CSF file?
+   */
+  docsPage?: boolean;
+};
+
 /**
  * The interface for Storybook configuration in `main.ts` files.
  */
@@ -413,6 +428,11 @@ export interface StorybookConfig {
    * Process CSF files for the story index.
    */
   storyIndexers?: (indexers: StoryIndexer[], options: Options) => StoryIndexer[];
+
+  /**
+   * Docs related features in index generation
+   */
+  docs?: DocsOptions;
 }
 
 export type PresetProperty<K, TStorybookConfig = StorybookConfig> =

--- a/lib/core-server/src/build-static.ts
+++ b/lib/core-server/src/build-static.ts
@@ -13,6 +13,7 @@ import type {
   Options,
   StorybookConfig,
   CoreConfig,
+  DocsOptions,
 } from '@storybook/core-common';
 import {
   loadAllPresets,
@@ -89,12 +90,13 @@ export async function buildStaticStandalone(
     ...options,
   });
 
-  const [features, core, staticDirs, storyIndexers, stories] = await Promise.all([
+  const [features, core, staticDirs, storyIndexers, stories, docsOptions] = await Promise.all([
     presets.apply<StorybookConfig['features']>('features'),
     presets.apply<CoreConfig>('core'),
     presets.apply<StorybookConfig['staticDirs']>('staticDirs'),
     presets.apply('storyIndexers', []),
     presets.apply('stories'),
+    presets.apply<DocsOptions>('docs', {}),
   ]);
 
   const fullOptions: Options = {
@@ -142,10 +144,10 @@ export async function buildStaticStandalone(
       workingDir,
     };
     const normalizedStories = normalizeStories(stories, directories);
-
     const generator = new StoryIndexGenerator(normalizedStories, {
       ...directories,
       storyIndexers,
+      docs: docsOptions,
       storiesV2Compatibility: !features?.breakingChangesV7 && !features?.storyStoreV7,
       storyStoreV7: !!features?.storyStoreV7,
     });

--- a/lib/core-server/src/core-presets.test.ts
+++ b/lib/core-server/src/core-presets.test.ts
@@ -186,7 +186,6 @@ describe.each([
       ['prod', buildStaticStandalone],
       ['dev', buildDevStandalone],
     ])('%s', async (mode, builder) => {
-      console.log('running for ', mode, builder);
       const options = {
         ...baseOptions,
         configDir: path.resolve(`${__dirname}/../../../examples/${example}/.storybook`),

--- a/lib/core-server/src/dev-server.ts
+++ b/lib/core-server/src/dev-server.ts
@@ -1,8 +1,14 @@
 import express, { Router } from 'express';
 import compression from 'compression';
 
-import type { CoreConfig, Options, StorybookConfig } from '@storybook/core-common';
-import { normalizeStories, logConfig } from '@storybook/core-common';
+import {
+  CoreConfig,
+  DocsOptions,
+  Options,
+  StorybookConfig,
+  normalizeStories,
+  logConfig,
+} from '@storybook/core-common';
 
 import { telemetry } from '@storybook/telemetry';
 import { getMiddleware } from './utils/middleware';
@@ -44,10 +50,12 @@ export async function storybookDevServer(options: Options) {
         directories
       );
       const storyIndexers = await options.presets.apply('storyIndexers', []);
+      const docsOptions = await options.presets.apply<DocsOptions>('docs', {});
 
       const generator = new StoryIndexGenerator(normalizedStories, {
         ...directories,
         storyIndexers,
+        docs: docsOptions,
         workingDir,
         storiesV2Compatibility: !features?.breakingChangesV7 && !features?.storyStoreV7,
         storyStoreV7: features?.storyStoreV7,

--- a/lib/core-server/src/dev-server.ts
+++ b/lib/core-server/src/dev-server.ts
@@ -1,14 +1,8 @@
 import express, { Router } from 'express';
 import compression from 'compression';
 
-import {
-  CoreConfig,
-  DocsOptions,
-  Options,
-  StorybookConfig,
-  normalizeStories,
-  logConfig,
-} from '@storybook/core-common';
+import type { CoreConfig, DocsOptions, Options, StorybookConfig } from '@storybook/core-common';
+import { normalizeStories, logConfig } from '@storybook/core-common';
 
 import { telemetry } from '@storybook/telemetry';
 import { getMiddleware } from './utils/middleware';

--- a/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -237,6 +237,31 @@ describe('StoryIndexGenerator', () => {
         );
       });
 
+      it('generates no docs entries when docs are disabled', async () => {
+        const generator = new StoryIndexGenerator([storiesSpecifier, docsSpecifier], {
+          ...options,
+          docs: {
+            ...options.docs,
+            enabled: false,
+          },
+        });
+        await generator.initialize();
+
+        expect(await generator.getIndex()).toMatchInlineSnapshot(`
+          Object {
+            "entries": Object {
+              "a--story-one": Object {
+                "id": "a--story-one",
+                "importPath": "./src/A.stories.js",
+                "name": "Story One",
+                "title": "A",
+                "type": "story",
+              },
+            },
+            "v": 4,
+          }
+        `);
+      });
       it('Allows you to override default name for docs files', async () => {
         const generator = new StoryIndexGenerator([storiesSpecifier, docsSpecifier], {
           ...options,

--- a/lib/core-server/src/utils/stories-json.test.ts
+++ b/lib/core-server/src/utils/stories-json.test.ts
@@ -61,6 +61,7 @@ const getInitializedStoryIndexGenerator = async (
     workingDir,
     storiesV2Compatibility: false,
     storyStoreV7: true,
+    docs: { enabled: true, defaultName: 'docs', docsPage: true },
     ...overrides,
   });
   await generator.initialize();


### PR DESCRIPTION
Added three options on the top-level field `docs`:

 - `enabled` - if unset, we don't generate any `type: docs` entries
 - `defaultName` - what name to use for docs entries?
 - `docsPage` - [NOT YET USED] -- will be used to drive the creation of docs entries per-CSF file.

## How to test

- See unit tests
- Can also set the field in an example app and see if enabled disables docs entries, and `defaultName` changes the entry for "Examples/Button":
<img width="227" alt="image" src="https://user-images.githubusercontent.com/132554/175813308-500ab49d-2a74-4490-957f-ad5f62152465.png">

