### PR TITLE
Core: Fix WebProjectAnnotations export in preview-web for back-compat

### DIFF
--- a/code/lib/preview-web/src/index.ts
+++ b/code/lib/preview-web/src/index.ts
@@ -1,5 +1,6 @@
 // FIXME: breaks builder-vite, remove this in 7.0
 export { composeConfigs } from '@storybook/store';
+export type { WebProjectAnnotations } from '@storybook/store';
 
 export { Preview } from './Preview';
 export { PreviewWeb } from './PreviewWeb';


### PR DESCRIPTION
Issue: https://github.com/storybookjs/testing-react/issues/106
Discussion: https://github.com/storybookjs/storybook/discussions/18531

## What I did

I added a type export to resolve.  It was unclear if this, too, would affect `builder-vite`, (I can't imagine it would), but I added the export immediately following for visibility and completeness.

Hope this helps!

## How to test

- [ ] ~~Is this testable with Jest or Chromatic screenshots?~~
- [ ] ~~Does this need a new example in the kitchen sink apps?~~
- [ ] ~~Does this need an update to the documentation?~~

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
