### PR TITLE
Cleanup Svelte generator

### DIFF
--- a/app/svelte/package.json
+++ b/app/svelte/package.json
@@ -54,6 +54,7 @@
     "@storybook/docs-tools": "6.5.0-rc.1",
     "@storybook/node-logger": "6.5.0-rc.1",
     "@storybook/store": "6.5.0-rc.1",
+    "@types/node": "^14.14.20 || ^16.0.0",
     "core-js": "^3.8.2",
     "global": "^4.4.0",
     "loader-utils": "^2.0.0",

--- a/app/svelte/src/server/svelte-docgen-loader.ts
+++ b/app/svelte/src/server/svelte-docgen-loader.ts
@@ -46,7 +46,13 @@ export default async function svelteDocgen(source: string) {
   const { resource } = this._module;
   const svelteOptions: any = { ...getOptions(this) };
 
-  const { preprocess: preprocessOptions, logDocgen = false } = svelteOptions;
+  let configPath = path.join(process.cwd(), './svelte.config.js');
+  if (!fs.existsSync(configPath)) configPath = path.join(process.cwd(), './svelte.config.mjs');
+  if (!fs.existsSync(configPath)) configPath = path.join(process.cwd(), './svelte.config.cjs');
+  if (!fs.existsSync(configPath)) throw new Error('Could not locate Svelte config file');
+  const config = (await import(configPath)).default;
+
+  const { preprocess: preprocessOptions = config.preprocess, logDocgen = false } = svelteOptions;
 
   let docOptions;
   if (preprocessOptions) {

--- a/lib/cli/src/generators/SVELTE/index.ts
+++ b/lib/cli/src/generators/SVELTE/index.ts
@@ -2,7 +2,6 @@ import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
-    extraPackages: ['@storybook/addon-svelte-csf'],
     extensions: ['js', 'jsx', 'ts', 'tsx', 'svelte'],
     commonJs: true,
   });

--- a/lib/cli/src/generators/SVELTE/index.ts
+++ b/lib/cli/src/generators/SVELTE/index.ts
@@ -1,39 +1,9 @@
-import fse from 'fs-extra';
-import { logger } from '@storybook/node-logger';
-
 import { baseGenerator, Generator } from '../baseGenerator';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  let extraMain;
-  // svelte.config.js ?
-  if (fse.existsSync('./svelte.config.js')) {
-    logger.info("Configuring preprocessor from 'svelte.config.js'");
-
-    extraMain = {
-      svelteOptions: { preprocess: '%%require("../svelte.config.js").preprocess%%' },
-    };
-  } else if (fse.existsSync('./svelte.config.cjs')) {
-    logger.info("Configuring preprocessor from 'svelte.config.cjs'");
-
-    extraMain = {
-      svelteOptions: { preprocess: '%%require("../svelte.config.cjs").preprocess%%' },
-    };
-  } else {
-    // svelte-preprocess dependencies ?
-    const packageJson = packageManager.retrievePackageJson();
-    if (packageJson.devDependencies && packageJson.devDependencies['svelte-preprocess']) {
-      logger.info("Configuring preprocessor with 'svelte-preprocess'");
-
-      extraMain = {
-        svelteOptions: { preprocess: '%%require("svelte-preprocess")()%%' },
-      };
-    }
-  }
-
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
-    extraPackages: ['svelte', 'svelte-loader'],
+    extraPackages: ['@storybook/addon-svelte-csf'],
     extensions: ['js', 'jsx', 'ts', 'tsx', 'svelte'],
-    extraMain,
     commonJs: true,
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8932,6 +8932,7 @@ __metadata:
     "@storybook/node-logger": 6.5.0-rc.1
     "@storybook/store": 6.5.0-rc.1
     "@types/loader-utils": ^2.0.0
+    "@types/node": ^14.14.20 || ^16.0.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0


### PR DESCRIPTION
## What I did

- Preprocessor should not be manually set in `main.cjs`. It's already set in `svelte.config.js`. Setting it manually results in duplication and is often wrong causing breakages when it does not match the user's own config (e.g. https://github.com/storybookjs/addon-svelte-csf/issues/4)
- `svelte-loader` should not be added indiscriminately. It is only needed for webpack projects, but Svelte projects use Vite by default, so it's mostly wrong to add it. Users will have set this up already if they're using Svelte and webpack

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
