### PR TITLE
CLI: allow to download templates in sb repro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
           name: Run E2E (extended) tests
           command: |
             cd code
-            yarn test:e2e-framework --clean --all --skip angular --skip angular12 --skip vue3 --skip web_components_typescript --skip cra --skip react
+            yarn test:e2e-framework --use-local-sb-cli --clean --all --skip angular --skip angular12 --skip vue3 --skip web_components_typescript --skip cra --skip react
           no_output_timeout: 5m
       - store_artifacts:
           path: /tmp/cypress-record
@@ -238,7 +238,7 @@ jobs:
           # TODO: Remove `web_components_typescript` as soon as Lit 2 stable is released
           command: |
             cd code
-            yarn test:e2e-framework vue3 angular130 angular13 angular12 web_components_typescript web_components_lit2 react react_legacy_root_api
+            yarn test:e2e-framework --use-local-sb-cli vue3 angular130 angular13 angular12 web_components_typescript web_components_lit2 react react_legacy_root_api
           no_output_timeout: 5m
       - run:
           name: prep artifacts

--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -132,13 +132,16 @@ program
   .option('-g --generator <generator>', 'Use custom generator command')
   .option('--registry <registry>', 'which registry to use for storybook packages')
   .option('--pnp', "Use Yarn Plug'n'Play mode instead of node_modules one")
+  .option('--url <url>', 'Use custom template from git url')
   .option('--local', "use storybook's local packages instead of yarn's registry")
   .option('--e2e', 'Used in e2e context')
-  .action((outputDirectory, { renderer, template, list, e2e, generator, pnp, local }) =>
-    repro({ outputDirectory, renderer, template, list, e2e, local, generator, pnp }).catch((e) => {
-      logger.error(e);
-      process.exit(1);
-    })
+  .action((outputDirectory, { renderer, template, list, e2e, generator, pnp, local, url }) =>
+    repro({ outputDirectory, renderer, template, list, e2e, local, generator, pnp, url }).catch(
+      (e) => {
+        logger.error(e);
+        process.exit(1);
+      }
+    )
   );
 
 program

--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -135,13 +135,12 @@ program
   .option('--url <url>', 'Use custom template from git url')
   .option('--local', "use storybook's local packages instead of yarn's registry")
   .option('--e2e', 'Used in e2e context')
-  .action((outputDirectory, { renderer, template, list, e2e, generator, pnp, local, url }) =>
-    repro({ outputDirectory, renderer, template, list, e2e, local, generator, pnp, url }).catch(
-      (e) => {
-        logger.error(e);
-        process.exit(1);
-      }
-    )
+  .option('--skip-git', 'Skip downloading templates from git and use local generators instead')
+  .action((outputDirectory, options) =>
+    repro({ outputDirectory, ...options }).catch((e) => {
+      logger.error(e);
+      process.exit(1);
+    })
   );
 
 program

--- a/code/lib/cli/src/repro-generators/configs.ts
+++ b/code/lib/cli/src/repro-generators/configs.ts
@@ -23,6 +23,10 @@ export interface Parameters {
   typescript?: boolean;
   /** Merge configurations to main.js before running the tests */
   mainOverrides?: Partial<StorybookConfig> & Record<string, any>;
+  /** Generator that downloads from remote repro in storybookjs/repro-templates on Github */
+  gitRepoGenerator?: string;
+  /** Whether to download from git templates */
+  preferGitTemplate?: boolean;
 }
 
 const fromDeps = (...args: string[]): string =>

--- a/code/lib/cli/src/repro-generators/scripts.ts
+++ b/code/lib/cli/src/repro-generators/scripts.ts
@@ -31,6 +31,10 @@ export interface Parameters {
   }[];
   /** Add typescript dependency and creates a tsconfig.json file */
   typescript?: boolean;
+  /** Generator that downloads from remote repro in storybookjs/repro-templates on Github */
+  gitRepoGenerator?: string;
+  /** Whether to download from git templates */
+  preferGitTemplate?: boolean;
 }
 
 interface Configuration {
@@ -287,8 +291,24 @@ export const createAndInit = async (
   logger.info(`🏃 Starting for ${name} ${version}`);
   logger.log();
 
-  await doTask(generate, { ...options, cwd: options.creationPath });
+  try {
+    if (!options.preferGitTemplate) {
+      throw new Error('using local generators instead..');
+    }
+    // try downloading from git repro first
+    await doTask(generate, {
+      ...options,
+      generator: options.gitRepoGenerator,
+      cwd: options.creationPath,
+    });
+  } catch (err) {
+    // fallback to local generators
+    logger.info(`⏩ Skipping git template and using local generator instead`);
+    await doTask(generate, { ...options, cwd: options.creationPath });
+  }
+
   await doTask(addAdditionalFiles, { ...options, cwd }, !!options.additionalFiles);
+
   if (e2e) {
     await doTask(addPackageResolutions, options);
   }

--- a/code/lib/cli/src/repro.ts
+++ b/code/lib/cli/src/repro.ts
@@ -6,6 +6,7 @@ import boxen from 'boxen';
 import { dedent } from 'ts-dedent';
 import { createAndInit, exec } from './repro-generators/scripts';
 import * as configs from './repro-generators/configs';
+import versions from './versions';
 import type { Parameters } from './repro-generators/configs';
 import { SupportedRenderers } from './project_types';
 
@@ -178,7 +179,9 @@ export const repro = async ({
       selectedDirectory = directory;
     }
 
-    selectedConfig.gitRepoGenerator = `npx degit storybookjs/repro-templates/${selectedConfig.name} ${selectedDirectory}`;
+    const [storybookVersion] = Object.values(versions);
+    const gitGeneratorBranch = storybookVersion.includes('-') ? 'next' : 'main';
+    selectedConfig.gitRepoGenerator = `npx degit storybookjs/repro-templates/${selectedConfig.name}#${gitGeneratorBranch} ${selectedDirectory}`;
     selectedConfig.preferGitTemplate = preferGitTemplate;
   }
 

--- a/code/lib/cli/src/repro.ts
+++ b/code/lib/cli/src/repro.ts
@@ -161,13 +161,9 @@ export const repro = async ({
           generator,
         } as Parameters);
 
-    selectedConfig.gitRepoGenerator = `npx degit storybookjs/repro-templates/${selectedConfig.name} ${selectedDirectory}`;
-    selectedConfig.preferGitTemplate = preferGitTemplate;
-
     if (!selectedConfig) {
       throw new Error('🚨 Repro: please specify a valid template type');
     }
-
     if (!selectedDirectory) {
       const { directory } = await prompts({
         type: 'text',
@@ -181,6 +177,9 @@ export const repro = async ({
       });
       selectedDirectory = directory;
     }
+
+    selectedConfig.gitRepoGenerator = `npx degit storybookjs/repro-templates/${selectedConfig.name} ${selectedDirectory}`;
+    selectedConfig.preferGitTemplate = preferGitTemplate;
   }
 
   try {

--- a/scripts/repros-generator/index.mjs
+++ b/scripts/repros-generator/index.mjs
@@ -36,7 +36,7 @@ await copy(`${templatesFolderPath}/${gitBranch}/README.md`, tmpFolder);
 
 // eslint-disable-next-line no-restricted-syntax
 for (const framework of frameworks) {
-  await $`npx sb@${sbCliVersion} repro --template ${framework} ${framework}`;
+  await $`npx sb@${sbCliVersion} repro --skip-git --template ${framework} ${framework}`;
   await $`rm -rf ${framework}/.git`;
   await copy(`${templatesFolderPath}/${gitBranch}/.stackblitzrc`, `${tmpFolder}/${framework}`);
 }


### PR DESCRIPTION
Issue: N/A

## What I did

This PR integrates `degit` into the sb cli.

It adds two features:

### Prefer downloading from storybook repro repository

This way, the CLI just downloads a git repo from [repro-templates](https://github.com/storybookjs/repro-templates) instead of having to run a generator (e.g. create-react-app myApp...). This could save time both in CI but also for the `sb repro` experience.

If the selected template does not exist in repro-templates, it will fallback to the original generator.

For the user, there's no change in the command. Optionally, you could use the `--skip-git` flag to use the generators directly instead.

The repro template has both `main` and `next` branches which old latest vs next versions of Storybook. The script will detect whether the user is using `sb repro` or `sb repro@some-alpha-version` and will download from the correct branch

### Set project via --url flag

`sb repro` now has a `--url` flag which allows you to download any git project (github, gitlab, bitbucket..) and bootstrap Storybook on top of it. Could be useful for QAing purposes in case we find big projects with certain settings that could be valuable to test out. 

This uses `degit` under the hood so you can use all kinds of formats for the URL such as `username/project` or `https://github.com/username/project` or other formats that degit supports.

## How to test

First check the branch, bootstrap it or just build the cli:
```
yarn build cli
```

Next, somewhere in an experimentation folder, run `sb repro` using the URL of a project that does not contain Storybook.

```
# This will prompt for location folder, using the repo as default folder name
../storybook/lib/cli/bin/index.js repro --url the-url-here
```

```
# This will download and install things automatically with no prompt
../storybook/lib/cli/bin/index.js repro --url the-url-here outputfoldername
```

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
