### PR TITLE
Vite: Set `resolve.preserveSymlinks` based on env vars

### DIFF
--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { Plugin } from 'vite';
 import viteReact from '@vitejs/plugin-react';
 import type { UserConfig } from 'vite';
+import { isPreservingSymlinks } from '@storybook/core-common';
 import { allowedEnvPrefix as envPrefix } from './envs';
 import { codeGeneratorPlugin } from './code-generator-plugin';
 import { injectExportOrderPlugin } from './inject-export-order-plugin';
@@ -33,6 +34,7 @@ export async function commonConfig(
     cacheDir: 'node_modules/.vite-storybook',
     envPrefix,
     define: {},
+    resolve: { preserveSymlinks: isPreservingSymlinks() },
     plugins: await pluginConfig(options, _type),
   };
 }

--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -17,6 +17,7 @@ import {
   normalizeStories,
   readTemplate,
   loadPreviewOrConfigFile,
+  isPreservingSymlinks,
 } from '@storybook/core-common';
 import { toRequireContextString, toImportFn } from '@storybook/core-webpack';
 import type { BuilderOptions, TypescriptOptions } from '../types';
@@ -168,10 +169,6 @@ export default async (
   const shouldCheckTs = typescriptOptions.check && !typescriptOptions.skipBabel;
   const tsCheckOptions = typescriptOptions.checkOptions || {};
 
-  const { NODE_OPTIONS, NODE_PRESERVE_SYMLINKS } = process.env;
-  const isPreservingSymlinks =
-    !!NODE_PRESERVE_SYMLINKS || NODE_OPTIONS?.includes('--preserve-symlinks');
-
   return {
     name: 'preview',
     mode: isProd ? 'production' : 'development',
@@ -275,7 +272,7 @@ export default async (
       },
       // Set webpack to resolve symlinks based on whether the user has asked node to.
       // This feels like it should be default out-of-the-box in webpack :shrug:
-      symlinks: !isPreservingSymlinks,
+      symlinks: !isPreservingSymlinks(),
     },
     optimization: {
       splitChunks: {

--- a/code/lib/core-common/src/index.ts
+++ b/code/lib/core-common/src/index.ts
@@ -26,6 +26,7 @@ export * from './utils/glob-to-regexp';
 export * from './utils/normalize-stories';
 export * from './utils/readTemplate';
 export * from './utils/findDistEsm';
+export * from './utils/symlinks';
 
 export * from './types';
 

--- a/code/lib/core-common/src/utils/symlinks.ts
+++ b/code/lib/core-common/src/utils/symlinks.ts
@@ -1,0 +1,4 @@
+export function isPreservingSymlinks() {
+  const { NODE_OPTIONS, NODE_PRESERVE_SYMLINKS } = process.env;
+  return !!NODE_PRESERVE_SYMLINKS || NODE_OPTIONS?.includes('--preserve-symlinks');
+}


### PR DESCRIPTION
Similar to how we do in webpack.

 - I think `core-common` is the right place for this util?

## How to test

A basic linked Vite sandbox should now work without modification.