### PR TITLE
Index: Don't prepend `titlePrefix` to a docs entry that references a CSF file's title

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,9 +423,6 @@ workflows:
       - e2e-tests-core:
           requires:
             - publish
-      - e2e-tests-sb-docs:
-          requires:
-            - publish
       - e2e-tests-pnp:
           requires:
             - publish

--- a/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -525,6 +525,33 @@ describe('StoryIndexGenerator', () => {
         `);
       });
 
+      it('does not append title prefix if meta references a CSF file', async () => {
+        const generator = new StoryIndexGenerator(
+          [
+            storiesSpecifier,
+            normalizeStoriesEntry(
+              { directory: './src/docs2', files: '**/*.mdx', titlePrefix: 'titlePrefix' },
+              options
+            ),
+          ],
+          options
+        );
+        await generator.initialize();
+
+        // NOTE: `toMatchInlineSnapshot` on objects sorts the keys, but in actuality, they are
+        // not sorted by default.
+        expect(Object.values((await generator.getIndex()).entries).map((e) => e.title))
+          .toMatchInlineSnapshot(`
+          Array [
+            "A",
+            "A",
+            "titlePrefix/NoTitle",
+            "A",
+            "titlePrefix/docs2/Yabbadabbadooo",
+          ]
+        `);
+      });
+
       it('generates no docs entries when docs are disabled', async () => {
         const generator = new StoryIndexGenerator([storiesSpecifier, docsSpecifier], {
           ...options,

--- a/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -307,7 +307,7 @@ export class StoryIndexGenerator {
         dep.dependents.push(absolutePath);
       });
 
-      const title = userOrAutoTitleFromSpecifier(importPath, specifier, result.title || ofTitle);
+      const title = ofTitle || userOrAutoTitleFromSpecifier(importPath, specifier, result.title);
       const name = result.name || this.options.docs.defaultName;
       const id = toId(title, name);
 


### PR DESCRIPTION
Telescoping on https://github.com/storybookjs/storybook/pull/18595

When using `<Meta of={csfFile}>` you want the `csfFile`'s title, not a prefixed version.