### PR TITLE
Add migration documentation for prebuild-manager & modern browser support

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -268,6 +268,8 @@ module.exports = {
 }
 ```
 
+Here's an example PR to one of the storybook addons: https://github.com/storybookjs/addon-coverage/pull/3 doing just that.
+
 #### No more configuration for manager
 
 The storybook manager no longer uses webpack to be built, instead it's using esbuild now.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -246,7 +246,7 @@ We now transpile our code with a target of `chrome >= 100` and node code is tran
 This means code-features such as (but not limited to) `async/await`, arrow-functions, `const`,`let`, etc will exists in the code at runtime, and thus the runtime environment must support it.
 Not just the runtime needs to support it, but some legacy loaders for webpack or other transpilation tools might need to be updated as well. For example certain versions of webpack 4 had parsers that could not parse the new syntax (e.g. optional chaining).
 
-Some addons or libraries might have depended on this legacy browser support, and thus might break. You might get an error like:
+Some addons or libraries might depended on this legacy browser support, and thus might break. You might get an error like:
 ```
 regeneratorRuntime is not defined
 ```
@@ -276,7 +276,7 @@ Here's an example PR to one of the storybook addons: https://github.com/storyboo
 The storybook manager is no longer built with webpack. Now it's built with esbuild.
 Therefore, it's no longer possible to configure the manager. Esbuild comes preconfigured to handle importing CSS, and images.
 
-If you're currently loading files other then CSS or images into the manager, you'll need change this so the files get converted to JS before publishing your addon.
+If you're currently loading files other than CSS or images into the manager, you'll need to make changes so the files get converted to JS before publishing your addon.
 
 This means the preset value `managerWebpack` is no longer respected, and should be removed from presets and `main.js` files.
 
@@ -287,7 +287,7 @@ For this reason it's recommended to have these dependencies as `devDependencies`
 The full list of packages that Storybook's manager bundler makes available for addons is here: https://github.com/storybookjs/storybook/blob/next/code/lib/ui/src/globals/types.ts
 
 Addons in the manager will no longer be bundled together anymore, which means that if 1 fails, it doesn't break the whole manager.
-Each addons is imported into the manager as an ESM module that's bundled separately.
+Each addon is imported into the manager as an ESM module that's bundled separately.
 
 #### start-storybook / build-storybook binaries removed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,8 @@
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [Alpha release notes](#alpha-release-notes)
   - [Breaking changes](#breaking-changes)
+    - [Modern browser support](#modern-browser-support)
+    - [No more configuration for manager](#no-more-configuration-for-manager)
     - [start-storybook / build-storybook binaries removed](#start-storybook--build-storybook-binaries-removed)
     - [storyStoreV7 enabled by default](#storystorev7-enabled-by-default)
     - [Webpack4 support discontinued](#webpack4-support-discontinued)
@@ -13,7 +15,7 @@
     - [Docs modern inline rendering by default](#docs-modern-inline-rendering-by-default)
     - [Babel mode v7 by default](#babel-mode-v7-by-default)
     - [7.0 feature flags removed](#70-feature-flags-removed)
-    - [Removed docs.getContainer and getPage parameters](#removed-docs-getcontainer-and-getpage-parameters)
+    - [Removed docs.getContainer and getPage parameters](#removed-docsgetcontainer-and-getpage-parameters)
 - [From version 6.4.x to 6.5.0](#from-version-64x-to-650)
   - [Vue 3 upgrade](#vue-3-upgrade)
   - [React18 new root API](#react18-new-root-api)
@@ -224,6 +226,54 @@ Storybook 7.0 is in early alpha. During the alpha, we are making a large number 
 In the meantime, these migration notes are the best available documentation on things you should know upgrading to 7.0.
 
 ### Breaking changes
+
+
+#### Modern browser support
+
+Starting in storybook 7.0, storybook will no longer support IE11, amongst other legacy browser versions.
+We now transpile our code with a target of `chrome >= 100` and node code is transpiled with a target of `node >= 14`.
+
+This means code-features such as (but not limited to) `async/await`, arrow-functions, `const`,`let`, etc will exists in the code at runtime, and thus the runtime environment must support it.
+Not just the runtime needs to support it, but some legacy loaders for webpack or other transpilation tools might need to be updated as well. For example certain version of webpack 4, had parsers that could not parse the new syntax.
+
+Some addons or libraries might have depended on this legacy browser support, and thus might break. You might get an error like:
+```
+regeneratorRuntime is not defined
+```
+To fix these error, the addon will have to be re-released with a newer browser-target for transpilation. This often looks something like this (but it's dependent on the build system the addon uses):
+```js
+// babel.config.js
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        shippedProposals: true,
+        useBuiltIns: 'usage',
+        corejs: '3',
+        modules: false,
+        targets: { chrome: '100' },
+      },
+    ],
+  ],
+}
+```
+
+#### No more configuration for manager
+
+The storybook manager no longer uses webpack to be built, instead it's using esbuild now.
+It's no longer possible to configure the manager. Esbuild comes preconfigured to handle importing CSS, and images.
+
+If you're currently loading files other then CSS or images into the manager, you'll need change this so the files get converted to JS before publishing.
+
+This means the preset value `managerWebpack` is no longer respected, and should be removed from presets and `main.js` files.
+
+Addons that run in the manager can depend on `react` and `@storybook/*` packages directly. They do not need to be peerDependencies.
+But very importantly the build system ensures there will only be 1 version of these packages at runtime. The version will come from the `@storybook/ui` package, and not from the addon.
+For this reason it's recommended to have these dependencies as `devDependencies` in your `package.json` of your addon.
+
+Addons in the manager will no longer be bundled together anymore, which means that if 1 fails, it doesn't break the whole manager.
+Each addons is imported into the manager as an ESM module that's bundled separately.
 
 #### start-storybook / build-storybook binaries removed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -237,19 +237,20 @@ The default export from `@storybook/addons` has been removed. Please use the nam
 import { addons } from '@storybook/addons';
 ```
 
+The named export has been available since 6.0 or earlier, so your updated code will be backwards-compatible with older versions of Storybook.
 #### Modern browser support
 
 Starting in storybook 7.0, storybook will no longer support IE11, amongst other legacy browser versions.
 We now transpile our code with a target of `chrome >= 100` and node code is transpiled with a target of `node >= 14`.
 
 This means code-features such as (but not limited to) `async/await`, arrow-functions, `const`,`let`, etc will exists in the code at runtime, and thus the runtime environment must support it.
-Not just the runtime needs to support it, but some legacy loaders for webpack or other transpilation tools might need to be updated as well. For example certain version of webpack 4, had parsers that could not parse the new syntax.
+Not just the runtime needs to support it, but some legacy loaders for webpack or other transpilation tools might need to be updated as well. For example certain versions of webpack 4 had parsers that could not parse the new syntax (e.g. optional chaining).
 
 Some addons or libraries might have depended on this legacy browser support, and thus might break. You might get an error like:
 ```
 regeneratorRuntime is not defined
 ```
-To fix these error, the addon will have to be re-released with a newer browser-target for transpilation. This often looks something like this (but it's dependent on the build system the addon uses):
+To fix these errors, the addon will have to be re-released with a newer browser-target for transpilation. This often looks something like this (but it's dependent on the build system the addon uses):
 ```js
 // babel.config.js
 module.exports = {
@@ -272,16 +273,18 @@ Here's an example PR to one of the storybook addons: https://github.com/storyboo
 
 #### No more configuration for manager
 
-The storybook manager no longer uses webpack to be built, instead it's using esbuild now.
-It's no longer possible to configure the manager. Esbuild comes preconfigured to handle importing CSS, and images.
+The storybook manager is no longer built with webpack. Now it's built with esbuild.
+Therefore, it's no longer possible to configure the manager. Esbuild comes preconfigured to handle importing CSS, and images.
 
-If you're currently loading files other then CSS or images into the manager, you'll need change this so the files get converted to JS before publishing.
+If you're currently loading files other then CSS or images into the manager, you'll need change this so the files get converted to JS before publishing your addon.
 
 This means the preset value `managerWebpack` is no longer respected, and should be removed from presets and `main.js` files.
 
 Addons that run in the manager can depend on `react` and `@storybook/*` packages directly. They do not need to be peerDependencies.
-But very importantly the build system ensures there will only be 1 version of these packages at runtime. The version will come from the `@storybook/ui` package, and not from the addon.
-For this reason it's recommended to have these dependencies as `devDependencies` in your `package.json` of your addon.
+But very importantly, the build system ensures there will only be 1 version of these packages at runtime. The version will come from the `@storybook/ui` package, and not from the addon.
+For this reason it's recommended to have these dependencies as `devDependencies` in your addon's `package.json`.
+
+The full list of packages that Storybook's manager bundler makes available for addons is here: https://github.com/storybookjs/storybook/blob/next/code/lib/ui/src/globals/types.ts
 
 Addons in the manager will no longer be bundled together anymore, which means that if 1 fails, it doesn't break the whole manager.
 Each addons is imported into the manager as an ESM module that's bundled separately.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [Alpha release notes](#alpha-release-notes)
   - [Breaking changes](#breaking-changes)
+    - [No more default export from `@storybook/addons`](#no-more-default-export-from-storybookaddons)
     - [Modern browser support](#modern-browser-support)
     - [No more configuration for manager](#no-more-configuration-for-manager)
     - [start-storybook / build-storybook binaries removed](#start-storybook--build-storybook-binaries-removed)
@@ -227,6 +228,14 @@ In the meantime, these migration notes are the best available documentation on t
 
 ### Breaking changes
 
+
+#### No more default export from `@storybook/addons`
+
+The default export from `@storybook/addons` has been removed. Please use the named exports instead:
+
+```js
+import { addons } from '@storybook/addons';
+```
 
 #### Modern browser support
 


### PR DESCRIPTION
I added documentation on what to do to migrate to 7.0.0:

- new browser support
- prebuilt manager