### PR TITLE
Vite: Don't add babel dependencies during init

### DIFF
--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -221,7 +221,10 @@ export async function baseGenerator(
     await fse.writeFile(`.storybook/preview-head.html`, previewHead, { encoding: 'utf8' });
   }
 
-  const babelDependencies = addBabel ? await getBabelDependencies(packageManager, packageJson) : [];
+  const babelDependencies =
+    addBabel && builder !== CoreBuilder.Vite
+      ? await getBabelDependencies(packageManager, packageJson)
+      : [];
   const isNewFolder = !files.some(
     (fname) => fname.startsWith('.babel') || fname.startsWith('babel') || fname === 'package.json'
   );


### PR DESCRIPTION
Issue: Vite projects are getting `babel-loader` and `@babel-core` dependencies added during `npx sb init`, when they don't need them.

In fact, in storybook 7.0, is installing these babel dependencies in a user project ever needed?

## What I did

Gated the installation of babel deps in the user's project to non-vite builders.

## How to test

CI should tell us if this is a problem, I presume, based on the sandboxes and e2e tests.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
