### PR TITLE
add a README contents to manager-builder package

### DIFF
--- a/code/lib/builder-manager/README.md
+++ b/code/lib/builder-manager/README.md
@@ -1,11 +1,12 @@
 # Manager-Builder
 
-Do not use this package unless you know what you are doing.
-Storybook uses this package internally to create the manager side of storybook.
+> NOTE: Do not use this package unless you know what you are doing.
 
-This package uses `esbuild` to bundle the manager-side of addons, and prepare it for modern ESM supporting browsers.
+This package is used internally by Storybook to create the manager side (UI) of Storybook.
+
+This package uses `esbuild` to bundle the manager-side of addons, and prepare it for modern, ESM supporting browsers.
 
 Each addon is bundled into a separate file, and the manager is responsible for loading them.
-In addition, if `manager.*` exists, it's also bundled, and loaded.
+If a `manager.*` file exists in the config dir (e.g. `.storybook`), it's also bundled, and loaded in the browser.
 
-Additionally this package also will add the manager ui via the `@storybook/ui` package, which is already build by `esbuild` in our build process before publishing.
+Additionally, this package also will add the manager ui via the `@storybook/ui` package, which is already built by `esbuild` in our build process before publishing.

--- a/code/lib/builder-manager/README.md
+++ b/code/lib/builder-manager/README.md
@@ -1,3 +1,11 @@
 # Manager-Builder
 
-TODO
+Do not use this package unless you know what you are doing.
+Storybook uses this package internally to create the manager side of storybook.
+
+This package uses `esbuild` to bundle the manager-side of addons, and prepare it for modern ESM supporting browsers.
+
+Each addon is bundled into a separate file, and the manager is responsible for loading them.
+In addition, if `manager.*` exists, it's also bundled, and loaded.
+
+Additionally this package also will add the manager ui via the `@storybook/ui` package, which is already build by `esbuild` in our build process before publishing.


### PR DESCRIPTION
When I added the `builder-manager` package I left the `README.md` file pretty much empty, because it was highly experimental, and didn't want to bother documenting it all if it didn't work.

Now that it's been in alpha for a bit, we know it works, and works well.

Still it doesn't require a lot of documentation because it's pretty much an internal package.