### PR TITLE
Build: Rename prepare to prep for npm8 and verdaccio

### DIFF
--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -59,7 +59,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addon-highlight": "7.0.0-alpha.23",

--- a/code/addons/actions/package.json
+++ b/code/addons/actions/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/backgrounds/package.json
+++ b/code/addons/backgrounds/package.json
@@ -59,7 +59,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/controls/package.json
+++ b/code/addons/controls/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -46,7 +46,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.12.12",

--- a/code/addons/essentials/package.json
+++ b/code/addons/essentials/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addon-actions": "7.0.0-alpha.23",

--- a/code/addons/highlight/package.json
+++ b/code/addons/highlight/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/interactions/package.json
+++ b/code/addons/interactions/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@devtools-ds/object-inspector": "^1.1.2",

--- a/code/addons/jest/package.json
+++ b/code/addons/jest/package.json
@@ -56,7 +56,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -60,7 +60,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/measure/package.json
+++ b/code/addons/measure/package.json
@@ -58,7 +58,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/outline/package.json
+++ b/code/addons/outline/package.json
@@ -61,7 +61,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/storyshots/storyshots-core/package.json
+++ b/code/addons/storyshots/storyshots-core/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build-storybook": "sb build",
     "example": "jest storyshot.test",
-    "prepare": "node ../../../../scripts/prepare.js",
+    "prep": "node ../../../../scripts/prepare.js",
     "storybook": "yarn sb dev -p 6006"
   },
   "dependencies": {

--- a/code/addons/storyshots/storyshots-puppeteer/package.json
+++ b/code/addons/storyshots/storyshots-puppeteer/package.json
@@ -30,7 +30,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "prepare": "node ../../../../scripts/prepare.js"
+    "prep": "node ../../../../scripts/prepare.js"
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/toolbars/package.json
+++ b/code/addons/toolbars/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/addons/viewport/package.json
+++ b/code/addons/viewport/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/frameworks/angular/package.json
+++ b/code/frameworks/angular/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/frameworks/ember/package.json
+++ b/code/frameworks/ember/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/builder-webpack5": "7.0.0-alpha.23",

--- a/code/frameworks/html-webpack5/package.json
+++ b/code/frameworks/html-webpack5/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/builder-webpack5": "7.0.0-alpha.23",

--- a/code/frameworks/preact-webpack5/package.json
+++ b/code/frameworks/preact-webpack5/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/builder-webpack5": "7.0.0-alpha.23",

--- a/code/frameworks/react-webpack5/package.json
+++ b/code/frameworks/react-webpack5/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/builder-webpack5": "7.0.0-alpha.23",

--- a/code/frameworks/server-webpack5/package.json
+++ b/code/frameworks/server-webpack5/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/builder-webpack5": "7.0.0-alpha.23",

--- a/code/frameworks/svelte-webpack5/package.json
+++ b/code/frameworks/svelte-webpack5/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/builder-webpack5": "7.0.0-alpha.23",

--- a/code/frameworks/vue-webpack5/package.json
+++ b/code/frameworks/vue-webpack5/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/builder-webpack5": "7.0.0-alpha.23",

--- a/code/frameworks/vue3-webpack5/package.json
+++ b/code/frameworks/vue3-webpack5/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/builder-webpack5": "7.0.0-alpha.23",

--- a/code/frameworks/web-components-webpack5/package.json
+++ b/code/frameworks/web-components-webpack5/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@babel/preset-env": "^7.12.11",

--- a/code/lib/addons/package.json
+++ b/code/lib/addons/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/api": "7.0.0-alpha.23",

--- a/code/lib/api/package.json
+++ b/code/lib/api/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/channels": "7.0.0-alpha.23",

--- a/code/lib/blocks/package.json
+++ b/code/lib/blocks/package.json
@@ -38,7 +38,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/api": "7.0.0-alpha.23",

--- a/code/lib/builder-manager/package.json
+++ b/code/lib/builder-manager/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@fal-works/esbuild-plugin-global-externals": "^2.1.2",

--- a/code/lib/builder-webpack5/package.json
+++ b/code/lib/builder-webpack5/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@babel/core": "^7.12.10",

--- a/code/lib/channel-postmessage/package.json
+++ b/code/lib/channel-postmessage/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/channels": "7.0.0-alpha.23",

--- a/code/lib/channel-websocket/package.json
+++ b/code/lib/channel-websocket/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/channels": "7.0.0-alpha.23",

--- a/code/lib/channels/package.json
+++ b/code/lib/channels/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "core-js": "^3.8.2",

--- a/code/lib/cli-sb/package.json
+++ b/code/lib/cli-sb/package.json
@@ -22,7 +22,7 @@
   "bin": "./index.js",
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/cli": "7.0.0-alpha.23"

--- a/code/lib/cli-storybook/package.json
+++ b/code/lib/cli-storybook/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/cli": "7.0.0-alpha.23"

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js",
+    "prep": "node ../../../scripts/prepare.js",
     "test": "jest test/**/*.test.js"
   },
   "dependencies": {

--- a/code/lib/client-api/package.json
+++ b/code/lib/client-api/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/lib/client-logger/package.json
+++ b/code/lib/client-logger/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "core-js": "^3.8.2",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@babel/types": "^7.12.11",

--- a/code/lib/components/package.json
+++ b/code/lib/components/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/client-logger": "7.0.0-alpha.23",

--- a/code/lib/core-client/package.json
+++ b/code/lib/core-client/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@babel/core": "^7.12.10",

--- a/code/lib/core-events/package.json
+++ b/code/lib/core-events/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "core-js": "^3.8.2"

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@aw-web-design/x-default-browser": "1.4.88",

--- a/code/lib/core-webpack/package.json
+++ b/code/lib/core-webpack/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/core-common": "7.0.0-alpha.23",

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@babel/core": "^7.12.10",

--- a/code/lib/docs-tools/package.json
+++ b/code/lib/docs-tools/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@babel/core": "^7.12.10",

--- a/code/lib/instrumenter/package.json
+++ b/code/lib/instrumenter/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/lib/node-logger/package.json
+++ b/code/lib/node-logger/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@types/npmlog": "^4.1.2",

--- a/code/lib/postinstall/package.json
+++ b/code/lib/postinstall/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "core-js": "^3.8.2"

--- a/code/lib/preview-web/package.json
+++ b/code/lib/preview-web/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/lib/router/package.json
+++ b/code/lib/router/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "ts-node ../../../scripts/prebundle.ts"
+    "prep": "ts-node ../../../scripts/prebundle.ts"
   },
   "dependencies": {
     "@storybook/client-logger": "7.0.0-alpha.23",

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/lib/store/package.json
+++ b/code/lib/store/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/lib/telemetry/package.json
+++ b/code/lib/telemetry/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "node ../../../scripts/prepare.js"
+    "prep": "node ../../../scripts/prepare.js"
   },
   "dependencies": {
     "@storybook/client-logger": "7.0.0-alpha.23",

--- a/code/lib/theming/package.json
+++ b/code/lib/theming/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/client-logger": "7.0.0-alpha.23",

--- a/code/lib/ui/package.json
+++ b/code/lib/ui/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/code/nx.json
+++ b/code/nx.json
@@ -10,8 +10,8 @@
     "default": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "cacheableOperations": ["build", "test", "lint", "package", "prepare"],
-        "strictlyOrderedTargets": ["build", "package", "prepare"],
+        "cacheableOperations": ["build", "test", "lint", "package", "prep"],
+        "strictlyOrderedTargets": ["build", "package", "prep"],
         "accessToken": "NGVmYTkxMmItYzY3OS00MjkxLTk1ZDktZDFmYTFmNmVlNGY4fHJlYWQ=",
         "canTrackAnalytics": false,
         "showUsageWarnings": true

--- a/code/presets/html-webpack/package.json
+++ b/code/presets/html-webpack/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/core-webpack": "7.0.0-alpha.23",

--- a/code/presets/preact-webpack/package.json
+++ b/code/presets/preact-webpack/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.12.12",

--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -68,7 +68,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@babel/preset-flow": "^7.12.1",

--- a/code/presets/server-webpack/package.json
+++ b/code/presets/server-webpack/package.json
@@ -52,7 +52,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/core-server": "7.0.0-alpha.23",

--- a/code/presets/svelte-webpack/package.json
+++ b/code/presets/svelte-webpack/package.json
@@ -62,7 +62,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/core-webpack": "7.0.0-alpha.23",

--- a/code/presets/vue-webpack/package.json
+++ b/code/presets/vue-webpack/package.json
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/core-webpack": "7.0.0-alpha.23",

--- a/code/presets/vue3-webpack/package.json
+++ b/code/presets/vue3-webpack/package.json
@@ -58,7 +58,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/core-webpack": "7.0.0-alpha.23",

--- a/code/presets/web-components-webpack/package.json
+++ b/code/presets/web-components-webpack/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",

--- a/code/renderers/html/package.json
+++ b/code/renderers/html/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/renderers/preact/package.json
+++ b/code/renderers/preact/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -51,7 +51,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/renderers/vue/package.json
+++ b/code/renderers/vue/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/code/renderers/web-components/package.json
+++ b/code/renderers/web-components/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "check": "tsc --noEmit",
-    "prepare": "../../../scripts/prepare/bundle.ts"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.23",

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -74,9 +74,9 @@ function run() {
       defaultValue: true,
       option: '--prep',
       command: () => {
-        log.info(prefix, 'prepare');
+        log.info(prefix, 'prep');
         spawn(
-          `nx run-many --target="prepare" --all --parallel --exclude=@storybook/addon-storyshots,@storybook/addon-storyshots-puppeteer -- --reset`
+          `nx run-many --target="prep" --all --parallel --exclude=@storybook/addon-storyshots,@storybook/addon-storyshots-puppeteer -- --reset`
         );
       },
       order: 2,
@@ -86,9 +86,9 @@ function run() {
       defaultValue: true,
       option: '--retry',
       command: () => {
-        log.info(prefix, 'prepare');
+        log.info(prefix, 'core');
         spawn(
-          `nx run-many --target=prepare --all --parallel --only-failed ${
+          `nx run-many --target="prep" --all --parallel --only-failed ${
             process.env.CI ? `--max-parallel=${maxConcurrentTasks}` : ''
           }`
         );
@@ -131,7 +131,7 @@ function run() {
       command: () => {
         log.info(prefix, 'build');
         spawn(
-          `nx run-many --target="prepare" --all --parallel=8 ${
+          `nx run-many --target="prep" --all --parallel=8 ${
             process.env.CI ? `--max-parallel=${maxConcurrentTasks}` : ''
           } -- --reset --optimized`
         );


### PR DESCRIPTION
Issue: N/A

## What I did

In `npm8` publishing packages to the local registry will cause each package to be rebuilt. Our dev workflow assumes that packages are built in a separate step, so building them during publish only slows things down and introduces inconsistencies.

This PR:
- [x] Renames `prepare` in each package to `prep`
- [x] Updates the bootstrap script

Self-merging @yannbf @IanVS @joshwooding 

## How to test

```
code code
yarn build --core
yarn local-registry --publish  --open
```
