### PR TITLE
Core: Fix frameworkOptions preset

### DIFF
--- a/code/lib/builder-webpack5/src/index.ts
+++ b/code/lib/builder-webpack5/src/index.ts
@@ -41,7 +41,7 @@ export const getConfig: WebpackBuilder['getConfig'] = async (options) => {
   const { presets } = options;
   const typescriptOptions = await presets.apply('typescript', {}, options);
   const babelOptions = await presets.apply('babel', {}, { ...options, typescriptOptions });
-  const framework = await presets.apply<any>('framework', {}, options);
+  const frameworkOptions = await presets.apply<any>('frameworkOptions');
 
   return presets.apply(
     'webpack',
@@ -50,7 +50,7 @@ export const getConfig: WebpackBuilder['getConfig'] = async (options) => {
       ...options,
       babelOptions,
       typescriptOptions,
-      frameworkOptions: typeof framework === 'string' ? {} : framework?.options,
+      frameworkOptions,
     }
   ) as any;
 };

--- a/code/lib/core-server/src/presets/common-preset.ts
+++ b/code/lib/core-server/src/presets/common-preset.ts
@@ -125,23 +125,18 @@ export const storyIndexers = async (indexers?: StoryIndexer[]) => {
 export const frameworkOptions = async (
   _: never,
   options: Options
-): Promise<StorybookConfig['framework']> => {
+): Promise<Record<string, any> | null> => {
   const config = await options.presets.apply<StorybookConfig['framework']>('framework');
 
   if (typeof config === 'string') {
-    return {
-      name: config,
-      options: {},
-    };
+    return {};
   }
+
   if (typeof config === 'undefined') {
     return null;
   }
 
-  return {
-    name: config.name,
-    options: config.options,
-  };
+  return config.options;
 };
 
 export const docs = (


### PR DESCRIPTION
Issue: N/A

## What I did

The `frameworkOptions` preset returned an object containing the preset AND its options.

This PR fixes that to just return the options object if it exists (or null)

Self-merging @ndelangen 

## How to test

- [ ] CI passes