### PR TITLE
Revert "more things fixed, it's running!!! (with a big error of course)"

### DIFF
--- a/code/lib/source-loader/src/dependencies-lookup/readAsObject.js
+++ b/code/lib/source-loader/src/dependencies-lookup/readAsObject.js
@@ -2,7 +2,7 @@ import injectDecorator from '../abstract-syntax-tree/inject-decorator';
 import { sanitizeSource } from '../abstract-syntax-tree/generate-helpers';
 
 function readAsObject(classLoader, inputSource, mainFile) {
-  const options = classLoader.getOptions();
+  const options = this.getOptions();
   const result = injectDecorator(
     inputSource,
     classLoader.resourcePath,


### PR DESCRIPTION
This reverts commit 631795b23e0dafbc9cece03c1829a25fff2a7b45.

It was causing the vite builder's custom `sourceLoaderPlugin` to break.  @shilman asked me to revert and see what happens in CI.
