### PR TITLE
Chore: (Docs) Minor polish to the A11y docs

### DIFF
--- a/docs/writing-tests/accessibility-testing.md
+++ b/docs/writing-tests/accessibility-testing.md
@@ -164,7 +164,7 @@ These tools work by auditing the rendered DOM against heuristics based on [WCAG]
 
 ### Setup
 
-To enable accessibility testing with the test runner, you will need to take additional steps to set it up properly. Detailed below is our recommendation to configure and execute them.
+To enable accessibility testing with the test runner, you will need to take additional steps to set it up properly. We recommend you go through the [test runner documentation](./test-runner.md) before proceeding with the rest of the required configuration.
 
 Run the following command to install the required dependencies.
 


### PR DESCRIPTION
With this small pull request, the A11y docs are updated to inform users to read the test-runner docs before jumping into the setup. With this change, it can unblock users.

What was done:
- Updated the A11y docs.