### PR TITLE
Core: Add previewHead and previewBody to StorybookConfig interface

### DIFF
--- a/code/lib/core-common/src/types.ts
+++ b/code/lib/core-common/src/types.ts
@@ -428,6 +428,15 @@ export interface StorybookConfig {
    * Docs related features in index generation
    */
   docs?: DocsOptions;
+
+  /**
+   * Programmatically modify the preview head/body HTML.
+   * The previewHead and previewBody functions accept a string,
+   * which is the existing head/body, and return a modified string.
+   */
+  previewHead?: (head: string) => string;
+
+  previewBody?: (body: string) => string;
 }
 
 export type PresetProperty<K, TStorybookConfig = StorybookConfig> =

--- a/code/lib/core-common/src/types.ts
+++ b/code/lib/core-common/src/types.ts
@@ -434,9 +434,9 @@ export interface StorybookConfig {
    * The previewHead and previewBody functions accept a string,
    * which is the existing head/body, and return a modified string.
    */
-  previewHead?: (head: string) => string;
+  previewHead?: (head: string, options: Options) => string;
 
-  previewBody?: (body: string) => string;
+  previewBody?: (body: string, options: Options) => string;
 }
 
 export type PresetProperty<K, TStorybookConfig = StorybookConfig> =


### PR DESCRIPTION
Issue: 

`previewHead` does not exist in the StorybookConfig interface. This results in type errors when using TypeScript configuration (`main.ts`). See screenshot:

![Screenshot 2022-08-29 at 8 03 31 PM](https://user-images.githubusercontent.com/6603745/187254997-a4ed1d22-3e6f-4d01-9945-f5dd9fe16354.png)

## What I did

I added `previewHead` and `previewBody` in the StorybookConfig interface.

This was raised [in this issue](https://github.com/nrwl/nx/issues/2838#issuecomment-1230566486) on the Nx side.