### PR TITLE
Build: Use ts-up to build addon-links

### DIFF
--- a/code/addons/links/manager.js
+++ b/code/addons/links/manager.js
@@ -1,1 +1,1 @@
-import './dist/esm/manager';
+import './dist/manager';

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -21,9 +21,37 @@
     "url": "https://opencollective.com/storybook"
   },
   "license": "MIT",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./manager": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./preview": {
+      "require": "./dist/preview.js",
+      "import": "./dist/preview.mjs",
+      "types": "./dist/preview.d.ts"
+    },
+    "./react": {
+      "require": "./dist/react/index.js",
+      "import": "./dist/react/index.mjs",
+      "types": "./dist/react.d.ts"
+    },
+    "./register.js": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
     "README.md",
@@ -32,7 +60,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prepare": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.18",
@@ -62,6 +90,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/index.ts",
+      "./src/manager.ts",
+      "./src/preview.ts",
+      "./src/react/index.ts"
+    ]
   },
   "gitHead": "bd59f1eef0f644175abdb0d9873ed0553f431f53",
   "storybook": {

--- a/code/addons/links/preview.js
+++ b/code/addons/links/preview.js
@@ -1,1 +1,1 @@
-export * from './dist/esm/preview';
+export * from './dist/preview';

--- a/code/addons/links/react.js
+++ b/code/addons/links/react.js
@@ -1,3 +1,3 @@
-import LinkTo from './dist/esm/react';
+import LinkTo from './dist/react';
 
 export default LinkTo;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18732

## What I did

Migrated `addon-links` to use the `ts-up` bundler.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? No
- [ ] Does this need a new example in the kitchen sink apps? No
- [ ] Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
