### PR TITLE
Bump dependency to support React 18

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -74,7 +74,7 @@
     "html-tags": "^3.1.0",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
-    "react-element-to-jsx-string": "^14.3.4",
+    "react-element-to-jsx-string": "^15.0.0",
     "react-refresh": "^0.11.0",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",


### PR DESCRIPTION
# Issue:

The package "react-element-to-jsx-string" was only supporting React <= 17.
Bumping it to a newer version adds support for React 18.

https://www.npmjs.com/package/react-element-to-jsx-string
https://github.com/algolia/react-element-to-jsx-string

## What I did

Bumped the dependency

## How to test

- Run the test suite/build

If your answer is yes to any of these, please make sure to include it in your PR.

