### PR TITLE
fix(CLI): throw error on failure in sb init

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -44,7 +44,12 @@ program
   .option('-y --yes', 'Answer yes to all prompts')
   .option('-b --builder <builder>', 'Builder library')
   .option('-l --linkable', 'Prepare installation for link (contributor helper)')
-  .action((options) => initiate(options, pkg));
+  .action((options) =>
+    initiate(options, pkg).catch((err) => {
+      logger.error(err);
+      process.exit(1);
+    })
+  );
 
 program
   .command('add <addon>')


### PR DESCRIPTION
Issue: N/A

## What I did

When running `sb init`, if there is an issue, it was being swallowed as Uncaught exception and exiting with code 0.

This PR fixes that behavior

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
