### PR TITLE
Core: Fix default story glob

### DIFF
--- a/code/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
+++ b/code/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
@@ -230,7 +230,7 @@ describe('normalizeStoriesEntry', () => {
       {
         "titlePrefix": "",
         "directory": ".",
-        "files": "**/*.(stories|docs).@(mdx|tsx|ts|jsx|js)",
+        "files": "**/*.@(mdx|stories.mdx|stories.tsx|stories.ts|stories.jsx|stories.js)",
         "importPathMatcher": {}
       }
     `);
@@ -241,7 +241,7 @@ describe('normalizeStoriesEntry', () => {
     expect(specifier).toMatchInlineSnapshot(`
       {
         "titlePrefix": "",
-        "files": "**/*.(stories|docs).@(mdx|tsx|ts|jsx|js)",
+        "files": "**/*.@(mdx|stories.mdx|stories.tsx|stories.ts|stories.jsx|stories.js)",
         "directory": ".",
         "importPathMatcher": {}
       }
@@ -265,7 +265,7 @@ describe('normalizeStoriesEntry', () => {
     expect(specifier).toMatchInlineSnapshot(`
       {
         "titlePrefix": "atoms",
-        "files": "**/*.(stories|docs).@(mdx|tsx|ts|jsx|js)",
+        "files": "**/*.@(mdx|stories.mdx|stories.tsx|stories.ts|stories.jsx|stories.js)",
         "directory": ".",
         "importPathMatcher": {}
       }

--- a/code/lib/core-common/src/utils/normalize-stories.ts
+++ b/code/lib/core-common/src/utils/normalize-stories.ts
@@ -10,7 +10,7 @@ import { normalizeStoryPath } from './paths';
 import { globToRegexp } from './glob-to-regexp';
 
 const DEFAULT_TITLE_PREFIX = '';
-const DEFAULT_FILES = '**/*.(stories|docs).@(mdx|tsx|ts|jsx|js)';
+const DEFAULT_FILES = '**/*.@(mdx|stories.mdx|stories.tsx|stories.ts|stories.jsx|stories.js)';
 
 // TODO: remove - LEGACY support for bad glob patterns we had in SB 5 - remove in SB7
 const fixBadGlob = deprecate(


### PR DESCRIPTION
Issue: 

This fixes a problem when using directory-based story config in 7.0.  The previous glob was not valid, and after talking with @shilman, he said `docs` was removed, and that we need to support `*.mdx` in addition to the previous `*.stories.` globs.

## What I did

Updated the default glob in `normalizeStories`

## How to test

I tested this in my own project, and it worked, but I don't use mdx very much.  

I think ideally, we should add an autoTitle / directory-based config to the sandbox repros, but I'm not sure how to do that.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
