### PR TITLE
Addon-docs: Fix canvas support expand code for non-story

### DIFF
--- a/code/examples/official-storybook/stories/addon-docs/addon-docs-mdx.stories.mdx
+++ b/code/examples/official-storybook/stories/addon-docs/addon-docs-mdx.stories.mdx
@@ -196,6 +196,12 @@ Fixed layout requires custom `height` since it can't be determined.
   </Story>
 </Canvas>
 
+### withSource="open"
+
+<Canvas withSource="open">
+  <h2>source open</h2>
+</Canvas>
+
 ## Docs Disable
 
 <Story name="docs disable" parameters={{ docs: { disable: true } }}>

--- a/code/lib/blocks/src/blocks/Canvas.tsx
+++ b/code/lib/blocks/src/blocks/Canvas.tsx
@@ -34,6 +34,7 @@ const getPreviewProps = (
       previewProps: {
         ...props,
         withSource: getSourceProps({ code: decodeURI(mdxSource) }, docsContext, sourceContext),
+        isExpanded: sourceState === SourceState.OPEN,
       },
     };
   }


### PR DESCRIPTION
Issue:

option `withSource="open"` describe in  https://storybook.js.org/docs/react/writing-docs/doc-block-canvas not work for non-story content

## What I did

## How to test

```mdx
<Canvas withSource="open">
  <h2>Some here</h2>
</Canvas>
```

- [ ] Is this testable with Jest or Chromatic screenshots?
- [x] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
