### PR TITLE
Change ArgsTable API to work with `of={storyRef}` and isolate channel

### DIFF
--- a/examples/external-docs/components/AccountForm.mdx
+++ b/examples/external-docs/components/AccountForm.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import * as AccountFormStories from './AccountForm.stories';
 
 ## Docs for Account form
@@ -6,3 +6,5 @@ import * as AccountFormStories from './AccountForm.stories';
 <Meta of={AccountFormStories} />
 
 <Story of={AccountFormStories.Standard} />
+
+<ArgsTable of={AccountFormStories.Standard} />

--- a/lib/blocks/package.json
+++ b/lib/blocks/package.json
@@ -41,7 +41,6 @@
     "prepare": "esrun ../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/addons": "7.0.0-alpha.13",
     "@storybook/api": "7.0.0-alpha.13",
     "@storybook/client-logger": "7.0.0-alpha.13",
     "@storybook/components": "7.0.0-alpha.13",
@@ -64,7 +63,8 @@
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
-    "@digitak/esrun": "^3.2.2"
+    "@digitak/esrun": "^3.2.2",
+    "@storybook/addons": "7.0.0-alpha.13"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/lib/blocks/package.json
+++ b/lib/blocks/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@storybook/api": "7.0.0-alpha.13",
+    "@storybook/channels": "7.0.0-alpha.13",
     "@storybook/client-logger": "7.0.0-alpha.13",
     "@storybook/components": "7.0.0-alpha.13",
     "@storybook/core-events": "7.0.0-alpha.13",

--- a/lib/blocks/src/blocks/DocsContainer.tsx
+++ b/lib/blocks/src/blocks/DocsContainer.tsx
@@ -40,7 +40,7 @@ export const DocsContainer: FunctionComponent<DocsContainerProps> = ({
 
   return (
     <DocsContext.Provider value={context}>
-      <SourceContainer>
+      <SourceContainer channel={context.channel}>
         <ThemeProvider theme={ensureTheme(theme)}>
           <DocsWrapper className="sbdocs sbdocs-wrapper">
             <DocsContent className="sbdocs sbdocs-content">{children}</DocsContent>

--- a/lib/blocks/src/blocks/SourceContainer.tsx
+++ b/lib/blocks/src/blocks/SourceContainer.tsx
@@ -1,7 +1,7 @@
 import React, { FC, Context, createContext, useEffect, useState } from 'react';
 
 import { dequal as deepEqual } from 'dequal';
-import { addons } from '@storybook/addons';
+import type { Channel } from '@storybook/addons';
 
 import { SNIPPET_RENDERED } from '@storybook/docs-tools';
 import type { SyntaxHighlighterFormatTypes } from '@storybook/components';
@@ -20,9 +20,8 @@ export interface SourceContextProps {
 
 export const SourceContext: Context<SourceContextProps> = createContext({ sources: {} });
 
-export const SourceContainer: FC<{}> = ({ children }) => {
+export const SourceContainer: FC<{ channel: Channel }> = ({ children, channel }) => {
   const [sources, setSources] = useState<StorySources>({});
-  const channel = addons.getChannel();
 
   useEffect(() => {
     const handleSnippetRendered = (

--- a/lib/blocks/src/blocks/enhanceSource.test.ts
+++ b/lib/blocks/src/blocks/enhanceSource.test.ts
@@ -1,4 +1,4 @@
-import type { StoryContext } from '@storybook/addons';
+import type { StoryContext } from '@storybook/csf';
 import { enhanceSource } from './enhanceSource';
 
 const emptyContext: StoryContext = {

--- a/lib/blocks/src/blocks/enhanceSource.ts
+++ b/lib/blocks/src/blocks/enhanceSource.ts
@@ -1,4 +1,4 @@
-import type { Parameters } from '@storybook/addons';
+import type { Parameters } from '@storybook/csf';
 import type { Story } from '@storybook/store';
 import { combineParameters } from '@storybook/store';
 

--- a/lib/blocks/src/blocks/external/ExternalDocsContext.ts
+++ b/lib/blocks/src/blocks/external/ExternalDocsContext.ts
@@ -1,17 +1,18 @@
-import { StoryId, AnyFramework, ComponentTitle, StoryName } from '@storybook/csf';
-import { DocsContext, DocsContextProps } from '@storybook/preview-web';
-import { CSFFile, ModuleExport, ModuleExports, StoryStore } from '@storybook/store';
+import { AnyFramework } from '@storybook/csf';
+import { DocsContext } from '@storybook/preview-web';
+import { StoryStore } from '@storybook/store';
+import type { DocsContextProps } from '@storybook/preview-web';
+import type { CSFFile, ModuleExport, ModuleExports } from '@storybook/store';
+import type { Channel } from '@storybook/channels';
 
 export class ExternalDocsContext<TFramework extends AnyFramework> extends DocsContext<TFramework> {
   constructor(
-    public readonly id: StoryId,
-    public readonly title: ComponentTitle,
-    public readonly name: StoryName,
+    public channel: Channel,
     protected store: StoryStore<TFramework>,
     public renderStoryToElement: DocsContextProps['renderStoryToElement'],
     private processMetaExports: (metaExports: ModuleExports) => CSFFile<TFramework>
   ) {
-    super(id, title, name, store, renderStoryToElement, [], true);
+    super(channel, store, renderStoryToElement, [], true);
   }
 
   setMeta = (metaExports: ModuleExports) => {

--- a/lib/blocks/src/blocks/external/ExternalPreview.ts
+++ b/lib/blocks/src/blocks/external/ExternalPreview.ts
@@ -1,6 +1,8 @@
 import { Preview } from '@storybook/preview-web';
 import { Path, ModuleExports, StoryIndex, composeConfigs } from '@storybook/store';
 import { AnyFramework, ComponentTitle, ProjectAnnotations } from '@storybook/csf';
+import { Channel } from '@storybook/channels';
+
 import { ExternalDocsContext } from './ExternalDocsContext';
 
 type MetaExports = ModuleExports;
@@ -31,7 +33,7 @@ export class ExternalPreview<
   private moduleExportsByImportPath: Record<Path, ModuleExports> = {};
 
   constructor(public projectAnnotations: ProjectAnnotations) {
-    super();
+    super(new Channel());
 
     this.initialize({
       getStoryIndex: () => this.storyIndex,

--- a/lib/blocks/src/blocks/external/ExternalPreview.ts
+++ b/lib/blocks/src/blocks/external/ExternalPreview.ts
@@ -75,9 +75,7 @@ export class ExternalPreview<
 
   docsContext = () => {
     return new ExternalDocsContext(
-      'storybook--docs',
-      'Storybook',
-      'Docs',
+      this.channel,
       this.storyStore,
       this.renderStoryToElement.bind(this),
       this.processMetaExports.bind(this)

--- a/lib/blocks/src/blocks/mdx.tsx
+++ b/lib/blocks/src/blocks/mdx.tsx
@@ -87,6 +87,7 @@ interface AnchorMdxProps {
 
 export const AnchorMdx: FC<AnchorMdxProps> = (props) => {
   const { href, target, children, ...rest } = props;
+  const context = useContext(DocsContext);
 
   if (href) {
     // Enable scrolling for in-page anchors.
@@ -103,7 +104,7 @@ export const AnchorMdx: FC<AnchorMdxProps> = (props) => {
             event.preventDefault();
             // use the A element's href, which has been modified for
             // local paths without a `?path=` query param prefix
-            navigate(event.currentTarget.getAttribute('href'));
+            navigate(context, event.currentTarget.getAttribute('href'));
           }}
           target={target}
           {...rest}
@@ -156,6 +157,8 @@ const HeaderWithOcticonAnchor: FC<HeaderWithOcticonAnchorProps> = ({
   children,
   ...rest
 }) => {
+  const context = useContext(DocsContext);
+
   // @ts-ignore
   const OcticonHeader = OcticonHeaders[as];
   const hash = `#${id}`;
@@ -170,7 +173,7 @@ const HeaderWithOcticonAnchor: FC<HeaderWithOcticonAnchorProps> = ({
         onClick={(event: SyntheticEvent) => {
           const element = document.getElementById(id);
           if (element) {
-            navigate(hash);
+            navigate(context, hash);
           }
         }}
       >

--- a/lib/blocks/src/blocks/mdx.tsx
+++ b/lib/blocks/src/blocks/mdx.tsx
@@ -1,5 +1,4 @@
-import React, { FC, SyntheticEvent } from 'react';
-import { addons } from '@storybook/addons';
+import React, { useContext, FC, SyntheticEvent } from 'react';
 import { NAVIGATE_URL } from '@storybook/core-events';
 import { Code, components } from '@storybook/components';
 import global from 'global';
@@ -50,8 +49,8 @@ export const CodeOrSourceMdx: FC<CodeOrSourceMdxProps> = ({ className, children,
   );
 };
 
-function navigate(url: string) {
-  addons.getChannel().emit(NAVIGATE_URL, url);
+function navigate(context: DocsContextProps, url: string) {
+  context.channel.emit(NAVIGATE_URL, url);
 }
 
 // @ts-ignore
@@ -61,21 +60,25 @@ interface AnchorInPageProps {
   hash: string;
 }
 
-const AnchorInPage: FC<AnchorInPageProps> = ({ hash, children }) => (
-  <A
-    href={hash}
-    target="_self"
-    onClick={(event: SyntheticEvent) => {
-      const id = hash.substring(1);
-      const element = document.getElementById(id);
-      if (element) {
-        navigate(hash);
-      }
-    }}
-  >
-    {children}
-  </A>
-);
+const AnchorInPage: FC<AnchorInPageProps> = ({ hash, children }) => {
+  const context = useContext(DocsContext);
+
+  return (
+    <A
+      href={hash}
+      target="_self"
+      onClick={(event: SyntheticEvent) => {
+        const id = hash.substring(1);
+        const element = document.getElementById(id);
+        if (element) {
+          navigate(context, hash);
+        }
+      }}
+    >
+      {children}
+    </A>
+  );
+};
 
 interface AnchorMdxProps {
   href: string;

--- a/lib/preview-web/package.json
+++ b/lib/preview-web/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.13",
     "@storybook/channel-postmessage": "7.0.0-alpha.13",
+    "@storybook/channels": "7.0.0-alpha.13",
     "@storybook/client-logger": "7.0.0-alpha.13",
     "@storybook/core-events": "7.0.0-alpha.13",
     "@storybook/csf": "0.0.2--canary.4566f4d.1",

--- a/lib/preview-web/src/Preview.tsx
+++ b/lib/preview-web/src/Preview.tsx
@@ -37,8 +37,6 @@ type MaybePromise<T> = Promise<T> | T;
 const STORY_INDEX_PATH = './index.json';
 
 export class Preview<TFramework extends AnyFramework> {
-  channel: Channel;
-
   serverChannel?: Channel;
 
   storyStore: StoryStore<TFramework>;
@@ -53,8 +51,7 @@ export class Preview<TFramework extends AnyFramework> {
 
   previewEntryError?: Error;
 
-  constructor() {
-    this.channel = addons.getChannel();
+  constructor(private channel: Channel = addons.getChannel()) {
     if (global.FEATURES?.storyStoreV7 && addons.hasServerChannel()) {
       this.serverChannel = addons.getServerChannel();
     }

--- a/lib/preview-web/src/Preview.tsx
+++ b/lib/preview-web/src/Preview.tsx
@@ -51,7 +51,7 @@ export class Preview<TFramework extends AnyFramework> {
 
   previewEntryError?: Error;
 
-  constructor(private channel: Channel = addons.getChannel()) {
+  constructor(protected channel: Channel = addons.getChannel()) {
     if (global.FEATURES?.storyStoreV7 && addons.hasServerChannel()) {
       this.serverChannel = addons.getServerChannel();
     }

--- a/lib/preview-web/src/docs-context/DocsContext.ts
+++ b/lib/preview-web/src/docs-context/DocsContext.ts
@@ -1,11 +1,5 @@
-import {
-  AnyFramework,
-  ComponentTitle,
-  StoryContextForLoaders,
-  StoryId,
-  StoryName,
-} from '@storybook/csf';
-import { CSFFile, ModuleExport, ModuleExports, Story, StoryStore } from '@storybook/store';
+import type { AnyFramework, StoryContextForLoaders, StoryId, StoryName } from '@storybook/csf';
+import type { CSFFile, ModuleExport, ModuleExports, Story, StoryStore } from '@storybook/store';
 import type { Channel } from '@storybook/channels';
 
 import { DocsContextProps } from './DocsContextProps';

--- a/lib/preview-web/src/docs-context/DocsContext.ts
+++ b/lib/preview-web/src/docs-context/DocsContext.ts
@@ -6,6 +6,7 @@ import {
   StoryName,
 } from '@storybook/csf';
 import { CSFFile, ModuleExport, ModuleExports, Story, StoryStore } from '@storybook/store';
+import type { Channel } from '@storybook/channels';
 
 import { DocsContextProps } from './DocsContextProps';
 
@@ -21,9 +22,7 @@ export class DocsContext<TFramework extends AnyFramework> implements DocsContext
   private primaryStory?: Story<TFramework>;
 
   constructor(
-    public readonly id: StoryId,
-    public readonly title: ComponentTitle,
-    public readonly name: StoryName,
+    public channel: Channel,
     protected store: StoryStore<TFramework>,
     public renderStoryToElement: DocsContextProps['renderStoryToElement'],
     /** The CSF files known (via the index) to be refererenced by this docs file */

--- a/lib/preview-web/src/docs-context/DocsContextProps.ts
+++ b/lib/preview-web/src/docs-context/DocsContextProps.ts
@@ -1,5 +1,6 @@
 import type { StoryId, StoryName, AnyFramework, StoryContextForLoaders } from '@storybook/csf';
 import type { ModuleExport, ModuleExports, Story } from '@storybook/store';
+import type { Channel } from '@storybook/channels';
 
 export interface DocsContextProps<TFramework extends AnyFramework = AnyFramework> {
   /**
@@ -42,4 +43,9 @@ export interface DocsContextProps<TFramework extends AnyFramework = AnyFramework
    * Render a story to a given HTML element and keep it up to date across context changes
    */
   renderStoryToElement: (story: Story<TFramework>, element: HTMLElement) => () => Promise<void>;
+
+  /**
+   * Storybook channel -- use for low level event watching/emitting
+   */
+  channel: Channel;
 }

--- a/lib/preview-web/src/render/StandaloneDocsRender.ts
+++ b/lib/preview-web/src/render/StandaloneDocsRender.ts
@@ -71,13 +71,9 @@ export class StandaloneDocsRender<TFramework extends AnyFramework> implements Re
       throw new Error('Cannot render docs before preparing');
 
     const docsContext = new DocsContext<TFramework>(
-      this.id,
-      this.entry.title,
-      this.entry.name,
-
+      this.channel,
       this.store,
       renderStoryToElement,
-
       this.csfFiles,
       false
     );

--- a/lib/preview-web/src/render/TemplateDocsRender.ts
+++ b/lib/preview-web/src/render/TemplateDocsRender.ts
@@ -88,13 +88,9 @@ export class TemplateDocsRender<TFramework extends AnyFramework> implements Rend
     if (!this.story || !this.csfFiles) throw new Error('Cannot render docs before preparing');
 
     const docsContext = new DocsContext<TFramework>(
-      this.story.id,
-      this.entry.title,
-      this.entry.name,
-
+      this.channel,
       this.store,
       renderStoryToElement,
-
       this.csfFiles,
       true
     );

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -47,7 +47,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
       // sourcemap: optimized,
       format: ['esm'],
       target: 'chrome100',
-      clean: true,
+      clean: !watch,
       platform: platform || 'browser',
       // shims: true,
       esbuildPlugins: [
@@ -85,7 +85,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
       format: ['cjs'],
       target: 'node14',
       platform: 'node',
-      clean: true,
+      clean: !watch,
       external: [name, ...Object.keys(dependencies || {}), ...Object.keys(peerDependencies || {})],
 
       esbuildOptions: (c) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9138,6 +9138,7 @@ __metadata:
   dependencies:
     "@storybook/addons": 7.0.0-alpha.13
     "@storybook/channel-postmessage": 7.0.0-alpha.13
+    "@storybook/channels": 7.0.0-alpha.13
     "@storybook/client-logger": 7.0.0-alpha.13
     "@storybook/core-events": 7.0.0-alpha.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -7817,6 +7817,7 @@ __metadata:
     "@digitak/esrun": ^3.2.2
     "@storybook/addons": 7.0.0-alpha.13
     "@storybook/api": 7.0.0-alpha.13
+    "@storybook/channels": 7.0.0-alpha.13
     "@storybook/client-logger": 7.0.0-alpha.13
     "@storybook/components": 7.0.0-alpha.13
     "@storybook/core-events": 7.0.0-alpha.13


### PR DESCRIPTION
Telescoping on https://github.com/storybookjs/storybook/pull/18708

https://user-images.githubusercontent.com/132554/179169985-8701ed68-a89e-443c-a061-373ef3d68344.mov

## What I did

- Change `<ArgsTable>` to allow `of={storyRef}` (which clashes with `of={Component}` but this will work OK. We will split it into `<Controls>` and `<Props>` soon!.

- Ensure events in external docs are isolated to a local channel for the `ExternalDocsContext`. In theory that means you can have two isolated ones 🤷 