### PR TITLE
Vue: Fix enum check in extractArgTypes

### DIFF
--- a/code/renderers/vue/src/docs/extractArgTypes.ts
+++ b/code/renderers/vue/src/docs/extractArgTypes.ts
@@ -11,7 +11,7 @@ const SECTIONS = ['props', 'events', 'slots', 'methods'];
 function isEnum(propDef: PropDef, docgenInfo: DocgenInfo): false | PropDef {
   // cast as any, since "values" doesn't exist in DocgenInfo type
   const { type, values } = docgenInfo as any;
-  const matched = Array.isArray(values) && values.length && type?.name !== 'enum';
+  const matched = Array.isArray(values) && values.length && type?.name === 'enum';
 
   if (!matched) {
     return false;


### PR DESCRIPTION
This is a followup to [PR#18710](https://github.com/storybookjs/storybook/pull/18710) as there was a second bug on the same line that wasn't apparent until my extra type check was implemented using nullish coallescing.

**If this can be included in v6.5.11 you have no idea how much of a help that would be for me personally on this particular client's work**

Issue:
The string check at the end of this line is wrong, allowing `null` or `undefined` to pass through to the rest of the method instead of returning `false`.

## What I did
```diff
// code/renderers/vue/src/docs/extractArgTypes.ts
- const matched = Array.isArray(values) && values.length && type?.name !== 'enum';
+ const matched = Array.isArray(values) && values.length && type?.name === 'enum';
```