### PR TITLE
CLI: install the same version as the user in sb-scripts automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.test.ts
@@ -88,16 +88,18 @@ describe('sb scripts fix', () => {
           checkSbScripts({
             packageJson,
           })
-        ).resolves.toEqual({
-          storybookScripts: {
-            official: {
-              storybook: 'storybook dev -p 6006',
-              'build-storybook': 'storybook build -o build/storybook',
+        ).resolves.toEqual(
+          expect.objectContaining({
+            storybookScripts: {
+              official: {
+                storybook: 'storybook dev -p 6006',
+                'build-storybook': 'storybook build -o build/storybook',
+              },
+              custom: {},
             },
-            custom: {},
-          },
-          storybookVersion: '^7.0.0-alpha.0',
-        });
+            storybookVersion: '^7.0.0-alpha.0',
+          })
+        );
       });
     });
 
@@ -122,18 +124,20 @@ describe('sb scripts fix', () => {
           checkSbScripts({
             packageJson,
           })
-        ).resolves.toEqual({
-          storybookScripts: {
-            custom: {
-              'sb:start': 'start-storybook -p 6006',
-              'sb:build': 'build-storybook -o buid/storybook',
-              'test-storybook:ci':
-                'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn build-storybook --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
+        ).resolves.toEqual(
+          expect.objectContaining({
+            storybookScripts: {
+              custom: {
+                'sb:start': 'start-storybook -p 6006',
+                'sb:build': 'build-storybook -o buid/storybook',
+                'test-storybook:ci':
+                  'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn build-storybook --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
+              },
+              official: {},
             },
-            official: {},
-          },
-          storybookVersion: '^7.0.0-alpha.0',
-        });
+            storybookVersion: '^7.0.0-alpha.0',
+          })
+        );
       });
 
       describe('with old official and custom scripts', () => {
@@ -156,19 +160,21 @@ describe('sb scripts fix', () => {
             checkSbScripts({
               packageJson,
             })
-          ).resolves.toEqual({
-            storybookScripts: {
-              custom: {
-                'storybook:build': 'build-storybook -o buid/storybook',
-                'test-storybook:ci':
-                  'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn build-storybook --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
+          ).resolves.toEqual(
+            expect.objectContaining({
+              storybookScripts: {
+                custom: {
+                  'storybook:build': 'build-storybook -o buid/storybook',
+                  'test-storybook:ci':
+                    'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn build-storybook --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
+                },
+                official: {
+                  storybook: 'storybook dev -p 6006',
+                },
               },
-              official: {
-                storybook: 'storybook dev -p 6006',
-              },
-            },
-            storybookVersion: '^7.0.0-alpha.0',
-          });
+              storybookVersion: '^7.0.0-alpha.0',
+            })
+          );
         });
       });
 

--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
@@ -79,7 +79,7 @@ export const sbScripts: Fix<SbScriptsRunOptions> = {
         .replace('build-storybook', 'storybook build');
     });
 
-    return semver.gte(storybookCoerced, '6.0.0')
+    return semver.gte(storybookCoerced, '7.0.0')
       ? { packageJson, storybookScripts, storybookVersion }
       : null;
   },

--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
@@ -3,6 +3,8 @@ import { dedent } from 'ts-dedent';
 import semver from '@storybook/semver';
 import { getStorybookInfo } from '@storybook/core-common';
 import { Fix } from '../types';
+import { getStorybookVersionSpecifier } from '../../helpers';
+import { PackageJsonWithDepsAndDevDeps } from '../../js-package-manager';
 
 interface SbScriptsRunOptions {
   storybookScripts: {
@@ -10,6 +12,7 @@ interface SbScriptsRunOptions {
     official: Record<string, string>;
   };
   storybookVersion: string;
+  packageJson: PackageJsonWithDepsAndDevDeps;
 }
 
 const logger = console;
@@ -76,7 +79,9 @@ export const sbScripts: Fix<SbScriptsRunOptions> = {
         .replace('build-storybook', 'storybook build');
     });
 
-    return semver.gte(storybookCoerced, '6.0.0') ? { storybookScripts, storybookVersion } : null;
+    return semver.gte(storybookCoerced, '6.0.0')
+      ? { packageJson, storybookScripts, storybookVersion }
+      : null;
   },
 
   prompt({ storybookVersion }) {
@@ -104,13 +109,16 @@ export const sbScripts: Fix<SbScriptsRunOptions> = {
       .join('\n\n');
   },
 
-  async run({ result: { storybookScripts }, packageManager, dryRun }) {
+  async run({ result: { storybookScripts, packageJson }, packageManager, dryRun }) {
     logger.log();
     logger.info(`Adding 'storybook' as dev dependency`);
     logger.log();
 
     if (!dryRun) {
-      packageManager.addDependencies({ installAsDevDependencies: true }, ['storybook']);
+      const versionToInstall = getStorybookVersionSpecifier(packageJson);
+      packageManager.addDependencies({ installAsDevDependencies: true }, [
+        `storybook@${versionToInstall}`,
+      ]);
     }
 
     logger.info(`Updating scripts in package.json`);

--- a/code/lib/cli/src/helpers.test.ts
+++ b/code/lib/cli/src/helpers.test.ts
@@ -109,7 +109,7 @@ describe('Helpers', () => {
     ).rejects.toThrowError(expectedMessage);
   });
 
-  describe.only('getStorybookVersionSpecifier', () => {
+  describe('getStorybookVersionSpecifier', () => {
     it(`should return the specifier if storybook lib exists in package.json`, () => {
       expect(
         helpers.getStorybookVersionSpecifier({

--- a/code/lib/cli/src/helpers.test.ts
+++ b/code/lib/cli/src/helpers.test.ts
@@ -108,4 +108,28 @@ describe('Helpers', () => {
       helpers.copyComponents(framework, SupportedLanguage.JAVASCRIPT)
     ).rejects.toThrowError(expectedMessage);
   });
+
+  describe.only('getStorybookVersionSpecifier', () => {
+    it(`should return the specifier if storybook lib exists in package.json`, () => {
+      expect(
+        helpers.getStorybookVersionSpecifier({
+          dependencies: {},
+          devDependencies: {
+            '@storybook/react': '^x.x.x',
+          },
+        })
+      ).toEqual('^x.x.x');
+    });
+
+    it(`should throw an error if no package is found`, () => {
+      expect(() => {
+        helpers.getStorybookVersionSpecifier({
+          dependencies: {},
+          devDependencies: {
+            'something-else': '^x.x.x',
+          },
+        });
+      }).toThrowError("Couldn't find any official storybook packages in package.json");
+    });
+  });
 });

--- a/code/lib/cli/src/helpers.ts
+++ b/code/lib/cli/src/helpers.ts
@@ -9,6 +9,7 @@ import stripJsonComments from 'strip-json-comments';
 import { SupportedRenderers, SupportedLanguage } from './project_types';
 import { JsPackageManager, PackageJson, PackageJsonWithDepsAndDevDeps } from './js-package-manager';
 import { getBaseDir } from './dirs';
+import storybookMonorepoPackages from './versions';
 
 const logger = console;
 
@@ -221,4 +222,21 @@ export async function copyComponents(framework: SupportedRenderers, language: Su
   await fse.copy(join(getBaseDir(), 'frameworks/common'), destinationPath, {
     overwrite: true,
   });
+}
+
+// Given a package.json, finds any official storybook package within it
+// and if it exists, returns the version of that package from the specified package.json
+export function getStorybookVersionSpecifier(packageJson: PackageJsonWithDepsAndDevDeps) {
+  const allDeps = { ...packageJson.dependencies, ...packageJson.devDependencies };
+  const storybookPackage = Object.keys(allDeps).find(
+    (name: keyof typeof storybookMonorepoPackages) => {
+      return storybookMonorepoPackages[name];
+    }
+  );
+
+  if (!storybookPackage) {
+    throw new Error(`Couldn't find any official storybook packages in package.json`);
+  }
+
+  return allDeps[storybookPackage];
 }


### PR DESCRIPTION
Issue: N/A

## What I did

The sb-scripts were doing a couple things that could result in a wrong structure in users' projects:

- It was running on Storybook >=6
- It was installing `storybook@latest`

This PR fixes both scenarios to:
- Run on Storybook >= 7
- Install `storybook@<specifier>`

The <specifier> comes from a new utility called `getStorybookVersionSpecifier` which will install the lib with the same specifier as the one from other @storybook packages. This is assuming that the @storybook packages are consistent when running this migration (something we will work on later to make sure it's always right)

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
