### PR TITLE
Preview: Fix standalone MDX files not HMR-ing

### DIFF
--- a/lib/preview-web/src/PreviewWeb.test.ts
+++ b/lib/preview-web/src/PreviewWeb.test.ts
@@ -2935,6 +2935,45 @@ describe('PreviewWeb', () => {
         expect(mockChannel.emit).toHaveBeenCalledWith(STORY_RENDERED, 'component-one--a');
       });
     });
+
+    describe('when a standalone docs file changes', () => {
+      const newStandaloneDocsExports = { default: jest.fn() };
+
+      const newImportFn = jest.fn(async (path) => {
+        return path === './src/Introduction.mdx' ? newStandaloneDocsExports : importFn(path);
+      });
+
+      it('renders with the generated docs parameters', async () => {
+        document.location.search = '?id=introduction--docs&viewMode=docs';
+        const preview = await createAndRenderPreview();
+        mockChannel.emit.mockClear();
+        docsRenderer.render.mockClear();
+
+        preview.onStoriesChanged({ importFn: newImportFn });
+        await waitForRender();
+
+        expect(docsRenderer.render).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.objectContaining({
+            page: newStandaloneDocsExports.default,
+            renderer: projectAnnotations.parameters.docs.renderer,
+          }),
+          'docs-element',
+          expect.any(Function)
+        );
+      });
+
+      it('emits DOCS_RENDERED', async () => {
+        document.location.search = '?id=introduction--docs&viewMode=docs';
+        const preview = await createAndRenderPreview();
+        mockChannel.emit.mockClear();
+
+        preview.onStoriesChanged({ importFn: newImportFn });
+        await waitForRender();
+
+        expect(mockChannel.emit).toHaveBeenCalledWith(DOCS_RENDERED, 'introduction--docs');
+      });
+    });
   });
 
   describe('onGetProjectAnnotationsChanged', () => {

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -262,7 +262,6 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
     }
 
     const storyIdChanged = this.currentSelection?.storyId !== storyId;
-    // FIXME: suspect line
     const viewModeChanged = this.currentRender?.type !== entry.type;
 
     // Show a spinner while we load the next story

--- a/lib/preview-web/src/render/StandaloneDocsRender.ts
+++ b/lib/preview-web/src/render/StandaloneDocsRender.ts
@@ -58,8 +58,8 @@ export class StandaloneDocsRender<TFramework extends AnyFramework> implements Re
   isEqual(other: Render<TFramework>): boolean {
     return !!(
       this.id === other.id &&
-      this.entry &&
-      this.entry === (other as StandaloneDocsRender<TFramework>).entry
+      this.exports &&
+      this.exports === (other as StandaloneDocsRender<TFramework>).exports
     );
   }
 


### PR DESCRIPTION
Issue: https://linear.app/chromaui/issue/SB-478/mdx-standalone-entries-do-not-hmr-properly

## What I did

We were checking the wrong object, `entry` rather than `exports`.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?

Change an `.mdx` file in `react-ts`.