### PR TITLE
Addon docs: Pass remarks plugins to mdx loader

### DIFF
--- a/addons/docs/src/preset.ts
+++ b/addons/docs/src/preset.ts
@@ -54,6 +54,7 @@ export async function webpack(
   } = options;
 
   const mdxLoaderOptions = {
+    // whether to skip storybook files, useful for docs only mdx or md files
     skipCsf: true,
     remarkPlugins: [remarkSlug, remarkExternalLinks],
   };
@@ -112,6 +113,10 @@ export async function webpack(
             },
             {
               loader: mdxLoader,
+              options: {
+                ...mdxLoaderOptions,
+                skipCsf: false,
+              },
             },
           ],
         },


### PR DESCRIPTION
Issue: #18395

## What I did

During the refactor to support mdx2, the mdxLoader options were missed.
This PR brings them back, so the remark plugins are passed and anchor tags now work in docs stories:

<img width="331" alt="image" src="https://user-images.githubusercontent.com/1671563/179793890-cebd7952-6725-4843-b593-7bcfdae0630b.png">

## How to test

1. Spin up official-storybook
2. Open a docs only story, e.g. `basics-typography--page`
3. Assert whether the anchor icon appears when you hover a title

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
