### PR TITLE
Build: Use updated circleci node images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
         default: 'medium'
     working_directory: /tmp/storybook
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.19
         environment:
           NODE_OPTIONS: --max_old_space_size=3076
     resource_class: <<parameters.class>>
@@ -23,7 +23,7 @@ executors:
         default: 'medium'
     working_directory: /tmp/storybook
     docker:
-      - image: circleci/node:14-browsers
+      - image: cimg/node:14.19-browsers
         environment:
           NODE_OPTIONS: --max_old_space_size=3076
     resource_class: <<parameters.class>>
@@ -45,6 +45,7 @@ executors:
 
 orbs:
   git-shallow-clone: guitarrapc/git-shallow-clone@2.0.3
+  browser-tools: circleci/browser-tools@1.4.0
 
 commands:
   ensure-pr-is-labeled-with:


### PR DESCRIPTION
Issue: 

## What I did

This updates the circleci node images to https://circleci.com/developer/images/image/cimg/node to replace the deprecated version that is locked on node 14.17, which does not support vite 3, causing the vite e2e tests to fail.

This change was attempted in https://github.com/storybookjs/storybook/pull/17832 previously, and reverted in https://github.com/storybookjs/storybook/commit/7ffc089ca285da0f2e7a68af4d36592e149f715d, but my guess is that it was because the new images do not actually include any browsers, which should be solved by using the browser-tool orb, according to https://github.com/CircleCI-Public/cimg-node/issues/186.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

This should cause the vite react e2e test to start to pass.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
