### PR TITLE
docs(addon-controls): custom matchers are no longer default

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -84,14 +84,14 @@ This replaces the input with a radio group for a more intuitive experience.
 
 ## Custom control type matchers
 
-For a few types, Controls will automatically infer them by using [regex](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp). You can change the matchers for a regex that suits you better.
+For a few types, Controls can automatically be infered with [regex](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp). If you've used the Storybook CLI to setup the configuration it will automatically have created the following defaults in `.storybook/preview.js`:
 
 | Data type |       Default regex       |                        Description                        |
 | :-------: | :-----------------------: | :-------------------------------------------------------: |
 | **color** | `/(background\|color)$/i` | Will display a color picker UI for the args that match it |
 | **date**  |         `/Date$/`         | Will display a date picker UI for the args that match it  |
 
-To do so, use the `matchers` property in the `controls` parameter:
+If you haven't used the CLI to setup the configuration, or if you want to define your own patterns, use the `matchers` property in the `controls` parameter:
 
 <!-- prettier-ignore-start -->
 

--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -88,7 +88,7 @@ For a few types, Controls can automatically be infered with [regex](https://deve
 
 | Data type |       Default regex       |                        Description                        |
 | :-------: | :-----------------------: | :-------------------------------------------------------: |
-| **color** | `/(background\|color)$/i` | Will display a color picker UI for the args that match it |
+| **color** | `/(background|color)$/i` | Will display a color picker UI for the args that match it |
 | **date**  |         `/Date$/`         | Will display a date picker UI for the args that match it  |
 
 If you haven't used the CLI to setup the configuration, or if you want to define your own patterns, use the `matchers` property in the `controls` parameter:

--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -84,7 +84,7 @@ This replaces the input with a radio group for a more intuitive experience.
 
 ## Custom control type matchers
 
-For a few types, Controls can automatically be infered with [regex](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp). If you've used the Storybook CLI to setup the configuration it will automatically have created the following defaults in `.storybook/preview.js`:
+For a few types, Controls can automatically be inferred with [regex](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp). If you've used the Storybook CLI to setup your project it should have automatically created the following defaults in `.storybook/preview.js`:
 
 | Data type |       Default regex       |                        Description                        |
 | :-------: | :-----------------------: | :-------------------------------------------------------: |


### PR DESCRIPTION
Issue:

A PR at https://github.com/storybookjs/storybook/pull/14182 removed the default custom regex matchers for colors and dates Controls, and instead made the CLI generate the matchers in the preview configuration when initialising Storybook.

However the docs don't reflect this change, and felt quite confusing for me working in a project that didn't use a recent version of the CLI to initialise the project, and therefore didn't have the "default" matchers from the CLI.

## What I did

I've tried to change the wording to reflect that they are only "defaults" if the reader actually sees them in their `.storybook/preview.js` file.

I'm open to inputs on wording, or basically anything.
