### PR TITLE
Docs: Fix Typo in list-story-starter.ts-3.ts.mdx

### DIFF
--- a/docs/snippets/vue/list-story-starter.ts-3.ts.mdx
+++ b/docs/snippets/vue/list-story-starter.ts-3.ts.mdx
@@ -12,7 +12,7 @@ export default {
    */
   title: 'List',
   component: List,
-} as Meta<typeof LoginForm>;
+} as Meta<typeof List>;
 
 // Always an empty list, not super interesting
 export const Empty: Story = {


### PR DESCRIPTION
The Component Object inferred the wrong Type < typeof LoginForm >.  Should be < typeof List > instead :)

Issue:

Component was declared with the woring type in the markdown docs.

## What I did
Replace the < typeof LoginForm >  with  < typeof List >



Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
