### PR TITLE
telemetry: improve addon extraction logic

### DIFF
--- a/code/lib/telemetry/src/storybook-metadata.ts
+++ b/code/lib/telemetry/src/storybook-metadata.ts
@@ -11,6 +11,7 @@ import type { StorybookConfig, PackageJson } from '@storybook/core-common';
 import type { StorybookMetadata, Dependency, StorybookAddon } from './types';
 import { getActualPackageVersion, getActualPackageVersions } from './package-versions';
 import { getMonorepoType } from './get-monorepo-type';
+import { cleanPaths } from './sanitize';
 
 export const metaFrameworks = {
   next: 'Next',
@@ -45,6 +46,15 @@ const getFrameworkOptions = (mainConfig: any) => {
   }
 
   return undefined;
+};
+
+export const sanitizeAddonName = (name: string) => {
+  return cleanPaths(name)
+    .replace(/\/dist\/.*/, '')
+    .replace(/\.[mc]?[tj]?s[x]?$/, '')
+    .replace(/\/register$/, '')
+    .replace(/\/manager$/, '')
+    .replace(/\/preset$/, '');
 };
 
 // Analyze a combination of information from main.js and package.json
@@ -128,16 +138,17 @@ export const computeStorybookMetadata = async ({
   const addons: Record<string, StorybookAddon> = {};
   if (mainConfig.addons) {
     mainConfig.addons.forEach((addon) => {
-      let result;
+      let addonName;
       let options;
+
       if (typeof addon === 'string') {
-        result = addon.replace('/register', '').replace('/preset', '');
+        addonName = sanitizeAddonName(addon);
       } else {
         options = addon.options;
-        result = addon.name;
+        addonName = sanitizeAddonName(addon.name);
       }
 
-      addons[result] = {
+      addons[addonName] = {
         options,
         version: undefined,
       };


### PR DESCRIPTION
## What I did

This PR changes the logic in extracting addon names, which were not entirely correct before, e.g. :

```
'@storybook/preset-create-react-app',
'@storybook/addon-ends-with-js/preset.js',
'@storybook/addon-postcss/dist/index.js',
```

Similar logic has to be implemented in the eslint-plugin too. Perhaps the addon extraction from main.js + sanitization should be a utility in a package shared between them?

## How to test

Run `yarn test storybook-metadata`

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
