### PR TITLE
remove node12 from the matrix

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node_version: [12, 14, 16]
+        node_version: [14, 16]
         include:
           - os: macos-latest
             node_version: 16


### PR DESCRIPTION
we no longer support node12 in 7.0, or at least do not actively support it. Maybe it works, but we won't commit to it.