### PR TITLE
Added Story/Meta typings for Svelte

### DIFF
--- a/app/svelte/src/client/index.ts
+++ b/app/svelte/src/client/index.ts
@@ -9,6 +9,8 @@ export {
   raw,
 } from './preview';
 
+export * from './preview/types-6-0';
+
 if (module && module.hot && module.hot.decline) {
   module.hot.decline();
 }

--- a/app/svelte/src/client/preview/types-6-0.ts
+++ b/app/svelte/src/client/preview/types-6-0.ts
@@ -1,0 +1,41 @@
+import type {
+  AnnotatedStoryFn,
+  Args,
+  ComponentAnnotations,
+  StoryAnnotations,
+} from '@storybook/csf';
+
+export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/csf';
+
+import type { SvelteFramework } from './types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+ export type Meta<TArgs = Args> = ComponentAnnotations<SvelteFramework, TArgs>;
+
+ /**
+  * Story function that represents a CSFv2 component example.
+  *
+  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+  */
+ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<SvelteFramework, TArgs>;
+ 
+ /**
+  * Story function that represents a CSFv3 component example.
+  *
+  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+  */
+ export type StoryObj<TArgs = Args> = StoryAnnotations<SvelteFramework, TArgs>;
+ 
+ /**
+  * Story function that represents a CSFv2 component example.
+  *
+  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+  *
+  * NOTE that in Storybook 7.0, this type will be renamed to `StoryFn` and replaced by the current `StoryObj` type.
+  *
+  */
+ export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/app/svelte/src/client/preview/types-7-0.ts
+++ b/app/svelte/src/client/preview/types-7-0.ts
@@ -1,0 +1,14 @@
+import type { Args } from '@storybook/csf';
+
+import type { StoryObj } from './types-6-0';
+
+export type { StoryFn, StoryObj, Meta } from './types-6-0';
+
+// NOTE these types are reversed from the way they are in types-6-0 and types-6-3
+
+/**
+ * Story function that represents a CSFv3 component example.
+ *
+ * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
+ */
+export type Story<TArgs = Args> = StoryObj<TArgs>;

--- a/app/svelte/types-6-0.d.ts
+++ b/app/svelte/types-6-0.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/client/preview/types-6-0';


### PR DESCRIPTION
Issue: Svelte renderer doesn't have support for the `Story` and `Meta` types like React and Vue do. This results in `Property 'args' does not exist on type` type errors when using TypeScript in stories.

## What I did

I added the missing typings.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots? No
- [x] Does this need a new example in the kitchen sink apps? No - the Svelte kitchen sink currently does not have TypeScript examples
- [x] Does this need an update to the documentation? I don't think so. The only Storybook + Svelte + TypeScript documentation I could find was a blog. If I'm wrong I'm happy to update documentation if you point me in the right direction.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
