### PR TITLE
Store: always call composeConfigs in setProjectAnnotations

### DIFF
--- a/code/lib/store/src/csf/testing-utils/index.ts
+++ b/code/lib/store/src/csf/testing-utils/index.ts
@@ -27,9 +27,8 @@ let GLOBAL_STORYBOOK_PROJECT_ANNOTATIONS = {};
 export function setProjectAnnotations<TFramework extends AnyFramework = AnyFramework>(
   projectAnnotations: ProjectAnnotations<TFramework> | ProjectAnnotations<TFramework>[]
 ) {
-  GLOBAL_STORYBOOK_PROJECT_ANNOTATIONS = Array.isArray(projectAnnotations)
-    ? composeConfigs(projectAnnotations)
-    : projectAnnotations;
+  const annotations = Array.isArray(projectAnnotations) ? projectAnnotations : [projectAnnotations];
+  GLOBAL_STORYBOOK_PROJECT_ANNOTATIONS = composeConfigs(annotations);
 }
 
 interface ComposeStory<TFramework extends AnyFramework = AnyFramework, TArgs extends Args = Args> {


### PR DESCRIPTION
Issue: N/A

## What I did

The testing utilities were only calling composeConfigs in case the project annotations providade were an array, which is wrong given that `composeConfigs` provides sensible defaults which are necessary in `prepareStory`.

This is needed for #18673 to work correctly with the testing utilities

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
