### PR TITLE
chore(cli): add uninstall deps to jsPackageManager

### DIFF
--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -131,6 +131,45 @@ export abstract class JsPackageManager {
   }
 
   /**
+   * Remove dependencies from a project using `yarn remove` or `npm uninstall`.
+   *
+   * @param {Object} options contains `skipInstall`, `packageJson` and `installAsDevDependencies` which we use to determine how we install packages.
+   * @param {Array} dependencies contains a list of packages to remove.
+   * @example
+   * removeDependencies(options, [
+   *   `@storybook/react`,
+   *   `@storybook/addon-actions`,
+   * ]);
+   */
+  public removeDependencies(
+    options: {
+      skipInstall?: boolean;
+      packageJson?: PackageJson;
+    },
+    dependencies: string[]
+  ): void {
+    const { skipInstall } = options;
+
+    if (skipInstall) {
+      const { packageJson } = options;
+
+      dependencies.forEach((dep) => {
+        delete packageJson[dep];
+      }, {});
+
+      writePackageJson(packageJson);
+    } else {
+      try {
+        this.runRemoveDeps(dependencies);
+      } catch (e) {
+        logger.error('An error occurred while removing dependencies.');
+        logger.log(e.message);
+        process.exit(1);
+      }
+    }
+  }
+
+  /**
    * Return an array of strings matching following format: `<package_name>@<package_latest_version>`
    *
    * @param packages
@@ -267,6 +306,8 @@ export abstract class JsPackageManager {
   protected abstract runInstall(): void;
 
   protected abstract runAddDeps(dependencies: string[], installAsDevDependencies: boolean): void;
+
+  protected abstract runRemoveDeps(dependencies: string[]): void;
 
   /**
    * Get the latest or all versions of the input package available on npmjs.com

--- a/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
@@ -75,6 +75,35 @@ describe('NPM Proxy', () => {
     });
   });
 
+  describe('removeDependencies', () => {
+    describe('npm6', () => {
+      it('with devDep it should run `npm uninstall @storybook/addons`', () => {
+        const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('6.0.0');
+
+        npmProxy.removeDependencies({}, ['@storybook/addons']);
+
+        expect(executeCommandSpy).toHaveBeenLastCalledWith(
+          'npm',
+          ['uninstall', '@storybook/addons'],
+          expect.any(String)
+        );
+      });
+    });
+    describe('npm7', () => {
+      it('with devDep it should run `npm uninstall @storybook/addons`', () => {
+        const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('7.0.0');
+
+        npmProxy.removeDependencies({}, ['@storybook/addons']);
+
+        expect(executeCommandSpy).toHaveBeenLastCalledWith(
+          'npm',
+          ['uninstall', '--legacy-peer-deps', '@storybook/addons'],
+          expect.any(String)
+        );
+      });
+    });
+  });
+
   describe('latestVersion', () => {
     it('without constraint it returns the latest version', async () => {
       const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('"5.3.19"');

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -6,6 +6,8 @@ export class NPMProxy extends JsPackageManager {
 
   installArgs: string[] | undefined;
 
+  uninstallArgs: string[] | undefined;
+
   initPackageJson() {
     return this.executeCommand('npm', ['init', '-y']);
   }
@@ -49,6 +51,15 @@ export class NPMProxy extends JsPackageManager {
     return this.installArgs;
   }
 
+  getUninstallArgs(): string[] {
+    if (!this.uninstallArgs) {
+      this.uninstallArgs = this.needsLegacyPeerDeps(this.getNpmVersion())
+        ? ['uninstall', '--legacy-peer-deps']
+        : ['uninstall'];
+    }
+    return this.uninstallArgs;
+  }
+
   protected runInstall(): void {
     this.executeCommand('npm', this.getInstallArgs(), 'inherit');
   }
@@ -61,6 +72,12 @@ export class NPMProxy extends JsPackageManager {
     }
 
     this.executeCommand('npm', [...this.getInstallArgs(), ...args], 'inherit');
+  }
+
+  protected runRemoveDeps(dependencies: string[]): void {
+    const args = [...dependencies];
+
+    this.executeCommand('npm', [...this.getUninstallArgs(), ...args], 'inherit');
   }
 
   protected runGetVersions<T extends boolean>(

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
@@ -45,6 +45,22 @@ describe('Yarn 1 Proxy', () => {
     });
   });
 
+  describe('removeDependencies', () => {
+    it('should run `yarn remove --ignore-workspace-root-check @storybook/addons`', () => {
+      const executeCommandSpy = jest.spyOn(yarn1Proxy, 'executeCommand').mockReturnValue('');
+
+      yarn1Proxy.removeDependencies({}, ['@storybook/addons']);
+
+      expect(executeCommandSpy).toHaveBeenCalledWith(
+        'yarn',
+        ['remove', '--ignore-workspace-root-check', '@storybook/addons'],
+        expect.any(String)
+      );
+    });
+
+    it.todo('with devDep it should update package json without running yarn remove');
+  });
+
   describe('latestVersion', () => {
     it('without constraint it returns the latest version', async () => {
       const executeCommandSpy = jest

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -29,6 +29,12 @@ export class Yarn1Proxy extends JsPackageManager {
     this.executeCommand('yarn', ['add', ...args], 'inherit');
   }
 
+  protected runRemoveDeps(dependencies: string[]): void {
+    const args = ['--ignore-workspace-root-check', ...dependencies];
+
+    this.executeCommand('yarn', ['remove', ...args], 'inherit');
+  }
+
   protected runGetVersions<T extends boolean>(
     packageName: string,
     fetchAllVersions: T

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
@@ -1,6 +1,6 @@
 import { Yarn2Proxy } from './Yarn2Proxy';
 
-describe('Yarn 1 Proxy', () => {
+describe('Yarn 2 Proxy', () => {
   let yarn2Proxy: Yarn2Proxy;
 
   beforeEach(() => {
@@ -43,6 +43,21 @@ describe('Yarn 1 Proxy', () => {
         expect.any(String)
       );
     });
+  });
+
+  describe('removeDependencies', () => {
+    it('it should run `yarn remove @storybook/addons`', () => {
+      const executeCommandSpy = jest.spyOn(yarn2Proxy, 'executeCommand').mockReturnValue('');
+
+      yarn2Proxy.removeDependencies({}, ['@storybook/addons']);
+
+      expect(executeCommandSpy).toHaveBeenCalledWith(
+        'yarn',
+        ['remove', '@storybook/addons'],
+        expect.any(String)
+      );
+    });
+    it.todo('with devDep it should update package json without running yarn remove');
   });
 
   describe('latestVersion', () => {

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -29,6 +29,12 @@ export class Yarn2Proxy extends JsPackageManager {
     this.executeCommand('yarn', ['add', ...args], 'inherit');
   }
 
+  protected runRemoveDeps(dependencies: string[]): void {
+    const args = [...dependencies];
+
+    this.executeCommand('yarn', ['remove', ...args], 'inherit');
+  }
+
   protected runGetVersions<T extends boolean>(
     packageName: string,
     fetchAllVersions: T


### PR DESCRIPTION
Issue: N/A

## What I did

As part of automigrations we'll need to uninstall dependencies, so I added such functionality.

## How to test

```yarn test jspackagemanager```

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
