### PR TITLE
improve sandbox command error handling and debugging

### DIFF
--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -1,6 +1,14 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
 import path from 'path';
-import { remove, pathExists, readJSON, writeJSON, ensureSymlink, ensureDir } from 'fs-extra';
+import {
+  remove,
+  pathExists,
+  readJSON,
+  writeJSON,
+  ensureSymlink,
+  ensureDir,
+  existsSync,
+} from 'fs-extra';
 import prompts from 'prompts';
 
 import { getOptionsOrPrompt } from './utils/options';
@@ -151,7 +159,7 @@ async function addPackageScripts({
 
 async function readMainConfig({ cwd }: { cwd: string }) {
   const configDir = path.join(cwd, '.storybook');
-  if (!pathExists(configDir)) {
+  if (!existsSync(configDir)) {
     throw new Error(
       `Unable to find the Storybook folder in "${configDir}". Are you sure it exists? Or maybe this folder uses a custom Storybook config directory?`
     );

--- a/scripts/utils/cli-step.ts
+++ b/scripts/utils/cli-step.ts
@@ -19,6 +19,7 @@ export async function executeCLIStep<TOptions extends OptionSpecifier>(
     optionValues?: Partial<OptionValues<TOptions>>;
     cwd: string;
     dryRun?: boolean;
+    debug: boolean;
   }
 ) {
   if (cliStep.hasArgument && !options.argument)
@@ -38,6 +39,7 @@ export async function executeCLIStep<TOptions extends OptionSpecifier>(
       startMessage: `${cliStep.icon} ${cliStep.description}`,
       errorMessage: `🚨 ${cliStep.description} failed`,
       dryRun: options.dryRun,
+      debug: options.debug,
     }
   );
 }

--- a/scripts/utils/exec.ts
+++ b/scripts/utils/exec.ts
@@ -32,7 +32,7 @@ export const exec = async (
   } catch (err) {
     logger.error(chalk.red(`An error occurred while executing: \`${command}\``));
     logger.log(errorMessage);
-    logger.log(err.message);
+    throw err;
   }
 
   return undefined;

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -5,6 +5,8 @@
 import prompts, { Falsy, PrevCaller, PromptType } from 'prompts';
 import type { PromptObject } from 'prompts';
 import program from 'commander';
+import dedent from 'ts-dedent';
+import chalk from 'chalk';
 import kebabCase from 'lodash/kebabCase';
 
 // Option types
@@ -125,8 +127,14 @@ export function getOptions<TOptions extends OptionSpecifier>(
       if (isBooleanOption(option)) return acc.option(flags, option.description, !!option.inverse);
 
       const checkStringValue = (raw: string) => {
-        if (!option.values.includes(raw))
-          throw new Error(`Unexpected value '${raw}' for option '${key}'`);
+        if (!option.values.includes(raw)) {
+          const possibleOptions = chalk.cyan(option.values.join(', '));
+          throw new Error(
+            dedent`Unexpected value '${chalk.yellow(raw)}' for option '${chalk.magenta(key)}'.
+            
+            These are the possible options: ${possibleOptions}\n\n`
+          );
+        }
         return raw;
       };
 


### PR DESCRIPTION
## What I did

The `yarn sandbox` command was failing silently when the sandbox folder didn't exist. This PR does:
- Ensure sandbox folder always exists before doing anything
- Replace shelljs implementation with execa
- Add "debug" flag so users can get full output, which is set to `false` by default to all steps but `yarn storybook`. The result is nice:

![image](https://user-images.githubusercontent.com/1671563/182834458-1772ae21-be2b-455c-9682-6a90dae97ca5.png)

Additionally, if you pass a wrong value to the possible values of a flag, you get a much better response now:

![image](https://user-images.githubusercontent.com/1671563/183468420-f040df26-6549-4aa0-aa94-7081f7b0dd55.png)


## How to test

1. have no sandbox folder
2. run `yarn sandbox` 

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
