### PR TITLE
Disable telemetry in monorepo and CI

### DIFF
--- a/scripts/repros-generator/templates/next/.stackblitzrc
+++ b/scripts/repros-generator/templates/next/.stackblitzrc
@@ -1,4 +1,4 @@
 {
   "installDependencies": true,
-  "startCommand": "yarn storybook"
+  "startCommand": "STORYBOOK_DISABLE_TELEMETRY=1 yarn storybook"
 }

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -308,6 +308,7 @@ export async function sandbox(optionValues: OptionValues<typeof options>) {
       ['previewEntries'],
       [`.${path.sep}${path.join(storiesPath, 'components')}`]
     );
+    mainConfig.setFieldValue(['core', 'disableTelemetry'], true);
 
     const storiesToAdd = [] as string[];
     storiesToAdd.push(rendererPath);

--- a/scripts/utils/cli-step.ts
+++ b/scripts/utils/cli-step.ts
@@ -34,7 +34,12 @@ export async function executeCLIStep<TOptions extends OptionSpecifier>(
 
   await exec(
     command,
-    { cwd: options.cwd },
+    {
+      cwd: options.cwd,
+      env: {
+        STORYBOOK_DISABLE_TELEMETRY: 'true',
+      },
+    },
     {
       startMessage: `${cliStep.icon} ${cliStep.description}`,
       errorMessage: `🚨 ${cliStep.description} failed`,


### PR DESCRIPTION
Issue: N/A

## What I did

Disabled telemetry in:
- stackblitz repros
- sandbox commands
- sandbox generated projects

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
