### PR TITLE
fix: type `storyIdToEntry` explicitly

### DIFF
--- a/code/lib/store/src/StoryStore.ts
+++ b/code/lib/store/src/StoryStore.ts
@@ -28,6 +28,7 @@ import type {
   PromiseLike,
   StoryIndex,
   V2CompatIndexEntry,
+  IndexEntry,
   StoryIndexV3,
   ModuleExports,
 } from './types';
@@ -126,7 +127,7 @@ export class StoryStore<TFramework extends AnyFramework> {
   }
 
   // Get an entry from the index, waiting on initialization if necessary
-  async storyIdToEntry(storyId: StoryId) {
+  async storyIdToEntry(storyId: StoryId): Promise<IndexEntry> {
     await this.initializationPromise;
     // The index will always be set before the initialization promise returns
     return this.storyIndex!.storyIdToEntry(storyId);


### PR DESCRIPTION
Issue: N/A

## What I did

Trying to test out v7, and I get this error:

```
../../node_modules/@storybook/store/dist/types/StoryStore.d.ts:32:54 - error TS2307: Cannot find module 'lib/addons/dist/types/types' or its corresponding type declarations.

32     storyIdToEntry(storyId: StoryId): Promise<import("lib/addons/dist/types/types").IndexEntry>;
```

Explicitly typing it should fix it 🙂  (it works in my `node_module` at least)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
