### PR TITLE
Generate lib/cli-storybook with ts-up

### DIFF
--- a/code/lib/cli-storybook/package.json
+++ b/code/lib/cli-storybook/package.json
@@ -23,9 +23,26 @@
     "sb": "./index.js",
     "storybook": "./index.js"
   },
+  "exports": { 
+    ".": { 
+      "require": "./dist/index.js", 
+      "import": "./dist/index.mjs", 
+      "types": "./dist/index.d.ts" 
+    },
+    "./package.json": "./package.json" 
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "templates/**/*",
+    "*.js",
+    "*.d.ts"
+  ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prepare": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/cli": "7.0.0-alpha.18"
@@ -35,6 +52,12 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+   "bundler": {
+    "entries": [
+     "./src/index.ts"
+    ],
+    "platform": "node"
   },
   "gitHead": "bd59f1eef0f644175abdb0d9873ed0553f431f53"
 }


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18732

## What I did
Migrated `lib/cli-storybook` to use the `ts-up` bundler.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? No
- [ ] Does this need a new example in the kitchen sink apps? No
- [ ] Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
