### PR TITLE
CLI: add --no-init to repro-next command

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -152,6 +152,7 @@ program
   .description('Create a reproduction from a set of possible templates')
   .option('-o --output <outDir>', 'Define an output directory')
   .option('-b --branch <branch>', 'Define the branch to degit from', 'next')
+  .option('--no-init', 'Whether to download a template without an initialized Storybook', false)
   .action((filterValue, options) =>
     reproNext({ filterValue, ...options }).catch((e) => {
       logger.error(e);

--- a/code/lib/cli/src/repro-next.ts
+++ b/code/lib/cli/src/repro-next.ts
@@ -14,12 +14,18 @@ interface ReproOptions {
   filterValue?: string;
   output?: string;
   branch?: string;
+  init?: boolean;
 }
 type Choice = keyof typeof TEMPLATES;
 
 const toChoices = (c: Choice): prompts.Choice => ({ title: TEMPLATES[c].name, value: c });
 
-export const reproNext = async ({ output: outputDirectory, filterValue, branch }: ReproOptions) => {
+export const reproNext = async ({
+  output: outputDirectory,
+  filterValue,
+  branch,
+  init,
+}: ReproOptions) => {
   const keys = Object.keys(TEMPLATES) as Choice[];
   // get value from template and reduce through TEMPLATES to filter out the correct template
   const choices = keys.reduce<Choice[]>((acc, group) => {
@@ -123,9 +129,10 @@ export const reproNext = async ({ output: outputDirectory, filterValue, branch }
 
     logger.log('📦 Downloading repro template...');
     try {
+      const templateType = init ? 'after-storybook' : 'before-storybook';
       // Download the repro based on subfolder "after-storybook" and selected branch
       await degit(
-        `storybookjs/repro-templates-temp/${selectedTemplate}/after-storybook#${branch}`,
+        `storybookjs/repro-templates-temp/${selectedTemplate}/${templateType}#${branch}`,
         {
           force: true,
         }
@@ -135,13 +142,17 @@ export const reproNext = async ({ output: outputDirectory, filterValue, branch }
       return;
     }
 
+    const initMessage = init
+      ? chalk.yellow(`yarn storybook`)
+      : `Recreate your setup, then ${chalk.yellow(`run npx storybook init`)}`;
+
     logger.info(
       boxen(
         dedent`
         🎉 Your Storybook reproduction project is ready to use! 🎉
 
         ${chalk.yellow(`cd ${selectedDirectory}`)}
-        ${chalk.yellow(`yarn storybook`)}
+        ${initMessage}
 
         Once you've recreated the problem you're experiencing, please:
         


### PR DESCRIPTION
Issue: N/A

## What I did

This PR adds a flag to download a project without Storybook, so we can run `sb init` on top of it in scenarios where we want to run local generators on top of it.

![image](https://user-images.githubusercontent.com/1671563/182790049-d0a2c033-3247-4098-96b0-f33c1b26dca6.png)


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
