### PR TITLE
CLI: Fix detection of type: module when initializing storybook

### DIFF
--- a/lib/cli/src/generators/baseGenerator.ts
+++ b/lib/cli/src/generators/baseGenerator.ts
@@ -12,6 +12,7 @@ export type GeneratorOptions = {
   language: SupportedLanguage;
   builder: Builder;
   linkable: boolean;
+  commonJs: boolean;
 };
 
 export interface FrameworkOptions {
@@ -67,7 +68,7 @@ const hasInteractiveStories = (framework: SupportedFrameworks) =>
 export async function baseGenerator(
   packageManager: JsPackageManager,
   npmOptions: NpmOptions,
-  { language, builder }: GeneratorOptions,
+  { language, builder, commonJs }: GeneratorOptions,
   framework: SupportedFrameworks,
   options: FrameworkOptions = defaultOptions
 ) {
@@ -150,7 +151,7 @@ export async function baseGenerator(
     framework: frameworkPackage,
     addons: [...addons, ...stripVersions(extraAddons)],
     extensions,
-    commonJs: options.commonJs,
+    commonJs,
     ...mainOptions,
   });
   if (addComponents) {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/builder-vite/issues/441

## What I did

I found that the `commonJs` option being set by `initiate` through auto-detection of the package.json `type: module` since https://github.com/storybookjs/storybook/pull/16184 was not actually being used, therefore ESM projects were not being created with `main.cjs`, causing the error linked above.

Vite recently changed their bootstrap to create projects with `"type": "module"` in their package.json, which brought this to light.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

The vite-based end-to-end tests should start to pass again. 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
