### PR TITLE
Repros: Add ability to generate repros using local registry

### DIFF
--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -41,6 +41,8 @@ export abstract class JsPackageManager {
 
   public abstract setRegistryURL(url: string): void;
 
+  public abstract getRegistryURL(): string;
+
   public readonly cwd?: string;
 
   constructor({ cwd }: JsPackageManagerOptions) {

--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -326,11 +326,22 @@ export abstract class JsPackageManager {
     });
   }
 
+  public addPackageResolutions(versions: Record<string, string>) {
+    const packageJson = this.retrievePackageJson();
+    const resolutions = this.getResolutions(packageJson, versions);
+    this.writePackageJson({ ...packageJson, ...resolutions });
+  }
+
   protected abstract runInstall(): void;
 
   protected abstract runAddDeps(dependencies: string[], installAsDevDependencies: boolean): void;
 
   protected abstract runRemoveDeps(dependencies: string[]): void;
+
+  protected abstract getResolutions(
+    packageJson: PackageJson,
+    versions: Record<string, string>
+  ): Record<string, any>;
 
   /**
    * Get the latest or all versions of the input package available on npmjs.com

--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -45,8 +45,8 @@ export abstract class JsPackageManager {
 
   public readonly cwd?: string;
 
-  constructor({ cwd }: JsPackageManagerOptions) {
-    this.cwd = cwd;
+  constructor(options?: JsPackageManagerOptions) {
+    this.cwd = options?.cwd;
   }
 
   /**

--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -36,6 +36,8 @@ export abstract class JsPackageManager {
 
   public abstract getRunCommand(command: string): string;
 
+  public abstract setRegistryURL(url: string): void;
+
   /**
    * Install dependencies listed in `package.json`
    */

--- a/code/lib/cli/src/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManagerFactory.ts
@@ -6,22 +6,22 @@ import { Yarn2Proxy } from './Yarn2Proxy';
 import { Yarn1Proxy } from './Yarn1Proxy';
 
 export class JsPackageManagerFactory {
-  public static getPackageManager(forceNpmUsage = false): JsPackageManager {
+  public static getPackageManager(forceNpmUsage = false, cwd?: string): JsPackageManager {
     if (forceNpmUsage) {
-      return new NPMProxy();
+      return new NPMProxy({ cwd });
     }
 
     const yarnVersion = getYarnVersion();
-    const hasYarnLockFile = findUpSync('yarn.lock');
+    const hasYarnLockFile = findUpSync('yarn.lock', { cwd });
 
     const hasNPMCommand = hasNPM();
 
     if (yarnVersion && (hasYarnLockFile || !hasNPMCommand)) {
-      return yarnVersion === 1 ? new Yarn1Proxy() : new Yarn2Proxy();
+      return yarnVersion === 1 ? new Yarn1Proxy({ cwd }) : new Yarn2Proxy({ cwd });
     }
 
     if (hasNPMCommand) {
-      return new NPMProxy();
+      return new NPMProxy({ cwd });
     }
 
     throw new Error('Unable to find a usable package manager within NPM, Yarn and Yarn 2');

--- a/code/lib/cli/src/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManagerFactory.ts
@@ -11,10 +11,10 @@ export class JsPackageManagerFactory {
       return new NPMProxy({ cwd });
     }
 
-    const yarnVersion = getYarnVersion();
+    const yarnVersion = getYarnVersion(cwd);
     const hasYarnLockFile = findUpSync('yarn.lock', { cwd });
 
-    const hasNPMCommand = hasNPM();
+    const hasNPMCommand = hasNPM(cwd);
 
     if (yarnVersion && (hasYarnLockFile || !hasNPMCommand)) {
       return yarnVersion === 1 ? new Yarn1Proxy({ cwd }) : new Yarn2Proxy({ cwd });
@@ -28,13 +28,13 @@ export class JsPackageManagerFactory {
   }
 }
 
-function hasNPM() {
-  const npmVersionCommand = spawnSync('npm', ['--version']);
+function hasNPM(cwd?: string) {
+  const npmVersionCommand = spawnSync('npm', ['--version'], { cwd });
   return npmVersionCommand.status === 0;
 }
 
-function getYarnVersion(): 1 | 2 | undefined {
-  const yarnVersionCommand = spawnSync('yarn', ['--version']);
+function getYarnVersion(cwd?: string): 1 | 2 | undefined {
+  const yarnVersionCommand = spawnSync('yarn', ['--version'], { cwd });
 
   if (yarnVersionCommand.status !== 0) {
     return undefined;

--- a/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
@@ -21,6 +21,21 @@ describe('NPM Proxy', () => {
     });
   });
 
+  describe('setRegistryUrl', () => {
+    it('should run `npm config set registry https://foo.bar`', () => {
+      const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('');
+
+      npmProxy.setRegistryURL('https://foo.bar');
+
+      expect(executeCommandSpy).toHaveBeenCalledWith('npm', [
+        'config',
+        'set',
+        'registry',
+        'https://foo.bar',
+      ]);
+    });
+  });
+
   describe('installDependencies', () => {
     describe('npm6', () => {
       it('should run `npm install`', () => {

--- a/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
@@ -204,4 +204,30 @@ describe('NPM Proxy', () => {
       expect(version).toEqual(`^${packageVersion}`);
     });
   });
+
+  describe('addPackageResolutions', () => {
+    it('adds resolutions to package.json and account for existing resolutions', () => {
+      const writePackageSpy = jest.spyOn(npmProxy, 'writePackageJson').mockImplementation(jest.fn);
+
+      jest.spyOn(npmProxy, 'retrievePackageJson').mockImplementation(
+        jest.fn(() => ({
+          overrides: {
+            bar: 'x.x.x',
+          },
+        }))
+      );
+
+      const versions = {
+        foo: 'x.x.x',
+      };
+      npmProxy.addPackageResolutions(versions);
+
+      expect(writePackageSpy).toHaveBeenCalledWith({
+        overrides: {
+          ...versions,
+          bar: 'x.x.x',
+        },
+      });
+    });
+  });
 });

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -61,6 +61,11 @@ export class NPMProxy extends JsPackageManager {
     return this.uninstallArgs;
   }
 
+  setRegistryURL(url: string) {
+    const args = ['config', 'set', 'registry', url];
+    this.executeCommand('npm', args);
+  }
+
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
     return {
       overrides: {

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -1,5 +1,6 @@
 import semver from '@storybook/semver';
 import { JsPackageManager } from './JsPackageManager';
+import type { PackageJson } from './PackageJson';
 
 export class NPMProxy extends JsPackageManager {
   readonly type = 'npm';
@@ -58,6 +59,15 @@ export class NPMProxy extends JsPackageManager {
         : ['uninstall'];
     }
     return this.uninstallArgs;
+  }
+
+  protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
+    return {
+      overrides: {
+        ...packageJson.overrides,
+        ...versions,
+      },
+    };
   }
 
   protected runInstall(): void {

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -62,8 +62,15 @@ export class NPMProxy extends JsPackageManager {
   }
 
   setRegistryURL(url: string) {
-    const args = ['config', 'set', 'registry', url];
-    this.executeCommand('npm', args);
+    if (url) {
+      this.executeCommand('npm', ['config', 'set', 'registry', url]);
+    } else {
+      this.executeCommand('npm', ['config', 'delete', 'registry']);
+    }
+  }
+
+  getRegistryURL() {
+    return this.executeCommand('npm', ['config', 'get', 'registry']).trim();
   }
 
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -70,7 +70,8 @@ export class NPMProxy extends JsPackageManager {
   }
 
   getRegistryURL() {
-    return this.executeCommand('npm', ['config', 'get', 'registry']).trim();
+    const url = this.executeCommand('npm', ['config', 'get', 'registry']).trim();
+    return url === 'undefined' ? undefined : url;
   }
 
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
@@ -21,6 +21,21 @@ describe('Yarn 1 Proxy', () => {
     });
   });
 
+  describe('setRegistryUrl', () => {
+    it('should run `yarn config set npmRegistryServer https://foo.bar`', () => {
+      const executeCommandSpy = jest.spyOn(yarn1Proxy, 'executeCommand').mockReturnValue('');
+
+      yarn1Proxy.setRegistryURL('https://foo.bar');
+
+      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', [
+        'config',
+        'set',
+        'npmRegistryServer',
+        'https://foo.bar',
+      ]);
+    });
+  });
+
   describe('installDependencies', () => {
     it('should run `yarn`', () => {
       const executeCommandSpy = jest.spyOn(yarn1Proxy, 'executeCommand').mockReturnValue('');

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
@@ -125,4 +125,32 @@ describe('Yarn 1 Proxy', () => {
       await expect(yarn1Proxy.latestVersion('@storybook/addons')).rejects.toThrow();
     });
   });
+
+  describe('addPackageResolutions', () => {
+    it('adds resolutions to package.json and account for existing resolutions', () => {
+      const writePackageSpy = jest
+        .spyOn(yarn1Proxy, 'writePackageJson')
+        .mockImplementation(jest.fn);
+
+      jest.spyOn(yarn1Proxy, 'retrievePackageJson').mockImplementation(
+        jest.fn(() => ({
+          resolutions: {
+            bar: 'x.x.x',
+          },
+        }))
+      );
+
+      const versions = {
+        foo: 'x.x.x',
+      };
+      yarn1Proxy.addPackageResolutions(versions);
+
+      expect(writePackageSpy).toHaveBeenCalledWith({
+        resolutions: {
+          ...versions,
+          bar: 'x.x.x',
+        },
+      });
+    });
+  });
 });

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -1,4 +1,5 @@
 import { JsPackageManager } from './JsPackageManager';
+import type { PackageJson } from './PackageJson';
 
 export class Yarn1Proxy extends JsPackageManager {
   readonly type = 'yarn1';
@@ -13,6 +14,15 @@ export class Yarn1Proxy extends JsPackageManager {
 
   getRunCommand(command: string): string {
     return `yarn ${command}`;
+  }
+
+  protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
+    return {
+      resolutions: {
+        ...packageJson.resolutions,
+        ...versions,
+      },
+    };
   }
 
   protected runInstall(): void {

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -16,6 +16,11 @@ export class Yarn1Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
+  setRegistryURL(url: string) {
+    const args = ['config', 'set', 'npmRegistryServer', url];
+    this.executeCommand('yarn', args);
+  }
+
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
     return {
       resolutions: {

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -17,8 +17,16 @@ export class Yarn1Proxy extends JsPackageManager {
   }
 
   setRegistryURL(url: string) {
-    const args = ['config', 'set', 'npmRegistryServer', url];
-    this.executeCommand('yarn', args);
+    if (url) {
+      this.executeCommand('yarn', ['config', 'set', 'npmRegistryServer', url]);
+    } else {
+      this.executeCommand('yarn', ['config', 'delete', 'npmRegistryServer']);
+    }
+  }
+
+  getRegistryURL() {
+    const url = this.executeCommand('yarn', ['config', 'get', 'npmRegistryServer']).trim();
+    return url === 'undefined' ? undefined : url;
   }
 
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
@@ -31,6 +31,21 @@ describe('Yarn 2 Proxy', () => {
     });
   });
 
+  describe('setRegistryUrl', () => {
+    it('should run `yarn config set npmRegistryServer https://foo.bar`', () => {
+      const executeCommandSpy = jest.spyOn(yarn2Proxy, 'executeCommand').mockReturnValue('');
+
+      yarn2Proxy.setRegistryURL('https://foo.bar');
+
+      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', [
+        'config',
+        'set',
+        'npmRegistryServer',
+        'https://foo.bar',
+      ]);
+    });
+  });
+
   describe('addDependencies', () => {
     it('with devDep it should run `yarn install -D @storybook/addons`', () => {
       const executeCommandSpy = jest.spyOn(yarn2Proxy, 'executeCommand').mockReturnValue('');

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
@@ -131,4 +131,32 @@ describe('Yarn 2 Proxy', () => {
       await expect(yarn2Proxy.latestVersion('@storybook/addons')).rejects.toThrow();
     });
   });
+
+  describe('addPackageResolutions', () => {
+    it('adds resolutions to package.json and account for existing resolutions', () => {
+      const writePackageSpy = jest
+        .spyOn(yarn2Proxy, 'writePackageJson')
+        .mockImplementation(jest.fn);
+
+      jest.spyOn(yarn2Proxy, 'retrievePackageJson').mockImplementation(
+        jest.fn(() => ({
+          resolutions: {
+            bar: 'x.x.x',
+          },
+        }))
+      );
+
+      const versions = {
+        foo: 'x.x.x',
+      };
+      yarn2Proxy.addPackageResolutions(versions);
+
+      expect(writePackageSpy).toHaveBeenCalledWith({
+        resolutions: {
+          ...versions,
+          bar: 'x.x.x',
+        },
+      });
+    });
+  });
 });

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -1,4 +1,5 @@
 import { JsPackageManager } from './JsPackageManager';
+import type { PackageJson } from './PackageJson';
 
 export class Yarn2Proxy extends JsPackageManager {
   readonly type = 'yarn2';
@@ -13,6 +14,15 @@ export class Yarn2Proxy extends JsPackageManager {
 
   getRunCommand(command: string): string {
     return `yarn ${command}`;
+  }
+
+  protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
+    return {
+      resolutions: {
+        ...packageJson.resolutions,
+        ...versions,
+      },
+    };
   }
 
   protected runInstall(): void {

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -17,8 +17,16 @@ export class Yarn2Proxy extends JsPackageManager {
   }
 
   setRegistryURL(url: string) {
-    const args = ['config', 'set', 'npmRegistryServer', url];
-    this.executeCommand('yarn', args);
+    if (url) {
+      this.executeCommand('yarn', ['config', 'set', 'npmRegistryServer', url]);
+    } else {
+      this.executeCommand('yarn', ['config', 'delete', 'npmRegistryServer']);
+    }
+  }
+
+  getRegistryURL() {
+    const url = this.executeCommand('yarn', ['config', 'get', 'npmRegistryServer']).trim();
+    return url === 'undefined' ? undefined : url;
   }
 
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -16,6 +16,11 @@ export class Yarn2Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
+  setRegistryURL(url: string) {
+    const args = ['config', 'set', 'npmRegistryServer', url];
+    this.executeCommand('yarn', args);
+  }
+
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
     return {
       resolutions: {

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -16,12 +16,33 @@ import { maxConcurrentTasks } from '../utils/concurrency';
 import { localizeYarnConfigFiles, setupYarn } from './utils/yarn';
 import { GeneratorConfig } from './utils/types';
 import { getStackblitzUrl, renderTemplate } from './utils/template';
+import { JsPackageManager } from '../../code/lib/cli/src/js-package-manager';
 
 const OUTPUT_DIRECTORY = join(__dirname, '..', '..', 'repros');
 const BEFORE_DIR_NAME = 'before-storybook';
 const AFTER_DIR_NAME = 'after-storybook';
 
-const addStorybook = async (baseDir: string) => {
+const sbInit = async (cwd: string) => {
+  const sbCliBinaryPath = join(__dirname, `../../code/lib/cli/bin/index.js`);
+  console.log(`🎁 Installing storybook`);
+  const env = { STORYBOOK_DISABLE_TELEMETRY: 'true' };
+  await runCommand(`${sbCliBinaryPath} init`, { cwd, env });
+};
+
+const LOCAL_REGISTRY_URL = 'http://localhost:6000';
+const withLocalRegistry = async (packageManager: JsPackageManager, action: () => Promise<void>) => {
+  const prevUrl = packageManager.getRegistryURL();
+  try {
+    console.log(`📦 Configuring local registry: ${LOCAL_REGISTRY_URL}`);
+    packageManager.setRegistryURL(LOCAL_REGISTRY_URL);
+    await action();
+  } finally {
+    console.log(`📦 Restoring registry: ${prevUrl}`);
+    packageManager.setRegistryURL(prevUrl);
+  }
+};
+
+const addStorybook = async (baseDir: string, localRegistry: boolean) => {
   const beforeDir = join(baseDir, BEFORE_DIR_NAME);
   const afterDir = join(baseDir, AFTER_DIR_NAME);
   const tmpDir = join(baseDir, 'tmp');
@@ -31,14 +52,16 @@ const addStorybook = async (baseDir: string) => {
 
   await copy(beforeDir, tmpDir);
 
-  const sbCliBinaryPath = join(__dirname, `../../code/lib/cli/bin/index.js`);
-  await runCommand(`${sbCliBinaryPath} init`, {
-    cwd: tmpDir,
-    env: {
-      STORYBOOK_DISABLE_TELEMETRY: 'true',
-    },
-  });
+  const packageManager = JsPackageManagerFactory.getPackageManager(false, tmpDir);
+  if (localRegistry) {
+    await withLocalRegistry(packageManager, async () => {
+      packageManager.addPackageResolutions(storybookVersions);
 
+      await sbInit(tmpDir);
+    });
+  } else {
+    await sbInit(tmpDir);
+  }
   await rename(tmpDir, afterDir);
 };
 
@@ -92,22 +115,11 @@ const runGenerators = async (
 
         await setupYarn({ cwd: baseDir });
 
-        const packageManager = JsPackageManagerFactory.getPackageManager();
-
         await runCommand(script, { cwd: beforeDir });
 
         await localizeYarnConfigFiles(baseDir, beforeDir);
 
-        if (localRegistry) {
-          // TODO: find a good way to have all this run in the correct cwd (beforeDir)
-          console.log(`📦 Configuring local registry`);
-          packageManager.addPackageResolutions(storybookVersions);
-          packageManager.setRegistryURL('https://foo.bar');
-          // TODO: remove this after we make sure the cwd is correct
-          process.exit(0);
-        }
-
-        await addStorybook(baseDir);
+        await addStorybook(baseDir, localRegistry);
 
         await addDocumentation(baseDir, { name, dirName });
 

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -99,6 +99,10 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
+  '@storybook/babel-plugin-require-context-hook':
+    access: $all
+    publish: $all
+    proxy: npmjs
 
   # storybook packages are NOT proxied to global registry
   # allowing us to republish any version during tests


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] PackageManager: Add package resolutions
- [x] PackageManager: Add registry utilities
- [x] PackageManager: Add ability to run in a different cwd
- [x] generate-repros: Add filter/local-registry options

## How to test

```
yarn generate-repros-next --template cra/default-js --local-registry
```
