### PR TITLE
Build: Prefix generic addon stories in sandbox storybooks

### DIFF
--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -269,7 +269,7 @@ async function addStories(paths: string[], { mainConfig }: { mainConfig: ConfigF
     .filter(([, exists]) => exists)
     .map(([p]) => ({
       directory: path.join(relativeCodeDir, p),
-      prefix: p.split('/').slice(-4, -2).join('/'),
+      titlePrefix: p.split('/').slice(-4, -2).join('/'),
       files: '*.stories.@(js|jsx|ts|tsx)',
     }));
   mainConfig.setFieldValue(['stories'], [...stories, ...extraStories]);

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -267,7 +267,11 @@ async function addStories(paths: string[], { mainConfig }: { mainConfig: ConfigF
   const relativeCodeDir = path.join('..', '..', '..', 'code');
   const extraStories = extraStoryDirsAndExistence
     .filter(([, exists]) => exists)
-    .map(([p]) => path.join(relativeCodeDir, p, '*.stories.@(js|jsx|ts|tsx)'));
+    .map(([p]) => ({
+      directory: path.join(relativeCodeDir, p),
+      prefix: p.split('/').slice(-4, -2).join('/'),
+      files: '*.stories.@(js|jsx|ts|tsx)',
+    }));
   mainConfig.setFieldValue(['stories'], [...stories, ...extraStories]);
 }
 


### PR DESCRIPTION
Issue: N/A

## What I did

When we copy template stories into a sandbox, prefix it appropriately, e.g. `addon-actions` would get the prefix `addons/actions`.

## How to test

```
yarn task --task create --template cra/default-ts
``` 