### PR TITLE
Convert @ts-ignore to @ts-expect-error

### DIFF
--- a/code/addons/actions/src/preview/action.ts
+++ b/code/addons/actions/src/preview/action.ts
@@ -20,7 +20,7 @@ const isReactSyntheticEvent = (e: unknown): e is SyntheticEvent =>
 const serializeArg = <T>(a: T) => {
   if (isReactSyntheticEvent(a)) {
     const e: SyntheticEvent = Object.create(
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       a.constructor.prototype,
       Object.getOwnPropertyDescriptors(a)
     );

--- a/code/addons/docs/angular/index.js
+++ b/code/addons/docs/angular/index.js
@@ -2,6 +2,6 @@
 /* global window */
 
 export const setCompodocJson = (compodocJson) => {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   window.__STORYBOOK_COMPODOC_JSON__ = compodocJson;
 };

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -145,7 +145,7 @@ export async function webpack(
 export const storyIndexers = async (indexers: StoryIndexer[] | null) => {
   const mdxIndexer = async (fileName: string, opts: IndexerOptions) => {
     let code = (await fs.readFile(fileName, 'utf-8')).toString();
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     const { compile } = global.FEATURES?.previewMdx2
       ? await import('@storybook/mdx2-csf')
       : await import('@storybook/mdx1-csf');

--- a/code/addons/jest/src/shared.test.ts
+++ b/code/addons/jest/src/shared.test.ts
@@ -27,7 +27,7 @@ describe('defineJestParameter', () => {
   });
 
   test('returns null if filename is a module ID that cannot be inferred from', () => {
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     expect(defineJestParameter({ fileName: 1234 })).toBeNull();
   });
 });

--- a/code/addons/links/src/react/components/link.test.tsx
+++ b/code/addons/links/src/react/components/link.test.tsx
@@ -14,7 +14,7 @@ jest.mock('global', () => ({
       search: 'search',
     },
   },
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   window: global,
   __STORYBOOK_STORY_STORE__: {
     getSelection: jest.fn(() => ({ id: 1 })),

--- a/code/addons/links/src/utils.test.ts
+++ b/code/addons/links/src/utils.test.ts
@@ -5,9 +5,9 @@ import { linkTo, hrefTo } from './utils';
 
 jest.mock('@storybook/addons');
 jest.mock('global', () => ({
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   document: global.document,
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   window: global,
 }));
 

--- a/code/addons/links/src/utils.ts
+++ b/code/addons/links/src/utils.ts
@@ -36,9 +36,9 @@ export const hrefTo = (title: ComponentTitle, name: StoryName): Promise<string> 
   return new Promise((resolve) => {
     const { location } = document;
     const query = parseQuery(location.search);
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     const existingId = [].concat(query.id)[0];
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     const titleToLink = title || existingId.split('--', 2)[0];
     const id = toId(titleToLink, name);
     const url = `${location.origin + location.pathname}?${Object.entries({ ...query, id })

--- a/code/addons/storyshots/storyshots-core/src/api/ensureOptionsDefaults.ts
+++ b/code/addons/storyshots/storyshots-core/src/api/ensureOptionsDefaults.ts
@@ -25,7 +25,6 @@ function getIntegrityOptions({ integrityOptions }: StoryshotsOptions) {
   };
 }
 
-// @ts-ignore
 function ensureOptionsDefaults(options: StoryshotsOptions) {
   const {
     suite = 'Storyshots',

--- a/code/addons/storyshots/storyshots-core/src/api/integrityTestTemplate.ts
+++ b/code/addons/storyshots/storyshots-core/src/api/integrityTestTemplate.ts
@@ -52,7 +52,7 @@ function integrityTest(integrityOptions: any, stories2snapsConverter: any) {
       const snapshotExtension = stories2snapsConverter.getSnapshotExtension();
       const storyshots = glob.sync(`**/*${snapshotExtension}`, integrityOptions);
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       expect(storyshots).notToBeAbandoned(stories2snapsConverter);
     });
   });

--- a/code/addons/storyshots/storyshots-core/src/frameworks/svelte/renderTree.ts
+++ b/code/addons/storyshots/storyshots-core/src/frameworks/svelte/renderTree.ts
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
 import global from 'global';
-// @ts-ignore
 import { set_current_component } from 'svelte/internal';
 
 const { document } = global;

--- a/code/addons/storyshots/storyshots-core/src/frameworks/vue/renderTree.ts
+++ b/code/addons/storyshots/storyshots-core/src/frameworks/vue/renderTree.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import Vue from 'vue';
 
 // this is defined in @storybook/vue but not exported,
@@ -14,7 +13,7 @@ function getRenderedTree(story: any) {
     },
   });
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   vm[VALUES] = story.initialArgs;
 
   return vm.$mount().$el;

--- a/code/examples/angular-cli/.storybook/preview.ts
+++ b/code/examples/angular-cli/.storybook/preview.ts
@@ -2,7 +2,6 @@
 import { setCompodocJson } from '@storybook/addon-docs/angular';
 import addCssWarning from '../src/cssWarning';
 
-// @ts-expect-error (Converted from ts-ignore)
 import docJson from '../documentation.json';
 // remove ButtonComponent to test #12009
 const filtered = !docJson?.components

--- a/code/examples/angular-cli/.storybook/preview.ts
+++ b/code/examples/angular-cli/.storybook/preview.ts
@@ -2,7 +2,7 @@
 import { setCompodocJson } from '@storybook/addon-docs/angular';
 import addCssWarning from '../src/cssWarning';
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import docJson from '../documentation.json';
 // remove ButtonComponent to test #12009
 const filtered = !docJson?.components

--- a/code/examples/cra-kitchen-sink/.storybook/main.ts
+++ b/code/examples/cra-kitchen-sink/.storybook/main.ts
@@ -25,7 +25,7 @@ const mainConfig: StorybookConfig = {
     const resolvePlugins = config.resolve?.plugins;
     if (Array.isArray(resolvePlugins)) {
       resolvePlugins.forEach((p) => {
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         const appSrcs = p.appSrcs as unknown as string[];
         if (Array.isArray(appSrcs)) {
           appSrcs.push(path.join(__dirname, '..', '..', '..'));

--- a/code/examples/cra-ts-essentials/.storybook/main.ts
+++ b/code/examples/cra-ts-essentials/.storybook/main.ts
@@ -20,7 +20,7 @@ const mainConfig: StorybookConfig = {
     const resolvePlugins = config.resolve?.plugins;
     if (Array.isArray(resolvePlugins)) {
       resolvePlugins.forEach((p) => {
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         const appSrcs = p.appSrcs as unknown as string[];
         if (Array.isArray(appSrcs)) {
           appSrcs.push(path.join(__dirname, '..', '..', '..'));

--- a/code/examples/cra-ts-kitchen-sink/.storybook/main.ts
+++ b/code/examples/cra-ts-kitchen-sink/.storybook/main.ts
@@ -20,7 +20,7 @@ const mainConfig: StorybookConfig = {
     const resolvePlugins = config.resolve?.plugins;
     if (Array.isArray(resolvePlugins)) {
       resolvePlugins.forEach((p) => {
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         const appSrcs = p.appSrcs as unknown as string[];
         if (Array.isArray(appSrcs)) {
           appSrcs.push(path.join(__dirname, '..', '..', '..'));

--- a/code/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/DocgenTS.tsx
+++ b/code/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/DocgenTS.tsx
@@ -15,7 +15,6 @@ export const ButtonReactFC: React.FC<ButtonProps> = ({ onClick, children }) => (
   <button onClick={onClick}>{children}</button>
 );
 ButtonReactFC.defaultProps = {
-  // @ts-expect-error (Converted from ts-ignore)
   onClick: null,
 };
 
@@ -26,7 +25,6 @@ export const ButtonFC: FC<ButtonProps> = ({ onClick, children }) => (
   <button onClick={onClick}>{children}</button>
 );
 ButtonFC.defaultProps = {
-  // @ts-expect-error (Converted from ts-ignore)
   onClick: null,
 };
 
@@ -37,6 +35,5 @@ export const ButtonFunctionComponent: FC<ButtonProps> = ({ onClick, children }) 
   <button onClick={onClick}>{children}</button>
 );
 ButtonFunctionComponent.defaultProps = {
-  // @ts-expect-error (Converted from ts-ignore)
   onClick: null,
 };

--- a/code/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/DocgenTS.tsx
+++ b/code/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/DocgenTS.tsx
@@ -15,7 +15,7 @@ export const ButtonReactFC: React.FC<ButtonProps> = ({ onClick, children }) => (
   <button onClick={onClick}>{children}</button>
 );
 ButtonReactFC.defaultProps = {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   onClick: null,
 };
 
@@ -26,7 +26,7 @@ export const ButtonFC: FC<ButtonProps> = ({ onClick, children }) => (
   <button onClick={onClick}>{children}</button>
 );
 ButtonFC.defaultProps = {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   onClick: null,
 };
 
@@ -37,6 +37,6 @@ export const ButtonFunctionComponent: FC<ButtonProps> = ({ onClick, children }) 
   <button onClick={onClick}>{children}</button>
 );
 ButtonFunctionComponent.defaultProps = {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   onClick: null,
 };

--- a/code/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/types/ext.js
+++ b/code/examples/cra-ts-kitchen-sink/src/stories/docgen-tests/types/ext.js
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import PropTypes from 'prop-types';
 
 export const PRESET_SHAPE = {

--- a/code/examples/vue-3-cli/.storybook/preview.ts
+++ b/code/examples/vue-3-cli/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import { Parameters, setup } from '@storybook/vue3';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import Button from '../src/stories/Button.vue';
 
 // TODO: I'd like to be able to export rather than imperatively calling an imported function

--- a/code/examples/vue-3-cli/src/stories/Button.vue
+++ b/code/examples/vue-3-cli/src/stories/Button.vue
@@ -37,7 +37,7 @@ export default defineComponent({
 
   emits: ['click'],
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   setup(props, { emit }) {
     props = reactive(props);
     return {

--- a/code/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
+++ b/code/examples/vue-3-cli/src/stories/DynamicHeading.stories.ts
@@ -15,7 +15,6 @@ export default {
       const story = storyFn();
       // Vue 3 "Functional" component as decorator
       return () => {
-        // @ts-ignore // this is an unfortunate side-effect of having vue & vue3 in 1 repo
         return h('div', { style: 'border: 2px solid red' }, h(story));
       };
     },
@@ -27,7 +26,6 @@ export default {
 
   Make sure to pass the `args` the component expects  to receive as the props!
  */
-// @ts-ignore // this is an unfortunate side-effect of having vue & vue3 in 1 repo
 const Template: StoryFn<Props> = (args, { argTypes }) => {
   const component: FunctionalComponent<Props> = () => h(DynamicHeading, args, 'Hello World!');
   component.props = Object.keys(argTypes);

--- a/code/examples/vue-3-cli/src/stories/OverrideArgs.vue
+++ b/code/examples/vue-3-cli/src/stories/OverrideArgs.vue
@@ -23,7 +23,7 @@ export default {
     },
   },
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   setup(props, { emit }) {
     const classes = {
       'storybook-button': true,

--- a/code/frameworks/angular/src/client/angular/helpers.ts
+++ b/code/frameworks/angular/src/client/angular/helpers.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import global from 'global';
 import { enableProdMode, NgModule, Component, NgModuleRef, Type, NgZone } from '@angular/core';
 import { FormsModule } from '@angular/forms';

--- a/code/frameworks/angular/src/client/docs/angular-properties.test.ts
+++ b/code/frameworks/angular/src/client/docs/angular-properties.test.ts
@@ -6,7 +6,7 @@ import { sync as spawnSync } from 'cross-spawn';
 
 import { findComponentByName, extractArgTypesFromData } from './compodoc';
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 const { SNAPSHOT_OS } = global;
 
 // File hierarchy: __testfixtures__ / some-test-case / input.*

--- a/code/frameworks/angular/src/client/docs/compodoc.ts
+++ b/code/frameworks/angular/src/client/docs/compodoc.ts
@@ -21,11 +21,11 @@ export const isMethod = (methodOrProp: Method | Property): methodOrProp is Metho
 };
 
 export const setCompodocJson = (compodocJson: CompodocJson) => {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   window.__STORYBOOK_COMPODOC_JSON__ = compodocJson;
 };
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 export const getCompodocJson = (): CompodocJson => window.__STORYBOOK_COMPODOC_JSON__;
 
 export const checkValidComponentOrDirective = (component: Component | Directive) => {
@@ -191,7 +191,6 @@ const extractDefaultValueFromComments = (property: Property, value: any) => {
   let commentValue = value;
   property.jsdoctags.forEach((tag: JsDocTag) => {
     if (['default', 'defaultvalue'].includes(tag.tagName.escapedText)) {
-      // @ts-ignore
       const dom = new window.DOMParser().parseFromString(tag.comment, 'text/html');
       commentValue = dom.body.textContent;
     }

--- a/code/frameworks/angular/src/server/angular-cli-webpack-older.ts
+++ b/code/frameworks/angular/src/server/angular-cli-webpack-older.ts
@@ -109,7 +109,6 @@ function mergeAngularCliWebpackConfig(
   // styleWebpackConfig.entry adds global style files to the webpack context
   const entry = [
     ...(baseConfig.entry as string[]),
-    // @ts-ignore
     ...Object.values(cliStyleWebpackConfig.entry).reduce((acc, item) => acc.concat(item), []),
   ];
 

--- a/code/frameworks/angular/src/server/angular-devkit-build-webpack.ts
+++ b/code/frameworks/angular/src/server/angular-devkit-build-webpack.ts
@@ -121,8 +121,6 @@ const buildWebpackConfigOptions = async (
     sourceMap: {},
     styles: [],
     // Deleted in angular 12. Keep for compatibility with versions lower than angular 12
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     lazyModules: [],
 
     // Project Options
@@ -139,8 +137,7 @@ const buildWebpackConfigOptions = async (
     statsJson: false,
 
     // Deleted in angular 12. Keep for compatibility with versions lower than angular 12
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     forkTypeChecker: false,
   };
 

--- a/code/frameworks/ember/src/client/preview/render.ts
+++ b/code/frameworks/ember/src/client/preview/render.ts
@@ -1,7 +1,7 @@
 import global from 'global';
 import { dedent } from 'ts-dedent';
 import type { RenderContext } from '@storybook/store';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import Component from '@ember/component'; // eslint-disable-line import/no-unresolved
 import { OptionsArgs, EmberFramework } from './types';
 

--- a/code/jest.init.ts
+++ b/code/jest.init.ts
@@ -3,11 +3,10 @@ import '@testing-library/jest-dom';
 
 // setup file
 import { configure } from 'enzyme';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import Adapter from 'enzyme-adapter-react-16';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import regeneratorRuntime from 'regenerator-runtime';
-// @ts-ignore
 import registerRequireContextHook from '@storybook/babel-plugin-require-context-hook/register';
 import EventEmitter from 'events';
 
@@ -25,9 +24,9 @@ const localStorageMock = {
   setItem: jest.fn().mockName('setItem'),
   clear: jest.fn().mockName('clear'),
 };
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 global.localStorage = localStorageMock;
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 global.regeneratorRuntime = regeneratorRuntime;
 
 configure({ adapter: new Adapter() });

--- a/code/lib/addons/src/hooks.ts
+++ b/code/lib/addons/src/hooks.ts
@@ -329,11 +329,11 @@ function useStateLike<S>(
 ): [S, (update: ((prevState: S) => S) | S) => void] {
   const stateRef = useRefLike(
     name,
-    // @ts-ignore S type should never be function, but there's no way to tell that to TypeScript
+    // @ts-expect-error S type should never be function, but there's no way to tell that to TypeScript
     typeof initialState === 'function' ? initialState() : initialState
   );
   const setState = (update: ((prevState: S) => S) | S) => {
-    // @ts-ignore S type should never be function, but there's no way to tell that to TypeScript
+    // @ts-expect-error S type should never be function, but there's no way to tell that to TypeScript
     stateRef.current = typeof update === 'function' ? update(stateRef.current) : update;
     triggerUpdate();
   };

--- a/code/lib/api/src/index.tsx
+++ b/code/lib/api/src/index.tsx
@@ -309,7 +309,7 @@ interface ManagerConsumerProps<P = unknown> {
 const defaultFilter = (c: Combo) => c;
 
 function ManagerConsumer<P = Combo>({
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   filter = defaultFilter,
   children,
 }: ManagerConsumerProps<P>): ReactElement {

--- a/code/lib/api/src/modules/versions.ts
+++ b/code/lib/api/src/modules/versions.ts
@@ -1,5 +1,5 @@
 import global from 'global';
-// @ts-ignore
+// @ts-expect-error no typedefs
 import semver from '@storybook/semver';
 import memoize from 'memoizerific';
 

--- a/code/lib/api/src/store.ts
+++ b/code/lib/api/src/store.ts
@@ -4,7 +4,6 @@ import storeSetup from './lib/store-setup';
 import type { State } from './index';
 
 // setting up the store, overriding set and get to use telejson
-// @ts-ignore
 storeSetup(store._);
 
 export const STORAGE_KEY = '@storybook/ui/store';

--- a/code/lib/blocks/src/blocks/Props.tsx
+++ b/code/lib/blocks/src/blocks/Props.tsx
@@ -13,7 +13,7 @@ export const Props = deprecate(
   `
 );
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 Props.defaultProps = {
   of: PRIMARY_STORY,
 };

--- a/code/lib/blocks/src/blocks/mdx.tsx
+++ b/code/lib/blocks/src/blocks/mdx.tsx
@@ -53,7 +53,6 @@ function navigate(context: DocsContextProps, url: string) {
   context.channel.emit(NAVIGATE_URL, url);
 }
 
-// @ts-ignore
 const A = components.a;
 
 interface AnchorInPageProps {
@@ -124,7 +123,7 @@ const SUPPORTED_MDX_HEADERS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 const OcticonHeaders = SUPPORTED_MDX_HEADERS.reduce(
   (acc, headerType) => ({
     ...acc,
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     [headerType]: styled(components[headerType])({
       '& svg': {
         visibility: 'hidden',
@@ -159,7 +158,7 @@ const HeaderWithOcticonAnchor: FC<HeaderWithOcticonAnchorProps> = ({
 }) => {
   const context = useContext(DocsContext);
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   const OcticonHeader = OcticonHeaders[as];
   const hash = `#${id}`;
 
@@ -213,7 +212,7 @@ export const HeaderMdx: FC<HeaderMdxProps> = (props) => {
     );
   }
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   const Header = components[as];
 
   // Make sure it still work if "remark-slug" plugin is not present.
@@ -223,7 +222,7 @@ export const HeaderMdx: FC<HeaderMdxProps> = (props) => {
 export const HeadersMdx = SUPPORTED_MDX_HEADERS.reduce(
   (acc, headerType) => ({
     ...acc,
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     [headerType]: (props: object) => <HeaderMdx as={headerType} {...props} />,
   }),
   {}

--- a/code/lib/blocks/src/components/ArgsTable/SectionRow.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/SectionRow.tsx
@@ -96,7 +96,7 @@ export const SectionRow: FC<SectionRowProps> = ({
 }) => {
   const [expanded, setExpanded] = useState(initialExpanded);
   const Level = level === 'subsection' ? Subsection : Section;
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   const itemCount = children?.length || 0;
   const caption = level === 'subsection' ? `${itemCount} item${itemCount !== 1 ? 's' : ''}` : '';
   const icon = expanded ? 'arrowdown' : 'arrowright';

--- a/code/lib/blocks/src/components/IFrame.tsx
+++ b/code/lib/blocks/src/components/IFrame.tsx
@@ -54,7 +54,6 @@ export class IFrame extends Component<IFrameProps> {
         title={title}
         src={src}
         allowFullScreen={allowFullScreen}
-        // @ts-ignore
         loading="lazy"
         {...rest}
       />

--- a/code/lib/blocks/src/components/Preview.tsx
+++ b/code/lib/blocks/src/components/Preview.tsx
@@ -215,7 +215,7 @@ export const Preview: FC<PreviewProps> = ({
   );
   const actionItems = [...defaultActionItems, ...additionalActionItems];
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   const layout = getLayout(Children.count(children) === 1 ? [children] : children);
 
   const { window: globalWindow } = global;

--- a/code/lib/blocks/src/controls/react-editable-json-tree/JsonNodes.tsx
+++ b/code/lib/blocks/src/controls/react-editable-json-tree/JsonNodes.tsx
@@ -81,12 +81,12 @@ export class JsonAddValue extends Component<JsonAddValueProps, JsonAddValueState
   }
 
   refInputKey(node: any) {
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     this.state.inputRefKey = node;
   }
 
   refInputValue(node: any) {
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     this.state.inputRefValue = node;
   }
 
@@ -144,7 +144,7 @@ interface JsonAddValueProps {
   onSubmitValueParser: (...args: any) => any;
 }
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 JsonAddValue.defaultProps = {
   onlyValue: false,
   addButtonElement: <button>+</button>,
@@ -193,7 +193,7 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
   onChildUpdate(childKey: string, childData: any) {
     const { data, keyPath } = this.state;
     // Update data
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     data[childKey] = childData;
     // Put new data
     this.setState({
@@ -484,7 +484,7 @@ interface JsonArrayProps {
   onSubmitValueParser: (...args: any) => any;
 }
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 JsonArray.defaultProps = {
   keyPath: [],
   deep: 0,
@@ -586,7 +586,7 @@ export class JsonFunctionValue extends Component<JsonFunctionValueProps, JsonFun
   }
 
   refInput(node: any) {
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     this.state.inputRef = node;
   }
 
@@ -693,7 +693,7 @@ interface JsonFunctionValueProps {
   onSubmitValueParser: (...args: any) => any;
 }
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 JsonFunctionValue.defaultProps = {
   keyPath: [],
   deep: 0,
@@ -1036,7 +1036,7 @@ interface JsonNodeProps {
   onSubmitValueParser: (...args: any) => any;
 }
 
-/// @ts-ignore
+/// @ts-expect-error (Converted from ts-ignore)
 JsonNode.defaultProps = {
   keyPath: [],
   deep: 0,
@@ -1085,7 +1085,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
   onChildUpdate(childKey: string, childData: any) {
     const { data, keyPath } = this.state;
     // Update data
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     data[childKey] = childData;
     // Put new data
     this.setState({
@@ -1116,7 +1116,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
     beforeAddAction(key, keyPath, deep, newValue)
       .then(() => {
         // Update data
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         data[key] = newValue;
         this.setState({
           data,
@@ -1142,7 +1142,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
     return () => {
       const { beforeRemoveAction, logger } = this.props;
       const { data, keyPath, nextDeep: deep } = this.state;
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       const oldValue = data[key];
       // Before Remove Action
       beforeRemoveAction(key, keyPath, deep, oldValue)
@@ -1155,7 +1155,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
             type: deltaTypes.REMOVE_DELTA_TYPE,
           };
 
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           delete data[key];
           this.setState({ data });
 
@@ -1181,14 +1181,14 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
       const { data, keyPath, nextDeep: deep } = this.state;
 
       // Old value
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       const oldValue = data[key];
 
       // Before update action
       beforeUpdateAction(key, keyPath, deep, oldValue, value)
         .then(() => {
           // Update value
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           data[key] = value;
           // Set state
           this.setState({
@@ -1385,7 +1385,7 @@ interface JsonObjectProps {
   onSubmitValueParser: (...args: any) => any;
 }
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 JsonObject.defaultProps = {
   keyPath: [],
   deep: 0,
@@ -1487,7 +1487,7 @@ export class JsonValue extends Component<JsonValueProps, JsonValueState> {
   }
 
   refInput(node: any) {
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     this.state.inputRef = node;
   }
 
@@ -1585,7 +1585,7 @@ interface JsonValueProps {
   onSubmitValueParser: (...args: any) => any;
 }
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 JsonValue.defaultProps = {
   keyPath: [],
   deep: 0,

--- a/code/lib/blocks/src/controls/react-editable-json-tree/index.tsx
+++ b/code/lib/blocks/src/controls/react-editable-json-tree/index.tsx
@@ -74,12 +74,12 @@ export class JsonTree extends Component<JsonTreeProps, JsonTreeState> {
     }
     let inputElementFunction = inputElement;
     if (inputElement && getObjectType(inputElement) !== 'Function') {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       inputElementFunction = () => inputElement;
     }
     let textareaElementFunction = textareaElement;
     if (textareaElement && getObjectType(textareaElement) !== 'Function') {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       textareaElementFunction = () => textareaElement;
     }
 
@@ -140,7 +140,7 @@ interface JsonTreeProps {
   onSubmitValueParser?: (...args: any) => any;
 }
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 JsonTree.defaultProps = {
   rootName: 'root',
   isCollapsed: (keyPath, deep) => deep !== -1,

--- a/code/lib/builder-webpack5/src/index.ts
+++ b/code/lib/builder-webpack5/src/index.ts
@@ -72,7 +72,7 @@ export const bail: WebpackBuilder['bail'] = async () => {
   }
   // we wait for the compiler to finish it's work, so it's command-line output doesn't interfere
   return new Promise((res, rej) => {
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     if (process && compilation) {
       try {
         compilation.close(() => res());
@@ -219,7 +219,7 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
 
       logger.trace({ message: '=> Preview built', time: process.hrtime(startTime) });
       if (stats && stats.hasWarnings()) {
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         stats
           .toJson({ warnings: true } as StatsOptions)
           .warnings.forEach((e) => logger.warn(e.message));

--- a/code/lib/builder-webpack5/src/presets/custom-webpack-preset.ts
+++ b/code/lib/builder-webpack5/src/presets/custom-webpack-preset.ts
@@ -8,7 +8,7 @@ import { loadCustomWebpackConfig } from '@storybook/core-webpack';
 import { createDefaultWebpackConfig } from '../preview/base-webpack.config';
 
 export async function webpack(config: Configuration, options: Options) {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   const { configDir, configType, presets, webpackConfig } = options;
 
   const coreOptions = await presets.apply<CoreConfig>('core');

--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { DefinePlugin, HotModuleReplacementPlugin, ProgressPlugin, ProvidePlugin } from 'webpack';
 import type { Configuration } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-// @ts-ignore // -- this has typings for webpack4 in it, won't work
+// @ts-expect-error // -- this has typings for webpack4 in it, won't work
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
 import VirtualModulePlugin from 'webpack-virtual-modules';

--- a/code/lib/channels/src/index.test.ts
+++ b/code/lib/channels/src/index.test.ts
@@ -103,7 +103,7 @@ describe('Channel', () => {
         listenerOutputData = data;
       });
       const sendSpy = jest.fn();
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       channel.transport.send = sendSpy;
       channel.emit(eventName, ...listenerInputData);
       expect(listenerOutputData).toEqual(listenerInputData);

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -128,7 +128,6 @@ export async function baseGenerator(
   const {
     packages: frameworkPackages,
     type,
-    // @ts-ignore
     renderer: rendererInclude, // deepscan-disable-line UNUSED_DECL
     rendererId,
     framework: frameworkInclude,

--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -259,7 +259,7 @@ export abstract class JsPackageManager {
     let current: string;
 
     if (/(@storybook|^sb$|^storybook$)/.test(packageName)) {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       current = storybookPackagesVersions[packageName];
     }
 

--- a/code/lib/client-api/src/ClientApi.test.ts
+++ b/code/lib/client-api/src/ClientApi.test.ts
@@ -17,7 +17,7 @@ describe('ClientApi', () => {
         },
       });
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       clientApi.storiesOf('none', module).aa();
       expect(data).toBe('foo');
     });
@@ -38,7 +38,7 @@ describe('ClientApi', () => {
         },
       });
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       clientApi.storiesOf('none', module).aa().bb();
       expect(data).toEqual(['foo', 'bar']);
     });
@@ -53,7 +53,7 @@ describe('ClientApi', () => {
         },
       });
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       clientApi.storiesOf('none', module).aa();
       expect(data).toBe('function');
     });
@@ -74,7 +74,7 @@ describe('ClientApi', () => {
         },
       });
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       clientApi.storiesOf('none', module).bb();
       expect(data).toBe('foo');
     });
@@ -90,7 +90,7 @@ describe('ClientApi', () => {
         },
       });
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       clientApi.storiesOf(kind, module).aa();
       expect(data).toBe(kind);
     });

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -2,7 +2,7 @@ import { describe } from '@jest/globals';
 import { dedent } from 'ts-dedent';
 import _transform from '../csf-2-to-3';
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 expect.addSnapshotSerializer({
   print: (val: any) => val,
   test: (val) => true,

--- a/code/lib/codemod/src/transforms/csf-2-to-3.ts
+++ b/code/lib/codemod/src/transforms/csf-2-to-3.ts
@@ -128,7 +128,7 @@ function transform({ source }: { source: string }, api: any, options: { parser?:
       }
 
       const keyId = t.identifier(key);
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       const { typeAnnotation } = id;
       if (typeAnnotation) {
         keyId.typeAnnotation = typeAnnotation;

--- a/code/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/code/lib/components/src/syntaxhighlighter/syntaxhighlighter.tsx
@@ -4,32 +4,32 @@ import { styled } from '@storybook/theming';
 import global from 'global';
 import memoize from 'memoizerific';
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import jsx from 'react-syntax-highlighter/dist/esm/languages/prism/jsx';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import css from 'react-syntax-highlighter/dist/esm/languages/prism/css';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import jsExtras from 'react-syntax-highlighter/dist/esm/languages/prism/js-extras';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import graphql from 'react-syntax-highlighter/dist/esm/languages/prism/graphql';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import html from 'react-syntax-highlighter/dist/esm/languages/prism/markup';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import md from 'react-syntax-highlighter/dist/esm/languages/prism/markdown';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import yml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import tsx from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import ReactSyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import { createElement } from 'react-syntax-highlighter/dist/esm/index';
 
 import { ActionBar } from '../ActionBar/ActionBar';

--- a/code/lib/components/src/tooltip/WithTooltip.tsx
+++ b/code/lib/components/src/tooltip/WithTooltip.tsx
@@ -81,7 +81,7 @@ const WithTooltipPure: FC<WithTooltipPureProps> = ({
       )}
     >
       {({ getTriggerProps, triggerRef }) => (
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         <Container ref={triggerRef} {...getTriggerProps()} {...props}>
           {children}
         </Container>

--- a/code/lib/core-client/src/preview/start.test.ts
+++ b/code/lib/core-client/src/preview/start.test.ts
@@ -8,7 +8,7 @@ import {
   emitter,
   mockChannel,
 } from '@storybook/preview-web/dist/cjs/PreviewWeb.mockdata';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import { WebView } from '@storybook/preview-web/dist/cjs/WebView';
 import { setGlobalRender } from '@storybook/client-api';
 
@@ -19,7 +19,7 @@ jest.spyOn(WebView.prototype, 'prepareForDocs').mockReturnValue('docs-root');
 jest.spyOn(WebView.prototype, 'prepareForStory').mockReturnValue('story-root');
 
 jest.mock('global', () => ({
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   ...jest.requireActual('global'),
   history: { replaceState: jest.fn() },
   document: {

--- a/code/lib/core-common/src/presets.ts
+++ b/code/lib/core-common/src/presets.ts
@@ -193,9 +193,9 @@ export async function loadPreset(
   storybookOptions: InterPresetOptions
 ): Promise<LoadedPreset[]> {
   try {
-    // @ts-ignores
+    // @ts-expect-error (Converted from ts-ignore)
     const name: string = input.name ? input.name : input;
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     const presetOptions = input.options ? input.options : {};
 
     let contents = await getContent(input);

--- a/code/lib/core-common/src/utils/envs.ts
+++ b/code/lib/core-common/src/utils/envs.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error does not have defs, but universal-dotenv is in TS now
 import { getEnvironment } from 'lazy-universal-dotenv';
 import { nodePathsToArray } from './paths';
 

--- a/code/lib/core-common/src/utils/normalize-stories.ts
+++ b/code/lib/core-common/src/utils/normalize-stories.ts
@@ -15,7 +15,7 @@ const DEFAULT_FILES = '**/*.@(mdx|stories.mdx|stories.tsx|stories.ts|stories.jsx
 // TODO: remove - LEGACY support for bad glob patterns we had in SB 5 - remove in SB7
 const fixBadGlob = deprecate(
   (match: RegExpMatchArray) => {
-    // @ts-ignore this will get removed later anyway
+    // @ts-expect-error this will get removed later anyway
     return match.input.replace(match[1], `@${match[1]}`);
   },
   dedent`

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -23,7 +23,7 @@ import { openInBrowser } from './utils/open-in-browser';
 import { getBuilders } from './utils/get-builders';
 import { StoryIndexGenerator } from './utils/StoryIndexGenerator';
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 export const router: Router = new Router();
 
 export const DEBOUNCE = 100;
@@ -137,7 +137,7 @@ export async function storybookDevServer(options: Options) {
 
   await new Promise<void>((resolve, reject) => {
     // FIXME: Following line doesn't match TypeScript signature at all 🤔
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     server.listen({ port, host }, (error: Error) => (error ? reject(error) : resolve()));
   });
 

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -426,7 +426,7 @@ export class StoryIndexGenerator {
         return acc;
       }, {} as Record<ComponentTitle, number>);
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       compat = Object.entries(sorted).reduce((acc, entry) => {
         const [id, story] = entry;
         if (story.type === 'docs') return acc;

--- a/code/lib/core-server/src/utils/open-in-browser.ts
+++ b/code/lib/core-server/src/utils/open-in-browser.ts
@@ -1,8 +1,6 @@
 import { logger } from '@storybook/node-logger';
-// @ts-ignore
 import betterOpn from 'better-opn'; // betterOpn alias used because also loading open
 import open from 'open';
-// @ts-ignore
 import getDefaultBrowser from '@aw-web-design/x-default-browser';
 import { dedent } from 'ts-dedent';
 

--- a/code/lib/core-server/src/utils/output-startup-information.ts
+++ b/code/lib/core-server/src/utils/output-startup-information.ts
@@ -39,7 +39,7 @@ export function outputStartupInformation(options: {
       'right-mid': '',
       middle: '',
     },
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     paddingLeft: 0,
     paddingRight: 0,
     paddingTop: 0,

--- a/code/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/code/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import Watchpack from 'watchpack';
 import slash from 'slash';
 import fs from 'fs';

--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -3,7 +3,7 @@ import { dedent } from 'ts-dedent';
 import yaml from 'js-yaml';
 import { loadCsf } from './CsfFile';
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 expect.addSnapshotSerializer({
   print: (val: any) => yaml.dump(val).trimEnd(),
   test: (val) => typeof val !== 'string',

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -190,7 +190,7 @@ export class CsfFile {
         if (p.key.name === 'title') {
           meta.title = this._parseTitle(p.value);
         } else if (['includeStories', 'excludeStories'].includes(p.key.name)) {
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           meta[p.key.name] = parseIncludeExclude(p.value);
         } else if (p.key.name === 'component') {
           const { code } = generate(p.value, {});

--- a/code/lib/csf-tools/src/getStorySortParameter.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.ts
@@ -31,7 +31,7 @@ const parseValue = (expr: t.Expression): any => {
     }, {} as any);
   }
   if (t.isLiteral(expr)) {
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     return expr.value;
   }
   throw new Error(`Unknown node type ${expr}`);

--- a/code/lib/docs-tools/src/argTypes/convert/flow/convert.ts
+++ b/code/lib/docs-tools/src/argTypes/convert/flow/convert.ts
@@ -43,7 +43,6 @@ export const convert = (type: FlowType): SBType | void => {
       return { ...base, ...convertSig(type) };
     case 'union':
       if (type.elements.every(isLiteral)) {
-        // @ts-ignore
         return { ...base, name: 'enum', value: type.elements.map(toEnumOption) };
       }
       return { ...base, name, value: type.elements.map(convert) };

--- a/code/lib/docs-tools/src/argTypes/docgen/extractDocgenProps.test.ts
+++ b/code/lib/docs-tools/src/argTypes/docgen/extractDocgenProps.test.ts
@@ -40,7 +40,7 @@ function createFuncType(typeSystemDef: TypeSystemDef, others: Record<string, any
 
 function createComponent(docgenInfo: Record<string, any>): Component {
   const component = () => {};
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   component.__docgenInfo = {
     [DOCGEN_SECTION]: {
       [PROP_NAME]: {

--- a/code/lib/preview-web/src/PreviewWeb.integration.test.ts
+++ b/code/lib/preview-web/src/PreviewWeb.integration.test.ts
@@ -29,7 +29,7 @@ jest.mock('./WebView');
 
 const { window, document } = global;
 jest.mock('global', () => ({
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   ...jest.requireActual('global'),
   history: { replaceState: jest.fn() },
   document: {

--- a/code/lib/preview-web/src/PreviewWeb.tsx
+++ b/code/lib/preview-web/src/PreviewWeb.tsx
@@ -75,7 +75,7 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
     this.urlStore = new UrlStore();
 
     // Add deprecated APIs for back-compat
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     this.storyStore.getSelection = deprecate(
       () => this.urlStore.selection,
       dedent`

--- a/code/lib/preview-web/src/render/StoryRender.ts
+++ b/code/lib/preview-web/src/render/StoryRender.ts
@@ -40,7 +40,7 @@ function createController(): AbortController {
   return {
     signal: { aborted: false },
     abort() {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       this.signal.aborted = true;
     },
   } as AbortController;

--- a/code/lib/source-loader/src/build.js
+++ b/code/lib/source-loader/src/build.js
@@ -16,9 +16,9 @@ export async function transform(inputSource) {
   const preamble = `
     /* eslint-disable */
     // @ts-nocheck
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     var __STORY__ = ${sourceJson};
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     var __LOCATIONS_MAP__ = ${JSON.stringify(addsMap)};
     `;
   return `${preamble}\n${source}`;

--- a/code/lib/source-loader/src/index.ts
+++ b/code/lib/source-loader/src/index.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import { transform } from './build';
 
 export * from './types';

--- a/code/lib/ui/src/FakeProvider.tsx
+++ b/code/lib/ui/src/FakeProvider.tsx
@@ -7,9 +7,9 @@ export class FakeProvider extends Provider {
   constructor() {
     super();
 
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     this.addons = addons;
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     this.channel = {
       on: () => {},
       off: () => {},
@@ -19,7 +19,7 @@ export class FakeProvider extends Provider {
     };
   }
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   getElements(type) {
     return addons.getElements(type);
   }
@@ -28,12 +28,12 @@ export class FakeProvider extends Provider {
     return <div>This is from a 'renderPreview' call from FakeProvider</div>;
   }
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   handleAPI(api) {
     addons.loadAddons(api);
   }
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   getConfig() {
     return {};
   }

--- a/code/lib/ui/src/__tests__/index.test.ts
+++ b/code/lib/ui/src/__tests__/index.test.ts
@@ -4,7 +4,7 @@ describe('Main API', () => {
   it('should fail if provider is not extended from the base Provider', () => {
     const run = () => {
       const fakeProvider = {};
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       renderStorybookUI(null, fakeProvider);
     };
 

--- a/code/lib/ui/src/components/preview/preview.tsx
+++ b/code/lib/ui/src/components/preview/preview.tsx
@@ -188,7 +188,7 @@ const Preview = React.memo<PreviewProps>((props) => {
         />
         <S.FrameWrap key="frame" offset={showToolbar ? 40 : 0}>
           {tabs.map(({ render: Render, match, ...t }, i) => {
-            // @ts-ignore
+            // @ts-expect-error (Converted from ts-ignore)
             const key = t.id || t.key || i;
             return (
               <Fragment key={key}>
@@ -224,10 +224,10 @@ function filterTabs(panels: Addon[], parameters: Record<string, any>) {
       .map((panel, index) => ({ ...panel, index } as Addon))
       .sort((p1, p2) => {
         const tab_1 = arrTabs.find((tab) => tab.id === p1.id);
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         const index_1 = tab_1 ? tab_1.index : arrTabs.length + p1.index;
         const tab_2 = arrTabs.find((tab) => tab.id === p2.id);
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         const index_2 = tab_2 ? tab_2.index : arrTabs.length + p2.index;
         return index_1 - index_2;
       })

--- a/code/lib/ui/src/components/preview/toolbar.tsx
+++ b/code/lib/ui/src/components/preview/toolbar.tsx
@@ -171,7 +171,7 @@ export const ToolbarComp = React.memo<ToolData>((props) => (
 export const Tools = React.memo<{ list: Addon[] }>(({ list }) => (
   <>
     {list.filter(Boolean).map(({ render: Render, id, ...t }, index) => (
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       <Render key={id || t.key || `f-${index}`} />
     ))}
   </>

--- a/code/lib/ui/src/components/sidebar/Menu.stories.tsx
+++ b/code/lib/ui/src/components/sidebar/Menu.stories.tsx
@@ -44,7 +44,7 @@ const DoubleThemeRenderingHack = styled.div({
 export const Expanded = () => {
   const menu = useMenu(
     {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       getShortcutKeys: () => ({}),
       getAddonsShortcuts: () => ({}),
       versionUpdateAvailable: () => false,
@@ -73,7 +73,7 @@ Expanded.play = async ({ canvasElement }) => {
 export const ExpandedWithoutReleaseNotes = () => {
   const menu = useMenu(
     {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       getShortcutKeys: () => ({}),
       getAddonsShortcuts: () => ({}),
       versionUpdateAvailable: () => false,

--- a/code/lib/ui/src/components/sidebar/Search.tsx
+++ b/code/lib/ui/src/components/sidebar/Search.tsx
@@ -291,7 +291,7 @@ export const Search = React.memo<{
       <Downshift<DownshiftItem>
         initialInputValue={initialQuery}
         stateReducer={stateReducer}
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         itemToString={(result) => result?.item?.name || ''}
       >
         {({

--- a/code/lib/ui/src/index.tsx
+++ b/code/lib/ui/src/index.tsx
@@ -23,12 +23,11 @@ import Provider from './provider';
 const emotionCache = createCache({ key: 'sto' });
 emotionCache.compat = true;
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 ThemeProvider.displayName = 'ThemeProvider';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 HelmetProvider.displayName = 'HelmetProvider';
 
-// @ts-ignore
 const Container = process.env.XSTORYBOOK_EXAMPLE_APP ? React.StrictMode : React.Fragment;
 
 export interface RootProps {

--- a/code/lib/ui/src/settings/shortcuts.tsx
+++ b/code/lib/ui/src/settings/shortcuts.tsx
@@ -274,7 +274,7 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
           className="modalInput"
           onBlur={this.onBlur}
           onFocus={this.onFocus(feature)}
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           onKeyDown={this.onKeyDown}
           value={shortcut ? shortcutToHumanString(shortcut) : ''}
           placeholder="Type keys"

--- a/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
@@ -16,7 +16,7 @@ describe('framework-preset-react-docgen', () => {
 
       const config = await preset.babel(babelConfig, {
         presets: {
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           apply: async () =>
             ({
               check: false,
@@ -55,7 +55,7 @@ describe('framework-preset-react-docgen', () => {
 
       const config = await preset.webpackFinal(webpackConfig, {
         presets: {
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           apply: async () =>
             ({
               check: false,
@@ -85,7 +85,7 @@ describe('framework-preset-react-docgen', () => {
 
       const outputBabelconfig = await preset.babel(babelConfig, {
         presets: {
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           apply: async () =>
             ({
               check: false,
@@ -96,7 +96,7 @@ describe('framework-preset-react-docgen', () => {
       });
       const outputWebpackconfig = await preset.webpackFinal(webpackConfig, {
         presets: {
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           apply: async () =>
             ({
               check: false,
@@ -131,7 +131,7 @@ describe('framework-preset-react-docgen', () => {
 
       const outputBabelconfig = await preset.babel(babelConfig, {
         presets: {
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           apply: async () =>
             ({
               check: false,
@@ -142,7 +142,7 @@ describe('framework-preset-react-docgen', () => {
       });
       const outputWebpackconfig = await preset.webpackFinal(webpackConfig, {
         presets: {
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           apply: async () =>
             ({
               check: false,

--- a/code/presets/react-webpack/src/framework-preset-react.test.ts
+++ b/code/presets/react-webpack/src/framework-preset-react.test.ts
@@ -23,7 +23,7 @@ describe('framework-preset-react', () => {
   const storybookOptions: Partial<Options> = {
     configType: 'DEVELOPMENT',
     presets: {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       apply: async () => ({
         name: '@storybook/react',
         options: {
@@ -37,7 +37,7 @@ describe('framework-preset-react', () => {
   const storybookOptionsDisabledRefresh: Partial<Options> = {
     configType: 'DEVELOPMENT',
     presets: {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       apply: async () => ({
         name: '@storybook/react',
         options: {

--- a/code/presets/svelte-webpack/src/svelte-docgen-loader.ts
+++ b/code/presets/svelte-webpack/src/svelte-docgen-loader.ts
@@ -75,7 +75,7 @@ export default async function svelteDocgen(this: any, source: string) {
 
   try {
     // FIXME
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     const componentDoc = await svelteDoc.parse(options);
 
     // get filename for source content

--- a/code/renderers/html/src/docs/sourceDecorator.test.ts
+++ b/code/renderers/html/src/docs/sourceDecorator.test.ts
@@ -35,7 +35,7 @@ describe('sourceDecorator', () => {
   let mockChannel: { on: jest.Mock; emit?: jest.Mock };
   beforeEach(() => {
     mockedAddons.getChannel.mockReset();
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     mockedUseEffect.mockImplementation((cb) => setTimeout(cb, 0));
 
     mockChannel = { on: jest.fn(), emit: jest.fn() };

--- a/code/renderers/html/src/docs/sourceDecorator.ts
+++ b/code/renderers/html/src/docs/sourceDecorator.ts
@@ -30,7 +30,7 @@ function defaultTransformSource(source: string) {
 function applyTransformSource(source: string, context: StoryContext): string {
   const docs = context.parameters.docs ?? {};
   const transformSource = docs.transformSource ?? defaultTransformSource;
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   return transformSource(source, context);
 }
 

--- a/code/renderers/html/src/globals.ts
+++ b/code/renderers/html/src/globals.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window: globalWindow } = global;

--- a/code/renderers/html/src/render.ts
+++ b/code/renderers/html/src/render.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 import { dedent } from 'ts-dedent';

--- a/code/renderers/preact/src/globals.ts
+++ b/code/renderers/preact/src/globals.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window: globalWindow } = global;

--- a/code/renderers/preact/src/render.tsx
+++ b/code/renderers/preact/src/render.tsx
@@ -6,7 +6,7 @@ import type { StoryFnPreactReturnType, PreactFramework } from './types';
 let renderedStory: Element;
 
 function preactRender(story: StoryFnPreactReturnType | null, domElement: Element): void {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   if (preact.Fragment) {
     // Preact 10 only:
     preact.render(story, domElement);

--- a/code/renderers/react/src/docs/extractProps.ts
+++ b/code/renderers/react/src/docs/extractProps.ts
@@ -14,7 +14,7 @@ export interface PropDefMap {
 const propTypesMap = new Map();
 
 Object.keys(PropTypes).forEach((typeName) => {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   const type = PropTypes[typeName];
 
   propTypesMap.set(type, typeName);

--- a/code/renderers/react/src/docs/jsxDecorator.test.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.test.tsx
@@ -47,7 +47,7 @@ describe('renderJsx', () => {
   });
   it('large objects', () => {
     const obj = Array.from({ length: 20 }).reduce((acc, _, i) => {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       acc[`key_${i}`] = `val_${i}`;
       return acc;
     }, {});
@@ -159,7 +159,7 @@ describe('renderJsx', () => {
   });
 });
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 const makeContext = (name: string, parameters: any, args: any, extra?: object): StoryContext => ({
   id: `jsx-test--${name}`,
   kind: 'js-text',
@@ -173,7 +173,7 @@ describe('jsxDecorator', () => {
   let mockChannel: { on: jest.Mock; emit?: jest.Mock };
   beforeEach(() => {
     mockedAddons.getChannel.mockReset();
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     mockedUseEffect.mockImplementation((cb) => setTimeout(cb, 0));
 
     mockChannel = { on: jest.fn(), emit: jest.fn() };
@@ -272,7 +272,7 @@ describe('jsxDecorator', () => {
   it('renders MDX properly', async () => {
     // FIXME: generate this from actual MDX
     const mdxElement: ReturnType<typeof createElement> = {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       type: { displayName: 'MDXCreateElement' },
       props: {
         mdxType: 'div',

--- a/code/renderers/react/src/docs/jsxDecorator.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.tsx
@@ -69,7 +69,7 @@ export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
   let renderedJSX = code;
   const Type = renderedJSX.type;
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   for (let i = 0; i < options.skip; i += 1) {
     if (typeof renderedJSX === 'undefined') {
       logger.warn('Cannot skip undefined element');
@@ -125,7 +125,7 @@ export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
     const toJSXString =
       typeof reactElementToJSXString === 'function'
         ? reactElementToJSXString
-        : // @ts-ignore
+        : // @ts-expect-error (Converted from ts-ignore)
           reactElementToJSXString.default;
     let string = applyBeforeRender(toJSXString(child, opts as Options), options);
 

--- a/code/renderers/react/src/docs/lib/defaultValues/createFromRawDefaultProp.ts
+++ b/code/renderers/react/src/docs/lib/defaultValues/createFromRawDefaultProp.ts
@@ -137,7 +137,7 @@ const functionResolver: TypeResolver = (rawDefaultProp, propDef) => {
       inspectionResult = inspectValue(rawDefaultProp.toString());
     }
 
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     const { hasParams } = inspectionResult.inferredType as InspectionFunction;
 
     return createSummaryValue(getPrettyFuncIdentifier(funcName, hasParams));

--- a/code/renderers/react/src/docs/lib/defaultValues/prettyIdentifier.ts
+++ b/code/renderers/react/src/docs/lib/defaultValues/prettyIdentifier.ts
@@ -17,10 +17,10 @@ export function getPrettyIdentifier(inferredType: InspectionIdentifiableInferedT
 
   switch (type) {
     case InspectionType.FUNCTION:
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       return getPrettyFuncIdentifier(identifier, (inferredType as InspectionFunction).hasParams);
     case InspectionType.ELEMENT:
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       return getPrettyElementIdentifier(identifier);
     default:
       return identifier;

--- a/code/renderers/react/src/docs/lib/inspection/acornParser.ts
+++ b/code/renderers/react/src/docs/lib/inspection/acornParser.ts
@@ -21,7 +21,7 @@ interface ParsingResult<T> {
 }
 
 const ACORN_WALK_VISITORS = {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   ...acornWalk.base,
   JSXElement: () => {},
 };
@@ -41,7 +41,7 @@ function calculateNodeDepth(node: estree.Expression): number {
   const depths: number[] = [];
 
   acornWalk.ancestor(
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     node,
     {
       ObjectExpression(_: any, ancestors: estree.Node[]) {
@@ -81,7 +81,7 @@ function parseFunction(
 
   // If there is at least a JSXElement in the body of the function, then it's a React component.
   acornWalk.simple(
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     funcNode.body,
     {
       JSXElement(node: any) {
@@ -117,7 +117,7 @@ function parseClass(
 
   // If there is at least a JSXElement in the body of the class, then it's a React component.
   acornWalk.simple(
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     classNode.body,
     {
       JSXElement(node: any) {

--- a/code/renderers/react/src/docs/propTypes/createType.ts
+++ b/code/renderers/react/src/docs/propTypes/createType.ts
@@ -183,10 +183,10 @@ function generateFunc(extractedProp: ExtractedProp): TypeDef {
     if (jsDocTags.params != null || jsDocTags.returns != null) {
       return createTypeDef({
         name: PropTypesType.FUNC,
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         short: generateShortFuncSignature(jsDocTags.params, jsDocTags.returns),
         compact: null,
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         full: generateFuncSignature(jsDocTags.params, jsDocTags.returns),
       });
     }

--- a/code/renderers/react/src/docs/propTypes/handleProp.test.tsx
+++ b/code/renderers/react/src/docs/propTypes/handleProp.test.tsx
@@ -47,7 +47,7 @@ function createComponent({ propTypes = {}, defaultProps = {}, docgenInfo = {} })
   component.propTypes = propTypes;
   component.defaultProps = defaultProps;
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   component.__docgenInfo = createDocgenSection(docgenInfo);
 
   return component;
@@ -1296,7 +1296,7 @@ describe('enhancePropTypesProp', () => {
       it('should support React element with props', () => {
         const component = createTestComponent(null);
 
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         const defaultProp = <ReactComponent className="toto" />;
         // Simulate babel-plugin-add-react-displayname.
         defaultProp.type.displayName = 'ReactComponent';

--- a/code/renderers/react/src/docs/typeScript/handleProp.test.tsx
+++ b/code/renderers/react/src/docs/typeScript/handleProp.test.tsx
@@ -47,7 +47,7 @@ function createComponent({ propTypes = {}, defaultProps = {}, docgenInfo = {} })
   component.propTypes = propTypes;
   component.defaultProps = defaultProps;
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   component.__docgenInfo = createDocgenSection(docgenInfo);
 
   return component;
@@ -408,7 +408,7 @@ describe('enhanceTypeScriptProp', () => {
       it('should support React element with props', () => {
         const component = createTestComponent(null);
 
-        // @ts-ignore
+        // @ts-expect-error (Converted from ts-ignore)
         const defaultProp = <ReactComponent className="toto" />;
         // Simulate babel-plugin-add-react-displayname.
         defaultProp.type.displayName = 'ReactComponent';

--- a/code/renderers/react/src/globals.ts
+++ b/code/renderers/react/src/globals.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window: globalWindow } = global;

--- a/code/renderers/react/src/render.tsx
+++ b/code/renderers/react/src/render.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 import React, {

--- a/code/renderers/react/src/testing-api.ts
+++ b/code/renderers/react/src/testing-api.ts
@@ -119,7 +119,7 @@ export function composeStories<TModule extends CSFExports<ReactFramework>>(
   csfExports: TModule,
   projectAnnotations?: ProjectAnnotations<ReactFramework>
 ) {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   const composedStories = originalComposeStories(csfExports, projectAnnotations, composeStory);
 
   return composedStories as unknown as Omit<

--- a/code/renderers/server/src/globals.ts
+++ b/code/renderers/server/src/globals.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window: globalWindow } = global;

--- a/code/renderers/server/src/render.ts
+++ b/code/renderers/server/src/render.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 import { dedent } from 'ts-dedent';

--- a/code/renderers/svelte/src/docs/extractArgTypes.ts
+++ b/code/renderers/svelte/src/docs/extractArgTypes.ts
@@ -110,7 +110,7 @@ const parseTypeToControl = (type: JSDocType | undefined): any => {
         return { type: type.type };
     }
   } else if (type.kind === 'union') {
-    // @ts-ignore TODO: fix, this seems like a broke in package update
+    // @ts-expect-error TODO: fix, this seems like a broke in package update
     if (Array.isArray(type.type) && !type.type.find((t) => t.type !== 'string')) {
       return {
         type: 'radio',

--- a/code/renderers/svelte/src/globals.ts
+++ b/code/renderers/svelte/src/globals.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window: globalWindow } = global;

--- a/code/renderers/svelte/src/render.ts
+++ b/code/renderers/svelte/src/render.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 import type { ArgsStoryFn } from '@storybook/csf';

--- a/code/renderers/vue/src/decorateStory.ts
+++ b/code/renderers/vue/src/decorateStory.ts
@@ -22,22 +22,22 @@ function prepare(
     return null;
   }
 
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   // eslint-disable-next-line no-underscore-dangle
   if (!story._isVue) {
     if (innerStory) {
       story.components = { ...(story.components || {}), story: innerStory };
     }
     story = Vue.extend(story);
-    // @ts-ignore // https://github.com/storybookjs/storybook/pull/7578#discussion_r307984824
+    // @ts-expect-error // https://github.com/storybookjs/storybook/pull/7578#discussion_r307984824
   } else if (story.options[WRAPS]) {
     return story as VueConstructor;
   }
 
   return Vue.extend({
-    // @ts-ignore // https://github.com/storybookjs/storybook/pull/7578#discussion_r307985279
+    // @ts-expect-error // https://github.com/storybookjs/storybook/pull/7578#discussion_r307985279
     [WRAPS]: story,
-    // @ts-ignore // https://github.com/storybookjs/storybook/pull/7578#discussion_r307984824
+    // @ts-expect-error // https://github.com/storybookjs/storybook/pull/7578#discussion_r307984824
     [VALUES]: { ...(innerStory ? innerStory.options[VALUES] : {}), ...extractProps(story) },
     functional: true,
     render(h, { data, parent, children }) {
@@ -45,7 +45,7 @@ function prepare(
         story,
         {
           ...data,
-          // @ts-ignore // https://github.com/storybookjs/storybook/pull/7578#discussion_r307986196
+          // @ts-expect-error // https://github.com/storybookjs/storybook/pull/7578#discussion_r307986196
           props: { ...(data.props || {}), ...parent.$root[VALUES] },
         },
         children

--- a/code/renderers/vue/src/globals.ts
+++ b/code/renderers/vue/src/globals.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window: globalWindow } = global;

--- a/code/renderers/vue/src/render.ts
+++ b/code/renderers/vue/src/render.ts
@@ -32,21 +32,17 @@ const getRoot = (domElement: Element): Instance => {
     },
     data() {
       return {
-        // @ts-ignore
         [COMPONENT]: undefined,
         [VALUES]: {},
       };
     },
-    // @ts-ignore
     render(h) {
-      // @ts-ignore
       map.set(domElement, instance);
       const children = this[COMPONENT] ? [h(this[COMPONENT])] : undefined;
       return h('div', { attrs: { id: 'storybook-root' } }, children);
     },
   });
 
-  // @ts-ignore
   return instance;
 };
 
@@ -67,8 +63,7 @@ export const render: ArgsStoryFn<VueFramework> = (props, context) => {
 
   // if there is a name property, we either use it or preprend with sb- in case it's an invalid name
   if (component.name) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore isReservedTag is an internal function from Vue, might be changed in future releases
+    // @ts-expect-error isReservedTag is an internal function from Vue, might be changed in future releases
     const isReservedTag = Vue.config.isReservedTag && Vue.config.isReservedTag(component.name);
 
     componentName = isReservedTag ? `sb-${component.name}` : component.name;
@@ -117,7 +112,7 @@ export function renderToDOM(
     root[COMPONENT] = element;
   }
 
-  // @ts-ignore https://github.com/storybookjs/storrybook/pull/7578#discussion_r307986139
+  // @ts-expect-error https://github.com/storybookjs/storrybook/pull/7578#discussion_r307986139
   root[VALUES] = { ...element.options[VALUES], ...args };
 
   if (!map.has(domElement)) {

--- a/code/renderers/vue/src/util.ts
+++ b/code/renderers/vue/src/util.ts
@@ -17,7 +17,7 @@ function resolveDefault({ type, default: def }: any) {
 }
 
 export function extractProps(component: VueConstructor) {
-  // @ts-ignore this options business seems not good according to the types
+  // @ts-expect-error this options business seems not good according to the types
   return Object.entries(component.options.props || {})
     .map(([name, prop]) => ({ [name]: resolveDefault(prop) }))
     .reduce((wrap, prop) => ({ ...wrap, ...prop }), {});

--- a/code/renderers/vue3/src/globals.ts
+++ b/code/renderers/vue3/src/globals.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window: globalWindow } = global;

--- a/code/renderers/web-components/src/docs/__testfixtures__/lit-element-demo-card/input.js
+++ b/code/renderers/web-components/src/docs/__testfixtures__/lit-element-demo-card/input.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-unresolved */
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 import { LitElement, html, css } from 'lit-element';

--- a/code/renderers/web-components/src/docs/custom-elements.test.ts
+++ b/code/renderers/web-components/src/docs/custom-elements.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 import { extractArgTypes } from './custom-elements';

--- a/code/renderers/web-components/src/framework-api.ts
+++ b/code/renderers/web-components/src/framework-api.ts
@@ -30,16 +30,16 @@ export function isValidMetaData(customElements: any) {
  * @param customElements any for now as spec is not super stable yet
  */
 export function setCustomElements(customElements: any) {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   window.__STORYBOOK_CUSTOM_ELEMENTS__ = customElements;
 }
 
 export function setCustomElementsManifest(customElements: any) {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   window.__STORYBOOK_CUSTOM_ELEMENTS_MANIFEST__ = customElements;
 }
 
 export function getCustomElements() {
-  // @ts-ignore
+  // @ts-expect-error (Converted from ts-ignore)
   return window.__STORYBOOK_CUSTOM_ELEMENTS__ || window.__STORYBOOK_CUSTOM_ELEMENTS_MANIFEST__;
 }

--- a/code/renderers/web-components/src/globals.ts
+++ b/code/renderers/web-components/src/globals.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window: globalWindow } = global;

--- a/code/renderers/web-components/src/index.ts
+++ b/code/renderers/web-components/src/index.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 const { window, EventSource } = global;

--- a/code/renderers/web-components/src/render.ts
+++ b/code/renderers/web-components/src/render.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import global from 'global';
 
 import { dedent } from 'ts-dedent';

--- a/scripts/dts-localize.ts
+++ b/scripts/dts-localize.ts
@@ -173,7 +173,7 @@ export const run = async (entrySourceFiles: string[], outputPath: string, option
       (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
       node.moduleSpecifier !== undefined
     ) {
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       const target: string = node.moduleSpecifier.text;
       let currentSourceFile = '';
       let referencedSourceFile = '';
@@ -198,7 +198,7 @@ export const run = async (entrySourceFiles: string[], outputPath: string, option
         referencedSourceFile
       );
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       node.moduleSpecifier = ts.factory.createStringLiteral(replacementPath);
 
       return true;
@@ -231,7 +231,7 @@ export const run = async (entrySourceFiles: string[], outputPath: string, option
         referencedSourceFile
       );
 
-      // @ts-ignore
+      // @ts-expect-error (Converted from ts-ignore)
       node.argument = ts.factory.createStringLiteral(replacementPath);
 
       return true;

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -12,7 +12,7 @@ import reproTemplates from '../../code/lib/cli/src/repro-templates';
 import storybookVersions from '../../code/lib/cli/src/versions';
 import { JsPackageManagerFactory } from '../../code/lib/cli/src/js-package-manager/JsPackageManagerFactory';
 
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import { maxConcurrentTasks } from '../utils/concurrency';
 
 import { localizeYarnConfigFiles, setupYarn } from './utils/yarn';
@@ -107,7 +107,7 @@ const runGenerators = async (
 
   let controller: AbortController;
   if (localRegistry) {
-    // @ts-ignore
+    // @ts-expect-error (Converted from ts-ignore)
     await publish.run();
     console.log(`⚙️ Starting local registry: ${LOCAL_REGISTRY_URL}`);
     controller = await servePackages({ debug: true });

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -5,7 +5,7 @@ import program from 'commander';
 import { readConfig, writeConfig } from '../code/lib/csf-tools';
 import { getInterpretedFile } from '../code/lib/core-common';
 import { serve } from './utils/serve';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import { filterDataForCurrentCircleCINode } from './utils/concurrency';
 
 import * as configs from '../code/lib/cli/src/repro-generators/configs';
@@ -292,10 +292,10 @@ const getConfig = async (): Promise<Parameters[]> => {
         min: 1,
         hint: 'You can also run directly with package name like `test:e2e-framework react`, or `yarn test:e2e-framework --all` for all packages!',
         choices: Object.keys(configs).map((key) => {
-          // @ts-ignore
+          // @ts-expect-error (Converted from ts-ignore)
           const { name, version } = configs[key];
           return {
-            // @ts-ignore
+            // @ts-expect-error (Converted from ts-ignore)
             value: configs[key],
             title: `${name}@${version}`,
             selected: false,

--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -9,7 +9,7 @@ import yaml from 'js-yaml';
 
 import startVerdaccioServer from 'verdaccio';
 import pLimit from 'p-limit';
-// @ts-ignore
+// @ts-expect-error (Converted from ts-ignore)
 import { maxConcurrentTasks } from './utils/concurrency';
 import { listOfPackages } from './utils/list-packages';
 

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -232,7 +232,7 @@ function addEsbuildLoaderToStories(mainConfig: ConfigFile) {
   })`;
   mainConfig.setFieldNode(
     ['webpackFinal'],
-    // @ts-ignore (not sure why TS complains here, it does exist)
+    // @ts-expect-error (not sure why TS complains here, it does exist)
     babelParse(webpackFinalCode).program.body[0].expression
   );
 }
@@ -250,7 +250,7 @@ function forceViteRebuilds(mainConfig: ConfigFile) {
   })`;
   mainConfig.setFieldNode(
     ['viteFinal'],
-    // @ts-ignore (not sure why TS complains here, it does exist)
+    // @ts-expect-error (not sure why TS complains here, it does exist)
     babelParse(viteFinalCode).program.body[0].expression
   );
 }


### PR DESCRIPTION
Issue: Usage of `// @ts-ignore` spread through the monorepo was potentially disabling type checks unnecessarily in some cases, potentially leading to unsafe code or bugs.

## What I did

Converted each `@ts-ignore` to `@ts-expect-error`.  If there was already a comment, I kept it, otherwise I added `(Converted from ts-ignore)` because there's a lint rule to give a reason.  Then, I ran `yarn bootstrap --build` and removed the failing (unnecessary) disable directives until the build passed.

Overall, this should improve type coverage and give a better pattern for other devs to follow.  

## How to test

CI

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
