### PR TITLE
change the location of placeholder images to something we host ourselves

### DIFF
--- a/code/examples/official-storybook/stories/addon-a11y/image.stories.js
+++ b/code/examples/official-storybook/stories/addon-a11y/image.stories.js
@@ -2,7 +2,7 @@
 import React from 'react';
 
 const text = 'Testing the a11y addon';
-const image = 'http://place-hold.it/350x150';
+const image = 'https://storybook.js.org/images/placeholders/350x150.png';
 
 export default {
   title: 'Addons/A11y/Image',

--- a/code/examples/official-storybook/stories/addon-controls.stories.tsx
+++ b/code/examples/official-storybook/stories/addon-controls.stories.tsx
@@ -98,7 +98,7 @@ Action.args = {
 
 export const ImageFileControl = (args) => <img src={args.imageUrls[0]} alt="Your Example Story" />;
 ImageFileControl.args = {
-  imageUrls: ['http://place-hold.it/350x150'],
+  imageUrls: ['https://storybook.js.org/images/placeholders/350x150.png'],
 };
 
 export const CustomControls = Template.bind({});

--- a/code/lib/blocks/src/components/Description.stories.tsx
+++ b/code/lib/blocks/src/components/Description.stories.tsx
@@ -10,7 +10,7 @@ const markdownCaption = `
 
 The group looked like tall, exotic grazing animals, swaying gracefully and unconsciously with the movement of the train, their high heels like polished hooves against the gray metal of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses.
 
-![An image](http://place-hold.it/350x150)
+![An image](https://storybook.js.org/images/placeholders/350x150.png)
 
 He stared at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a skyscraper canyon.
 `;

--- a/code/lib/blocks/src/components/DocsPageExampleCaption.md
+++ b/code/lib/blocks/src/components/DocsPageExampleCaption.md
@@ -2,7 +2,7 @@
 
 The group looked like tall, exotic grazing animals, swaying gracefully and unconsciously with the movement of the train, their high heels like polished hooves against the gray metal of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses.
 
-![An image](http://place-hold.it/350x150)
+![An image](https://storybook.js.org/images/placeholders/350x150.png)
 
 He stared at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a skyscraper canyon. Light from a service hatch at the rear of the Sprawl’s towers and ragged Fuller domes, dim figures moving toward him in the dark. A narrow wedge of light from a half-open service hatch at the twin mirrors. Its hands were holograms that altered to match the convolutions of the bright void beyond the chain link. Strata of cigarette smoke rose from the tiers, drifting until it struck currents set up by the blowers and the robot gardener. Still it was a steady pulse of pain midway down his spine. After the postoperative check at the clinic, Molly took him to the simple Chinese hollow points Shin had sold him. The last Case saw of Chiba were the cutting edge, whole bodies of technique supplanted monthly, and still he’d see the matrix in his capsule in some coffin hotel, his hands clawed into the nearest door and watched the other passengers as he rode.
 

--- a/code/lib/blocks/src/components/DocsPageExampleCaption.mdx
+++ b/code/lib/blocks/src/components/DocsPageExampleCaption.mdx
@@ -2,7 +2,7 @@
 
 The group looked like tall, exotic grazing animals, swaying gracefully and unconsciously with the movement of the train, their high heels like polished hooves against the gray metal of the Flatline as a construct, a hardwired ROM cassette replicating a dead man’s skills, obsessions, kneejerk responses.
 
-![An image](http://place-hold.it/350x150)
+![An image](https://storybook.js.org/images/placeholders/350x150.png)
 
 He stared at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a skyscraper canyon. Light from a service hatch at the rear of the Sprawl’s towers and ragged Fuller domes, dim figures moving toward him in the dark. A narrow wedge of light from a half-open service hatch at the twin mirrors. Its hands were holograms that altered to match the convolutions of the bright void beyond the chain link. Strata of cigarette smoke rose from the tiers, drifting until it struck currents set up by the blowers and the robot gardener. Still it was a steady pulse of pain midway down his spine. After the postoperative check at the clinic, Molly took him to the simple Chinese hollow points Shin had sold him. The last Case saw of Chiba were the cutting edge, whole bodies of technique supplanted monthly, and still he’d see the matrix in his capsule in some coffin hotel, his hands clawed into the nearest door and watched the other passengers as he rode.
 

--- a/code/lib/blocks/src/components/IconGallery.stories.tsx
+++ b/code/lib/blocks/src/components/IconGallery.stories.tsx
@@ -21,10 +21,10 @@ export const DefaultStyle = () => (
       <ExampleIcon icon="facehappy" />
     </IconItem>
     <IconItem name="bar">
-      <img src="https://place-hold.it/50x50" alt="example" />
+      <img src="https://storybook.js.org/images/placeholders/50x50.png" alt="example" />
     </IconItem>
     <IconItem name="bar">
-      <img src="https://place-hold.it/50x50" alt="example" />
+      <img src="https://storybook.js.org/images/placeholders/50x50.png" alt="example" />
     </IconItem>
   </IconGallery>
 );

--- a/code/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.input.js
+++ b/code/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.input.js
@@ -98,7 +98,7 @@ storiesOf('Button').addWithInfo(
       </a>
     </p>
     <p>
-      <img src="http://place-hold.it/350x150" />
+      <img src="https://storybook.js.org/images/placeholders/350x150.png" />
     </p>
   </div>,
   () => (
@@ -128,7 +128,7 @@ storiesOf('Button').addWithInfo(
       </a>
     </p>
     <p>
-      <img src="http://place-hold.it/350x150" />
+      <img src="https://storybook.js.org/images/placeholders/350x150.png" />
     </p>
   </div>,
   () => <Button label="The Button" onClick={action('onClick')} />,

--- a/code/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.output.snapshot
+++ b/code/lib/codemod/src/transforms/__testfixtures__/update-addon-info/update-addon-info.output.snapshot
@@ -98,7 +98,7 @@ storiesOf('Button').add('simple usage (JSX description)', withInfo(<div>
     </a>
   </p>
   <p>
-    <img src=\\"http://place-hold.it/350x150\\" />
+    <img src=\\"https://storybook.js.org/images/placeholders/350x150.png\\" />
   </p>
 </div>)(() => (
   <div>
@@ -125,7 +125,7 @@ storiesOf('Button').add('simple usage (inline JSX description)', withInfo({
       </a>
     </p>
     <p>
-      <img src=\\"http://place-hold.it/350x150\\" />
+      <img src=\\"https://storybook.js.org/images/placeholders/350x150.png\\" />
     </p>
   </div>,
 

--- a/code/lib/theming/src/tests/create.test.js
+++ b/code/lib/theming/src/tests/create.test.js
@@ -74,14 +74,14 @@ describe('create brand', () => {
   it('should accept values', () => {
     const result = create({
       base: 'light',
-      brandImage: 'https://place-hold.it/350x150',
+      brandImage: 'https://storybook.js.org/images/placeholders/350x150.png',
       brandTitle: 'my custom storybook',
       brandUrl: 'https://example.com',
       brandTarget: '_top',
     });
 
     expect(result).toMatchObject({
-      brandImage: 'https://place-hold.it/350x150',
+      brandImage: 'https://storybook.js.org/images/placeholders/350x150.png',
       brandTitle: 'my custom storybook',
       brandUrl: 'https://example.com',
       brandTarget: '_top',

--- a/code/lib/ui/src/components/sidebar/Heading.stories.tsx
+++ b/code/lib/ui/src/components/sidebar/Heading.stories.tsx
@@ -150,7 +150,7 @@ export const CustomBrandImage: Story = () => {
         brand: {
           title: 'My Title',
           url: 'https://example.com',
-          image: 'https://via.placeholder.com/150x22',
+          image: 'https://storybook.js.org/images/placeholders/150x22.png',
         },
       }}
     >
@@ -168,7 +168,7 @@ export const CustomBrandImageTall: Story = () => {
         brand: {
           title: 'My Title',
           url: 'https://example.com',
-          image: 'https://via.placeholder.com/100x150',
+          image: 'https://storybook.js.org/images/placeholders/100x150.png',
         },
       }}
     >

--- a/code/lib/ui/src/components/sidebar/Menu.stories.tsx
+++ b/code/lib/ui/src/components/sidebar/Menu.stories.tsx
@@ -21,7 +21,7 @@ const fakemenu = [
   { title: 'has icon', left: <MenuItemIcon icon="check" />, id: 'icon' },
   {
     title: 'has imgSrc',
-    left: <MenuItemIcon imgSrc="https://via.placeholder.com/20" />,
+    left: <MenuItemIcon imgSrc="https://storybook.js.org/images/placeholders/20x20.png" />,
     id: 'img',
   },
   { title: 'has neither', left: <MenuItemIcon />, id: 'non' },

--- a/docs/snippets/angular/component-story-static-asset-cdn.mdx.mdx
+++ b/docs/snippets/angular/component-story-static-asset-cdn.mdx.mdx
@@ -17,6 +17,6 @@ import { MyComponent } from './MyComponent.component';
 <Story 
   name="WithAnImage"
   render={() => ({
-    template: `<img src="https://place-hold.it/350x150" alt="My CDN placeholder" />`,
+    template: `<img src="https://storybook.js.org/images/placeholders/350x150.png" alt="My CDN placeholder" />`,
   })} />
 ```

--- a/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
@@ -22,7 +22,7 @@ export default {
 export const WithAnImage: Story = {
   render: () => ({
     props: {
-      src: 'https://place-hold.it/350x150',
+      src: 'https://storybook.js.org/images/placeholders/350x150.png',
       alt: 'My CDN placeholder',
     },
   }),

--- a/docs/snippets/common/storybook-theme-example-variables.ts.mdx
+++ b/docs/snippets/common/storybook-theme-example-variables.ts.mdx
@@ -7,7 +7,7 @@ export default create({
   base: 'light',
   brandTitle: 'My custom storybook',
   brandUrl: 'https://example.com',
-  brandImage: 'https://place-hold.it/350x150',
+  brandImage: 'https://storybook.js.org/images/placeholders/350x150.png',
   brandTarget: '_self',
 });
 ```

--- a/docs/snippets/common/your-theme.js.mdx
+++ b/docs/snippets/common/your-theme.js.mdx
@@ -36,7 +36,7 @@ export default create({
 
   brandTitle: 'My custom storybook',
   brandUrl: 'https://example.com',
-  brandImage: 'https://place-hold.it/350x150',
+  brandImage: 'https://storybook.js.org/images/placeholders/350x150.png',
   brandTarget: '_self',
 });
 ```

--- a/docs/snippets/react/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.js.mdx
@@ -17,6 +17,6 @@ export default {
  * to learn how to use render functions.
  */
 export const WithAnImage = {
-  render: () => <img src="https://place-hold.it/350x150" alt="My CDN placeholder" />,
+  render: () => <img src="https://storybook.js.org/images/placeholders/350x150.png" alt="My CDN placeholder" />,
 };
 ```

--- a/docs/snippets/react/component-story-static-asset-cdn.mdx.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.mdx.mdx
@@ -8,6 +8,6 @@ import { MyComponent } from './MyComponent';
 <Meta title="img" component={MyComponent} />
 
 <Story name="WithAnImage">
-  <img src="https://place-hold.it/350x150" alt="My CDN placeholder" />}
+  <img src="https://storybook.js.org/images/placeholders/350x150.png" alt="My CDN placeholder" />}
 </Story>
 ```

--- a/docs/snippets/react/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.ts.mdx
@@ -14,6 +14,6 @@ export default {
 } as Meta;
 
 export const WithAnImage = {
-  render: () => <img src="https://place-hold.it/350x150" alt="My CDN placeholder" />,
+  render: () => <img src="https://storybook.js.org/images/placeholders/350x150.png" alt="My CDN placeholder" />,
 };
 ```

--- a/docs/snippets/svelte/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-cdn.js.mdx
@@ -21,7 +21,7 @@ export const WithAnImage = {
   render: () => ({
     Component: MyComponent,
     props: {
-      src: 'https://place-hold.it/350x150',
+      src: 'https://storybook.js.org/images/placeholders/350x150.png',
       alt: 'My CDN placeholder',
     },
   }),

--- a/docs/snippets/svelte/component-story-static-asset-cdn.mdx.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-cdn.mdx.mdx
@@ -18,7 +18,7 @@ import MyComponent from './MyComponent.svelte';
   render={() => ({
     Component: MyComponent,
     props: {
-      src: 'https://place-hold.it/350x150',
+      src: 'https://storybook.js.org/images/placeholders/350x150.png',
       alt: 'my image',
     },
   })} />

--- a/docs/snippets/svelte/component-story-static-asset-cdn.native-format.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-cdn.native-format.mdx
@@ -13,7 +13,7 @@
 />
 
 <Template>
-  <MyComponent src="https://place-hold.it/350x150" alt="My CDN placeholder" />
+  <MyComponent src="https://storybook.js.org/images/placeholders/350x150.png" alt="My CDN placeholder" />
 </Template>
 
 <Story name="WithAnImage" />

--- a/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
@@ -16,7 +16,7 @@ export default {
  */
 export const WithAnImage = {
   render: () => ({
-    template: '<img src="https://place-hold.it/350x150" alt="My CDN placeholder"/>',
+    template: '<img src="https://storybook.js.org/images/placeholders/350x150.png" alt="My CDN placeholder"/>',
   }),
 };
 ```

--- a/docs/snippets/vue/component-story-static-asset-cdn.mdx.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.mdx.mdx
@@ -16,6 +16,6 @@ import MyComponent from './MyComponent.vue';
 <Story 
   name="withAnImage"
   render={() => ({
-    template: `<img src="https://place-hold.it/350x150" alt="My CDN placeholder"/>`,
+    template: `<img src="https://storybook.js.org/images/placeholders/350x150.png" alt="My CDN placeholder"/>`,
   })} />
 ```


### PR DESCRIPTION
The placeholder image services we have used in the past, sometimes fail, and then chromatic detects UI changes which are not actually there..

Let's make these stories more stable, aka... less flaky.