### PR TITLE
Remove babel-loader from core-common

### DIFF
--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -75,7 +75,6 @@
     "@types/express": "^4.7.0",
     "@types/node": "^14.0.10 || ^16.0.0",
     "@types/pretty-hrtime": "^1.0.0",
-    "babel-loader": "^8.2.5",
     "babel-plugin-macros": "^3.0.1",
     "babel-plugin-polyfill-corejs3": "^0.1.0",
     "chalk": "^4.1.0",

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -58,13 +58,13 @@
   "devDependencies": {
     "@babel/core": "^7.11.5",
     "@types/util-deprecate": "^1.0.0",
+    "jest-specific-snapshot": "^4.0.0",
+    "require-from-string": "^2.0.2",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {
-    "jest-specific-snapshot": "^4.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "require-from-string": "^2.0.2"
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8129,7 +8129,6 @@ __metadata:
     "@types/node": ^14.0.10 || ^16.0.0
     "@types/picomatch": ^2.3.0
     "@types/pretty-hrtime": ^1.0.0
-    babel-loader: ^8.2.5
     babel-plugin-macros: ^3.0.1
     babel-plugin-polyfill-corejs3: ^0.1.0
     chalk: ^4.1.0

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -9083,17 +9083,17 @@ __metadata:
     escodegen: ^2.0.0
     global: ^4.4.0
     html-tags: ^3.1.0
+    jest-specific-snapshot: ^4.0.0
     lodash: ^4.17.21
     prop-types: ^15.7.2
     react-element-to-jsx-string: ^14.3.4
+    require-from-string: ^2.0.2
     ts-dedent: ^2.0.0
     typescript: ~4.6.3
     util-deprecate: ^1.0.2
   peerDependencies:
-    jest-specific-snapshot: ^4.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    require-from-string: ^2.0.2
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
Issue: #19021

## What I did

Removed `babel-loader` from `@storybook/core-common`
Moved `jest-specific-snapshot` and `require-from-string` to devDependencies in `@storybook/react`

## How to test

CI shouldn't have any problems. 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
