### PR TITLE
build(addon-measure): use tsup to build `addon-measure` and fix related imports in `examples/official-storybook`

### DIFF
--- a/code/addons/measure/manager.js
+++ b/code/addons/measure/manager.js
@@ -1,1 +1,1 @@
-import './dist/esm/manager';
+import './dist/manager';

--- a/code/addons/measure/package.json
+++ b/code/addons/measure/package.json
@@ -24,9 +24,32 @@
   },
   "license": "MIT",
   "author": "winkerVSbecks",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./manager": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./preview": {
+      "require": "./dist/preview.js",
+      "import": "./dist/preview.mjs",
+      "types": "./dist/preview.d.ts"
+    },
+    "./register.js": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
     "README.md",
@@ -35,7 +58,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prepare": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.17",
@@ -64,6 +87,13 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/index.ts",
+      "./src/manager.tsx",
+      "./src/preview.tsx"
+    ]
   },
   "gitHead": "7d44bfd3e759c6f17b75029ee2e067fab811f27b",
   "storybook": {

--- a/code/addons/measure/preview.js
+++ b/code/addons/measure/preview.js
@@ -1,1 +1,1 @@
-export * from './dist/esm/preview';
+export * from './dist/preview';

--- a/code/examples/official-storybook/components/addon-measure/ShadowRoot.js
+++ b/code/examples/official-storybook/components/addon-measure/ShadowRoot.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { drawSelectedElement } from '@storybook/addon-measure/dist/esm/box-model/visualizer';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { init, destroy } from '@storybook/addon-measure/dist/esm/box-model/canvas';
+import { drawSelectedElement } from '../../../../addons/measure/src/box-model/visualizer';
+import { init, destroy } from '../../../../addons/measure/src/box-model/canvas';
 
 export const ShadowRoot = ({ label = 'Hello from shadow DOM', drawMode = 'ROOT' }) => {
   const ref = React.useRef();

--- a/code/examples/official-storybook/components/addon-measure/Visualization.js
+++ b/code/examples/official-storybook/components/addon-measure/Visualization.js
@@ -1,9 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { drawSelectedElement } from '@storybook/addon-measure/dist/esm/box-model/visualizer';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { init, destroy } from '@storybook/addon-measure/dist/esm/box-model/canvas';
+import { drawSelectedElement } from '../../../../addons/measure/src/box-model/visualizer';
+import { init, destroy } from '../../../../addons/measure/src/box-model/canvas';
 
 export const Visualization = ({ render }) => {
   const element = useRef(null);


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18732

## What I did
- Migrated `addon-measure` to use the `ts-up` bundler
- Fixed the import paths in `examples/official-storybook` related to `addons/measure`, as it was using the compiled output from `@storybook/addon-measure/dist/esm/`

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? No
- [ ] Does this need a new example in the kitchen sink apps? No
- [ ] Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
