### PR TITLE
CLI: Fix include rendererAssets in npm bundle

### DIFF
--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -29,6 +29,7 @@
   "files": [
     "bin/**/*",
     "dist/**/*",
+    "rendererAssets/**/*",
     "README.md",
     "*.js",
     "*.d.ts"


### PR DESCRIPTION
Issue: `npx sb@future init` fails with `Error: Unsupported renderer: react`

## What I did

The asset files for the renderers were missing in the npm package, so I added them to the `files` in `package.json`.

## How to test

I'm not sure how to test this automatically, since I kind of would have thought that vercaddio tests we already have would have caught this.  But, I copied those files into a local project, and then `init` worked correctly after that.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
