### PR TITLE
CLI: Fix local repro publishing

### DIFF
--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -39,9 +39,20 @@ export abstract class JsPackageManager {
 
   public abstract getRunCommand(command: string): string;
 
-  public abstract setRegistryURL(url: string): void;
+  // NOTE: for some reason yarn prefers the npm registry in
+  // local development, so always use npm
+  setRegistryURL(url: string) {
+    if (url) {
+      this.executeCommand('npm', ['config', 'set', 'registry', url]);
+    } else {
+      this.executeCommand('npm', ['config', 'delete', 'registry']);
+    }
+  }
 
-  public abstract getRegistryURL(): string;
+  getRegistryURL() {
+    const url = this.executeCommand('npm', ['config', 'get', 'registry']).trim();
+    return url === 'undefined' ? undefined : url;
+  }
 
   public readonly cwd?: string;
 

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -61,19 +61,6 @@ export class NPMProxy extends JsPackageManager {
     return this.uninstallArgs;
   }
 
-  setRegistryURL(url: string) {
-    if (url) {
-      this.executeCommand('npm', ['config', 'set', 'registry', url]);
-    } else {
-      this.executeCommand('npm', ['config', 'delete', 'registry']);
-    }
-  }
-
-  getRegistryURL() {
-    const url = this.executeCommand('npm', ['config', 'get', 'registry']).trim();
-    return url === 'undefined' ? undefined : url;
-  }
-
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
     return {
       overrides: {

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
@@ -27,10 +27,10 @@ describe('Yarn 1 Proxy', () => {
 
       yarn1Proxy.setRegistryURL('https://foo.bar');
 
-      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', [
+      expect(executeCommandSpy).toHaveBeenCalledWith('npm', [
         'config',
         'set',
-        'npmRegistryServer',
+        'registry',
         'https://foo.bar',
       ]);
     });

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -16,19 +16,6 @@ export class Yarn1Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
-  setRegistryURL(url: string) {
-    if (url) {
-      this.executeCommand('yarn', ['config', 'set', 'npmRegistryServer', url]);
-    } else {
-      this.executeCommand('yarn', ['config', 'delete', 'npmRegistryServer']);
-    }
-  }
-
-  getRegistryURL() {
-    const url = this.executeCommand('yarn', ['config', 'get', 'npmRegistryServer']).trim();
-    return url === 'undefined' ? undefined : url;
-  }
-
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
     return {
       resolutions: {

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
@@ -37,10 +37,10 @@ describe('Yarn 2 Proxy', () => {
 
       yarn2Proxy.setRegistryURL('https://foo.bar');
 
-      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', [
+      expect(executeCommandSpy).toHaveBeenCalledWith('npm', [
         'config',
         'set',
-        'npmRegistryServer',
+        'registry',
         'https://foo.bar',
       ]);
     });

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -16,19 +16,6 @@ export class Yarn2Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
-  setRegistryURL(url: string) {
-    if (url) {
-      this.executeCommand('yarn', ['config', 'set', 'npmRegistryServer', url]);
-    } else {
-      this.executeCommand('yarn', ['config', 'delete', 'npmRegistryServer']);
-    }
-  }
-
-  getRegistryURL() {
-    const url = this.executeCommand('yarn', ['config', 'get', 'npmRegistryServer']).trim();
-    return url === 'undefined' ? undefined : url;
-  }
-
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {
     return {
       resolutions: {


### PR DESCRIPTION
Issue: N/A

## What I did

To publish using the local registry, always use NPM config.

## How to test

In the `vite-frameworks` branch (which also has this change):

```
yarn generate-repros-next --template vue3-vite/default-js --local-registry
```

Before this will fail, after it will succeed