### PR TITLE
Add optional typing to the useArgs hook

### DIFF
--- a/lib/api/src/index.tsx
+++ b/lib/api/src/index.tsx
@@ -442,7 +442,11 @@ export function useAddonState<S>(addonId: string, defaultState?: S) {
   return useSharedState<S>(addonId, defaultState);
 }
 
-export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[]) => void] {
+export function useArgs<Args extends Record<string, any> = { [key: string]: any }>(): [
+  Args,
+  (newArgs: Args) => void,
+  (argNames?: string[]) => void
+] {
   const { getCurrentStoryData, updateStoryArgs, resetStoryArgs } = useStorybookApi();
 
   const data = getCurrentStoryData();
@@ -457,7 +461,7 @@ export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[])
     [id, refId, resetStoryArgs]
   );
 
-  return [args, updateArgs, resetArgs];
+  return [args as Args, updateArgs, resetArgs];
 }
 
 export function useGlobals(): [Args, (newGlobals: Args) => void] {


### PR DESCRIPTION
Issue: `args` returned by the `useArgs` hook cannot be typed.

## What I did

Added a generic type to the `useArgs` function so the returned `args` object type can match the actual component props type.

Also added default value to the generic of `{[key]: string}` so the hook still works as intended without passing a generic to `useArgs`.