### PR TITLE
api: return defaultValue in useParameter if story is not prepared

### DIFF
--- a/code/lib/api/src/modules/stories.ts
+++ b/code/lib/api/src/modules/stories.ts
@@ -162,8 +162,6 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
         if (parameters) {
           return parameterName ? parameters[parameterName] : parameters;
         }
-
-        return {};
       }
 
       return null;


### PR DESCRIPTION
## What I did

Given the changes in Storybook 7.0, when calling `useParameter` and a story existed but had `story.prepared === false`, the code was returning an empty object rather than just null, which is a breaking change and broke addons that relied on the value being `undefined`.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
