### PR TITLE
Generate-repros: Run local registry on `--local-registry` option

### DIFF
--- a/.github/workflows/generate-repros-next.yml
+++ b/.github/workflows/generate-repros-next.yml
@@ -2,7 +2,7 @@ name: Generate and push repros to the next branch
 
 on:
   schedule:
-    - cron: "2 2 */1 * *"
+    - cron: '2 2 */1 * *'
   workflow_dispatch:
   # To remove when the branch will be merged
   push:
@@ -26,7 +26,7 @@ jobs:
         run: yarn bootstrap --prep
         working-directory: ./code
       - name: Generate repros
-        run: yarn generate-repros-next
+        run: yarn generate-repros-next --local-registry
         working-directory: ./code
       - name: Publish repros to GitHub
         run: yarn publish-repros --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/repro-templates-temp.git --push


### PR DESCRIPTION
Issue: N/A

## What I did

Make `generate-repros` command run the local registry, so that we can publish repro-templates for new frameworks/templates even before they have been published to NPM

- [x] Update the generate-repros-next script
- [x] Update the github action that runs daily to run from local registry

@yannbf self-merging

@tmeasday we should probably refactor this and more stuff into the `task` framework. let's discuss when you get back

## How to test

```
yarn generate-repros-next --template cra/default-js --local-registry
```
