### PR TITLE
add breaking change for the `Story` type change

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -273,6 +273,8 @@ export const Primary: Story<ButtonProps> = {
 
 If you want to be explicit, you can also import `StoryObj` instead of `Story`, they are the same type.
 
+For Storybook for react users: We also changed `ComponentStory` to refer to `ComponentStoryObj` instead of `ComponentStoryFn`, so if you were using `ComponentStory` you should now import/use `ComponentStoryFn` instead.
+
 You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
 
 #### Change of root html IDs

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -256,7 +256,7 @@ import type { StoryFn } from '@storybook/react';
 export const MyStory: StoryFn = () => <div />;
 ```
 
-This change was done to improve the experience of writing CSF3 stories, which the recommended way of writing stories in 7.0.:
+This change was done to improve the experience of writing CSF3 stories, which is the recommended way of writing stories in 7.0:
 
 ```js
 import type { Story } from '@storybook/react';

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [Alpha release notes](#alpha-release-notes)
   - [Breaking changes](#breaking-changes)
+    - [`Story` type change to `StoryFn`, and the new `Story` type now refers to `StoryObj`](#story-type-change-to-storyfn-and-the-new-story-type-now-refers-to-storyobj)
     - [Change of root html IDs](#change-of-root-html-ids)
     - [No more default export from `@storybook/addons`](#no-more-default-export-from-storybookaddons)
     - [Modern browser support](#modern-browser-support)
@@ -235,6 +236,45 @@ Storybook 7.0 is in early alpha. During the alpha, we are making a large number 
 In the meantime, these migration notes are the best available documentation on things you should know upgrading to 7.0.
 
 ### Breaking changes
+
+#### `Story` type change to `StoryFn`, and the new `Story` type now refers to `StoryObj`
+
+In 6.x you were able to do this:
+
+```js
+import type { Story } from '@storybook/react';
+
+export const MyStory: Story = () => <div />;
+```
+
+But this will produce an error in 7.0 because `Story` is now a type that refers to the `StoryObj` type.
+You must now use the new `StoryFn` type:
+
+```js
+import type { StoryFn } from '@storybook/react';
+
+export const MyStory: StoryFn = () => <div />;
+```
+
+This change was done to improve the experience of writing CSF3 stories, which the recommended way of writing stories in 7.0.:
+
+```js
+import type { Story } from '@storybook/react';
+import { Button, ButtonProps } from './Button';
+
+export default {
+  component: Button,
+};
+
+
+export const Primary: Story<ButtonProps> = {
+  variant: 'primary',
+};
+```
+
+If want to be explicit, you can also import `StoryObj` instead of `Story`, they are the same type.
+
+You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
 
 #### Change of root html IDs
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -271,7 +271,7 @@ export const Primary: Story<ButtonProps> = {
 };
 ```
 
-If want to be explicit, you can also import `StoryObj` instead of `Story`, they are the same type.
+If you want to be explicit, you can also import `StoryObj` instead of `Story`, they are the same type.
 
 You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -266,7 +266,6 @@ export default {
   component: Button,
 };
 
-
 export const Primary: Story<ButtonProps> = {
   variant: 'primary',
 };


### PR DESCRIPTION
`Story` changes to `StoryFn` before, but we didn't add an entry in the `MIGRATION.md` document.
This PR adds that entry, so users know what is expected of them, and it gives us a link we can provide to users with the instruction.