### PR TITLE
Vite: Fix framework option checks, and SSv6

### DIFF
--- a/code/lib/builder-vite/src/codegen-iframe-script.ts
+++ b/code/lib/builder-vite/src/codegen-iframe-script.ts
@@ -2,11 +2,11 @@ import { isAbsolute, resolve } from 'path';
 import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 import { transformAbsPath } from './utils/transform-abs-path';
 import type { ExtendedOptions } from './types';
+import { getFrameworkName } from './utils/get-framework-name';
 
 export async function generateIframeScriptCode(options: ExtendedOptions) {
-  const { presets, frameworkPath, framework } = options;
-  const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
-
+  const { presets } = options;
+  const frameworkName = await getFrameworkName(options);
   const presetEntries = await presets.apply('config', [], options);
   const previewEntries = await presets.apply('previewEntries', [], options);
   const absolutePreviewEntries = previewEntries.map((entry) =>
@@ -28,7 +28,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
   const code = `
     // Ensure that the client API is initialized by the framework before any other iframe code
     // is loaded. That way our client-apis can assume the existence of the API+store
-    import { configure } from '${frameworkImportPath}';
+    import { configure } from '${frameworkName}';
 
     import * as clientApi from "@storybook/client-api";
     import { logger } from '@storybook/client-logger';

--- a/code/lib/builder-vite/src/codegen-iframe-script.ts
+++ b/code/lib/builder-vite/src/codegen-iframe-script.ts
@@ -1,8 +1,8 @@
 import { isAbsolute, resolve } from 'path';
+import { getFrameworkName } from '@storybook/core-common';
 import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 import { transformAbsPath } from './utils/transform-abs-path';
 import type { ExtendedOptions } from './types';
-import { getFrameworkName } from './utils/get-framework-name';
 
 export async function generateIframeScriptCode(options: ExtendedOptions) {
   const { presets } = options;

--- a/code/lib/builder-vite/src/codegen-modern-iframe-script.ts
+++ b/code/lib/builder-vite/src/codegen-modern-iframe-script.ts
@@ -2,10 +2,12 @@ import { isAbsolute, resolve } from 'path';
 import { loadPreviewOrConfigFile } from '@storybook/core-common';
 import { virtualStoriesFile, virtualAddonSetupFile } from './virtual-file-names';
 import { transformAbsPath } from './utils/transform-abs-path';
+import { getFrameworkName } from './utils/get-framework-name';
 import type { ExtendedOptions } from './types';
 
 export async function generateModernIframeScriptCode(options: ExtendedOptions) {
-  const { presets, configDir, framework } = options;
+  const { presets, configDir } = options;
+  const framework = await getFrameworkName(options);
 
   const previewOrConfigFile = loadPreviewOrConfigFile({ configDir });
   const presetEntries = await presets.apply('config', [], options);
@@ -19,7 +21,7 @@ export async function generateModernIframeScriptCode(options: ExtendedOptions) {
 
   const generateHMRHandler = (framework: string): string => {
     // Web components are not compatible with HMR, so disable HMR, reload page instead.
-    if (framework === 'web-components') {
+    if (framework === '@storybook/web-components-vite') {
       return `
       if (import.meta.hot) {
         import.meta.hot.decline();

--- a/code/lib/builder-vite/src/codegen-modern-iframe-script.ts
+++ b/code/lib/builder-vite/src/codegen-modern-iframe-script.ts
@@ -1,13 +1,12 @@
 import { isAbsolute, resolve } from 'path';
-import { loadPreviewOrConfigFile } from '@storybook/core-common';
+import { loadPreviewOrConfigFile, getFrameworkName } from '@storybook/core-common';
 import { virtualStoriesFile, virtualAddonSetupFile } from './virtual-file-names';
 import { transformAbsPath } from './utils/transform-abs-path';
-import { getFrameworkName } from './utils/get-framework-name';
 import type { ExtendedOptions } from './types';
 
 export async function generateModernIframeScriptCode(options: ExtendedOptions) {
   const { presets, configDir } = options;
-  const framework = await getFrameworkName(options);
+  const frameworkName = await getFrameworkName(options);
 
   const previewOrConfigFile = loadPreviewOrConfigFile({ configDir });
   const presetEntries = await presets.apply('config', [], options);
@@ -19,9 +18,9 @@ export async function generateModernIframeScriptCode(options: ExtendedOptions) {
     .filter(Boolean)
     .map((configEntry) => transformAbsPath(configEntry as string));
 
-  const generateHMRHandler = (framework: string): string => {
+  const generateHMRHandler = (frameworkName: string): string => {
     // Web components are not compatible with HMR, so disable HMR, reload page instead.
-    if (framework === '@storybook/web-components-vite') {
+    if (frameworkName === '@storybook/web-components-vite') {
       return `
       if (import.meta.hot) {
         import.meta.hot.decline();
@@ -71,7 +70,7 @@ export async function generateModernIframeScriptCode(options: ExtendedOptions) {
 
     preview.initialize({ importFn, getProjectAnnotations });
     
-    ${generateHMRHandler(framework)};
+    ${generateHMRHandler(frameworkName)};
     `.trim();
   return code;
 }

--- a/code/lib/builder-vite/src/transform-iframe-html.ts
+++ b/code/lib/builder-vite/src/transform-iframe-html.ts
@@ -1,15 +1,25 @@
 import { normalizeStories } from '@storybook/core-common';
 import type { CoreConfig } from '@storybook/core-common';
+import { getFrameworkName } from './utils/get-framework-name';
 import type { ExtendedOptions } from './types';
 
 export type PreviewHtml = string | undefined;
 
 export async function transformIframeHtml(html: string, options: ExtendedOptions) {
-  const { configType, features, framework, presets, serverChannelUrl, title } = options;
+  const { configType, features, presets, serverChannelUrl, title } = options;
+  const framework = await getFrameworkName(options);
   const headHtmlSnippet = await presets.apply<PreviewHtml>('previewHead');
   const bodyHtmlSnippet = await presets.apply<PreviewHtml>('previewBody');
   const logLevel = await presets.apply('logLevel', undefined);
-  const frameworkOptions = await presets.apply(`${framework}Options`, {});
+
+  // TODO: pull this into frameworks?
+  let frameworkOptions;
+  if (framework.includes('react')) {
+    frameworkOptions = await presets.apply(`reactOptions`, {});
+  } else if (framework.includes('svelte')) {
+    frameworkOptions = await presets.apply(`svelteOptions`, {});
+  }
+
   const coreOptions = await presets.apply<CoreConfig>('core');
   const stories = normalizeStories(await options.presets.apply('stories', [], options), {
     configDir: options.configDir,

--- a/code/lib/builder-vite/src/transform-iframe-html.ts
+++ b/code/lib/builder-vite/src/transform-iframe-html.ts
@@ -1,24 +1,15 @@
 import { normalizeStories } from '@storybook/core-common';
 import type { CoreConfig } from '@storybook/core-common';
-import { getFrameworkName } from './utils/get-framework-name';
 import type { ExtendedOptions } from './types';
 
 export type PreviewHtml = string | undefined;
 
 export async function transformIframeHtml(html: string, options: ExtendedOptions) {
   const { configType, features, presets, serverChannelUrl, title } = options;
-  const framework = await getFrameworkName(options);
+  const frameworkOptions = await presets.apply<Record<string, any> | null>('frameworkOptions');
   const headHtmlSnippet = await presets.apply<PreviewHtml>('previewHead');
   const bodyHtmlSnippet = await presets.apply<PreviewHtml>('previewBody');
   const logLevel = await presets.apply('logLevel', undefined);
-
-  // TODO: pull this into frameworks?
-  let frameworkOptions;
-  if (framework.includes('react')) {
-    frameworkOptions = await presets.apply(`reactOptions`, {});
-  } else if (framework.includes('svelte')) {
-    frameworkOptions = await presets.apply(`svelteOptions`, {});
-  }
 
   const coreOptions = await presets.apply<CoreConfig>('core');
   const stories = normalizeStories(await options.presets.apply('stories', [], options), {
@@ -33,7 +24,7 @@ export async function transformIframeHtml(html: string, options: ExtendedOptions
     .replace('<!-- [TITLE HERE] -->', title || 'Storybook')
     .replace('[CONFIG_TYPE HERE]', configType || '')
     .replace('[LOGLEVEL HERE]', logLevel || '')
-    .replace(`'[FRAMEWORK_OPTIONS HERE]'`, JSON.stringify(frameworkOptions || {}))
+    .replace(`'[FRAMEWORK_OPTIONS HERE]'`, JSON.stringify(frameworkOptions))
     .replace(
       `'[CHANNEL_OPTIONS HERE]'`,
       JSON.stringify(coreOptions && coreOptions.channelOptions ? coreOptions.channelOptions : {})

--- a/code/lib/builder-vite/src/types/extended-options.type.ts
+++ b/code/lib/builder-vite/src/types/extended-options.type.ts
@@ -2,10 +2,7 @@ import type { Options } from '@storybook/core-common';
 
 // Using instead of `Record<string, string>` to provide better aware of used options
 type IframeOptions = {
-  frameworkPath: string;
   title: string;
-  // FIXME: Use @ndelangen's improved types
-  framework: string;
 };
 
 export type ExtendedOptions = Options & IframeOptions;

--- a/code/lib/builder-vite/src/utils/get-framework-name.ts
+++ b/code/lib/builder-vite/src/utils/get-framework-name.ts
@@ -1,0 +1,6 @@
+import type { ExtendedOptions } from '../types';
+
+export async function getFrameworkName(options: ExtendedOptions) {
+  const framework = await options.presets.apply('framework', '', options);
+  return typeof framework === 'object' ? framework.name : framework;
+}

--- a/code/lib/builder-vite/src/utils/get-framework-name.ts
+++ b/code/lib/builder-vite/src/utils/get-framework-name.ts
@@ -1,6 +1,0 @@
-import type { ExtendedOptions } from '../types';
-
-export async function getFrameworkName(options: ExtendedOptions) {
-  const framework = await options.presets.apply('framework', '', options);
-  return typeof framework === 'object' ? framework.name : framework;
-}

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -9,6 +9,7 @@ import { codeGeneratorPlugin } from './code-generator-plugin';
 import { injectExportOrderPlugin } from './inject-export-order-plugin';
 import { mdxPlugin } from './plugins/mdx-plugin';
 import { noFouc } from './plugins/no-fouc';
+import { getFrameworkName } from './utils/get-framework-name';
 import type { ExtendedOptions } from './types';
 
 export type PluginConfigType = 'build' | 'development';
@@ -40,7 +41,7 @@ export async function commonConfig(
 }
 
 export async function pluginConfig(options: ExtendedOptions, _type: PluginConfigType) {
-  const { framework } = options;
+  const framework = await getFrameworkName(options);
 
   const plugins = [
     codeGeneratorPlugin(options),
@@ -52,7 +53,7 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
     viteReact({
       // Do not treat story files as HMR boundaries, storybook itself needs to handle them.
       exclude: [/\.stories\.([tj])sx?$/, /node_modules/].concat(
-        framework === 'react' ? [] : [/\.([tj])sx?$/]
+        framework === '@storybook/react-vite' ? [] : [/\.([tj])sx?$/]
       ),
     }),
     {
@@ -70,12 +71,14 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
     },
   ] as Plugin[];
 
-  if (framework === 'preact') {
+  // TODO: framework doesn't exist, should move into framework when/if built
+  if (framework === '@storybook/preact-vite') {
     // eslint-disable-next-line global-require
     plugins.push(require('@preact/preset-vite').default());
   }
 
-  if (framework === 'glimmerx') {
+  // TODO: framework doesn't exist, should move into framework when/if built
+  if (framework === '@storybook/glimmerx-vite') {
     // eslint-disable-next-line global-require, import/extensions
     const plugin = require('vite-plugin-glimmerx/index.cjs');
     plugins.push(plugin.default());

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -3,13 +3,12 @@ import fs from 'fs';
 import { Plugin } from 'vite';
 import viteReact from '@vitejs/plugin-react';
 import type { UserConfig } from 'vite';
-import { isPreservingSymlinks } from '@storybook/core-common';
+import { isPreservingSymlinks, getFrameworkName } from '@storybook/core-common';
 import { allowedEnvPrefix as envPrefix } from './envs';
 import { codeGeneratorPlugin } from './code-generator-plugin';
 import { injectExportOrderPlugin } from './inject-export-order-plugin';
 import { mdxPlugin } from './plugins/mdx-plugin';
 import { noFouc } from './plugins/no-fouc';
-import { getFrameworkName } from './utils/get-framework-name';
 import type { ExtendedOptions } from './types';
 
 export type PluginConfigType = 'build' | 'development';
@@ -41,7 +40,7 @@ export async function commonConfig(
 }
 
 export async function pluginConfig(options: ExtendedOptions, _type: PluginConfigType) {
-  const framework = await getFrameworkName(options);
+  const frameworkName = await getFrameworkName(options);
 
   const plugins = [
     codeGeneratorPlugin(options),
@@ -53,7 +52,7 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
     viteReact({
       // Do not treat story files as HMR boundaries, storybook itself needs to handle them.
       exclude: [/\.stories\.([tj])sx?$/, /node_modules/].concat(
-        framework === '@storybook/react-vite' ? [] : [/\.([tj])sx?$/]
+        frameworkName === '@storybook/react-vite' ? [] : [/\.([tj])sx?$/]
       ),
     }),
     {
@@ -72,13 +71,13 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
   ] as Plugin[];
 
   // TODO: framework doesn't exist, should move into framework when/if built
-  if (framework === '@storybook/preact-vite') {
+  if (frameworkName === '@storybook/preact-vite') {
     // eslint-disable-next-line global-require
     plugins.push(require('@preact/preset-vite').default());
   }
 
   // TODO: framework doesn't exist, should move into framework when/if built
-  if (framework === '@storybook/glimmerx-vite') {
+  if (frameworkName === '@storybook/glimmerx-vite') {
     // eslint-disable-next-line global-require, import/extensions
     const plugin = require('vite-plugin-glimmerx/index.cjs');
     plugins.push(plugin.default());

--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -18,6 +18,7 @@ import {
   readTemplate,
   loadPreviewOrConfigFile,
   isPreservingSymlinks,
+  getFrameworkName,
 } from '@storybook/core-common';
 import { toRequireContextString, toImportFn } from '@storybook/core-webpack';
 import type { BuilderOptions, TypescriptOptions } from '../types';
@@ -67,15 +68,7 @@ export default async (
     serverChannelUrl,
   } = options;
 
-  const framework = await presets.apply('framework', undefined);
-  if (!framework) {
-    throw new Error(dedent`
-      You must to specify a framework in '.storybook/main.js' config.
-
-      https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#framework-field-mandatory
-    `);
-  }
-  const frameworkName = typeof framework === 'string' ? framework : framework.name;
+  const frameworkName = await getFrameworkName(options);
   const frameworkOptions = await presets.apply('frameworkOptions');
 
   const isProd = configType === 'PRODUCTION';

--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { dedent } from 'ts-dedent';
 import { DefinePlugin, HotModuleReplacementPlugin, ProgressPlugin, ProvidePlugin } from 'webpack';
 import type { Configuration } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';

--- a/code/lib/core-common/src/index.ts
+++ b/code/lib/core-common/src/index.ts
@@ -9,6 +9,7 @@ export * from './utils/interpret-files';
 export * from './utils/interpret-require';
 export * from './utils/load-custom-presets';
 export * from './utils/load-main-config';
+export * from './utils/get-framework-name';
 export * from './utils/get-storybook-configuration';
 export * from './utils/get-storybook-info';
 export * from './utils/get-storybook-refs';

--- a/code/lib/core-common/src/utils/get-framework-name.ts
+++ b/code/lib/core-common/src/utils/get-framework-name.ts
@@ -1,0 +1,19 @@
+import { dedent } from 'ts-dedent';
+import type { Options } from '../types';
+
+/**
+ * Framework can be a string or an object.  This utility always returns the string name.
+ */
+export async function getFrameworkName(options: Options) {
+  const framework = await options.presets.apply('framework', '', options);
+
+  if (!framework) {
+    throw new Error(dedent`
+      You must specify a framework in '.storybook/main.js' config.
+
+      https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#framework-field-mandatory
+    `);
+  }
+
+  return typeof framework === 'object' ? framework.name : framework;
+}


### PR DESCRIPTION
Issue:

We used to be able to get a simple `react` or `svelte` from `options.framework`, but no longer.  This adds a bit of a helper to check whether the framework is a string or an object, and return the value.  It also adjusts the format of the expected returns to be `@storybook/react-vite` for instance.  This should be merged before https://github.com/storybookjs/storybook/pull/19026, which will need to be updated a bit after these changes.

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
