### PR TITLE
Build: Fix yarn build to use new prep script

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -113,7 +113,7 @@ async function run() {
   }
 
   selection?.filter(Boolean).forEach(async (v) => {
-    const commmand = (await readJSON(resolve(v.location, 'package.json'))).scripts.prepare;
+    const commmand = (await readJSON(resolve(v.location, 'package.json'))).scripts.prep;
     const cwd = resolve(__dirname, '..', 'code', v.location);
     const sub = require('execa').command(
       `${commmand}${watchMode ? ' --watch' : ''}${prodMode ? ' --optimized' : ''}`,


### PR DESCRIPTION
Issue: N/A

## What I did

#18980 broke the `yarn build` script. This fixes it by referencing `prep` instead!

Self-merging @ndelangen 

## How to test

```
yarn build cli
```
