### PR TITLE
fix(generator): use devDependencies to determine angular/core version for init

### DIFF
--- a/code/lib/cli/src/generators/ANGULAR/index.ts
+++ b/code/lib/cli/src/generators/ANGULAR/index.ts
@@ -31,9 +31,15 @@ function editAngularAppTsConfig() {
 const generator: Generator = async (packageManager, npmOptions, options) => {
   checkForProjects();
 
-  const angularVersion = semver.coerce(
+  const angularVersionFromDependencies = semver.coerce(
     packageManager.retrievePackageJson().dependencies['@angular/core']
   )?.version;
+
+  const angularVersionFromDevDependencies = semver.coerce(
+    packageManager.retrievePackageJson().devDependencies['@angular/core']
+  )?.version;
+  
+  const angularVersion = angularVersionFromDependencies || angularVersionFromDevDependencies;
   const isWebpack5 = semver.gte(angularVersion, '12.0.0');
   const updatedOptions = isWebpack5 ? { ...options, builder: CoreBuilder.Webpack5 } : options;
 


### PR DESCRIPTION
When determining the existing project angular/core version, from now we can use devDepencies too.

Issue:

## What I did
Added support retrieving angular/core version from devDependencies in package.json

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
