### PR TITLE
CLI: remove outdated comment in Angular starter

### DIFF
--- a/code/lib/cli/rendererAssets/angular/Button.stories.ts
+++ b/code/lib/cli/rendererAssets/angular/Button.stories.ts
@@ -1,4 +1,3 @@
-// also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
 import type { Meta, StoryFn } from '@storybook/angular';
 import Button from './button.component';
 


### PR DESCRIPTION
Issue: N/A

## What I did

There was a comment in the angular CLI starter mentioning Storybook 6.1 🙈 

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
