### PR TITLE
move webpack to be a devDependency

### DIFF
--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -74,7 +74,6 @@
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2",
     "watchpack": "^2.2.0",
-    "webpack": "5",
     "ws": "^8.2.3"
   },
   "devDependencies": {
@@ -84,7 +83,8 @@
     "@types/serve-favicon": "^2.5.2",
     "@types/ws": "^8",
     "jest-specific-snapshot": "^4.0.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.6.3",
+    "webpack": "5"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",


### PR DESCRIPTION
When running `yarn why webpack` , I was expecting to see webpack only being part of the @storybook/react-webpack5 package, but it seems to be coming from here as well:

```
- Hoisted from "sb#@storybook#cli#@storybook#core-server#webpack"
```
