### PR TITLE
CLI: Fix race condition in sb init

### DIFF
--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -208,7 +208,7 @@ export async function baseGenerator(
   await configurePreview(renderer, options.commonJs);
 
   if (addComponents) {
-    copyComponents(renderer, language);
+    await copyComponents(renderer, language);
   }
 
   // FIXME: temporary workaround for https://github.com/storybookjs/storybook/issues/17516


### PR DESCRIPTION
Issue: N/A

## What I did

There is a race condition in `sb init` where it can begin running the migrations before the template files are properly copied. This fixes that.

Self-merging @ndelangen 

## How to test

Not sure. We need to create a testing strategy for the CLI when we do a rewrite cc @tmeasday 
