### PR TITLE
CLI: create temporary sb repro-next command that only degits repros

### DIFF
--- a/.github/workflows/generate-repros-next.yml
+++ b/.github/workflows/generate-repros-next.yml
@@ -3,11 +3,6 @@ name: Generate and push repros to the next branch
 on:
   schedule:
     - cron: '2 2 */1 * *'
-  workflow_dispatch:
-  # To remove when the branch will be merged
-  push:
-    branches:
-      - yann/sb-509-create-github-action
 
 jobs:
   generate:

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -42,6 +42,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
+    "preprepare": "node ./scripts/generate-repro-templates-list.js",
     "prepare": "node ../../../scripts/prepare.js",
     "test": "jest test/**/*.test.js"
   },
@@ -67,6 +68,7 @@
     "fs-extra": "^9.0.1",
     "get-port": "^5.1.1",
     "globby": "^11.0.2",
+    "js-yaml": "^3.14.1",
     "jscodeshift": "^0.13.1",
     "json5": "^2.1.3",
     "leven": "^3.1.0",

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -61,6 +61,7 @@
     "commander": "^6.2.1",
     "core-js": "^3.8.2",
     "cross-spawn": "^7.0.3",
+    "degit": "^2.8.4",
     "envinfo": "^7.7.3",
     "execa": "^5.0.0",
     "express": "^4.17.1",
@@ -83,6 +84,7 @@
   "devDependencies": {
     "@storybook/client-api": "7.0.0-alpha.17",
     "@types/cross-spawn": "^6.0.2",
+    "@types/degit": "^2.8.3",
     "@types/prompts": "^2.0.9",
     "@types/puppeteer-core": "^2.1.0",
     "@types/semver": "^7.3.4",

--- a/code/lib/cli/scripts/generate-repro-templates-list.js
+++ b/code/lib/cli/scripts/generate-repro-templates-list.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const { writeFile } = require('fs-extra');
+const { exec } = require('child_process');
+const path = require('path');
+const { default: dedent } = require('ts-dedent');
+const { readFile } = require('fs-extra');
+const yml = require('js-yaml');
+
+const logger = console;
+
+async function getTemplatesData(filePath) {
+  const configContents = await readFile(filePath, 'utf8');
+  return yml.load(configContents);
+}
+
+const run = async () => {
+  logger.log('Generating templates list...');
+  const templatesData = await getTemplatesData(
+    path.resolve(__dirname, '../../../../scripts/next-repro-generators/repro-config.yml')
+  );
+  const destination = path.join(__dirname, '..', 'src', 'repro-templates.ts');
+
+  await writeFile(
+    destination,
+    dedent`
+      // This file was auto generated from generate-repro-templates-list.js, please do not edit!
+      export default ${JSON.stringify(templatesData, null, 2)}
+    `
+  );
+
+  exec(`yarn lint:js:cmd --fix ${destination}`, {
+    cwd: path.join(__dirname, '..', '..', '..'),
+  });
+
+  logger.log('Done! generated ', destination);
+};
+
+run().catch((e) => {
+  logger.error(e);
+  process.exit(1);
+});

--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -13,6 +13,7 @@ import { migrate } from './migrate';
 import { extract } from './extract';
 import { upgrade } from './upgrade';
 import { repro } from './repro';
+import { reproNext } from './repro-next';
 import { link } from './link';
 import { automigrate } from './automigrate';
 import { generateStorybookBabelConfigInCWD } from './babel-config';
@@ -141,6 +142,18 @@ program
   .option('--e2e', 'Used in e2e context')
   .action((outputDirectory, { renderer, template, list, e2e, generator, pnp, local }) =>
     repro({ outputDirectory, renderer, template, list, e2e, local, generator, pnp }).catch((e) => {
+      logger.error(e);
+      process.exit(1);
+    })
+  );
+
+program
+  .command('repro-next [filterValue]')
+  .description('Create a reproduction from a set of possible templates')
+  .option('-o --output <outDir>', 'Define an output directory')
+  .option('-b --branch <branch>', 'Define the branch to degit from', 'next')
+  .action((filterValue, options) =>
+    reproNext({ filterValue, ...options }).catch((e) => {
       logger.error(e);
       process.exit(1);
     })

--- a/code/lib/cli/src/repro-next.ts
+++ b/code/lib/cli/src/repro-next.ts
@@ -1,0 +1,172 @@
+import prompts from 'prompts';
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import boxen from 'boxen';
+import { dedent } from 'ts-dedent';
+import degit from 'degit';
+
+import TEMPLATES from './repro-templates';
+
+const logger = console;
+
+interface ReproOptions {
+  filterValue?: string;
+  output?: string;
+  branch?: string;
+}
+type Choice = keyof typeof TEMPLATES;
+
+const toChoices = (c: Choice): prompts.Choice => ({ title: TEMPLATES[c].name, value: c });
+
+export const reproNext = async ({ output: outputDirectory, filterValue, branch }: ReproOptions) => {
+  const keys = Object.keys(TEMPLATES) as Choice[];
+  // get value from template and reduce through TEMPLATES to filter out the correct template
+  const choices = keys.reduce<Choice[]>((acc, group) => {
+    const current = TEMPLATES[group];
+
+    const filterRegex = new RegExp(filterValue, 'i');
+    if (!filterValue) {
+      acc.push(group);
+      return acc;
+    }
+
+    if (
+      current.name.match(filterRegex) ||
+      group.match(filterRegex) ||
+      current.expected.builder.match(filterRegex) ||
+      current.expected.framework.match(filterRegex) ||
+      current.expected.renderer.match(filterRegex)
+    ) {
+      acc.push(group);
+      return acc;
+    }
+
+    return acc;
+  }, []);
+
+  if (choices.length === 0) {
+    logger.info(
+      boxen(
+        dedent`
+          🔎 You filtered out all templates. 🔍
+          After filtering all the templates with "${chalk.yellow(
+            filterValue
+          )}", we found no templates.
+
+          Available templates:
+          ${keys.map((key) => chalk.blue`- ${key}`).join('\n')}
+          `.trim(),
+        { borderStyle: 'round', padding: 1, borderColor: '#F1618C' } as any
+      )
+    );
+    return;
+  }
+
+  let selectedTemplate: Choice | null = null;
+
+  if (choices.length === 1) {
+    [selectedTemplate] = choices;
+  } else {
+    logger.info(
+      boxen(
+        dedent`
+          🤗 Welcome to ${chalk.yellow('sb repro NEXT')}! 🤗 
+  
+          Create a ${chalk.green('new project')} to minimally reproduce Storybook issues.
+          
+          1. select an environment that most closely matches your project setup.
+          2. select a location for the reproduction, outside of your project.
+          
+          After the reproduction is ready, we'll guide you through the next steps.
+          `.trim(),
+        { borderStyle: 'round', padding: 1, borderColor: '#F1618C' } as any
+      )
+    );
+
+    selectedTemplate = await promptSelectedTemplate(choices);
+  }
+
+  const hasSelectedTemplate = !!(selectedTemplate ?? null);
+  if (!hasSelectedTemplate) {
+    logger.error('Somehow we got no templates. Please rerun this command!');
+    return;
+  }
+
+  const selectedConfig = TEMPLATES[selectedTemplate];
+
+  if (!selectedConfig) {
+    throw new Error('🚨 Repro: please specify a valid template type');
+  }
+
+  let selectedDirectory = outputDirectory;
+  if (!selectedDirectory) {
+    const { directory } = await prompts({
+      type: 'text',
+      message: 'Enter the output directory',
+      name: 'directory',
+      initial: selectedTemplate,
+      validate: (directoryName) =>
+        fs.existsSync(directoryName)
+          ? `${directoryName} already exists. Please choose another name.`
+          : true,
+    });
+    selectedDirectory = directory;
+  }
+
+  try {
+    const cwd = path.isAbsolute(selectedDirectory)
+      ? selectedDirectory
+      : path.join(process.cwd(), selectedDirectory);
+
+    logger.info(`🏃 Adding ${selectedConfig.name} into ${cwd}`);
+
+    logger.log('📦 Downloading repro template...');
+    try {
+      // Download the repro based on subfolder "after-storybook" and selected branch
+      await degit(
+        `storybookjs/repro-templates-temp/${selectedTemplate}/after-storybook#${branch}`,
+        {
+          force: true,
+        }
+      ).clone(selectedTemplate.replace('/', '-'));
+    } catch (err) {
+      logger.error(`🚨 Failed to download repro template: ${err.message}`);
+      return;
+    }
+
+    logger.info(
+      boxen(
+        dedent`
+        🎉 Your Storybook reproduction project is ready to use! 🎉
+
+        ${chalk.yellow(`cd ${selectedDirectory}`)}
+        ${chalk.yellow(`yarn storybook`)}
+
+        Once you've recreated the problem you're experiencing, please:
+        
+        1. Document any additional steps in ${chalk.cyan('README.md')}
+        2. Publish the repository to github
+        3. Link to the repro repository in your issue
+
+        Having a clean repro helps us solve your issue faster! 🙏
+      `.trim(),
+        { borderStyle: 'round', padding: 1, borderColor: '#F1618C' } as any
+      )
+    );
+  } catch (error) {
+    logger.error('🚨 Failed to create repro');
+    throw error;
+  }
+};
+
+async function promptSelectedTemplate(choices: Choice[]): Promise<Choice | null> {
+  const { template } = await prompts({
+    type: 'select',
+    message: '🌈 Select the template',
+    name: 'template',
+    choices: choices.map(toChoices),
+  });
+
+  return template || null;
+}

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -1,0 +1,21 @@
+// auto generated file, do not edit
+export default {
+  'cra/default-js': {
+    name: 'Create React App (Javascript)',
+    script: 'npx create-react-app .',
+    expected: {
+      framework: '@storybook/cra',
+      renderer: '@storybook/react',
+      builder: '@storybook/builder-webpack5',
+    },
+  },
+  'cra/default-ts': {
+    name: 'Create React App (Typescript)',
+    script: 'npx create-react-app . --template typescript',
+    expected: {
+      framework: '@storybook/cra',
+      renderer: '@storybook/react',
+      builder: '@storybook/builder-webpack5',
+    },
+  },
+} as const;

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7691,6 +7691,7 @@ __metadata:
     "@storybook/semver": ^7.3.2
     "@storybook/telemetry": 7.0.0-alpha.17
     "@types/cross-spawn": ^6.0.2
+    "@types/degit": ^2.8.3
     "@types/prompts": ^2.0.9
     "@types/puppeteer-core": ^2.1.0
     "@types/semver": ^7.3.4
@@ -7701,6 +7702,7 @@ __metadata:
     commander: ^6.2.1
     core-js: ^3.8.2
     cross-spawn: ^7.0.3
+    degit: ^2.8.4
     envinfo: ^7.7.3
     execa: ^5.0.0
     express: ^4.17.1
@@ -10108,6 +10110,13 @@ __metadata:
   dependencies:
     "@types/ms": "*"
   checksum: 742b752b60e14a752d9bf172e64f28e172f630b9933e763d2b54c7c8c1f33b99b1ef067d7312665a4d0539d8df7ea3eb664a8039f900e4b8234c647a569d123a
+  languageName: node
+  linkType: hard
+
+"@types/degit@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "@types/degit@npm:2.8.3"
+  checksum: 1693dc0033aa5aa5c339b76d570c462e3e0ff41e22a7cc2d0164276199ddbd6ed18813042868355bc5f60ee257c0b18bce904c193008685b790392454ec9fcbd
   languageName: node
   linkType: hard
 
@@ -18444,6 +18453,15 @@ __metadata:
   version: 1.0.0
   resolution: "defined@npm:1.0.0"
   checksum: 2b9929414857729a97cfcc77987e65005e03b3fd92747e1d6a743b054c1387b62e669dc453b53e3a8105f1398df6aad54c07eed984871c93be8c7f4560a1828b
+  languageName: node
+  linkType: hard
+
+"degit@npm:^2.8.4":
+  version: 2.8.4
+  resolution: "degit@npm:2.8.4"
+  bin:
+    degit: degit
+  checksum: 25ae9daf8010b450ffe8307c5ca903fe8bfaa8bb8622da12f81f2b6c3b1bb24e96fe3ab0b4ec4a1a19684f674b2158a8a3a2178c481882cc4991c7a0859ec40a
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7708,6 +7708,7 @@ __metadata:
     fs-extra: ^9.0.1
     get-port: ^5.1.1
     globby: ^11.0.2
+    js-yaml: ^3.14.1
     jscodeshift: ^0.13.1
     json5: ^2.1.3
     leven: ^3.1.0


### PR DESCRIPTION
Issue: N/A

## What I did

Added a `sb repro-next` command which will use the new format of repros by just degitting templates from https://github.com/storybookjs/repro-templates-temp

Here's the initial prompt. It will read configurations coming from `repro-config.yml`:
![image](https://user-images.githubusercontent.com/1671563/182187434-89ec0e09-6d38-426f-87c1-ff005d291466.png)

And once done:
![image](https://user-images.githubusercontent.com/1671563/182187504-16f9db2e-17b2-4484-a0d4-24d0053939a6.png)


## How to test

1. `yarn build cli`
2. refer to the CLI bin and run `repro-next`

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
