### PR TITLE
CI: use runner with playwright installed for cra_bench

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,19 @@ executors:
         environment:
           NODE_OPTIONS: --max_old_space_size=3076
     resource_class: <<parameters.class>>
+  sb_playwright:
+    parameters:
+      class:
+        description: The Resource class
+        type: enum
+        enum: ['small', 'medium', 'medium+', 'large', 'xlarge']
+        default: 'medium'
+    working_directory: /tmp/storybook
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.24.0-focal
+        environment:
+          NODE_OPTIONS: --max_old_space_size=3076
+    resource_class: <<parameters.class>>
 
 orbs:
   git-shallow-clone: guitarrapc/git-shallow-clone@2.0.3
@@ -277,18 +290,13 @@ jobs:
   cra-bench:
     executor:
       class: medium
-      name: sb_cypress_8_node_14
+      name: sb_playwright
     working_directory: /tmp/storybook
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
-      - run:
-          name: install playright
-          command: |
-            cd code
-            npx playwright install
       - run:
           name: Running local registry
           command: |
@@ -547,8 +555,9 @@ jobs:
       - store_test_results:
           path: code/test-results
   e2e-sandboxes:
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.24.0-focal
+    executor:
+      class: medium+
+      name: sb_playwright
     parallelism: 2
     steps:
       - git-shallow-clone/checkout_advanced:


### PR DESCRIPTION
Issue: N/A

## What I did

The cra_bench step is failing in CI because of missing playwright binaries

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
