### PR TITLE
Addon-docs: Include Vue methods in ArgsTable

### DIFF
--- a/app/vue3/src/client/docs/extractArgTypes.ts
+++ b/app/vue3/src/client/docs/extractArgTypes.ts
@@ -2,7 +2,7 @@ import type { StrictArgTypes } from '@storybook/csf';
 import type { ArgTypesExtractor } from '@storybook/docs-tools';
 import { hasDocgen, extractComponentProps, convert } from '@storybook/docs-tools';
 
-const SECTIONS = ['props', 'events', 'slots'];
+const SECTIONS = ['props', 'events', 'slots', 'methods'];
 
 export const extractArgTypes: ArgTypesExtractor = (component) => {
   if (!hasDocgen(component)) {


### PR DESCRIPTION
Replaces See https://github.com/storybookjs/storybook/pull/13127
Because the contributor deleted their repository, I cannot get it updated with changes from next

Issue: Methods not shown use ArgsTable with vue framework( https://github.com/storybookjs/storybook/issues/13105)

## add SECTION Methods

test in node_modules: change file content as same as in PR（node_modules\@storybook\addon-docs\dist\frameworks\vue\extractArgTypes.js），and it worked in my project

@hmleo