### PR TITLE
Output junit xml from smoketest, examples and chromatic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,8 @@ jobs:
           command: |
             cd code
             yarn run-chromatics
+      - store_test_results:
+          path: code/test-results
   examples:
     executor:
       class: medium+
@@ -397,7 +399,7 @@ jobs:
             cd code
             yarn smoketest-storybooks --all --junit test-results/smoketest.xml
       - store_test_results:
-          path: code/test-results/smoketest.xml
+          path: code/test-results
   lint:
     executor:
       class: medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,7 +395,9 @@ jobs:
           name: smoke tests
           command: |
             cd code
-            yarn smoketest-storybooks --all
+            yarn smoketest-storybooks --all --junit test-results/smoketest.xml
+      - store_test_results:
+          path: code/test-results/smoketest.xml
   lint:
     executor:
       class: medium

--- a/code/package.json
+++ b/code/package.json
@@ -55,7 +55,7 @@
     "await-serve-storybooks": "wait-on http://localhost:8001",
     "bootstrap": "node ../scripts/bootstrap.js",
     "build": "NODE_ENV=production node ../scripts/build-package.js",
-    "build-storybooks": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true node -r esm ../scripts/build-storybooks.js",
+    "build-storybooks": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true node -r esm ../scripts/build-storybooks.js --junit test-results/examples.xml",
     "changelog": "pr-log --sloppy --cherry-pick",
     "changelog:next": "pr-log --sloppy --since-prerelease",
     "check": "NODE_ENV=production node ../scripts/check-package.js",

--- a/scripts/build-storybooks.js
+++ b/scripts/build-storybooks.js
@@ -126,24 +126,27 @@ const handleExamples = async (deployables) =>
     logger.log(`-----------------${Array(d.length).fill('-').join('')}`);
     const out = p(['built-storybooks', d]);
     const cwd = p(['examples', d]);
+    const execaOptions = { cwd, shell: true };
 
     if (existsSync(join(cwd, 'yarn.lock'))) {
-      await execa(`yarn`, [`install`], { cwd });
+      await execa(`yarn`, [`install`], execaOptions);
     }
 
     const start = new Date();
     const result = { example: d, timestamp: start };
     try {
-      const { all } = await execa(`yarn`, [`build-storybook`, `--output-dir=${out}`, '--quiet'], {
-        cwd,
-      });
+      const { all } = await execa(
+        `yarn`,
+        [`build-storybook`, `--output-dir=${out}`, '--quiet'],
+        execaOptions
+      );
 
       // If the example uses `storyStoreV7` or `buildStoriesJson`, stories.json already exists
       // It can fail on local machines if puppeteer fails to install, that's not critical, it will work without it
       if (!existsSync(`${out}/stories.json`)) {
-        await execa(`npx`, [`sb`, 'extract', out, `${out}/stories.json`], {
-          cwd,
-        }).catch(() => {});
+        await execa(`npx`, [`sb`, 'extract', out, `${out}/stories.json`], execaOptions).catch(
+          () => {}
+        );
       }
 
       logger.log('-------');

--- a/scripts/build-storybooks.js
+++ b/scripts/build-storybooks.js
@@ -196,12 +196,12 @@ const run = async () => {
   if (deployables.length) {
     logger.log(`🏗  Will build Storybook for: ${chalk.cyan(deployables.join(', '))}`);
 
-    const s = new Date();
+    const start = new Date();
     const results = await handleExamples(deployables);
 
     if (junitPath) {
       const junitXml = getJunitXml({
-        time: (Date.now() - s) / 1000,
+        time: (Date.now() - start) / 1000,
         name: 'Build Storybooks',
         suites: results.map(({ example, timestamp, time, ok, err, output }) => ({
           name: example,
@@ -221,23 +221,23 @@ const run = async () => {
         })),
       });
       await outputFile(junitPath, junitXml);
-      console.log(`Test results written to ${resolve(junitPath)}`);
+      logger.log(`Test results written to ${resolve(junitPath)}`);
     }
 
     const failures = results.filter((r) => !r.ok);
     if (failures.length > 0) {
-      console.log(`BUILDING STORYBOOKS FAILED:`);
+      logger.log(`BUILDING STORYBOOKS FAILED:`);
 
       failures.forEach(({ example, err, output }) => {
-        console.log(`${example} failed:`);
-        console.log();
-        console.log(err.message);
-        console.log('==========================================');
+        logger.log(`${example} failed:`);
+        logger.log();
+        logger.log(err.message);
+        logger.log('==========================================');
       });
 
       process.exit(1);
     }
-    console.log('All Storybooks built!');
+    logger.log('All Storybooks built!');
   }
 
   if (

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -143,6 +143,7 @@
     "jest-serializer-html": "^7.0.0",
     "jest-watch-typeahead": "^0.6.1",
     "js-yaml": "^3.14.1",
+    "junit-xml": "^1.2.0",
     "lint-staged": "^10.5.4",
     "lodash": "^4.17.21",
     "mocha-list-tests": "^1.0.5",

--- a/scripts/run-chromatics.js
+++ b/scripts/run-chromatics.js
@@ -52,7 +52,7 @@ const handleExamples = async (deployables) => {
 
     const out = p(['built-storybooks', d]);
     const cwd = p([]);
-    const junitPath = p(['test-results', `chromatic-${d}.xml]);
+    const junitPath = p(['test-results', `chromatic-${d}.xml`]);
     const {
       storybook: {
         chromatic: { projectToken },

--- a/scripts/run-chromatics.js
+++ b/scripts/run-chromatics.js
@@ -52,6 +52,7 @@ const handleExamples = async (deployables) => {
 
     const out = p(['built-storybooks', d]);
     const cwd = p([]);
+    const junitPath = p(['test-results', d]);
     const {
       storybook: {
         chromatic: { projectToken },
@@ -66,6 +67,7 @@ const handleExamples = async (deployables) => {
           `--storybook-build-dir="${out}"`,
           '--exit-zero-on-changes',
           `--project-token="${projectToken}"`,
+          `--junit-report="${junitPath}`,
         ],
         { cwd }
       );

--- a/scripts/run-chromatics.js
+++ b/scripts/run-chromatics.js
@@ -67,7 +67,7 @@ const handleExamples = async (deployables) => {
           `--storybook-build-dir="${out}"`,
           '--exit-zero-on-changes',
           `--project-token="${projectToken}"`,
-          `--junit-report="${junitPath}`,
+          `--junit-report="${junitPath}"`,
         ],
         { cwd }
       );

--- a/scripts/run-chromatics.js
+++ b/scripts/run-chromatics.js
@@ -52,7 +52,7 @@ const handleExamples = async (deployables) => {
 
     const out = p(['built-storybooks', d]);
     const cwd = p([]);
-    const junitPath = p(['test-results', d]);
+    const junitPath = p(['test-results', `chromatic-${d}.xml]);
     const {
       storybook: {
         chromatic: { projectToken },

--- a/scripts/smoketest-storybooks.js
+++ b/scripts/smoketest-storybooks.js
@@ -52,15 +52,17 @@ const handleExamples = async (deployables) =>
     logger.log(`------------------${Array(d.length).fill('-').join('')}`);
     const cwd = p(['examples', d]);
 
+    const execaOptions = { cwd, shell: true };
+
     // ensure web-components example works, because it's outside the yarn workspace
     if (existsSync(join(cwd, 'yarn.lock'))) {
-      await execa(`yarn`, [`install`], { cwd });
+      await execa(`yarn`, [`install`], execaOptions);
     }
 
     const start = new Date();
     const result = { example: d, timestamp: start };
     try {
-      const { all } = await execa(`yarn`, ['storybook', '--smoke-test', '--quiet'], { cwd });
+      const { all } = await execa(`yarn`, ['storybook', '--smoke-test', '--quiet'], execaOptions);
 
       logger.log(`----------${Array(d.length).fill('-').join('')}`);
       logger.log(`✅ ${d} passed`);

--- a/scripts/smoketest-storybooks.js
+++ b/scripts/smoketest-storybooks.js
@@ -1,6 +1,6 @@
 import { promisify } from 'util';
 import { readdir as readdirRaw, readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import path, { join } from 'path';
 import program from 'commander';
 import prompts from 'prompts';
 import chalk from 'chalk';
@@ -136,6 +136,7 @@ const run = async () => {
         })),
       });
       await outputFile(junitPath, junitXml);
+      console.log(`Test results written to ${path.resolve(junitPath)}`);
     }
 
     const failures = results.filter((r) => !r.ok);

--- a/scripts/smoketest-storybooks.js
+++ b/scripts/smoketest-storybooks.js
@@ -52,7 +52,7 @@ const handleExamples = async (deployables) =>
     logger.log(`------------------${Array(d.length).fill('-').join('')}`);
     const cwd = p(['examples', d]);
 
-    const execaOptions = { cwd, shell: true };
+    const execaOptions = { cwd, shell: true, stdio: 'inherit' };
 
     // ensure web-components example works, because it's outside the yarn workspace
     if (existsSync(join(cwd, 'yarn.lock'))) {

--- a/scripts/smoketest-storybooks.js
+++ b/scripts/smoketest-storybooks.js
@@ -124,7 +124,7 @@ const run = async () => {
           time,
           testCases: [
             {
-              name: 'Start',
+              name: `Start ${example}`,
               assertions: 1,
               time,
               systemOut: output,

--- a/scripts/smoketest-storybooks.js
+++ b/scripts/smoketest-storybooks.js
@@ -111,12 +111,12 @@ const run = async () => {
 
   if (deployables.length) {
     logger.log(`🏗  Will smoke test: ${chalk.cyan(deployables.join(', '))}`);
-    const s = new Date();
+    const start = new Date();
     const results = await handleExamples(deployables);
 
     if (junitPath) {
       const junitXml = getJunitXml({
-        time: (Date.now() - s) / 1000,
+        time: (Date.now() - start) / 1000,
         name: 'Storybook Smoke Tests',
         suites: results.map(({ example, timestamp, time, ok, err, output }) => ({
           name: example,
@@ -136,23 +136,23 @@ const run = async () => {
         })),
       });
       await outputFile(junitPath, junitXml);
-      console.log(`Test results written to ${resolve(junitPath)}`);
+      logger.log(`Test results written to ${resolve(junitPath)}`);
     }
 
     const failures = results.filter((r) => !r.ok);
     if (failures.length > 0) {
-      console.log(`SMOKE TESTS FAILED:`);
+      logger.log(`SMOKE TESTS FAILED:`);
 
       failures.forEach(({ example, err, output }) => {
-        console.log(`${example} failed:`);
-        console.log();
-        console.log(err.message);
-        console.log('==========================================');
+        logger.log(`${example} failed:`);
+        logger.log();
+        logger.log(err.message);
+        logger.log('==========================================');
       });
 
       process.exit(1);
     }
-    console.log('All smoke tests succeeded!');
+    logger.log('All smoke tests succeeded!');
   }
 };
 

--- a/scripts/smoketest-storybooks.js
+++ b/scripts/smoketest-storybooks.js
@@ -1,6 +1,6 @@
 import { promisify } from 'util';
 import { readdir as readdirRaw, readFileSync, existsSync } from 'fs';
-import path, { join } from 'path';
+import { join, resolve } from 'path';
 import program from 'commander';
 import prompts from 'prompts';
 import chalk from 'chalk';
@@ -136,7 +136,7 @@ const run = async () => {
         })),
       });
       await outputFile(junitPath, junitXml);
-      console.log(`Test results written to ${path.resolve(junitPath)}`);
+      console.log(`Test results written to ${resolve(junitPath)}`);
     }
 
     const failures = results.filter((r) => !r.ok);

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -3330,6 +3330,7 @@ __metadata:
     jest-serializer-html: ^7.0.0
     jest-watch-typeahead: ^0.6.1
     js-yaml: ^3.14.1
+    junit-xml: ^1.2.0
     lint-staged: ^10.5.4
     lodash: ^4.17.21
     mocha-list-tests: ^1.0.5
@@ -12898,6 +12899,15 @@ __metadata:
     jstransform: ^11.0.3
     through2: ^2.0.0
   checksum: c861e279841360de1d840157d61d999a5b00aabd678017782f21b5fa63ff2bfb92a2982503ca22d56b5c9a10cef86d86c668ca55089ce3dbe5a5f488e5a8571d
+  languageName: node
+  linkType: hard
+
+"junit-xml@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "junit-xml@npm:1.2.0"
+  dependencies:
+    xml: ^1.0.1
+  checksum: 4e72ffac0f2e77784ab81380f385e9b0757bebaf2d841598423d889fbaf397cc38cd524d5cd9efe7bfeb6b96937b5c497582df6de33f67e2c5ad7f174d3f800f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: https://linear.app/chromaui/issue/SB-640/generate-junitxml-for-current-e2e-tests-config-to-get-better-error

## What I did

- [x] Added junit xml results from our `smoke-test` step
- [x] Added junit xml results from our `examples` step
- [x] Add junit xml results from our `chromatic` step

<img width="956" alt="image" src="https://user-images.githubusercontent.com/132554/182997453-deb66e8e-a0e5-4dae-a4f6-a93210aaebe0.png">

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/132554/182997429-46e7fd4d-a1c9-49b4-b2ca-d5b6bac301cf.png">


## What I didn't do

- Add it to the test runner (we don't currently use the test runner, I will add when we do)
- Add it to cypress (I already have it in the playwright PoC: #18826) 

## How to test

See CI job