### PR TITLE
Build: Run verdaccio on 6001 to enable web UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,13 +195,13 @@ jobs:
           name: running local registry
           command: |
             cd code
-            yarn local-registry --port 6000 --open
+            yarn local-registry --port 6001 --open
           background: true
       - run:
           name: Wait for registry
           command: |
             cd code
-            yarn wait-on http://localhost:6000
+            yarn wait-on http://localhost:6001
       - run:
           name: Run E2E (extended) tests
           command: |
@@ -225,13 +225,13 @@ jobs:
           name: Running local registry
           command: |
             cd code
-            yarn local-registry --port 6000 --open
+            yarn local-registry --port 6001 --open
           background: true
       - run:
           name: Wait for registry
           command: |
             cd code
-            yarn wait-on http://localhost:6000
+            yarn wait-on http://localhost:6001
       - run:
           name: Run E2E (core) tests
           # Do not test CRA here because it's done in PnP part
@@ -265,11 +265,11 @@ jobs:
   #         at: .
   #     - run:
   #         name: Running local registry
-  #         command: yarn local-registry --port 6000 --open
+  #         command: yarn local-registry --port 6001 --open
   #         background: true
   #     - run:
   #         name: Wait for registry
-  #         command: yarn wait-on http://localhost:6000
+  #         command: yarn wait-on http://localhost:6001
   #     - run:
   #         name: Run smoke tests
   #         command: yarn test:e2e-framework angular_modern_inline_rendering --test-runner --docs-mode
@@ -293,13 +293,13 @@ jobs:
           name: Running local registry
           command: |
             cd code
-            yarn local-registry --port 6000 --open
+            yarn local-registry --port 6001 --open
           background: true
       - run:
           name: Wait for registry
           command: |
             cd code
-            yarn wait-on http://localhost:6000
+            yarn wait-on http://localhost:6001
       - run:
           name: set up cra repro, skip tests
           command: |
@@ -324,13 +324,13 @@ jobs:
           name: Running local registry
           command: |
             cd code
-            yarn local-registry --port 6000 --open
+            yarn local-registry --port 6001 --open
           background: true
       - run:
           name: Wait for registry
           command: |
             cd code
-            yarn wait-on http://localhost:6000
+            yarn wait-on http://localhost:6001
       - run:
           name: run e2e tests cra
           command: |

--- a/code/lib/cli/src/repro-generators/scripts.ts
+++ b/code/lib/cli/src/repro-generators/scripts.ts
@@ -144,7 +144,7 @@ const installYarn2 = async ({ cwd, pnp, name }: Options) => {
 const configureYarn2ForE2E = async ({ cwd }: Options) => {
   const command = [
     // ⚠️ Need to set registry because Yarn 2 is not using the conf of Yarn 1 (URL is hardcoded in CircleCI config.yml)
-    `yarn config set npmScopes --json '{ "storybook": { "npmRegistryServer": "http://localhost:6000/" } }'`,
+    `yarn config set npmScopes --json '{ "storybook": { "npmRegistryServer": "http://localhost:6001/" } }'`,
     // Some required magic to be able to fetch deps from local registry
     `yarn config set unsafeHttpWhitelist --json '["localhost"]'`,
     // Disable fallback mode to make sure everything is required correctly

--- a/code/package.json
+++ b/code/package.json
@@ -75,7 +75,7 @@
     "lint:md": "remark -q .",
     "lint:other": "prettier --write '**/*.{css,html,json,md,yml}'",
     "lint:package": "sort-package-json",
-    "local-registry": "ts-node --project=../scripts/tsconfig.json ../scripts/run-registry.ts --port 6000",
+    "local-registry": "ts-node --project=../scripts/tsconfig.json ../scripts/run-registry.ts --port 6001",
     "publish-repros": "ts-node ../scripts/next-repro-generators/publish.ts",
     "publish:debug": "npm run publish:latest -- --npm-tag=debug --no-push",
     "publish:latest": "lerna publish --exact --concurrency 1 --force-publish",

--- a/docs/contribute/code.md
+++ b/docs/contribute/code.md
@@ -101,7 +101,7 @@ Unit tests ensure that Storybook doesn't break accidentally. If your code can re
 Storybook's monorepo is set up to rely on end-to-end testing with [Cypress](https://www.cypress.io/) during CI. To help with testing, we encourage running this test suite before submitting your contribution. Detailed below are some steps you can take:
 
 1. Ensure you have Storybook successfully built in your local branch (i.e., run `yarn bootstrap --core`)
-2. Open a terminal and run `yarn local-registry --port 6000 --open --publish` to publish Storybook's packages into a local registry.
+2. Open a terminal and run `yarn local-registry --port 6001 --open --publish` to publish Storybook's packages into a local registry.
 3. In a second terminal, set up a reproduction using the local registry and run the Cypress tests with `yarn test:e2e-framework`.
 
 ## Submit a pull request

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -143,7 +143,7 @@ function run() {
       defaultValue: false,
       option: '--reg',
       command: () => {
-        spawn('yarn local-registry --publish --open --port 6000');
+        spawn('yarn local-registry --publish --open --port 6001');
       },
       order: 11,
     }),

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -29,7 +29,7 @@ const sbInit = async (cwd: string) => {
   await runCommand(`${sbCliBinaryPath} init --yes`, { cwd, env });
 };
 
-const LOCAL_REGISTRY_URL = 'http://localhost:6000';
+const LOCAL_REGISTRY_URL = 'http://localhost:6001';
 const withLocalRegistry = async (packageManager: JsPackageManager, action: () => Promise<void>) => {
   const prevUrl = packageManager.getRegistryURL();
   try {

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -163,7 +163,7 @@ const runTests = async ({ name, ...rest }: Parameters) => {
       targetFolder,
       `--renderer ${options.renderer}`,
       `--template ${options.name}`,
-      `--registry http://localhost:6000`,
+      `--registry http://localhost:6001`,
       '--e2e',
     ];
 

--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -43,7 +43,7 @@ const startVerdaccio = (port: number): Promise<any> => {
         });
       };
 
-      startVerdaccioServer(config, 6000, cache, '1.0.0', 'verdaccio', onReady);
+      startVerdaccioServer(config, 6001, cache, '1.0.0', 'verdaccio', onReady);
     }),
     new Promise((_, rej) => {
       setTimeout(() => {

--- a/scripts/utils/serve-packages.ts
+++ b/scripts/utils/serve-packages.ts
@@ -14,7 +14,7 @@ export async function servePackages({ dryRun, debug }: { dryRun?: boolean; debug
     // If aborted, we want to make sure the rejection is handled.
     if (!err.killed) throw err;
   });
-  await exec('yarn wait-on http://localhost:6000', { cwd: codeDir }, { dryRun, debug });
+  await exec('yarn wait-on http://localhost:6001', { cwd: codeDir }, { dryRun, debug });
 
   return controller;
 }

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -50,7 +50,7 @@ export const configureYarn2ForVerdaccio = async ({ cwd, dryRun, debug }: YarnOpt
     `yarn config set enableGlobalCache false`,
     `yarn config set enableMirror false`,
     // ⚠️ Need to set registry because Yarn 2 is not using the conf of Yarn 1 (URL is hardcoded in CircleCI config.yml)
-    `yarn config set npmScopes --json '{ "storybook": { "npmRegistryServer": "http://localhost:6000/" } }'`,
+    `yarn config set npmScopes --json '{ "storybook": { "npmRegistryServer": "http://localhost:6001/" } }'`,
     // Some required magic to be able to fetch deps from local registry
     `yarn config set unsafeHttpWhitelist --json '["localhost"]'`,
     // Disable fallback mode to make sure everything is required correctly


### PR DESCRIPTION
Issue: N/A

## What I did

Chrome blocks port 6000 as an "unsafe" port because that's where X11 runs.

Change the verdaccio port to 6001 so we can browse its web UI

Self-merging @yannbf 

## How to test

Terminal 1:
```
yarn bootstrap --prep
yarn local-registry --publish --open
```

Terminal 2:
```
open http://localhost:6001
```