### PR TITLE
Svelte: don't add `svelte-loader` nor `svelte` when initializing Svelte projects

### DIFF
--- a/code/lib/cli/src/generators/SVELTE/index.ts
+++ b/code/lib/cli/src/generators/SVELTE/index.ts
@@ -1,9 +1,7 @@
-import { CoreBuilder } from '../../project_types';
 import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
     extensions: ['js', 'jsx', 'ts', 'tsx', 'svelte'],
     commonJs: true,

--- a/code/lib/cli/src/generators/SVELTE/index.ts
+++ b/code/lib/cli/src/generators/SVELTE/index.ts
@@ -6,7 +6,6 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
   const extraPackages = options.builder === CoreBuilder.Webpack5 ? ['svelte'] : [];
 
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
-    extraPackages,
     extensions: ['js', 'jsx', 'ts', 'tsx', 'svelte'],
     commonJs: true,
   });

--- a/code/lib/cli/src/generators/SVELTE/index.ts
+++ b/code/lib/cli/src/generators/SVELTE/index.ts
@@ -3,7 +3,6 @@ import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  const extraPackages = options.builder === CoreBuilder.Webpack5 ? ['svelte'] : [];
 
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
     extensions: ['js', 'jsx', 'ts', 'tsx', 'svelte'],

--- a/code/lib/cli/src/generators/SVELTE/index.ts
+++ b/code/lib/cli/src/generators/SVELTE/index.ts
@@ -3,7 +3,7 @@ import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  const extraPackages = options.builder === CoreBuilder.Webpack5 ? ['svelte', 'svelte-loader'] : [];
+  const extraPackages = options.builder === CoreBuilder.Webpack5 ? ['svelte'] : [];
 
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
     extraPackages,


### PR DESCRIPTION
## What I did

 `svelte-loader` should not be added indiscriminately. It is only needed for webpack projects, but Svelte projects use Vite by default, so it's mostly wrong to add it. Users will have set this up already if they're using Svelte and webpack

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
