### PR TITLE
docs: consistent with CONTRIBUTING.md

### DIFF
--- a/docs/contribute/code.md
+++ b/docs/contribute/code.md
@@ -4,6 +4,11 @@ title: 'Code contributions'
 
 Contribute a new feature or bug fix to [Storybook's monorepo](https://github.com/storybookjs/storybook). This page outlines how to get your environment set up to contribute code.
 
+## Prerequisites
+
+- Ensure you have node version 14 installed (suggestion: v14.18.1).
+- Ensure if you are using Windows to use the Windows Subsystem for Linux (WSL).
+
 ## Initial setup
 
 Start by [forking](https://docs.github.com/en/github/getting-started-with-github/quickstart/fork-a-repo) the Storybook monorepo and cloning it locally.
@@ -12,7 +17,7 @@ Start by [forking](https://docs.github.com/en/github/getting-started-with-github
 git clone https://github.com/your-username/storybook.git
 ```
 
-Navigate to the `storybook` directory and install the required dependencies with the following commands:
+Navigate to the `storybook/code` directory and install the required dependencies with the following commands:
 
 ```shell
 yarn && yarn bootstrap --core


### PR DESCRIPTION
Issue: this PR is just a documentation update.

## What I did

Keep `code.md` **Initial setup** consistent with `CONTRIBUTING.md`.

## How to test

No need test.

- [ ] Is this testable with Jest or Chromatic screenshots? 
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation? 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
