### PR TITLE
Chore: (Docs) Addons URLs updates

### DIFF
--- a/code/addons/a11y/README.md
+++ b/code/addons/a11y/README.md
@@ -4,7 +4,7 @@ This Storybook addon can be helpful to make your UI components more accessible.
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/a11y/docs/screenshot.png)
+![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/a11y/docs/screenshot.png)
 
 ## Getting started
 

--- a/code/addons/actions/README.md
+++ b/code/addons/actions/README.md
@@ -4,7 +4,7 @@ Storybook Addon Actions can be used to display data received by event handlers i
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/actions/docs/screenshot.png)
+![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/actions/docs/screenshot.png)
 
 ## Installation
 

--- a/code/addons/backgrounds/README.md
+++ b/code/addons/backgrounds/README.md
@@ -4,7 +4,7 @@ Storybook Addon Backgrounds can be used to change background colors inside the p
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-![React Storybook Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/backgrounds/docs/addon-backgrounds.gif)
+![React Storybook Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/backgrounds/docs/addon-backgrounds.gif)
 
 ## Installation
 

--- a/code/addons/controls/README.md
+++ b/code/addons/controls/README.md
@@ -4,7 +4,7 @@
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/controls/docs/media/addon-controls-hero.gif)
+![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/controls/docs/media/addon-controls-hero.gif)
 
 ## Installation
 

--- a/code/addons/essentials/README.md
+++ b/code/addons/essentials/README.md
@@ -8,12 +8,12 @@ Each addon is documented and maintained by the core team and will be upgraded al
 
 Storybook essentials includes the following addons. Addons can be disabled and re-configured as [described below](#configuration):
 
-- [Actions](https://github.com/storybookjs/storybook/tree/next/addons/actions)
-- [Backgrounds](https://github.com/storybookjs/storybook/tree/next/addons/backgrounds)
-- [Controls](https://github.com/storybookjs/storybook/tree/next/addons/controls)
-- [Docs](https://github.com/storybookjs/storybook/tree/next/addons/docs)
-- [Viewport](https://github.com/storybookjs/storybook/tree/next/addons/viewport)
-- [Toolbars](https://github.com/storybookjs/storybook/tree/next/addons/toolbars)
+- [Actions](https://github.com/storybookjs/storybook/tree/next/code/addons/actions)
+- [Backgrounds](https://github.com/storybookjs/storybook/tree/next/code/addons/backgrounds)
+- [Controls](https://github.com/storybookjs/storybook/tree/next/code/addons/controls)
+- [Docs](https://github.com/storybookjs/storybook/tree/next/code/addons/docs)
+- [Viewport](https://github.com/storybookjs/storybook/tree/next/code/addons/viewport)
+- [Toolbars](https://github.com/storybookjs/storybook/tree/next/code/addons/toolbars)
 
 ## Installation
 

--- a/code/addons/jest/README.md
+++ b/code/addons/jest/README.md
@@ -4,7 +4,7 @@ Storybook addon for inspecting Jest unit test results.
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-[![Storybook Jest Addon Demo](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/jest/docs/storybook-addon-jest.gif)](http://storybooks-official.netlify.com/?selectedKind=Addons%7Cjest&selectedStory=withTests&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Ftests%2Fpanel)
+[![Storybook Jest Addon Demo](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/jest/docs/storybook-addon-jest.gif)](http://storybooks-official.netlify.com/?selectedKind=Addons%7Cjest&selectedStory=withTests&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Ftests%2Fpanel)
 
 > Check out the above [Live Storybook](http://storybooks-official.netlify.com/?selectedKind=Addons%7Cjest&selectedStory=withTests&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Ftests%2Fpanel).
 
@@ -87,7 +87,7 @@ Assuming that you have already created a test file for your component (e.g., `My
 In your story file, add a [decorator](https://storybook.js.org/docs/react/writing-stories/decorators) to your story's default export to display the results:
 
 ```js
-// MyComponent.stories.js |  MyComponent.stories.jsx
+// MyComponent.stories.js|jsx
 
 import MyComponent from './MyComponent';
 
@@ -105,7 +105,7 @@ export default {
 You can also add multiple tests results within your story by including the `jest` [parameter](https://storybook.js.org/docs/react/writing-stories/parameters), for example:
 
 ```js
-// MyComponent.stories.js |  MyComponent.stories.jsx
+// MyComponent.stories.js|jsx
 
 import MyComponent from './MyComponent';
 
@@ -152,7 +152,7 @@ export const decorators = [
 Then in your story file:
 
 ```js
-// MyComponent.stories.js |  MyComponent.stories.jsx
+// MyComponent.stories.js|jsx
 
 import MyComponent from './MyComponent';
 
@@ -180,6 +180,8 @@ then "MyComponent" will be used to find your test file results. It currently doe
 You can disable the addon for a single story by setting the `jest` parameter to `{disable: true}`:
 
 ```js
+// MyComponent.stories.js|jsx
+
 import MyComponent from './MyComponent';
 
 export default {
@@ -206,6 +208,8 @@ Using this addon with Angular will require some additional configuration. You'll
 Then, in your `.storybook/preview.js`, you'll need to add a decorator with the following:
 
 ```js
+// .storybook/preview.js
+
 import { withTests } from '@storybook/addon-jest';
 
 import results from '../.jest-test-results.json';
@@ -221,6 +225,8 @@ export const decorators = [
 Finally, in your story, you'll need to include the following:
 
 ```ts
+// MyComponent.stories.ts
+
 import type { Meta, StoryFn } from '@storybook/angular';
 
 import MyComponent from './MyComponent.component';

--- a/code/addons/storyshots/storyshots-core/README.md
+++ b/code/addons/storyshots/storyshots-core/README.md
@@ -4,7 +4,7 @@ StoryShots adds automatic Jest Snapshot Testing for [Storybook](https://storyboo
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-![StoryShots In Action](https://raw.githubusercontent.com/storybookjs/storybook/HEAD/addons/storyshots/storyshots-core/docs/storyshots-fail.png)
+![StoryShots In Action](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/storyshots/storyshots-core/docs/storyshots-fail.png)
 
 To use StoryShots, you must use your existing Storybook stories as the input for Jest Snapshot Testing.
 
@@ -31,7 +31,7 @@ That's all.
 
 Now run your Jest test command. (Usually, `npm test`.) Then you can see all of your stories are converted as Jest snapshot tests.
 
-![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/HEAD/addons/storyshots/storyshots-core/docs/storyshots.png)
+![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/storyshots/storyshots-core/docs/storyshots.png)
 
 ### Testing stories that rely on addon-added decorators
 

--- a/code/addons/storyshots/storyshots-puppeteer/README.md
+++ b/code/addons/storyshots/storyshots-puppeteer/README.md
@@ -228,7 +228,7 @@ import { axeTest } from '@storybook/addon-storyshots-puppeteer';
 initStoryshots({ suite: 'A11y checks', test: axeTest() });
 ```
 
-For configuration, it uses the same `story.parameters.a11y` parameter as [`@storybook/addon-a11y`](https://github.com/storybookjs/storybook/tree/next/addons/a11y#parameters)
+For configuration, it uses the same `story.parameters.a11y` parameter as [`@storybook/addon-a11y`](https://github.com/storybookjs/storybook/tree/next/code/addons/a11y#parameters)
 
 ### Specifying options to `axeTest`
 

--- a/code/addons/storysource/README.md
+++ b/code/addons/storysource/README.md
@@ -4,7 +4,7 @@ This addon is used to show stories source in the addon panel.
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-![Storysource Demo](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/storysource/docs/demo.gif)
+![Storysource Demo](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/storysource/docs/demo.gif)
 
 - [Getting Started](#getting-started)
   - [Install using preset](#install-using-preset)

--- a/code/addons/toolbars/README.md
+++ b/code/addons/toolbars/README.md
@@ -8,7 +8,7 @@ The Toolbars addon controls global story rendering options from [Storybook's](ht
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/toolbars/docs/hero.gif)
+![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/toolbars/docs/hero.gif)
 
 ## Installation
 

--- a/code/addons/viewport/README.md
+++ b/code/addons/viewport/README.md
@@ -4,7 +4,7 @@ Storybook Viewport Addon allows your stories to be displayed in different sizes 
 
 [Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
-![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/viewport/docs/viewport.png)
+![Screenshot](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/viewport/docs/viewport.png)
 
 ## Installation
 


### PR DESCRIPTION
With this pull request, the URLs contained within the addons are updated to reflect the recent change to the monorepo by introducing a `code` directory and moving the code inside it, which leads to a few broken links.


@shilman , @ndelangen  and @yannbf would love to hear your feedback on this. Let me know and we'll go from there.
