### PR TITLE
fix missing ability to set docs.`extractArgTypes` for html framework

### DIFF
--- a/code/renderers/html/src/config.ts
+++ b/code/renderers/html/src/config.ts
@@ -1,5 +1,5 @@
 import { parameters as docsParams } from './docs/config';
 
 export const parameters = { framework: 'html' as const, ...docsParams };
-export { decorators } from './docs/config';
+export { decorators, argTypesEnhancers } from './docs/config';
 export { renderToDOM } from './render';

--- a/code/renderers/html/src/docs/config.ts
+++ b/code/renderers/html/src/docs/config.ts
@@ -1,4 +1,4 @@
-import { SourceType } from '@storybook/docs-tools';
+import { SourceType, enhanceArgTypes } from '@storybook/docs-tools';
 import { sourceDecorator } from './sourceDecorator';
 
 export const decorators = [sourceDecorator];
@@ -15,3 +15,5 @@ export const parameters = {
     },
   },
 };
+
+export const argTypesEnhancers = [enhanceArgTypes];


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18376

## What I did

@yannbf and I found that in https://github.com/storybookjs/storybook/pull/17695 a feature was not migrated to the html renderer, that was migrated for the other frameworks:
```ts
export const argTypesEnhancers = [enhanceArgTypes];
```
...was essentially missing.

I've added it and tested editing `preview.ts` in the `html-kichten-sink` example.

Note that in order for this feature to work, a `component` property has to be set in the default export of the story, see:
https://github.com/storybookjs/storybook/blob/e3115fd152ccf81a8044caae5dc611d9243047f9/code/lib/docs-tools/src/argTypes/enhanceArgTypes.ts#L14