### PR TITLE
CLI: auto-accept migrations when running `generate-repros-next`

### DIFF
--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -307,7 +307,7 @@ export async function initiate(options: CommandOptions, pkg: Package): Promise<v
     packageManager.installDependencies();
   }
 
-  await automigrate({ yes: process.env.CI === 'true' });
+  await automigrate({ yes: options.yes || process.env.CI === 'true' });
 
   logger.log('\nTo run your Storybook, type:\n');
   codeLog([packageManager.getRunStorybookCommand()]);

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -26,7 +26,7 @@ const sbInit = async (cwd: string) => {
   const sbCliBinaryPath = join(__dirname, `../../code/lib/cli/bin/index.js`);
   console.log(`🎁 Installing storybook`);
   const env = { STORYBOOK_DISABLE_TELEMETRY: 'true' };
-  await runCommand(`${sbCliBinaryPath} init`, { cwd, env });
+  await runCommand(`${sbCliBinaryPath} init --yes`, { cwd, env });
 };
 
 const LOCAL_REGISTRY_URL = 'http://localhost:6000';


### PR DESCRIPTION
Issue:

## What I did

1. Added `--yes` flag to `init` command run as part of `generate-repros-next`
2. Made the `automigrate` step of `init` respect `options.yes`

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? **No**
- [x] Does this need a new example in the kitchen sink apps? **No**
- [x] Does this need an update to the documentation? **No**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
