### PR TITLE
Chore: (Docs) Updates to the CLI options

### DIFF
--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -5,9 +5,9 @@ title: 'CLI options'
 Storybook comes with two CLI utilities: [`start-storybook`](#start-storybook) and [`build-storybook`](#build-storybook).
 
 <div class="aside">
-  
+
 Storybook collects completely anonymous data to help us improve user experience. Participation is optional, and you may [opt-out](../configure/telemetry.md#how-to-opt-out) if you'd not like to share any information.
-  
+
 </div>
 
 Pass these commands the following options to alter Storybook's behavior.


### PR DESCRIPTION
While reviewing another pull request related to this part of the documentation, I discovered that there's an issue with the link mentioning how to opt-out of the telemetry.

This pull request fixes it.

What was done:
- Removed additional spacing in the docs

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
