### PR TITLE
Add a new `throwPlayFunctionExceptions` parameter

### DIFF
--- a/code/addons/interactions/src/preset/preview.ts
+++ b/code/addons/interactions/src/preset/preview.ts
@@ -59,3 +59,7 @@ export const { step: runStep } = instrument(
   { step: (label: StepLabel, play: PlayFunction, context: PlayFunctionContext) => play(context) },
   { intercept: true }
 );
+
+export const parameters = {
+  hidePlayFunctionExceptions: true,
+};

--- a/code/addons/interactions/src/preset/preview.ts
+++ b/code/addons/interactions/src/preset/preview.ts
@@ -61,5 +61,5 @@ export const { step: runStep } = instrument(
 );
 
 export const parameters = {
-  hidePlayFunctionExceptions: true,
+  throwPlayFunctionExceptions: false,
 };

--- a/code/lib/preview-web/src/PreviewWeb.mockdata.ts
+++ b/code/lib/preview-web/src/PreviewWeb.mockdata.ts
@@ -64,7 +64,7 @@ export const projectAnnotations = {
   renderToDOM: jest.fn().mockReturnValue(teardownRenderToDOM),
   parameters: { docs: { renderer: () => docsRenderer } },
 };
-export const getProjectAnnotations = () => projectAnnotations;
+export const getProjectAnnotations = jest.fn(() => projectAnnotations as any);
 
 export const storyIndex: StoryIndex = {
   v: 4,

--- a/code/lib/preview-web/src/PreviewWeb.test.ts
+++ b/code/lib/preview-web/src/PreviewWeb.test.ts
@@ -530,7 +530,7 @@ describe('PreviewWeb', () => {
                       `);
       });
 
-      describe('when `hidePlayFunctionExceptions` is set', () => {
+      describe('when `throwPlayFunctionExceptions` is set', () => {
         it('emits but does not render exception if the play function throws', async () => {
           const error = new Error('error');
           componentOneExports.a.play.mockImplementationOnce(() => {
@@ -541,7 +541,7 @@ describe('PreviewWeb', () => {
             ...projectAnnotations,
             parameters: {
               ...projectAnnotations.parameters,
-              hidePlayFunctionExceptions: true,
+              throwPlayFunctionExceptions: false,
             },
           });
 
@@ -560,7 +560,7 @@ describe('PreviewWeb', () => {
         });
       });
 
-      describe('when `hidePlayFunctionExceptions` is unset', () => {
+      describe('when `throwPlayFunctionExceptions` is unset', () => {
         it('emits AND renders exception if the play function throws', async () => {
           const error = new Error('error');
           componentOneExports.a.play.mockImplementationOnce(() => {

--- a/code/lib/preview-web/src/PreviewWeb.test.ts
+++ b/code/lib/preview-web/src/PreviewWeb.test.ts
@@ -3144,6 +3144,16 @@ describe('PreviewWeb', () => {
       });
     });
 
+    describe('with no selection', () => {
+      // eslint-disable-next-line jest/expect-expect
+      it('does not error', async () => {
+        const preview = await createAndRenderPreview();
+        await preview.onGetProjectAnnotationsChanged({
+          getProjectAnnotations: newGetProjectAnnotations,
+        });
+      });
+    });
+
     it('shows an error the new value throws', async () => {
       document.location.search = '?id=component-one--a';
       const preview = await createAndRenderPreview();

--- a/code/lib/preview-web/src/PreviewWeb.test.ts
+++ b/code/lib/preview-web/src/PreviewWeb.test.ts
@@ -553,6 +553,10 @@ describe('PreviewWeb', () => {
             serializeError(error)
           );
           expect(preview.view.showErrorDisplay).not.toHaveBeenCalled();
+          expect(mockChannel.emit).not.toHaveBeenCalledWith(
+            STORY_THREW_EXCEPTION,
+            serializeError(error)
+          );
         });
       });
 
@@ -571,6 +575,10 @@ describe('PreviewWeb', () => {
             serializeError(error)
           );
           expect(preview.view.showErrorDisplay).toHaveBeenCalled();
+          expect(mockChannel.emit).toHaveBeenCalledWith(
+            STORY_THREW_EXCEPTION,
+            serializeError(error)
+          );
         });
       });
 

--- a/code/lib/preview-web/src/PreviewWeb.tsx
+++ b/code/lib/preview-web/src/PreviewWeb.tsx
@@ -181,7 +181,9 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
   }) {
     await super.onGetProjectAnnotationsChanged({ getProjectAnnotations });
 
-    this.renderSelection();
+    if (this.urlStore.selection) {
+      this.renderSelection();
+    }
   }
 
   // This happens when a glob gets HMR-ed

--- a/code/lib/preview-web/src/render/StoryRender.ts
+++ b/code/lib/preview-web/src/render/StoryRender.ts
@@ -242,7 +242,7 @@ export class StoryRender<TFramework extends AnyFramework> implements Render<TFra
           await this.runPhase(abortSignal, 'errored', async () => {
             this.channel.emit(PLAY_FUNCTION_THREW_EXCEPTION, serializeError(error));
           });
-          if (!this.story.parameters.hidePlayFunctionExceptions) throw error;
+          if (this.story.parameters.throwPlayFunctionExceptions !== false) throw error;
         }
         this.disableKeyListeners = false;
         if (abortSignal.aborted) return;

--- a/code/lib/preview-web/src/render/StoryRender.ts
+++ b/code/lib/preview-web/src/render/StoryRender.ts
@@ -242,6 +242,7 @@ export class StoryRender<TFramework extends AnyFramework> implements Render<TFra
           await this.runPhase(abortSignal, 'errored', async () => {
             this.channel.emit(PLAY_FUNCTION_THREW_EXCEPTION, serializeError(error));
           });
+          if (!this.story.parameters.hidePlayFunctionExceptions) throw error;
         }
         this.disableKeyListeners = false;
         if (abortSignal.aborted) return;


### PR DESCRIPTION
Issue: Play function errors were swallowed if you didn't have the interactions addon installed.

## What I did

- Add `parameters.hidePlayFunctionExceptions`
- If unset, revert to throwing play function errors
- Set it in the interactions addon

## How to test

- See unit tests
- Run a sandbox, throw an error in a play function. Check it is still swallowed.
- Disable the interactions addon, check the play function is displayed:
<img width="886" alt="image" src="https://user-images.githubusercontent.com/132554/189051055-9f70b4ed-aeb8-44ce-8509-65babd1033a9.png">

## How to set in external tools (e.g. Chromatic)

1. Browse to `iframe.html`.
2. Update project parameters:

```js
const preview = __STORYBOOK_PREVIEW__
const { projectAnnotations } = preview.storyStore;
const newAnnotations = {
  ...projectAnnotations,
  parameters: {
    ...projectAnnotations.parameters, 
    throwPlayFunctionExceptions: false,
  },
};

preview.onGetProjectAnnotationsChanged({ getProjectAnnotations: () => newAnnotations })
```

3. Render story as usual.

