### PR TITLE
Build: Use ts-up to build addon-viewport

### DIFF
--- a/code/addons/viewport/manager.js
+++ b/code/addons/viewport/manager.js
@@ -1,1 +1,1 @@
-import './dist/esm/manager';
+import './dist/manager';

--- a/code/addons/viewport/package.json
+++ b/code/addons/viewport/package.json
@@ -22,9 +22,32 @@
     "url": "https://opencollective.com/storybook"
   },
   "license": "MIT",
-  "main": "dist/cjs/preview.js",
-  "module": "dist/esm/preview.js",
-  "types": "dist/types/preview.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./manager": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./preview": {
+      "require": "./dist/preview.ts",
+      "import": "./dist/preview.mjs",
+      "types": "./dist/preview.d.ts"
+    },
+    "./register.js": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
     "README.md",
@@ -33,7 +56,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prepare": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",
@@ -64,6 +87,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/index.ts",
+      "./src/models/index.ts",
+      "./src/manager.tsx",
+      "./src/preview.ts"
+    ]
   },
   "gitHead": "0900e20acfbc12551c6a3f788b8de5dd6af5f80a",
   "storybook": {

--- a/code/addons/viewport/src/index.ts
+++ b/code/addons/viewport/src/index.ts
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './defaults';
+export * from './shortcuts';


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18732

## What I did

Migrated `addon-viewport` to use the `ts-up` bundler.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots? No
- [ ] Does this need a new example in the kitchen sink apps? No
- [ ] Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
