### PR TITLE
cleanup: remove react dependency

### DIFF
--- a/app/server/package.json
+++ b/app/server/package.json
@@ -58,8 +58,6 @@
     "@types/webpack-env": "^1.16.0",
     "core-js": "^3.8.2",
     "global": "^4.4.0",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",
     "safe-identifier": "^0.4.1",

--- a/lib/client-api/package.json
+++ b/lib/client-api/package.json
@@ -61,10 +61,6 @@
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"
   },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/lib/core-client/package.json
+++ b/lib/core-client/package.json
@@ -61,11 +61,6 @@
     "unfetch": "^4.2.0",
     "util-deprecate": "^1.0.2"
   },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "webpack": "*"
-  },
   "peerDependenciesMeta": {
     "typescript": {
       "optional": true

--- a/lib/store/package.json
+++ b/lib/store/package.json
@@ -56,10 +56,6 @@
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"
   },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7518,9 +7518,6 @@ __metadata:
     synchronous-promise: ^2.0.15
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -7642,10 +7639,6 @@ __metadata:
     ts-dedent: ^2.0.0
     unfetch: ^4.2.0
     util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    webpack: "*"
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -8860,8 +8853,6 @@ __metadata:
     core-js: ^3.8.2
     fs-extra: ^9.0.1
     global: ^4.4.0
-    react: 16.14.0
-    react-dom: 16.14.0
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     safe-identifier: ^0.4.1
@@ -8914,9 +8905,6 @@ __metadata:
     synchronous-promise: ^2.0.15
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What I did

Remove dependency on react. E.g. `grep -r react app/server/` returns no results, so I don't know why it would be there

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? - existing tests should cover it
- [ ] Does this need a new example in the kitchen sink apps? - no
- [ ] Does this need an update to the documentation? - no

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
