### PR TITLE
Examples: Remove refs in angular example

### DIFF
--- a/code/examples/angular-cli/.storybook/main.ts
+++ b/code/examples/angular-cli/.storybook/main.ts
@@ -19,7 +19,6 @@ const mainConfig: import('@storybook/angular').StorybookConfig = {
     channelOptions: { allowFunction: false, maxDepth: 10 },
     disableTelemetry: true,
   },
-  // These are just here to test composition. They could be added to any storybook example project
   staticDirs: ['../src/assets'],
   features: {
     buildStoriesJson: false,

--- a/code/examples/angular-cli/.storybook/main.ts
+++ b/code/examples/angular-cli/.storybook/main.ts
@@ -20,24 +20,6 @@ const mainConfig: import('@storybook/angular').StorybookConfig = {
     disableTelemetry: true,
   },
   // These are just here to test composition. They could be added to any storybook example project
-  refs: {
-    react: {
-      title: 'ReactTS',
-      url: 'http://localhost:9011',
-    },
-    first: {
-      title: 'Composition test one',
-      url: 'https://storybookjs.netlify.app/cra-ts-essentials',
-    },
-    second: {
-      title: 'Composition test two',
-      url: 'https://storybookjs.netlify.app/cra-ts-essentials',
-    },
-    third: {
-      title: 'Composition test three',
-      url: 'https://storybookjs.netlify.app/cra-ts-essentials',
-    },
-  },
   staticDirs: ['../src/assets'],
   features: {
     buildStoriesJson: false,


### PR DESCRIPTION
we're tired of seeing this:
```
ERR! FetchError: request to https://storybookjs.netlify.app/cra-ts-essentials/iframe.html failed, reason: Client network socket disconnected before secure TLS connection was established
ERR!     at ClientRequest.<anonymous> (/tmp/storybook/code/node_modules/node-fetch/lib/index.js:1491:11)
ERR!     at ClientRequest.emit (events.js:400:28)
ERR!     at TLSSocket.socketErrorListener (_http_client.js:475:9)
ERR!     at TLSSocket.emit (events.js:400:28)
ERR!     at emitErrorNT (internal/streams/destroy.js:106:8)
ERR!     at emitErrorCloseNT (internal/streams/destroy.js:74:3)
ERR!     at processTicksAndRejections (internal/process/task_queues.js:82:21)
ERR!  FetchError: request to https://storybookjs.netlify.app/cra-ts-essentials/iframe.html failed, reason: Client network socket disconnected before secure TLS connection was established
ERR!     at ClientRequest.<anonymous> (/tmp/storybook/code/node_modules/node-fetch/lib/index.js:1491:11)
ERR!     at ClientRequest.emit (events.js:400:28)
ERR!     at TLSSocket.socketErrorListener (_http_client.js:475:9)
ERR!     at TLSSocket.emit (events.js:400:28)
ERR!     at emitErrorNT (internal/streams/destroy.js:106:8)
ERR!     at emitErrorCloseNT (internal/streams/destroy.js:74:3)
ERR!     at processTicksAndRejections (internal/process/task_queues.js:82:21) {
ERR!   type: 'system',
ERR!   errno: 'ECONNRESET',
ERR!   code: 'ECONNRESET'
ERR! }
```