### PR TITLE
fix typo in gizmo example

### DIFF
--- a/docs/snippets/common/gizmo-story-controls-customization.js.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.js.mdx
@@ -52,7 +52,7 @@ export default {
     meshColors: {
       control: {
         type: 'color',
-        presetsColors: ['#ff0000', '#00ff00', '#0000ff'],
+        presetColors: ['#ff0000', '#00ff00', '#0000ff'],
       },
     },
     revisionDate: {

--- a/docs/snippets/common/gizmo-story-controls-customization.mdx.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.mdx.mdx
@@ -60,7 +60,7 @@ import { Gizmo } from './Gizmo';
     meshColors: {
       control: {
         type: 'color',
-        presetsColors: ['#ff0000', '#00ff00', '#0000ff'],
+        presetColors: ['#ff0000', '#00ff00', '#0000ff'],
       },
     },
     revisionDate: {


### PR DESCRIPTION
## What I did

I fixed a typo in the Gizmo component examples
`presetsColors` should be `presetColors`
