### PR TITLE
cleanup: remove webpack dependency

### DIFF
--- a/lib/core-client/package.json
+++ b/lib/core-client/package.json
@@ -63,8 +63,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "webpack": "*"
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/lib/core-common/package.json
+++ b/lib/core-common/package.json
@@ -88,8 +88,7 @@
     "slash": "^3.0.0",
     "telejson": "^6.0.8",
     "ts-dedent": "^2.0.0",
-    "util-deprecate": "^1.0.2",
-    "webpack": "4"
+    "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@storybook/react-docgen-typescript-plugin": "1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0",
@@ -97,7 +96,8 @@
     "@types/interpret": "^1.1.1",
     "@types/mock-fs": "^4.13.0",
     "@types/picomatch": "^2.3.0",
-    "mock-fs": "^4.13.0"
+    "mock-fs": "^4.13.0",
+    "webpack": "4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7645,7 +7645,6 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    webpack: "*"
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
## What I did

Removed `webpack` as a dependency from `core-client` as it isn't actually used by this package

Made `webpack` only a devDependency in `core-common` as it's only used in the tests

I want to remove this dependency because people who are using `builder-vite` don't need it

## How to test

This should be covered by existing tests and shouldn't need any new tests

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

<!--
If your answer is yes to any of these, please make sure to include it in your PR.

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
