### PR TITLE
Got verdaccio working, borrowing heavily from the old repro command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 junit.xml
 /repros
 /sandbox
+.verdaccio-cache
 
 # Yarn stuff
 /**/.yarn/*

--- a/scripts/utils/cli-step.ts
+++ b/scripts/utils/cli-step.ts
@@ -1,5 +1,5 @@
 import { getCommand, OptionSpecifier, OptionValues } from './options';
-import { exec } from '../../code/lib/cli/src/repro-generators/scripts';
+import { exec } from './exec';
 
 const cliExecutable = require.resolve('../../code/lib/cli/bin/index.js');
 

--- a/scripts/utils/exec.ts
+++ b/scripts/utils/exec.ts
@@ -1,0 +1,46 @@
+import shell, { ExecOptions } from 'shelljs';
+import chalk from 'chalk';
+
+const logger = console;
+
+export const exec = async (
+  command: string,
+  options: ExecOptions = {},
+  {
+    startMessage,
+    errorMessage,
+    dryRun,
+  }: { startMessage?: string; errorMessage?: string; dryRun?: boolean } = {}
+) => {
+  if (startMessage) logger.info(startMessage);
+
+  if (dryRun) {
+    logger.info(`\n> ${command}\n`);
+    return undefined;
+  }
+
+  logger.debug(command);
+  return new Promise((resolve, reject) => {
+    const defaultOptions: ExecOptions = {
+      silent: false,
+    };
+    const child = shell.exec(command, {
+      ...defaultOptions,
+      ...options,
+      async: true,
+      silent: false,
+    });
+
+    child.stderr.pipe(process.stderr);
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve(undefined);
+      } else {
+        logger.error(chalk.red(`An error occurred while executing: \`${command}\``));
+        logger.log(errorMessage);
+        reject(new Error(`command exited with code: ${code}: `));
+      }
+    });
+  });
+};

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -23,7 +23,12 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 };
 
 export const installYarn2 = async ({ cwd, dryRun }: YarnOptions) => {
-  const command = [`yarn set version berry`, `yarn config set nodeLinker node-modules`];
+  const command = [
+    `yarn set version berry`,
+    // Use the global cache so we aren't re-caching dependencies each time
+    `yarn config set enableGlobalCache true`,
+    `yarn config set nodeLinker node-modules`,
+  ];
 
   await exec(
     command.join(' && '),

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -25,7 +25,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 export const installYarn2 = async ({ cwd, dryRun }: YarnOptions) => {
   const command = [
     `yarn set version berry`,
-    // Use the global cache so we aren't re-caching dependencies each time
+    // Use the global cache so we aren't re-caching dependencies each time we run sandbox
     `yarn config set enableGlobalCache true`,
     `yarn config set nodeLinker node-modules`,
   ];

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -1,0 +1,58 @@
+import { readJSON, writeJSON } from 'fs-extra';
+import path from 'path';
+
+import { exec } from './exec';
+// TODO -- should we generate this file a second time outside of CLI?
+import storybookVersions from '../../code/lib/cli/src/versions';
+
+export type YarnOptions = {
+  cwd: string;
+  dryRun?: boolean;
+};
+
+const logger = console;
+
+export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
+  logger.info(`🔢 Adding package resolutions:`);
+  if (dryRun) return;
+
+  const packageJsonPath = path.join(cwd, 'package.json');
+  const packageJson = await readJSON(packageJsonPath);
+  packageJson.resolutions = storybookVersions;
+  await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
+};
+
+export const installYarn2 = async ({ cwd, dryRun }: YarnOptions) => {
+  const command = [`yarn set version berry`, `yarn config set nodeLinker node-modules`];
+
+  await exec(
+    command.join(' && '),
+    { cwd },
+    { dryRun, startMessage: `🧶 Installing Yarn 2`, errorMessage: `🚨 Installing Yarn 2 failed` }
+  );
+};
+
+export const configureYarn2ForVerdaccio = async ({ cwd, dryRun }: YarnOptions) => {
+  const command = [
+    // We don't want to use the cache or we might get older copies of our built packages
+    // (with identical versions), as yarn (correctly I guess) assumes the same version hasn't changed
+    `yarn config set enableGlobalCache false`,
+    `yarn config set enableMirror false`,
+    // ⚠️ Need to set registry because Yarn 2 is not using the conf of Yarn 1 (URL is hardcoded in CircleCI config.yml)
+    `yarn config set npmScopes --json '{ "storybook": { "npmRegistryServer": "http://localhost:6000/" } }'`,
+    // Some required magic to be able to fetch deps from local registry
+    `yarn config set unsafeHttpWhitelist --json '["localhost"]'`,
+    // Disable fallback mode to make sure everything is required correctly
+    `yarn config set pnpFallbackMode none`,
+    // We need to be able to update lockfile when bootstrapping the examples
+    `yarn config set enableImmutableInstalls false`,
+    // Discard all YN0013 - FETCH_NOT_CACHED messages
+    `yarn config set logFilters --json '[ { "code": "YN0013", "level": "discard" } ]'`,
+  ].join(' && ');
+
+  await exec(
+    command,
+    { cwd },
+    { startMessage: `🎛 Configuring Yarn 2`, errorMessage: `🚨 Configuring Yarn 2 failed`, dryRun }
+  );
+};


### PR DESCRIPTION
Issue: https://linear.app/chromaui/issue/SB-593/start-verdaccio-publish-packages-install-packages

## What I did

 - Publish verdaccio, then start in serving mode
 - Setup `--no-link` projects to use verdaccio and the correct caching etc settings (mostly from the old `repro --e2e` command)
 - Fix story inclusion so it works without src code symlinked in `node_modules`