### PR TITLE
Exit sandbox gracefully on cancel

### DIFF
--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -234,7 +234,12 @@ export async function promptOptions<TOptions extends OptionSpecifier>(
     };
   });
 
-  const selection = await prompts(questions);
+  const selection = await prompts(questions, {
+    onCancel: () => {
+      console.log('Command cancelled by the user. Exiting...');
+      process.exit(0);
+    },
+  });
   // Again the structure of the questions guarantees we get responses of the type we need
   return selection as OptionValues<TOptions>;
 }

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -237,7 +237,7 @@ export async function promptOptions<TOptions extends OptionSpecifier>(
   const selection = await prompts(questions, {
     onCancel: () => {
       console.log('Command cancelled by the user. Exiting...');
-      process.exit(0);
+      process.exit(1);
     },
   });
   // Again the structure of the questions guarantees we get responses of the type we need


### PR DESCRIPTION
Issue: N/A

## What I did

When using sandbox and cancelling (e.g. ctrl C) mid prompts:

before:
![image](https://user-images.githubusercontent.com/1671563/184604889-dad3314f-79ae-4e17-8022-82503df49540.png)

after:
![image](https://user-images.githubusercontent.com/1671563/184604902-8a85e89b-1b12-4268-b87f-5cdbb4370f1a.png)


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
