### PR TITLE
docs: Add SEO section to Publish docs page

### DIFF
--- a/docs/sharing/publish-storybook.md
+++ b/docs/sharing/publish-storybook.md
@@ -142,3 +142,39 @@ This level of service can serve published Storybooks but has no further integrat
 Examples: [Netlify](https://www.netlify.com/), [S3](https://aws.amazon.com/en/s3/)
 
 </details>
+
+## Search engine optimization (SEO)
+
+If your Storybook is publically viewable, you may wish to configure how it is represented in search engine result pages.
+
+### Description
+
+You can provide a description for search engines to display in the results listing, by adding the following to the `manager-head.html` file in your config directory:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/seo-description.html.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+<div class="aside">
+💡 You cannot also define <code>&lt;title></code> in this file, because Storybook generates the document title for you to include information about the currently-viewed component and story.
+</div>
+
+### Preventing your Storybook from being crawled
+
+You can prevent your published Storybook from appearing in search engine results by including a noindex meta tag, which you can do by adding the following to the `manager-head.html` file in your config directory:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/seo-noindex.html.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->

--- a/docs/snippets/common/seo-description.html.mdx
+++ b/docs/snippets/common/seo-description.html.mdx
@@ -1,0 +1,5 @@
+```html
+<!-- .storybook/manager-head.html -->
+
+<meta name="description" content="Components for my awesome project" key="desc" />
+```

--- a/docs/snippets/common/seo-noindex.html.mdx
+++ b/docs/snippets/common/seo-noindex.html.mdx
@@ -1,0 +1,5 @@
+```html
+<!-- .storybook/manager-head.html -->
+
+<meta name="robots" content="noindex" />
+```


### PR DESCRIPTION
## What I did

Added a new section for SEO configuration to the Publish page in docs

![Screenshot of new section](https://user-images.githubusercontent.com/486540/178279804-e4284b1f-ff41-4574-8c78-3248b9e71384.png)
