### PR TITLE
Add ability to selectively hide columns on ArgsTable

### DIFF
--- a/code/lib/blocks/src/components/ArgsTable/ArgRow.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgRow.tsx
@@ -1,12 +1,12 @@
-import React, { FC } from 'react';
+import { codeCommon } from '@storybook/components';
+import { styled } from '@storybook/theming';
 import Markdown from 'markdown-to-jsx';
 import { transparentize } from 'polished';
-import { styled } from '@storybook/theming';
-import { codeCommon } from '@storybook/components';
-import { ArgType, Args, TableAnnotation, HidableColumn } from './types';
+import React, { FC } from 'react';
+import { ArgControl, ArgControlProps } from './ArgControl';
 import { ArgJsDoc } from './ArgJsDoc';
 import { ArgValue } from './ArgValue';
-import { ArgControl, ArgControlProps } from './ArgControl';
+import { Args, ArgType, HidableColumn, TableAnnotation } from './types';
 
 interface ArgRowProps {
   row: ArgType;
@@ -88,7 +88,7 @@ export const ArgRow: FC<ArgRowProps> = (props) => {
         <Name>{name}</Name>
         {required ? <Required title="Required">*</Required> : null}
       </StyledTd>
-      {compact || hideColumns?.includes('descrption') ? null : (
+      {compact || hideColumns?.includes('description') ? null : (
         <td>
           {hasDescription && (
             <Description>

--- a/code/lib/blocks/src/components/ArgsTable/ArgRow.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgRow.tsx
@@ -3,7 +3,7 @@ import Markdown from 'markdown-to-jsx';
 import { transparentize } from 'polished';
 import { styled } from '@storybook/theming';
 import { codeCommon } from '@storybook/components';
-import { ArgType, Args, TableAnnotation } from './types';
+import { ArgType, Args, TableAnnotation, HidableColumn } from './types';
 import { ArgJsDoc } from './ArgJsDoc';
 import { ArgValue } from './ArgValue';
 import { ArgControl, ArgControlProps } from './ArgControl';
@@ -15,6 +15,7 @@ interface ArgRowProps {
   compact?: boolean;
   expandable?: boolean;
   initialExpandedArgs?: boolean;
+  hideColumns: HidableColumn[];
 }
 
 const Name = styled.span({ fontWeight: 'bold' });
@@ -73,7 +74,7 @@ const StyledTd = styled.td<{ expandable: boolean }>(({ theme, expandable }) => (
 }));
 
 export const ArgRow: FC<ArgRowProps> = (props) => {
-  const { row, updateArgs, compact, expandable, initialExpandedArgs } = props;
+  const { row, updateArgs, compact, expandable, initialExpandedArgs, hideColumns } = props;
   const { name, description } = row;
   const table = (row.table || {}) as TableAnnotation;
   const type = table.type || row.type;
@@ -87,7 +88,7 @@ export const ArgRow: FC<ArgRowProps> = (props) => {
         <Name>{name}</Name>
         {required ? <Required title="Required">*</Required> : null}
       </StyledTd>
-      {compact ? null : (
+      {compact || hideColumns?.includes('descrption') ? null : (
         <td>
           {hasDescription && (
             <Description>
@@ -108,12 +109,12 @@ export const ArgRow: FC<ArgRowProps> = (props) => {
           )}
         </td>
       )}
-      {compact ? null : (
+      {compact || hideColumns?.includes('default') ? null : (
         <td>
           <ArgValue value={defaultValue} initialExpandedArgs={initialExpandedArgs} />
         </td>
       )}
-      {updateArgs ? (
+      {updateArgs && !hideColumns?.includes('control') ? (
         <td>
           <ArgControl {...(props as ArgControlProps)} />
         </td>

--- a/code/lib/blocks/src/components/ArgsTable/ArgsTable.stories.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgsTable.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { styled } from '@storybook/theming';
+import React from 'react';
+import * as ArgRow from './ArgRow.stories';
 import { ArgsTable, ArgsTableError } from './ArgsTable';
 import { NoControlsWarning } from './NoControlsWarning';
-import * as ArgRow from './ArgRow.stories';
 
 export default {
   component: ArgsTable,
@@ -160,7 +160,7 @@ export const HidingDefaultColumn = {
 };
 
 export const HidingDescriptionColumn = {
-  args: { ...Normal.args, inAddonPanel: true, hideColumns: ['descr'] },
+  args: { ...Normal.args, inAddonPanel: true, hideColumns: ['description'] },
   decorators: [(storyFn) => <AddonPanelLayout>{storyFn()}</AddonPanelLayout>],
 };
 

--- a/code/lib/blocks/src/components/ArgsTable/ArgsTable.stories.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgsTable.stories.tsx
@@ -153,3 +153,18 @@ export const WithDefaultExpandedArgs = {
     initialExpandedArgs: true,
   },
 };
+
+export const HidingDefaultColumn = {
+  args: { ...Normal.args, inAddonPanel: true, hideColumns: ['default'] },
+  decorators: [(storyFn) => <AddonPanelLayout>{storyFn()}</AddonPanelLayout>],
+};
+
+export const HidingDescriptionColumn = {
+  args: { ...Normal.args, inAddonPanel: true, hideColumns: ['descr'] },
+  decorators: [(storyFn) => <AddonPanelLayout>{storyFn()}</AddonPanelLayout>],
+};
+
+export const HidingControlColumn = {
+  args: { ...Normal.args, inAddonPanel: true, hideColumns: ['control'] },
+  decorators: [(storyFn) => <AddonPanelLayout>{storyFn()}</AddonPanelLayout>],
+};

--- a/code/lib/blocks/src/components/ArgsTable/ArgsTable.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgsTable.tsx
@@ -1,14 +1,14 @@
-import React, { FC } from 'react';
-import pickBy from 'lodash/pickBy';
-import { styled } from '@storybook/theming';
-import { opacify, transparentize, darken, lighten } from 'polished';
-import { includeConditionalArg } from '@storybook/csf';
 import { once } from '@storybook/client-logger';
 import { Icons, Link, ResetWrapper } from '@storybook/components';
+import { includeConditionalArg } from '@storybook/csf';
+import { styled } from '@storybook/theming';
+import pickBy from 'lodash/pickBy';
+import { darken, lighten, opacify, transparentize } from 'polished';
+import React, { FC } from 'react';
+import { EmptyBlock } from '..';
 import { ArgRow } from './ArgRow';
 import { SectionRow } from './SectionRow';
-import { ArgType, ArgTypes, Args, Globals, HidableColumn } from './types';
-import { EmptyBlock } from '..';
+import { Args, ArgType, ArgTypes, Globals, HidableColumn } from './types';
 
 export const TableWrapper = styled.table<{
   compact?: boolean;
@@ -459,7 +459,7 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
             <th>
               <span>Name</span>
             </th>
-            {compact || hideColumns?.includes('descrption') ? null : (
+            {compact || hideColumns?.includes('description') ? null : (
               <th>
                 <span>Description</span>
               </th>

--- a/code/lib/blocks/src/components/ArgsTable/ArgsTable.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgsTable.tsx
@@ -7,7 +7,7 @@ import { once } from '@storybook/client-logger';
 import { Icons, Link, ResetWrapper } from '@storybook/components';
 import { ArgRow } from './ArgRow';
 import { SectionRow } from './SectionRow';
-import { ArgType, ArgTypes, Args, Globals } from './types';
+import { ArgType, ArgTypes, Args, Globals, HidableColumn } from './types';
 import { EmptyBlock } from '..';
 
 export const TableWrapper = styled.table<{
@@ -267,6 +267,7 @@ export interface ArgsTableOptionProps {
   initialExpandedArgs?: boolean;
   isLoading?: boolean;
   sort?: SortType;
+  hideColumns?: HidableColumn[];
 }
 export interface ArgsTableDataProps {
   rows: ArgTypes;
@@ -411,6 +412,7 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     inAddonPanel,
     initialExpandedArgs,
     sort = 'none',
+    hideColumns,
   } = props;
   const isLoading = 'isLoading' in props;
   const { rows, args, globals } = 'rows' in props ? props : argsTableLoadingData;
@@ -443,7 +445,7 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   if (!compact) colSpan += 2;
   const expandable = Object.keys(groups.sections).length > 0;
 
-  const common = { updateArgs, compact, inAddonPanel, initialExpandedArgs };
+  const common = { updateArgs, compact, inAddonPanel, initialExpandedArgs, hideColumns };
 
   return (
     <ResetWrapper>
@@ -457,17 +459,17 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
             <th>
               <span>Name</span>
             </th>
-            {compact ? null : (
+            {compact || hideColumns?.includes('descrption') ? null : (
               <th>
                 <span>Description</span>
               </th>
             )}
-            {compact ? null : (
+            {compact || hideColumns?.includes('default') ? null : (
               <th>
                 <span>Default</span>
               </th>
             )}
-            {updateArgs ? (
+            {updateArgs && !hideColumns?.includes('control') ? (
               <th>
                 <ControlHeadingWrapper>
                   Control{' '}

--- a/code/lib/blocks/src/components/ArgsTable/types.ts
+++ b/code/lib/blocks/src/components/ArgsTable/types.ts
@@ -47,3 +47,5 @@ export interface Args {
 }
 
 export type Globals = { [name: string]: any };
+
+export type HidableColumn = 'descrption' | 'default' | 'control';

--- a/code/lib/blocks/src/components/ArgsTable/types.ts
+++ b/code/lib/blocks/src/components/ArgsTable/types.ts
@@ -48,4 +48,4 @@ export interface Args {
 
 export type Globals = { [name: string]: any };
 
-export type HidableColumn = 'descrption' | 'default' | 'control';
+export type HidableColumn = 'description' | 'default' | 'control';

--- a/docs/snippets/common/component-story-mdx-argstable-hide-columns.with-story.mdx.mdx
+++ b/docs/snippets/common/component-story-mdx-argstable-hide-columns.with-story.mdx.mdx
@@ -1,0 +1,17 @@
+```md
+<!-- MyComponent.stories.mdx -->
+
+import { ArgsTable, Meta, Story } from '@storybook/addon-docs';
+
+import { MyComponent } from './MyComponent';
+
+<Meta title="MyComponent" component={MyComponent} />
+
+# My Component!
+
+<Story 
+  name="My Story"
+  render={() => ({ // Your implementation here })} />
+
+<ArgsTable story="My Story" hideColumns={['default','description']} />
+```

--- a/docs/writing-docs/doc-block-argstable.md
+++ b/docs/writing-docs/doc-block-argstable.md
@@ -48,11 +48,11 @@ To use the `ArgsTable` in [DocsPage](./docs-page.md#component-parameter), export
 
 If you need, you can also include the `ArgsTable` block in your MDX stories. Below is a condensed table of available options and examples:
 
-| Option        | Description                                                                                         |
-| -------       | --------------------------------------------------------------------------------------------------- |
-| `of`          | Infers the args table from the component. <br/> `<ArgsTable of={MyComponent} />`                    |
-| `story`       | Infers the args table based on a story. <br/> `<ArgsTable story="example-mycomponent--my-story" />` |
-| `hideColumns` | An array of columns to hide. Hidable Columns: `descrption`, `default`, `control`. <br/> `<ArgsTable of={MyComponent} hideColumns={['default', 'description']}` |
+| Option        | Description                                                                                                                                                       |
+| -------       | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `of`          | Infers the args table from the component. <br/> `<ArgsTable of={MyComponent} />`                                                                                  |
+| `story`       | Infers the args table based on a story. <br/> `<ArgsTable story="example-mycomponent--my-story" />`                                                               |
+| `hideColumns` | An array of columns to hide. Hidable Columns: `descrption`, `default`, `control`. <br/> `<ArgsTable of={MyComponent} hideColumns={['default', 'description']} />` |
 
 <!-- prettier-ignore-start -->
 
@@ -60,6 +60,7 @@ If you need, you can also include the `ArgsTable` block in your MDX stories. Bel
   paths={[
     'common/component-story-mdx-argstable-block-for-component.with-component.mdx.mdx',
     'common/component-story-mdx-argstable-block-for-story.with-story.mdx.mdx',
+    'common/component-story-mdx-argstable-hide-columns.with-story.mdx.mdx'
   ]}
 />
 

--- a/docs/writing-docs/doc-block-argstable.md
+++ b/docs/writing-docs/doc-block-argstable.md
@@ -48,10 +48,11 @@ To use the `ArgsTable` in [DocsPage](./docs-page.md#component-parameter), export
 
 If you need, you can also include the `ArgsTable` block in your MDX stories. Below is a condensed table of available options and examples:
 
-| Option  | Description                                                                                         |
-| ------- | --------------------------------------------------------------------------------------------------- |
-| `of`    | Infers the args table from the component. <br/> `<ArgsTable of={MyComponent} />`                    |
-| `story` | Infers the args table based on a story. <br/> `<ArgsTable story="example-mycomponent--my-story" />` |
+| Option        | Description                                                                                         |
+| -------       | --------------------------------------------------------------------------------------------------- |
+| `of`          | Infers the args table from the component. <br/> `<ArgsTable of={MyComponent} />`                    |
+| `story`       | Infers the args table based on a story. <br/> `<ArgsTable story="example-mycomponent--my-story" />` |
+| `hideColumns` | An array of columns to hide. Hidable Columns: `descrption`, `default`, `control`. <br/> `<ArgsTable of={MyComponent} hideColumns={['default', 'description']}` |
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
Issue: #16179

## What I did
- Added a `hideColumns` prop to the ArgsTable component.
  - It allows for hiding the description, default, and control columns
- Added stories for each column being hidden
- Updated docs to include new prop

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?
