### PR TITLE
Remove deprecated `stable` dependency

### DIFF
--- a/code/lib/addons/src/types.ts
+++ b/code/lib/addons/src/types.ts
@@ -77,7 +77,8 @@ export type IndexEntry = StoryIndexEntry | DocsIndexEntry;
 
 // The `any` here is the story store's `StoreItem` record. Ideally we should probably only
 // pass a defined subset of that full data, but we pass it all so far :shrug:
-export type StorySortComparator = Comparator<[StoryId, any, Parameters, Parameters]>;
+export type IndexEntryLegacy = [StoryId, any, Parameters, Parameters];
+export type StorySortComparator = Comparator<IndexEntryLegacy>;
 export type StorySortParameter = StorySortComparator | StorySortObjectParameter;
 export type StorySortComparatorV7 = Comparator<IndexEntry>;
 export type StorySortParameterV7 = StorySortComparatorV7 | StorySortObjectParameter;

--- a/code/lib/builder-vite/src/optimizeDeps.ts
+++ b/code/lib/builder-vite/src/optimizeDeps.ts
@@ -84,7 +84,6 @@ const INCLUDE_CANDIDATES = [
   'refractor/lang/yaml.js',
   'regenerator-runtime/runtime.js',
   'slash',
-  'stable',
   'store2',
   'synchronous-promise',
   'telejson',

--- a/code/lib/builder-webpack5/package.json
+++ b/code/lib/builder-webpack5/package.json
@@ -65,7 +65,6 @@
     "html-webpack-plugin": "^5.5.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
-    "stable": "^0.1.8",
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.1",
     "ts-dedent": "^2.0.0",

--- a/code/lib/store/package.json
+++ b/code/lib/store/package.json
@@ -44,7 +44,6 @@
     "lodash": "^4.17.21",
     "memoizerific": "^1.11.3",
     "slash": "^3.0.0",
-    "stable": "^0.1.8",
     "synchronous-promise": "^2.0.15",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"

--- a/code/lib/store/src/sortStories.ts
+++ b/code/lib/store/src/sortStories.ts
@@ -1,6 +1,10 @@
-import stable from 'stable';
 import { dedent } from 'ts-dedent';
-import type { Comparator, StorySortParameter, StorySortParameterV7 } from '@storybook/addons';
+import type {
+  Comparator,
+  IndexEntryLegacy,
+  StorySortParameter,
+  StorySortParameterV7,
+} from '@storybook/addons';
 import { storySort } from './storySort';
 import type { Story, StoryIndexEntry, IndexEntry, Path, Parameters } from './types';
 
@@ -16,10 +20,9 @@ const sortStoriesCommon = (
     } else {
       sortFn = storySort(storySortParameter);
     }
-    stable.inplace(stories, sortFn);
+    stories.sort(sortFn as (a: IndexEntry, b: IndexEntry) => number);
   } else {
-    stable.inplace(
-      stories,
+    stories.sort(
       (s1, s2) => fileNameOrder.indexOf(s1.importPath) - fileNameOrder.indexOf(s2.importPath)
     );
   }
@@ -57,7 +60,7 @@ export const sortStoriesV6 = (
   fileNameOrder: Path[]
 ) => {
   if (storySortParameter && typeof storySortParameter === 'function') {
-    stable.inplace(stories, storySortParameter);
+    stories.sort(storySortParameter as (a: IndexEntryLegacy, b: IndexEntryLegacy) => number);
     return stories.map((s) => toIndexEntry(s[1]));
   }
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7777,7 +7777,6 @@ __metadata:
     html-webpack-plugin: ^5.5.0
     path-browserify: ^1.0.1
     process: ^0.11.10
-    stable: ^0.1.8
     style-loader: ^3.3.1
     terser-webpack-plugin: ^5.3.1
     ts-dedent: ^2.0.0
@@ -9440,7 +9439,6 @@ __metadata:
     lodash: ^4.17.21
     memoizerific: ^1.11.3
     slash: ^3.0.0
-    stable: ^0.1.8
     synchronous-promise: ^2.0.15
     ts-dedent: ^2.0.0
     typescript: ~4.6.3


### PR DESCRIPTION
Issue:

https://github.com/storybookjs/storybook/issues/17019 (related)

## What I did

Replace package `stable` to native `Array#sort` method.

Why:

When a storybook is installed, among other things, I get this warning:

```
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
```

If I understood the usage correctly, the package was used by Node.js. Sorting is stable since version 12 of Node.js. storybook requires Node.js above version 10. Do you plan to upgrade the engine version in version 7?

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
