### PR TITLE
Vite: Ensure we set `DOCS_OPTIONS` in the vite builder

### DIFF
--- a/code/lib/builder-vite/input/iframe.html
+++ b/code/lib/builder-vite/input/iframe.html
@@ -12,6 +12,7 @@
       window.CHANNEL_OPTIONS = '[CHANNEL_OPTIONS HERE]';
       window.FEATURES = '[FEATURES HERE]';
       window.STORIES = '[STORIES HERE]';
+      window.DOCS_OPTIONS = '[DOCS_OPTIONS HERE]';
       window.SERVER_CHANNEL_URL = '[SERVER_CHANNEL_URL HERE]';
 
       // We do this so that "module && module.hot" etc. in Storybook source code

--- a/code/lib/builder-vite/src/transform-iframe-html.ts
+++ b/code/lib/builder-vite/src/transform-iframe-html.ts
@@ -1,5 +1,5 @@
 import { normalizeStories } from '@storybook/core-common';
-import type { CoreConfig } from '@storybook/core-common';
+import type { CoreConfig, DocsOptions } from '@storybook/core-common';
 import type { ExtendedOptions } from './types';
 
 export type PreviewHtml = string | undefined;
@@ -10,6 +10,7 @@ export async function transformIframeHtml(html: string, options: ExtendedOptions
   const headHtmlSnippet = await presets.apply<PreviewHtml>('previewHead');
   const bodyHtmlSnippet = await presets.apply<PreviewHtml>('previewBody');
   const logLevel = await presets.apply('logLevel', undefined);
+  const docsOptions = await presets.apply<DocsOptions>('docs');
 
   const coreOptions = await presets.apply<CoreConfig>('core');
   const stories = normalizeStories(await options.presets.apply('stories', [], options), {
@@ -31,6 +32,7 @@ export async function transformIframeHtml(html: string, options: ExtendedOptions
     )
     .replace(`'[FEATURES HERE]'`, JSON.stringify(features || {}))
     .replace(`'[STORIES HERE]'`, JSON.stringify(stories || {}))
+    .replace(`'[DOCS_OPTIONS HERE]'`, JSON.stringify(docsOptions || {}))
     .replace(`'[SERVER_CHANNEL_URL HERE]'`, JSON.stringify(serverChannelUrl))
     .replace('<!-- [HEAD HTML SNIPPET HERE] -->', headHtmlSnippet || '')
     .replace('<!-- [BODY HTML SNIPPET HERE] -->', bodyHtmlSnippet || '');


### PR DESCRIPTION
Issue: https://github.com/storybookjs/builder-vite/issues/492

 I guess I forgot to tell y'all we needed to do this as part of https://github.com/storybookjs/storybook/pull/18763

## What I did

Set `DOCS_OPTIONS` in vite, similar to other options like `FEATURES`.

## How to test

Try running a vite sandbox with `features: { storyStoreV7: false }`.

One important note: "docs only" stories (e.g. `Introduction.stories.mdx`) *do not* currently work at all w/ the v6 store (not in any builder): https://github.com/storybookjs/storybook/issues/19126